### PR TITLE
Deduplicate notification RPC delivery across NATS leaves

### DIFF
--- a/app/notifications/ent/migrate/schema.go
+++ b/app/notifications/ent/migrate/schema.go
@@ -18,6 +18,7 @@ var (
 		{Name: "level", Type: field.TypeEnum, Enums: []string{"info", "success", "warning", "critical"}, Default: "info"},
 		{Name: "created_by", Type: field.TypeUint64},
 		{Name: "created_by_login", Type: field.TypeString},
+		{Name: "request_id", Type: field.TypeString, Unique: true, Nullable: true},
 		{Name: "created_at", Type: field.TypeTime},
 		{Name: "expires_at", Type: field.TypeTime, Nullable: true},
 	}
@@ -35,7 +36,7 @@ var (
 			{
 				Name:    "notification_created_at",
 				Unique:  false,
-				Columns: []*schema.Column{NotificationsColumns[8]},
+				Columns: []*schema.Column{NotificationsColumns[9]},
 			},
 		},
 	}

--- a/app/notifications/ent/mutation.go
+++ b/app/notifications/ent/mutation.go
@@ -44,6 +44,7 @@ type NotificationMutation struct {
 	created_by        *uint64
 	addcreated_by     *int64
 	created_by_login  *string
+	request_id        *string
 	created_at        *time.Time
 	expires_at        *time.Time
 	clearedFields     map[string]struct{}
@@ -459,6 +460,55 @@ func (m *NotificationMutation) ResetCreatedByLogin() {
 	m.created_by_login = nil
 }
 
+// SetRequestID sets the "request_id" field.
+func (m *NotificationMutation) SetRequestID(s string) {
+	m.request_id = &s
+}
+
+// RequestID returns the value of the "request_id" field in the mutation.
+func (m *NotificationMutation) RequestID() (r string, exists bool) {
+	v := m.request_id
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldRequestID returns the old "request_id" field's value of the Notification entity.
+// If the Notification object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *NotificationMutation) OldRequestID(ctx context.Context) (v *string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldRequestID is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldRequestID requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldRequestID: %w", err)
+	}
+	return oldValue.RequestID, nil
+}
+
+// ClearRequestID clears the value of the "request_id" field.
+func (m *NotificationMutation) ClearRequestID() {
+	m.request_id = nil
+	m.clearedFields[notification.FieldRequestID] = struct{}{}
+}
+
+// RequestIDCleared returns if the "request_id" field was cleared in this mutation.
+func (m *NotificationMutation) RequestIDCleared() bool {
+	_, ok := m.clearedFields[notification.FieldRequestID]
+	return ok
+}
+
+// ResetRequestID resets all changes to the "request_id" field.
+func (m *NotificationMutation) ResetRequestID() {
+	m.request_id = nil
+	delete(m.clearedFields, notification.FieldRequestID)
+}
+
 // SetCreatedAt sets the "created_at" field.
 func (m *NotificationMutation) SetCreatedAt(t time.Time) {
 	m.created_at = &t
@@ -632,7 +682,7 @@ func (m *NotificationMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *NotificationMutation) Fields() []string {
-	fields := make([]string, 0, 9)
+	fields := make([]string, 0, 10)
 	if m.scope != nil {
 		fields = append(fields, notification.FieldScope)
 	}
@@ -653,6 +703,9 @@ func (m *NotificationMutation) Fields() []string {
 	}
 	if m.created_by_login != nil {
 		fields = append(fields, notification.FieldCreatedByLogin)
+	}
+	if m.request_id != nil {
+		fields = append(fields, notification.FieldRequestID)
 	}
 	if m.created_at != nil {
 		fields = append(fields, notification.FieldCreatedAt)
@@ -682,6 +735,8 @@ func (m *NotificationMutation) Field(name string) (ent.Value, bool) {
 		return m.CreatedBy()
 	case notification.FieldCreatedByLogin:
 		return m.CreatedByLogin()
+	case notification.FieldRequestID:
+		return m.RequestID()
 	case notification.FieldCreatedAt:
 		return m.CreatedAt()
 	case notification.FieldExpiresAt:
@@ -709,6 +764,8 @@ func (m *NotificationMutation) OldField(ctx context.Context, name string) (ent.V
 		return m.OldCreatedBy(ctx)
 	case notification.FieldCreatedByLogin:
 		return m.OldCreatedByLogin(ctx)
+	case notification.FieldRequestID:
+		return m.OldRequestID(ctx)
 	case notification.FieldCreatedAt:
 		return m.OldCreatedAt(ctx)
 	case notification.FieldExpiresAt:
@@ -770,6 +827,13 @@ func (m *NotificationMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetCreatedByLogin(v)
+		return nil
+	case notification.FieldRequestID:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetRequestID(v)
 		return nil
 	case notification.FieldCreatedAt:
 		v, ok := value.(time.Time)
@@ -845,6 +909,9 @@ func (m *NotificationMutation) ClearedFields() []string {
 	if m.FieldCleared(notification.FieldTargetUserID) {
 		fields = append(fields, notification.FieldTargetUserID)
 	}
+	if m.FieldCleared(notification.FieldRequestID) {
+		fields = append(fields, notification.FieldRequestID)
+	}
 	if m.FieldCleared(notification.FieldExpiresAt) {
 		fields = append(fields, notification.FieldExpiresAt)
 	}
@@ -864,6 +931,9 @@ func (m *NotificationMutation) ClearField(name string) error {
 	switch name {
 	case notification.FieldTargetUserID:
 		m.ClearTargetUserID()
+		return nil
+	case notification.FieldRequestID:
+		m.ClearRequestID()
 		return nil
 	case notification.FieldExpiresAt:
 		m.ClearExpiresAt()
@@ -896,6 +966,9 @@ func (m *NotificationMutation) ResetField(name string) error {
 		return nil
 	case notification.FieldCreatedByLogin:
 		m.ResetCreatedByLogin()
+		return nil
+	case notification.FieldRequestID:
+		m.ResetRequestID()
 		return nil
 	case notification.FieldCreatedAt:
 		m.ResetCreatedAt()

--- a/app/notifications/ent/notification.go
+++ b/app/notifications/ent/notification.go
@@ -31,6 +31,8 @@ type Notification struct {
 	CreatedBy uint64 `json:"created_by,omitempty"`
 	// CreatedByLogin holds the value of the "created_by_login" field.
 	CreatedByLogin string `json:"created_by_login,omitempty"`
+	// RequestID holds the value of the "request_id" field.
+	RequestID *string `json:"request_id,omitempty"`
 	// CreatedAt holds the value of the "created_at" field.
 	CreatedAt time.Time `json:"created_at,omitempty"`
 	// ExpiresAt holds the value of the "expires_at" field.
@@ -66,7 +68,7 @@ func (*Notification) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case notification.FieldID, notification.FieldTargetUserID, notification.FieldCreatedBy:
 			values[i] = new(sql.NullInt64)
-		case notification.FieldScope, notification.FieldTitle, notification.FieldBody, notification.FieldLevel, notification.FieldCreatedByLogin:
+		case notification.FieldScope, notification.FieldTitle, notification.FieldBody, notification.FieldLevel, notification.FieldCreatedByLogin, notification.FieldRequestID:
 			values[i] = new(sql.NullString)
 		case notification.FieldCreatedAt, notification.FieldExpiresAt:
 			values[i] = new(sql.NullTime)
@@ -133,6 +135,13 @@ func (_m *Notification) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field created_by_login", values[i])
 			} else if value.Valid {
 				_m.CreatedByLogin = value.String
+			}
+		case notification.FieldRequestID:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field request_id", values[i])
+			} else if value.Valid {
+				_m.RequestID = new(string)
+				*_m.RequestID = value.String
 			}
 		case notification.FieldCreatedAt:
 			if value, ok := values[i].(*sql.NullTime); !ok {
@@ -210,6 +219,11 @@ func (_m *Notification) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("created_by_login=")
 	builder.WriteString(_m.CreatedByLogin)
+	builder.WriteString(", ")
+	if v := _m.RequestID; v != nil {
+		builder.WriteString("request_id=")
+		builder.WriteString(*v)
+	}
 	builder.WriteString(", ")
 	builder.WriteString("created_at=")
 	builder.WriteString(_m.CreatedAt.Format(time.ANSIC))

--- a/app/notifications/ent/notification/notification.go
+++ b/app/notifications/ent/notification/notification.go
@@ -29,6 +29,8 @@ const (
 	FieldCreatedBy = "created_by"
 	// FieldCreatedByLogin holds the string denoting the created_by_login field in the database.
 	FieldCreatedByLogin = "created_by_login"
+	// FieldRequestID holds the string denoting the request_id field in the database.
+	FieldRequestID = "request_id"
 	// FieldCreatedAt holds the string denoting the created_at field in the database.
 	FieldCreatedAt = "created_at"
 	// FieldExpiresAt holds the string denoting the expires_at field in the database.
@@ -56,6 +58,7 @@ var Columns = []string{
 	FieldLevel,
 	FieldCreatedBy,
 	FieldCreatedByLogin,
+	FieldRequestID,
 	FieldCreatedAt,
 	FieldExpiresAt,
 }
@@ -173,6 +176,11 @@ func ByCreatedBy(opts ...sql.OrderTermOption) OrderOption {
 // ByCreatedByLogin orders the results by the created_by_login field.
 func ByCreatedByLogin(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldCreatedByLogin, opts...).ToFunc()
+}
+
+// ByRequestID orders the results by the request_id field.
+func ByRequestID(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldRequestID, opts...).ToFunc()
 }
 
 // ByCreatedAt orders the results by the created_at field.

--- a/app/notifications/ent/notification/where.go
+++ b/app/notifications/ent/notification/where.go
@@ -80,6 +80,11 @@ func CreatedByLogin(v string) predicate.Notification {
 	return predicate.Notification(sql.FieldEQ(FieldCreatedByLogin, v))
 }
 
+// RequestID applies equality check predicate on the "request_id" field. It's identical to RequestIDEQ.
+func RequestID(v string) predicate.Notification {
+	return predicate.Notification(sql.FieldEQ(FieldRequestID, v))
+}
+
 // CreatedAt applies equality check predicate on the "created_at" field. It's identical to CreatedAtEQ.
 func CreatedAt(v time.Time) predicate.Notification {
 	return predicate.Notification(sql.FieldEQ(FieldCreatedAt, v))
@@ -413,6 +418,81 @@ func CreatedByLoginEqualFold(v string) predicate.Notification {
 // CreatedByLoginContainsFold applies the ContainsFold predicate on the "created_by_login" field.
 func CreatedByLoginContainsFold(v string) predicate.Notification {
 	return predicate.Notification(sql.FieldContainsFold(FieldCreatedByLogin, v))
+}
+
+// RequestIDEQ applies the EQ predicate on the "request_id" field.
+func RequestIDEQ(v string) predicate.Notification {
+	return predicate.Notification(sql.FieldEQ(FieldRequestID, v))
+}
+
+// RequestIDNEQ applies the NEQ predicate on the "request_id" field.
+func RequestIDNEQ(v string) predicate.Notification {
+	return predicate.Notification(sql.FieldNEQ(FieldRequestID, v))
+}
+
+// RequestIDIn applies the In predicate on the "request_id" field.
+func RequestIDIn(vs ...string) predicate.Notification {
+	return predicate.Notification(sql.FieldIn(FieldRequestID, vs...))
+}
+
+// RequestIDNotIn applies the NotIn predicate on the "request_id" field.
+func RequestIDNotIn(vs ...string) predicate.Notification {
+	return predicate.Notification(sql.FieldNotIn(FieldRequestID, vs...))
+}
+
+// RequestIDGT applies the GT predicate on the "request_id" field.
+func RequestIDGT(v string) predicate.Notification {
+	return predicate.Notification(sql.FieldGT(FieldRequestID, v))
+}
+
+// RequestIDGTE applies the GTE predicate on the "request_id" field.
+func RequestIDGTE(v string) predicate.Notification {
+	return predicate.Notification(sql.FieldGTE(FieldRequestID, v))
+}
+
+// RequestIDLT applies the LT predicate on the "request_id" field.
+func RequestIDLT(v string) predicate.Notification {
+	return predicate.Notification(sql.FieldLT(FieldRequestID, v))
+}
+
+// RequestIDLTE applies the LTE predicate on the "request_id" field.
+func RequestIDLTE(v string) predicate.Notification {
+	return predicate.Notification(sql.FieldLTE(FieldRequestID, v))
+}
+
+// RequestIDContains applies the Contains predicate on the "request_id" field.
+func RequestIDContains(v string) predicate.Notification {
+	return predicate.Notification(sql.FieldContains(FieldRequestID, v))
+}
+
+// RequestIDHasPrefix applies the HasPrefix predicate on the "request_id" field.
+func RequestIDHasPrefix(v string) predicate.Notification {
+	return predicate.Notification(sql.FieldHasPrefix(FieldRequestID, v))
+}
+
+// RequestIDHasSuffix applies the HasSuffix predicate on the "request_id" field.
+func RequestIDHasSuffix(v string) predicate.Notification {
+	return predicate.Notification(sql.FieldHasSuffix(FieldRequestID, v))
+}
+
+// RequestIDIsNil applies the IsNil predicate on the "request_id" field.
+func RequestIDIsNil() predicate.Notification {
+	return predicate.Notification(sql.FieldIsNull(FieldRequestID))
+}
+
+// RequestIDNotNil applies the NotNil predicate on the "request_id" field.
+func RequestIDNotNil() predicate.Notification {
+	return predicate.Notification(sql.FieldNotNull(FieldRequestID))
+}
+
+// RequestIDEqualFold applies the EqualFold predicate on the "request_id" field.
+func RequestIDEqualFold(v string) predicate.Notification {
+	return predicate.Notification(sql.FieldEqualFold(FieldRequestID, v))
+}
+
+// RequestIDContainsFold applies the ContainsFold predicate on the "request_id" field.
+func RequestIDContainsFold(v string) predicate.Notification {
+	return predicate.Notification(sql.FieldContainsFold(FieldRequestID, v))
 }
 
 // CreatedAtEQ applies the EQ predicate on the "created_at" field.

--- a/app/notifications/ent/notification_create.go
+++ b/app/notifications/ent/notification_create.go
@@ -79,6 +79,20 @@ func (_c *NotificationCreate) SetCreatedByLogin(v string) *NotificationCreate {
 	return _c
 }
 
+// SetRequestID sets the "request_id" field.
+func (_c *NotificationCreate) SetRequestID(v string) *NotificationCreate {
+	_c.mutation.SetRequestID(v)
+	return _c
+}
+
+// SetNillableRequestID sets the "request_id" field if the given value is not nil.
+func (_c *NotificationCreate) SetNillableRequestID(v *string) *NotificationCreate {
+	if v != nil {
+		_c.SetRequestID(*v)
+	}
+	return _c
+}
+
 // SetCreatedAt sets the "created_at" field.
 func (_c *NotificationCreate) SetCreatedAt(v time.Time) *NotificationCreate {
 	_c.mutation.SetCreatedAt(v)
@@ -268,6 +282,10 @@ func (_c *NotificationCreate) createSpec() (*Notification, *sqlgraph.CreateSpec)
 	if value, ok := _c.mutation.CreatedByLogin(); ok {
 		_spec.SetField(notification.FieldCreatedByLogin, field.TypeString, value)
 		_node.CreatedByLogin = value
+	}
+	if value, ok := _c.mutation.RequestID(); ok {
+		_spec.SetField(notification.FieldRequestID, field.TypeString, value)
+		_node.RequestID = &value
 	}
 	if value, ok := _c.mutation.CreatedAt(); ok {
 		_spec.SetField(notification.FieldCreatedAt, field.TypeTime, value)

--- a/app/notifications/ent/notification_update.go
+++ b/app/notifications/ent/notification_update.go
@@ -307,6 +307,9 @@ func (_u *NotificationUpdate) sqlSave(ctx context.Context) (_node int, err error
 	if value, ok := _u.mutation.CreatedByLogin(); ok {
 		_spec.SetField(notification.FieldCreatedByLogin, field.TypeString, value)
 	}
+	if _u.mutation.RequestIDCleared() {
+		_spec.ClearField(notification.FieldRequestID, field.TypeString)
+	}
 	if value, ok := _u.mutation.ExpiresAt(); ok {
 		_spec.SetField(notification.FieldExpiresAt, field.TypeTime, value)
 	}
@@ -685,6 +688,9 @@ func (_u *NotificationUpdateOne) sqlSave(ctx context.Context) (_node *Notificati
 	}
 	if value, ok := _u.mutation.CreatedByLogin(); ok {
 		_spec.SetField(notification.FieldCreatedByLogin, field.TypeString, value)
+	}
+	if _u.mutation.RequestIDCleared() {
+		_spec.ClearField(notification.FieldRequestID, field.TypeString)
 	}
 	if value, ok := _u.mutation.ExpiresAt(); ok {
 		_spec.SetField(notification.FieldExpiresAt, field.TypeTime, value)

--- a/app/notifications/ent/runtime.go
+++ b/app/notifications/ent/runtime.go
@@ -28,7 +28,7 @@ func init() {
 	// notification.CreatedByLoginValidator is a validator for the "created_by_login" field. It is called by the builders before save.
 	notification.CreatedByLoginValidator = notificationDescCreatedByLogin.Validators[0].(func(string) error)
 	// notificationDescCreatedAt is the schema descriptor for created_at field.
-	notificationDescCreatedAt := notificationFields[7].Descriptor()
+	notificationDescCreatedAt := notificationFields[8].Descriptor()
 	// notification.DefaultCreatedAt holds the default value on creation for the created_at field.
 	notification.DefaultCreatedAt = notificationDescCreatedAt.Default.(func() time.Time)
 	notificationreadFields := schema.NotificationRead{}.Fields()

--- a/app/notifications/ent/schema/notification.go
+++ b/app/notifications/ent/schema/notification.go
@@ -36,6 +36,10 @@ func (Notification) Fields() []ent.Field {
 
 		field.String("created_by_login").NotEmpty(),
 
+		// Stable across all deliveries of one admin RPC. Nullable so existing
+		// rows migrate cleanly; every new admin send supplies a value.
+		field.String("request_id").Optional().Nillable().Unique().Immutable(),
+
 		field.Time("created_at").Default(time.Now).Immutable(),
 
 		// Unset means the notification never expires.

--- a/app/notifications/repository/notifications.go
+++ b/app/notifications/repository/notifications.go
@@ -27,6 +27,7 @@ func New(client *ent.Client) *Notifications {
 // Create records a notification. targetUserID is nil for scope=broadcast.
 func (r *Notifications) Create(
 	ctx context.Context,
+	requestID string,
 	scope notification.Scope,
 	targetUserID *uint64,
 	title, body string,
@@ -34,8 +35,8 @@ func (r *Notifications) Create(
 	createdBy uint64,
 	createdByLogin string,
 	expiresAt *time.Time,
-) (*ent.Notification, error) {
-	return db.WithQuery(ctx, func(ctx context.Context) (*ent.Notification, error) {
+) (*ent.Notification, bool, error) {
+	row, err := db.WithQuery(ctx, func(ctx context.Context) (*ent.Notification, error) {
 		q := r.client.Notification.Create().
 			SetScope(scope).
 			SetTitle(title).
@@ -45,8 +46,28 @@ func (r *Notifications) Create(
 			SetCreatedByLogin(createdByLogin).
 			SetNillableTargetUserID(targetUserID).
 			SetNillableExpiresAt(expiresAt)
+		if requestID != "" {
+			q.SetRequestID(requestID)
+		}
 		return q.Save(ctx)
 	})
+	if err == nil {
+		return row, true, nil
+	}
+	if !ent.IsConstraintError(err) || requestID == "" {
+		return nil, false, err
+	}
+
+	// Another replica may have committed this logical send first. Return that
+	// row as success so every RPC delivery produces the same reply without a
+	// second insert or cache invalidation.
+	row, lookupErr := db.WithQuery(ctx, func(ctx context.Context) (*ent.Notification, error) {
+		return r.client.Notification.Query().Where(notification.RequestIDEQ(requestID)).Only(ctx)
+	})
+	if lookupErr != nil {
+		return nil, false, lookupErr
+	}
+	return row, false, nil
 }
 
 // ListForAdmin returns rows newest-first for the admin console.

--- a/app/notifications/repository/notifications_test.go
+++ b/app/notifications/repository/notifications_test.go
@@ -21,7 +21,7 @@ func TestBroadcastVisibleToEveryUser(t *testing.T) {
 	repo := repository.New(client)
 	ctx := context.Background()
 
-	_, err := repo.Create(ctx, notification.ScopeBroadcast, nil, "Maintenance", "Downtime tonight", notification.LevelWarning, 1, "itsmavey", nil)
+	_, _, err := repo.Create(ctx, "broadcast-1", notification.ScopeBroadcast, nil, "Maintenance", "Downtime tonight", notification.LevelWarning, 1, "itsmavey", nil)
 	require.NoError(t, err)
 
 	rows, read, err := repo.ListForUser(ctx, 1001, 50)
@@ -42,7 +42,7 @@ func TestDirectNotificationScopedToTarget(t *testing.T) {
 	ctx := context.Background()
 
 	target := uint64(1001)
-	_, err := repo.Create(ctx, notification.ScopeDirect, &target, "Welcome", "Thanks for subscribing", notification.LevelInfo, 1, "itsmavey", nil)
+	_, _, err := repo.Create(ctx, "direct-1", notification.ScopeDirect, &target, "Welcome", "Thanks for subscribing", notification.LevelInfo, 1, "itsmavey", nil)
 	require.NoError(t, err)
 
 	rows, _, err := repo.ListForUser(ctx, 1001, 50)
@@ -61,7 +61,7 @@ func TestMarkReadIsIdempotentAndPerUser(t *testing.T) {
 	repo := repository.New(client)
 	ctx := context.Background()
 
-	row, err := repo.Create(ctx, notification.ScopeBroadcast, nil, "Heads up", "Body", notification.LevelInfo, 1, "itsmavey", nil)
+	row, _, err := repo.Create(ctx, "read-1", notification.ScopeBroadcast, nil, "Heads up", "Body", notification.LevelInfo, 1, "itsmavey", nil)
 	require.NoError(t, err)
 
 	require.NoError(t, repo.MarkRead(ctx, row.ID, 1001))
@@ -84,11 +84,11 @@ func TestExpiredNotificationExcluded(t *testing.T) {
 	ctx := context.Background()
 
 	past := time.Now().Add(-time.Hour)
-	_, err := repo.Create(ctx, notification.ScopeBroadcast, nil, "Expired", "Body", notification.LevelInfo, 1, "itsmavey", &past)
+	_, _, err := repo.Create(ctx, "expired-1", notification.ScopeBroadcast, nil, "Expired", "Body", notification.LevelInfo, 1, "itsmavey", &past)
 	require.NoError(t, err)
 
 	future := time.Now().Add(time.Hour)
-	_, err = repo.Create(ctx, notification.ScopeBroadcast, nil, "Still live", "Body", notification.LevelInfo, 1, "itsmavey", &future)
+	_, _, err = repo.Create(ctx, "live-1", notification.ScopeBroadcast, nil, "Still live", "Body", notification.LevelInfo, 1, "itsmavey", &future)
 	require.NoError(t, err)
 
 	rows, _, err := repo.ListForUser(ctx, 1001, 50)
@@ -104,7 +104,7 @@ func TestDeleteCascadesReads(t *testing.T) {
 	repo := repository.New(client)
 	ctx := context.Background()
 
-	row, err := repo.Create(ctx, notification.ScopeBroadcast, nil, "Bye", "Body", notification.LevelInfo, 1, "itsmavey", nil)
+	row, _, err := repo.Create(ctx, "delete-1", notification.ScopeBroadcast, nil, "Bye", "Body", notification.LevelInfo, 1, "itsmavey", nil)
 	require.NoError(t, err)
 	require.NoError(t, repo.MarkRead(ctx, row.ID, 1001))
 
@@ -115,4 +115,22 @@ func TestDeleteCascadesReads(t *testing.T) {
 	admin, err := repo.ListForAdmin(ctx, 20, 0)
 	require.NoError(t, err)
 	assert.Empty(t, admin)
+}
+
+func TestCreateIsIdempotentByRequestID(t *testing.T) {
+	client := enttest.Open(t, "sqlite3", "file:notifidempotency?mode=memory&cache=shared&_fk=1")
+	t.Cleanup(func() { _ = client.Close() })
+
+	repo := repository.New(client)
+	ctx := context.Background()
+
+	first, created, err := repo.Create(ctx, "send-123", notification.ScopeBroadcast, nil, "Once", "Body", notification.LevelInfo, 1, "itsmavey", nil)
+	require.NoError(t, err)
+	assert.True(t, created)
+
+	duplicate, created, err := repo.Create(ctx, "send-123", notification.ScopeBroadcast, nil, "Once", "Body", notification.LevelInfo, 1, "itsmavey", nil)
+	require.NoError(t, err)
+	assert.False(t, created)
+	assert.Equal(t, first.ID, duplicate.ID)
+	assert.Equal(t, 1, client.Notification.Query().CountX(ctx))
 }

--- a/app/notifications/rpc/admin.go
+++ b/app/notifications/rpc/admin.go
@@ -72,7 +72,6 @@ func (a *adminRPC) send(ctx context.Context, req notificationsrpc.SendRequest) n
 	if err != nil {
 		return notificationsrpc.SendReply{Error: "actor_id must be numeric"}
 	}
-
 	var target *uint64
 	if scope == notification.ScopeDirect {
 		id, err := a.resolveTarget(ctx, req.TargetUserID, req.TargetUsername)
@@ -82,14 +81,19 @@ func (a *adminRPC) send(ctx context.Context, req notificationsrpc.SendRequest) n
 		target = &id
 	}
 
-	row, err := a.repo.Create(ctx, scope, target, req.Title, req.Body, level, actorID, req.ActorLogin, req.ExpiresAt)
+	row, created, err := a.repo.Create(ctx, req.RequestID, scope, target, req.Title, req.Body, level, actorID, req.ActorLogin, req.ExpiresAt)
 	if err != nil {
 		return notificationsrpc.SendReply{Error: err.Error()}
 	}
 
-	a.invalidate(target)
-	a.log.Info("admin notification sent",
-		zap.String("scope", req.Scope), zap.Int("id", row.ID), zap.Uint64("actor", actorID))
+	if created {
+		a.invalidate(target)
+		a.log.Info("admin notification sent",
+			zap.String("scope", req.Scope), zap.Int("id", row.ID), zap.Uint64("actor", actorID))
+	} else {
+		a.log.Warn("duplicate admin notification suppressed",
+			zap.String("scope", req.Scope), zap.Int("id", row.ID), zap.Uint64("actor", actorID))
+	}
 
 	view := viewOf(row, false)
 	return notificationsrpc.SendReply{Notification: &view}

--- a/console/admin/src/lib/server/services.ts
+++ b/console/admin/src/lib/server/services.ts
@@ -396,7 +396,10 @@ export const notificationSend = defineWrite({
     level: params.level,
     expires_at: params.expiresAt || undefined,
     actor_id: params.actorId,
-    actor_login: params.actorLogin
+    actor_login: params.actorLogin,
+    // One value per logical send. If NATS transports the request over more
+    // than one route, every delivery carries the same database idempotency key.
+    request_id: crypto.randomUUID()
   }),
   map: (reply: { notification: NotificationWire }) => reply.notification,
   after: () => invalidate('notifications:')

--- a/deploy/k8s/nats-leaf-server.conf
+++ b/deploy/k8s/nats-leaf-server.conf
@@ -59,7 +59,17 @@ leafnodes {
 #
 # NATS prefers a locally-connected queue member before routing across the
 # cluster, so an RPC answered by a node-local responder pays zero hops; only a
-# call with no local responder takes one direct leaf-to-leaf hop. 
+# call with no local responder takes one direct leaf-to-leaf hop.
+cluster {
+  name: "nats-leaf"
+  port: 6222
+  routes: [ "nats://nats-leaf-peers.production.svc.cluster.local:6222" ]
+  # DNS already resolves every leaf pod. Suppress route gossip so each pair
+  # keeps one route instead of opening parallel paths that can duplicate queue
+  # interest propagation.
+  no_advertise: true
+}
+
 max_subscriptions: 0
 max_control_line: 4KB
 

--- a/deploy/k8s/nats-leaf.yaml
+++ b/deploy/k8s/nats-leaf.yaml
@@ -25,6 +25,9 @@ spec:
     metadata:
       annotations:
         linkerd.io/inject: enabled
+        # Cluster listener/routes cannot be introduced by a config reload;
+        # force a rolling restart when the leaf cluster topology changes.
+        itsbagelbot.dev/config-revision: "leaf-cluster-v1"
         # NATS speaks first on the wire, so protocol detection would stall;
         # opaque keeps Linkerd mTLS without the detection timeout. 6222 is the
         # leaf-to-leaf cluster route port.

--- a/internal/domain/rpc/notifications/notifications.go
+++ b/internal/domain/rpc/notifications/notifications.go
@@ -32,6 +32,7 @@ type SendRequest struct {
 	ExpiresAt      *time.Time `json:"expires_at,omitempty"`
 	ActorID        string     `json:"actor_id"`
 	ActorLogin     string     `json:"actor_login"`
+	RequestID      string     `json:"request_id,omitempty"`
 }
 
 type SendReply struct {

--- a/internal/domain/rpc/notifications/notifications_test.go
+++ b/internal/domain/rpc/notifications/notifications_test.go
@@ -7,10 +7,13 @@ import (
 
 func TestSendRequestDecodesStringActorID(t *testing.T) {
 	var req SendRequest
-	if err := json.Unmarshal([]byte(`{"actor_id":"804932984"}`), &req); err != nil {
+	if err := json.Unmarshal([]byte(`{"actor_id":"804932984","request_id":"send-123"}`), &req); err != nil {
 		t.Fatalf("decode send request: %v", err)
 	}
 	if req.ActorID != "804932984" {
 		t.Fatalf("actor id = %q, want %q", req.ActorID, "804932984")
+	}
+	if req.RequestID != "send-123" {
+		t.Fatalf("request id = %q, want %q", req.RequestID, "send-123")
 	}
 }


### PR DESCRIPTION
## Summary
- restore the NATS leaf cluster so queue groups share one routing domain
- force a rolling leaf restart for the topology change
- attach a UUID to each logical admin notification send
- enforce that request ID with a nullable unique database column
- return the existing row when another replica wins the insert race

## Verification
- `go test ./app/notifications/... ./internal/domain/rpc/notifications`
- `npm run check` in `console/admin`
- production `nats-server -t` accepted the patched config
- repository regression test confirms repeated request IDs create one row