### PR TITLE
fix(dns): roll dnsConfig onto external-facing services

### DIFF
--- a/deploy/k8s/console-admin.yaml
+++ b/deploy/k8s/console-admin.yaml
@@ -80,6 +80,15 @@ spec:
                   matchExpressions:
                     - {key: app, operator: In, values: [console-admin]}
                 topologyKey: kubernetes.io/hostname
+      # Resolve external hosts (Twitch OAuth login) without the cluster
+      # search-domain fan-out (ndots:1) and serialize A/AAAA to dodge the
+      # conntrack race; cap any DNS stall well under a few seconds.
+      dnsConfig:
+        options:
+          - {name: ndots, value: "1"}
+          - {name: single-request-reopen}
+          - {name: timeout, value: "2"}
+          - {name: attempts, value: "2"}
       securityContext:
         runAsNonRoot: true
         runAsUser: 65532

--- a/deploy/k8s/console-dashboard.yaml
+++ b/deploy/k8s/console-dashboard.yaml
@@ -90,6 +90,15 @@ spec:
               app: console-dashboard
       # DaemonSet placement keeps one dashboard pod per schedulable node, so
       # cloudflared -> traefik can prefer a local backend on every node.
+      # Resolve external hosts (Twitch OAuth login) without the cluster
+      # search-domain fan-out (ndots:1) and serialize A/AAAA to dodge the
+      # conntrack race; cap any DNS stall well under a few seconds.
+      dnsConfig:
+        options:
+          - {name: ndots, value: "1"}
+          - {name: single-request-reopen}
+          - {name: timeout, value: "2"}
+          - {name: attempts, value: "2"}
       securityContext:
         runAsNonRoot: true
         runAsUser: 65532

--- a/deploy/k8s/twitch-ingress.yaml
+++ b/deploy/k8s/twitch-ingress.yaml
@@ -100,6 +100,15 @@ spec:
           labelSelector:
             matchLabels:
               app: twitch-ingress
+      # Resolve external hosts (Twitch EventSub/Helix) without the cluster
+      # search-domain fan-out (ndots:1) and serialize A/AAAA to dodge the
+      # conntrack race; cap any DNS stall well under a few seconds.
+      dnsConfig:
+        options:
+          - {name: ndots, value: "1"}
+          - {name: single-request-reopen}
+          - {name: timeout, value: "2"}
+          - {name: attempts, value: "2"}
       securityContext:
         runAsNonRoot: true
         runAsUser: 999 # the image's `ingress` user; numeric so kubelet can verify

--- a/deploy/k8s/users.yaml
+++ b/deploy/k8s/users.yaml
@@ -64,6 +64,15 @@ spec:
             matchLabels:
               app: users
       # DaemonSet placement keeps one users pod per schedulable node.
+      # Resolve external hosts (Twitch OAuth token refresh) without the cluster
+      # search-domain fan-out (ndots:1) and serialize A/AAAA to dodge the
+      # conntrack race; cap any DNS stall well under a few seconds.
+      dnsConfig:
+        options:
+          - {name: ndots, value: "1"}
+          - {name: single-request-reopen}
+          - {name: timeout, value: "2"}
+          - {name: attempts, value: "2"}
       securityContext:
         runAsNonRoot: true
         runAsUser: 65532


### PR DESCRIPTION
Extends outgress DNS hardening (#133) to services resolving external hosts: twitch-ingress (EventSub/Helix), users (OAuth refresh), console-admin/dashboard (OAuth login). dnsConfig ndots:1 + single-request-reopen + timeout:2/attempts:2. Pairs with CoreDNS DaemonSet + kube-dns internalTrafficPolicy: Local. Merging applies via Flux (pod restarts, no new images).