### PR TITLE
fix(console): rename commands in place, fix race conditions, stream RPC

### DIFF
--- a/app/commands/repository/commands.go
+++ b/app/commands/repository/commands.go
@@ -136,6 +136,75 @@ func (r *Commands) Upsert(userID uint64, name string, response string, isActive 
 	return nil
 }
 
+// Rename changes a command's key (name) in place, preserving the row, and
+// updates its other fields in the same write. Done immediately (not
+// write-behind) because the batcher coalesces by (user, name); a name change
+// can't be represented as a queued edit of the old key. Emits a delete for the
+// old name and a change for the new so name-keyed consumers (projector, bot)
+// drop the stale entry and pick up the renamed command.
+func (r *Commands) Rename(ctx context.Context, userID uint64, oldName, newName, response string, isActive bool, perm string, cooldown uint, allowedUserID uint64) error {
+
+	if err := validate.UserID(userID); err != nil {
+		return err
+	}
+	if err := validate.CommandName(oldName); err != nil {
+		return err
+	}
+	if err := validate.CommandName(newName); err != nil {
+		return err
+	}
+	if err := validate.CommandResponse(response); err != nil {
+		return err
+	}
+	if err := validate.Perm(perm); err != nil {
+		return err
+	}
+	if err := validate.Cooldown(cooldown); err != nil {
+		return err
+	}
+
+	updated, err := r.client.Commands.Update().
+		Where(
+			commands.UserIDEQ(userID),
+			commands.NameEQ(oldName),
+		).
+		SetName(newName).
+		SetResponse(response).
+		SetIsActive(isActive).
+		SetPerm(perm).
+		SetCooldown(cooldown).
+		SetAllowedUserID(allowedUserID).
+		Save(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Old row absent (already renamed/deleted elsewhere): fall back to a plain
+	// write of the new command so the edit is not lost.
+	if updated == 0 {
+		return r.Upsert(userID, newName, response, isActive, perm, cooldown, allowedUserID)
+	}
+
+	r.Invalidate(userID)
+
+	if err := bus.PublishJSON(ctx, r.pub, data.SubjectCommandChanged, data.CommandChangedDTO{
+		UserID:  userID,
+		Name:    oldName,
+		Deleted: true,
+	}); err != nil {
+		return err
+	}
+	return bus.PublishJSON(ctx, r.pub, data.SubjectCommandChanged, data.CommandChangedDTO{
+		UserID:        userID,
+		Name:          newName,
+		Response:      response,
+		IsActive:      isActive,
+		Perm:          perm,
+		Cooldown:      cooldown,
+		AllowedUserID: allowedUserID,
+	})
+}
+
 // Delete removes a command immediately and announces it.
 func (r *Commands) Delete(ctx context.Context, userID uint64, name string) error {
 

--- a/app/commands/repository/commands_test.go
+++ b/app/commands/repository/commands_test.go
@@ -68,6 +68,54 @@ func TestDeleteIsImmediateAndAnnounced(t *testing.T) {
 	assert.True(t, dto.Deleted)
 }
 
+func TestRenameUpdatesRowInPlace(t *testing.T) {
+	client, pub, repo := setup(t)
+	ctx := context.Background()
+
+	repo.Upsert(1001, "!old", "the response", true, "everyone", 7, 0)
+	repo.Close(ctx)
+	originalID := client.Commands.Query().FirstX(ctx).ID
+
+	repo2 := repository.NewCommands(client, pub, nil, zap.NewNop())
+	defer repo2.Close(ctx)
+
+	baseline := len(pub.On(data.SubjectCommandChanged)) // the create flush above
+
+	require.NoError(t, repo2.Rename(ctx, 1001, "!old", "!new", "the response", true, "everyone", 7, 0))
+
+	// Exactly one row, same primary key (updated in place, not deleted+recreated).
+	rows := client.Commands.Query().AllX(ctx)
+	require.Len(t, rows, 1)
+	assert.Equal(t, "!new", rows[0].Name)
+	assert.Equal(t, originalID, rows[0].ID, "rename must preserve the row identity")
+
+	// A delete for the old name and a change for the new name are announced so
+	// name-keyed consumers drop the stale key.
+	events := pub.On(data.SubjectCommandChanged)
+	require.Len(t, events, baseline+2)
+	renameEvents := events[baseline:]
+
+	var del, changed data.CommandChangedDTO
+	require.NoError(t, json.Unmarshal(renameEvents[0].Payload, &del))
+	require.NoError(t, json.Unmarshal(renameEvents[1].Payload, &changed))
+	assert.True(t, del.Deleted)
+	assert.Equal(t, "!old", del.Name)
+	assert.False(t, changed.Deleted)
+	assert.Equal(t, "!new", changed.Name)
+}
+
+func TestRenameMissingRowFallsBackToCreate(t *testing.T) {
+	client, _, repo := setup(t)
+	ctx := context.Background()
+
+	require.NoError(t, repo.Rename(ctx, 1001, "!ghost", "!new", "resp", true, "everyone", 0, 0))
+	repo.Close(ctx) // flush the fallback upsert
+
+	rows := client.Commands.Query().AllX(ctx)
+	require.Len(t, rows, 1)
+	assert.Equal(t, "!new", rows[0].Name)
+}
+
 func TestListServedFromCache(t *testing.T) {
 	client, _, repo := setup(t)
 	ctx := context.Background()

--- a/app/commands/rpc/dashboard.go
+++ b/app/commands/rpc/dashboard.go
@@ -48,6 +48,10 @@ type dashboardRequest struct {
 	Perm          string `json:"perm"`
 	Cooldown      uint   `json:"cooldown"`
 	AllowedUserID string `json:"allowed_user_id"`
+	// OriginalName, when set and different from Name, makes upsert a rename:
+	// the existing row keeps its identity and its name field is updated in
+	// place instead of being deleted and recreated under the new name.
+	OriginalName string `json:"original_name"`
 }
 
 type dashboardReply struct {
@@ -108,26 +112,45 @@ func (d *dashboardRPC) handleUpsert(msg *nats.Msg) {
 		allowedUserID = parsed
 	}
 
-	if err := d.repo.Upsert(id, req.Name, req.Response, req.IsActive, req.Perm, req.Cooldown, allowedUserID); err != nil {
-		// Validation error: return it alongside the current (unmodified) list.
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-		defer cancel()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	// A rename updates the existing row's name field in place; a plain edit or
+	// create goes through the write-behind upsert.
+	rename := req.OriginalName != "" && req.OriginalName != req.Name
+	var opErr error
+	if rename {
+		opErr = d.repo.Rename(ctx, id, req.OriginalName, req.Name, req.Response, req.IsActive, req.Perm, req.Cooldown, allowedUserID)
+	} else {
+		opErr = d.repo.Upsert(id, req.Name, req.Response, req.IsActive, req.Perm, req.Cooldown, allowedUserID)
+	}
+	if opErr != nil {
+		// Validation/conflict error: return it alongside the current list.
 		views, _ := d.repo.List(ctx, id)
-		respondDash(msg, dashboardReply{Commands: views, Error: err.Error()})
+		respondDash(msg, dashboardReply{Commands: views, Error: opErr.Error()})
 		return
 	}
 
 	// Upsert is write-behind (~2 s), so build an optimistic reply.
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-
 	views, err := d.repo.List(ctx, id)
 	if err != nil {
 		respondDash(msg, dashboardReply{Error: err.Error()})
 		return
 	}
 
-	// Merge the just-upserted command: replace existing entry or append.
+	// Drop the pre-rename key from the optimistic view (rename is immediate, so
+	// a fresh list won't carry it, but a cached one might).
+	if rename {
+		filtered := views[:0]
+		for _, v := range views {
+			if v.Name != req.OriginalName {
+				filtered = append(filtered, v)
+			}
+		}
+		views = filtered
+	}
+
+	// Merge the just-written command: replace existing entry or append.
 	upserted := repository.CommandView{
 		Name:          req.Name,
 		Response:      req.Response,

--- a/console/dashboard/src/lib/server/rpc.ts
+++ b/console/dashboard/src/lib/server/rpc.ts
@@ -79,9 +79,13 @@ export interface CommandInput {
   allowedUserId: string;
 }
 
+// originalName, when set and different from cmd.name, renames the command: the
+// commands service updates the existing row's name field in place instead of
+// deleting the old command and recreating it under the new name.
 export async function upsertCommand(
   userId: string,
-  cmd: CommandInput
+  cmd: CommandInput,
+  originalName?: string
 ): Promise<{ commands: CommandView[]; error?: string }> {
   const r = await rpc<{ commands: CommandView[]; error?: string }>(`${SUB.commands}.upsert`, {
     user_id: userId,
@@ -90,7 +94,8 @@ export async function upsertCommand(
     is_active: cmd.isActive,
     perm: cmd.perm,
     cooldown: cmd.cooldown,
-    allowed_user_id: cmd.allowedUserId
+    allowed_user_id: cmd.allowedUserId,
+    original_name: originalName ?? ''
   });
   return { commands: r.commands ?? [], error: r.error };
 }

--- a/console/dashboard/src/routes/(app)/+page.server.ts
+++ b/console/dashboard/src/routes/(app)/+page.server.ts
@@ -3,29 +3,31 @@ import { hasGrant, accountState, setActive, publishEventSub, type AccountStatus 
 import { env } from '$env/dynamic/private';
 import { fail } from '@sveltejs/kit';
 
-export const load: PageServerLoad = async ({ locals }) => {
+export type ConnState = { enabled: boolean; receiving: boolean; status: AccountStatus };
+
+// Resolve the bot connection state in one round trip (grant presence + the
+// coalesced active/tier state_get). allSettled keeps a slow or down responder
+// from failing the whole render; receiving stays gated on the grant.
+async function connState(uid: string): Promise<ConnState> {
+  const [grant, state] = await Promise.allSettled([hasGrant(uid), accountState(uid)]);
+  const enabled = grant.status === 'fulfilled' && grant.value;
+  const receiving = enabled && state.status === 'fulfilled' && state.value.active;
+  const status: AccountStatus = state.status === 'fulfilled' ? state.value.status : 'free';
+  return { enabled, receiving, status };
+}
+
+export const load: PageServerLoad = ({ locals }) => {
   const uid = locals.session?.user_id ?? 'demo';
 
-  let enabled = false;
-  let receiving = false;
-  let status: AccountStatus = 'free';
+  // Return the RPC as an unawaited promise so SvelteKit streams it: the page
+  // shell flushes immediately and the connection state hydrates when the round
+  // trip lands, instead of blocking SSR (and the post-login redirect) on NATS.
+  const conn: Promise<ConnState> =
+    env.DEMO === '1'
+      ? Promise.resolve({ enabled: true, receiving: true, status: 'vip' })
+      : connState(uid);
 
-  if (env.DEMO === '1') {
-    enabled = true;
-    receiving = true;
-    status = 'vip';
-  } else {
-    // Two independent reads (grant presence, plus active+tier coalesced into one
-    // state_get): fire them together so SSR waits one round trip, not three.
-    // allSettled keeps the page rendering even if one responder is slow or down.
-    // receiving stays gated on the grant being present.
-    const [grant, state] = await Promise.allSettled([hasGrant(uid), accountState(uid)]);
-    enabled = grant.status === 'fulfilled' && grant.value;
-    receiving = enabled && state.status === 'fulfilled' && state.value.active;
-    status = state.status === 'fulfilled' ? state.value.status : 'free';
-  }
-
-  return { enabled, receiving, status };
+  return { conn };
 };
 
 export const actions: Actions = {

--- a/console/dashboard/src/routes/(app)/+page.svelte
+++ b/console/dashboard/src/routes/(app)/+page.svelte
@@ -3,8 +3,8 @@
   import { Button } from '@bagel/shared';
   let { data } = $props();
 
-  const statusLabel = $derived({ free: 'Free', paid: 'Paid', vip: 'VIP' }[data.status] ?? 'Free');
-  const paid = $derived(data.status !== 'free');
+  const statusLabel = (s: string) =>
+    ({ free: 'Free', paid: 'Paid', vip: 'VIP' })[s] ?? 'Free';
 
   // Confirm modal state
   type PendingAction = 'restart' | 'disconnect' | null;
@@ -44,28 +44,39 @@
 
   <div class="card sheen status-hero">
     <div class="botmark"><img src="/logo.png" alt="" /></div>
-    <div>
-      <div class="live {data.receiving ? '' : 'off'}">
-        <span class="dot"></span> {data.receiving ? 'Online · in chat' : data.enabled ? 'Connected · idle' : 'Not connected'}
+    <!-- Connection state streams in after the shell renders; show a neutral
+         placeholder until the RPC lands so navigation stays instant. -->
+    {#await data.conn}
+      <div>
+        <div class="live off"><span class="dot"></span> Checking connection…</div>
+        <h2>#{data.login ?? 'itsmavey'}</h2>
+        <div class="meta"><span class="status-tag">—</span></div>
       </div>
-      <h2>#{data.login ?? 'itsmavey'}</h2>
-      <div class="meta">
-        <span class="status-tag {paid ? 'premium' : ''}">{statusLabel}</span>
+      <div class="actions"></div>
+    {:then c}
+      <div>
+        <div class="live {c.receiving ? '' : 'off'}">
+          <span class="dot"></span> {c.receiving ? 'Online · in chat' : c.enabled ? 'Connected · idle' : 'Not connected'}
+        </div>
+        <h2>#{data.login ?? 'itsmavey'}</h2>
+        <div class="meta">
+          <span class="status-tag {c.status !== 'free' ? 'premium' : ''}">{statusLabel(c.status)}</span>
+        </div>
       </div>
-    </div>
-    <div class="actions">
-      {#if data.receiving}
-        <!-- Hidden real forms — only submitted after modal confirm -->
-        <form id="form-restart" method="POST" action="?/restart" use:enhance style="display:none"></form>
-        <form id="form-disconnect" method="POST" action="?/disconnect" use:enhance style="display:none"></form>
-        <Button variant="ghost" icon="activity" type="button" onclick={() => openModal('restart')}>Restart</Button>
-        <Button variant="tan" icon="power" type="button" onclick={() => openModal('disconnect')}>Disconnect</Button>
-      {:else}
-        <form method="POST" action="?/enable" use:enhance>
-          <Button variant="primary" icon="power" type="submit">Enable</Button>
-        </form>
-      {/if}
-    </div>
+      <div class="actions">
+        {#if c.receiving}
+          <!-- Hidden real forms — only submitted after modal confirm -->
+          <form id="form-restart" method="POST" action="?/restart" use:enhance style="display:none"></form>
+          <form id="form-disconnect" method="POST" action="?/disconnect" use:enhance style="display:none"></form>
+          <Button variant="ghost" icon="activity" type="button" onclick={() => openModal('restart')}>Restart</Button>
+          <Button variant="tan" icon="power" type="button" onclick={() => openModal('disconnect')}>Disconnect</Button>
+        {:else}
+          <form method="POST" action="?/enable" use:enhance>
+            <Button variant="primary" icon="power" type="submit">Enable</Button>
+          </form>
+        {/if}
+      </div>
+    {/await}
   </div>
 </section>
 

--- a/console/dashboard/src/routes/(app)/commands/+page.server.ts
+++ b/console/dashboard/src/routes/(app)/commands/+page.server.ts
@@ -58,26 +58,24 @@ export const actions: Actions = {
     if (!cmd.name) return fail(400, { ok: false, error: 'Command name is required.' });
     if (!cmd.response) return fail(400, { ok: false, error: 'Response is required.' });
 
-    // Name is the row key (user_id, name), so a rename is delete-old + create-new.
-    // Write the new row first; its optimistic reply already lists the renamed
-    // command (the old delete is immediate but the new write is behind a ~2s
-    // batch, so deleteCommand's fresh DB list wouldn't include it yet).
-    const { commands, error } = await upsertCommand(uid, { ...cmd, isActive });
+    // A rename passes original_name so the commands service updates the row's
+    // name field in place (single write) instead of delete-old + create-new.
+    // The optimistic reply already drops the old key and lists the renamed
+    // command, so one round trip covers it.
+    const { commands, error } = await upsertCommand(
+      uid,
+      { ...cmd, isActive },
+      renamed ? originalName : undefined
+    );
     if (error) return fail(400, { ok: false, error, commands });
 
-    if (renamed) {
-      const del = await deleteCommand(uid, originalName);
-      if (del.error) return fail(400, { ok: false, error: del.error, commands });
-      // Drop the old key from the optimistic list returned by the upsert.
-      return {
-        ok: true,
-        action: 'updated',
-        name: cmd.name,
-        commands: commands.filter((c) => c.name !== originalName)
-      };
-    }
-
-    return { ok: true, action: isEdit ? 'updated' : 'created', name: cmd.name, commands };
+    return {
+      ok: true,
+      action: isEdit ? 'updated' : 'created',
+      name: cmd.name,
+      original: renamed ? originalName : undefined,
+      commands
+    };
   },
 
   // Lightweight toggle: flips is_active without going through the full editor.

--- a/console/dashboard/src/routes/(app)/commands/+page.svelte
+++ b/console/dashboard/src/routes/(app)/commands/+page.svelte
@@ -1,18 +1,78 @@
 <script lang="ts">
   import { enhance } from '$app/forms';
+  import type { SubmitFunction } from '@sveltejs/kit';
   import { Icon, Badge, PERMS, PERM_LABELS } from '@bagel/shared';
   import type { Perm, CommandView } from '@bagel/shared';
-  let { data, form } = $props();
+  let { data } = $props();
 
-  // Action results return the fresh list; fall back to the loaded data.
-  const commands = $derived(form?.commands ?? data.commands);
+  // Local source of truth, seeded from the SSR load. Each action result is
+  // reconciled row-by-row into this list (see applyResult) rather than wholesale
+  // replacing it with the server's snapshot. Concurrent submits (e.g. toggling
+  // two rows fast) then only touch their own row, so a slower reply built from a
+  // pre-flush DB snapshot can no longer clobber another in-flight change.
+  // svelte-ignore state_referenced_locally
+  let items = $state<CommandView[]>(data.commands ?? []);
+
+  // Resync when a fresh SSR load delivers a different list (full reload), but
+  // not on optimistic edits — those mutate items without touching data.commands.
+  // svelte-ignore state_referenced_locally
+  let seed = data.commands;
+  $effect(() => {
+    if (data.commands !== seed) {
+      seed = data.commands;
+      items = data.commands ?? [];
+    }
+  });
+
+  // Reconcile one action result into the local list. Uses only the affected
+  // command (looked up by name) plus the original name on rename, never the
+  // whole returned list, so it is order-independent across concurrent results.
+  type ActionResult = {
+    ok: boolean;
+    action?: 'created' | 'updated' | 'deleted';
+    name?: string;
+    original?: string;
+    silent?: boolean;
+    error?: string;
+    commands?: CommandView[];
+  };
+
+  function applyResult(d: ActionResult) {
+    if (!d.ok) {
+      if (d.error) flash('err', d.error);
+      return;
+    }
+
+    if (d.action === 'deleted') {
+      items = items.filter((c) => c.name !== d.name);
+    } else {
+      const next = d.commands?.find((c) => c.name === d.name);
+      if (next) {
+        // Drop the pre-rename key, then replace-or-append the affected row.
+        const without = items.filter((c) => c.name !== d.name && c.name !== d.original);
+        items = [...without, next];
+      }
+    }
+
+    if (!d.silent) {
+      const verb = d.action === 'deleted' ? 'deleted' : (d.action ?? 'updated');
+      flash('ok', `Command ${d.name} ${verb}.`);
+    }
+  }
+
+  // Custom enhance: apply the result locally and skip the default invalidateAll,
+  // so navigation does not refetch a write-behind (stale) list mid-edit.
+  const reconcile: SubmitFunction = () => async ({ result }) => {
+    if (result.type === 'success' && result.data) applyResult(result.data as ActionResult);
+    else if (result.type === 'failure' && result.data) applyResult(result.data as ActionResult);
+  };
 
   const filters = ['All', 'Custom', 'Built-in', 'Disabled'] as const;
   let active = $state<(typeof filters)[number]>('All');
   let search = $state('');
 
   const rows = $derived(
-    commands
+    items
       .filter((c) => (active === 'Disabled' ? !c.is_active : true))
       .filter((c) => c.name.toLowerCase().includes(search.toLowerCase()))
   );
@@ -73,17 +133,6 @@
     toastTimer = setTimeout(() => (toast = null), 3200);
   }
 
-  // React to the latest form action result.
-  $effect(() => {
-    if (!form) return;
-    if (form.ok && !form.silent) {
-      const verb = form.action === 'deleted' ? 'deleted' : form.action;
-      flash('ok', `Command ${form.name} ${verb}.`);
-    } else if (form.ok === false && form.error) {
-      flash('err', form.error);
-    }
-  });
-
   const cd = (n?: number) => (n && n > 0 ? `${n}s` : '0s');
 </script>
 
@@ -91,7 +140,7 @@
   <div class="page-head">
     <span class="eyebrow">Manage</span>
     <h1>Chat <em>commands</em></h1>
-    <p>Custom responses your viewers can trigger in chat. {commands.filter((c) => c.is_active).length} active, {commands.filter((c) => !c.is_active).length} disabled.</p>
+    <p>Custom responses your viewers can trigger in chat. {items.filter((c) => c.is_active).length} active, {items.filter((c) => !c.is_active).length} disabled.</p>
   </div>
 
   <div class="toolbar">
@@ -130,7 +179,7 @@
             <span class="uses">{c.uses ?? '0'}</span>
             <span class="row-act">
               <!-- Toggle: silent upsert that flips is_active, preserving config -->
-              <form method="POST" action="?/toggle" use:enhance>
+              <form method="POST" action="?/toggle" use:enhance={reconcile}>
                 <input type="hidden" name="name" value={c.name} />
                 <input type="hidden" name="response" value={c.response} />
                 <input type="hidden" name="perm" value={c.perm ?? 'everyone'} />
@@ -165,8 +214,9 @@
     <form
       method="POST"
       action="?/save"
-      use:enhance={() => async ({ update, result }) => {
-        await update({ reset: false });
+      use:enhance={() => async ({ result }) => {
+        if (result.type === 'success' && result.data) applyResult(result.data as ActionResult);
+        else if (result.type === 'failure' && result.data) applyResult(result.data as ActionResult);
         if (result.type === 'success' && result.data?.ok) closeEditor();
       }}
     >
@@ -253,7 +303,11 @@
     <form
       method="POST"
       action="?/delete"
-      use:enhance={() => async ({ update }) => { deleteTarget = null; await update(); }}
+      use:enhance={() => async ({ result }) => {
+        deleteTarget = null;
+        if (result.type === 'success' && result.data) applyResult(result.data as ActionResult);
+        else if (result.type === 'failure' && result.data) applyResult(result.data as ActionResult);
+      }}
       class="modal-actions"
     >
       <input type="hidden" name="name" value={deleteTarget} />

--- a/docs/src/content/docs/reference/rpc-contracts.md
+++ b/docs/src/content/docs/reference/rpc-contracts.md
@@ -66,7 +66,7 @@ Shared reply shape:
 | Verb | Request | Notes |
 |---|---|---|
 | `list` | `{user_id}` | returns the current command set |
-| `upsert` | `{user_id, name, response, is_active}` | write-behind (~2s); reply is an **optimistic** merged list. A validation error returns the error alongside the unmodified list |
+| `upsert` | `{user_id, name, response, is_active, original_name?}` | write-behind (~2s); reply is an **optimistic** merged list. A validation error returns the error alongside the unmodified list. When `original_name` is set and differs from `name`, the row is **renamed in place** (name field updated, row identity kept) — immediate, not write-behind — instead of delete+recreate |
 | `delete` | `{user_id, name}` | immediate; invalidates cache, so the returned list is fresh |
 
 ## Admin users — `bagel.rpc.admin.user.*`


### PR DESCRIPTION
Dashboard command CRUD was broken and sluggish. Three fixes plus the backend support they need.

Command rename (was delete + recreate):
- repository.Rename updates the existing row's name field in place, preserving row identity, and announces delete(old) + changed(new) so name-keyed consumers (projector, bot) drop the stale key. Falls back to a plain create if the old row is gone.
- commands dashboard RPC: upsert now accepts original_name and routes to Rename when it differs from name.
- dashboard rpc.ts / save action send original_name in one round trip instead of upsert(new) + delete(old).

Race conditions (commands page):
- The list was wholesale-replaced from each action's optimistic, pre-flush (write-behind) snapshot, so concurrent toggles/edits clobbered each other. The page now keeps local row state and reconciles per affected row via a custom enhance, without invalidateAll, so concurrent submits only touch their own row.

Responsiveness:
- Overview load no longer awaits NATS; it returns the connection state as a streamed promise so the shell (and the post-login redirect) renders immediately and the state hydrates via {#await}.
- Commands page no longer refetches mid-edit (invalidate removed).

Tests: rename-in-place preserves row identity and announces both events; missing-row rename falls back to create.