### PR TITLE
fix(users): flush console caches on account delete/recreate

### DIFF
--- a/app/users/rpc/dashboard.go
+++ b/app/users/rpc/dashboard.go
@@ -87,6 +87,13 @@ func (d *dashboardRPC) handleUpsertUser(ctx context.Context, msg *nats.Msg) {
 		return
 	}
 
+	// Push-drop cached account state on every console replica: a recreated
+	// account must not keep serving another pod's deleted-era view for the
+	// rest of that pod's SWR window.
+	if err := invalidate.Publish(d.nc, d.invalidationPrefix, "status", req.UserID); err != nil {
+		d.log.Warn("upsert_user invalidation publish failed", zap.Error(err))
+	}
+
 	bus.Respond(msg, map[string]any{"ok": true})
 }
 
@@ -283,6 +290,15 @@ func (d *dashboardRPC) handleDeleteSelf(ctx context.Context, msg *nats.Msg) {
 		d.log.Error("delete_self user", zap.Error(err))
 		bus.Respond(msg, map[string]any{"error": err.Error()})
 		return
+	}
+
+	// "user" is not a routed scope on the console side, so it falls through to
+	// the '*' entry: a coarse per-user flush of every cached prefix. That is
+	// exactly right for deletion — no replica may keep any view of this user,
+	// and without this ping other pods would serve stale state for the rest of
+	// their SWR windows (the deleting pod only drops its own L1).
+	if err := invalidate.Publish(d.nc, d.invalidationPrefix, "user", req.UserID); err != nil {
+		d.log.Warn("delete_self invalidation publish failed", zap.Error(err))
 	}
 
 	bus.Respond(msg, map[string]any{"ok": true})

--- a/console/dashboard/src/routes/auth/callback/+server.ts
+++ b/console/dashboard/src/routes/auth/callback/+server.ts
@@ -98,7 +98,24 @@ export const GET: RequestHandler = async ({ url, cookies }) => {
       throw redirect(302, '/');
     }
 
-    // Issue session cookie immediately — no NATS round-trip on the hot path.
+    // Register the user BEFORE sealing a session. The (app) layout's
+    // ghost-session gate treats a missing user row as a deleted account and
+    // wipes the cookie, so minting a session for a row that failed to land
+    // is an instant sign-out loop. If the upsert cannot land, refuse the
+    // session and let the user retry the flow.
+    let registered = false;
+    try {
+      await rpc(`${DASHBOARD}.upsert_user`, {
+        user_id: userId,
+        username: login,
+        display_name: displayName
+      });
+      registered = true;
+    } catch (err: unknown) {
+      console.error('[callback] upsert_user failed, refusing session:', err);
+    }
+    if (!registered) throw redirect(302, '/login?e=retry');
+
     const value = seal({
       user_id: userId,
       login: login,
@@ -115,20 +132,15 @@ export const GET: RequestHandler = async ({ url, cookies }) => {
       maxAge: SESSION_TTL
     });
 
-    // Register the user, then persist the OAuth grant (access + refresh). The
-    // token row references the user, so upsert must land first. Both are awaited:
-    // skipping grant_save is exactly the bug where login succeeds but the bot
-    // never gets a token to act in the channel. A failure here is logged but does
-    // not block sign-in — the user can re-auth to retry.
+    // Persist the OAuth grant (access + refresh) after the user row exists —
+    // the token row references it. Grant failure stays non-fatal: the session
+    // is still valid (the row exists), the bot just has no channel token yet,
+    // and the home needs-attention strip surfaces that. The user can re-auth
+    // to retry.
     try {
-      await rpc(`${DASHBOARD}.upsert_user`, {
-        user_id: userId,
-        username: login,
-        display_name: displayName
-      });
       await saveGrant(userId, tokens.accessToken(), tokens.refreshToken());
     } catch (err: unknown) {
-      console.error('[callback] upsert_user/grant_save failed (non-fatal):', err);
+      console.error('[callback] grant_save failed (non-fatal):', err);
     }
   } catch (e) {
     if (e instanceof OAuth2RequestError) throw redirect(302, '/login?e=oauth');

--- a/console/dashboard/src/routes/login/+page.svelte
+++ b/console/dashboard/src/routes/login/+page.svelte
@@ -8,7 +8,8 @@
   const NOTICES: Record<string, string> = {
     signedout: 'You were signed out — that account no longer exists on ItsBagelBot.',
     banned: 'This account can no longer use the console.',
-    link: 'That share link is no longer valid. Ask the broadcaster for a new one.'
+    link: 'That share link is no longer valid. Ask the broadcaster for a new one.',
+    retry: 'Sign-in did not finish on our side — nothing was saved. Please try again.'
   };
   const notice = $derived(NOTICES[page.url.searchParams.get('e') ?? ''] ?? null);
 


### PR DESCRIPTION
## Root cause (Jul 2 /goodbye incident)

Deleted-then-recreated accounts bounced between pods seeing different account states:

1. `delete_self` and `upsert_user` published **no console cache-bus invalidation** — only the serving pod dropped its own L1. Other dashboard pods kept the stale `account:<id>` view for up to freshMs+swrMs (~12 min), so reload-spam hit pods in different cache states.
2. The OAuth callback sealed the session cookie **before** `upsert_user` and treated its failure as non-fatal — a failed upsert (e.g. during NATS credential churn) minted a valid session for a nonexistent user row, which the ghost-session gate then bounced in a sign-out loop.

## Changes

- **users/rpc/dashboard.go**
  - `delete_self`: publish invalidation scope `user` — unrouted on the console side, falls through to the `'*'` entry = coarse per-user flush of every cached prefix on every replica.
  - `upsert_user`: publish scope `status` — recreated account drops the deleted-era `account/tier/ban/billing` view everywhere.
- **dashboard auth callback**: `upsert_user` runs before sealing; failure refuses the session with `302 /login?e=retry`. `grant_save` moved after the cookie, stays non-fatal (missing grant surfaces on the home needs-attention strip).
- **login page**: banner for `e=retry`.

## Verification

- `go build ./app/users/...` clean; `go test ./app/users/rpc ./app/users/repository` ok
- `svelte-check` on dashboard: 0 errors / 0 warnings
- Live fleet probed post-deploy of 5933fa2 with a minted ghost session: 12/12 `GET /` → `302 /login?e=signedout`, 9/9 `GET /goodbye` → `302 /login` — this PR closes the two remaining gaps (cross-pod flush + callback ordering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)