### PR TITLE
fix(bus): keep reconnecting through NATS authorization errors

### DIFF
--- a/pkg/bus/connect.go
+++ b/pkg/bus/connect.go
@@ -66,6 +66,12 @@ func baseOptions(name, user, pass string) []nats.Option {
 		// Honor serverList order on the initial dial and on every reconnect; the
 		// default shuffles the pool and would let a client pin the hub.
 		nats.DontRandomize(),
+		// Keep reconnecting through authorization errors. The default aborts the
+		// connection for good after two consecutive auth failures against the
+		// same server, which permanently strands a pod when the broker's account
+		// env lags a credential rotation (readyz stays 503 but healthz keeps the
+		// container alive, so it never restarts on its own).
+		nats.IgnoreAuthErrorAbort(),
 	}
 
 	if name != "" {


### PR DESCRIPTION
## Summary
- Adds `nats.IgnoreAuthErrorAbort()` to the fleet-wide `baseOptions` in `pkg/bus/connect.go`.
- Without it, the nats.go client permanently closes the connection after two consecutive authorization failures against the same server. During a credential rotation the broker pods' `nats-auth-env` (env-injected, not hot-reloadable) can lag the app's credentials, and any pod that dials inside that window strands forever: `/readyz` stays 503, but `/healthz` is process-liveness only, so kubelet never restarts the container.
- Seen live today: all 3 notifications pods sat 1/2 ready for ~6h after the broker pods were rolled with the new account hashes, because their NATS connections had already aborted and nothing retried.

With this option the client keeps cycling the (leaf-first, ordered) server pool through auth errors, so a pod self-heals as soon as the broker catches up — no manual rollout restart needed.

## Test plan
- [x] `go build ./pkg/bus/...` / `go test ./pkg/bus/...` / `go vet` — clean
- [ ] Next credential rotation: confirm app pods recover without a manual restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)