### PR TITLE
fix(outgress): DNS hardening + synthetic latency probe

### DIFF
--- a/app/ingress/lib/ingress/application.ex
+++ b/app/ingress/lib/ingress/application.ex
@@ -61,6 +61,7 @@ defmodule Ingress.Application do
        ]},
       nats_connection(),
       nats_bus_connection(),
+      Ingress.NatsFailback,
       Ingress.BroadcasterCache,
       {Task.Supervisor, name: Ingress.Dispatcher.TaskSupervisor},
       Ingress.Dispatcher,

--- a/app/ingress/lib/ingress/nats_failback.ex
+++ b/app/ingress/lib/ingress/nats_failback.ex
@@ -1,0 +1,116 @@
+defmodule Ingress.NatsFailback do
+  @moduledoc """
+  Returns displaced NATS connections to the same-node leaf after recovery.
+
+  The ordinary `nats-leaf` Service remains available cluster-wide for failover;
+  `nats-leaf-local` has `internalTrafficPolicy: Local` and is used only as proof
+  that this node's leaf has recovered. Connections are moved one at a time.
+  """
+
+  use GenServer
+
+  @connections [:gnat, :gnat_bus]
+
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @impl true
+  def init(_opts) do
+    interval = positive_env("NATS_FAILBACK_INTERVAL_MS", 30_000)
+
+    state = %{
+      node: System.get_env("NODE_NAME", ""),
+      address: System.get_env("NATS_LOCAL_LEAF_ADDR", "nats-leaf-local:4222"),
+      interval: interval,
+      required: positive_env("NATS_FAILBACK_SUCCESSES", 3),
+      timeout: positive_env("NATS_FAILBACK_PROBE_TIMEOUT_MS", 1_000),
+      successes: Map.new(@connections, &{&1, 0})
+    }
+
+    Process.send_after(self(), :check, :rand.uniform(interval))
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_info(:check, %{node: ""} = state) do
+    schedule(state)
+  end
+
+  def handle_info(:check, state) do
+    local_ready = local_leaf_ready?(state.address, state.timeout)
+
+    {successes, candidate} =
+      Enum.reduce(@connections, {state.successes, nil}, fn name, {counts, candidate} ->
+        cond do
+          local_connection?(name, state.node) ->
+            {Map.put(counts, name, 0), candidate}
+
+          !local_ready ->
+            {Map.put(counts, name, 0), candidate}
+
+          true ->
+            count = Map.get(counts, name, 0) + 1
+            next = if is_nil(candidate) and count >= state.required, do: name, else: candidate
+            {Map.put(counts, name, count), next}
+        end
+      end)
+
+    # One connection per check limits the blast radius for in-flight RPCs and
+    # lets subscriptions settle before the other account is re-homed.
+    successes =
+      if candidate do
+        stop_connection(candidate)
+        Map.put(successes, candidate, 0)
+      else
+        successes
+      end
+
+    schedule(%{state | successes: successes})
+  end
+
+  defp schedule(state) do
+    Process.send_after(self(), :check, state.interval)
+    {:noreply, state}
+  end
+
+  defp local_connection?(name, node) do
+    case Process.whereis(name) do
+      nil -> false
+      _pid ->
+        try do
+          Gnat.server_info(name).server_name |> String.starts_with?(node <> "--")
+        catch
+          :exit, _ -> false
+        end
+    end
+  end
+
+  defp stop_connection(name) do
+    if Process.whereis(name) do
+      try do
+        Gnat.stop(name)
+      catch
+        :exit, _ -> :ok
+      end
+    end
+  end
+
+  defp local_leaf_ready?(address, timeout) do
+    with [host, port_string] <- String.split(address, ":", parts: 2),
+         {port, ""} <- Integer.parse(port_string),
+         {:ok, socket} <- :gen_tcp.connect(String.to_charlist(host), port, [:binary, active: false], timeout) do
+      :gen_tcp.close(socket)
+      true
+    else
+      _ -> false
+    end
+  end
+
+  defp positive_env(key, fallback) do
+    case Integer.parse(System.get_env(key, "")) do
+      {value, ""} when value > 0 -> value
+      _ -> fallback
+    end
+  end
+end

--- a/console/admin/src/lib/server/feed.ts
+++ b/console/admin/src/lib/server/feed.ts
@@ -3,6 +3,7 @@
 // request/reply client so a long-lived subscription never interferes with the
 // short-lived RPC requests (and vice versa).
 import { connect, type ConnectionOptions, type NatsConnection, type Subscription } from 'nats';
+import { enableLeafFailback } from '@bagel/shared/server/nats';
 
 let conn: NatsConnection | null = null;
 let dialing: Promise<NatsConnection> | null = null;
@@ -28,6 +29,7 @@ async function get(): Promise<NatsConnection> {
   dialing = connect(opts)
     .then((c) => {
       conn = c;
+      enableLeafFailback(c);
       return c;
     })
     .finally(() => {

--- a/console/shared/lib/server/nats.ts
+++ b/console/shared/lib/server/nats.ts
@@ -2,6 +2,7 @@
 // reused across requests (connection setup is the expensive part; a warm conn
 // keeps request/reply in the low-ms range, which is what the p99 budget needs).
 import newrelic from 'newrelic';
+import { createConnection } from 'node:net';
 import {
   connect,
   JSONCodec,
@@ -42,6 +43,87 @@ const pools: Record<Role, Pool> = {
   rpc: { conn: null, dialing: null },
   bus: { conn: null, dialing: null }
 };
+
+const failbackEnabled = new WeakSet<NatsConnection>();
+let failbackQueue: Promise<void> = Promise.resolve();
+
+function positiveNumber(value: string | undefined, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function localLeafReady(address: string, timeoutMs: number): Promise<boolean> {
+  const separator = address.lastIndexOf(':');
+  const host = separator > 0 ? address.slice(0, separator) : address;
+  const port = separator > 0 ? Number(address.slice(separator + 1)) : 4222;
+  return new Promise((resolve) => {
+    const socket = createConnection({ host, port });
+    let settled = false;
+    const finish = (ready: boolean) => {
+      if (settled) return;
+      settled = true;
+      socket.destroy();
+      resolve(ready);
+    };
+    socket.setTimeout(timeoutMs, () => finish(false));
+    socket.once('connect', () => finish(true));
+    socket.once('error', () => finish(false));
+  });
+}
+
+/**
+ * Re-home a connection only after it is known to be remote and the strict
+ * same-node probe has succeeded repeatedly. Reconnects are serialized across
+ * the process and initially jittered to avoid a fleet-wide recovery stampede.
+ */
+export function enableLeafFailback(nc: NatsConnection): void {
+  const nodeName = process.env.NODE_NAME;
+  if (!nodeName || failbackEnabled.has(nc)) return;
+  failbackEnabled.add(nc);
+
+  const intervalMs = positiveNumber(process.env.NATS_FAILBACK_INTERVAL_MS, 30_000);
+  const required = positiveNumber(process.env.NATS_FAILBACK_SUCCESSES, 3);
+  const timeoutMs = positiveNumber(process.env.NATS_FAILBACK_PROBE_TIMEOUT_MS, 1_000);
+  const localAddress = process.env.NATS_LOCAL_LEAF_ADDR ?? 'nats-leaf-local:4222';
+  let consecutive = 0;
+  let running = false;
+
+  const check = async () => {
+    if (running || nc.isClosed()) return;
+    running = true;
+    try {
+      const serverName = nc.info?.server_name ?? '';
+      if (serverName.startsWith(`${nodeName}--`)) {
+        consecutive = 0;
+        return;
+      }
+      if (!(await localLeafReady(localAddress, timeoutMs))) {
+        consecutive = 0;
+        return;
+      }
+      consecutive++;
+      if (consecutive < required) return;
+      consecutive = 0;
+      failbackQueue = failbackQueue.catch(() => {}).then(async () => {
+        if (!nc.isClosed() && !nc.info?.server_name?.startsWith(`${nodeName}--`)) {
+          await nc.reconnect();
+        }
+      });
+      await failbackQueue;
+    } catch {
+      consecutive = 0;
+    } finally {
+      running = false;
+    }
+  };
+
+  const initial = setTimeout(() => {
+    void check();
+    const timer = setInterval(() => void check(), intervalMs);
+    timer.unref();
+  }, Math.random() * intervalMs);
+  initial.unref();
+}
 
 // serverList returns the ordered endpoint list, leaf first then hub. `override`
 // (NATS_RPC_URL for rpc, NATS_URL for bus) is used as the leaf endpoint when the
@@ -95,6 +177,7 @@ async function get(role: Role): Promise<NatsConnection> {
   pool.dialing = connect(options(role))
     .then((c) => {
       pool.conn = c;
+      enableLeafFailback(c);
       return c;
     })
     .finally(() => {

--- a/deploy/k8s/commands.yaml
+++ b/deploy/k8s/commands.yaml
@@ -85,6 +85,10 @@ spec:
               value: nats://nats-leaf:4222
             - name: NATS_LEAF_URL
               value: nats://nats-leaf:4222
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
             - name: DB_MAX_OPEN_CONNS
               value: "4"
             - name: DB_QUERY_CONCURRENCY

--- a/deploy/k8s/console-admin.yaml
+++ b/deploy/k8s/console-admin.yaml
@@ -108,6 +108,10 @@ spec:
               value: nats://nats-leaf:4222
             - name: NATS_LEAF_URL
               value: nats://nats-leaf:4222
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
             - name: NATS_ADMIN_SUBJECT
               value: twitch.ingress.admin.shards.get
             - name: NATS_STATUS_SUBJECT_PREFIX

--- a/deploy/k8s/console-dashboard.yaml
+++ b/deploy/k8s/console-dashboard.yaml
@@ -121,6 +121,10 @@ spec:
               value: nats://nats-leaf:4222
             - name: NATS_LEAF_URL
               value: nats://nats-leaf:4222
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
             - name: NATS_PROJECTOR_DASHBOARD_SUBJECT_PREFIX
               value: bagel.rpc.projector.dashboard
             # Reuse the old tier's 32-byte AES key as the session key.

--- a/deploy/k8s/modules.yaml
+++ b/deploy/k8s/modules.yaml
@@ -85,6 +85,10 @@ spec:
               value: nats://nats-leaf:4222
             - name: NATS_LEAF_URL
               value: nats://nats-leaf:4222
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
             - name: DB_MAX_OPEN_CONNS
               value: "4"
             - name: DB_QUERY_CONCURRENCY

--- a/deploy/k8s/nats-leaf-server.conf
+++ b/deploy/k8s/nats-leaf-server.conf
@@ -4,7 +4,9 @@
 # leaf user's credentials (nats-leaf://leaf:<password>@nats.production.svc.cluster.local:7422)
 # and comes from the nats-auth-env secret.
 
-server_name: $POD_NAME
+# The node prefix lets clients distinguish a same-node connection from a
+# fallback. POD_NAME keeps identities unique during maxSurge leaf rollouts.
+server_name: $NATS_SERVER_NAME
 
 port: 4222
 http_port: 8222
@@ -65,9 +67,9 @@ cluster {
   port: 6222
   routes: [ "nats://nats-leaf-peers:6222" ]
   # The headless route URL already resolves to every leaf pod, so each node dials
-  # every peer directly. no_advertise stops route gossip from re-advertising those
-  # peers (which, behind the per-pod IPs + Linkerd, otherwise opens 3-4 duplicate
-  # routes per pair instead of one) — DNS forms the full mesh, gossip doesn't storm it.
+  # every peer directly. no_advertise also keeps peer addresses out of client
+  # INFO connect_urls, ensuring every reconnect is evaluated by the topology-
+  # aware nats-leaf Service instead of pinning a discovered remote pod IP.
   no_advertise: true
 }
 
@@ -75,4 +77,3 @@ max_subscriptions: 0
 max_control_line: 4KB
 
 include "auth.conf"
-

--- a/deploy/k8s/nats-leaf.yaml
+++ b/deploy/k8s/nats-leaf.yaml
@@ -64,12 +64,18 @@ spec:
           image: nats:2.11-alpine
           imagePullPolicy: IfNotPresent
           # --pid writes a pidfile the reloader reads to signal this process.
-          args: ["--config", "/etc/nats/nats.conf", "--pid", "/var/run/nats/nats.pid"]
+          command: ["/bin/sh", "-c"]
+          args:
+            - 'export NATS_SERVER_NAME="${NODE_NAME}--${POD_NAME}"; exec nats-server --config /etc/nats/nats.conf --pid /var/run/nats/nats.pid'
           env:
             - name: POD_NAME
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
           envFrom:
             - secretRef:
                 name: nats-auth-env
@@ -171,16 +177,40 @@ metadata:
   annotations:
     config.linkerd.io/opaque-ports: "4222"
 spec:
-  # Prefer the node-local leaf for the normal fast path, but allow kube-proxy to
-  # spill to another node while the local leaf or its Linkerd sidecar is rolling.
-  # internalTrafficPolicy: Local made every app on that node lose NATS RPC during
-  # leaf updates, which surfaced as dashboard/admin 500s.
-  trafficDistribution: PreferClose
+  # Same-node first, then same-zone, then cluster-wide. Unlike Local this keeps
+  # applications available while their node's leaf is down; unlike PreferClose
+  # it makes node locality explicit on Kubernetes 1.34+. Short ClientIP
+  # affinity keeps one pod's independent RPC/JetStream/KV connections on the
+  # same fallback leaf, but expires before the controlled 90s failback check.
+  trafficDistribution: PreferSameNode
+  sessionAffinity: ClientIP
+  sessionAffinityConfig:
+    clientIP:
+      timeoutSeconds: 60
   selector:
     app: nats-leaf
   ports:
     - {name: client, port: 4222, targetPort: client}
     - {name: monitor, port: 8222, targetPort: monitor}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: nats-leaf
+  name: nats-leaf-local
+  namespace: production
+  annotations:
+    config.linkerd.io/opaque-ports: "4222"
+spec:
+  # Health/failback probe only. With no local endpoint this Service is
+  # unreachable, so clients never mistake a remote leaf for the recovered
+  # same-node leaf.
+  internalTrafficPolicy: Local
+  selector:
+    app: nats-leaf
+  ports:
+    - {name: client, port: 4222, targetPort: client}
 ---
 apiVersion: v1
 kind: Service

--- a/deploy/k8s/outgress.yaml
+++ b/deploy/k8s/outgress.yaml
@@ -86,6 +86,10 @@ spec:
               value: nats://nats-leaf:4222
             - name: NATS_LEAF_URL
               value: nats://nats-leaf:4222
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
             - name: NODE_IP
               valueFrom:
                 fieldRef:

--- a/deploy/k8s/outgress.yaml
+++ b/deploy/k8s/outgress.yaml
@@ -65,6 +65,17 @@ spec:
             matchLabels:
               app: outgress
       # DaemonSet placement keeps one outgress pod per schedulable node.
+      # Resolving api.twitch.tv is on the hot path. With the default ndots:5 the
+      # external FQDN first fans out into cluster-domain queries (…svc.cluster.local
+      # etc.), each a chance to hit the cross-node DNS stall; ndots:1 sends the
+      # absolute name first. A shorter timeout with a retry caps a stall well under
+      # the 5s outgress message lifetime instead of blowing it.
+      dnsConfig:
+        options:
+          - {name: ndots, value: "1"}
+          - {name: single-request-reopen}
+          - {name: timeout, value: "2"}
+          - {name: attempts, value: "2"}
       securityContext:
         runAsNonRoot: true
         runAsUser: 65532

--- a/deploy/k8s/projector.yaml
+++ b/deploy/k8s/projector.yaml
@@ -86,6 +86,10 @@ spec:
               value: nats://nats-leaf:4222
             - name: NATS_LEAF_URL
               value: nats://nats-leaf:4222
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
             - name: NODE_IP
               valueFrom:
                 fieldRef:

--- a/deploy/k8s/transactions.yaml
+++ b/deploy/k8s/transactions.yaml
@@ -82,6 +82,10 @@ spec:
               value: nats://nats-leaf:4222
             - name: NATS_LEAF_URL
               value: nats://nats-leaf:4222
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
             - name: DB_MAX_OPEN_CONNS
               value: "4"
             - name: DB_QUERY_CONCURRENCY

--- a/deploy/k8s/users.yaml
+++ b/deploy/k8s/users.yaml
@@ -85,6 +85,10 @@ spec:
               value: nats://nats-leaf:4222
             - name: NATS_LEAF_URL
               value: nats://nats-leaf:4222
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
             - name: DB_MAX_OPEN_CONNS
               value: "4"
             - name: DB_QUERY_CONCURRENCY

--- a/deploy/k8s/worker.yaml
+++ b/deploy/k8s/worker.yaml
@@ -87,6 +87,10 @@ spec:
               value: nats://nats-leaf:4222
             - name: NATS_LEAF_URL
               value: nats://nats-leaf:4222
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
             - name: NODE_IP
               valueFrom:
                 fieldRef:

--- a/docs/src/content/docs/infrastructure/new-relic-bottleneck-plan.md
+++ b/docs/src/content/docs/infrastructure/new-relic-bottleneck-plan.md
@@ -1,0 +1,271 @@
+---
+title: New Relic bottleneck plan
+description: An efficiency-first plan for tracing and capacity telemetry across Twitch ingress, NATS, projector, Valkey, and database-owning services.
+---
+
+## Objective
+
+Make a slow or overloaded event explain itself in New Relic from Twitch ingress through NATS and the projector, while
+also distinguishing application work from database-pool, concurrency-gate, broker, Valkey, CPU, and network waiting.
+The plan deliberately reuses the agents already running in production and keeps telemetry cardinality and ingest
+bounded.
+
+The database-owning services in scope are `users`, `modules`, `commands`, and `transactions`. The projector does not
+query MySQL; its datastore is Valkey.
+
+## Existing baseline
+
+Keep and build on the instrumentation that already exists:
+
+- `pkg/monitor` starts one Go APM application per service, enables distributed tracing, and correlates zap logs.
+- `pkg/bus` creates one transaction per JetStream delivery and propagates trace headers for Go Watermill publishes.
+- `nrmysql` creates datastore segments for ent queries that carry the transaction context.
+- projection Valkey operations create Redis-compatible datastore segments.
+- ingress already reports low-volume `Custom/Ingress/*` counters and `IngressEvent` lifecycle events.
+- the cluster New Relic bundle already collects Kubernetes, logs, Prometheus data, NATS exporter metrics, and Valkey
+  integration metrics.
+
+The missing information is primarily queueing and saturation, not another general-purpose collector.
+
+## Efficiency rules
+
+1. **Reuse APM for code timing and the existing agents for infrastructure.** Do not add OpenTelemetry, Pixie, a
+   second Prometheus scraper, or an application metrics server in the first rollout.
+2. **Emit state snapshots every 30 seconds, not per-message custom events.** Per-message detail belongs on sampled
+   APM transactions and spans. Capacity snapshots belong in one `ServiceCapacitySample` event.
+3. **Keep names finite.** Metric, transaction, and span names may contain only enumerated operations, normalized
+   subjects, stages, lanes, and outcomes. User IDs, message IDs, stream IDs, pod UIDs, raw errors, and arbitrary NATS
+   subjects must never enter a name or facet used by alerts.
+4. **Prefer deltas and ratios to duplicate counters.** NATS delivery and Kubernetes resource metrics already exist;
+   dashboards should query them rather than republish them from application code.
+5. **Instrument boundaries first.** Add an inner span only when a boundary remains opaque after the outer timing is
+   visible. This keeps the hot ingress path small.
+6. **Gate optional integrations on evidence.** Add server-side MySQL collection only if client pool/query telemetry
+   cannot explain observed latency.
+
+## Signal model
+
+### Trace attributes
+
+Use these bounded attributes across Go and Elixir transactions:
+
+| Attribute | Values |
+| --- | --- |
+| `messaging.system` | `nats` |
+| `messaging.operation` | `publish`, `request`, `process`, `reply` |
+| `messaging.destination` | normalized configured subject, never an ID-expanded subject |
+| `event.type` | the finite Twitch/domain event type set |
+| `event.lane` | `premium`, `standard`, `stream` |
+| `result` | `ok`, `error`, `timeout`, `dropped`, `deferred`, `invalid` |
+| `dependency` | `nats`, `valkey`, `mysql`, `twitch` |
+| `cache.result` | `hit`, `miss`, `negative_hit`, `error` |
+| `prewarm.branch` | `users`, `modules`, `commands` |
+
+Message IDs may be included on sampled traces and correlated logs for diagnosis, but never on aggregate custom
+events, metrics, dashboards, or alerts. Do not send Twitch payloads, chat text, SQL parameter values, credentials, or
+tokens.
+
+### Capacity event
+
+Add a small helper to the Go and Elixir monitoring wrappers that reports one event with this shape every 30 seconds:
+
+```text
+ServiceCapacitySample
+  service                 projector | ingress | users | modules | commands | transactions
+  component               dispatcher | db_pool | db_gate
+  capacity                configured maximum
+  inUse                   current active work
+  queued                  current waiting work
+  waitCountDelta           waits since the previous sample
+  waitMsDelta              cumulative wait milliseconds since the previous sample
+  timeoutCountDelta        timeouts since the previous sample
+  droppedCountDelta        drops since the previous sample
+```
+
+Only fields applicable to the component are set. At a 30-second interval this is two events per component per pod per
+minute, which is small beside per-message telemetry and produces directly alertable utilization and wait-rate signals.
+
+## Phase 1: restore trace continuity
+
+This phase has the highest diagnostic value and should ship first.
+
+### Core NATS request/reply
+
+Update `pkg/bus/rpc.go`:
+
+1. In `RequestJSON`, create a `nats.Msg`, call `InsertDistributedTraceHeaders` from the transaction in `ctx`, copy
+   those values into `Msg.Header`, and use `RequestMsgWithContext`.
+2. In `QueueSubscribeJSON`, copy `msg.Header` into an `http.Header` and call
+   `AcceptDistributedTraceHeaders(newrelic.TransportQueue, headers)` before the request is decoded.
+3. Add a client segment covering request/reply wait. Keep the segment name normalized to the configured RPC subject.
+4. Add tests proving W3C/New Relic headers are injected and accepted without requiring a live New Relic account.
+
+This closes the current ingress/projector-to-data-service and projector-to-outgress RPC trace gaps.
+
+### Ingress notification transaction
+
+Update `Ingress.Dispatcher`, `Ingress.Pipeline`, `Ingress.Nats`, and `Ingress.BroadcasterStatus`:
+
+1. Store `enqueued_at` with the dispatcher item.
+2. Start one `NewRelic.other_transaction("Ingress", "Notification")` inside the supervised task. Record dispatcher
+   wait as an attribute and custom metric; starting it in the task avoids contaminating the long-lived shard process.
+3. Add only four initial spans: `route`, `broadcaster_status.request` on a cache miss, `encode`, and `nats.publish`.
+4. Pass `NewRelic.distributed_trace_headers(:other)` through Gnat's existing `headers:` option for both publish and
+   request calls.
+5. Classify the result and record the finite event type and lane. Notice errors, but do not treat expected filtered
+   chat messages as errors.
+
+Gnat 1.15.1 already supports headers for `pub` and `request`, and the installed Elixir agent exposes both transaction
+and distributed-trace header APIs, so this requires no dependency change.
+
+### Projector prewarm
+
+The three prewarm goroutines currently use `context.Background()`, so their RPC and Valkey work is invisible to the
+stream-event trace. Do not keep the original consumer transaction open for up to five seconds merely to attach
+best-effort work.
+
+Instead:
+
+1. Before launching the goroutines, extract distributed headers from the stream-event transaction.
+2. Start one background transaction per `users`, `modules`, and `commands` branch, accept the copied parent headers,
+   and put that child transaction in the branch context.
+3. End each branch transaction after its RPC and Valkey write complete.
+4. Add `prewarm.branch` and `result`; keep user ID only in trace/log context.
+
+This preserves the fire-and-forget behavior while producing three causally linked child transactions.
+
+### Phase 1 acceptance
+
+- A synthetic ingress notification yields an ingress transaction followed by the correct Go consumer transaction.
+- A broadcaster cache miss includes the users RPC responder and its MySQL segment in the same distributed trace.
+- A stream-online trace links the projector consumer and all three prewarm branches.
+- Existing local tests still run with no license key and make no network calls.
+
+## Phase 2: expose application saturation
+
+### Ingress dispatcher and cache
+
+Extend `Ingress.Metrics` with a 30-second sampler and cheap monotonic counters. Report:
+
+- dispatcher `running`, queue length, configured limits, queue wait, drops, and abnormal task exits;
+- broadcaster cache hits, misses, negative hits, load errors, and current entry count;
+- NATS publish/request outcomes and timeouts;
+- shard reconnect, zombie-timeout, and notification counts as existing counters, not custom events per notification.
+
+Queue length is read in the dispatcher GenServer and cache size via `:ets.info(table, :size)`. Do not walk either data
+structure to produce telemetry.
+
+### Database pool and gate
+
+Add `monitor.ObserveDBPool(ctx, app, service, driver.DB(), 30*time.Second)` in the four database service mains.
+The observer samples the standard `sql.DBStats` values:
+
+- `OpenConnections`, `InUse`, `Idle`, and `MaxOpenConnections`;
+- deltas for `WaitCount`, `WaitDuration`, `MaxIdleClosed`, `MaxIdleTimeClosed`, and `MaxLifetimeClosed`.
+
+Extend `pkg/db/gate.go` with atomics for current holders, current waiters, cumulative waits, wait duration, and acquire
+timeouts. Atomics avoid a second lock on every query. The same 30-second observer reports the pool and gate as two
+`ServiceCapacitySample` components.
+
+Keep `nrmysql` as the source of query execution timing. Add repository-level segments only for operations whose
+multiple datastore calls remain ambiguous in traces; do not wrap every generated ent method.
+
+### Projector throughput
+
+Do not duplicate NATS exporter consumer metrics. Add application data only for information the broker cannot know:
+
+- handler result and duration by normalized event subject;
+- invalid payload drops;
+- Valkey write/invalidation outcome;
+- prewarm branch result and duration.
+
+Use the existing NATS Prometheus series for durable pending, ack-pending, redelivery, and delivery-rate charts.
+
+### Phase 2 acceptance
+
+- Reducing a DB service pool from four connections to one makes pool utilization and pool/gate wait rise separately
+  from MySQL execution time.
+- Saturating the ingress dispatcher shows queue depth and queue wait before a drop counter increases.
+- Pausing projector consumption raises broker durable lag without falsely reporting slow Valkey writes.
+- The capacity sampler stops promptly when its service context is cancelled and creates no goroutine leak.
+
+## Phase 3: New Relic views and alerts as code
+
+Create a small `deploy/newrelic/` Terraform module only after the new attributes have been observed in production.
+Keep account ID and user/API keys outside git. Manage the following four dashboards:
+
+1. **Event journey:** ingress accepted/published, NATS rate and lag, projector rate, errors, and Valkey duration.
+2. **Ingress pressure:** dispatcher utilization/wait, drops, cache hit ratio, RPC latency, shard reconnects, CPU, and
+   memory.
+3. **Projector pressure:** durable lag/redelivery, handler percentiles, Valkey segments, prewarm branches, CPU, and
+   memory.
+4. **Database pressure:** pool/gate utilization and waiting by service beside MySQL datastore duration and service
+   resource usage.
+
+Start with alerts that indicate loss or hard saturation:
+
+| Signal | Warning | Critical |
+| --- | --- | --- |
+| ingress dispatcher utilization | >70% for 10 min | >90% for 5 min |
+| dispatcher or NATS publish drops | n/a | >0 for 2 min |
+| DB pool utilization with waiters | >80% for 10 min | >95% for 5 min |
+| DB gate acquire timeouts | n/a | >0 for 5 min |
+| projector durable lag | positive growth for 10 min | oldest pending exceeds the event freshness target |
+| RPC/prewarm error ratio | >2% for 10 min | >5% for 5 min |
+| required telemetry | n/a | loss of signal for 5 min |
+
+After two weeks of baseline data, replace guessed latency thresholds with anomaly conditions or thresholds derived from
+the observed p95/p99. Do not page on cache misses, normal chat filtering, or isolated best-effort prewarm failures.
+
+## Phase 4: evidence-gated MySQL server telemetry
+
+Client telemetry should answer whether time is spent before a connection, waiting at the process gate, or executing a
+query. Add server telemetry only when query execution remains the unexplained dominant segment.
+
+Preferred order:
+
+1. Enable the OCI-to-New Relic integration for managed HeatWave service metrics if the existing OCI integration can
+   expose the needed connection, CPU, storage, and HeatWave signals with no in-cluster workload.
+2. If lock, buffer-pool, thread, or slow-query data is still required, deploy exactly one remote `nri-mysql` runner
+   with a TLS-enabled, read-only monitoring account. Do not configure the same remote target on every kubelet
+   infrastructure DaemonSet, which would duplicate data four times.
+3. Enable only the extended metric sets needed for an active investigation, then measure ingest before retaining them.
+
+## Rollout sequence
+
+Use four independently reversible changes:
+
+1. **Trace propagation:** shared Go RPC, ingress transactions/headers, and projector prewarm linkage.
+2. **Capacity samples:** ingress dispatcher/cache and Go DB pool/gate observers.
+3. **New Relic as code:** dashboards, loss/saturation alerts, and a single workload grouping the six services.
+4. **Optional database integration:** only after Phase 2 evidence satisfies the gate above.
+
+Roll out to one pod or one database service first where the deployment shape permits it. Compare for 24 hours before
+fleet rollout:
+
+- service CPU and memory;
+- p50/p95 transaction duration;
+- New Relic ingest volume by data type;
+- agent supportability errors and dropped spans/events;
+- trace completeness across NATS.
+
+Proceed when CPU regression is below 2%, memory growth is below 10 MiB per pod, hot-path p95 regression is below 2%,
+and projected monthly ingest remains inside the account budget. Otherwise increase sampling intervals, remove the
+least useful inner spans, or retain traces only at the boundary level.
+
+## Definition of done
+
+The integration is complete when a controlled test can independently create each bottleneck below and the New Relic
+views identify the correct boundary without reading raw logs:
+
+- ingress dispatcher queue saturation;
+- NATS/JetStream projector backlog;
+- projector Valkey latency;
+- database process-gate waiting;
+- database pool waiting;
+- MySQL query execution latency;
+- service CPU throttling or memory pressure;
+- dependency timeout or loss of telemetry.
+
+Completion also requires bounded names/facets, no sensitive payload capture, documented NRQL/dashboard ownership,
+passing no-license tests, and measured overhead within the rollout limits.

--- a/pkg/bus/connect.go
+++ b/pkg/bus/connect.go
@@ -76,6 +76,13 @@ func baseOptions(name, user, pass string) []nats.Option {
 		opts = append(opts, nats.UserInfo(user, pass))
 	}
 
+	// Kubernetes may temporarily place this connection on a fallback leaf. Once
+	// the same-node leaf is stably healthy, recycle only that displaced
+	// connection so topology-aware Service routing can return it locally.
+	if option := leafFailbackOption(); option != nil {
+		opts = append(opts, option)
+	}
+
 	return opts
 }
 

--- a/pkg/bus/failback.go
+++ b/pkg/bus/failback.go
@@ -1,0 +1,117 @@
+package bus
+
+import (
+	"math/rand/v2"
+	"net"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/nats-io/nats.go"
+
+	"ItsBagelBot/pkg/env"
+)
+
+const (
+	defaultFailbackInterval  = 30 * time.Second
+	defaultFailbackSuccesses = 3
+	defaultFailbackTimeout   = time.Second
+)
+
+type failbackConfig struct {
+	nodeName  string
+	localAddr string
+	interval  time.Duration
+	successes int
+	timeout   time.Duration
+}
+
+func leafFailbackOption() nats.Option {
+	cfg := loadFailbackConfig()
+	if cfg.nodeName == "" {
+		return nil // Local development and tests do not need topology failback.
+	}
+	return nats.ConnectHandler(func(nc *nats.Conn) {
+		go runLeafFailback(nc, cfg)
+	})
+}
+
+func loadFailbackConfig() failbackConfig {
+	return failbackConfig{
+		nodeName:  env.Get("NODE_NAME", ""),
+		localAddr: env.Get("NATS_LOCAL_LEAF_ADDR", "nats-leaf-local:4222"),
+		interval:  durationEnv("NATS_FAILBACK_INTERVAL", defaultFailbackInterval),
+		successes: positiveIntEnv("NATS_FAILBACK_SUCCESSES", defaultFailbackSuccesses),
+		timeout:   durationEnv("NATS_FAILBACK_PROBE_TIMEOUT", defaultFailbackTimeout),
+	}
+}
+
+func runLeafFailback(nc *nats.Conn, cfg failbackConfig) {
+	// Spread checks from replicas that were started by the same rollout.
+	initial := time.NewTimer(time.Duration(rand.Int64N(int64(cfg.interval))))
+	defer initial.Stop()
+	<-initial.C
+
+	ticker := time.NewTicker(cfg.interval)
+	defer ticker.Stop()
+
+	consecutive := 0
+	for range ticker.C {
+		if nc.IsClosed() {
+			return
+		}
+		if nc.Status() != nats.CONNECTED || isLocalLeaf(nc.ConnectedServerName(), cfg.nodeName) {
+			consecutive = 0
+			continue
+		}
+
+		if !localLeafReady(cfg.localAddr, cfg.timeout) {
+			consecutive = 0
+			continue
+		}
+		consecutive++
+		if consecutive < cfg.successes {
+			continue
+		}
+
+		// ForceReconnect preserves subscriptions and buffers new publishes using
+		// the normal NATS reconnect machinery. Reset first so a slow reconnect
+		// cannot trigger repeatedly.
+		consecutive = 0
+		_ = nc.ForceReconnect()
+	}
+}
+
+func isLocalLeaf(serverName, nodeName string) bool {
+	return nodeName != "" && strings.HasPrefix(serverName, nodeName+"--")
+}
+
+func localLeafReady(addr string, timeout time.Duration) bool {
+	conn, err := net.DialTimeout("tcp", addr, timeout)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
+}
+
+func durationEnv(key string, fallback time.Duration) time.Duration {
+	v := env.Get(key, "")
+	if v == "" {
+		return fallback
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil || d <= 0 {
+		return fallback
+	}
+	return d
+}
+
+func positiveIntEnv(key string, fallback int) int {
+	v := env.Get(key, "")
+	n, err := strconv.Atoi(v)
+	if err != nil || n <= 0 {
+		return fallback
+	}
+	return n
+}

--- a/pkg/bus/failback_test.go
+++ b/pkg/bus/failback_test.go
@@ -1,0 +1,24 @@
+package bus
+
+import "testing"
+
+func TestIsLocalLeaf(t *testing.T) {
+	tests := []struct {
+		name   string
+		server string
+		node   string
+		want   bool
+	}{
+		{name: "same node", server: "node1--nats-leaf-abc", node: "node1", want: true},
+		{name: "other node", server: "node2--nats-leaf-def", node: "node1", want: false},
+		{name: "prefix collision", server: "node10--nats-leaf-def", node: "node1", want: false},
+		{name: "disabled without node", server: "node1--nats-leaf-abc", node: "", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isLocalLeaf(tt.server, tt.node); got != tt.want {
+				t.Fatalf("isLocalLeaf(%q, %q) = %v, want %v", tt.server, tt.node, got, tt.want)
+			}
+		})
+	}
+}

--- a/tools/synthsend/main.go
+++ b/tools/synthsend/main.go
@@ -1,0 +1,245 @@
+// Command synthsend is a synthetic end-to-end latency probe for the outgress
+// path. It publishes real chat sends onto the outgress premium lane (a real
+// message lands in the target channel) and measures two stages:
+//
+//   - publish -> JetStream ack: how long NATS takes to accept the command.
+//   - publish -> echo: the full round trip. The bot's own message comes back
+//     as a channel.chat.message EventSub on the ingress event stream, so
+//     subscribing to twitch.ingress.event.> and matching a per-send nonce
+//     times the whole pipeline (hub -> leaf -> outgress -> Twitch POST ->
+//     Twitch fanout -> EventSub -> ingress).
+//
+// The per-node split of the Twitch POST leg itself lives in New Relic (the
+// outgress external segment is tagged node.region/node.name). This tool finds
+// whether the bottleneck is NATS ingest, our pipeline, or Twitch-side, and
+// generates the labeled traffic NR needs.
+//
+// Usage:
+//
+//	NATS_URL='nats://user:pass@127.0.0.1:4222' go run ./tools/synthsend \
+//	  -id 804932984 -n 8 -pace 2s
+//
+// Point NATS_URL at a port-forward to the hub:
+//
+//	kubectl -n production port-forward svc/nats 4222:4222
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"ItsBagelBot/internal/domain/outgress"
+
+	"github.com/nats-io/nats.go"
+)
+
+func main() {
+	var (
+		broadcasterID = flag.String("id", "804932984", "target broadcaster id (default itsmavey)")
+		count         = flag.Int("n", 8, "number of probe messages to send")
+		pace          = flag.Duration("pace", 2*time.Second, "delay between sends (keep under the 20/30s chat limit)")
+		subject       = flag.String("subject", "twitch.outgress.premium", "outgress lane subject")
+		ingressSubj   = flag.String("ingress", "twitch.ingress.event.premium,twitch.ingress.event.standard", "comma-separated ingress subjects to watch for the echo (best-effort; worker_bus cannot use the wildcard)")
+		domain        = flag.String("domain", "hub", "JetStream domain")
+		echoWait      = flag.Duration("wait", 12*time.Second, "how long to wait for echoes after the last send")
+		prefix        = flag.String("msg", "ItsBagelBot latency probe", "message text prefix")
+	)
+	flag.Parse()
+
+	url := os.Getenv("NATS_URL")
+	if url == "" {
+		log.Fatal("NATS_URL is required (point it at a port-forward to the hub, with creds)")
+	}
+
+	// The hub advertises its in-cluster client URLs (10.42.x). Behind a
+	// port-forward those are unreachable, so pin the client to the given URL.
+	opts := []nats.Option{
+		nats.Name("synthsend"), nats.Timeout(10 * time.Second),
+		nats.IgnoreDiscoveredServers(), nats.DontRandomize(),
+	}
+	// The BUS account authenticates with NATS_USER/NATS_PASSWORD (e.g. worker_bus
+	// from the worker Doppler project), matching pkg/bus. Inject via
+	// `doppler run -- ...` so the password is never printed.
+	if u := os.Getenv("NATS_USER"); u != "" {
+		opts = append(opts, nats.UserInfo(u, os.Getenv("NATS_PASSWORD")))
+	}
+	nc, err := nats.Connect(url, opts...)
+	if err != nil {
+		log.Fatalf("connect: %v", err)
+	}
+	defer nc.Close()
+
+	js, err := nc.JetStream(nats.Domain(*domain))
+	if err != nil {
+		log.Fatalf("jetstream: %v", err)
+	}
+
+	runID := time.Now().Format("150405")
+
+	type probe struct {
+		nonce   string
+		sentAt  time.Time
+		ackDur  time.Duration
+		echoAt  time.Time
+		gotEcho bool
+		ackErr  error
+	}
+	probes := make([]*probe, *count)
+	for i := range probes {
+		probes[i] = &probe{nonce: fmt.Sprintf("bagelprobe-%s-%d", runID, i)}
+	}
+
+	var mu sync.Mutex
+
+	// Watch the ingress event stream for our nonce coming back. JetStream
+	// publishes are ordinary core messages on the subject, so a plain
+	// subscription sees them live.
+	echoHandler := func(m *nats.Msg) {
+		now := time.Now()
+		mu.Lock()
+		defer mu.Unlock()
+		for _, p := range probes {
+			if p.gotEcho {
+				continue
+			}
+			// Substring match on the raw payload avoids depending on the exact
+			// ingress event schema.
+			if containsToken(m.Data, p.nonce) {
+				p.echoAt = now
+				p.gotEcho = true
+			}
+		}
+	}
+	for _, subj := range strings.Split(*ingressSubj, ",") {
+		subj = strings.TrimSpace(subj)
+		if subj == "" {
+			continue
+		}
+		sub, err := nc.Subscribe(subj, echoHandler)
+		if err != nil {
+			log.Fatalf("subscribe %s: %v", subj, err)
+		}
+		defer func() { _ = sub.Unsubscribe() }()
+	}
+	_ = nc.Flush()
+
+	fmt.Printf("synthsend: target=%s subject=%s n=%d pace=%s\n", *broadcasterID, *subject, *count, *pace)
+
+	for i, p := range probes {
+		text := fmt.Sprintf("%s %s", *prefix, p.nonce)
+		inner, _ := json.Marshal(struct {
+			BroadcasterID string `json:"broadcaster_id"`
+			Message       string `json:"message"`
+		}{*broadcasterID, text})
+
+		msg := outgress.Message{
+			Type:          outgress.TypeChat,
+			BroadcasterID: *broadcasterID,
+			Payload:       json.RawMessage(inner),
+		}
+		data, _ := json.Marshal(msg)
+
+		sentAt := time.Now()
+		_, ackErr := js.Publish(*subject, data)
+		ackDur := time.Since(sentAt)
+
+		mu.Lock()
+		p.sentAt, p.ackDur, p.ackErr = sentAt, ackDur, ackErr
+		mu.Unlock()
+
+		if ackErr != nil {
+			fmt.Printf("  [%d] publish FAILED: %v\n", i, ackErr)
+		} else {
+			fmt.Printf("  [%d] published ack=%.1fms\n", i, ms(ackDur))
+		}
+		if i < len(probes)-1 {
+			time.Sleep(*pace)
+		}
+	}
+
+	fmt.Printf("waiting up to %s for echoes...\n", *echoWait)
+	deadline := time.Now().Add(*echoWait)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		done := true
+		for _, p := range probes {
+			if p.ackErr == nil && !p.gotEcho {
+				done = false
+				break
+			}
+		}
+		mu.Unlock()
+		if done {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	// Report.
+	mu.Lock()
+	defer mu.Unlock()
+	var acks, e2es []time.Duration
+	echoed := 0
+	fmt.Println("\nper-send:")
+	for i, p := range probes {
+		if p.ackErr != nil {
+			fmt.Printf("  [%d] ack-error\n", i)
+			continue
+		}
+		acks = append(acks, p.ackDur)
+		if p.gotEcho {
+			e2e := p.echoAt.Sub(p.sentAt)
+			e2es = append(e2es, e2e)
+			echoed++
+			fmt.Printf("  [%d] ack=%6.1fms  e2e=%7.1fms\n", i, ms(p.ackDur), ms(e2e))
+		} else {
+			fmt.Printf("  [%d] ack=%6.1fms  e2e=  (no echo)\n", i, ms(p.ackDur))
+		}
+	}
+
+	fmt.Printf("\nsummary: sent=%d echoed=%d\n", len(acks), echoed)
+	if len(acks) > 0 {
+		fmt.Printf("  publish->ack   (NATS ingest):   %s\n", stat(acks))
+	}
+	if len(e2es) > 0 {
+		fmt.Printf("  publish->echo  (full round trip): %s\n", stat(e2es))
+		fmt.Println("  note: e2e includes Twitch-side fanout + EventSub delivery (~hundreds of ms, not ours).")
+		fmt.Println("  the per-node Twitch POST leg is in New Relic, faceted by node.name.")
+	} else {
+		fmt.Println("  no echoes seen: channel chat EventSub may be inactive, or the send was rejected.")
+		fmt.Println("  check outgress pod logs for the Twitch response.")
+	}
+}
+
+func containsToken(data []byte, token string) bool {
+	t := []byte(token)
+	for i := 0; i+len(t) <= len(data); i++ {
+		if string(data[i:i+len(t)]) == token {
+			return true
+		}
+	}
+	return false
+}
+
+func ms(d time.Duration) float64 { return float64(d.Microseconds()) / 1000 }
+
+func stat(ds []time.Duration) string {
+	s := append([]time.Duration(nil), ds...)
+	sort.Slice(s, func(i, j int) bool { return s[i] < s[j] })
+	p := func(q float64) time.Duration {
+		if len(s) == 0 {
+			return 0
+		}
+		idx := int(q * float64(len(s)-1))
+		return s[idx]
+	}
+	return fmt.Sprintf("min=%.1f p50=%.1f p95=%.1f max=%.1f ms (n=%d)",
+		ms(s[0]), ms(p(0.5)), ms(p(0.95)), ms(s[len(s)-1]), len(s))
+}


### PR DESCRIPTION
## Root cause
"Outgress slow" was **cluster DNS**, not outgress code. Both CoreDNS replicas were on node1, so pods on node2/node3/worker1 resolved `api.twitch.tv` over the tailnet overlay and hit the Kubernetes 5s DNS timeout. Since an outgress message lives exactly 5s, a DNS stall makes the Helix send expire.

Per-node curl probes confirmed it (node2 was 6/6 × 5s; node1, which runs CoreDNS, was clean).

## Cluster change (already applied, not in this PR)
- CoreDNS converted to a **DaemonSet** (one per node, incl. worker1) via the k3s addon manifest on node1.
- kube-dns Service `internalTrafficPolicy: Local` so each node resolves from its own CoreDNS, no overlay hop. Post-change probe: node2 now resolves locally in ~1.6ms; worker1 6/6 fast.

## This PR (outgress side)
- `dnsConfig` options: `ndots:1` (skip the cluster search-domain fan-out for the external FQDN), `single-request-reopen` (serialize A/AAAA to dodge the conntrack race that still drops a parallel UDP query — Go honors this), `timeout:2 attempts:2` (cap any residual stall under the 5s budget).
- `tools/synthsend`: a Go probe that publishes real chat sends onto the outgress lane and times the round trip. Run with `worker_bus` creds via `doppler run -p worker -c prd` against a `nats-leaf` port-forward.

## Follow-up (recommended, not done)
NodeLocal DNSCache would kill the residual conntrack-race 5s stalls for *every* pod (not just Go ones with `single-request`).

## Deploy
Merging applies the dnsConfig via Flux (outgress pods restart; no new image needed).