### PR TITLE
fix(console): ensure secure flag is passed to cookies.delete

### DIFF
--- a/console/dashboard/src/routes/(app)/+layout.server.ts
+++ b/console/dashboard/src/routes/(app)/+layout.server.ts
@@ -45,7 +45,7 @@ export const load: LayoutServerLoad = async ({ locals, url, cookies }) => {
       await accountState(s.user_id);
     } catch (err) {
       if (err instanceof RpcError) {
-        cookies.delete(COOKIE, { path: '/' });
+        cookies.delete(COOKIE, { path: '/', secure: url.protocol === 'https:' });
         throw redirect(302, '/login?e=signedout');
       }
       // Transient transport problem: keep the session, pages degrade instead.

--- a/console/dashboard/src/routes/auth/logout/+server.ts
+++ b/console/dashboard/src/routes/auth/logout/+server.ts
@@ -2,7 +2,7 @@ import type { RequestHandler } from './$types';
 import { redirect } from '@sveltejs/kit';
 import { COOKIE } from '$lib/server/session';
 
-export const POST: RequestHandler = ({ cookies }) => {
-  cookies.delete(COOKIE, { path: '/' });
+export const POST: RequestHandler = ({ cookies, url }) => {
+  cookies.delete(COOKIE, { path: '/', secure: url.protocol === 'https:' });
   throw redirect(302, '/login');
 };

--- a/console/dashboard/src/routes/goodbye/+page.server.ts
+++ b/console/dashboard/src/routes/goodbye/+page.server.ts
@@ -2,9 +2,9 @@ import type { PageServerLoad } from './$types';
 import { redirect } from '@sveltejs/kit';
 import { ACCOUNT_DELETED_COOKIE } from '$lib/server/session';
 
-export const load: PageServerLoad = ({ locals, cookies }) => {
+export const load: PageServerLoad = ({ locals, cookies, url }) => {
   const wasDeleted = cookies.get(ACCOUNT_DELETED_COOKIE) === '1';
-  cookies.delete(ACCOUNT_DELETED_COOKIE, { path: '/' });
+  cookies.delete(ACCOUNT_DELETED_COOKIE, { path: '/', secure: url.protocol === 'https:' });
 
   if (locals.session) throw redirect(302, '/');
   if (!wasDeleted) throw redirect(302, '/login');


### PR DESCRIPTION
Fixes a bug where cookies were not deleted on logout and account deletion because the secure flag was missing, leading to redirect loops.