### PR TITLE
feat: gift premium to another streamer

### DIFF
--- a/app/transactions/main.go
+++ b/app/transactions/main.go
@@ -74,6 +74,14 @@ func main() {
 
 	repo := repository.NewTransactions(client, pub)
 
+	// RPC-plane connection (TRANSACTIONS_RPC account): answers the checkout
+	// basket verb and issues the recipient-lookup / gift-notification requests.
+	nc, err := bus.Connect(bus.RPCURL(natsURL), serviceName)
+	if err != nil {
+		log.Fatal("failed to connect rpc nats", zap.Error(err))
+	}
+	defer nc.Close()
+
 	// Checkout RPC (dashboard -> basket_create). Optional: without the Tebex
 	// Headless credentials the service stays webhook-only, exactly as before.
 	checkoutConfigured := false
@@ -93,14 +101,9 @@ func main() {
 			log.Fatal("failed to build tebex client", zap.Error(err))
 		}
 
-		nc, err := bus.Connect(bus.RPCURL(natsURL), serviceName)
-		if err != nil {
-			log.Fatal("failed to connect rpc nats", zap.Error(err))
-		}
-		defer nc.Close()
-
+		userGetSubject := env.Get("NATS_ADMIN_USER_SUBJECT_PREFIX", "bagel.rpc.admin.user") + ".get"
 		prefix := env.Get("NATS_TRANSACTIONS_SUBJECT_PREFIX", "bagel.rpc.transactions")
-		if err := rpc.SubscribeCheckout(nc, tebexClient, prefix, "transactions-rpc", nrApp, log); err != nil {
+		if err := rpc.SubscribeCheckout(nc, tebexClient, prefix, userGetSubject, "transactions-rpc", nrApp, log); err != nil {
 			log.Fatal("failed to subscribe checkout rpc", zap.Error(err))
 		}
 		checkoutConfigured = true
@@ -108,9 +111,13 @@ func main() {
 		log.Warn("tebex checkout rpc disabled: TEBEX_WEBSTORE_TOKEN / TEBEX_PACKAGE_ID not configured")
 	}
 
+	sendSubject := env.Get("NATS_ADMIN_NOTIFICATIONS_SUBJECT_PREFIX", "bagel.rpc.admin.notifications") + ".send"
+	notifier := rpc.NewGiftNotifier(nc, sendSubject)
+
 	listenAddr := env.Get("LISTEN_ADDR", ":8080")
 	httpApp := web.New(repo, web.Config{
 		WebhookSecret: env.Get("TEBEX_WEBHOOK_SECRET", ""),
+		NotifyGift:    notifier.Notify,
 	}, log.Named("http"))
 
 	serverErr := make(chan error, 1)

--- a/app/transactions/rpc/checkout.go
+++ b/app/transactions/rpc/checkout.go
@@ -3,6 +3,7 @@ package rpc
 import (
 	"context"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/nats-io/nats.go"
@@ -11,40 +12,115 @@ import (
 
 	"ItsBagelBot/app/transactions/tebex"
 	transactionsrpc "ItsBagelBot/internal/domain/rpc/transactions"
+	usersrpc "ItsBagelBot/internal/domain/rpc/users"
 	"ItsBagelBot/pkg/bus"
 )
 
 type checkoutRPC struct {
-	tebex *tebex.Client
-	log   *zap.Logger
+	tebex          *tebex.Client
+	nc             *nats.Conn
+	userGetSubject string
+	log            *zap.Logger
 }
 
 // SubscribeCheckout registers the dashboard-facing basket_create verb: mint a
-// Tebex basket for one user so the dashboard can launch the embedded checkout.
-func SubscribeCheckout(nc *nats.Conn, client *tebex.Client, prefix, queueGroup string, app *newrelic.Application, log *zap.Logger) error {
-	c := &checkoutRPC{tebex: client, log: log}
+// Tebex basket so the dashboard can launch the embedded checkout, either for
+// the signed-in buyer or as a gift to another registered user. userGetSubject
+// is the users service admin lookup (bagel.rpc.admin.user.get) used to resolve
+// and vet gift recipients.
+func SubscribeCheckout(nc *nats.Conn, client *tebex.Client, prefix, userGetSubject, queueGroup string, app *newrelic.Application, log *zap.Logger) error {
+	c := &checkoutRPC{tebex: client, nc: nc, userGetSubject: userGetSubject, log: log}
 
-	// Basket creation is two upstream HTTP calls, so give it more room than the
-	// default in-cluster RPC budget.
+	// Basket creation is two upstream HTTP calls (plus a recipient lookup for
+	// gifts), so give it more room than the default in-cluster RPC budget.
 	return bus.QueueSubscribeJSON[transactionsrpc.BasketCreateRequest, transactionsrpc.BasketCreateReply](
 		nc, prefix+".basket_create", queueGroup, 15*time.Second, app, log, c.basketCreate)
 }
 
 func (c *checkoutRPC) basketCreate(ctx context.Context, req transactionsrpc.BasketCreateRequest) transactionsrpc.BasketCreateReply {
 
-	userID, err := strconv.ParseUint(req.UserID, 10, 64)
-	if err != nil || userID == 0 {
+	buyerID, err := strconv.ParseUint(req.UserID, 10, 64)
+	if err != nil || buyerID == 0 {
 		return transactionsrpc.BasketCreateReply{Error: "user_id must be numeric"}
 	}
 
-	basket, err := c.tebex.CreateBasket(ctx, userID, req.Username)
+	spec := tebex.BasketSpec{UserID: buyerID, Username: req.Username}
+	recipientLogin := ""
+
+	if recipient := normalizeLogin(req.RecipientUsername); recipient != "" {
+		view, err := c.resolveRecipient(ctx, recipient)
+		if err != nil {
+			return transactionsrpc.BasketCreateReply{Error: err.Error()}
+		}
+		if view.ID == buyerID {
+			return transactionsrpc.BasketCreateReply{Error: "that is your own account — use Subscribe instead"}
+		}
+		spec = tebex.BasketSpec{
+			UserID:        view.ID,
+			Username:      view.Username,
+			GiftedByID:    buyerID,
+			GiftedByLogin: req.Username,
+		}
+		recipientLogin = view.Username
+	}
+
+	basket, err := c.tebex.CreateBasket(ctx, spec)
 	if err != nil {
-		c.log.Warn("tebex basket create failed", zap.Uint64("user_id", userID), zap.Error(err))
+		c.log.Warn("tebex basket create failed",
+			zap.Uint64("user_id", spec.UserID), zap.Uint64("gifted_by", spec.GiftedByID), zap.Error(err))
 		return transactionsrpc.BasketCreateReply{Error: "checkout is unavailable right now"}
 	}
 
 	return transactionsrpc.BasketCreateReply{
-		Ident:       basket.Ident,
-		CheckoutURL: basket.CheckoutURL,
+		Ident:          basket.Ident,
+		CheckoutURL:    basket.CheckoutURL,
+		RecipientLogin: recipientLogin,
 	}
+}
+
+// resolveRecipient vets a gift target: the Twitch login must belong to a
+// registered ItsBagelBot user who is not banned and does not already have a
+// paid or VIP plan. Error strings are user-facing (the dashboard surfaces them
+// on the gift form verbatim).
+func (c *checkoutRPC) resolveRecipient(ctx context.Context, login string) (*usersrpc.AdminUserView, error) {
+
+	reply, err := bus.RequestJSONTimeout[usersrpc.AdminReply](ctx, c.nc, c.userGetSubject,
+		usersrpc.AdminRequest{Username: login}, 3*time.Second)
+	if err != nil {
+		if _, isReply := err.(bus.RPCReplyError); isReply {
+			return nil, errRecipientNotRegistered
+		}
+		c.log.Warn("gift recipient lookup failed", zap.String("login", login), zap.Error(err))
+		return nil, errRecipientLookup
+	}
+	if reply.User == nil {
+		return nil, errRecipientNotRegistered
+	}
+	if reply.User.Banned {
+		return nil, errRecipientNotEligible
+	}
+	switch strings.ToLower(reply.User.Status) {
+	case "paid", "vip":
+		return nil, errRecipientAlreadyPremium
+	}
+	return reply.User, nil
+}
+
+var (
+	errRecipientNotRegistered  = constError("that user hasn't signed in to ItsBagelBot yet, so premium can't be gifted to them")
+	errRecipientNotEligible    = constError("that account can't receive premium")
+	errRecipientAlreadyPremium = constError("that user already has premium")
+	errRecipientLookup         = constError("could not verify the recipient right now — try again in a moment")
+)
+
+type constError string
+
+func (e constError) Error() string { return string(e) }
+
+// normalizeLogin turns user input into a Twitch login: trimmed, lowercased,
+// leading @ dropped.
+func normalizeLogin(input string) string {
+	login := strings.TrimSpace(input)
+	login = strings.TrimPrefix(login, "@")
+	return strings.ToLower(login)
 }

--- a/app/transactions/rpc/giftnotify.go
+++ b/app/transactions/rpc/giftnotify.go
@@ -1,0 +1,56 @@
+package rpc
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/nats-io/nats.go"
+
+	"ItsBagelBot/app/transactions/web"
+	notificationsrpc "ItsBagelBot/internal/domain/rpc/notifications"
+	"ItsBagelBot/pkg/bus"
+)
+
+// GiftNotifier sends the "you received premium" direct notification through the
+// notifications service admin send RPC when a gifted payment lands.
+type GiftNotifier struct {
+	nc          *nats.Conn
+	sendSubject string
+}
+
+func NewGiftNotifier(nc *nats.Conn, sendSubject string) *GiftNotifier {
+	return &GiftNotifier{nc: nc, sendSubject: sendSubject}
+}
+
+// Notify satisfies web.Config.NotifyGift. The webhook id doubles as the
+// notification request id, so Tebex webhook retries collapse into one row on
+// the notifications side.
+func (g *GiftNotifier) Notify(ctx context.Context, notice web.GiftNotice) error {
+
+	body := "You have been gifted ItsBagelBot Premium"
+	if notice.GiftedByLogin != "" {
+		body = fmt.Sprintf("%s gifted you ItsBagelBot Premium", notice.GiftedByLogin)
+	}
+	body += " — the priority lane and premium perks are active on your account now."
+
+	reply, err := bus.RequestJSONTimeout[notificationsrpc.SendReply](ctx, g.nc, g.sendSubject,
+		notificationsrpc.SendRequest{
+			Scope:        "direct",
+			TargetUserID: strconv.FormatUint(notice.RecipientID, 10),
+			Title:        "You received Premium",
+			Body:         body,
+			Level:        "success",
+			ActorID:      strconv.FormatUint(notice.GiftedByID, 10),
+			ActorLogin:   notice.GiftedByLogin,
+			RequestID:    "tebex-gift-" + notice.WebhookID,
+		}, 5*time.Second)
+	if err != nil {
+		return err
+	}
+	if reply.Error != "" {
+		return fmt.Errorf("notifications send: %s", reply.Error)
+	}
+	return nil
+}

--- a/app/transactions/tebex/client.go
+++ b/app/transactions/tebex/client.go
@@ -72,19 +72,36 @@ func New(cfg Config) (*Client, error) {
 	return &Client{cfg: cfg}, nil
 }
 
-// CreateBasket mints a basket for one user and adds the premium package. The
+// BasketSpec names who the entitlement lands on (UserID/Username) and, for
+// gifts, who pays (GiftedByID/GiftedByLogin). For a self-purchase the gifted-by
+// fields stay zero.
+type BasketSpec struct {
+	UserID        uint64
+	Username      string
+	GiftedByID    uint64
+	GiftedByLogin string
+}
+
+// CreateBasket mints a basket and adds the premium package. The recipient's
 // user id rides in the basket's custom payload, which Tebex echoes back on the
-// payment webhook — that is the whole attribution chain.
-func (c *Client) CreateBasket(ctx context.Context, userID uint64, username string) (Basket, error) {
+// payment webhook — that is the whole attribution chain; gifted_by is carried
+// alongside for the gift notification and the audit trail.
+func (c *Client) CreateBasket(ctx context.Context, spec BasketSpec) (Basket, error) {
+
+	custom := map[string]string{
+		"user_id":  strconv.FormatUint(spec.UserID, 10),
+		"username": spec.Username,
+	}
+	if spec.GiftedByID != 0 {
+		custom["gifted_by"] = strconv.FormatUint(spec.GiftedByID, 10)
+		custom["gifted_by_login"] = spec.GiftedByLogin
+	}
 
 	create := map[string]any{
 		"complete_url":           c.cfg.CompleteURL,
 		"cancel_url":             c.cfg.CancelURL,
 		"complete_auto_redirect": true,
-		"custom": map[string]string{
-			"user_id":  strconv.FormatUint(userID, 10),
-			"username": username,
-		},
+		"custom":                 custom,
 	}
 
 	var created basketData

--- a/app/transactions/tebex/client_test.go
+++ b/app/transactions/tebex/client_test.go
@@ -53,7 +53,7 @@ func TestCreateBasket(t *testing.T) {
 		})
 	})
 
-	basket, err := newTestClient(t, mux).CreateBasket(context.Background(), 804932984, "mavey")
+	basket, err := newTestClient(t, mux).CreateBasket(context.Background(), BasketSpec{UserID: 804932984, Username: "mavey"})
 	if err != nil {
 		t.Fatalf("CreateBasket: %v", err)
 	}
@@ -69,6 +69,9 @@ func TestCreateBasket(t *testing.T) {
 	if custom["user_id"] != "804932984" {
 		t.Errorf("custom.user_id = %v, want 804932984", custom["user_id"])
 	}
+	if _, present := custom["gifted_by"]; present {
+		t.Errorf("self-purchase basket must not carry gifted_by, got %v", custom["gifted_by"])
+	}
 	if createBody["complete_url"] != "https://dashboard.example/billing?checkout=complete" {
 		t.Errorf("complete_url = %v", createBody["complete_url"])
 	}
@@ -81,13 +84,59 @@ func TestCreateBasket(t *testing.T) {
 	}
 }
 
+func TestCreateBasketGiftCarriesAttribution(t *testing.T) {
+	var createBody map[string]any
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/accounts/token-123/baskets", func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&createBody); err != nil {
+			t.Fatalf("decode create body: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{
+				"ident": "bkt-gift",
+				"links": map[string]any{"checkout": "https://pay.tebex.io/bkt-gift"},
+			},
+		})
+	})
+	mux.HandleFunc("POST /api/baskets/bkt-gift/packages", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{
+				"ident": "bkt-gift",
+				"links": map[string]any{"checkout": "https://pay.tebex.io/bkt-gift"},
+			},
+		})
+	})
+
+	_, err := newTestClient(t, mux).CreateBasket(context.Background(), BasketSpec{
+		UserID:        111,
+		Username:      "recipient",
+		GiftedByID:    804932984,
+		GiftedByLogin: "mavey",
+	})
+	if err != nil {
+		t.Fatalf("CreateBasket: %v", err)
+	}
+
+	custom, _ := createBody["custom"].(map[string]any)
+	if custom["user_id"] != "111" {
+		t.Errorf("custom.user_id = %v, want recipient 111", custom["user_id"])
+	}
+	if custom["gifted_by"] != "804932984" {
+		t.Errorf("custom.gifted_by = %v, want 804932984", custom["gifted_by"])
+	}
+	if custom["gifted_by_login"] != "mavey" {
+		t.Errorf("custom.gifted_by_login = %v, want mavey", custom["gifted_by_login"])
+	}
+}
+
 func TestCreateBasketUpstreamError(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"message":"store disabled"}`, http.StatusForbidden)
 	})
 
-	if _, err := newTestClient(t, mux).CreateBasket(context.Background(), 1, ""); err == nil {
+	if _, err := newTestClient(t, mux).CreateBasket(context.Background(), BasketSpec{UserID: 1}); err == nil {
 		t.Fatal("expected error on 403 upstream")
 	}
 }
@@ -98,7 +147,7 @@ func TestCreateBasketMissingIdent(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{}})
 	})
 
-	if _, err := newTestClient(t, mux).CreateBasket(context.Background(), 1, ""); err == nil {
+	if _, err := newTestClient(t, mux).CreateBasket(context.Background(), BasketSpec{UserID: 1}); err == nil {
 		t.Fatal("expected error on missing ident")
 	}
 }

--- a/app/transactions/web/server.go
+++ b/app/transactions/web/server.go
@@ -24,9 +24,23 @@ type Store interface {
 	SaveWebhookEvent(ctx context.Context, event repository.WebhookEvent) error
 }
 
+// GiftNotice describes a gifted entitlement that just landed: who received it,
+// who paid, and the webhook id (used as the idempotency key so Tebex's webhook
+// retries never duplicate the notification).
+type GiftNotice struct {
+	WebhookID     string
+	RecipientID   uint64
+	GiftedByID    uint64
+	GiftedByLogin string
+}
+
 type Config struct {
 	WebhookSecret string
 	Ready         func() bool
+	// NotifyGift is called after a gifted payment is recorded (initial payment
+	// only, not renewals). Best-effort: failures are logged, never surfaced to
+	// Tebex — the entitlement is already durable at that point.
+	NotifyGift func(ctx context.Context, notice GiftNotice) error
 }
 
 type Server struct {
@@ -67,6 +81,9 @@ type usernameRef struct {
 type recordablePayment struct {
 	TransactionID string
 	UserID        uint64
+	// Gift attribution from the basket custom payload; zero for self-purchases.
+	GiftedByID    uint64
+	GiftedByLogin string
 }
 
 var errNoRecordablePayment = errors.New("no recordable Tebex payment for event")
@@ -167,6 +184,7 @@ func (s *Server) tebexWebhook(c *fiber.Ctx) error {
 		if err := s.saveEvent(ctx, event, repository.WebhookProcessed, payment, ""); err != nil {
 			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "failed to save webhook state"})
 		}
+		s.notifyGift(ctx, event, payment)
 		return c.SendStatus(fiber.StatusNoContent)
 	}
 
@@ -199,6 +217,34 @@ func (s *Server) failEvent(c *fiber.Ctx, event tebexEvent, payment recordablePay
 		zap.Error(cause),
 	)
 	return c.Status(status).JSON(fiber.Map{"error": cause.Error()})
+}
+
+// notifyGift tells the recipient their gifted premium landed. Initial payments
+// only — a renewal keeps the plan running and does not warrant a ping. Never
+// fails the webhook: the entitlement is already recorded.
+func (s *Server) notifyGift(ctx context.Context, event tebexEvent, payment recordablePayment) {
+
+	if s.cfg.NotifyGift == nil || payment.GiftedByID == 0 {
+		return
+	}
+	if event.Type == "recurring-payment.renewed" {
+		return
+	}
+
+	err := s.cfg.NotifyGift(ctx, GiftNotice{
+		WebhookID:     event.ID,
+		RecipientID:   payment.UserID,
+		GiftedByID:    payment.GiftedByID,
+		GiftedByLogin: payment.GiftedByLogin,
+	})
+	if err != nil {
+		s.log.Warn("gift notification failed",
+			zap.String("webhook_id", event.ID),
+			zap.Uint64("recipient", payment.UserID),
+			zap.Uint64("gifted_by", payment.GiftedByID),
+			zap.Error(err),
+		)
+	}
 }
 
 func (s *Server) saveEvent(ctx context.Context, event tebexEvent, status repository.WebhookStatus, payment recordablePayment, message string) error {
@@ -272,10 +318,44 @@ func recordableFromPayment(payment paymentSubject) (recordablePayment, error) {
 	}
 
 	if userID, ok := userIDFromPayment(payment); ok {
-		return recordablePayment{TransactionID: payment.TransactionID, UserID: userID}, nil
+		giftedBy, giftedByLogin := giftFromPayment(payment)
+		// A basket gifted to yourself is a plain purchase; drop the marker.
+		if giftedBy == userID {
+			giftedBy, giftedByLogin = 0, ""
+		}
+		return recordablePayment{
+			TransactionID: payment.TransactionID,
+			UserID:        userID,
+			GiftedByID:    giftedBy,
+			GiftedByLogin: giftedByLogin,
+		}, nil
 	}
 
 	return recordablePayment{TransactionID: payment.TransactionID}, errors.New("payment user id missing")
+}
+
+// giftFromPayment reads the gifted_by attribution the basket carried. Checked
+// on the payment-level custom payload first, then per-product (mirrors
+// userIDFromPayment's search order).
+func giftFromPayment(payment paymentSubject) (uint64, string) {
+
+	if id, ok := rawUint(payment.Custom["gifted_by"]); ok {
+		return id, rawString(payment.Custom["gifted_by_login"])
+	}
+	for _, product := range payment.Products {
+		if id, ok := rawUint(product.Custom["gifted_by"]); ok {
+			return id, rawString(product.Custom["gifted_by_login"])
+		}
+	}
+	return 0, ""
+}
+
+func rawString(raw json.RawMessage) string {
+	var value string
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return ""
+	}
+	return value
 }
 
 func userIDFromPayment(payment paymentSubject) (uint64, bool) {

--- a/app/transactions/web/server_test.go
+++ b/app/transactions/web/server_test.go
@@ -193,3 +193,83 @@ func doWebhook(t *testing.T, app *fiber.App, body string, secret string, validSi
 	require.NoError(t, err)
 	return resp
 }
+
+func TestGiftedPaymentNotifiesRecipientOnce(t *testing.T) {
+
+	store := &fakeStore{}
+	var notices []GiftNotice
+	app := New(store, Config{
+		WebhookSecret: testSecret,
+		NotifyGift: func(_ context.Context, n GiftNotice) error {
+			notices = append(notices, n)
+			return nil
+		},
+	}, nil)
+
+	body := `{"id":"evt-gift","type":"payment.completed","subject":{"transaction_id":"tbx-gift-1","custom":{"user_id":"111","username":"recipient","gifted_by":"804932984","gifted_by_login":"mavey"}}}`
+	resp := doWebhook(t, app, body, testSecret, true)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.Len(t, store.records, 1)
+	assert.Equal(t, uint64(111), store.records[0].UserID)
+	require.Len(t, notices, 1)
+	assert.Equal(t, GiftNotice{
+		WebhookID:     "evt-gift",
+		RecipientID:   111,
+		GiftedByID:    804932984,
+		GiftedByLogin: "mavey",
+	}, notices[0])
+}
+
+func TestGiftNotificationSkippedOnRenewalAndSelfPurchase(t *testing.T) {
+
+	store := &fakeStore{}
+	var notices []GiftNotice
+	app := New(store, Config{
+		WebhookSecret: testSecret,
+		NotifyGift: func(_ context.Context, n GiftNotice) error {
+			notices = append(notices, n)
+			return nil
+		},
+	}, nil)
+
+	// Renewal of a gifted subscription: entitlement recorded, no ping.
+	renewal := `{"id":"evt-renew","type":"recurring-payment.renewed","subject":{"reference":"sub-1","last_payment":{"transaction_id":"tbx-gift-2","custom":{"user_id":"111","gifted_by":"804932984","gifted_by_login":"mavey"}}}}`
+	resp := doWebhook(t, app, renewal, testSecret, true)
+	resp.Body.Close()
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+
+	// Self-purchase (no gifted_by): no ping.
+	self := `{"id":"evt-self","type":"payment.completed","subject":{"transaction_id":"tbx-3","custom":{"user_id":"222"}}}`
+	resp = doWebhook(t, app, self, testSecret, true)
+	resp.Body.Close()
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+
+	// Basket "gifted" to its own buyer collapses to a plain purchase: no ping.
+	selfGift := `{"id":"evt-selfgift","type":"payment.completed","subject":{"transaction_id":"tbx-4","custom":{"user_id":"333","gifted_by":"333","gifted_by_login":"me"}}}`
+	resp = doWebhook(t, app, selfGift, testSecret, true)
+	resp.Body.Close()
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+
+	assert.Len(t, store.records, 3)
+	assert.Empty(t, notices)
+}
+
+func TestGiftNotificationFailureDoesNotFailWebhook(t *testing.T) {
+
+	store := &fakeStore{}
+	app := New(store, Config{
+		WebhookSecret: testSecret,
+		NotifyGift: func(_ context.Context, _ GiftNotice) error {
+			return context.DeadlineExceeded
+		},
+	}, nil)
+
+	body := `{"id":"evt-gift-fail","type":"payment.completed","subject":{"transaction_id":"tbx-5","custom":{"user_id":"111","gifted_by":"804932984","gifted_by_login":"mavey"}}}`
+	resp := doWebhook(t, app, body, testSecret, true)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.Len(t, store.records, 1)
+}

--- a/console/dashboard/src/lib/server/services.ts
+++ b/console/dashboard/src/lib/server/services.ts
@@ -418,21 +418,28 @@ export const billingState = defineRead({
   }
 });
 
-// Mint a Tebex Headless basket for this user via the transactions service. The
-// ident feeds Tebex.js's embedded checkout; the checkout URL is the hosted
-// fallback. Never cached — every checkout attempt gets a fresh basket. Basket
-// creation is two Tebex HTTP calls upstream, so the timeout is looser than the
-// in-cluster read budget.
-export type CheckoutBasket = { ident: string; checkoutUrl: string | null };
+// Mint a Tebex Headless basket via the transactions service. The ident feeds
+// Tebex.js's embedded checkout; the checkout URL is the hosted fallback. When
+// recipientUsername is set the basket is a gift: the transactions service
+// resolves and vets the recipient (registered, not banned, not already
+// premium) and the entitlement lands on them while this user pays. Never
+// cached — every checkout attempt gets a fresh basket. Basket creation is two
+// Tebex HTTP calls upstream, so the timeout is looser than the in-cluster
+// read budget.
+export type CheckoutBasket = { ident: string; checkoutUrl: string | null; recipientLogin: string | null };
 
-export async function checkoutBasketCreate(userId: string, username: string): Promise<CheckoutBasket> {
-  const r = await rpc<{ ident?: string; checkout_url?: string }>(
+export async function checkoutBasketCreate(
+  userId: string,
+  username: string,
+  recipientUsername?: string
+): Promise<CheckoutBasket> {
+  const r = await rpc<{ ident?: string; checkout_url?: string; recipient_login?: string }>(
     `${SUB.transactions}.basket_create`,
-    { user_id: userId, username },
+    { user_id: userId, username, recipient_username: recipientUsername || undefined },
     16000
   );
   if (!r.ident) throw new Error('basket create returned no ident');
-  return { ident: r.ident, checkoutUrl: r.checkout_url ?? null };
+  return { ident: r.ident, checkoutUrl: r.checkout_url ?? null, recipientLogin: r.recipient_login ?? null };
 }
 
 // ---------------------------------------------------------------------------

--- a/console/dashboard/src/routes/(app)/billing/+page.server.ts
+++ b/console/dashboard/src/routes/(app)/billing/+page.server.ts
@@ -1,6 +1,7 @@
 import type { Actions, PageServerLoad } from './$types';
 import { redirect, fail } from '@sveltejs/kit';
 import { billingState, checkoutBasketCreate, type BillingState } from '$lib/server/services';
+import { RpcError } from '@bagel/shared/server/nats';
 import { env } from '$env/dynamic/private';
 
 type BillingLinks = {
@@ -101,6 +102,38 @@ export const actions: Actions = {
     const url = links().checkoutUrl;
     if (!url) return fail(503, { error: 'Subscriptions are not available right now.' });
     throw redirect(303, url);
+  },
+
+  // Gift premium to another registered user. The transactions service resolves
+  // the Twitch login and vets the recipient (registered, not banned, not
+  // already premium); its error strings are user-facing, so surface them
+  // verbatim on the gift form. The buyer's own plan does not gate gifting.
+  gift: async ({ locals, request }) => {
+    const s = locals.session;
+    if (!s) return fail(401, { gift: true, error: 'Not signed in.' });
+    if (s.delegate_of || s.impersonator_id) {
+      return fail(403, { gift: true, error: 'Only the account owner can gift premium.' });
+    }
+
+    const form = await request.formData();
+    const recipient = String(form.get('recipient') ?? '').trim();
+    if (!recipient) return fail(400, { gift: true, error: 'Enter the Twitch username to gift to.' });
+    if (!/^@?[A-Za-z0-9_]{3,25}$/.test(recipient)) {
+      return fail(400, { gift: true, error: 'That does not look like a Twitch username.' });
+    }
+
+    try {
+      const basket = await checkoutBasketCreate(s.user_id, s.login, recipient);
+      return {
+        ident: basket.ident,
+        checkoutUrl: basket.checkoutUrl,
+        recipientLogin: basket.recipientLogin
+      };
+    } catch (err) {
+      if (err instanceof RpcError) return fail(409, { gift: true, error: err.message });
+      console.error('[billing] gift basket create failed:', err);
+      return fail(502, { gift: true, error: 'Gifting is not available right now. Try again in a moment.' });
+    }
   },
 
   // Cancellation/account management lives on Tebex. We still gate the button

--- a/console/dashboard/src/routes/(app)/billing/+page.svelte
+++ b/console/dashboard/src/routes/(app)/billing/+page.svelte
@@ -37,6 +37,45 @@
 
   let launching = $state(false);
   let subscribeForm = $state<HTMLFormElement | null>(null);
+  let giftLaunching = $state(false);
+  let giftRecipient = $state('');
+
+  // Shared enhance handler for both checkout forms (subscribe + gift): a
+  // successful action returns a basket ident to launch, the hosted-checkout
+  // fallback arrives as an external redirect, anything else releases the
+  // button and lets the form-error toast handle it.
+  function checkoutEnhance(setBusy: (busy: boolean) => void) {
+    return () => {
+      setBusy(true);
+      return async ({
+        result,
+        update
+      }: {
+        result: import('@sveltejs/kit').ActionResult;
+        update: () => Promise<void>;
+      }) => {
+        if (result.type === 'success' && result.data?.ident) {
+          if (result.data.recipientLogin) {
+            toast('ok', `Gifting premium to ${String(result.data.recipientLogin)} — complete the payment to send it.`);
+          }
+          await launchCheckout(
+            String(result.data.ident),
+            result.data.checkoutUrl ? String(result.data.checkoutUrl) : null,
+            setBusy
+          );
+          return;
+        }
+        if (result.type === 'redirect') {
+          // Hosted-checkout fallback is an external URL; goto() cannot take
+          // it, so navigate directly.
+          window.location.href = result.location;
+          return;
+        }
+        setBusy(false);
+        await update();
+      };
+    };
+  }
 
   function waitForTebex(timeoutMs = 6000): Promise<TebexGlobal | null> {
     return new Promise((resolve) => {
@@ -51,7 +90,7 @@
     });
   }
 
-  async function launchCheckout(ident: string, fallbackUrl: string | null) {
+  async function launchCheckout(ident: string, fallbackUrl: string | null, setBusy: (busy: boolean) => void) {
     const tebex = await waitForTebex();
     if (!tebex) {
       // Script blocked or offline: hosted checkout still works.
@@ -59,14 +98,14 @@
         window.location.href = fallbackUrl;
         return;
       }
-      launching = false;
+      setBusy(false);
       toast('err', 'Could not open checkout. Please try again.');
       return;
     }
 
     tebex.checkout.init({ ident, theme: 'dark' });
     tebex.checkout.on('payment:complete', () => {
-      toast('ok', 'Payment received — your plan activates within a minute.');
+      toast('ok', 'Payment received — it activates within a minute.');
       tebex.checkout.close();
       // The entitlement lands via the Tebex webhook; refetch shortly after.
       setTimeout(() => void invalidateAll(), 1500);
@@ -75,7 +114,7 @@
       toast('err', 'Payment did not go through. No charge was made.');
     });
     tebex.checkout.on('close', () => {
-      launching = false;
+      setBusy(false);
     });
     tebex.checkout.launch();
   }
@@ -171,26 +210,7 @@
             method="POST"
             action="?/subscribe"
             bind:this={subscribeForm}
-            use:enhance={() => {
-              launching = true;
-              return async ({ result, update }) => {
-                if (result.type === 'success' && result.data?.ident) {
-                  await launchCheckout(
-                    String(result.data.ident),
-                    result.data.checkoutUrl ? String(result.data.checkoutUrl) : null
-                  );
-                  return;
-                }
-                if (result.type === 'redirect') {
-                  // Hosted-checkout fallback is an external URL; goto() cannot
-                  // take it, so navigate directly.
-                  window.location.href = result.location;
-                  return;
-                }
-                launching = false;
-                await update();
-              };
-            }}
+            use:enhance={checkoutEnhance((busy) => (launching = busy))}
           >
             <button class="btn primary" type="submit" disabled={launching}>
               <Icon name="heart" size={14} />
@@ -205,6 +225,43 @@
           <p class="hint tiny">You will leave the dashboard and manage the subscription on Tebex.</p>
         {/if}
       </div>
+    </div>
+  </Card>
+
+  <!-- GIFT: pay for someone else's premium. Open regardless of your own plan;
+       the recipient must be a registered, non-premium ItsBagelBot user (the
+       transactions service vets this and its errors surface as toasts). -->
+  <Card class="billing-card">
+    <div class="gift-top">
+      <div>
+        <h2>Gift premium</h2>
+        <p class="hint">
+          Pay for another streamer's premium. They need an ItsBagelBot account, and they get a
+          notification the moment your payment lands.
+        </p>
+      </div>
+      <form
+        class="gift-form"
+        method="POST"
+        action="?/gift"
+        use:enhance={checkoutEnhance((busy) => (giftLaunching = busy))}
+      >
+        <input
+          class="gift-input"
+          type="text"
+          name="recipient"
+          placeholder="Twitch username"
+          autocomplete="off"
+          spellcheck="false"
+          maxlength="26"
+          bind:value={giftRecipient}
+          disabled={giftLaunching}
+        />
+        <button class="btn primary" type="submit" disabled={giftLaunching || !giftRecipient.trim()}>
+          <Icon name="heart" size={14} />
+          {giftLaunching ? 'Opening checkout…' : 'Gift premium'}
+        </button>
+      </form>
     </div>
   </Card>
 </section>
@@ -261,9 +318,39 @@
   .plan-actions .hint { text-align: right; }
   .btn.danger { color: #e08f8f; }
 
+  .gift-top {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 18px;
+  }
+  .gift-form {
+    display: flex;
+    gap: 10px;
+    flex-shrink: 0;
+    align-items: center;
+  }
+  .gift-input {
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid var(--bb-border, rgba(255, 255, 255, 0.1));
+    border-radius: var(--bb-radius-md, 10px);
+    color: var(--bb-white, #f0ece4);
+    font-family: var(--bb-font-body);
+    font-size: 13.5px;
+    padding: 10px 14px;
+    width: 200px;
+  }
+  .gift-input:focus {
+    outline: none;
+    border-color: var(--bb-tan, #c9a87c);
+  }
+
   @media (max-width: 760px) {
     .plan-top { flex-direction: column; }
     .plan-actions { align-items: stretch; width: 100%; }
     .plan-actions .hint { text-align: left; }
+    .gift-top { flex-direction: column; }
+    .gift-form { width: 100%; flex-wrap: wrap; }
+    .gift-input { flex: 1; min-width: 0; }
   }
 </style>

--- a/deploy/k8s/nats-auth.conf
+++ b/deploy/k8s/nats-auth.conf
@@ -257,12 +257,17 @@ accounts: {
   }
 
   # TRANSACTIONS_RPC answers the dashboard checkout RPC (Tebex basket minting).
-  # It imports nothing: attribution rides in the basket custom payload and the
-  # entitlement comes back through the Tebex webhook, not an RPC.
+  # It resolves and vets gift recipients through the users admin lookup, and
+  # sends the "you received premium" direct notification when a gifted payment
+  # webhook lands. Entitlements still come back through the Tebex webhook.
   TRANSACTIONS_RPC: {
     users: [ { user: "transactions_rpc", password: $NATS_BCRYPT_TRANSACTIONS_RPC } ]
     exports: [
       { service: "bagel.rpc.transactions.>" }
+    ]
+    imports: [
+      { service: { account: "USERS_RPC",         subject: "bagel.rpc.admin.user.get" } }
+      { service: { account: "NOTIFICATIONS_RPC", subject: "bagel.rpc.admin.notifications.send" } }
     ]
   }
 

--- a/internal/domain/rpc/transactions/transactions.go
+++ b/internal/domain/rpc/transactions/transactions.go
@@ -4,11 +4,15 @@
 package transactionsrpc
 
 // BasketCreateRequest asks the transactions service to mint a Tebex Headless
-// basket for the premium package, tagged with the buyer's Twitch user id so the
-// payment webhook can attribute the entitlement.
+// basket for the premium package. UserID/Username identify the signed-in buyer.
+// When RecipientUsername is set the purchase is a gift: the service resolves
+// that Twitch login against the users service (must be a registered, non-banned
+// account without premium) and the entitlement lands on the recipient while the
+// buyer pays.
 type BasketCreateRequest struct {
-	UserID   string `json:"user_id"`
-	Username string `json:"username,omitempty"`
+	UserID            string `json:"user_id"`
+	Username          string `json:"username,omitempty"`
+	RecipientUsername string `json:"recipient_username,omitempty"`
 }
 
 type BasketCreateReply struct {
@@ -17,5 +21,7 @@ type BasketCreateReply struct {
 	// CheckoutURL is the hosted-checkout link for the same basket, kept as a
 	// fallback when the embedded checkout cannot run.
 	CheckoutURL string `json:"checkout_url,omitempty"`
-	Error       string `json:"error,omitempty"`
+	// RecipientLogin echoes the resolved gift recipient (gift baskets only).
+	RecipientLogin string `json:"recipient_login,omitempty"`
+	Error          string `json:"error,omitempty"`
 }


### PR DESCRIPTION
## Summary
- **Gift flow**: billing page gets a "Gift premium" card — enter a Twitch username, pay via the same embedded Tebex.js overlay, entitlement lands on the recipient (basket `custom.user_id` = recipient, `gifted_by`/`gifted_by_login` = buyer). Attribution machinery unchanged; Tebex's native gifting stays off (it resolves to Tebex-internal ids, not Twitch ids).
- **Recipient vetting** (transactions `basket_create`): resolves the login through `bagel.rpc.admin.user.get` — must be a registered ItsBagelBot user, not banned, not already paid/VIP, not the buyer. Error strings surface verbatim on the gift form.
- **Automatic notification**: when the payment webhook records a gifted initial payment, transactions sends the recipient a direct success notification via `bagel.rpc.admin.notifications.send`. Webhook id doubles as the notification `request_id`, so Tebex webhook retries collapse into one row. Renewals are silent; a basket gifted to its own buyer collapses to a plain purchase.
- **NATS**: TRANSACTIONS_RPC now imports the users lookup + notifications send subjects (conf hot-reloads via Flux push).

## Test plan
- `go test ./app/transactions/...` green — new coverage: gift custom payload on basket create, gift notice fired once on `payment.completed`, skipped on renewal/self-purchase/self-gift, notify failure never fails the webhook.
- `svelte-check` clean; preview-verified: gift card renders, button gates on input, Tebex.js loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)