### PR TITLE
Fix admin notification sends and New Relic CSP

### DIFF
--- a/app/notifications/rpc/admin.go
+++ b/app/notifications/rpc/admin.go
@@ -3,6 +3,7 @@ package rpc
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/nats-io/nats.go"
@@ -67,6 +68,10 @@ func (a *adminRPC) send(ctx context.Context, req notificationsrpc.SendRequest) n
 	if err := notification.LevelValidator(level); err != nil {
 		return notificationsrpc.SendReply{Error: "level must be info, success, warning or critical"}
 	}
+	actorID, err := strconv.ParseUint(req.ActorID, 10, 64)
+	if err != nil {
+		return notificationsrpc.SendReply{Error: "actor_id must be numeric"}
+	}
 
 	var target *uint64
 	if scope == notification.ScopeDirect {
@@ -77,14 +82,14 @@ func (a *adminRPC) send(ctx context.Context, req notificationsrpc.SendRequest) n
 		target = &id
 	}
 
-	row, err := a.repo.Create(ctx, scope, target, req.Title, req.Body, level, req.ActorID, req.ActorLogin, req.ExpiresAt)
+	row, err := a.repo.Create(ctx, scope, target, req.Title, req.Body, level, actorID, req.ActorLogin, req.ExpiresAt)
 	if err != nil {
 		return notificationsrpc.SendReply{Error: err.Error()}
 	}
 
 	a.invalidate(target)
 	a.log.Info("admin notification sent",
-		zap.String("scope", req.Scope), zap.Int("id", row.ID), zap.Uint64("actor", req.ActorID))
+		zap.String("scope", req.Scope), zap.Int("id", row.ID), zap.Uint64("actor", actorID))
 
 	view := viewOf(row, false)
 	return notificationsrpc.SendReply{Notification: &view}

--- a/console/admin/svelte.config.js
+++ b/console/admin/svelte.config.js
@@ -26,12 +26,16 @@ export default {
       mode: 'auto',
       directives: {
         'default-src': ['self'],
-        'script-src': ['self'],
+        // js-agent.newrelic.com hosts the New Relic Browser (RUM) agent that the
+        // nonce'd inline loader (injected in hooks.server.ts) pulls in.
+        'script-src': ['self', 'https://js-agent.newrelic.com'],
         'style-src': ['self'],
         'style-src-attr': ['unsafe-inline'],
         'font-src': ['self'],
         'img-src': ['self', 'data:'],
-        'connect-src': ['self', 'https://dashboard.itsbagelbot.com'],
+        // *.nr-data.net is the New Relic Browser beacon (RUM page views, JS
+        // errors, SPA routes, web vitals).
+        'connect-src': ['self', 'https://dashboard.itsbagelbot.com', 'https://*.nr-data.net'],
         'object-src': ['none'],
         'base-uri': ['self'],
         'frame-ancestors': ['none']

--- a/internal/domain/rpc/notifications/notifications.go
+++ b/internal/domain/rpc/notifications/notifications.go
@@ -30,7 +30,7 @@ type SendRequest struct {
 	Body           string     `json:"body"`
 	Level          string     `json:"level"`
 	ExpiresAt      *time.Time `json:"expires_at,omitempty"`
-	ActorID        uint64     `json:"actor_id"`
+	ActorID        string     `json:"actor_id"`
 	ActorLogin     string     `json:"actor_login"`
 }
 

--- a/internal/domain/rpc/notifications/notifications_test.go
+++ b/internal/domain/rpc/notifications/notifications_test.go
@@ -1,0 +1,16 @@
+package notificationsrpc
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestSendRequestDecodesStringActorID(t *testing.T) {
+	var req SendRequest
+	if err := json.Unmarshal([]byte(`{"actor_id":"804932984"}`), &req); err != nil {
+		t.Fatalf("decode send request: %v", err)
+	}
+	if req.ActorID != "804932984" {
+		t.Fatalf("actor id = %q, want %q", req.ActorID, "804932984")
+	}
+}


### PR DESCRIPTION
## Summary
- decode admin actor IDs using the existing string-based Twitch ID wire convention
- validate and parse the actor ID before persisting notifications
- allow the New Relic browser agent and beacon endpoints in the admin CSP
- add a regression test for the notification RPC payload

## Testing
- `GOCACHE=/tmp/itsbagelbot-go-cache go test ./app/notifications/... ./internal/domain/rpc/notifications`
- `npm run check` in `console/admin`
- `npm run check` in `console/dashboard`