### PR TITLE
fix: bot_token

### DIFF
--- a/app/outgress/internal/twitch/client.go
+++ b/app/outgress/internal/twitch/client.go
@@ -110,12 +110,11 @@ func (c *Client) Do(ctx context.Context, method, endpoint string, body []byte) (
 
 // userScopedPrefixes are Helix path prefixes that must run under the bot's USER
 // token rather than the app token, because they read or act in a moderator/user
-// context the app token cannot satisfy. Chat sends ride the bot token so the
-// bot badge appears in chat.
+// context the app token cannot satisfy. Cloud-bot chat sends are intentionally
+// absent: Twitch requires the app token for the Chat Bot badge.
 var userScopedPrefixes = []string{
 	"/helix/moderation/",        // moderated channels, bans, etc.
 	"/helix/chat/chatters",      // moderator:read:chatters
-	"/helix/chat/messages",      // send chat message (needs bot user token for bot badge)
 	"/helix/channels/followers", // moderator:read:followers
 }
 

--- a/app/outgress/internal/twitch/client_test.go
+++ b/app/outgress/internal/twitch/client_test.go
@@ -51,6 +51,22 @@ func TestHTTPClientPoolMatchesWorkerConcurrency(t *testing.T) {
 	client.CloseIdleConnections()
 }
 
+func TestCloudBotChatAutoRoutingUsesAppToken(t *testing.T) {
+	app := &Source{}
+	user := &Source{}
+	client := &Client{app: app, user: user}
+
+	for _, endpoint := range []string{
+		"/helix/chat/messages",
+		"/helix/chat/announcements?broadcaster_id=1&moderator_id=2",
+		"/helix/chat/shoutouts?from_broadcaster_id=1&to_broadcaster_id=2&moderator_id=3",
+	} {
+		if got := client.sourceFor(endpoint); got != app {
+			t.Errorf("sourceFor(%q) = user token, want app token", endpoint)
+		}
+	}
+}
+
 func TestMissingScope401DoesNotRefreshToken(t *testing.T) {
 	refreshes := 0
 	source := &Source{

--- a/app/outgress/internal/worker/worker.go
+++ b/app/outgress/internal/worker/worker.go
@@ -120,17 +120,18 @@ type helixRoute struct {
 //   - ad/commercial: the broadcaster starts the ad (channel:edit:commercial).
 //   - clip:        the broadcaster's grant creates the clip (clips:edit).
 var typeRoutes = map[string]helixRoute{
-	outgress.TypeChat:       {http.MethodPost, "/helix/chat/messages", ""},
+	outgress.TypeChat:       {http.MethodPost, "/helix/chat/messages", outgress.AsApp},
 	outgress.TypeBan:        {http.MethodPost, "/helix/moderation/bans", outgress.AsBot},
 	outgress.TypeTimeout:    {http.MethodPost, "/helix/moderation/bans", outgress.AsBot},
 	outgress.TypeUnban:      {http.MethodDelete, "/helix/moderation/bans", outgress.AsBot},
 	outgress.TypeAd:         {http.MethodPost, "/helix/channels/commercial", outgress.AsBroadcaster},
 	outgress.TypeCommercial: {http.MethodPost, "/helix/channels/commercial", outgress.AsBroadcaster},
 	outgress.TypeClip:       {http.MethodPost, "/helix/clips", outgress.AsBroadcaster},
-	// Chat actions use the bot token so the bot badge appears in chat. Twitch
-	// requires a user access token for the badge; the app token would hide it.
-	outgress.TypeAnnounce: {http.MethodPost, "/helix/chat/announcements", outgress.AsBot},
-	outgress.TypeShoutout: {http.MethodPost, "/helix/chat/shoutouts", outgress.AsBot},
+	// Cloud-bot chat actions use the app token. Twitch only awards the Chat Bot
+	// badge to Send Chat Message calls made with an app access token, backed by
+	// the bot's user:bot/action grants and the broadcaster's channel:bot grant.
+	outgress.TypeAnnounce: {http.MethodPost, "/helix/chat/announcements", outgress.AsApp},
+	outgress.TypeShoutout: {http.MethodPost, "/helix/chat/shoutouts", outgress.AsApp},
 }
 
 type Worker struct {
@@ -439,7 +440,7 @@ func (w *Worker) processAnnounce(ctx context.Context, payload outgress.Message) 
 		color = "primary"
 	}
 
-	payload.As = outgress.AsBot
+	payload.As = outgress.AsApp
 	payload.Method = http.MethodPost
 	payload.Endpoint = "/helix/chat/announcements?broadcaster_id=" +
 		url.QueryEscape(payload.BroadcasterID) + "&moderator_id=" + url.QueryEscape(mod)
@@ -509,7 +510,7 @@ func (w *Worker) processShoutout(ctx context.Context, payload outgress.Message) 
 		return err
 	}
 
-	payload.As = outgress.AsBot
+	payload.As = outgress.AsApp
 	payload.Method = http.MethodPost
 	payload.Endpoint = shoutoutEndpoint(payload.BroadcasterID, toID, mod)
 	payload.Payload = nil

--- a/app/outgress/internal/worker/worker_test.go
+++ b/app/outgress/internal/worker/worker_test.go
@@ -65,11 +65,11 @@ func TestDrainResponseIsBounded(t *testing.T) {
 	}
 }
 
-func TestSlashActionRoutesUseWarmAppToken(t *testing.T) {
-	for _, typ := range []string{outgress.TypeAnnounce, outgress.TypeShoutout} {
+func TestCloudBotChatActionsUseAppToken(t *testing.T) {
+	for _, typ := range []string{outgress.TypeChat, outgress.TypeAnnounce, outgress.TypeShoutout} {
 		route := typeRoutes[typ]
-		if route.as != outgress.AsBot {
-			t.Fatalf("%s route identity = %q, want %q", typ, route.as, outgress.AsBot)
+		if route.as != outgress.AsApp {
+			t.Fatalf("%s route identity = %q, want %q", typ, route.as, outgress.AsApp)
 		}
 	}
 }

--- a/app/worker/REWRITE_PLAN.md
+++ b/app/worker/REWRITE_PLAN.md
@@ -216,8 +216,8 @@ registry := module.NewRegistry(
 Wire the pools.
 
 ### 10. Outgress (`app/outgress/internal/worker/worker.go`)
-- `typeRoutes`: add `announce -> {POST, /helix/chat/announcements, AsBot}` and
-  `shoutout -> {POST, /helix/chat/shoutouts, AsBot}`.
+- `typeRoutes`: add `announce -> {POST, /helix/chat/announcements, AsApp}` and
+  `shoutout -> {POST, /helix/chat/shoutouts, AsApp}`.
 - Single `typeRoutes` lookup (drop the double `_, mapped` + `r, ok`).
 - `processAnnounce`: inject `moderator_id` = bot (query + body per Twitch), pay the general
   bucket, execute.

--- a/console/admin/src/lib/server/oauth.ts
+++ b/console/admin/src/lib/server/oauth.ts
@@ -31,8 +31,9 @@ export function botClientId(): string {
 }
 
 export function botScopes(): string[] {
-  // Bot account grant. Mirrors the v1 bot scope set (settings.py): chat read/edit
-  // + chat read/write + user/channel bot + moderator scopes.
+  // Bot account grant. These prior authorizations let the app token act as the
+  // cloud bot. channel:bot belongs to each broadcaster's dashboard grant, not
+  // this bot-account grant.
   return [
     'openid',
     'chat:read',
@@ -40,15 +41,14 @@ export function botScopes(): string[] {
     'user:read:chat',
     'user:write:chat',
     'user:bot',
-    'channel:bot',
     'moderator:read:followers',
     'moderator:read:chatters',
     'moderator:manage:banned_users',
     'moderator:manage:chat_messages',
     // Required by the worker's slash-command outgress paths: announcements back
     // /announce[color] (POST /helix/chat/announcements) and shoutouts back
-    // /shoutout (POST /helix/chat/shoutouts). Without these the bot token 401s on
-    // those endpoints. The bot must also be a moderator of the target channel.
+    // /shoutout (POST /helix/chat/shoutouts). The app-token calls rely on these
+    // prior bot authorizations. The bot must also moderate the target channel.
     'moderator:manage:announcements',
     'moderator:manage:shoutouts',
     // Required by outgress mod-status verification (GET /helix/moderation/channels):

--- a/docs/src/content/docs/reference/system-overview.md
+++ b/docs/src/content/docs/reference/system-overview.md
@@ -70,8 +70,10 @@ non-special, non-premium users is dropped before it reaches a lane.
 3. The owning worker consumes the lane, resolves the command via the **commands**
    projection (or RPC), and produces a reply.
 4. The reply is published on `twitch.outgress.{premium|standard|system}`.
-5. **outgress** applies the per-broadcaster rate limit and sends to Twitch using
-   the bot account token (refreshed and rotated through the users token RPC).
+5. **outgress** applies the per-broadcaster rate limit and sends via Helix using
+   the app access token. Twitch associates `sender_id` with the bot's prior
+   `user:bot` / `user:write:chat` grant and the broadcaster's `channel:bot`
+   grant, which makes eligible replies display the Chat Bot badge.
 
 ## Infrastructure
 


### PR DESCRIPTION
## Summary
- route Helix chat messages through the app access token so Twitch can display the Chat Bot badge
- use app-token cloud-bot authorization for announcements and shoutouts
- align bot and broadcaster OAuth scopes with Twitch's documented cloud chatbot grants
- add regression coverage for app-token routing

## Verification
- GOCACHE=/tmp/itsbagelbot-go-build go test ./app/outgress/... ./app/worker/...
- bun run --filter admin check