### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,8 @@ jobs:
   test:
     name: Run Unit Tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       # 1. Check out the code


### PR DESCRIPTION
Potential fix for [https://github.com/ItsMavey/ItsBagelBot/security/code-scanning/2](https://github.com/ItsMavey/ItsBagelBot/security/code-scanning/2)

In general, the fix is to explicitly specify a `permissions` block that grants the least privileges required. For this workflow, the job only needs to read repository contents to check out code and run tests. Therefore, adding `permissions: contents: read` is sufficient. You can set this either at the workflow root (applies to all jobs) or at the job level (applies only to that job). To minimally change existing functionality while clearly addressing the CodeQL finding (which flags the job), the best approach is to add a job‑level `permissions` block under `jobs.test`.

Concretely, in `.github/workflows/main.yml`, under `jobs:`, within the `test:` job definition, add:

```yaml
    permissions:
      contents: read
```

indented to align with `runs-on`. No imports or additional methods are needed, as this is purely a YAML configuration change for GitHub Actions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
