### PR TITLE
fix(console): make hydration bundles deterministic

### DIFF
--- a/console/admin/Containerfile
+++ b/console/admin/Containerfile
@@ -2,14 +2,14 @@
 # Node (adapter-node output). Native per-node build (ARM/Intel); no emulation.
 FROM docker.io/oven/bun:1.3.10 AS build
 WORKDIR /src
-# Pin SvelteKit's build version to the commit SHA so the ARM and Intel native
-# builds emit IDENTICAL hashed asset names (else per-build timestamps diverge
-# and a stateless LB serves HTML from one arch with chunk 404s from the other).
+# Pin SvelteKit's version metadata to the commit SHA. sorted-readdir.cjs also
+# makes route-node assignment deterministic across the native ARM/Intel builds.
 ARG BUILD_VERSION=dev
 ENV BUILD_VERSION=$BUILD_VERSION
 # bunfig.toml MUST be present so the hoisted linker applies (flat node_modules).
 COPY package.json bun.lock bunfig.toml ./
 COPY tsconfig.base.json tsconfig.base.json
+COPY sorted-readdir.cjs sorted-readdir.cjs
 COPY shared/package.json shared/package.json
 COPY dashboard/package.json dashboard/package.json
 COPY admin/package.json admin/package.json

--- a/console/admin/package.json
+++ b/console/admin/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite dev",
-    "build": "vite build",
+    "build": "NODE_OPTIONS=--require=../sorted-readdir.cjs vite build",
     "preview": "node build",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json"
   },

--- a/console/admin/src/app.html
+++ b/console/admin/src/app.html
@@ -7,13 +7,16 @@
   %sveltekit.head%
 </head>
 <body data-role="admin" data-sveltekit-preload-data="hover">
+  <!-- Decorative siblings must stay outside the hydration root below. SvelteKit
+       passes the body-script's parent to app.start(), whose first managed node
+       must be Svelte's hydration marker. -->
+  <div class="bg-orb"></div>
+  <div class="bg-orb two"></div>
   <!-- display:contents wrapper isolates the hydration root from browser
        extensions that inject nodes directly into <body>. Without it, an injected
        sibling shifts SvelteKit's hydration index walk, the hydrate throws, and
        the app unmounts to a blank page (only for users with such extensions). -->
   <div style="display: contents">
-    <div class="bg-orb"></div>
-    <div class="bg-orb two"></div>
     %sveltekit.body%
   </div>
 </body>

--- a/console/admin/svelte.config.js
+++ b/console/admin/svelte.config.js
@@ -9,10 +9,9 @@ export default {
     output: {
       bundleStrategy: 'single'
     },
-    // Deterministic build id (commit SHA via BUILD_VERSION) so the per-arch
-    // native builds (ARM/Intel) emit identical hashed asset names. Default is a
-    // timestamp, which diverges across the two builds and 404s chunks under the
-    // stateless LB.
+    // Pin the version metadata to the commit SHA. The build script separately
+    // sorts route-directory reads so native ARM/Intel builds also assign the
+    // same SvelteKit node IDs and emit byte-identical client bundles.
     // pollInterval lets the client poll _app/version.json and flip the `updated`
     // store on a new deploy, so the root layout can force a full reload instead
     // of fetching a now-deleted bundle hash (404 -> dead SPA until hard refresh).

--- a/console/dashboard/Containerfile
+++ b/console/dashboard/Containerfile
@@ -3,16 +3,15 @@
 # node2); no cross-arch emulation.
 FROM docker.io/oven/bun:1.3.10 AS build
 WORKDIR /src
-# Pin SvelteKit's build version to the commit SHA so the ARM and Intel native
-# builds emit IDENTICAL hashed asset names. Otherwise version defaults to a
-# per-build timestamp, the two arches diverge, and a stateless LB serves HTML
-# from one arch with chunk 404s from the other.
+# Pin SvelteKit's version metadata to the commit SHA. sorted-readdir.cjs also
+# makes route-node assignment deterministic across the native ARM/Intel builds.
 ARG BUILD_VERSION=dev
 ENV BUILD_VERSION=$BUILD_VERSION
 # Workspace manifests first for cached installs. bunfig.toml MUST be present for
 # the install so the hoisted linker applies (flat node_modules the image can ship).
 COPY package.json bun.lock bunfig.toml ./
 COPY tsconfig.base.json tsconfig.base.json
+COPY sorted-readdir.cjs sorted-readdir.cjs
 COPY shared/package.json shared/package.json
 COPY dashboard/package.json dashboard/package.json
 COPY admin/package.json admin/package.json

--- a/console/dashboard/package.json
+++ b/console/dashboard/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite dev",
-    "build": "vite build",
+    "build": "NODE_OPTIONS=--require=../sorted-readdir.cjs vite build",
     "preview": "node build",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json"
   },

--- a/console/dashboard/src/app.html
+++ b/console/dashboard/src/app.html
@@ -7,13 +7,16 @@
   %sveltekit.head%
 </head>
 <body data-role="streamer" data-sveltekit-preload-data="hover">
+  <!-- Decorative siblings must stay outside the hydration root below. SvelteKit
+       passes the body-script's parent to app.start(), whose first managed node
+       must be Svelte's hydration marker. -->
+  <div class="bg-orb"></div>
+  <div class="bg-orb two"></div>
   <!-- display:contents wrapper isolates the hydration root from browser
        extensions that inject nodes directly into <body>. Without it, an injected
        sibling shifts SvelteKit's hydration index walk, the hydrate throws, and
        the app unmounts to a blank page (only for users with such extensions). -->
   <div style="display: contents">
-    <div class="bg-orb"></div>
-    <div class="bg-orb two"></div>
     %sveltekit.body%
   </div>
 </body>

--- a/console/dashboard/svelte.config.js
+++ b/console/dashboard/svelte.config.js
@@ -9,10 +9,9 @@ export default {
     output: {
       bundleStrategy: 'single'
     },
-    // Deterministic build id (commit SHA via BUILD_VERSION) so the per-arch
-    // native builds (ARM/Intel) emit identical hashed asset names. Default is a
-    // timestamp, which diverges across the two builds and 404s chunks under the
-    // stateless LB.
+    // Pin the version metadata to the commit SHA. The build script separately
+    // sorts route-directory reads so native ARM/Intel builds also assign the
+    // same SvelteKit node IDs and emit byte-identical client bundles.
     // pollInterval lets the client poll _app/version.json and flip the `updated`
     // store on a new deploy, so the root layout can force a full reload instead
     // of fetching a now-deleted bundle hash (404 -> dead SPA until hard refresh).
@@ -38,7 +37,13 @@ export default {
         // *.nr-data.net is the New Relic Browser beacon (RUM page views, JS
         // errors, SPA routes, web vitals). pay.tebex.io answers Tebex.js's
         // checkout bootstrap calls from the parent page.
-        'connect-src': ['self', 'https://dashboard.itsbagelbot.com', 'https://*.nr-data.net', 'https://pay.tebex.io'],
+        'connect-src': [
+          'self',
+          'https://dashboard.itsbagelbot.com',
+          'https://*.nr-data.net',
+          'https://js.tebex.io',
+          'https://pay.tebex.io'
+        ],
         'object-src': ['none'],
         'base-uri': ['self'],
         // The Tebex.js payment overlay is an iframe served from pay.tebex.io

--- a/console/serve-node.js
+++ b/console/serve-node.js
@@ -1,5 +1,5 @@
 import { createServer } from 'node:http';
-import { existsSync, readdirSync } from 'node:fs';
+import { existsSync } from 'node:fs';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import sirv from 'sirv';
@@ -13,30 +13,6 @@ const socketPath = process.env.SOCKET_PATH;
 const shutdownTimeout = Number(process.env.SHUTDOWN_TIMEOUT || 30);
 
 const immutable = '/_app/immutable/';
-
-// SvelteKit's single-bundle output hashes can diverge between the ARM and Intel
-// builds despite BUILD_VERSION pinning, causing 404s when Traefik routes a request
-// to a different arch than the one that served the HTML. We dynamically find the
-// local bundle names and rewrite mismatched requests to them.
-let localBundleJs;
-let localBundleCss;
-try {
-  const immutableDir = path.join(build, 'client', '_app', 'immutable');
-  if (existsSync(immutableDir)) {
-    const files = readdirSync(immutableDir);
-    const jsFile = files.find(f => f.startsWith('bundle.') && f.endsWith('.js'));
-    if (jsFile) localBundleJs = `/_app/immutable/${jsFile}`;
-    
-    const assetsDir = path.join(immutableDir, 'assets');
-    if (existsSync(assetsDir)) {
-      const assetFiles = readdirSync(assetsDir);
-      const cssFile = assetFiles.find(f => f.startsWith('bundle.') && f.endsWith('.css'));
-      if (cssFile) localBundleCss = `/_app/immutable/assets/${cssFile}`;
-    }
-  }
-} catch (e) {
-  console.warn('Failed to resolve local bundle hashes:', e);
-}
 
 const client = sirv(path.join(build, 'client'), {
   etag: true,
@@ -79,15 +55,6 @@ const prerendered = existsSync(prerenderedDir)
   : undefined;
 
 const server = createServer((req, res) => {
-  if (req.url) {
-    const urlPath = req.url.split('?')[0];
-    if (localBundleJs && urlPath.startsWith('/_app/immutable/bundle.') && urlPath.endsWith('.js')) {
-      req.url = localBundleJs;
-    } else if (localBundleCss && urlPath.startsWith('/_app/immutable/assets/bundle.') && urlPath.endsWith('.css')) {
-      req.url = localBundleCss;
-    }
-  }
-
   client(req, res, () => {
     const next = () => {
       // A static asset under /_app that sirv could not find: it does not exist on

--- a/console/sorted-readdir.cjs
+++ b/console/sorted-readdir.cjs
@@ -1,0 +1,20 @@
+// SvelteKit assigns client node IDs in the order returned by readdirSync while
+// walking src/routes. Overlay filesystems can return a different order on the
+// native ARM64 and x86_64 image builds, which makes their SSR HTML and client
+// bundles incompatible even when they come from the same commit.
+const fs = require('node:fs');
+
+const readdirSync = fs.readdirSync;
+
+fs.readdirSync = function deterministicRouteRead(directory, options) {
+  const entries = readdirSync.call(this, directory, options);
+  const path = String(directory).replaceAll('\\', '/');
+
+  if (!path.includes('/src/routes')) return entries;
+
+  return entries.sort((a, b) => {
+    const aName = typeof a === 'string' || Buffer.isBuffer(a) ? a : a.name;
+    const bName = typeof b === 'string' || Buffer.isBuffer(b) ? b : b.name;
+    return Buffer.from(aName).compare(Buffer.from(bName));
+  });
+};


### PR DESCRIPTION
## Summary
- make SvelteKit route node ordering deterministic across native ARM64 and x86_64 builds
- stop rewriting missing immutable bundle hashes to incompatible local bundles
- keep decorative DOM outside the hydration roots and allow Tebex source-map connections

## Verification
- dashboard: svelte-check (0 errors; 1 existing CSS compatibility warning) and production build
- admin: svelte-check (0 errors) and production build
- runtime: valid bundle returns immutable 200; unknown bundle hash returns non-cacheable 404