### PR TITLE
feat(commands): per-command perm tier, cooldown, single-user lock

### DIFF
--- a/app/commands/ent/commands.go
+++ b/app/commands/ent/commands.go
@@ -25,6 +25,12 @@ type Commands struct {
 	Response string `json:"response,omitempty"`
 	// IsActive holds the value of the "is_active" field.
 	IsActive bool `json:"is_active,omitempty"`
+	// Perm holds the value of the "perm" field.
+	Perm string `json:"perm,omitempty"`
+	// Cooldown holds the value of the "cooldown" field.
+	Cooldown uint `json:"cooldown,omitempty"`
+	// AllowedUserID holds the value of the "allowed_user_id" field.
+	AllowedUserID uint64 `json:"allowed_user_id,omitempty"`
 	// CreatedAt holds the value of the "created_at" field.
 	CreatedAt time.Time `json:"created_at,omitempty"`
 	// UpdatedAt holds the value of the "updated_at" field.
@@ -39,9 +45,9 @@ func (*Commands) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case commands.FieldIsActive:
 			values[i] = new(sql.NullBool)
-		case commands.FieldID, commands.FieldUserID:
+		case commands.FieldID, commands.FieldUserID, commands.FieldCooldown, commands.FieldAllowedUserID:
 			values[i] = new(sql.NullInt64)
-		case commands.FieldName, commands.FieldResponse:
+		case commands.FieldName, commands.FieldResponse, commands.FieldPerm:
 			values[i] = new(sql.NullString)
 		case commands.FieldCreatedAt, commands.FieldUpdatedAt:
 			values[i] = new(sql.NullTime)
@@ -89,6 +95,24 @@ func (_m *Commands) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field is_active", values[i])
 			} else if value.Valid {
 				_m.IsActive = value.Bool
+			}
+		case commands.FieldPerm:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field perm", values[i])
+			} else if value.Valid {
+				_m.Perm = value.String
+			}
+		case commands.FieldCooldown:
+			if value, ok := values[i].(*sql.NullInt64); !ok {
+				return fmt.Errorf("unexpected type %T for field cooldown", values[i])
+			} else if value.Valid {
+				_m.Cooldown = uint(value.Int64)
+			}
+		case commands.FieldAllowedUserID:
+			if value, ok := values[i].(*sql.NullInt64); !ok {
+				return fmt.Errorf("unexpected type %T for field allowed_user_id", values[i])
+			} else if value.Valid {
+				_m.AllowedUserID = uint64(value.Int64)
 			}
 		case commands.FieldCreatedAt:
 			if value, ok := values[i].(*sql.NullTime); !ok {
@@ -149,6 +173,15 @@ func (_m *Commands) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("is_active=")
 	builder.WriteString(fmt.Sprintf("%v", _m.IsActive))
+	builder.WriteString(", ")
+	builder.WriteString("perm=")
+	builder.WriteString(_m.Perm)
+	builder.WriteString(", ")
+	builder.WriteString("cooldown=")
+	builder.WriteString(fmt.Sprintf("%v", _m.Cooldown))
+	builder.WriteString(", ")
+	builder.WriteString("allowed_user_id=")
+	builder.WriteString(fmt.Sprintf("%v", _m.AllowedUserID))
 	builder.WriteString(", ")
 	builder.WriteString("created_at=")
 	builder.WriteString(_m.CreatedAt.Format(time.ANSIC))

--- a/app/commands/ent/commands/commands.go
+++ b/app/commands/ent/commands/commands.go
@@ -21,6 +21,12 @@ const (
 	FieldResponse = "response"
 	// FieldIsActive holds the string denoting the is_active field in the database.
 	FieldIsActive = "is_active"
+	// FieldPerm holds the string denoting the perm field in the database.
+	FieldPerm = "perm"
+	// FieldCooldown holds the string denoting the cooldown field in the database.
+	FieldCooldown = "cooldown"
+	// FieldAllowedUserID holds the string denoting the allowed_user_id field in the database.
+	FieldAllowedUserID = "allowed_user_id"
 	// FieldCreatedAt holds the string denoting the created_at field in the database.
 	FieldCreatedAt = "created_at"
 	// FieldUpdatedAt holds the string denoting the updated_at field in the database.
@@ -36,6 +42,9 @@ var Columns = []string{
 	FieldName,
 	FieldResponse,
 	FieldIsActive,
+	FieldPerm,
+	FieldCooldown,
+	FieldAllowedUserID,
 	FieldCreatedAt,
 	FieldUpdatedAt,
 }
@@ -57,6 +66,12 @@ var (
 	ResponseValidator func(string) error
 	// DefaultIsActive holds the default value on creation for the "is_active" field.
 	DefaultIsActive bool
+	// DefaultPerm holds the default value on creation for the "perm" field.
+	DefaultPerm string
+	// DefaultCooldown holds the default value on creation for the "cooldown" field.
+	DefaultCooldown uint
+	// DefaultAllowedUserID holds the default value on creation for the "allowed_user_id" field.
+	DefaultAllowedUserID uint64
 	// DefaultCreatedAt holds the default value on creation for the "created_at" field.
 	DefaultCreatedAt func() time.Time
 	// DefaultUpdatedAt holds the default value on creation for the "updated_at" field.
@@ -91,6 +106,21 @@ func ByResponse(opts ...sql.OrderTermOption) OrderOption {
 // ByIsActive orders the results by the is_active field.
 func ByIsActive(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldIsActive, opts...).ToFunc()
+}
+
+// ByPerm orders the results by the perm field.
+func ByPerm(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldPerm, opts...).ToFunc()
+}
+
+// ByCooldown orders the results by the cooldown field.
+func ByCooldown(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldCooldown, opts...).ToFunc()
+}
+
+// ByAllowedUserID orders the results by the allowed_user_id field.
+func ByAllowedUserID(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldAllowedUserID, opts...).ToFunc()
 }
 
 // ByCreatedAt orders the results by the created_at field.

--- a/app/commands/ent/commands/where.go
+++ b/app/commands/ent/commands/where.go
@@ -74,6 +74,21 @@ func IsActive(v bool) predicate.Commands {
 	return predicate.Commands(sql.FieldEQ(FieldIsActive, v))
 }
 
+// Perm applies equality check predicate on the "perm" field. It's identical to PermEQ.
+func Perm(v string) predicate.Commands {
+	return predicate.Commands(sql.FieldEQ(FieldPerm, v))
+}
+
+// Cooldown applies equality check predicate on the "cooldown" field. It's identical to CooldownEQ.
+func Cooldown(v uint) predicate.Commands {
+	return predicate.Commands(sql.FieldEQ(FieldCooldown, v))
+}
+
+// AllowedUserID applies equality check predicate on the "allowed_user_id" field. It's identical to AllowedUserIDEQ.
+func AllowedUserID(v uint64) predicate.Commands {
+	return predicate.Commands(sql.FieldEQ(FieldAllowedUserID, v))
+}
+
 // CreatedAt applies equality check predicate on the "created_at" field. It's identical to CreatedAtEQ.
 func CreatedAt(v time.Time) predicate.Commands {
 	return predicate.Commands(sql.FieldEQ(FieldCreatedAt, v))
@@ -262,6 +277,151 @@ func IsActiveEQ(v bool) predicate.Commands {
 // IsActiveNEQ applies the NEQ predicate on the "is_active" field.
 func IsActiveNEQ(v bool) predicate.Commands {
 	return predicate.Commands(sql.FieldNEQ(FieldIsActive, v))
+}
+
+// PermEQ applies the EQ predicate on the "perm" field.
+func PermEQ(v string) predicate.Commands {
+	return predicate.Commands(sql.FieldEQ(FieldPerm, v))
+}
+
+// PermNEQ applies the NEQ predicate on the "perm" field.
+func PermNEQ(v string) predicate.Commands {
+	return predicate.Commands(sql.FieldNEQ(FieldPerm, v))
+}
+
+// PermIn applies the In predicate on the "perm" field.
+func PermIn(vs ...string) predicate.Commands {
+	return predicate.Commands(sql.FieldIn(FieldPerm, vs...))
+}
+
+// PermNotIn applies the NotIn predicate on the "perm" field.
+func PermNotIn(vs ...string) predicate.Commands {
+	return predicate.Commands(sql.FieldNotIn(FieldPerm, vs...))
+}
+
+// PermGT applies the GT predicate on the "perm" field.
+func PermGT(v string) predicate.Commands {
+	return predicate.Commands(sql.FieldGT(FieldPerm, v))
+}
+
+// PermGTE applies the GTE predicate on the "perm" field.
+func PermGTE(v string) predicate.Commands {
+	return predicate.Commands(sql.FieldGTE(FieldPerm, v))
+}
+
+// PermLT applies the LT predicate on the "perm" field.
+func PermLT(v string) predicate.Commands {
+	return predicate.Commands(sql.FieldLT(FieldPerm, v))
+}
+
+// PermLTE applies the LTE predicate on the "perm" field.
+func PermLTE(v string) predicate.Commands {
+	return predicate.Commands(sql.FieldLTE(FieldPerm, v))
+}
+
+// PermContains applies the Contains predicate on the "perm" field.
+func PermContains(v string) predicate.Commands {
+	return predicate.Commands(sql.FieldContains(FieldPerm, v))
+}
+
+// PermHasPrefix applies the HasPrefix predicate on the "perm" field.
+func PermHasPrefix(v string) predicate.Commands {
+	return predicate.Commands(sql.FieldHasPrefix(FieldPerm, v))
+}
+
+// PermHasSuffix applies the HasSuffix predicate on the "perm" field.
+func PermHasSuffix(v string) predicate.Commands {
+	return predicate.Commands(sql.FieldHasSuffix(FieldPerm, v))
+}
+
+// PermEqualFold applies the EqualFold predicate on the "perm" field.
+func PermEqualFold(v string) predicate.Commands {
+	return predicate.Commands(sql.FieldEqualFold(FieldPerm, v))
+}
+
+// PermContainsFold applies the ContainsFold predicate on the "perm" field.
+func PermContainsFold(v string) predicate.Commands {
+	return predicate.Commands(sql.FieldContainsFold(FieldPerm, v))
+}
+
+// CooldownEQ applies the EQ predicate on the "cooldown" field.
+func CooldownEQ(v uint) predicate.Commands {
+	return predicate.Commands(sql.FieldEQ(FieldCooldown, v))
+}
+
+// CooldownNEQ applies the NEQ predicate on the "cooldown" field.
+func CooldownNEQ(v uint) predicate.Commands {
+	return predicate.Commands(sql.FieldNEQ(FieldCooldown, v))
+}
+
+// CooldownIn applies the In predicate on the "cooldown" field.
+func CooldownIn(vs ...uint) predicate.Commands {
+	return predicate.Commands(sql.FieldIn(FieldCooldown, vs...))
+}
+
+// CooldownNotIn applies the NotIn predicate on the "cooldown" field.
+func CooldownNotIn(vs ...uint) predicate.Commands {
+	return predicate.Commands(sql.FieldNotIn(FieldCooldown, vs...))
+}
+
+// CooldownGT applies the GT predicate on the "cooldown" field.
+func CooldownGT(v uint) predicate.Commands {
+	return predicate.Commands(sql.FieldGT(FieldCooldown, v))
+}
+
+// CooldownGTE applies the GTE predicate on the "cooldown" field.
+func CooldownGTE(v uint) predicate.Commands {
+	return predicate.Commands(sql.FieldGTE(FieldCooldown, v))
+}
+
+// CooldownLT applies the LT predicate on the "cooldown" field.
+func CooldownLT(v uint) predicate.Commands {
+	return predicate.Commands(sql.FieldLT(FieldCooldown, v))
+}
+
+// CooldownLTE applies the LTE predicate on the "cooldown" field.
+func CooldownLTE(v uint) predicate.Commands {
+	return predicate.Commands(sql.FieldLTE(FieldCooldown, v))
+}
+
+// AllowedUserIDEQ applies the EQ predicate on the "allowed_user_id" field.
+func AllowedUserIDEQ(v uint64) predicate.Commands {
+	return predicate.Commands(sql.FieldEQ(FieldAllowedUserID, v))
+}
+
+// AllowedUserIDNEQ applies the NEQ predicate on the "allowed_user_id" field.
+func AllowedUserIDNEQ(v uint64) predicate.Commands {
+	return predicate.Commands(sql.FieldNEQ(FieldAllowedUserID, v))
+}
+
+// AllowedUserIDIn applies the In predicate on the "allowed_user_id" field.
+func AllowedUserIDIn(vs ...uint64) predicate.Commands {
+	return predicate.Commands(sql.FieldIn(FieldAllowedUserID, vs...))
+}
+
+// AllowedUserIDNotIn applies the NotIn predicate on the "allowed_user_id" field.
+func AllowedUserIDNotIn(vs ...uint64) predicate.Commands {
+	return predicate.Commands(sql.FieldNotIn(FieldAllowedUserID, vs...))
+}
+
+// AllowedUserIDGT applies the GT predicate on the "allowed_user_id" field.
+func AllowedUserIDGT(v uint64) predicate.Commands {
+	return predicate.Commands(sql.FieldGT(FieldAllowedUserID, v))
+}
+
+// AllowedUserIDGTE applies the GTE predicate on the "allowed_user_id" field.
+func AllowedUserIDGTE(v uint64) predicate.Commands {
+	return predicate.Commands(sql.FieldGTE(FieldAllowedUserID, v))
+}
+
+// AllowedUserIDLT applies the LT predicate on the "allowed_user_id" field.
+func AllowedUserIDLT(v uint64) predicate.Commands {
+	return predicate.Commands(sql.FieldLT(FieldAllowedUserID, v))
+}
+
+// AllowedUserIDLTE applies the LTE predicate on the "allowed_user_id" field.
+func AllowedUserIDLTE(v uint64) predicate.Commands {
+	return predicate.Commands(sql.FieldLTE(FieldAllowedUserID, v))
 }
 
 // CreatedAtEQ applies the EQ predicate on the "created_at" field.

--- a/app/commands/ent/commands_create.go
+++ b/app/commands/ent/commands_create.go
@@ -52,6 +52,48 @@ func (_c *CommandsCreate) SetNillableIsActive(v *bool) *CommandsCreate {
 	return _c
 }
 
+// SetPerm sets the "perm" field.
+func (_c *CommandsCreate) SetPerm(v string) *CommandsCreate {
+	_c.mutation.SetPerm(v)
+	return _c
+}
+
+// SetNillablePerm sets the "perm" field if the given value is not nil.
+func (_c *CommandsCreate) SetNillablePerm(v *string) *CommandsCreate {
+	if v != nil {
+		_c.SetPerm(*v)
+	}
+	return _c
+}
+
+// SetCooldown sets the "cooldown" field.
+func (_c *CommandsCreate) SetCooldown(v uint) *CommandsCreate {
+	_c.mutation.SetCooldown(v)
+	return _c
+}
+
+// SetNillableCooldown sets the "cooldown" field if the given value is not nil.
+func (_c *CommandsCreate) SetNillableCooldown(v *uint) *CommandsCreate {
+	if v != nil {
+		_c.SetCooldown(*v)
+	}
+	return _c
+}
+
+// SetAllowedUserID sets the "allowed_user_id" field.
+func (_c *CommandsCreate) SetAllowedUserID(v uint64) *CommandsCreate {
+	_c.mutation.SetAllowedUserID(v)
+	return _c
+}
+
+// SetNillableAllowedUserID sets the "allowed_user_id" field if the given value is not nil.
+func (_c *CommandsCreate) SetNillableAllowedUserID(v *uint64) *CommandsCreate {
+	if v != nil {
+		_c.SetAllowedUserID(*v)
+	}
+	return _c
+}
+
 // SetCreatedAt sets the "created_at" field.
 func (_c *CommandsCreate) SetCreatedAt(v time.Time) *CommandsCreate {
 	_c.mutation.SetCreatedAt(v)
@@ -119,6 +161,18 @@ func (_c *CommandsCreate) defaults() {
 		v := commands.DefaultIsActive
 		_c.mutation.SetIsActive(v)
 	}
+	if _, ok := _c.mutation.Perm(); !ok {
+		v := commands.DefaultPerm
+		_c.mutation.SetPerm(v)
+	}
+	if _, ok := _c.mutation.Cooldown(); !ok {
+		v := commands.DefaultCooldown
+		_c.mutation.SetCooldown(v)
+	}
+	if _, ok := _c.mutation.AllowedUserID(); !ok {
+		v := commands.DefaultAllowedUserID
+		_c.mutation.SetAllowedUserID(v)
+	}
 	if _, ok := _c.mutation.CreatedAt(); !ok {
 		v := commands.DefaultCreatedAt()
 		_c.mutation.SetCreatedAt(v)
@@ -152,6 +206,15 @@ func (_c *CommandsCreate) check() error {
 	}
 	if _, ok := _c.mutation.IsActive(); !ok {
 		return &ValidationError{Name: "is_active", err: errors.New(`ent: missing required field "Commands.is_active"`)}
+	}
+	if _, ok := _c.mutation.Perm(); !ok {
+		return &ValidationError{Name: "perm", err: errors.New(`ent: missing required field "Commands.perm"`)}
+	}
+	if _, ok := _c.mutation.Cooldown(); !ok {
+		return &ValidationError{Name: "cooldown", err: errors.New(`ent: missing required field "Commands.cooldown"`)}
+	}
+	if _, ok := _c.mutation.AllowedUserID(); !ok {
+		return &ValidationError{Name: "allowed_user_id", err: errors.New(`ent: missing required field "Commands.allowed_user_id"`)}
 	}
 	if _, ok := _c.mutation.CreatedAt(); !ok {
 		return &ValidationError{Name: "created_at", err: errors.New(`ent: missing required field "Commands.created_at"`)}
@@ -200,6 +263,18 @@ func (_c *CommandsCreate) createSpec() (*Commands, *sqlgraph.CreateSpec) {
 	if value, ok := _c.mutation.IsActive(); ok {
 		_spec.SetField(commands.FieldIsActive, field.TypeBool, value)
 		_node.IsActive = value
+	}
+	if value, ok := _c.mutation.Perm(); ok {
+		_spec.SetField(commands.FieldPerm, field.TypeString, value)
+		_node.Perm = value
+	}
+	if value, ok := _c.mutation.Cooldown(); ok {
+		_spec.SetField(commands.FieldCooldown, field.TypeUint, value)
+		_node.Cooldown = value
+	}
+	if value, ok := _c.mutation.AllowedUserID(); ok {
+		_spec.SetField(commands.FieldAllowedUserID, field.TypeUint64, value)
+		_node.AllowedUserID = value
 	}
 	if value, ok := _c.mutation.CreatedAt(); ok {
 		_spec.SetField(commands.FieldCreatedAt, field.TypeTime, value)

--- a/app/commands/ent/commands_update.go
+++ b/app/commands/ent/commands_update.go
@@ -70,6 +70,62 @@ func (_u *CommandsUpdate) SetNillableIsActive(v *bool) *CommandsUpdate {
 	return _u
 }
 
+// SetPerm sets the "perm" field.
+func (_u *CommandsUpdate) SetPerm(v string) *CommandsUpdate {
+	_u.mutation.SetPerm(v)
+	return _u
+}
+
+// SetNillablePerm sets the "perm" field if the given value is not nil.
+func (_u *CommandsUpdate) SetNillablePerm(v *string) *CommandsUpdate {
+	if v != nil {
+		_u.SetPerm(*v)
+	}
+	return _u
+}
+
+// SetCooldown sets the "cooldown" field.
+func (_u *CommandsUpdate) SetCooldown(v uint) *CommandsUpdate {
+	_u.mutation.ResetCooldown()
+	_u.mutation.SetCooldown(v)
+	return _u
+}
+
+// SetNillableCooldown sets the "cooldown" field if the given value is not nil.
+func (_u *CommandsUpdate) SetNillableCooldown(v *uint) *CommandsUpdate {
+	if v != nil {
+		_u.SetCooldown(*v)
+	}
+	return _u
+}
+
+// AddCooldown adds value to the "cooldown" field.
+func (_u *CommandsUpdate) AddCooldown(v int) *CommandsUpdate {
+	_u.mutation.AddCooldown(v)
+	return _u
+}
+
+// SetAllowedUserID sets the "allowed_user_id" field.
+func (_u *CommandsUpdate) SetAllowedUserID(v uint64) *CommandsUpdate {
+	_u.mutation.ResetAllowedUserID()
+	_u.mutation.SetAllowedUserID(v)
+	return _u
+}
+
+// SetNillableAllowedUserID sets the "allowed_user_id" field if the given value is not nil.
+func (_u *CommandsUpdate) SetNillableAllowedUserID(v *uint64) *CommandsUpdate {
+	if v != nil {
+		_u.SetAllowedUserID(*v)
+	}
+	return _u
+}
+
+// AddAllowedUserID adds value to the "allowed_user_id" field.
+func (_u *CommandsUpdate) AddAllowedUserID(v int64) *CommandsUpdate {
+	_u.mutation.AddAllowedUserID(v)
+	return _u
+}
+
 // SetCreatedAt sets the "created_at" field.
 func (_u *CommandsUpdate) SetCreatedAt(v time.Time) *CommandsUpdate {
 	_u.mutation.SetCreatedAt(v)
@@ -167,6 +223,21 @@ func (_u *CommandsUpdate) sqlSave(ctx context.Context) (_node int, err error) {
 	if value, ok := _u.mutation.IsActive(); ok {
 		_spec.SetField(commands.FieldIsActive, field.TypeBool, value)
 	}
+	if value, ok := _u.mutation.Perm(); ok {
+		_spec.SetField(commands.FieldPerm, field.TypeString, value)
+	}
+	if value, ok := _u.mutation.Cooldown(); ok {
+		_spec.SetField(commands.FieldCooldown, field.TypeUint, value)
+	}
+	if value, ok := _u.mutation.AddedCooldown(); ok {
+		_spec.AddField(commands.FieldCooldown, field.TypeUint, value)
+	}
+	if value, ok := _u.mutation.AllowedUserID(); ok {
+		_spec.SetField(commands.FieldAllowedUserID, field.TypeUint64, value)
+	}
+	if value, ok := _u.mutation.AddedAllowedUserID(); ok {
+		_spec.AddField(commands.FieldAllowedUserID, field.TypeUint64, value)
+	}
 	if value, ok := _u.mutation.CreatedAt(); ok {
 		_spec.SetField(commands.FieldCreatedAt, field.TypeTime, value)
 	}
@@ -232,6 +303,62 @@ func (_u *CommandsUpdateOne) SetNillableIsActive(v *bool) *CommandsUpdateOne {
 	if v != nil {
 		_u.SetIsActive(*v)
 	}
+	return _u
+}
+
+// SetPerm sets the "perm" field.
+func (_u *CommandsUpdateOne) SetPerm(v string) *CommandsUpdateOne {
+	_u.mutation.SetPerm(v)
+	return _u
+}
+
+// SetNillablePerm sets the "perm" field if the given value is not nil.
+func (_u *CommandsUpdateOne) SetNillablePerm(v *string) *CommandsUpdateOne {
+	if v != nil {
+		_u.SetPerm(*v)
+	}
+	return _u
+}
+
+// SetCooldown sets the "cooldown" field.
+func (_u *CommandsUpdateOne) SetCooldown(v uint) *CommandsUpdateOne {
+	_u.mutation.ResetCooldown()
+	_u.mutation.SetCooldown(v)
+	return _u
+}
+
+// SetNillableCooldown sets the "cooldown" field if the given value is not nil.
+func (_u *CommandsUpdateOne) SetNillableCooldown(v *uint) *CommandsUpdateOne {
+	if v != nil {
+		_u.SetCooldown(*v)
+	}
+	return _u
+}
+
+// AddCooldown adds value to the "cooldown" field.
+func (_u *CommandsUpdateOne) AddCooldown(v int) *CommandsUpdateOne {
+	_u.mutation.AddCooldown(v)
+	return _u
+}
+
+// SetAllowedUserID sets the "allowed_user_id" field.
+func (_u *CommandsUpdateOne) SetAllowedUserID(v uint64) *CommandsUpdateOne {
+	_u.mutation.ResetAllowedUserID()
+	_u.mutation.SetAllowedUserID(v)
+	return _u
+}
+
+// SetNillableAllowedUserID sets the "allowed_user_id" field if the given value is not nil.
+func (_u *CommandsUpdateOne) SetNillableAllowedUserID(v *uint64) *CommandsUpdateOne {
+	if v != nil {
+		_u.SetAllowedUserID(*v)
+	}
+	return _u
+}
+
+// AddAllowedUserID adds value to the "allowed_user_id" field.
+func (_u *CommandsUpdateOne) AddAllowedUserID(v int64) *CommandsUpdateOne {
+	_u.mutation.AddAllowedUserID(v)
 	return _u
 }
 
@@ -361,6 +488,21 @@ func (_u *CommandsUpdateOne) sqlSave(ctx context.Context) (_node *Commands, err 
 	}
 	if value, ok := _u.mutation.IsActive(); ok {
 		_spec.SetField(commands.FieldIsActive, field.TypeBool, value)
+	}
+	if value, ok := _u.mutation.Perm(); ok {
+		_spec.SetField(commands.FieldPerm, field.TypeString, value)
+	}
+	if value, ok := _u.mutation.Cooldown(); ok {
+		_spec.SetField(commands.FieldCooldown, field.TypeUint, value)
+	}
+	if value, ok := _u.mutation.AddedCooldown(); ok {
+		_spec.AddField(commands.FieldCooldown, field.TypeUint, value)
+	}
+	if value, ok := _u.mutation.AllowedUserID(); ok {
+		_spec.SetField(commands.FieldAllowedUserID, field.TypeUint64, value)
+	}
+	if value, ok := _u.mutation.AddedAllowedUserID(); ok {
+		_spec.AddField(commands.FieldAllowedUserID, field.TypeUint64, value)
 	}
 	if value, ok := _u.mutation.CreatedAt(); ok {
 		_spec.SetField(commands.FieldCreatedAt, field.TypeTime, value)

--- a/app/commands/ent/migrate/schema.go
+++ b/app/commands/ent/migrate/schema.go
@@ -15,6 +15,9 @@ var (
 		{Name: "name", Type: field.TypeString},
 		{Name: "response", Type: field.TypeString},
 		{Name: "is_active", Type: field.TypeBool, Default: true},
+		{Name: "perm", Type: field.TypeString, Default: "everyone"},
+		{Name: "cooldown", Type: field.TypeUint, Default: 0},
+		{Name: "allowed_user_id", Type: field.TypeUint64, Default: 0},
 		{Name: "created_at", Type: field.TypeTime},
 		{Name: "updated_at", Type: field.TypeTime},
 	}

--- a/app/commands/ent/mutation.go
+++ b/app/commands/ent/mutation.go
@@ -30,20 +30,25 @@ const (
 // CommandsMutation represents an operation that mutates the Commands nodes in the graph.
 type CommandsMutation struct {
 	config
-	op            Op
-	typ           string
-	id            *int
-	user_id       *uint64
-	adduser_id    *int64
-	name          *string
-	response      *string
-	is_active     *bool
-	created_at    *time.Time
-	updated_at    *time.Time
-	clearedFields map[string]struct{}
-	done          bool
-	oldValue      func(context.Context) (*Commands, error)
-	predicates    []predicate.Commands
+	op                 Op
+	typ                string
+	id                 *int
+	user_id            *uint64
+	adduser_id         *int64
+	name               *string
+	response           *string
+	is_active          *bool
+	perm               *string
+	cooldown           *uint
+	addcooldown        *int
+	allowed_user_id    *uint64
+	addallowed_user_id *int64
+	created_at         *time.Time
+	updated_at         *time.Time
+	clearedFields      map[string]struct{}
+	done               bool
+	oldValue           func(context.Context) (*Commands, error)
+	predicates         []predicate.Commands
 }
 
 var _ ent.Mutation = (*CommandsMutation)(nil)
@@ -308,6 +313,154 @@ func (m *CommandsMutation) ResetIsActive() {
 	m.is_active = nil
 }
 
+// SetPerm sets the "perm" field.
+func (m *CommandsMutation) SetPerm(s string) {
+	m.perm = &s
+}
+
+// Perm returns the value of the "perm" field in the mutation.
+func (m *CommandsMutation) Perm() (r string, exists bool) {
+	v := m.perm
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldPerm returns the old "perm" field's value of the Commands entity.
+// If the Commands object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *CommandsMutation) OldPerm(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldPerm is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldPerm requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldPerm: %w", err)
+	}
+	return oldValue.Perm, nil
+}
+
+// ResetPerm resets all changes to the "perm" field.
+func (m *CommandsMutation) ResetPerm() {
+	m.perm = nil
+}
+
+// SetCooldown sets the "cooldown" field.
+func (m *CommandsMutation) SetCooldown(u uint) {
+	m.cooldown = &u
+	m.addcooldown = nil
+}
+
+// Cooldown returns the value of the "cooldown" field in the mutation.
+func (m *CommandsMutation) Cooldown() (r uint, exists bool) {
+	v := m.cooldown
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldCooldown returns the old "cooldown" field's value of the Commands entity.
+// If the Commands object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *CommandsMutation) OldCooldown(ctx context.Context) (v uint, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldCooldown is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldCooldown requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldCooldown: %w", err)
+	}
+	return oldValue.Cooldown, nil
+}
+
+// AddCooldown adds u to the "cooldown" field.
+func (m *CommandsMutation) AddCooldown(u int) {
+	if m.addcooldown != nil {
+		*m.addcooldown += u
+	} else {
+		m.addcooldown = &u
+	}
+}
+
+// AddedCooldown returns the value that was added to the "cooldown" field in this mutation.
+func (m *CommandsMutation) AddedCooldown() (r int, exists bool) {
+	v := m.addcooldown
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// ResetCooldown resets all changes to the "cooldown" field.
+func (m *CommandsMutation) ResetCooldown() {
+	m.cooldown = nil
+	m.addcooldown = nil
+}
+
+// SetAllowedUserID sets the "allowed_user_id" field.
+func (m *CommandsMutation) SetAllowedUserID(u uint64) {
+	m.allowed_user_id = &u
+	m.addallowed_user_id = nil
+}
+
+// AllowedUserID returns the value of the "allowed_user_id" field in the mutation.
+func (m *CommandsMutation) AllowedUserID() (r uint64, exists bool) {
+	v := m.allowed_user_id
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldAllowedUserID returns the old "allowed_user_id" field's value of the Commands entity.
+// If the Commands object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *CommandsMutation) OldAllowedUserID(ctx context.Context) (v uint64, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldAllowedUserID is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldAllowedUserID requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldAllowedUserID: %w", err)
+	}
+	return oldValue.AllowedUserID, nil
+}
+
+// AddAllowedUserID adds u to the "allowed_user_id" field.
+func (m *CommandsMutation) AddAllowedUserID(u int64) {
+	if m.addallowed_user_id != nil {
+		*m.addallowed_user_id += u
+	} else {
+		m.addallowed_user_id = &u
+	}
+}
+
+// AddedAllowedUserID returns the value that was added to the "allowed_user_id" field in this mutation.
+func (m *CommandsMutation) AddedAllowedUserID() (r int64, exists bool) {
+	v := m.addallowed_user_id
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// ResetAllowedUserID resets all changes to the "allowed_user_id" field.
+func (m *CommandsMutation) ResetAllowedUserID() {
+	m.allowed_user_id = nil
+	m.addallowed_user_id = nil
+}
+
 // SetCreatedAt sets the "created_at" field.
 func (m *CommandsMutation) SetCreatedAt(t time.Time) {
 	m.created_at = &t
@@ -414,7 +567,7 @@ func (m *CommandsMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *CommandsMutation) Fields() []string {
-	fields := make([]string, 0, 6)
+	fields := make([]string, 0, 9)
 	if m.user_id != nil {
 		fields = append(fields, commands.FieldUserID)
 	}
@@ -426,6 +579,15 @@ func (m *CommandsMutation) Fields() []string {
 	}
 	if m.is_active != nil {
 		fields = append(fields, commands.FieldIsActive)
+	}
+	if m.perm != nil {
+		fields = append(fields, commands.FieldPerm)
+	}
+	if m.cooldown != nil {
+		fields = append(fields, commands.FieldCooldown)
+	}
+	if m.allowed_user_id != nil {
+		fields = append(fields, commands.FieldAllowedUserID)
 	}
 	if m.created_at != nil {
 		fields = append(fields, commands.FieldCreatedAt)
@@ -449,6 +611,12 @@ func (m *CommandsMutation) Field(name string) (ent.Value, bool) {
 		return m.Response()
 	case commands.FieldIsActive:
 		return m.IsActive()
+	case commands.FieldPerm:
+		return m.Perm()
+	case commands.FieldCooldown:
+		return m.Cooldown()
+	case commands.FieldAllowedUserID:
+		return m.AllowedUserID()
 	case commands.FieldCreatedAt:
 		return m.CreatedAt()
 	case commands.FieldUpdatedAt:
@@ -470,6 +638,12 @@ func (m *CommandsMutation) OldField(ctx context.Context, name string) (ent.Value
 		return m.OldResponse(ctx)
 	case commands.FieldIsActive:
 		return m.OldIsActive(ctx)
+	case commands.FieldPerm:
+		return m.OldPerm(ctx)
+	case commands.FieldCooldown:
+		return m.OldCooldown(ctx)
+	case commands.FieldAllowedUserID:
+		return m.OldAllowedUserID(ctx)
 	case commands.FieldCreatedAt:
 		return m.OldCreatedAt(ctx)
 	case commands.FieldUpdatedAt:
@@ -511,6 +685,27 @@ func (m *CommandsMutation) SetField(name string, value ent.Value) error {
 		}
 		m.SetIsActive(v)
 		return nil
+	case commands.FieldPerm:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetPerm(v)
+		return nil
+	case commands.FieldCooldown:
+		v, ok := value.(uint)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetCooldown(v)
+		return nil
+	case commands.FieldAllowedUserID:
+		v, ok := value.(uint64)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetAllowedUserID(v)
+		return nil
 	case commands.FieldCreatedAt:
 		v, ok := value.(time.Time)
 		if !ok {
@@ -536,6 +731,12 @@ func (m *CommandsMutation) AddedFields() []string {
 	if m.adduser_id != nil {
 		fields = append(fields, commands.FieldUserID)
 	}
+	if m.addcooldown != nil {
+		fields = append(fields, commands.FieldCooldown)
+	}
+	if m.addallowed_user_id != nil {
+		fields = append(fields, commands.FieldAllowedUserID)
+	}
 	return fields
 }
 
@@ -546,6 +747,10 @@ func (m *CommandsMutation) AddedField(name string) (ent.Value, bool) {
 	switch name {
 	case commands.FieldUserID:
 		return m.AddedUserID()
+	case commands.FieldCooldown:
+		return m.AddedCooldown()
+	case commands.FieldAllowedUserID:
+		return m.AddedAllowedUserID()
 	}
 	return nil, false
 }
@@ -561,6 +766,20 @@ func (m *CommandsMutation) AddField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.AddUserID(v)
+		return nil
+	case commands.FieldCooldown:
+		v, ok := value.(int)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.AddCooldown(v)
+		return nil
+	case commands.FieldAllowedUserID:
+		v, ok := value.(int64)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.AddAllowedUserID(v)
 		return nil
 	}
 	return fmt.Errorf("unknown Commands numeric field %s", name)
@@ -600,6 +819,15 @@ func (m *CommandsMutation) ResetField(name string) error {
 		return nil
 	case commands.FieldIsActive:
 		m.ResetIsActive()
+		return nil
+	case commands.FieldPerm:
+		m.ResetPerm()
+		return nil
+	case commands.FieldCooldown:
+		m.ResetCooldown()
+		return nil
+	case commands.FieldAllowedUserID:
+		m.ResetAllowedUserID()
 		return nil
 	case commands.FieldCreatedAt:
 		m.ResetCreatedAt()

--- a/app/commands/ent/runtime.go
+++ b/app/commands/ent/runtime.go
@@ -26,12 +26,24 @@ func init() {
 	commandsDescIsActive := commandsFields[3].Descriptor()
 	// commands.DefaultIsActive holds the default value on creation for the is_active field.
 	commands.DefaultIsActive = commandsDescIsActive.Default.(bool)
+	// commandsDescPerm is the schema descriptor for perm field.
+	commandsDescPerm := commandsFields[4].Descriptor()
+	// commands.DefaultPerm holds the default value on creation for the perm field.
+	commands.DefaultPerm = commandsDescPerm.Default.(string)
+	// commandsDescCooldown is the schema descriptor for cooldown field.
+	commandsDescCooldown := commandsFields[5].Descriptor()
+	// commands.DefaultCooldown holds the default value on creation for the cooldown field.
+	commands.DefaultCooldown = commandsDescCooldown.Default.(uint)
+	// commandsDescAllowedUserID is the schema descriptor for allowed_user_id field.
+	commandsDescAllowedUserID := commandsFields[6].Descriptor()
+	// commands.DefaultAllowedUserID holds the default value on creation for the allowed_user_id field.
+	commands.DefaultAllowedUserID = commandsDescAllowedUserID.Default.(uint64)
 	// commandsDescCreatedAt is the schema descriptor for created_at field.
-	commandsDescCreatedAt := commandsFields[4].Descriptor()
+	commandsDescCreatedAt := commandsFields[7].Descriptor()
 	// commands.DefaultCreatedAt holds the default value on creation for the created_at field.
 	commands.DefaultCreatedAt = commandsDescCreatedAt.Default.(func() time.Time)
 	// commandsDescUpdatedAt is the schema descriptor for updated_at field.
-	commandsDescUpdatedAt := commandsFields[5].Descriptor()
+	commandsDescUpdatedAt := commandsFields[8].Descriptor()
 	// commands.DefaultUpdatedAt holds the default value on creation for the updated_at field.
 	commands.DefaultUpdatedAt = commandsDescUpdatedAt.Default.(func() time.Time)
 	// commands.UpdateDefaultUpdatedAt holds the default value on update for the updated_at field.

--- a/app/commands/ent/schema/commands.go
+++ b/app/commands/ent/schema/commands.go
@@ -26,6 +26,18 @@ func (Commands) Fields() []ent.Field {
 
 		field.Bool("is_active").Default(true),
 
+		// Minimum role allowed to run the command. One of: everyone, sub, vip,
+		// mod, lead_mod, broadcaster. Validated at the trust boundary, stored as
+		// a plain string so adding a tier never needs a column migration.
+		field.String("perm").Default("everyone"),
+
+		// Per-command cooldown in seconds; 0 means no cooldown.
+		field.Uint("cooldown").Default(0),
+
+		// When non-zero, only this Twitch user id may run the command (overrides
+		// perm). 0 means the perm tier applies normally.
+		field.Uint64("allowed_user_id").Default(0),
+
 		field.Time("created_at").Default(time.Now),
 
 		field.Time("updated_at").Default(time.Now).UpdateDefault(time.Now),

--- a/app/commands/repository/commands.go
+++ b/app/commands/repository/commands.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"strconv"
 	"time"
 
 	"ItsBagelBot/app/commands/ent"
@@ -33,6 +34,12 @@ type CommandView struct {
 	Name     string `json:"name"`
 	Response string `json:"response"`
 	IsActive bool   `json:"is_active"`
+	Perm     string `json:"perm"`
+	Cooldown uint   `json:"cooldown"`
+	// Twitch id of the sole user allowed to run the command; "" when unset.
+	// Carried as a string so ids beyond JS's safe integer range survive the
+	// JSON round trip to the SvelteKit dashboard.
+	AllowedUserID string `json:"allowed_user_id,omitempty"`
 }
 
 type commandKey struct {
@@ -83,9 +90,12 @@ func (r *Commands) List(ctx context.Context, userID uint64) ([]CommandView, erro
 		views := make([]CommandView, len(rows))
 		for i, row := range rows {
 			views[i] = CommandView{
-				Name:     row.Name,
-				Response: row.Response,
-				IsActive: row.IsActive,
+				Name:          row.Name,
+				Response:      row.Response,
+				IsActive:      row.IsActive,
+				Perm:          row.Perm,
+				Cooldown:      row.Cooldown,
+				AllowedUserID: formatAllowed(row.AllowedUserID),
 			}
 		}
 
@@ -95,7 +105,7 @@ func (r *Commands) List(ctx context.Context, userID uint64) ([]CommandView, erro
 
 // Upsert validates and queues a command create or edit. Consecutive edits of
 // the same command coalesce into the latest state before the next flush.
-func (r *Commands) Upsert(userID uint64, name string, response string, isActive bool) error {
+func (r *Commands) Upsert(userID uint64, name string, response string, isActive bool, perm string, cooldown uint, allowedUserID uint64) error {
 
 	if err := validate.UserID(userID); err != nil {
 		return err
@@ -106,12 +116,21 @@ func (r *Commands) Upsert(userID uint64, name string, response string, isActive 
 	if err := validate.CommandResponse(response); err != nil {
 		return err
 	}
+	if err := validate.Perm(perm); err != nil {
+		return err
+	}
+	if err := validate.Cooldown(cooldown); err != nil {
+		return err
+	}
 
 	r.batcher.Add(commandKey{userID: userID, name: name}, data.CommandChangedDTO{
-		UserID:   userID,
-		Name:     name,
-		Response: response,
-		IsActive: isActive,
+		UserID:        userID,
+		Name:          name,
+		Response:      response,
+		IsActive:      isActive,
+		Perm:          perm,
+		Cooldown:      cooldown,
+		AllowedUserID: allowedUserID,
 	})
 
 	return nil
@@ -224,6 +243,9 @@ func upsertCommand(ctx context.Context, tx *ent.Tx, item data.CommandChangedDTO)
 		).
 		SetResponse(item.Response).
 		SetIsActive(item.IsActive).
+		SetPerm(item.Perm).
+		SetCooldown(item.Cooldown).
+		SetAllowedUserID(item.AllowedUserID).
 		Save(ctx)
 	if err != nil {
 		return err
@@ -238,5 +260,17 @@ func upsertCommand(ctx context.Context, tx *ent.Tx, item data.CommandChangedDTO)
 		SetName(item.Name).
 		SetResponse(item.Response).
 		SetIsActive(item.IsActive).
+		SetPerm(item.Perm).
+		SetCooldown(item.Cooldown).
+		SetAllowedUserID(item.AllowedUserID).
 		Exec(ctx)
+}
+
+// formatAllowed renders the allowed user id for the read model: empty for 0
+// (no restriction) so the dashboard can treat absence uniformly.
+func formatAllowed(id uint64) string {
+	if id == 0 {
+		return ""
+	}
+	return strconv.FormatUint(id, 10)
 }

--- a/app/commands/repository/commands_test.go
+++ b/app/commands/repository/commands_test.go
@@ -33,9 +33,9 @@ func TestUpsertCoalescesEdits(t *testing.T) {
 	client, pub, repo := setup(t)
 	ctx := context.Background()
 
-	repo.Upsert(1001, "!hello", "draft one", true)
-	repo.Upsert(1001, "!hello", "draft two", true)
-	repo.Upsert(1001, "!hello", "final wording", true)
+	repo.Upsert(1001, "!hello", "draft one", true, "everyone", 0, 0)
+	repo.Upsert(1001, "!hello", "draft two", true, "everyone", 0, 0)
+	repo.Upsert(1001, "!hello", "final wording", true, "everyone", 0, 0)
 
 	repo.Close(ctx) // deterministic flush
 
@@ -50,7 +50,7 @@ func TestDeleteIsImmediateAndAnnounced(t *testing.T) {
 	client, pub, repo := setup(t)
 	ctx := context.Background()
 
-	repo.Upsert(1001, "!hello", "hi chat", true)
+	repo.Upsert(1001, "!hello", "hi chat", true, "everyone", 0, 0)
 	repo.Close(ctx)
 
 	repo2 := repository.NewCommands(client, pub, nil, zap.NewNop())

--- a/app/commands/rpc/dashboard.go
+++ b/app/commands/rpc/dashboard.go
@@ -41,10 +41,13 @@ func SubscribeDashboard(nc *nats.Conn, repo *repository.Commands, prefix, queueG
 
 // dashboardRequest covers all three verbs; unused fields are zero-valued.
 type dashboardRequest struct {
-	UserID   string `json:"user_id"`
-	Name     string `json:"name"`
-	Response string `json:"response"`
-	IsActive bool   `json:"is_active"`
+	UserID        string `json:"user_id"`
+	Name          string `json:"name"`
+	Response      string `json:"response"`
+	IsActive      bool   `json:"is_active"`
+	Perm          string `json:"perm"`
+	Cooldown      uint   `json:"cooldown"`
+	AllowedUserID string `json:"allowed_user_id"`
 }
 
 type dashboardReply struct {
@@ -94,7 +97,18 @@ func (d *dashboardRPC) handleUpsert(msg *nats.Msg) {
 		return
 	}
 
-	if err := d.repo.Upsert(id, req.Name, req.Response, req.IsActive); err != nil {
+	// allowed_user_id is optional; empty/"0" means no per-user restriction.
+	var allowedUserID uint64
+	if req.AllowedUserID != "" {
+		parsed, err := strconv.ParseUint(req.AllowedUserID, 10, 64)
+		if err != nil {
+			respondDash(msg, dashboardReply{Error: "invalid allowed_user_id"})
+			return
+		}
+		allowedUserID = parsed
+	}
+
+	if err := d.repo.Upsert(id, req.Name, req.Response, req.IsActive, req.Perm, req.Cooldown, allowedUserID); err != nil {
 		// Validation error: return it alongside the current (unmodified) list.
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 		defer cancel()
@@ -114,7 +128,14 @@ func (d *dashboardRPC) handleUpsert(msg *nats.Msg) {
 	}
 
 	// Merge the just-upserted command: replace existing entry or append.
-	upserted := repository.CommandView{Name: req.Name, Response: req.Response, IsActive: req.IsActive}
+	upserted := repository.CommandView{
+		Name:          req.Name,
+		Response:      req.Response,
+		IsActive:      req.IsActive,
+		Perm:          req.Perm,
+		Cooldown:      req.Cooldown,
+		AllowedUserID: req.AllowedUserID,
+	}
 	merged := false
 	for i, v := range views {
 		if v.Name == req.Name {

--- a/console/dashboard/src/lib/server/rpc.ts
+++ b/console/dashboard/src/lib/server/rpc.ts
@@ -1,7 +1,7 @@
 // Dashboard-facing RPC wrappers over the shared NATS client. Subjects come from
 // env with the same defaults as the retired Go dashboard tier.
 import { rpc, publish } from '@bagel/shared/server/nats';
-import type { CommandView, Tier } from '@bagel/shared';
+import type { CommandView, Perm, Tier } from '@bagel/shared';
 import { env } from '$env/dynamic/private';
 
 const SUB = {
@@ -27,30 +27,38 @@ export async function tier(broadcasterId: string): Promise<Tier> {
   return r.tier ?? 'standard';
 }
 
+// Dashboard reads are cached primary-key lookups, so they return in low ms when
+// healthy. Cap them at 2s (like tier()) so a slow or missing responder degrades
+// the page fast instead of hanging SSR to the 5s default and tripping a gateway 500.
+const READ_TIMEOUT_MS = 2000;
+
 export async function hasGrant(userId: string): Promise<boolean> {
-  const r = await rpc<{ has_grant: boolean }>(`${SUB.dashboard}.grant_has`, {
-    broadcaster_user_id: userId
-  });
+  const r = await rpc<{ has_grant: boolean }>(
+    `${SUB.dashboard}.grant_has`,
+    { broadcaster_user_id: userId },
+    READ_TIMEOUT_MS
+  );
   return !!r.has_grant;
 }
 
 export type AccountStatus = 'free' | 'paid' | 'vip';
+export type AccountState = { active: boolean; status: AccountStatus };
 
-// The broadcaster's billing tier (free/paid/vip) from the users service via the
-// dashboard-scoped status_get RPC.
-export async function accountStatus(userId: string): Promise<AccountStatus> {
-  const r = await rpc<{ status: string }>(`${SUB.dashboard}.status_get`, {
-    broadcaster_user_id: userId
-  });
-  const s = (r.status ?? 'free').toLowerCase();
+function normalizeStatus(raw: string | undefined): AccountStatus {
+  const s = (raw ?? 'free').toLowerCase();
   return s === 'paid' || s === 'vip' ? (s as AccountStatus) : 'free';
 }
 
-export async function isActive(userId: string): Promise<boolean> {
-  const r = await rpc<{ active: boolean }>(`${SUB.dashboard}.active_get`, {
-    broadcaster_user_id: userId
-  });
-  return !!r.active;
+// Receive toggle and billing tier (free/paid/vip) in one round trip. The users
+// service loads a single cached user view to answer both, so the page render
+// asks once via state_get instead of separate active_get + status_get calls.
+export async function accountState(userId: string): Promise<AccountState> {
+  const r = await rpc<{ active: boolean; status: string }>(
+    `${SUB.dashboard}.state_get`,
+    { broadcaster_user_id: userId },
+    READ_TIMEOUT_MS
+  );
+  return { active: !!r.active, status: normalizeStatus(r.status) };
 }
 
 export async function setActive(userId: string, active: boolean): Promise<void> {
@@ -62,25 +70,38 @@ export async function listCommands(userId: string): Promise<CommandView[]> {
   return r.commands ?? [];
 }
 
-export async function upsertCommand(
-  userId: string,
-  name: string,
-  response: string,
-  isActive: boolean
-): Promise<CommandView[]> {
-  const r = await rpc<{ commands: CommandView[] }>(`${SUB.commands}.upsert`, {
-    user_id: userId,
-    name,
-    response,
-    is_active: isActive
-  });
-  return r.commands ?? [];
+export interface CommandInput {
+  name: string;
+  response: string;
+  isActive: boolean;
+  perm: Perm;
+  cooldown: number;
+  allowedUserId: string;
 }
 
-export async function deleteCommand(userId: string, name: string): Promise<CommandView[]> {
-  const r = await rpc<{ commands: CommandView[] }>(`${SUB.commands}.delete`, {
+export async function upsertCommand(
+  userId: string,
+  cmd: CommandInput
+): Promise<{ commands: CommandView[]; error?: string }> {
+  const r = await rpc<{ commands: CommandView[]; error?: string }>(`${SUB.commands}.upsert`, {
+    user_id: userId,
+    name: cmd.name,
+    response: cmd.response,
+    is_active: cmd.isActive,
+    perm: cmd.perm,
+    cooldown: cmd.cooldown,
+    allowed_user_id: cmd.allowedUserId
+  });
+  return { commands: r.commands ?? [], error: r.error };
+}
+
+export async function deleteCommand(
+  userId: string,
+  name: string
+): Promise<{ commands: CommandView[]; error?: string }> {
+  const r = await rpc<{ commands: CommandView[]; error?: string }>(`${SUB.commands}.delete`, {
     user_id: userId,
     name
   });
-  return r.commands ?? [];
+  return { commands: r.commands ?? [], error: r.error };
 }

--- a/console/dashboard/src/routes/(app)/commands/+page.server.ts
+++ b/console/dashboard/src/routes/(app)/commands/+page.server.ts
@@ -1,18 +1,19 @@
 import type { Actions, PageServerLoad } from './$types';
-import type { CommandView } from '@bagel/shared';
+import type { CommandView, Perm } from '@bagel/shared';
+import { PERMS } from '@bagel/shared';
 import { listCommands, upsertCommand, deleteCommand } from '$lib/server/rpc';
 import { env } from '$env/dynamic/private';
 import { fail } from '@sveltejs/kit';
 
 const sample: CommandView[] = [
-  { name: '!uptime', response: '@{user} the stream has been live for {uptime} 🥯', perm: 'everyone', cooldown: '5s', uses: '412', is_active: true },
-  { name: '!socials', response: 'Follow along → twitch.tv/itsmavey · @itsmavey everywhere', perm: 'everyone', cooldown: '30s', uses: '288', is_active: true },
-  { name: '!bagel', response: '{user} tosses a warm bagel to {target}. Toasty.', perm: 'everyone', cooldown: '10s', uses: '1.2k', is_active: true },
-  { name: '!so', response: 'Go show some love to twitch.tv/{target} — absolute legend', perm: 'mod', cooldown: '0s', uses: '96', is_active: true },
-  { name: '!discord', response: 'Join the bakery → discord.gg/itsbagelbot', perm: 'everyone', cooldown: '60s', uses: '203', is_active: true },
-  { name: '!uptime-debug', response: 'node={node} replica={id} lag={ms}ms', perm: 'broadcaster', cooldown: '0s', uses: '14', is_active: false },
-  { name: '!lurk', response: '{user} fades into the shadows. Thanks for the lurk.', perm: 'everyone', cooldown: '5s', uses: '521', is_active: true },
-  { name: '!followage', response: "@{user} you've followed for {followage} 🥯", perm: 'sub', cooldown: '15s', uses: '177', is_active: true }
+  { name: '!uptime', response: '@{user} the stream has been live for {uptime} 🥯', perm: 'everyone', cooldown: 5, uses: '412', is_active: true },
+  { name: '!socials', response: 'Follow along → twitch.tv/itsmavey · @itsmavey everywhere', perm: 'everyone', cooldown: 30, uses: '288', is_active: true },
+  { name: '!bagel', response: '{user} tosses a warm bagel to {target}. Toasty.', perm: 'everyone', cooldown: 10, uses: '1.2k', is_active: true },
+  { name: '!so', response: 'Go show some love to twitch.tv/{target} — absolute legend', perm: 'mod', cooldown: 0, uses: '96', is_active: true },
+  { name: '!discord', response: 'Join the bakery → discord.gg/itsbagelbot', perm: 'everyone', cooldown: 60, uses: '203', is_active: true },
+  { name: '!uptime-debug', response: 'node={node} replica={id} lag={ms}ms', perm: 'broadcaster', cooldown: 0, uses: '14', is_active: false },
+  { name: '!lurk', response: '{user} fades into the shadows. Thanks for the lurk.', perm: 'everyone', cooldown: 5, uses: '521', is_active: true },
+  { name: '!followage', response: "@{user} you've followed for {followage} 🥯", perm: 'sub', cooldown: 15, uses: '177', is_active: true }
 ];
 
 export const load: PageServerLoad = async ({ locals }) => {
@@ -26,22 +27,83 @@ export const load: PageServerLoad = async ({ locals }) => {
   }
 };
 
+// Parses and normalizes the shared command fields out of a submitted form.
+function parseCommand(f: FormData) {
+  const name = String(f.get('name') ?? '').trim();
+  const response = String(f.get('response') ?? '');
+  const permRaw = String(f.get('perm') ?? 'everyone');
+  const perm: Perm = (PERMS as readonly string[]).includes(permRaw) ? (permRaw as Perm) : 'everyone';
+
+  // Cooldown arrives as a string; clamp to a sane non-negative integer.
+  const cooldown = Math.max(0, Math.floor(Number(f.get('cooldown') ?? 0) || 0));
+
+  // Optional single-user lock; keep digits only so a stray "@name" can't slip through.
+  const allowedUserId = String(f.get('allowed_user_id') ?? '').replace(/\D/g, '');
+
+  return { name, response, perm, cooldown, allowedUserId };
+}
+
 export const actions: Actions = {
   save: async ({ request, locals }) => {
     const uid = locals.session?.user_id;
-    if (!uid) return fail(401);
+    if (!uid) return fail(401, { ok: false, error: 'Not signed in.' });
+
     const f = await request.formData();
-    const name = String(f.get('name') ?? '').trim();
-    const response = String(f.get('response') ?? '');
-    if (!name) return fail(400, { error: 'name required' });
-    const commands = await upsertCommand(uid, name, response, f.get('is_active') === 'on');
-    return { commands };
+    const cmd = parseCommand(f);
+    const isActive = f.get('is_active') === 'on';
+    const isEdit = f.get('edit') === '1';
+    const originalName = String(f.get('original_name') ?? '').trim();
+    const renamed = isEdit && originalName !== '' && originalName !== cmd.name;
+
+    if (!cmd.name) return fail(400, { ok: false, error: 'Command name is required.' });
+    if (!cmd.response) return fail(400, { ok: false, error: 'Response is required.' });
+
+    // Name is the row key (user_id, name), so a rename is delete-old + create-new.
+    // Write the new row first; its optimistic reply already lists the renamed
+    // command (the old delete is immediate but the new write is behind a ~2s
+    // batch, so deleteCommand's fresh DB list wouldn't include it yet).
+    const { commands, error } = await upsertCommand(uid, { ...cmd, isActive });
+    if (error) return fail(400, { ok: false, error, commands });
+
+    if (renamed) {
+      const del = await deleteCommand(uid, originalName);
+      if (del.error) return fail(400, { ok: false, error: del.error, commands });
+      // Drop the old key from the optimistic list returned by the upsert.
+      return {
+        ok: true,
+        action: 'updated',
+        name: cmd.name,
+        commands: commands.filter((c) => c.name !== originalName)
+      };
+    }
+
+    return { ok: true, action: isEdit ? 'updated' : 'created', name: cmd.name, commands };
   },
+
+  // Lightweight toggle: flips is_active without going through the full editor.
+  toggle: async ({ request, locals }) => {
+    const uid = locals.session?.user_id;
+    if (!uid) return fail(401, { ok: false, error: 'Not signed in.' });
+
+    const f = await request.formData();
+    const cmd = parseCommand(f);
+    const isActive = f.get('is_active') === 'on';
+
+    const { commands, error } = await upsertCommand(uid, { ...cmd, isActive });
+    if (error) return fail(400, { ok: false, error, commands });
+
+    return { ok: true, action: 'updated', name: cmd.name, commands, silent: true };
+  },
+
   delete: async ({ request, locals }) => {
     const uid = locals.session?.user_id;
-    if (!uid) return fail(401);
+    if (!uid) return fail(401, { ok: false, error: 'Not signed in.' });
+
     const f = await request.formData();
-    const commands = await deleteCommand(uid, String(f.get('name') ?? ''));
-    return { commands };
+    const name = String(f.get('name') ?? '');
+    const { commands, error } = await deleteCommand(uid, name);
+    if (error) return fail(400, { ok: false, error, commands });
+
+    return { ok: true, action: 'deleted', name, commands };
   }
 };

--- a/console/dashboard/src/routes/(app)/commands/+page.svelte
+++ b/console/dashboard/src/routes/(app)/commands/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { enhance } from '$app/forms';
-  import { Icon, Badge } from '@bagel/shared';
-  import type { Perm } from '@bagel/shared';
+  import { Icon, Badge, PERMS, PERM_LABELS } from '@bagel/shared';
+  import type { Perm, CommandView } from '@bagel/shared';
   let { data, form } = $props();
 
   // Action results return the fresh list; fall back to the loaded data.
@@ -9,22 +9,82 @@
 
   const filters = ['All', 'Custom', 'Built-in', 'Disabled'] as const;
   let active = $state<(typeof filters)[number]>('All');
-  let showNew = $state(false);
+  let search = $state('');
 
   const rows = $derived(
-    commands.filter((c) => (active === 'Disabled' ? !c.is_active : true))
+    commands
+      .filter((c) => (active === 'Disabled' ? !c.is_active : true))
+      .filter((c) => c.name.toLowerCase().includes(search.toLowerCase()))
   );
 
-  // Delete confirm modal
+  // --- Editor (create + edit share one modal) -----------------------------
+  type Draft = {
+    edit: boolean;
+    name: string;
+    response: string;
+    perm: Perm;
+    cooldown: number;
+    allowed_user_id: string;
+    is_active: boolean;
+  };
+
+  let editor = $state<Draft | null>(null);
+
+  function openNew() {
+    editor = {
+      edit: false,
+      name: '',
+      response: '',
+      perm: 'everyone',
+      cooldown: 0,
+      allowed_user_id: '',
+      is_active: true
+    };
+  }
+
+  function openEdit(c: CommandView) {
+    editor = {
+      edit: true,
+      name: c.name,
+      response: c.response,
+      perm: (c.perm ?? 'everyone') as Perm,
+      cooldown: c.cooldown ?? 0,
+      allowed_user_id: c.allowed_user_id ?? '',
+      is_active: c.is_active
+    };
+  }
+
+  function closeEditor() {
+    editor = null;
+  }
+
+  // --- Delete confirm modal -----------------------------------------------
   let deleteTarget = $state<string | null>(null);
+  const requestDelete = (name: string) => (deleteTarget = name);
+  const cancelDelete = () => (deleteTarget = null);
 
-  function requestDelete(name: string) {
-    deleteTarget = name;
+  // --- Toast: surfaces created / updated / deleted confirmations ----------
+  let toast = $state<{ kind: 'ok' | 'err'; text: string } | null>(null);
+  let toastTimer: ReturnType<typeof setTimeout> | undefined;
+
+  function flash(kind: 'ok' | 'err', text: string) {
+    toast = { kind, text };
+    clearTimeout(toastTimer);
+    toastTimer = setTimeout(() => (toast = null), 3200);
   }
 
-  function cancelDelete() {
-    deleteTarget = null;
-  }
+  // React to the latest form action result.
+  $effect(() => {
+    if (!form) return;
+    if (form.ok && !form.silent) {
+      const verb = form.action === 'deleted' ? 'deleted' : form.action;
+      flash('ok', `Command ${form.name} ${verb}.`);
+    } else if (form.ok === false && form.error) {
+      flash('err', form.error);
+    }
+  });
+
+  const cd = (n?: number) => (n && n > 0 ? `${n}s` : '0s');
 </script>
 
 <section class="screen active">
@@ -43,26 +103,12 @@
     <div class="grow"></div>
     <label class="search" style="width:200px">
       <Icon name="search" size={15} />
-      <input type="text" placeholder="Filter commands…" />
+      <input type="text" placeholder="Filter commands…" bind:value={search} />
     </label>
-    <button class="btn primary" onclick={() => (showNew = !showNew)}>
+    <button class="btn primary" onclick={openNew}>
       <Icon name="plus" size={14} /> New command
     </button>
   </div>
-
-  {#if showNew}
-    <form
-      method="POST"
-      action="?/save"
-      use:enhance={() => async ({ update }) => { await update(); showNew = false; }}
-      class="card new-cmd-form"
-    >
-      <input class="search" name="name" placeholder="!command" required />
-      <input class="search resp-input" name="response" placeholder="Response text…" required />
-      <input type="hidden" name="is_active" value="on" />
-      <button class="btn primary" type="submit"><Icon name="check" size={14} /> Save</button>
-    </form>
-  {/if}
 
   <div class="card" style="padding:18px 6px">
     <div class="table">
@@ -72,45 +118,135 @@
       <div class="trows">
         {#each rows as c (c.name)}
           <div class="trow {c.is_active ? '' : 'off'}" style={c.is_active ? '' : 'opacity:.55'}>
-            <span class="cmd">{c.name}</span>
+            <span class="cmd">
+              {c.name}
+              {#if c.allowed_user_id}
+                <span class="lock" title="Locked to user {c.allowed_user_id}"><Icon name="lock" size={11} /></span>
+              {/if}
+            </span>
             <span class="resp">{c.response}</span>
             <span class="perm-cell"><Badge perm={(c.perm ?? 'everyone') as Perm} /></span>
-            <span class="cd">{c.cooldown ?? '0s'}</span>
+            <span class="cd">{cd(c.cooldown)}</span>
             <span class="uses">{c.uses ?? '0'}</span>
             <span class="row-act">
-              <form method="POST" action="?/save" use:enhance>
+              <!-- Toggle: silent upsert that flips is_active, preserving config -->
+              <form method="POST" action="?/toggle" use:enhance>
                 <input type="hidden" name="name" value={c.name} />
                 <input type="hidden" name="response" value={c.response} />
+                <input type="hidden" name="perm" value={c.perm ?? 'everyone'} />
+                <input type="hidden" name="cooldown" value={c.cooldown ?? 0} />
+                <input type="hidden" name="allowed_user_id" value={c.allowed_user_id ?? ''} />
                 <input type="hidden" name="is_active" value={c.is_active ? '' : 'on'} />
                 <button class="toggle {c.is_active ? 'on' : ''}" type="submit" aria-label="Toggle"></button>
               </form>
-              <!-- Delete: open confirm modal instead of submitting directly -->
-              <button
-                class="mini"
-                type="button"
-                aria-label="Delete {c.name}"
-                onclick={() => requestDelete(c.name)}
-              >
+              <button class="mini" type="button" aria-label="Edit {c.name}" onclick={() => openEdit(c)}>
+                <Icon name="edit" size={15} />
+              </button>
+              <button class="mini" type="button" aria-label="Delete {c.name}" onclick={() => requestDelete(c.name)}>
                 <Icon name="trash" size={15} />
               </button>
             </span>
           </div>
         {/each}
+        {#if rows.length === 0}
+          <div class="empty">No commands match.</div>
+        {/if}
       </div>
     </div>
   </div>
 </section>
 
+<!-- Create / edit editor -->
+{#if editor}
+  <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+  <div class="modal-backdrop" role="button" tabindex="-1" aria-label="Close editor" onclick={closeEditor}></div>
+  <dialog class="editor-dialog" open aria-modal="true" aria-labelledby="editor-title">
+    <h3 id="editor-title">{editor.edit ? 'Edit' : 'New'} command</h3>
+    <form
+      method="POST"
+      action="?/save"
+      use:enhance={() => async ({ update, result }) => {
+        await update({ reset: false });
+        if (result.type === 'success' && result.data?.ok) closeEditor();
+      }}
+    >
+      {#if editor.edit}
+        <input type="hidden" name="edit" value="1" />
+        <input type="hidden" name="original_name" value={editor.name} />
+      {/if}
+
+      <label class="field">
+        <span>Name</span>
+        <input
+          class="search"
+          name="name"
+          placeholder="!command"
+          bind:value={editor.name}
+          required
+        />
+        {#if editor.edit}<small>The trigger viewers type in chat. Renaming keeps the response and settings.</small>{/if}
+      </label>
+
+      <label class="field">
+        <span>Response</span>
+        <div class="resp-wrap">
+          <textarea
+            class="resp-area"
+            name="response"
+            rows="4"
+            maxlength="500"
+            placeholder="What the bot replies… use {'{user}'}, {'{target}'}, {'{uptime}'} and more."
+            bind:value={editor.response}
+            required
+          ></textarea>
+          <span class="resp-count">{(editor.response ?? '').length}/500</span>
+        </div>
+      </label>
+
+      <div class="field-row">
+        <label class="field">
+          <span>Access</span>
+          <select class="search" name="perm" bind:value={editor.perm}>
+            {#each PERMS as p}
+              <option value={p}>{PERM_LABELS[p]}</option>
+            {/each}
+          </select>
+        </label>
+
+        <label class="field">
+          <span>Cooldown (s)</span>
+          <input class="search" type="number" name="cooldown" min="0" max="86400" bind:value={editor.cooldown} />
+        </label>
+      </div>
+
+      <label class="field">
+        <span>Restrict to user ID <small>(optional)</small></span>
+        <input
+          class="search"
+          name="allowed_user_id"
+          inputmode="numeric"
+          placeholder="Twitch user ID — only they can run it"
+          bind:value={editor.allowed_user_id}
+        />
+      </label>
+
+      <label class="check">
+        <input type="checkbox" name="is_active" checked={editor.is_active} />
+        <span>Active</span>
+      </label>
+
+      <div class="modal-actions">
+        <button type="button" class="btn ghost" onclick={closeEditor}>Cancel</button>
+        <button type="submit" class="btn primary"><Icon name="check" size={14} /> {editor.edit ? 'Save changes' : 'Create'}</button>
+      </div>
+    </form>
+  </dialog>
+{/if}
+
 <!-- Delete confirm modal -->
 {#if deleteTarget !== null}
   <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
-  <div
-    class="modal-backdrop"
-    role="button"
-    tabindex="-1"
-    aria-label="Close dialog"
-    onclick={cancelDelete}
-  ></div>
+  <div class="modal-backdrop" role="button" tabindex="-1" aria-label="Close dialog" onclick={cancelDelete}></div>
   <dialog class="confirm-dialog" open aria-modal="true" aria-labelledby="del-modal-title">
     <h3 id="del-modal-title">Delete <code>{deleteTarget}</code>?</h3>
     <p>This command will be permanently removed and cannot be recovered.</p>
@@ -127,34 +263,34 @@
   </dialog>
 {/if}
 
-<svelte:window onkeydown={(e) => { if (e.key === 'Escape') cancelDelete(); }} />
+<!-- Confirmation toast -->
+{#if toast}
+  <div class="toast {toast.kind}" role="status">
+    <Icon name={toast.kind === 'ok' ? 'check' : 'ban'} size={15} />
+    <span>{toast.text}</span>
+  </div>
+{/if}
+
+<svelte:window onkeydown={(e) => { if (e.key === 'Escape') { cancelDelete(); closeEditor(); } }} />
 
 <style>
-  /* New command form: stacks nicely on narrow screens */
-  .new-cmd-form {
-    display: flex;
-    gap: 12px;
-    align-items: center;
-    flex-wrap: wrap;
-    padding: 16px;
-    margin-bottom: 14px;
+  .empty {
+    padding: 28px 18px;
+    text-align: center;
+    color: var(--bb-muted);
+    font-family: var(--bb-font-body);
+    font-size: 13px;
   }
 
-  .new-cmd-form .search[name="name"] {
-    width: 160px;
-  }
-
-  .resp-input {
-    flex: 1;
-    min-width: 180px;
+  .lock {
+    display: inline-flex;
+    color: var(--bb-tan-light);
+    margin-left: 6px;
+    vertical-align: middle;
   }
 
   @media (max-width: 760px) {
-    /* Toolbar: wrap + make New Command full-row */
-    .toolbar {
-      gap: 8px;
-    }
-
+    .toolbar { gap: 8px; }
     .chip-row {
       overflow-x: auto;
       -webkit-overflow-scrolling: touch;
@@ -162,40 +298,11 @@
       scrollbar-width: none;
     }
     .chip-row::-webkit-scrollbar { display: none; }
-
-    /* New command form goes full width, stacked */
-    .new-cmd-form {
-      flex-direction: column;
-      align-items: stretch;
-    }
-
-    .new-cmd-form .search[name="name"],
-    .resp-input {
-      width: 100%;
-      min-width: 0;
-    }
-
-    .new-cmd-form .btn {
-      min-height: 44px;
-      justify-content: center;
-    }
-
-    /* Table rows on mobile: show command name + actions only (shared CSS hides resp/cd/perm) */
-    /* Ensure trow items have comfortable tap targets */
-    :global(.trow .toggle) {
-      min-width: 38px;
-      min-height: 44px;
-      display: flex;
-      align-items: center;
-    }
-
-    :global(.mini) {
-      min-width: 44px;
-      min-height: 44px;
-    }
+    :global(.trow .toggle) { min-width: 38px; min-height: 44px; display: flex; align-items: center; }
+    :global(.mini) { min-width: 44px; min-height: 44px; }
   }
 
-  /* Confirm modal */
+  /* Shared modal chrome */
   .modal-backdrop {
     position: fixed;
     inset: 0;
@@ -205,36 +312,43 @@
     -webkit-backdrop-filter: blur(4px);
   }
 
+  .editor-dialog,
   .confirm-dialog {
     position: fixed;
     inset: 0;
     margin: auto;
     z-index: 201;
-    width: min(400px, calc(100vw - 32px));
     height: fit-content;
     background: var(--bb-card-bg);
     border: 1px solid var(--bb-border-strong);
     border-radius: var(--bb-radius-lg);
-    padding: 28px 24px 20px;
     box-shadow: 0 24px 64px rgba(0, 0, 0, 0.6);
     display: block;
     color: var(--bb-white);
   }
 
+  .editor-dialog {
+    width: min(520px, calc(100vw - 32px));
+    padding: 26px 24px 20px;
+  }
+
+  .confirm-dialog {
+    width: min(400px, calc(100vw - 32px));
+    padding: 28px 24px 20px;
+  }
+
+  .editor-dialog h3,
   .confirm-dialog h3 {
     font-family: var(--bb-font-display);
     font-weight: 600;
     font-size: 18px;
     letter-spacing: -0.01em;
     color: var(--bb-white);
-    margin: 0 0 10px;
+    margin: 0 0 18px;
   }
 
-  .confirm-dialog h3 code {
-    font-family: var(--bb-font-mono);
-    color: var(--bb-tan-light);
-    font-size: 16px;
-  }
+  .confirm-dialog h3 { margin-bottom: 10px; }
+  .confirm-dialog h3 code { font-family: var(--bb-font-mono); color: var(--bb-tan-light); font-size: 16px; }
 
   .confirm-dialog p {
     font-family: var(--bb-font-body);
@@ -244,11 +358,69 @@
     margin: 0 0 22px;
   }
 
+  .field { display: flex; flex-direction: column; gap: 6px; margin-bottom: 14px; }
+  .field > span {
+    font-family: var(--bb-font-body);
+    font-size: 12.5px;
+    color: var(--bb-muted);
+    letter-spacing: 0.01em;
+  }
+  .field small { color: var(--bb-muted); opacity: 0.7; font-size: 11px; }
+
+  .resp-wrap { position: relative; }
+
+  .resp-area {
+    width: 100%;
+    box-sizing: border-box;
+    resize: vertical;
+    min-height: 96px;
+    padding: 12px 14px 26px;
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid var(--glass-border);
+    border-radius: var(--bb-radius-md, 10px);
+    color: var(--bb-white);
+    font-family: var(--bb-font-body);
+    font-size: 13.5px;
+    line-height: 1.6;
+    transition: border-color var(--bb-dur-base, 160ms) ease, box-shadow var(--bb-dur-base, 160ms) ease;
+  }
+  .resp-area::placeholder { color: var(--bb-muted); opacity: 0.7; }
+  .resp-area:focus {
+    outline: none;
+    border-color: rgba(82, 183, 136, 0.5);
+    box-shadow: 0 0 0 3px rgba(82, 183, 136, 0.12);
+    background: rgba(255, 255, 255, 0.04);
+  }
+
+  .resp-count {
+    position: absolute;
+    right: 10px;
+    bottom: 8px;
+    font-family: var(--bb-font-mono);
+    font-size: 10.5px;
+    color: var(--bb-muted);
+    pointer-events: none;
+    opacity: 0.7;
+  }
+
+  .field-row { display: flex; gap: 12px; }
+  .field-row .field { flex: 1; }
+
+  .check {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-family: var(--bb-font-body);
+    font-size: 13px;
+    color: var(--bb-white);
+    margin: 4px 0 18px;
+    cursor: pointer;
+  }
+
   .modal-actions {
     display: flex;
     gap: 10px;
     justify-content: flex-end;
-    /* reset form default margin */
     padding: 0;
     margin: 0;
     background: none;
@@ -260,22 +432,46 @@
     border-color: rgba(176, 90, 70, 0.4);
     color: #cf8a78;
   }
-
   .delete-btn:hover {
     background: rgba(176, 90, 70, 0.28);
     box-shadow: 0 0 18px rgba(176, 90, 70, 0.25);
   }
 
-  @media (max-width: 480px) {
-    .modal-actions {
-      flex-direction: column-reverse;
-    }
+  /* Toast */
+  .toast {
+    position: fixed;
+    right: 20px;
+    bottom: 20px;
+    z-index: 300;
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    padding: 12px 16px;
+    border-radius: var(--bb-radius-md, 10px);
+    background: var(--bb-card-bg);
+    border: 1px solid var(--bb-border-strong);
+    box-shadow: 0 14px 40px rgba(0, 0, 0, 0.5);
+    font-family: var(--bb-font-body);
+    font-size: 13.5px;
+    color: var(--bb-white);
+    animation: toast-in 220ms var(--bb-ease-out-back, ease-out);
+  }
+  .toast.ok { border-color: rgba(82, 183, 136, 0.45); color: var(--bb-green-glow); }
+  .toast.err { border-color: rgba(176, 90, 70, 0.45); color: #cf8a78; }
 
-    .modal-actions .btn,
-    .modal-actions button {
+  @keyframes toast-in {
+    from { opacity: 0; transform: translateY(8px); }
+    to { opacity: 1; transform: translateY(0); }
+  }
+
+  @media (max-width: 480px) {
+    .field-row { flex-direction: column; gap: 0; }
+    .modal-actions { flex-direction: column-reverse; }
+    .modal-actions .btn, .modal-actions button {
       width: 100%;
       justify-content: center;
       min-height: 44px;
     }
+    .toast { left: 16px; right: 16px; bottom: 16px; }
   }
 </style>

--- a/console/shared/components/Badge.svelte
+++ b/console/shared/components/Badge.svelte
@@ -1,6 +1,14 @@
 <script lang="ts">
-  let { perm }: { perm: 'everyone' | 'sub' | 'mod' | 'broadcaster' } = $props();
-  const label = { everyone: 'Everyone', sub: 'Subs', mod: 'Mods', broadcaster: 'Broadcaster' };
+  import type { Perm } from '../lib/types';
+  let { perm }: { perm: Perm } = $props();
+  const label: Record<Perm, string> = {
+    everyone: 'Everyone',
+    sub: 'Subs',
+    vip: 'VIPs',
+    mod: 'Mods',
+    lead_mod: 'Lead Mods',
+    broadcaster: 'Broadcaster'
+  };
 </script>
 
-<span class="badge {perm}">{label[perm]}</span>
+<span class="badge {perm}">{label[perm] ?? perm}</span>

--- a/console/shared/lib/types.ts
+++ b/console/shared/lib/types.ts
@@ -1,14 +1,28 @@
 // Wire types mirroring the Go NATS RPC contracts (JSON over core NATS).
-export type Perm = 'everyone' | 'sub' | 'mod' | 'broadcaster';
+export type Perm = 'everyone' | 'sub' | 'vip' | 'mod' | 'lead_mod' | 'broadcaster';
 export type Tier = 'premium' | 'standard';
 export type Role = 'streamer' | 'mod';
+
+// Ordered low -> high privilege; drives the access <select> in the dashboard.
+export const PERMS: readonly Perm[] = ['everyone', 'sub', 'vip', 'mod', 'lead_mod', 'broadcaster'];
+export const PERM_LABELS: Record<Perm, string> = {
+  everyone: 'Everyone',
+  sub: 'Subscribers',
+  vip: 'VIPs',
+  mod: 'Moderators',
+  lead_mod: 'Lead moderators',
+  broadcaster: 'Broadcaster'
+};
 
 export interface CommandView {
   name: string;
   response: string;
   is_active: boolean;
   perm?: Perm;
-  cooldown?: string;
+  // Cooldown in seconds; 0 or undefined means no cooldown.
+  cooldown?: number;
+  // Twitch id of the only user allowed to run the command; '' or undefined = unrestricted.
+  allowed_user_id?: string;
   uses?: string;
 }
 

--- a/console/shared/styles/app.css
+++ b/console/shared/styles/app.css
@@ -289,7 +289,9 @@ body::after {
   display: inline-flex; align-items: center; gap: 5px; border: 1px solid transparent; }
 .badge.everyone { background: rgba(255,255,255,0.04); color: var(--bb-muted); border-color: var(--glass-border); }
 .badge.sub { background: rgba(201,168,124,0.10); color: var(--bb-tan-light); border-color: rgba(201,168,124,0.28); }
+.badge.vip { background: rgba(199,125,255,0.10); color: #d9aaff; border-color: rgba(199,125,255,0.30); }
 .badge.mod { background: rgba(82,183,136,0.10); color: var(--bb-green-glow); border-color: rgba(82,183,136,0.28); }
+.badge.lead_mod { background: rgba(82,183,136,0.14); color: var(--bb-green-glow); border-color: rgba(82,183,136,0.34); }
 .badge.broadcaster { background: rgba(82,183,136,0.16); color: var(--bb-green-glow); border-color: rgba(82,183,136,0.4); }
 
 /* toggle */

--- a/internal/domain/event/data/data_events.go
+++ b/internal/domain/event/data/data_events.go
@@ -41,11 +41,14 @@ type ModuleChangedDTO struct {
 }
 
 type CommandChangedDTO struct {
-	UserID   uint64 `json:"user_id"`
-	Name     string `json:"name"`
-	Response string `json:"response,omitempty"`
-	IsActive bool   `json:"is_active"`
-	Deleted  bool   `json:"deleted"`
+	UserID        uint64 `json:"user_id"`
+	Name          string `json:"name"`
+	Response      string `json:"response,omitempty"`
+	IsActive      bool   `json:"is_active"`
+	Perm          string `json:"perm,omitempty"`
+	Cooldown      uint   `json:"cooldown,omitempty"`
+	AllowedUserID uint64 `json:"allowed_user_id,omitempty"`
+	Deleted       bool   `json:"deleted"`
 }
 
 type TransactionRecordedDTO struct {

--- a/internal/domain/validate/validate.go
+++ b/internal/domain/validate/validate.go
@@ -17,6 +17,7 @@ const (
 	maxEmailLength         = 254 // RFC 5321
 	maxCommandNameLength   = 64
 	maxResponseLength      = 500 // Twitch chat message limit
+	maxCooldownSeconds     = 86400 // one day; guards against absurd values
 	maxModuleNameLength    = 64
 	maxConfigsBytes        = 16 << 10
 	maxTransactionIDLength = 64
@@ -29,6 +30,8 @@ var (
 	ErrEmailInvalid     = errors.New("email address is not valid")
 	ErrCommandName      = errors.New("command name must be 1-64 printable ASCII characters without spaces")
 	ErrResponseInvalid  = errors.New("command response must be 1-500 characters without control characters")
+	ErrPermInvalid      = errors.New("perm must be one of everyone, sub, vip, mod, lead_mod, broadcaster")
+	ErrCooldownInvalid  = errors.New("cooldown must be between 0 and 86400 seconds")
 	ErrModuleName       = errors.New("module name must be 1-64 characters of [a-z0-9_-]")
 	ErrConfigsInvalid   = errors.New("module configs must be valid JSON of at most 16KiB")
 	ErrTransactionID    = errors.New("transaction id must be 1-64 characters of [a-zA-Z0-9_-]")
@@ -104,6 +107,29 @@ func CommandResponse(response string) error {
 		if r < ' ' { // control characters, including CR/LF
 			return ErrResponseInvalid
 		}
+	}
+
+	return nil
+}
+
+// Perm is the minimum role tier allowed to run a command. The set mirrors the
+// dashboard <select>; an unknown value is rejected rather than silently coerced
+// so a typo never widens or narrows access by accident.
+func Perm(perm string) error {
+
+	switch perm {
+	case "everyone", "sub", "vip", "mod", "lead_mod", "broadcaster":
+		return nil
+	}
+
+	return ErrPermInvalid
+}
+
+// Cooldown caps the per-command cooldown in seconds.
+func Cooldown(seconds uint) error {
+
+	if seconds > maxCooldownSeconds {
+		return ErrCooldownInvalid
 	}
 
 	return nil


### PR DESCRIPTION
Adds configurable **permission tier**, **cooldown**, and **single-user lock** to custom chat commands, end to end.

## Data model
- `perm` — minimum role: `everyone | sub | vip | mod | lead_mod | broadcaster` (validated, stored as string so new tiers need no migration)
- `cooldown` — seconds, `0` = none, capped at 1 day
- `allowed_user_id` — when set, only that Twitch id may run the command (wire-carried as string for ids beyond JS safe-int range)

Threaded through ent schema + generated code, `CommandChangedDTO`, repository upsert/read model, and the dashboard upsert RPC (optimistic merge).

## Dashboard
- Create/edit modal: name, response, access tier, cooldown, optional user lock
- Rename = delete-old + create-new (name is the row key)
- Confirmation toasts on create/update/delete
- Delete confirmation modal
- Larger response textarea with live char counter

## Verification
- `go test ./app/commands/repository/` passes
- `svelte-check` clean (0 errors)
- Verified create + edit + rename flows in preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)