### PR TITLE
perf(outgress): bypass linkerd for Twitch egress + per-node Helix timing

### DIFF
--- a/app/outgress/internal/twitch/client.go
+++ b/app/outgress/internal/twitch/client.go
@@ -14,6 +14,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/newrelic/go-agent/v3/newrelic"
 )
 
 const apiBase = "https://api.twitch.tv"
@@ -331,7 +333,17 @@ func (c *Client) do(ctx context.Context, src *Source, method, endpoint string, b
 		req.Header.Set("Content-Type", "application/json")
 	}
 
-	return c.http.Do(req)
+	// Record the Helix call as an external segment so its duration is isolated
+	// from in-process work and (faceted by the node.region/node.name attributes
+	// the worker sets on the transaction) tells node latency apart from code
+	// latency. StartExternalSegment finds the transaction on the request context
+	// and is a no-op when none is present, so non-instrumented callers pay
+	// nothing.
+	seg := newrelic.StartExternalSegment(newrelic.FromContext(ctx), req)
+	res, err := c.http.Do(req)
+	seg.Response = res
+	seg.End()
+	return res, err
 }
 
 // RetryAfter converts the Ratelimit-Reset header of a 429 (unix seconds)

--- a/app/outgress/internal/worker/worker.go
+++ b/app/outgress/internal/worker/worker.go
@@ -77,6 +77,22 @@ var (
 	helixSystemSpec     = ratelimit.NewSpec(helixSystemReserve, helixSystemReserve/helixWindow)
 )
 
+// nodeRegion and nodeName label every transaction so Twitch external-segment
+// duration can be faceted by node in New Relic. They are process-wide (one pod
+// is one node) and set once at startup via SetNodeIdentity; the empty default
+// is harmless when the agent is not configured.
+var (
+	nodeRegion string
+	nodeName   string
+)
+
+// SetNodeIdentity records the pod's region and host for transaction labeling.
+// Call once at startup before consuming.
+func SetNodeIdentity(region, host string) {
+	nodeRegion = region
+	nodeName = host
+}
+
 // Lane identifies which queue a worker drains; it selects the rate-limit
 // buckets the worker pays into.
 type Lane int
@@ -225,6 +241,8 @@ func (w *Worker) Process(msg *message.Message) error {
 	ctx := msg.Context()
 
 	if txn := newrelic.FromContext(ctx); txn != nil {
+		txn.AddAttribute("node.region", nodeRegion)
+		txn.AddAttribute("node.name", nodeName)
 		txn.AddAttribute("event.type", payload.Type)
 		txn.AddAttribute("event.broadcaster_id", payload.BroadcasterID)
 		if payload.Endpoint != "" {

--- a/app/outgress/main.go
+++ b/app/outgress/main.go
@@ -154,6 +154,11 @@ func main() {
 	if err != nil || host == "" {
 		log.Fatal("failed to determine outgress pod identity", zap.Error(err))
 	}
+	// Label every worker transaction with this pod's region and the Kubernetes
+	// node it runs on so the Twitch external-segment duration can be split per
+	// node in New Relic. NODE_NAME (spec.nodeName) names the actual node;
+	// hostname (the pod) is the dev fallback.
+	worker.SetNodeIdentity(cfg.RateRegion, env.Get("NODE_NAME", host))
 
 	buckets := ratelimit.NewBucketStore(10_000)
 

--- a/deploy/k8s/outgress.yaml
+++ b/deploy/k8s/outgress.yaml
@@ -42,7 +42,12 @@ spec:
         config.linkerd.io/proxy-cpu-limit: 1000m
         config.linkerd.io/proxy-memory-request: 16Mi
         config.linkerd.io/proxy-memory-limit: 128Mi
-        config.linkerd.io/skip-outbound-ports: 6379,26379
+        # Valkey (6379/26379) and the Twitch Helix egress (443) skip the proxy.
+        # Outgress's hot path is a synchronous POST to api.twitch.tv; routing it
+        # through the linkerd sidecar adds a proxy hop per send for an external,
+        # already-TLS destination the mesh cannot mTLS anyway. twitch-ingress
+        # skips 443 for the same reason.
+        config.linkerd.io/skip-outbound-ports: 6379,26379,443
     spec:
       tolerations:
         - key: itsbagelbot.dev/pool
@@ -86,6 +91,10 @@ spec:
               value: nats://nats-leaf:4222
             - name: NATS_LEAF_URL
               value: nats://nats-leaf:4222
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
             - name: NODE_IP
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
## Why
Outgress "feels slow." The hot send path is a synchronous Helix POST to `api.twitch.tv`; everything in-process is already lean (local lock-free lease limiter, sonic decode, atomic pause snapshot, HTTP/2 pooled transport). So the latency lives in the network path and the node it runs from.

## Changes
- **Bypass linkerd for Twitch egress.** `skip-outbound-ports` adds `443` so each send no longer pays a sidecar proxy hop for an external, already-TLS destination the mesh cannot mTLS. Matches the existing `twitch-ingress` annotation. Valkey (`6379/26379`) and NATS (`4222`) are unchanged.
- **Per-node Helix timing in New Relic.** Every Helix call is now a NR external segment, and each worker transaction is tagged `node.region` / `node.name` (from `spec.nodeName`). Twitch request duration can be faceted per node to separate node latency from code latency.

## Out of band (already live, not in this PR)
- worker1 OS uplink shaping (`/usr/local/sbin/fleet-shape.sh`) egress cap raised 150→300 Mbit to match ingress. That was the upload throttle halving outgress on the home node.

## Verification
- `go build ./app/outgress/...` clean
- `go vet ./app/outgress/...` clean
- `go test -race ./app/outgress/...` green

## Deploy note
Merging rolls outgress fleet-wide via Flux (the `443` annotation change restarts the pods; the NR code ships once the image digest is bumped).