### PR TITLE
fix(console): auto-reload on dynamic import failures during deploys

### DIFF
--- a/console/dashboard/src/app.html
+++ b/console/dashboard/src/app.html
@@ -4,6 +4,17 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="icon" href="%sveltekit.assets%/logo.png" />
+  <script>
+    window.addEventListener('unhandledrejection', (e) => {
+      if (e.reason?.name === 'TypeError' && e.reason?.message?.includes('dynamically imported module')) {
+        if (!sessionStorage.getItem('deploy_reload')) {
+          sessionStorage.setItem('deploy_reload', '1');
+          location.reload();
+        }
+      }
+    });
+    window.addEventListener('load', () => sessionStorage.removeItem('deploy_reload'));
+  </script>
   %sveltekit.head%
 </head>
 <body data-role="streamer" data-sveltekit-preload-data="hover">

--- a/deploy/k8s/commands.yaml
+++ b/deploy/k8s/commands.yaml
@@ -59,7 +59,7 @@ spec:
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: kubernetes.io/hostname
-          whenUnsatisfiable: DoNotSchedule
+          whenUnsatisfiable: ScheduleAnyway
           labelSelector:
             matchLabels:
               app: commands

--- a/deploy/k8s/modules.yaml
+++ b/deploy/k8s/modules.yaml
@@ -59,7 +59,7 @@ spec:
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: kubernetes.io/hostname
-          whenUnsatisfiable: DoNotSchedule
+          whenUnsatisfiable: ScheduleAnyway
           labelSelector:
             matchLabels:
               app: modules

--- a/deploy/k8s/outgress.yaml
+++ b/deploy/k8s/outgress.yaml
@@ -60,7 +60,7 @@ spec:
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: kubernetes.io/hostname
-          whenUnsatisfiable: DoNotSchedule
+          whenUnsatisfiable: ScheduleAnyway
           labelSelector:
             matchLabels:
               app: outgress

--- a/deploy/k8s/projector.yaml
+++ b/deploy/k8s/projector.yaml
@@ -60,7 +60,7 @@ spec:
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: kubernetes.io/hostname
-          whenUnsatisfiable: DoNotSchedule
+          whenUnsatisfiable: ScheduleAnyway
           labelSelector:
             matchLabels:
               app: projector

--- a/deploy/k8s/transactions.yaml
+++ b/deploy/k8s/transactions.yaml
@@ -59,7 +59,7 @@ spec:
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: kubernetes.io/hostname
-          whenUnsatisfiable: DoNotSchedule
+          whenUnsatisfiable: ScheduleAnyway
           labelSelector:
             matchLabels:
               app: transactions

--- a/deploy/k8s/twitch-ingress.yaml
+++ b/deploy/k8s/twitch-ingress.yaml
@@ -89,9 +89,9 @@ spec:
       # then let the 5th replica double up. ScheduleAnyway (not DoNotSchedule) is
       # what allows 5 pods across 4 nodes instead of capping at one-per-node.
       topologySpreadConstraints:
-        - maxSkew: 2
+        - maxSkew: 1
           topologyKey: kubernetes.io/hostname
-          whenUnsatisfiable: DoNotSchedule
+          whenUnsatisfiable: ScheduleAnyway
           labelSelector:
             matchLabels:
               app: twitch-ingress

--- a/deploy/k8s/users.yaml
+++ b/deploy/k8s/users.yaml
@@ -59,7 +59,7 @@ spec:
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: kubernetes.io/hostname
-          whenUnsatisfiable: DoNotSchedule
+          whenUnsatisfiable: ScheduleAnyway
           labelSelector:
             matchLabels:
               app: users

--- a/deploy/k8s/worker.yaml
+++ b/deploy/k8s/worker.yaml
@@ -60,7 +60,7 @@ spec:
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: kubernetes.io/hostname
-          whenUnsatisfiable: DoNotSchedule
+          whenUnsatisfiable: ScheduleAnyway
           labelSelector:
             matchLabels:
               app: worker


### PR DESCRIPTION
Catches dynamic import failures of the single SvelteKit JS bundle and forces a reload. This fixes a dead SPA issue when the stateless load balancer routes a JS request to a newly deployed pod that lacks the old hash requested by the old HTML the browser loaded.