### PR TITLE
fix(billing): complete Tebex subscription lifecycle

### DIFF
--- a/app/transactions/main.go
+++ b/app/transactions/main.go
@@ -113,11 +113,14 @@ func main() {
 
 	sendSubject := env.Get("NATS_ADMIN_NOTIFICATIONS_SUBJECT_PREFIX", "bagel.rpc.admin.notifications") + ".send"
 	notifier := rpc.NewGiftNotifier(nc, sendSubject)
+	billingSubject := env.Get("NATS_INTERNAL_BILLING_SUBJECT", "bagel.rpc.internal.billing.apply")
+	billing := rpc.NewBillingApplier(nc, billingSubject)
 
 	listenAddr := env.Get("LISTEN_ADDR", ":8080")
 	httpApp := web.New(repo, web.Config{
 		WebhookSecret: env.Get("TEBEX_WEBHOOK_SECRET", ""),
 		NotifyGift:    notifier.Notify,
+		ApplyBilling:  billing.Apply,
 	}, log.Named("http"))
 
 	serverErr := make(chan error, 1)

--- a/app/transactions/rpc/billing.go
+++ b/app/transactions/rpc/billing.go
@@ -1,0 +1,25 @@
+package rpc
+
+import (
+	"context"
+	"time"
+
+	billingrpc "ItsBagelBot/internal/domain/rpc/billing"
+	"ItsBagelBot/pkg/bus"
+
+	"github.com/nats-io/nats.go"
+)
+
+type BillingApplier struct {
+	nc      *nats.Conn
+	subject string
+}
+
+func NewBillingApplier(nc *nats.Conn, subject string) *BillingApplier {
+	return &BillingApplier{nc: nc, subject: subject}
+}
+
+func (a *BillingApplier) Apply(ctx context.Context, req billingrpc.ApplyRequest) error {
+	_, err := bus.RequestJSONTimeout[billingrpc.ApplyReply](ctx, a.nc, a.subject, req, 5*time.Second)
+	return err
+}

--- a/app/transactions/rpc/checkout.go
+++ b/app/transactions/rpc/checkout.go
@@ -2,6 +2,7 @@ package rpc
 
 import (
 	"context"
+	"net"
 	"strconv"
 	"strings"
 	"time"
@@ -33,8 +34,15 @@ func SubscribeCheckout(nc *nats.Conn, client *tebex.Client, prefix, userGetSubje
 
 	// Basket creation is two upstream HTTP calls (plus a recipient lookup for
 	// gifts), so give it more room than the default in-cluster RPC budget.
-	return bus.QueueSubscribeJSON[transactionsrpc.BasketCreateRequest, transactionsrpc.BasketCreateReply](
-		nc, prefix+".basket_create", queueGroup, 15*time.Second, app, log, c.basketCreate)
+	if err := bus.QueueSubscribeJSON[transactionsrpc.BasketCreateRequest, transactionsrpc.BasketCreateReply](
+		nc, prefix+".basket_create", queueGroup, 15*time.Second, app, log, c.basketCreate); err != nil {
+		return err
+	}
+	return bus.QueueSubscribeJSON[struct{}, transactionsrpc.ConfigReply](
+		nc, prefix+".config_get", queueGroup, 2*time.Second, app, log,
+		func(context.Context, struct{}) transactionsrpc.ConfigReply {
+			return transactionsrpc.ConfigReply{PublicToken: client.PublicToken()}
+		})
 }
 
 func (c *checkoutRPC) basketCreate(ctx context.Context, req transactionsrpc.BasketCreateRequest) transactionsrpc.BasketCreateReply {
@@ -44,7 +52,7 @@ func (c *checkoutRPC) basketCreate(ctx context.Context, req transactionsrpc.Bask
 		return transactionsrpc.BasketCreateReply{Error: "user_id must be numeric"}
 	}
 
-	spec := tebex.BasketSpec{UserID: buyerID, Username: req.Username}
+	spec := tebex.BasketSpec{UserID: buyerID, Username: req.Username, IPAddress: validIPv4(req.IPAddress)}
 	recipientLogin := ""
 
 	if recipient := normalizeLogin(req.RecipientUsername); recipient != "" {
@@ -58,6 +66,7 @@ func (c *checkoutRPC) basketCreate(ctx context.Context, req transactionsrpc.Bask
 		spec = tebex.BasketSpec{
 			UserID:        view.ID,
 			Username:      view.Username,
+			IPAddress:     validIPv4(req.IPAddress),
 			GiftedByID:    buyerID,
 			GiftedByLogin: req.Username,
 		}
@@ -76,6 +85,14 @@ func (c *checkoutRPC) basketCreate(ctx context.Context, req transactionsrpc.Bask
 		CheckoutURL:    basket.CheckoutURL,
 		RecipientLogin: recipientLogin,
 	}
+}
+
+func validIPv4(raw string) string {
+	ip := net.ParseIP(strings.TrimSpace(raw))
+	if ip == nil || ip.To4() == nil {
+		return ""
+	}
+	return ip.String()
 }
 
 // resolveRecipient vets a gift target: the Twitch login must belong to a

--- a/app/transactions/tebex/client.go
+++ b/app/transactions/tebex/client.go
@@ -38,6 +38,10 @@ type Client struct {
 	cfg Config
 }
 
+// PublicToken is safe to expose to the browser and is required by Tebex.js's
+// Payment Portal. The private API key is never held by this Headless client.
+func (c *Client) PublicToken() string { return c.cfg.WebstoreToken }
+
 type Basket struct {
 	Ident       string
 	CheckoutURL string
@@ -78,6 +82,7 @@ func New(cfg Config) (*Client, error) {
 type BasketSpec struct {
 	UserID        uint64
 	Username      string
+	IPAddress     string
 	GiftedByID    uint64
 	GiftedByLogin string
 }
@@ -102,6 +107,10 @@ func (c *Client) CreateBasket(ctx context.Context, spec BasketSpec) (Basket, err
 		"cancel_url":             c.cfg.CancelURL,
 		"complete_auto_redirect": true,
 		"custom":                 custom,
+		"username":               spec.Username,
+	}
+	if spec.IPAddress != "" {
+		create["ip_address"] = spec.IPAddress
 	}
 
 	var created basketData

--- a/app/transactions/tebex/client_test.go
+++ b/app/transactions/tebex/client_test.go
@@ -53,7 +53,7 @@ func TestCreateBasket(t *testing.T) {
 		})
 	})
 
-	basket, err := newTestClient(t, mux).CreateBasket(context.Background(), BasketSpec{UserID: 804932984, Username: "mavey"})
+	basket, err := newTestClient(t, mux).CreateBasket(context.Background(), BasketSpec{UserID: 804932984, Username: "mavey", IPAddress: "203.0.113.10"})
 	if err != nil {
 		t.Fatalf("CreateBasket: %v", err)
 	}
@@ -74,6 +74,12 @@ func TestCreateBasket(t *testing.T) {
 	}
 	if createBody["complete_url"] != "https://dashboard.example/billing?checkout=complete" {
 		t.Errorf("complete_url = %v", createBody["complete_url"])
+	}
+	if createBody["username"] != "mavey" {
+		t.Errorf("username = %v, want mavey", createBody["username"])
+	}
+	if createBody["ip_address"] != "203.0.113.10" {
+		t.Errorf("ip_address = %v, want 203.0.113.10", createBody["ip_address"])
 	}
 
 	if packageBody["package_id"] != float64(42) {

--- a/app/transactions/web/server.go
+++ b/app/transactions/web/server.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"ItsBagelBot/app/transactions/repository"
+	billingrpc "ItsBagelBot/internal/domain/rpc/billing"
 
 	"github.com/gofiber/fiber/v2"
 	"go.uber.org/zap"
@@ -41,6 +42,10 @@ type Config struct {
 	// only, not renewals). Best-effort: failures are logged, never surfaced to
 	// Tebex — the entitlement is already durable at that point.
 	NotifyGift func(ctx context.Context, notice GiftNotice) error
+	// ApplyBilling synchronously updates the users service after signature
+	// verification. Returning an error makes Tebex retry the webhook, so a
+	// transient NATS/users outage cannot lose a paid entitlement.
+	ApplyBilling func(ctx context.Context, req billingrpc.ApplyRequest) error
 }
 
 type Server struct {
@@ -57,19 +62,22 @@ type tebexEvent struct {
 }
 
 type paymentSubject struct {
-	TransactionID string                     `json:"transaction_id"`
-	Custom        map[string]json.RawMessage `json:"custom"`
-	Customer      struct {
+	TransactionID             string                     `json:"transaction_id"`
+	RecurringPaymentReference string                     `json:"recurring_payment_reference"`
+	Custom                    map[string]json.RawMessage `json:"custom"`
+	Customer                  struct {
 		Username usernameRef `json:"username"`
 	} `json:"customer"`
 	Products []struct {
-		Custom   map[string]json.RawMessage `json:"custom"`
-		Username usernameRef                `json:"username"`
+		Custom    map[string]json.RawMessage `json:"custom"`
+		Username  usernameRef                `json:"username"`
+		ExpiresAt string                     `json:"expires_at"`
 	} `json:"products"`
 }
 
 type recurringSubject struct {
 	Reference      string          `json:"reference"`
+	NextPaymentAt  string          `json:"next_payment_at"`
 	InitialPayment *paymentSubject `json:"initial_payment"`
 	LastPayment    *paymentSubject `json:"last_payment"`
 }
@@ -82,8 +90,10 @@ type recordablePayment struct {
 	TransactionID string
 	UserID        uint64
 	// Gift attribution from the basket custom payload; zero for self-purchases.
-	GiftedByID    uint64
-	GiftedByLogin string
+	GiftedByID         uint64
+	GiftedByLogin      string
+	RecurringReference string
+	ExpiresAt          *time.Time
 }
 
 var errNoRecordablePayment = errors.New("no recordable Tebex payment for event")
@@ -181,21 +191,61 @@ func (s *Server) tebexWebhook(c *fiber.Ctx) error {
 		if err := s.store.Record(ctx, payment.TransactionID, payment.UserID); err != nil {
 			return s.failEvent(c, event, payment, fiber.StatusInternalServerError, err)
 		}
+		if err := s.applyBilling(ctx, event, payment, billingrpc.ActionActivate); err != nil {
+			return s.failEvent(c, event, payment, fiber.StatusInternalServerError, err)
+		}
 		if err := s.saveEvent(ctx, event, repository.WebhookProcessed, payment, ""); err != nil {
 			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "failed to save webhook state"})
 		}
 		s.notifyGift(ctx, event, payment)
 		return c.SendStatus(fiber.StatusNoContent)
-	}
 
-	if unsupportedActionable(event.Type) {
-		return s.failEvent(c, event, recordablePayment{}, fiber.StatusNotImplemented, fmt.Errorf("handler not implemented for %s", event.Type))
+	case "recurring-payment.cancellation.requested":
+		return s.applyLifecycle(c, event, billingrpc.ActionCancelRequested)
+
+	case "recurring-payment.cancellation.aborted", "payment.dispute.won":
+		return s.applyLifecycle(c, event, billingrpc.ActionCancelAborted)
+
+	case "recurring-payment.ended", "payment.refunded", "payment.dispute.opened", "payment.dispute.lost":
+		return s.applyLifecycle(c, event, billingrpc.ActionRevoke)
 	}
 
 	if err := s.saveEvent(ctx, event, repository.WebhookIgnored, recordablePayment{}, ""); err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "failed to save webhook state"})
 	}
 	return c.SendStatus(fiber.StatusNoContent)
+}
+
+func (s *Server) applyLifecycle(c *fiber.Ctx, event tebexEvent, action billingrpc.Action) error {
+	payment, err := recordableFromEvent(event)
+	if err != nil {
+		return s.failEvent(c, event, payment, fiber.StatusUnprocessableEntity, err)
+	}
+	if err := s.applyBilling(c.UserContext(), event, payment, action); err != nil {
+		return s.failEvent(c, event, payment, fiber.StatusInternalServerError, err)
+	}
+	if err := s.saveEvent(c.UserContext(), event, repository.WebhookProcessed, payment, ""); err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "failed to save webhook state"})
+	}
+	return c.SendStatus(fiber.StatusNoContent)
+}
+
+func (s *Server) applyBilling(ctx context.Context, event tebexEvent, payment recordablePayment, action billingrpc.Action) error {
+	if s.cfg.ApplyBilling == nil {
+		return errors.New("billing entitlement handler not configured")
+	}
+	occurredAt, err := time.Parse(time.RFC3339, event.Date)
+	if err != nil {
+		return fmt.Errorf("invalid webhook date: %w", err)
+	}
+	return s.cfg.ApplyBilling(ctx, billingrpc.ApplyRequest{
+		UserID:             payment.UserID,
+		EventID:            event.ID,
+		Action:             action,
+		OccurredAt:         occurredAt,
+		ExpiresAt:          payment.ExpiresAt,
+		RecurringReference: payment.RecurringReference,
+	})
 }
 
 func (s *Server) failEvent(c *fiber.Ctx, event tebexEvent, payment recordablePayment, status int, cause error) error {
@@ -290,21 +340,37 @@ func recordableFromEvent(event tebexEvent) (recordablePayment, error) {
 		}
 		return recordableFromPayment(payment)
 
-	case "recurring-payment.started", "recurring-payment.renewed":
+	case "payment.refunded", "payment.dispute.opened", "payment.dispute.won", "payment.dispute.lost", "payment.dispute.closed":
+		var payment paymentSubject
+		if err := json.Unmarshal(event.Subject, &payment); err != nil {
+			return recordablePayment{}, err
+		}
+		return recordableFromPayment(payment)
+
+	case "recurring-payment.started", "recurring-payment.renewed", "recurring-payment.ended", "recurring-payment.cancellation.requested", "recurring-payment.cancellation.aborted":
 		var recurring recurringSubject
 		if err := json.Unmarshal(event.Subject, &recurring); err != nil {
 			return recordablePayment{}, err
 		}
+		var payment recordablePayment
+		var err error
 		if event.Type == "recurring-payment.renewed" && recurring.LastPayment != nil {
-			return recordableFromPayment(*recurring.LastPayment)
+			payment, err = recordableFromPayment(*recurring.LastPayment)
+		} else if recurring.InitialPayment != nil {
+			payment, err = recordableFromPayment(*recurring.InitialPayment)
+		} else if recurring.LastPayment != nil {
+			payment, err = recordableFromPayment(*recurring.LastPayment)
+		} else {
+			return recordablePayment{}, errNoRecordablePayment
 		}
-		if recurring.InitialPayment != nil {
-			return recordableFromPayment(*recurring.InitialPayment)
+		if err != nil {
+			return recordablePayment{}, err
 		}
-		if recurring.LastPayment != nil {
-			return recordableFromPayment(*recurring.LastPayment)
+		payment.RecurringReference = recurring.Reference
+		if expiresAt, ok := parseTebexTime(recurring.NextPaymentAt); ok {
+			payment.ExpiresAt = &expiresAt
 		}
-		return recordablePayment{}, errNoRecordablePayment
+		return payment, nil
 
 	default:
 		return recordablePayment{}, errNoRecordablePayment
@@ -323,15 +389,30 @@ func recordableFromPayment(payment paymentSubject) (recordablePayment, error) {
 		if giftedBy == userID {
 			giftedBy, giftedByLogin = 0, ""
 		}
-		return recordablePayment{
-			TransactionID: payment.TransactionID,
-			UserID:        userID,
-			GiftedByID:    giftedBy,
-			GiftedByLogin: giftedByLogin,
-		}, nil
+		result := recordablePayment{
+			TransactionID:      payment.TransactionID,
+			UserID:             userID,
+			GiftedByID:         giftedBy,
+			GiftedByLogin:      giftedByLogin,
+			RecurringReference: payment.RecurringPaymentReference,
+		}
+		for _, product := range payment.Products {
+			if expiresAt, ok := parseTebexTime(product.ExpiresAt); ok && (result.ExpiresAt == nil || expiresAt.After(*result.ExpiresAt)) {
+				result.ExpiresAt = &expiresAt
+			}
+		}
+		return result, nil
 	}
 
 	return recordablePayment{TransactionID: payment.TransactionID}, errors.New("payment user id missing")
+}
+
+func parseTebexTime(raw string) (time.Time, bool) {
+	if raw == "" {
+		return time.Time{}, false
+	}
+	parsed, err := time.Parse(time.RFC3339, raw)
+	return parsed, err == nil
 }
 
 // giftFromPayment reads the gifted_by attribution the basket carried. Checked
@@ -413,21 +494,4 @@ func rawUint(raw json.RawMessage) (uint64, bool) {
 	}
 	parsed, err := strconv.ParseUint(number.String(), 10, 64)
 	return parsed, err == nil && parsed != 0
-}
-
-func unsupportedActionable(eventType string) bool {
-
-	switch eventType {
-	case "payment.refunded",
-		"payment.dispute.opened",
-		"payment.dispute.won",
-		"payment.dispute.lost",
-		"payment.dispute.closed",
-		"recurring-payment.ended",
-		"recurring-payment.cancellation.requested",
-		"recurring-payment.cancellation.aborted":
-		return true
-	default:
-		return false
-	}
 }

--- a/app/transactions/web/server_test.go
+++ b/app/transactions/web/server_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"ItsBagelBot/app/transactions/repository"
+	billingrpc "ItsBagelBot/internal/domain/rpc/billing"
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/stretchr/testify/assert"
@@ -18,6 +19,7 @@ import (
 type fakeStore struct {
 	records []recordablePayment
 	events  []repository.WebhookEvent
+	changes []billingrpc.ApplyRequest
 }
 
 func (f *fakeStore) Record(_ context.Context, id string, userID uint64) error {
@@ -116,20 +118,21 @@ func TestPaymentCompletedWithoutUserIDStoresFailedState(t *testing.T) {
 	assert.Contains(t, store.events[0].Error, "user id")
 }
 
-func TestUnsupportedActionableWebhookStoresFailedState(t *testing.T) {
+func TestRefundRevokesEntitlementAndStoresProcessedState(t *testing.T) {
 
 	store := &fakeStore{}
 	app := newTestApp(store)
-	body := `{"id":"evt-refund","type":"payment.refunded","date":"2026-07-02T00:00:00+00:00","subject":{}}`
+	body := `{"id":"evt-refund","type":"payment.refunded","date":"2026-07-02T00:00:00+00:00","subject":{"transaction_id":"tbx-refund","custom":{"user_id":"1001"}}}`
 
 	resp := doWebhook(t, app, body, testSecret, true)
 	defer resp.Body.Close()
 
-	assert.Equal(t, http.StatusNotImplemented, resp.StatusCode)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 	assert.Empty(t, store.records)
 	require.Len(t, store.events, 1)
-	assert.Equal(t, repository.WebhookFailed, store.events[0].Status)
-	assert.Contains(t, store.events[0].Error, "not implemented")
+	assert.Equal(t, repository.WebhookProcessed, store.events[0].Status)
+	require.Len(t, store.changes, 1)
+	assert.Equal(t, billingrpc.ActionRevoke, store.changes[0].Action)
 }
 
 func TestBadSignatureIsRejectedBeforeStoringState(t *testing.T) {
@@ -174,7 +177,14 @@ func TestRecurringRenewedUsesLastPayment(t *testing.T) {
 const testSecret = "webhook-secret"
 
 func newTestApp(store *fakeStore) *fiber.App {
-	return New(store, Config{WebhookSecret: testSecret}, nil)
+	return New(store, Config{WebhookSecret: testSecret, ApplyBilling: applyFor(store)}, nil)
+}
+
+func applyFor(store *fakeStore) func(context.Context, billingrpc.ApplyRequest) error {
+	return func(_ context.Context, req billingrpc.ApplyRequest) error {
+		store.changes = append(store.changes, req)
+		return nil
+	}
 }
 
 func doWebhook(t *testing.T, app *fiber.App, body string, secret string, validSignature bool) *http.Response {
@@ -200,13 +210,14 @@ func TestGiftedPaymentNotifiesRecipientOnce(t *testing.T) {
 	var notices []GiftNotice
 	app := New(store, Config{
 		WebhookSecret: testSecret,
+		ApplyBilling:  applyFor(store),
 		NotifyGift: func(_ context.Context, n GiftNotice) error {
 			notices = append(notices, n)
 			return nil
 		},
 	}, nil)
 
-	body := `{"id":"evt-gift","type":"payment.completed","subject":{"transaction_id":"tbx-gift-1","custom":{"user_id":"111","username":"recipient","gifted_by":"804932984","gifted_by_login":"mavey"}}}`
+	body := `{"id":"evt-gift","type":"payment.completed","date":"2026-07-02T00:00:00Z","subject":{"transaction_id":"tbx-gift-1","custom":{"user_id":"111","username":"recipient","gifted_by":"804932984","gifted_by_login":"mavey"}}}`
 	resp := doWebhook(t, app, body, testSecret, true)
 	defer resp.Body.Close()
 
@@ -228,6 +239,7 @@ func TestGiftNotificationSkippedOnRenewalAndSelfPurchase(t *testing.T) {
 	var notices []GiftNotice
 	app := New(store, Config{
 		WebhookSecret: testSecret,
+		ApplyBilling:  applyFor(store),
 		NotifyGift: func(_ context.Context, n GiftNotice) error {
 			notices = append(notices, n)
 			return nil
@@ -235,19 +247,19 @@ func TestGiftNotificationSkippedOnRenewalAndSelfPurchase(t *testing.T) {
 	}, nil)
 
 	// Renewal of a gifted subscription: entitlement recorded, no ping.
-	renewal := `{"id":"evt-renew","type":"recurring-payment.renewed","subject":{"reference":"sub-1","last_payment":{"transaction_id":"tbx-gift-2","custom":{"user_id":"111","gifted_by":"804932984","gifted_by_login":"mavey"}}}}`
+	renewal := `{"id":"evt-renew","type":"recurring-payment.renewed","date":"2026-07-02T00:00:00Z","subject":{"reference":"sub-1","last_payment":{"transaction_id":"tbx-gift-2","custom":{"user_id":"111","gifted_by":"804932984","gifted_by_login":"mavey"}}}}`
 	resp := doWebhook(t, app, renewal, testSecret, true)
 	resp.Body.Close()
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 
 	// Self-purchase (no gifted_by): no ping.
-	self := `{"id":"evt-self","type":"payment.completed","subject":{"transaction_id":"tbx-3","custom":{"user_id":"222"}}}`
+	self := `{"id":"evt-self","type":"payment.completed","date":"2026-07-02T00:01:00Z","subject":{"transaction_id":"tbx-3","custom":{"user_id":"222"}}}`
 	resp = doWebhook(t, app, self, testSecret, true)
 	resp.Body.Close()
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 
 	// Basket "gifted" to its own buyer collapses to a plain purchase: no ping.
-	selfGift := `{"id":"evt-selfgift","type":"payment.completed","subject":{"transaction_id":"tbx-4","custom":{"user_id":"333","gifted_by":"333","gifted_by_login":"me"}}}`
+	selfGift := `{"id":"evt-selfgift","type":"payment.completed","date":"2026-07-02T00:02:00Z","subject":{"transaction_id":"tbx-4","custom":{"user_id":"333","gifted_by":"333","gifted_by_login":"me"}}}`
 	resp = doWebhook(t, app, selfGift, testSecret, true)
 	resp.Body.Close()
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
@@ -261,12 +273,13 @@ func TestGiftNotificationFailureDoesNotFailWebhook(t *testing.T) {
 	store := &fakeStore{}
 	app := New(store, Config{
 		WebhookSecret: testSecret,
+		ApplyBilling:  applyFor(store),
 		NotifyGift: func(_ context.Context, _ GiftNotice) error {
 			return context.DeadlineExceeded
 		},
 	}, nil)
 
-	body := `{"id":"evt-gift-fail","type":"payment.completed","subject":{"transaction_id":"tbx-5","custom":{"user_id":"111","gifted_by":"804932984","gifted_by_login":"mavey"}}}`
+	body := `{"id":"evt-gift-fail","type":"payment.completed","date":"2026-07-02T00:00:00Z","subject":{"transaction_id":"tbx-5","custom":{"user_id":"111","gifted_by":"804932984","gifted_by_login":"mavey"}}}`
 	resp := doWebhook(t, app, body, testSecret, true)
 	defer resp.Body.Close()
 

--- a/app/users/ent/migrate/schema.go
+++ b/app/users/ent/migrate/schema.go
@@ -136,6 +136,12 @@ var (
 		{Name: "is_active", Type: field.TypeBool, Default: true},
 		{Name: "banned", Type: field.TypeBool, Default: false},
 		{Name: "status", Type: field.TypeEnum, Enums: []string{"free", "paid", "vip"}, Default: "free"},
+		{Name: "subscription_source", Type: field.TypeString, Default: ""},
+		{Name: "subscription_expires_at", Type: field.TypeTime, Nullable: true},
+		{Name: "subscription_ref", Type: field.TypeString, Nullable: true},
+		{Name: "subscription_cancel_pending", Type: field.TypeBool, Default: false},
+		{Name: "billing_event_at", Type: field.TypeTime, Nullable: true},
+		{Name: "billing_event_id", Type: field.TypeString, Nullable: true},
 		{Name: "created_at", Type: field.TypeTime},
 		{Name: "updated_at", Type: field.TypeTime},
 	}

--- a/app/users/ent/mutation.go
+++ b/app/users/ent/mutation.go
@@ -3030,23 +3030,29 @@ func (m *TokensMutation) ResetEdge(name string) error {
 // UserMutation represents an operation that mutates the User nodes in the graph.
 type UserMutation struct {
 	config
-	op            Op
-	typ           string
-	id            *uint64
-	username      *string
-	email         *string
-	is_active     *bool
-	banned        *bool
-	status        *user.Status
-	created_at    *time.Time
-	updated_at    *time.Time
-	clearedFields map[string]struct{}
-	tokens        map[int]struct{}
-	removedtokens map[int]struct{}
-	clearedtokens bool
-	done          bool
-	oldValue      func(context.Context) (*User, error)
-	predicates    []predicate.User
+	op                          Op
+	typ                         string
+	id                          *uint64
+	username                    *string
+	email                       *string
+	is_active                   *bool
+	banned                      *bool
+	status                      *user.Status
+	subscription_source         *string
+	subscription_expires_at     *time.Time
+	subscription_ref            *string
+	subscription_cancel_pending *bool
+	billing_event_at            *time.Time
+	billing_event_id            *string
+	created_at                  *time.Time
+	updated_at                  *time.Time
+	clearedFields               map[string]struct{}
+	tokens                      map[int]struct{}
+	removedtokens               map[int]struct{}
+	clearedtokens               bool
+	done                        bool
+	oldValue                    func(context.Context) (*User, error)
+	predicates                  []predicate.User
 }
 
 var _ ent.Mutation = (*UserMutation)(nil)
@@ -3333,6 +3339,274 @@ func (m *UserMutation) ResetStatus() {
 	m.status = nil
 }
 
+// SetSubscriptionSource sets the "subscription_source" field.
+func (m *UserMutation) SetSubscriptionSource(s string) {
+	m.subscription_source = &s
+}
+
+// SubscriptionSource returns the value of the "subscription_source" field in the mutation.
+func (m *UserMutation) SubscriptionSource() (r string, exists bool) {
+	v := m.subscription_source
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldSubscriptionSource returns the old "subscription_source" field's value of the User entity.
+// If the User object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *UserMutation) OldSubscriptionSource(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldSubscriptionSource is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldSubscriptionSource requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldSubscriptionSource: %w", err)
+	}
+	return oldValue.SubscriptionSource, nil
+}
+
+// ResetSubscriptionSource resets all changes to the "subscription_source" field.
+func (m *UserMutation) ResetSubscriptionSource() {
+	m.subscription_source = nil
+}
+
+// SetSubscriptionExpiresAt sets the "subscription_expires_at" field.
+func (m *UserMutation) SetSubscriptionExpiresAt(t time.Time) {
+	m.subscription_expires_at = &t
+}
+
+// SubscriptionExpiresAt returns the value of the "subscription_expires_at" field in the mutation.
+func (m *UserMutation) SubscriptionExpiresAt() (r time.Time, exists bool) {
+	v := m.subscription_expires_at
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldSubscriptionExpiresAt returns the old "subscription_expires_at" field's value of the User entity.
+// If the User object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *UserMutation) OldSubscriptionExpiresAt(ctx context.Context) (v *time.Time, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldSubscriptionExpiresAt is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldSubscriptionExpiresAt requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldSubscriptionExpiresAt: %w", err)
+	}
+	return oldValue.SubscriptionExpiresAt, nil
+}
+
+// ClearSubscriptionExpiresAt clears the value of the "subscription_expires_at" field.
+func (m *UserMutation) ClearSubscriptionExpiresAt() {
+	m.subscription_expires_at = nil
+	m.clearedFields[user.FieldSubscriptionExpiresAt] = struct{}{}
+}
+
+// SubscriptionExpiresAtCleared returns if the "subscription_expires_at" field was cleared in this mutation.
+func (m *UserMutation) SubscriptionExpiresAtCleared() bool {
+	_, ok := m.clearedFields[user.FieldSubscriptionExpiresAt]
+	return ok
+}
+
+// ResetSubscriptionExpiresAt resets all changes to the "subscription_expires_at" field.
+func (m *UserMutation) ResetSubscriptionExpiresAt() {
+	m.subscription_expires_at = nil
+	delete(m.clearedFields, user.FieldSubscriptionExpiresAt)
+}
+
+// SetSubscriptionRef sets the "subscription_ref" field.
+func (m *UserMutation) SetSubscriptionRef(s string) {
+	m.subscription_ref = &s
+}
+
+// SubscriptionRef returns the value of the "subscription_ref" field in the mutation.
+func (m *UserMutation) SubscriptionRef() (r string, exists bool) {
+	v := m.subscription_ref
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldSubscriptionRef returns the old "subscription_ref" field's value of the User entity.
+// If the User object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *UserMutation) OldSubscriptionRef(ctx context.Context) (v *string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldSubscriptionRef is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldSubscriptionRef requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldSubscriptionRef: %w", err)
+	}
+	return oldValue.SubscriptionRef, nil
+}
+
+// ClearSubscriptionRef clears the value of the "subscription_ref" field.
+func (m *UserMutation) ClearSubscriptionRef() {
+	m.subscription_ref = nil
+	m.clearedFields[user.FieldSubscriptionRef] = struct{}{}
+}
+
+// SubscriptionRefCleared returns if the "subscription_ref" field was cleared in this mutation.
+func (m *UserMutation) SubscriptionRefCleared() bool {
+	_, ok := m.clearedFields[user.FieldSubscriptionRef]
+	return ok
+}
+
+// ResetSubscriptionRef resets all changes to the "subscription_ref" field.
+func (m *UserMutation) ResetSubscriptionRef() {
+	m.subscription_ref = nil
+	delete(m.clearedFields, user.FieldSubscriptionRef)
+}
+
+// SetSubscriptionCancelPending sets the "subscription_cancel_pending" field.
+func (m *UserMutation) SetSubscriptionCancelPending(b bool) {
+	m.subscription_cancel_pending = &b
+}
+
+// SubscriptionCancelPending returns the value of the "subscription_cancel_pending" field in the mutation.
+func (m *UserMutation) SubscriptionCancelPending() (r bool, exists bool) {
+	v := m.subscription_cancel_pending
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldSubscriptionCancelPending returns the old "subscription_cancel_pending" field's value of the User entity.
+// If the User object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *UserMutation) OldSubscriptionCancelPending(ctx context.Context) (v bool, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldSubscriptionCancelPending is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldSubscriptionCancelPending requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldSubscriptionCancelPending: %w", err)
+	}
+	return oldValue.SubscriptionCancelPending, nil
+}
+
+// ResetSubscriptionCancelPending resets all changes to the "subscription_cancel_pending" field.
+func (m *UserMutation) ResetSubscriptionCancelPending() {
+	m.subscription_cancel_pending = nil
+}
+
+// SetBillingEventAt sets the "billing_event_at" field.
+func (m *UserMutation) SetBillingEventAt(t time.Time) {
+	m.billing_event_at = &t
+}
+
+// BillingEventAt returns the value of the "billing_event_at" field in the mutation.
+func (m *UserMutation) BillingEventAt() (r time.Time, exists bool) {
+	v := m.billing_event_at
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldBillingEventAt returns the old "billing_event_at" field's value of the User entity.
+// If the User object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *UserMutation) OldBillingEventAt(ctx context.Context) (v *time.Time, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldBillingEventAt is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldBillingEventAt requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldBillingEventAt: %w", err)
+	}
+	return oldValue.BillingEventAt, nil
+}
+
+// ClearBillingEventAt clears the value of the "billing_event_at" field.
+func (m *UserMutation) ClearBillingEventAt() {
+	m.billing_event_at = nil
+	m.clearedFields[user.FieldBillingEventAt] = struct{}{}
+}
+
+// BillingEventAtCleared returns if the "billing_event_at" field was cleared in this mutation.
+func (m *UserMutation) BillingEventAtCleared() bool {
+	_, ok := m.clearedFields[user.FieldBillingEventAt]
+	return ok
+}
+
+// ResetBillingEventAt resets all changes to the "billing_event_at" field.
+func (m *UserMutation) ResetBillingEventAt() {
+	m.billing_event_at = nil
+	delete(m.clearedFields, user.FieldBillingEventAt)
+}
+
+// SetBillingEventID sets the "billing_event_id" field.
+func (m *UserMutation) SetBillingEventID(s string) {
+	m.billing_event_id = &s
+}
+
+// BillingEventID returns the value of the "billing_event_id" field in the mutation.
+func (m *UserMutation) BillingEventID() (r string, exists bool) {
+	v := m.billing_event_id
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldBillingEventID returns the old "billing_event_id" field's value of the User entity.
+// If the User object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *UserMutation) OldBillingEventID(ctx context.Context) (v *string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldBillingEventID is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldBillingEventID requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldBillingEventID: %w", err)
+	}
+	return oldValue.BillingEventID, nil
+}
+
+// ClearBillingEventID clears the value of the "billing_event_id" field.
+func (m *UserMutation) ClearBillingEventID() {
+	m.billing_event_id = nil
+	m.clearedFields[user.FieldBillingEventID] = struct{}{}
+}
+
+// BillingEventIDCleared returns if the "billing_event_id" field was cleared in this mutation.
+func (m *UserMutation) BillingEventIDCleared() bool {
+	_, ok := m.clearedFields[user.FieldBillingEventID]
+	return ok
+}
+
+// ResetBillingEventID resets all changes to the "billing_event_id" field.
+func (m *UserMutation) ResetBillingEventID() {
+	m.billing_event_id = nil
+	delete(m.clearedFields, user.FieldBillingEventID)
+}
+
 // SetCreatedAt sets the "created_at" field.
 func (m *UserMutation) SetCreatedAt(t time.Time) {
 	m.created_at = &t
@@ -3493,7 +3767,7 @@ func (m *UserMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *UserMutation) Fields() []string {
-	fields := make([]string, 0, 7)
+	fields := make([]string, 0, 13)
 	if m.username != nil {
 		fields = append(fields, user.FieldUsername)
 	}
@@ -3508,6 +3782,24 @@ func (m *UserMutation) Fields() []string {
 	}
 	if m.status != nil {
 		fields = append(fields, user.FieldStatus)
+	}
+	if m.subscription_source != nil {
+		fields = append(fields, user.FieldSubscriptionSource)
+	}
+	if m.subscription_expires_at != nil {
+		fields = append(fields, user.FieldSubscriptionExpiresAt)
+	}
+	if m.subscription_ref != nil {
+		fields = append(fields, user.FieldSubscriptionRef)
+	}
+	if m.subscription_cancel_pending != nil {
+		fields = append(fields, user.FieldSubscriptionCancelPending)
+	}
+	if m.billing_event_at != nil {
+		fields = append(fields, user.FieldBillingEventAt)
+	}
+	if m.billing_event_id != nil {
+		fields = append(fields, user.FieldBillingEventID)
 	}
 	if m.created_at != nil {
 		fields = append(fields, user.FieldCreatedAt)
@@ -3533,6 +3825,18 @@ func (m *UserMutation) Field(name string) (ent.Value, bool) {
 		return m.Banned()
 	case user.FieldStatus:
 		return m.Status()
+	case user.FieldSubscriptionSource:
+		return m.SubscriptionSource()
+	case user.FieldSubscriptionExpiresAt:
+		return m.SubscriptionExpiresAt()
+	case user.FieldSubscriptionRef:
+		return m.SubscriptionRef()
+	case user.FieldSubscriptionCancelPending:
+		return m.SubscriptionCancelPending()
+	case user.FieldBillingEventAt:
+		return m.BillingEventAt()
+	case user.FieldBillingEventID:
+		return m.BillingEventID()
 	case user.FieldCreatedAt:
 		return m.CreatedAt()
 	case user.FieldUpdatedAt:
@@ -3556,6 +3860,18 @@ func (m *UserMutation) OldField(ctx context.Context, name string) (ent.Value, er
 		return m.OldBanned(ctx)
 	case user.FieldStatus:
 		return m.OldStatus(ctx)
+	case user.FieldSubscriptionSource:
+		return m.OldSubscriptionSource(ctx)
+	case user.FieldSubscriptionExpiresAt:
+		return m.OldSubscriptionExpiresAt(ctx)
+	case user.FieldSubscriptionRef:
+		return m.OldSubscriptionRef(ctx)
+	case user.FieldSubscriptionCancelPending:
+		return m.OldSubscriptionCancelPending(ctx)
+	case user.FieldBillingEventAt:
+		return m.OldBillingEventAt(ctx)
+	case user.FieldBillingEventID:
+		return m.OldBillingEventID(ctx)
 	case user.FieldCreatedAt:
 		return m.OldCreatedAt(ctx)
 	case user.FieldUpdatedAt:
@@ -3604,6 +3920,48 @@ func (m *UserMutation) SetField(name string, value ent.Value) error {
 		}
 		m.SetStatus(v)
 		return nil
+	case user.FieldSubscriptionSource:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetSubscriptionSource(v)
+		return nil
+	case user.FieldSubscriptionExpiresAt:
+		v, ok := value.(time.Time)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetSubscriptionExpiresAt(v)
+		return nil
+	case user.FieldSubscriptionRef:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetSubscriptionRef(v)
+		return nil
+	case user.FieldSubscriptionCancelPending:
+		v, ok := value.(bool)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetSubscriptionCancelPending(v)
+		return nil
+	case user.FieldBillingEventAt:
+		v, ok := value.(time.Time)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetBillingEventAt(v)
+		return nil
+	case user.FieldBillingEventID:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetBillingEventID(v)
+		return nil
 	case user.FieldCreatedAt:
 		v, ok := value.(time.Time)
 		if !ok {
@@ -3647,7 +4005,20 @@ func (m *UserMutation) AddField(name string, value ent.Value) error {
 // ClearedFields returns all nullable fields that were cleared during this
 // mutation.
 func (m *UserMutation) ClearedFields() []string {
-	return nil
+	var fields []string
+	if m.FieldCleared(user.FieldSubscriptionExpiresAt) {
+		fields = append(fields, user.FieldSubscriptionExpiresAt)
+	}
+	if m.FieldCleared(user.FieldSubscriptionRef) {
+		fields = append(fields, user.FieldSubscriptionRef)
+	}
+	if m.FieldCleared(user.FieldBillingEventAt) {
+		fields = append(fields, user.FieldBillingEventAt)
+	}
+	if m.FieldCleared(user.FieldBillingEventID) {
+		fields = append(fields, user.FieldBillingEventID)
+	}
+	return fields
 }
 
 // FieldCleared returns a boolean indicating if a field with the given name was
@@ -3660,6 +4031,20 @@ func (m *UserMutation) FieldCleared(name string) bool {
 // ClearField clears the value of the field with the given name. It returns an
 // error if the field is not defined in the schema.
 func (m *UserMutation) ClearField(name string) error {
+	switch name {
+	case user.FieldSubscriptionExpiresAt:
+		m.ClearSubscriptionExpiresAt()
+		return nil
+	case user.FieldSubscriptionRef:
+		m.ClearSubscriptionRef()
+		return nil
+	case user.FieldBillingEventAt:
+		m.ClearBillingEventAt()
+		return nil
+	case user.FieldBillingEventID:
+		m.ClearBillingEventID()
+		return nil
+	}
 	return fmt.Errorf("unknown User nullable field %s", name)
 }
 
@@ -3681,6 +4066,24 @@ func (m *UserMutation) ResetField(name string) error {
 		return nil
 	case user.FieldStatus:
 		m.ResetStatus()
+		return nil
+	case user.FieldSubscriptionSource:
+		m.ResetSubscriptionSource()
+		return nil
+	case user.FieldSubscriptionExpiresAt:
+		m.ResetSubscriptionExpiresAt()
+		return nil
+	case user.FieldSubscriptionRef:
+		m.ResetSubscriptionRef()
+		return nil
+	case user.FieldSubscriptionCancelPending:
+		m.ResetSubscriptionCancelPending()
+		return nil
+	case user.FieldBillingEventAt:
+		m.ResetBillingEventAt()
+		return nil
+	case user.FieldBillingEventID:
+		m.ResetBillingEventID()
 		return nil
 	case user.FieldCreatedAt:
 		m.ResetCreatedAt()

--- a/app/users/ent/runtime.go
+++ b/app/users/ent/runtime.go
@@ -95,12 +95,20 @@ func init() {
 	userDescBanned := userFields[4].Descriptor()
 	// user.DefaultBanned holds the default value on creation for the banned field.
 	user.DefaultBanned = userDescBanned.Default.(bool)
+	// userDescSubscriptionSource is the schema descriptor for subscription_source field.
+	userDescSubscriptionSource := userFields[6].Descriptor()
+	// user.DefaultSubscriptionSource holds the default value on creation for the subscription_source field.
+	user.DefaultSubscriptionSource = userDescSubscriptionSource.Default.(string)
+	// userDescSubscriptionCancelPending is the schema descriptor for subscription_cancel_pending field.
+	userDescSubscriptionCancelPending := userFields[9].Descriptor()
+	// user.DefaultSubscriptionCancelPending holds the default value on creation for the subscription_cancel_pending field.
+	user.DefaultSubscriptionCancelPending = userDescSubscriptionCancelPending.Default.(bool)
 	// userDescCreatedAt is the schema descriptor for created_at field.
-	userDescCreatedAt := userFields[6].Descriptor()
+	userDescCreatedAt := userFields[12].Descriptor()
 	// user.DefaultCreatedAt holds the default value on creation for the created_at field.
 	user.DefaultCreatedAt = userDescCreatedAt.Default.(func() time.Time)
 	// userDescUpdatedAt is the schema descriptor for updated_at field.
-	userDescUpdatedAt := userFields[7].Descriptor()
+	userDescUpdatedAt := userFields[13].Descriptor()
 	// user.DefaultUpdatedAt holds the default value on creation for the updated_at field.
 	user.DefaultUpdatedAt = userDescUpdatedAt.Default.(func() time.Time)
 	// user.UpdateDefaultUpdatedAt holds the default value on update for the updated_at field.

--- a/app/users/ent/schema/user.go
+++ b/app/users/ent/schema/user.go
@@ -33,6 +33,16 @@ func (User) Fields() []ent.Field {
 			Values("free", "paid", "vip"). // vip is a permanent paid tier
 			Default("free"),
 
+		// Billing ownership is deliberately stored with the user tier. This lets
+		// webhook retries apply idempotently and prevents a Tebex cancellation
+		// from revoking a staff grant or permanent VIP status.
+		field.String("subscription_source").Default(""),
+		field.Time("subscription_expires_at").Optional().Nillable(),
+		field.String("subscription_ref").Optional().Nillable(),
+		field.Bool("subscription_cancel_pending").Default(false),
+		field.Time("billing_event_at").Optional().Nillable(),
+		field.String("billing_event_id").Optional().Nillable(),
+
 		field.Time("created_at").Default(time.Now),
 
 		field.Time("updated_at").

--- a/app/users/ent/user.go
+++ b/app/users/ent/user.go
@@ -27,6 +27,18 @@ type User struct {
 	Banned bool `json:"banned,omitempty"`
 	// Status holds the value of the "status" field.
 	Status user.Status `json:"status,omitempty"`
+	// SubscriptionSource holds the value of the "subscription_source" field.
+	SubscriptionSource string `json:"subscription_source,omitempty"`
+	// SubscriptionExpiresAt holds the value of the "subscription_expires_at" field.
+	SubscriptionExpiresAt *time.Time `json:"subscription_expires_at,omitempty"`
+	// SubscriptionRef holds the value of the "subscription_ref" field.
+	SubscriptionRef *string `json:"subscription_ref,omitempty"`
+	// SubscriptionCancelPending holds the value of the "subscription_cancel_pending" field.
+	SubscriptionCancelPending bool `json:"subscription_cancel_pending,omitempty"`
+	// BillingEventAt holds the value of the "billing_event_at" field.
+	BillingEventAt *time.Time `json:"billing_event_at,omitempty"`
+	// BillingEventID holds the value of the "billing_event_id" field.
+	BillingEventID *string `json:"billing_event_id,omitempty"`
 	// CreatedAt holds the value of the "created_at" field.
 	CreatedAt time.Time `json:"created_at,omitempty"`
 	// UpdatedAt holds the value of the "updated_at" field.
@@ -60,13 +72,13 @@ func (*User) scanValues(columns []string) ([]any, error) {
 	values := make([]any, len(columns))
 	for i := range columns {
 		switch columns[i] {
-		case user.FieldIsActive, user.FieldBanned:
+		case user.FieldIsActive, user.FieldBanned, user.FieldSubscriptionCancelPending:
 			values[i] = new(sql.NullBool)
 		case user.FieldID:
 			values[i] = new(sql.NullInt64)
-		case user.FieldUsername, user.FieldEmail, user.FieldStatus:
+		case user.FieldUsername, user.FieldEmail, user.FieldStatus, user.FieldSubscriptionSource, user.FieldSubscriptionRef, user.FieldBillingEventID:
 			values[i] = new(sql.NullString)
-		case user.FieldCreatedAt, user.FieldUpdatedAt:
+		case user.FieldSubscriptionExpiresAt, user.FieldBillingEventAt, user.FieldCreatedAt, user.FieldUpdatedAt:
 			values[i] = new(sql.NullTime)
 		default:
 			values[i] = new(sql.UnknownType)
@@ -118,6 +130,46 @@ func (_m *User) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field status", values[i])
 			} else if value.Valid {
 				_m.Status = user.Status(value.String)
+			}
+		case user.FieldSubscriptionSource:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field subscription_source", values[i])
+			} else if value.Valid {
+				_m.SubscriptionSource = value.String
+			}
+		case user.FieldSubscriptionExpiresAt:
+			if value, ok := values[i].(*sql.NullTime); !ok {
+				return fmt.Errorf("unexpected type %T for field subscription_expires_at", values[i])
+			} else if value.Valid {
+				_m.SubscriptionExpiresAt = new(time.Time)
+				*_m.SubscriptionExpiresAt = value.Time
+			}
+		case user.FieldSubscriptionRef:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field subscription_ref", values[i])
+			} else if value.Valid {
+				_m.SubscriptionRef = new(string)
+				*_m.SubscriptionRef = value.String
+			}
+		case user.FieldSubscriptionCancelPending:
+			if value, ok := values[i].(*sql.NullBool); !ok {
+				return fmt.Errorf("unexpected type %T for field subscription_cancel_pending", values[i])
+			} else if value.Valid {
+				_m.SubscriptionCancelPending = value.Bool
+			}
+		case user.FieldBillingEventAt:
+			if value, ok := values[i].(*sql.NullTime); !ok {
+				return fmt.Errorf("unexpected type %T for field billing_event_at", values[i])
+			} else if value.Valid {
+				_m.BillingEventAt = new(time.Time)
+				*_m.BillingEventAt = value.Time
+			}
+		case user.FieldBillingEventID:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field billing_event_id", values[i])
+			} else if value.Valid {
+				_m.BillingEventID = new(string)
+				*_m.BillingEventID = value.String
 			}
 		case user.FieldCreatedAt:
 			if value, ok := values[i].(*sql.NullTime); !ok {
@@ -185,6 +237,32 @@ func (_m *User) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("status=")
 	builder.WriteString(fmt.Sprintf("%v", _m.Status))
+	builder.WriteString(", ")
+	builder.WriteString("subscription_source=")
+	builder.WriteString(_m.SubscriptionSource)
+	builder.WriteString(", ")
+	if v := _m.SubscriptionExpiresAt; v != nil {
+		builder.WriteString("subscription_expires_at=")
+		builder.WriteString(v.Format(time.ANSIC))
+	}
+	builder.WriteString(", ")
+	if v := _m.SubscriptionRef; v != nil {
+		builder.WriteString("subscription_ref=")
+		builder.WriteString(*v)
+	}
+	builder.WriteString(", ")
+	builder.WriteString("subscription_cancel_pending=")
+	builder.WriteString(fmt.Sprintf("%v", _m.SubscriptionCancelPending))
+	builder.WriteString(", ")
+	if v := _m.BillingEventAt; v != nil {
+		builder.WriteString("billing_event_at=")
+		builder.WriteString(v.Format(time.ANSIC))
+	}
+	builder.WriteString(", ")
+	if v := _m.BillingEventID; v != nil {
+		builder.WriteString("billing_event_id=")
+		builder.WriteString(*v)
+	}
 	builder.WriteString(", ")
 	builder.WriteString("created_at=")
 	builder.WriteString(_m.CreatedAt.Format(time.ANSIC))

--- a/app/users/ent/user/user.go
+++ b/app/users/ent/user/user.go
@@ -25,6 +25,18 @@ const (
 	FieldBanned = "banned"
 	// FieldStatus holds the string denoting the status field in the database.
 	FieldStatus = "status"
+	// FieldSubscriptionSource holds the string denoting the subscription_source field in the database.
+	FieldSubscriptionSource = "subscription_source"
+	// FieldSubscriptionExpiresAt holds the string denoting the subscription_expires_at field in the database.
+	FieldSubscriptionExpiresAt = "subscription_expires_at"
+	// FieldSubscriptionRef holds the string denoting the subscription_ref field in the database.
+	FieldSubscriptionRef = "subscription_ref"
+	// FieldSubscriptionCancelPending holds the string denoting the subscription_cancel_pending field in the database.
+	FieldSubscriptionCancelPending = "subscription_cancel_pending"
+	// FieldBillingEventAt holds the string denoting the billing_event_at field in the database.
+	FieldBillingEventAt = "billing_event_at"
+	// FieldBillingEventID holds the string denoting the billing_event_id field in the database.
+	FieldBillingEventID = "billing_event_id"
 	// FieldCreatedAt holds the string denoting the created_at field in the database.
 	FieldCreatedAt = "created_at"
 	// FieldUpdatedAt holds the string denoting the updated_at field in the database.
@@ -50,6 +62,12 @@ var Columns = []string{
 	FieldIsActive,
 	FieldBanned,
 	FieldStatus,
+	FieldSubscriptionSource,
+	FieldSubscriptionExpiresAt,
+	FieldSubscriptionRef,
+	FieldSubscriptionCancelPending,
+	FieldBillingEventAt,
+	FieldBillingEventID,
 	FieldCreatedAt,
 	FieldUpdatedAt,
 }
@@ -73,6 +91,10 @@ var (
 	DefaultIsActive bool
 	// DefaultBanned holds the default value on creation for the "banned" field.
 	DefaultBanned bool
+	// DefaultSubscriptionSource holds the default value on creation for the "subscription_source" field.
+	DefaultSubscriptionSource string
+	// DefaultSubscriptionCancelPending holds the default value on creation for the "subscription_cancel_pending" field.
+	DefaultSubscriptionCancelPending bool
 	// DefaultCreatedAt holds the default value on creation for the "created_at" field.
 	DefaultCreatedAt func() time.Time
 	// DefaultUpdatedAt holds the default value on creation for the "updated_at" field.
@@ -139,6 +161,36 @@ func ByBanned(opts ...sql.OrderTermOption) OrderOption {
 // ByStatus orders the results by the status field.
 func ByStatus(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldStatus, opts...).ToFunc()
+}
+
+// BySubscriptionSource orders the results by the subscription_source field.
+func BySubscriptionSource(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldSubscriptionSource, opts...).ToFunc()
+}
+
+// BySubscriptionExpiresAt orders the results by the subscription_expires_at field.
+func BySubscriptionExpiresAt(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldSubscriptionExpiresAt, opts...).ToFunc()
+}
+
+// BySubscriptionRef orders the results by the subscription_ref field.
+func BySubscriptionRef(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldSubscriptionRef, opts...).ToFunc()
+}
+
+// BySubscriptionCancelPending orders the results by the subscription_cancel_pending field.
+func BySubscriptionCancelPending(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldSubscriptionCancelPending, opts...).ToFunc()
+}
+
+// ByBillingEventAt orders the results by the billing_event_at field.
+func ByBillingEventAt(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldBillingEventAt, opts...).ToFunc()
+}
+
+// ByBillingEventID orders the results by the billing_event_id field.
+func ByBillingEventID(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldBillingEventID, opts...).ToFunc()
 }
 
 // ByCreatedAt orders the results by the created_at field.

--- a/app/users/ent/user/where.go
+++ b/app/users/ent/user/where.go
@@ -75,6 +75,36 @@ func Banned(v bool) predicate.User {
 	return predicate.User(sql.FieldEQ(FieldBanned, v))
 }
 
+// SubscriptionSource applies equality check predicate on the "subscription_source" field. It's identical to SubscriptionSourceEQ.
+func SubscriptionSource(v string) predicate.User {
+	return predicate.User(sql.FieldEQ(FieldSubscriptionSource, v))
+}
+
+// SubscriptionExpiresAt applies equality check predicate on the "subscription_expires_at" field. It's identical to SubscriptionExpiresAtEQ.
+func SubscriptionExpiresAt(v time.Time) predicate.User {
+	return predicate.User(sql.FieldEQ(FieldSubscriptionExpiresAt, v))
+}
+
+// SubscriptionRef applies equality check predicate on the "subscription_ref" field. It's identical to SubscriptionRefEQ.
+func SubscriptionRef(v string) predicate.User {
+	return predicate.User(sql.FieldEQ(FieldSubscriptionRef, v))
+}
+
+// SubscriptionCancelPending applies equality check predicate on the "subscription_cancel_pending" field. It's identical to SubscriptionCancelPendingEQ.
+func SubscriptionCancelPending(v bool) predicate.User {
+	return predicate.User(sql.FieldEQ(FieldSubscriptionCancelPending, v))
+}
+
+// BillingEventAt applies equality check predicate on the "billing_event_at" field. It's identical to BillingEventAtEQ.
+func BillingEventAt(v time.Time) predicate.User {
+	return predicate.User(sql.FieldEQ(FieldBillingEventAt, v))
+}
+
+// BillingEventID applies equality check predicate on the "billing_event_id" field. It's identical to BillingEventIDEQ.
+func BillingEventID(v string) predicate.User {
+	return predicate.User(sql.FieldEQ(FieldBillingEventID, v))
+}
+
 // CreatedAt applies equality check predicate on the "created_at" field. It's identical to CreatedAtEQ.
 func CreatedAt(v time.Time) predicate.User {
 	return predicate.User(sql.FieldEQ(FieldCreatedAt, v))
@@ -253,6 +283,331 @@ func StatusIn(vs ...Status) predicate.User {
 // StatusNotIn applies the NotIn predicate on the "status" field.
 func StatusNotIn(vs ...Status) predicate.User {
 	return predicate.User(sql.FieldNotIn(FieldStatus, vs...))
+}
+
+// SubscriptionSourceEQ applies the EQ predicate on the "subscription_source" field.
+func SubscriptionSourceEQ(v string) predicate.User {
+	return predicate.User(sql.FieldEQ(FieldSubscriptionSource, v))
+}
+
+// SubscriptionSourceNEQ applies the NEQ predicate on the "subscription_source" field.
+func SubscriptionSourceNEQ(v string) predicate.User {
+	return predicate.User(sql.FieldNEQ(FieldSubscriptionSource, v))
+}
+
+// SubscriptionSourceIn applies the In predicate on the "subscription_source" field.
+func SubscriptionSourceIn(vs ...string) predicate.User {
+	return predicate.User(sql.FieldIn(FieldSubscriptionSource, vs...))
+}
+
+// SubscriptionSourceNotIn applies the NotIn predicate on the "subscription_source" field.
+func SubscriptionSourceNotIn(vs ...string) predicate.User {
+	return predicate.User(sql.FieldNotIn(FieldSubscriptionSource, vs...))
+}
+
+// SubscriptionSourceGT applies the GT predicate on the "subscription_source" field.
+func SubscriptionSourceGT(v string) predicate.User {
+	return predicate.User(sql.FieldGT(FieldSubscriptionSource, v))
+}
+
+// SubscriptionSourceGTE applies the GTE predicate on the "subscription_source" field.
+func SubscriptionSourceGTE(v string) predicate.User {
+	return predicate.User(sql.FieldGTE(FieldSubscriptionSource, v))
+}
+
+// SubscriptionSourceLT applies the LT predicate on the "subscription_source" field.
+func SubscriptionSourceLT(v string) predicate.User {
+	return predicate.User(sql.FieldLT(FieldSubscriptionSource, v))
+}
+
+// SubscriptionSourceLTE applies the LTE predicate on the "subscription_source" field.
+func SubscriptionSourceLTE(v string) predicate.User {
+	return predicate.User(sql.FieldLTE(FieldSubscriptionSource, v))
+}
+
+// SubscriptionSourceContains applies the Contains predicate on the "subscription_source" field.
+func SubscriptionSourceContains(v string) predicate.User {
+	return predicate.User(sql.FieldContains(FieldSubscriptionSource, v))
+}
+
+// SubscriptionSourceHasPrefix applies the HasPrefix predicate on the "subscription_source" field.
+func SubscriptionSourceHasPrefix(v string) predicate.User {
+	return predicate.User(sql.FieldHasPrefix(FieldSubscriptionSource, v))
+}
+
+// SubscriptionSourceHasSuffix applies the HasSuffix predicate on the "subscription_source" field.
+func SubscriptionSourceHasSuffix(v string) predicate.User {
+	return predicate.User(sql.FieldHasSuffix(FieldSubscriptionSource, v))
+}
+
+// SubscriptionSourceEqualFold applies the EqualFold predicate on the "subscription_source" field.
+func SubscriptionSourceEqualFold(v string) predicate.User {
+	return predicate.User(sql.FieldEqualFold(FieldSubscriptionSource, v))
+}
+
+// SubscriptionSourceContainsFold applies the ContainsFold predicate on the "subscription_source" field.
+func SubscriptionSourceContainsFold(v string) predicate.User {
+	return predicate.User(sql.FieldContainsFold(FieldSubscriptionSource, v))
+}
+
+// SubscriptionExpiresAtEQ applies the EQ predicate on the "subscription_expires_at" field.
+func SubscriptionExpiresAtEQ(v time.Time) predicate.User {
+	return predicate.User(sql.FieldEQ(FieldSubscriptionExpiresAt, v))
+}
+
+// SubscriptionExpiresAtNEQ applies the NEQ predicate on the "subscription_expires_at" field.
+func SubscriptionExpiresAtNEQ(v time.Time) predicate.User {
+	return predicate.User(sql.FieldNEQ(FieldSubscriptionExpiresAt, v))
+}
+
+// SubscriptionExpiresAtIn applies the In predicate on the "subscription_expires_at" field.
+func SubscriptionExpiresAtIn(vs ...time.Time) predicate.User {
+	return predicate.User(sql.FieldIn(FieldSubscriptionExpiresAt, vs...))
+}
+
+// SubscriptionExpiresAtNotIn applies the NotIn predicate on the "subscription_expires_at" field.
+func SubscriptionExpiresAtNotIn(vs ...time.Time) predicate.User {
+	return predicate.User(sql.FieldNotIn(FieldSubscriptionExpiresAt, vs...))
+}
+
+// SubscriptionExpiresAtGT applies the GT predicate on the "subscription_expires_at" field.
+func SubscriptionExpiresAtGT(v time.Time) predicate.User {
+	return predicate.User(sql.FieldGT(FieldSubscriptionExpiresAt, v))
+}
+
+// SubscriptionExpiresAtGTE applies the GTE predicate on the "subscription_expires_at" field.
+func SubscriptionExpiresAtGTE(v time.Time) predicate.User {
+	return predicate.User(sql.FieldGTE(FieldSubscriptionExpiresAt, v))
+}
+
+// SubscriptionExpiresAtLT applies the LT predicate on the "subscription_expires_at" field.
+func SubscriptionExpiresAtLT(v time.Time) predicate.User {
+	return predicate.User(sql.FieldLT(FieldSubscriptionExpiresAt, v))
+}
+
+// SubscriptionExpiresAtLTE applies the LTE predicate on the "subscription_expires_at" field.
+func SubscriptionExpiresAtLTE(v time.Time) predicate.User {
+	return predicate.User(sql.FieldLTE(FieldSubscriptionExpiresAt, v))
+}
+
+// SubscriptionExpiresAtIsNil applies the IsNil predicate on the "subscription_expires_at" field.
+func SubscriptionExpiresAtIsNil() predicate.User {
+	return predicate.User(sql.FieldIsNull(FieldSubscriptionExpiresAt))
+}
+
+// SubscriptionExpiresAtNotNil applies the NotNil predicate on the "subscription_expires_at" field.
+func SubscriptionExpiresAtNotNil() predicate.User {
+	return predicate.User(sql.FieldNotNull(FieldSubscriptionExpiresAt))
+}
+
+// SubscriptionRefEQ applies the EQ predicate on the "subscription_ref" field.
+func SubscriptionRefEQ(v string) predicate.User {
+	return predicate.User(sql.FieldEQ(FieldSubscriptionRef, v))
+}
+
+// SubscriptionRefNEQ applies the NEQ predicate on the "subscription_ref" field.
+func SubscriptionRefNEQ(v string) predicate.User {
+	return predicate.User(sql.FieldNEQ(FieldSubscriptionRef, v))
+}
+
+// SubscriptionRefIn applies the In predicate on the "subscription_ref" field.
+func SubscriptionRefIn(vs ...string) predicate.User {
+	return predicate.User(sql.FieldIn(FieldSubscriptionRef, vs...))
+}
+
+// SubscriptionRefNotIn applies the NotIn predicate on the "subscription_ref" field.
+func SubscriptionRefNotIn(vs ...string) predicate.User {
+	return predicate.User(sql.FieldNotIn(FieldSubscriptionRef, vs...))
+}
+
+// SubscriptionRefGT applies the GT predicate on the "subscription_ref" field.
+func SubscriptionRefGT(v string) predicate.User {
+	return predicate.User(sql.FieldGT(FieldSubscriptionRef, v))
+}
+
+// SubscriptionRefGTE applies the GTE predicate on the "subscription_ref" field.
+func SubscriptionRefGTE(v string) predicate.User {
+	return predicate.User(sql.FieldGTE(FieldSubscriptionRef, v))
+}
+
+// SubscriptionRefLT applies the LT predicate on the "subscription_ref" field.
+func SubscriptionRefLT(v string) predicate.User {
+	return predicate.User(sql.FieldLT(FieldSubscriptionRef, v))
+}
+
+// SubscriptionRefLTE applies the LTE predicate on the "subscription_ref" field.
+func SubscriptionRefLTE(v string) predicate.User {
+	return predicate.User(sql.FieldLTE(FieldSubscriptionRef, v))
+}
+
+// SubscriptionRefContains applies the Contains predicate on the "subscription_ref" field.
+func SubscriptionRefContains(v string) predicate.User {
+	return predicate.User(sql.FieldContains(FieldSubscriptionRef, v))
+}
+
+// SubscriptionRefHasPrefix applies the HasPrefix predicate on the "subscription_ref" field.
+func SubscriptionRefHasPrefix(v string) predicate.User {
+	return predicate.User(sql.FieldHasPrefix(FieldSubscriptionRef, v))
+}
+
+// SubscriptionRefHasSuffix applies the HasSuffix predicate on the "subscription_ref" field.
+func SubscriptionRefHasSuffix(v string) predicate.User {
+	return predicate.User(sql.FieldHasSuffix(FieldSubscriptionRef, v))
+}
+
+// SubscriptionRefIsNil applies the IsNil predicate on the "subscription_ref" field.
+func SubscriptionRefIsNil() predicate.User {
+	return predicate.User(sql.FieldIsNull(FieldSubscriptionRef))
+}
+
+// SubscriptionRefNotNil applies the NotNil predicate on the "subscription_ref" field.
+func SubscriptionRefNotNil() predicate.User {
+	return predicate.User(sql.FieldNotNull(FieldSubscriptionRef))
+}
+
+// SubscriptionRefEqualFold applies the EqualFold predicate on the "subscription_ref" field.
+func SubscriptionRefEqualFold(v string) predicate.User {
+	return predicate.User(sql.FieldEqualFold(FieldSubscriptionRef, v))
+}
+
+// SubscriptionRefContainsFold applies the ContainsFold predicate on the "subscription_ref" field.
+func SubscriptionRefContainsFold(v string) predicate.User {
+	return predicate.User(sql.FieldContainsFold(FieldSubscriptionRef, v))
+}
+
+// SubscriptionCancelPendingEQ applies the EQ predicate on the "subscription_cancel_pending" field.
+func SubscriptionCancelPendingEQ(v bool) predicate.User {
+	return predicate.User(sql.FieldEQ(FieldSubscriptionCancelPending, v))
+}
+
+// SubscriptionCancelPendingNEQ applies the NEQ predicate on the "subscription_cancel_pending" field.
+func SubscriptionCancelPendingNEQ(v bool) predicate.User {
+	return predicate.User(sql.FieldNEQ(FieldSubscriptionCancelPending, v))
+}
+
+// BillingEventAtEQ applies the EQ predicate on the "billing_event_at" field.
+func BillingEventAtEQ(v time.Time) predicate.User {
+	return predicate.User(sql.FieldEQ(FieldBillingEventAt, v))
+}
+
+// BillingEventAtNEQ applies the NEQ predicate on the "billing_event_at" field.
+func BillingEventAtNEQ(v time.Time) predicate.User {
+	return predicate.User(sql.FieldNEQ(FieldBillingEventAt, v))
+}
+
+// BillingEventAtIn applies the In predicate on the "billing_event_at" field.
+func BillingEventAtIn(vs ...time.Time) predicate.User {
+	return predicate.User(sql.FieldIn(FieldBillingEventAt, vs...))
+}
+
+// BillingEventAtNotIn applies the NotIn predicate on the "billing_event_at" field.
+func BillingEventAtNotIn(vs ...time.Time) predicate.User {
+	return predicate.User(sql.FieldNotIn(FieldBillingEventAt, vs...))
+}
+
+// BillingEventAtGT applies the GT predicate on the "billing_event_at" field.
+func BillingEventAtGT(v time.Time) predicate.User {
+	return predicate.User(sql.FieldGT(FieldBillingEventAt, v))
+}
+
+// BillingEventAtGTE applies the GTE predicate on the "billing_event_at" field.
+func BillingEventAtGTE(v time.Time) predicate.User {
+	return predicate.User(sql.FieldGTE(FieldBillingEventAt, v))
+}
+
+// BillingEventAtLT applies the LT predicate on the "billing_event_at" field.
+func BillingEventAtLT(v time.Time) predicate.User {
+	return predicate.User(sql.FieldLT(FieldBillingEventAt, v))
+}
+
+// BillingEventAtLTE applies the LTE predicate on the "billing_event_at" field.
+func BillingEventAtLTE(v time.Time) predicate.User {
+	return predicate.User(sql.FieldLTE(FieldBillingEventAt, v))
+}
+
+// BillingEventAtIsNil applies the IsNil predicate on the "billing_event_at" field.
+func BillingEventAtIsNil() predicate.User {
+	return predicate.User(sql.FieldIsNull(FieldBillingEventAt))
+}
+
+// BillingEventAtNotNil applies the NotNil predicate on the "billing_event_at" field.
+func BillingEventAtNotNil() predicate.User {
+	return predicate.User(sql.FieldNotNull(FieldBillingEventAt))
+}
+
+// BillingEventIDEQ applies the EQ predicate on the "billing_event_id" field.
+func BillingEventIDEQ(v string) predicate.User {
+	return predicate.User(sql.FieldEQ(FieldBillingEventID, v))
+}
+
+// BillingEventIDNEQ applies the NEQ predicate on the "billing_event_id" field.
+func BillingEventIDNEQ(v string) predicate.User {
+	return predicate.User(sql.FieldNEQ(FieldBillingEventID, v))
+}
+
+// BillingEventIDIn applies the In predicate on the "billing_event_id" field.
+func BillingEventIDIn(vs ...string) predicate.User {
+	return predicate.User(sql.FieldIn(FieldBillingEventID, vs...))
+}
+
+// BillingEventIDNotIn applies the NotIn predicate on the "billing_event_id" field.
+func BillingEventIDNotIn(vs ...string) predicate.User {
+	return predicate.User(sql.FieldNotIn(FieldBillingEventID, vs...))
+}
+
+// BillingEventIDGT applies the GT predicate on the "billing_event_id" field.
+func BillingEventIDGT(v string) predicate.User {
+	return predicate.User(sql.FieldGT(FieldBillingEventID, v))
+}
+
+// BillingEventIDGTE applies the GTE predicate on the "billing_event_id" field.
+func BillingEventIDGTE(v string) predicate.User {
+	return predicate.User(sql.FieldGTE(FieldBillingEventID, v))
+}
+
+// BillingEventIDLT applies the LT predicate on the "billing_event_id" field.
+func BillingEventIDLT(v string) predicate.User {
+	return predicate.User(sql.FieldLT(FieldBillingEventID, v))
+}
+
+// BillingEventIDLTE applies the LTE predicate on the "billing_event_id" field.
+func BillingEventIDLTE(v string) predicate.User {
+	return predicate.User(sql.FieldLTE(FieldBillingEventID, v))
+}
+
+// BillingEventIDContains applies the Contains predicate on the "billing_event_id" field.
+func BillingEventIDContains(v string) predicate.User {
+	return predicate.User(sql.FieldContains(FieldBillingEventID, v))
+}
+
+// BillingEventIDHasPrefix applies the HasPrefix predicate on the "billing_event_id" field.
+func BillingEventIDHasPrefix(v string) predicate.User {
+	return predicate.User(sql.FieldHasPrefix(FieldBillingEventID, v))
+}
+
+// BillingEventIDHasSuffix applies the HasSuffix predicate on the "billing_event_id" field.
+func BillingEventIDHasSuffix(v string) predicate.User {
+	return predicate.User(sql.FieldHasSuffix(FieldBillingEventID, v))
+}
+
+// BillingEventIDIsNil applies the IsNil predicate on the "billing_event_id" field.
+func BillingEventIDIsNil() predicate.User {
+	return predicate.User(sql.FieldIsNull(FieldBillingEventID))
+}
+
+// BillingEventIDNotNil applies the NotNil predicate on the "billing_event_id" field.
+func BillingEventIDNotNil() predicate.User {
+	return predicate.User(sql.FieldNotNull(FieldBillingEventID))
+}
+
+// BillingEventIDEqualFold applies the EqualFold predicate on the "billing_event_id" field.
+func BillingEventIDEqualFold(v string) predicate.User {
+	return predicate.User(sql.FieldEqualFold(FieldBillingEventID, v))
+}
+
+// BillingEventIDContainsFold applies the ContainsFold predicate on the "billing_event_id" field.
+func BillingEventIDContainsFold(v string) predicate.User {
+	return predicate.User(sql.FieldContainsFold(FieldBillingEventID, v))
 }
 
 // CreatedAtEQ applies the EQ predicate on the "created_at" field.

--- a/app/users/ent/user_create.go
+++ b/app/users/ent/user_create.go
@@ -75,6 +75,90 @@ func (_c *UserCreate) SetNillableStatus(v *user.Status) *UserCreate {
 	return _c
 }
 
+// SetSubscriptionSource sets the "subscription_source" field.
+func (_c *UserCreate) SetSubscriptionSource(v string) *UserCreate {
+	_c.mutation.SetSubscriptionSource(v)
+	return _c
+}
+
+// SetNillableSubscriptionSource sets the "subscription_source" field if the given value is not nil.
+func (_c *UserCreate) SetNillableSubscriptionSource(v *string) *UserCreate {
+	if v != nil {
+		_c.SetSubscriptionSource(*v)
+	}
+	return _c
+}
+
+// SetSubscriptionExpiresAt sets the "subscription_expires_at" field.
+func (_c *UserCreate) SetSubscriptionExpiresAt(v time.Time) *UserCreate {
+	_c.mutation.SetSubscriptionExpiresAt(v)
+	return _c
+}
+
+// SetNillableSubscriptionExpiresAt sets the "subscription_expires_at" field if the given value is not nil.
+func (_c *UserCreate) SetNillableSubscriptionExpiresAt(v *time.Time) *UserCreate {
+	if v != nil {
+		_c.SetSubscriptionExpiresAt(*v)
+	}
+	return _c
+}
+
+// SetSubscriptionRef sets the "subscription_ref" field.
+func (_c *UserCreate) SetSubscriptionRef(v string) *UserCreate {
+	_c.mutation.SetSubscriptionRef(v)
+	return _c
+}
+
+// SetNillableSubscriptionRef sets the "subscription_ref" field if the given value is not nil.
+func (_c *UserCreate) SetNillableSubscriptionRef(v *string) *UserCreate {
+	if v != nil {
+		_c.SetSubscriptionRef(*v)
+	}
+	return _c
+}
+
+// SetSubscriptionCancelPending sets the "subscription_cancel_pending" field.
+func (_c *UserCreate) SetSubscriptionCancelPending(v bool) *UserCreate {
+	_c.mutation.SetSubscriptionCancelPending(v)
+	return _c
+}
+
+// SetNillableSubscriptionCancelPending sets the "subscription_cancel_pending" field if the given value is not nil.
+func (_c *UserCreate) SetNillableSubscriptionCancelPending(v *bool) *UserCreate {
+	if v != nil {
+		_c.SetSubscriptionCancelPending(*v)
+	}
+	return _c
+}
+
+// SetBillingEventAt sets the "billing_event_at" field.
+func (_c *UserCreate) SetBillingEventAt(v time.Time) *UserCreate {
+	_c.mutation.SetBillingEventAt(v)
+	return _c
+}
+
+// SetNillableBillingEventAt sets the "billing_event_at" field if the given value is not nil.
+func (_c *UserCreate) SetNillableBillingEventAt(v *time.Time) *UserCreate {
+	if v != nil {
+		_c.SetBillingEventAt(*v)
+	}
+	return _c
+}
+
+// SetBillingEventID sets the "billing_event_id" field.
+func (_c *UserCreate) SetBillingEventID(v string) *UserCreate {
+	_c.mutation.SetBillingEventID(v)
+	return _c
+}
+
+// SetNillableBillingEventID sets the "billing_event_id" field if the given value is not nil.
+func (_c *UserCreate) SetNillableBillingEventID(v *string) *UserCreate {
+	if v != nil {
+		_c.SetBillingEventID(*v)
+	}
+	return _c
+}
+
 // SetCreatedAt sets the "created_at" field.
 func (_c *UserCreate) SetCreatedAt(v time.Time) *UserCreate {
 	_c.mutation.SetCreatedAt(v)
@@ -171,6 +255,14 @@ func (_c *UserCreate) defaults() {
 		v := user.DefaultStatus
 		_c.mutation.SetStatus(v)
 	}
+	if _, ok := _c.mutation.SubscriptionSource(); !ok {
+		v := user.DefaultSubscriptionSource
+		_c.mutation.SetSubscriptionSource(v)
+	}
+	if _, ok := _c.mutation.SubscriptionCancelPending(); !ok {
+		v := user.DefaultSubscriptionCancelPending
+		_c.mutation.SetSubscriptionCancelPending(v)
+	}
 	if _, ok := _c.mutation.CreatedAt(); !ok {
 		v := user.DefaultCreatedAt()
 		_c.mutation.SetCreatedAt(v)
@@ -212,6 +304,12 @@ func (_c *UserCreate) check() error {
 		if err := user.StatusValidator(v); err != nil {
 			return &ValidationError{Name: "status", err: fmt.Errorf(`ent: validator failed for field "User.status": %w`, err)}
 		}
+	}
+	if _, ok := _c.mutation.SubscriptionSource(); !ok {
+		return &ValidationError{Name: "subscription_source", err: errors.New(`ent: missing required field "User.subscription_source"`)}
+	}
+	if _, ok := _c.mutation.SubscriptionCancelPending(); !ok {
+		return &ValidationError{Name: "subscription_cancel_pending", err: errors.New(`ent: missing required field "User.subscription_cancel_pending"`)}
 	}
 	if _, ok := _c.mutation.CreatedAt(); !ok {
 		return &ValidationError{Name: "created_at", err: errors.New(`ent: missing required field "User.created_at"`)}
@@ -270,6 +368,30 @@ func (_c *UserCreate) createSpec() (*User, *sqlgraph.CreateSpec) {
 	if value, ok := _c.mutation.Status(); ok {
 		_spec.SetField(user.FieldStatus, field.TypeEnum, value)
 		_node.Status = value
+	}
+	if value, ok := _c.mutation.SubscriptionSource(); ok {
+		_spec.SetField(user.FieldSubscriptionSource, field.TypeString, value)
+		_node.SubscriptionSource = value
+	}
+	if value, ok := _c.mutation.SubscriptionExpiresAt(); ok {
+		_spec.SetField(user.FieldSubscriptionExpiresAt, field.TypeTime, value)
+		_node.SubscriptionExpiresAt = &value
+	}
+	if value, ok := _c.mutation.SubscriptionRef(); ok {
+		_spec.SetField(user.FieldSubscriptionRef, field.TypeString, value)
+		_node.SubscriptionRef = &value
+	}
+	if value, ok := _c.mutation.SubscriptionCancelPending(); ok {
+		_spec.SetField(user.FieldSubscriptionCancelPending, field.TypeBool, value)
+		_node.SubscriptionCancelPending = value
+	}
+	if value, ok := _c.mutation.BillingEventAt(); ok {
+		_spec.SetField(user.FieldBillingEventAt, field.TypeTime, value)
+		_node.BillingEventAt = &value
+	}
+	if value, ok := _c.mutation.BillingEventID(); ok {
+		_spec.SetField(user.FieldBillingEventID, field.TypeString, value)
+		_node.BillingEventID = &value
 	}
 	if value, ok := _c.mutation.CreatedAt(); ok {
 		_spec.SetField(user.FieldCreatedAt, field.TypeTime, value)

--- a/app/users/ent/user_update.go
+++ b/app/users/ent/user_update.go
@@ -99,6 +99,114 @@ func (_u *UserUpdate) SetNillableStatus(v *user.Status) *UserUpdate {
 	return _u
 }
 
+// SetSubscriptionSource sets the "subscription_source" field.
+func (_u *UserUpdate) SetSubscriptionSource(v string) *UserUpdate {
+	_u.mutation.SetSubscriptionSource(v)
+	return _u
+}
+
+// SetNillableSubscriptionSource sets the "subscription_source" field if the given value is not nil.
+func (_u *UserUpdate) SetNillableSubscriptionSource(v *string) *UserUpdate {
+	if v != nil {
+		_u.SetSubscriptionSource(*v)
+	}
+	return _u
+}
+
+// SetSubscriptionExpiresAt sets the "subscription_expires_at" field.
+func (_u *UserUpdate) SetSubscriptionExpiresAt(v time.Time) *UserUpdate {
+	_u.mutation.SetSubscriptionExpiresAt(v)
+	return _u
+}
+
+// SetNillableSubscriptionExpiresAt sets the "subscription_expires_at" field if the given value is not nil.
+func (_u *UserUpdate) SetNillableSubscriptionExpiresAt(v *time.Time) *UserUpdate {
+	if v != nil {
+		_u.SetSubscriptionExpiresAt(*v)
+	}
+	return _u
+}
+
+// ClearSubscriptionExpiresAt clears the value of the "subscription_expires_at" field.
+func (_u *UserUpdate) ClearSubscriptionExpiresAt() *UserUpdate {
+	_u.mutation.ClearSubscriptionExpiresAt()
+	return _u
+}
+
+// SetSubscriptionRef sets the "subscription_ref" field.
+func (_u *UserUpdate) SetSubscriptionRef(v string) *UserUpdate {
+	_u.mutation.SetSubscriptionRef(v)
+	return _u
+}
+
+// SetNillableSubscriptionRef sets the "subscription_ref" field if the given value is not nil.
+func (_u *UserUpdate) SetNillableSubscriptionRef(v *string) *UserUpdate {
+	if v != nil {
+		_u.SetSubscriptionRef(*v)
+	}
+	return _u
+}
+
+// ClearSubscriptionRef clears the value of the "subscription_ref" field.
+func (_u *UserUpdate) ClearSubscriptionRef() *UserUpdate {
+	_u.mutation.ClearSubscriptionRef()
+	return _u
+}
+
+// SetSubscriptionCancelPending sets the "subscription_cancel_pending" field.
+func (_u *UserUpdate) SetSubscriptionCancelPending(v bool) *UserUpdate {
+	_u.mutation.SetSubscriptionCancelPending(v)
+	return _u
+}
+
+// SetNillableSubscriptionCancelPending sets the "subscription_cancel_pending" field if the given value is not nil.
+func (_u *UserUpdate) SetNillableSubscriptionCancelPending(v *bool) *UserUpdate {
+	if v != nil {
+		_u.SetSubscriptionCancelPending(*v)
+	}
+	return _u
+}
+
+// SetBillingEventAt sets the "billing_event_at" field.
+func (_u *UserUpdate) SetBillingEventAt(v time.Time) *UserUpdate {
+	_u.mutation.SetBillingEventAt(v)
+	return _u
+}
+
+// SetNillableBillingEventAt sets the "billing_event_at" field if the given value is not nil.
+func (_u *UserUpdate) SetNillableBillingEventAt(v *time.Time) *UserUpdate {
+	if v != nil {
+		_u.SetBillingEventAt(*v)
+	}
+	return _u
+}
+
+// ClearBillingEventAt clears the value of the "billing_event_at" field.
+func (_u *UserUpdate) ClearBillingEventAt() *UserUpdate {
+	_u.mutation.ClearBillingEventAt()
+	return _u
+}
+
+// SetBillingEventID sets the "billing_event_id" field.
+func (_u *UserUpdate) SetBillingEventID(v string) *UserUpdate {
+	_u.mutation.SetBillingEventID(v)
+	return _u
+}
+
+// SetNillableBillingEventID sets the "billing_event_id" field if the given value is not nil.
+func (_u *UserUpdate) SetNillableBillingEventID(v *string) *UserUpdate {
+	if v != nil {
+		_u.SetBillingEventID(*v)
+	}
+	return _u
+}
+
+// ClearBillingEventID clears the value of the "billing_event_id" field.
+func (_u *UserUpdate) ClearBillingEventID() *UserUpdate {
+	_u.mutation.ClearBillingEventID()
+	return _u
+}
+
 // SetCreatedAt sets the "created_at" field.
 func (_u *UserUpdate) SetCreatedAt(v time.Time) *UserUpdate {
 	_u.mutation.SetCreatedAt(v)
@@ -243,6 +351,36 @@ func (_u *UserUpdate) sqlSave(ctx context.Context) (_node int, err error) {
 	if value, ok := _u.mutation.Status(); ok {
 		_spec.SetField(user.FieldStatus, field.TypeEnum, value)
 	}
+	if value, ok := _u.mutation.SubscriptionSource(); ok {
+		_spec.SetField(user.FieldSubscriptionSource, field.TypeString, value)
+	}
+	if value, ok := _u.mutation.SubscriptionExpiresAt(); ok {
+		_spec.SetField(user.FieldSubscriptionExpiresAt, field.TypeTime, value)
+	}
+	if _u.mutation.SubscriptionExpiresAtCleared() {
+		_spec.ClearField(user.FieldSubscriptionExpiresAt, field.TypeTime)
+	}
+	if value, ok := _u.mutation.SubscriptionRef(); ok {
+		_spec.SetField(user.FieldSubscriptionRef, field.TypeString, value)
+	}
+	if _u.mutation.SubscriptionRefCleared() {
+		_spec.ClearField(user.FieldSubscriptionRef, field.TypeString)
+	}
+	if value, ok := _u.mutation.SubscriptionCancelPending(); ok {
+		_spec.SetField(user.FieldSubscriptionCancelPending, field.TypeBool, value)
+	}
+	if value, ok := _u.mutation.BillingEventAt(); ok {
+		_spec.SetField(user.FieldBillingEventAt, field.TypeTime, value)
+	}
+	if _u.mutation.BillingEventAtCleared() {
+		_spec.ClearField(user.FieldBillingEventAt, field.TypeTime)
+	}
+	if value, ok := _u.mutation.BillingEventID(); ok {
+		_spec.SetField(user.FieldBillingEventID, field.TypeString, value)
+	}
+	if _u.mutation.BillingEventIDCleared() {
+		_spec.ClearField(user.FieldBillingEventID, field.TypeString)
+	}
 	if value, ok := _u.mutation.CreatedAt(); ok {
 		_spec.SetField(user.FieldCreatedAt, field.TypeTime, value)
 	}
@@ -381,6 +519,114 @@ func (_u *UserUpdateOne) SetNillableStatus(v *user.Status) *UserUpdateOne {
 	if v != nil {
 		_u.SetStatus(*v)
 	}
+	return _u
+}
+
+// SetSubscriptionSource sets the "subscription_source" field.
+func (_u *UserUpdateOne) SetSubscriptionSource(v string) *UserUpdateOne {
+	_u.mutation.SetSubscriptionSource(v)
+	return _u
+}
+
+// SetNillableSubscriptionSource sets the "subscription_source" field if the given value is not nil.
+func (_u *UserUpdateOne) SetNillableSubscriptionSource(v *string) *UserUpdateOne {
+	if v != nil {
+		_u.SetSubscriptionSource(*v)
+	}
+	return _u
+}
+
+// SetSubscriptionExpiresAt sets the "subscription_expires_at" field.
+func (_u *UserUpdateOne) SetSubscriptionExpiresAt(v time.Time) *UserUpdateOne {
+	_u.mutation.SetSubscriptionExpiresAt(v)
+	return _u
+}
+
+// SetNillableSubscriptionExpiresAt sets the "subscription_expires_at" field if the given value is not nil.
+func (_u *UserUpdateOne) SetNillableSubscriptionExpiresAt(v *time.Time) *UserUpdateOne {
+	if v != nil {
+		_u.SetSubscriptionExpiresAt(*v)
+	}
+	return _u
+}
+
+// ClearSubscriptionExpiresAt clears the value of the "subscription_expires_at" field.
+func (_u *UserUpdateOne) ClearSubscriptionExpiresAt() *UserUpdateOne {
+	_u.mutation.ClearSubscriptionExpiresAt()
+	return _u
+}
+
+// SetSubscriptionRef sets the "subscription_ref" field.
+func (_u *UserUpdateOne) SetSubscriptionRef(v string) *UserUpdateOne {
+	_u.mutation.SetSubscriptionRef(v)
+	return _u
+}
+
+// SetNillableSubscriptionRef sets the "subscription_ref" field if the given value is not nil.
+func (_u *UserUpdateOne) SetNillableSubscriptionRef(v *string) *UserUpdateOne {
+	if v != nil {
+		_u.SetSubscriptionRef(*v)
+	}
+	return _u
+}
+
+// ClearSubscriptionRef clears the value of the "subscription_ref" field.
+func (_u *UserUpdateOne) ClearSubscriptionRef() *UserUpdateOne {
+	_u.mutation.ClearSubscriptionRef()
+	return _u
+}
+
+// SetSubscriptionCancelPending sets the "subscription_cancel_pending" field.
+func (_u *UserUpdateOne) SetSubscriptionCancelPending(v bool) *UserUpdateOne {
+	_u.mutation.SetSubscriptionCancelPending(v)
+	return _u
+}
+
+// SetNillableSubscriptionCancelPending sets the "subscription_cancel_pending" field if the given value is not nil.
+func (_u *UserUpdateOne) SetNillableSubscriptionCancelPending(v *bool) *UserUpdateOne {
+	if v != nil {
+		_u.SetSubscriptionCancelPending(*v)
+	}
+	return _u
+}
+
+// SetBillingEventAt sets the "billing_event_at" field.
+func (_u *UserUpdateOne) SetBillingEventAt(v time.Time) *UserUpdateOne {
+	_u.mutation.SetBillingEventAt(v)
+	return _u
+}
+
+// SetNillableBillingEventAt sets the "billing_event_at" field if the given value is not nil.
+func (_u *UserUpdateOne) SetNillableBillingEventAt(v *time.Time) *UserUpdateOne {
+	if v != nil {
+		_u.SetBillingEventAt(*v)
+	}
+	return _u
+}
+
+// ClearBillingEventAt clears the value of the "billing_event_at" field.
+func (_u *UserUpdateOne) ClearBillingEventAt() *UserUpdateOne {
+	_u.mutation.ClearBillingEventAt()
+	return _u
+}
+
+// SetBillingEventID sets the "billing_event_id" field.
+func (_u *UserUpdateOne) SetBillingEventID(v string) *UserUpdateOne {
+	_u.mutation.SetBillingEventID(v)
+	return _u
+}
+
+// SetNillableBillingEventID sets the "billing_event_id" field if the given value is not nil.
+func (_u *UserUpdateOne) SetNillableBillingEventID(v *string) *UserUpdateOne {
+	if v != nil {
+		_u.SetBillingEventID(*v)
+	}
+	return _u
+}
+
+// ClearBillingEventID clears the value of the "billing_event_id" field.
+func (_u *UserUpdateOne) ClearBillingEventID() *UserUpdateOne {
+	_u.mutation.ClearBillingEventID()
 	return _u
 }
 
@@ -557,6 +803,36 @@ func (_u *UserUpdateOne) sqlSave(ctx context.Context) (_node *User, err error) {
 	}
 	if value, ok := _u.mutation.Status(); ok {
 		_spec.SetField(user.FieldStatus, field.TypeEnum, value)
+	}
+	if value, ok := _u.mutation.SubscriptionSource(); ok {
+		_spec.SetField(user.FieldSubscriptionSource, field.TypeString, value)
+	}
+	if value, ok := _u.mutation.SubscriptionExpiresAt(); ok {
+		_spec.SetField(user.FieldSubscriptionExpiresAt, field.TypeTime, value)
+	}
+	if _u.mutation.SubscriptionExpiresAtCleared() {
+		_spec.ClearField(user.FieldSubscriptionExpiresAt, field.TypeTime)
+	}
+	if value, ok := _u.mutation.SubscriptionRef(); ok {
+		_spec.SetField(user.FieldSubscriptionRef, field.TypeString, value)
+	}
+	if _u.mutation.SubscriptionRefCleared() {
+		_spec.ClearField(user.FieldSubscriptionRef, field.TypeString)
+	}
+	if value, ok := _u.mutation.SubscriptionCancelPending(); ok {
+		_spec.SetField(user.FieldSubscriptionCancelPending, field.TypeBool, value)
+	}
+	if value, ok := _u.mutation.BillingEventAt(); ok {
+		_spec.SetField(user.FieldBillingEventAt, field.TypeTime, value)
+	}
+	if _u.mutation.BillingEventAtCleared() {
+		_spec.ClearField(user.FieldBillingEventAt, field.TypeTime)
+	}
+	if value, ok := _u.mutation.BillingEventID(); ok {
+		_spec.SetField(user.FieldBillingEventID, field.TypeString, value)
+	}
+	if _u.mutation.BillingEventIDCleared() {
+		_spec.ClearField(user.FieldBillingEventID, field.TypeString)
 	}
 	if value, ok := _u.mutation.CreatedAt(); ok {
 		_spec.SetField(user.FieldCreatedAt, field.TypeTime, value)

--- a/app/users/main.go
+++ b/app/users/main.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
 
 	"ItsBagelBot/app/users/ent"
 	// Wire the ent schema runtime (field defaults/hooks); without this blank
@@ -145,6 +146,13 @@ func main() {
 		log.Fatal("failed to subscribe admin rpc", zap.Error(err))
 	}
 
+	billingSubject := env.Get("NATS_INTERNAL_BILLING_SUBJECT", "bagel.rpc.internal.billing.apply")
+	if err := rpc.SubscribeBilling(nc, repo, billingSubject, invalidationPrefix, queueGroup, nrApp, log); err != nil {
+		log.Fatal("failed to subscribe billing rpc", zap.Error(err))
+	}
+
+	go expireSubscriptions(ctx, repo, log)
+
 	// Lane (JetStream consumer) telemetry for the admin console. Served under
 
 	// Admin authorization + audit. Seed the bootstrap owners/admins so a fresh
@@ -184,11 +192,34 @@ func main() {
 	log.Info("users service ready",
 		zap.String("dashboard_prefix", dashPrefix),
 		zap.String("admin_prefix", adminPrefix),
+		zap.String("billing_subject", billingSubject),
 		zap.String("projection_subject", projectionSubject))
 
 	<-ctx.Done()
 
 	log.Info("users service shutting down")
+}
+
+func expireSubscriptions(ctx context.Context, repo *repository.Users, log *zap.Logger) {
+	const tebexGrace = 24 * time.Hour
+	ticker := time.NewTicker(time.Minute)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case now := <-ticker.C:
+			runCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+			count, err := repo.ExpireSubscriptions(runCtx, now, tebexGrace)
+			cancel()
+			if err != nil {
+				log.Error("failed to expire subscriptions", zap.Error(err))
+			} else if count > 0 {
+				log.Info("expired subscriptions", zap.Int("count", count))
+			}
+		}
+	}
 }
 
 // parseIDs splits a comma-separated list of Twitch ids, dropping blanks and

--- a/app/users/repository/billing.go
+++ b/app/users/repository/billing.go
@@ -1,0 +1,196 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"ItsBagelBot/app/users/ent"
+	"ItsBagelBot/app/users/ent/user"
+	billingrpc "ItsBagelBot/internal/domain/rpc/billing"
+	"ItsBagelBot/internal/domain/validate"
+	"ItsBagelBot/pkg/db"
+)
+
+// ApplyBilling applies one verified Tebex lifecycle event. Event timestamps
+// make delivery order monotonic, while recurring-reference matching prevents
+// a late event from an old subscription revoking a newer one.
+func (r *Users) ApplyBilling(ctx context.Context, req billingrpc.ApplyRequest) (bool, error) {
+	if err := validate.UserID(req.UserID); err != nil {
+		return false, err
+	}
+	if req.EventID == "" || req.OccurredAt.IsZero() {
+		return false, errors.New("billing event id and timestamp are required")
+	}
+
+	u, err := db.WithQuery(ctx, func(ctx context.Context) (*ent.User, error) {
+		return r.client.User.Query().Where(user.IDEQ(req.UserID)).Only(ctx)
+	})
+	if err != nil {
+		return false, err
+	}
+	if u.BillingEventAt != nil && req.OccurredAt.Before(*u.BillingEventAt) {
+		return false, nil
+	}
+	if u.BillingEventAt != nil && req.OccurredAt.Equal(*u.BillingEventAt) &&
+		u.BillingEventID != nil && *u.BillingEventID == req.EventID {
+		// The database commit may have succeeded while the change-event publish
+		// failed. A Tebex retry of that exact event must re-announce the state.
+		return true, r.publishChanged(ctx, req.UserID)
+	}
+	if u.Status == user.StatusVip {
+		return false, nil
+	}
+	if req.Action == billingrpc.ActionRevoke && u.SubscriptionSource != "tebex" {
+		return false, nil
+	}
+	if req.Action == billingrpc.ActionRevoke && req.RecurringReference != "" &&
+		u.SubscriptionRef != nil && *u.SubscriptionRef != req.RecurringReference {
+		return false, nil
+	}
+
+	updated, err := db.WithQuery(ctx, func(ctx context.Context) (int, error) {
+		q := r.client.User.Update().Where(
+			user.IDEQ(req.UserID),
+			user.Or(user.BillingEventAtIsNil(), user.BillingEventAtLTE(req.OccurredAt)),
+		)
+		switch req.Action {
+		case billingrpc.ActionActivate, billingrpc.ActionCancelAborted:
+			q.SetStatus(user.StatusPaid).
+				SetSubscriptionSource("tebex").
+				SetSubscriptionCancelPending(false).
+				SetBillingEventAt(req.OccurredAt).
+				SetBillingEventID(req.EventID)
+			if req.ExpiresAt != nil {
+				q.SetSubscriptionExpiresAt(*req.ExpiresAt)
+			}
+			if req.RecurringReference != "" {
+				q.SetSubscriptionRef(req.RecurringReference)
+			}
+
+		case billingrpc.ActionCancelRequested:
+			q.SetStatus(user.StatusPaid).
+				SetSubscriptionSource("tebex").
+				SetSubscriptionCancelPending(true).
+				SetBillingEventAt(req.OccurredAt).
+				SetBillingEventID(req.EventID)
+			if req.ExpiresAt != nil {
+				q.SetSubscriptionExpiresAt(*req.ExpiresAt)
+			}
+			if req.RecurringReference != "" {
+				q.SetSubscriptionRef(req.RecurringReference)
+			}
+
+		case billingrpc.ActionRevoke:
+			q.SetStatus(user.StatusFree).
+				SetSubscriptionSource("").
+				SetSubscriptionCancelPending(false).
+				ClearSubscriptionExpiresAt().
+				ClearSubscriptionRef().
+				SetBillingEventAt(req.OccurredAt).
+				SetBillingEventID(req.EventID)
+
+		default:
+			return 0, errors.New("invalid billing action")
+		}
+		return q.Save(ctx)
+	})
+	if err != nil || updated == 0 {
+		return false, err
+	}
+	if err := r.publishChanged(ctx, req.UserID); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// SetAdminStatus owns operator grants. Paid grants require an expiry and are
+// marked "admin" so Tebex lifecycle events can never revoke them.
+func (r *Users) SetAdminStatus(ctx context.Context, id uint64, status user.Status, expiresAt *time.Time) error {
+	if err := validate.UserID(id); err != nil {
+		return err
+	}
+	if err := validate.Status(string(status)); err != nil {
+		return err
+	}
+	if status == user.StatusPaid && (expiresAt == nil || !expiresAt.After(time.Now())) {
+		return errors.New("paid status requires a future expiry")
+	}
+
+	err := db.WithExec(ctx, func(ctx context.Context) error {
+		q := r.client.User.UpdateOneID(id).
+			SetStatus(status).
+			SetSubscriptionCancelPending(false).
+			ClearSubscriptionRef().
+			SetBillingEventAt(time.Now()).
+			ClearBillingEventID()
+		if status == user.StatusPaid {
+			q.SetSubscriptionSource("admin").SetSubscriptionExpiresAt(*expiresAt)
+		} else {
+			q.SetSubscriptionSource("").ClearSubscriptionExpiresAt()
+		}
+		return q.Exec(ctx)
+	})
+	if err != nil {
+		return err
+	}
+	return r.publishChanged(ctx, id)
+}
+
+// ExpireSubscriptions is the safety net for grants whose terminal event never
+// arrives. Operator grants expire exactly on time; Tebex gets a grace period
+// so a briefly delayed renewal webhook cannot interrupt a paying customer.
+func (r *Users) ExpireSubscriptions(ctx context.Context, now time.Time, tebexGrace time.Duration) (int, error) {
+	expired, err := db.WithQuery(ctx, func(ctx context.Context) ([]*ent.User, error) {
+		return r.client.User.Query().Where(
+			user.StatusEQ(user.StatusPaid),
+			user.SubscriptionExpiresAtNotNil(),
+			user.Or(
+				user.And(
+					user.SubscriptionSourceEQ("admin"),
+					user.SubscriptionExpiresAtLTE(now),
+				),
+				user.And(
+					user.SubscriptionSourceEQ("tebex"),
+					user.SubscriptionExpiresAtLTE(now.Add(-tebexGrace)),
+				),
+			),
+		).All(ctx)
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	count := 0
+	for _, candidate := range expired {
+		cutoff := now
+		if candidate.SubscriptionSource == "tebex" {
+			cutoff = now.Add(-tebexGrace)
+		}
+		updated, err := db.WithQuery(ctx, func(ctx context.Context) (int, error) {
+			return r.client.User.Update().Where(
+				user.IDEQ(candidate.ID),
+				user.StatusEQ(user.StatusPaid),
+				user.SubscriptionSourceEQ(candidate.SubscriptionSource),
+				user.SubscriptionExpiresAtLTE(cutoff),
+			).
+				SetStatus(user.StatusFree).
+				SetSubscriptionSource("").
+				SetSubscriptionCancelPending(false).
+				ClearSubscriptionExpiresAt().
+				ClearSubscriptionRef().
+				Save(ctx)
+		})
+		if err != nil {
+			return count, err
+		}
+		if updated == 0 {
+			continue
+		}
+		count++
+		if err := r.publishChanged(ctx, candidate.ID); err != nil {
+			return count, err
+		}
+	}
+	return count, nil
+}

--- a/app/users/repository/users.go
+++ b/app/users/repository/users.go
@@ -27,11 +27,15 @@ const (
 // UserView is the read model served from the in-process cache. It carries no
 // sensitive fields, so holding it in memory is safe.
 type UserView struct {
-	ID       uint64 `json:"id"`
-	Username string `json:"username"`
-	IsActive bool   `json:"is_active"`
-	Status   string `json:"status"`
-	Banned   bool   `json:"banned"`
+	ID                        uint64     `json:"id"`
+	Username                  string     `json:"username"`
+	IsActive                  bool       `json:"is_active"`
+	Status                    string     `json:"status"`
+	Banned                    bool       `json:"banned"`
+	SubscriptionSource        string     `json:"subscription_source"`
+	SubscriptionExpiresAt     *time.Time `json:"subscription_expires_at,omitempty"`
+	SubscriptionRef           *string    `json:"subscription_ref,omitempty"`
+	SubscriptionCancelPending bool       `json:"subscription_cancel_pending"`
 }
 
 // Users persists the user records and their OAuth tokens. Status reads are
@@ -115,11 +119,15 @@ func (r *Users) Get(ctx context.Context, id uint64) (UserView, error) {
 			}
 
 			return UserView{
-				ID:       u.ID,
-				Username: u.Username,
-				IsActive: u.IsActive,
-				Status:   string(u.Status),
-				Banned:   u.Banned,
+				ID:                        u.ID,
+				Username:                  u.Username,
+				IsActive:                  u.IsActive,
+				Status:                    string(u.Status),
+				Banned:                    u.Banned,
+				SubscriptionSource:        u.SubscriptionSource,
+				SubscriptionExpiresAt:     u.SubscriptionExpiresAt,
+				SubscriptionRef:           u.SubscriptionRef,
+				SubscriptionCancelPending: u.SubscriptionCancelPending,
 			}, nil
 		})
 	})

--- a/app/users/repository/users_test.go
+++ b/app/users/repository/users_test.go
@@ -12,6 +12,7 @@ import (
 	"ItsBagelBot/app/users/ent/user"
 	"ItsBagelBot/app/users/repository"
 	"ItsBagelBot/internal/domain/event/data"
+	billingrpc "ItsBagelBot/internal/domain/rpc/billing"
 	"ItsBagelBot/pkg/bus/bustest"
 	"ItsBagelBot/pkg/crypto"
 
@@ -131,6 +132,120 @@ func TestSetStatusRefreshesViewAndPublishes(t *testing.T) {
 
 	assert.Len(t, pub.On(data.SubjectUserChanged), 2, "register and status change must both announce state")
 }
+
+func TestApplyBillingLifecycleIsMonotonicAndProtectsAdminGrants(t *testing.T) {
+	_, _, repo := setup(t)
+	ctx := context.Background()
+	require.NoError(t, repo.Register(ctx, 1001, "Mavey", "mavey@example.com"))
+
+	started := time.Date(2026, 7, 2, 12, 0, 0, 0, time.UTC)
+	expires := started.AddDate(0, 1, 0)
+	applied, err := repo.ApplyBilling(ctx, billingrpc.ApplyRequest{
+		UserID: 1001, EventID: "evt-start", Action: billingrpc.ActionActivate,
+		OccurredAt: started, ExpiresAt: &expires, RecurringReference: "tbx-r-current",
+	})
+	require.NoError(t, err)
+	assert.True(t, applied)
+
+	view, err := repo.Get(ctx, 1001)
+	require.NoError(t, err)
+	assert.Equal(t, "paid", view.Status)
+	assert.Equal(t, "tebex", view.SubscriptionSource)
+	assert.Equal(t, "tbx-r-current", *view.SubscriptionRef)
+	assert.Equal(t, expires, *view.SubscriptionExpiresAt)
+
+	// An older delivery cannot roll back current state.
+	applied, err = repo.ApplyBilling(ctx, billingrpc.ApplyRequest{
+		UserID: 1001, EventID: "evt-old", Action: billingrpc.ActionRevoke,
+		OccurredAt: started.Add(-time.Minute), RecurringReference: "tbx-r-current",
+	})
+	require.NoError(t, err)
+	assert.False(t, applied)
+
+	// Nor can a late event for another recurring reference revoke this one.
+	applied, err = repo.ApplyBilling(ctx, billingrpc.ApplyRequest{
+		UserID: 1001, EventID: "evt-other", Action: billingrpc.ActionRevoke,
+		OccurredAt: started.Add(time.Minute), RecurringReference: "tbx-r-old",
+	})
+	require.NoError(t, err)
+	assert.False(t, applied)
+
+	grantExpiry := expires.AddDate(0, 1, 0)
+	require.NoError(t, repo.SetAdminStatus(ctx, 1001, user.StatusPaid, &grantExpiry))
+	applied, err = repo.ApplyBilling(ctx, billingrpc.ApplyRequest{
+		UserID: 1001, EventID: "evt-refund", Action: billingrpc.ActionRevoke,
+		OccurredAt: time.Now().Add(time.Minute), RecurringReference: "tbx-r-current",
+	})
+	require.NoError(t, err)
+	assert.False(t, applied, "Tebex must not revoke an operator grant")
+}
+
+func TestApplyBillingCancellationAndEnd(t *testing.T) {
+	_, _, repo := setup(t)
+	ctx := context.Background()
+	require.NoError(t, repo.Register(ctx, 2002, "Bagel", "bagel@example.com"))
+
+	started := time.Now().Add(-time.Hour)
+	_, err := repo.ApplyBilling(ctx, billingrpc.ApplyRequest{
+		UserID: 2002, EventID: "evt-start", Action: billingrpc.ActionActivate,
+		OccurredAt: started, RecurringReference: "tbx-r-2",
+	})
+	require.NoError(t, err)
+
+	_, err = repo.ApplyBilling(ctx, billingrpc.ApplyRequest{
+		UserID: 2002, EventID: "evt-cancel", Action: billingrpc.ActionCancelRequested,
+		OccurredAt: started.Add(time.Minute), RecurringReference: "tbx-r-2",
+	})
+	require.NoError(t, err)
+	view, _ := repo.Get(ctx, 2002)
+	assert.True(t, view.SubscriptionCancelPending)
+	assert.Equal(t, "paid", view.Status)
+
+	_, err = repo.ApplyBilling(ctx, billingrpc.ApplyRequest{
+		UserID: 2002, EventID: "evt-ended", Action: billingrpc.ActionRevoke,
+		OccurredAt: started.Add(2 * time.Minute), RecurringReference: "tbx-r-2",
+	})
+	require.NoError(t, err)
+	view, _ = repo.Get(ctx, 2002)
+	assert.Equal(t, "free", view.Status)
+	assert.Empty(t, view.SubscriptionSource)
+}
+
+func TestExpireSubscriptionsHonorsTebexGrace(t *testing.T) {
+	client, _, repo := setup(t)
+	ctx := context.Background()
+	now := time.Date(2026, 7, 2, 12, 0, 0, 0, time.UTC)
+
+	require.NoError(t, repo.Register(ctx, 3003, "AdminGrant", "admin@example.com"))
+	adminExpiry := now.Add(-time.Minute)
+	require.NoError(t, repo.SetAdminStatus(ctx, 3003, user.StatusPaid, ptrTime(time.Now().Add(time.Hour))))
+	require.NoError(t, client.User.UpdateOneID(3003).SetSubscriptionExpiresAt(adminExpiry).Exec(ctx))
+
+	require.NoError(t, repo.Register(ctx, 4004, "TebexGrace", "tebex@example.com"))
+	tebexExpiry := now.Add(-time.Hour)
+	_, err := repo.ApplyBilling(ctx, billingrpc.ApplyRequest{
+		UserID: 4004, EventID: "evt-tebex", Action: billingrpc.ActionActivate,
+		OccurredAt: now.Add(-48 * time.Hour), ExpiresAt: &tebexExpiry,
+	})
+	require.NoError(t, err)
+
+	count, err := repo.ExpireSubscriptions(ctx, now, 24*time.Hour)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+
+	admin, _ := repo.Get(ctx, 3003)
+	tebex, _ := repo.Get(ctx, 4004)
+	assert.Equal(t, "free", admin.Status)
+	assert.Equal(t, "paid", tebex.Status)
+
+	count, err = repo.ExpireSubscriptions(ctx, now.Add(24*time.Hour), 24*time.Hour)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+	tebex, _ = repo.Get(ctx, 4004)
+	assert.Equal(t, "free", tebex.Status)
+}
+
+func ptrTime(value time.Time) *time.Time { return &value }
 
 func TestDeleteCascadesAndPublishes(t *testing.T) {
 	client, pub, repo := setup(t)

--- a/app/users/rpc/admin.go
+++ b/app/users/rpc/admin.go
@@ -159,7 +159,15 @@ func (a *adminRPC) setStatus(ctx context.Context, req usersrpc.AdminRequest) use
 		return usersrpc.AdminReply{Error: "status must be free, paid or vip"}
 	}
 
-	if err := a.repo.SetStatus(ctx, u.ID, status); err != nil {
+	var expiresAt *time.Time
+	if req.ExpiresAt != "" {
+		parsed, err := time.Parse(time.RFC3339, req.ExpiresAt)
+		if err != nil {
+			return usersrpc.AdminReply{Error: "expires_at must be an RFC3339 timestamp"}
+		}
+		expiresAt = &parsed
+	}
+	if err := a.repo.SetAdminStatus(ctx, u.ID, status, expiresAt); err != nil {
 		return usersrpc.AdminReply{Error: err.Error()}
 	}
 
@@ -341,12 +349,16 @@ func (a *adminRPC) invalidate(id uint64) {
 
 func viewOf(u *ent.User) usersrpc.AdminUserView {
 	return usersrpc.AdminUserView{
-		ID:        u.ID,
-		Username:  u.Username,
-		IsActive:  u.IsActive,
-		Status:    string(u.Status),
-		Banned:    u.Banned,
-		UpdatedAt: u.UpdatedAt,
+		ID:                        u.ID,
+		Username:                  u.Username,
+		IsActive:                  u.IsActive,
+		Status:                    string(u.Status),
+		Banned:                    u.Banned,
+		SubscriptionExpiresAt:     u.SubscriptionExpiresAt,
+		SubscriptionSource:        u.SubscriptionSource,
+		SubscriptionRef:           u.SubscriptionRef,
+		SubscriptionCancelPending: u.SubscriptionCancelPending,
+		UpdatedAt:                 u.UpdatedAt,
 	}
 }
 

--- a/app/users/rpc/billing.go
+++ b/app/users/rpc/billing.go
@@ -1,0 +1,36 @@
+package rpc
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"ItsBagelBot/app/users/repository"
+	"ItsBagelBot/internal/domain/invalidate"
+	billingrpc "ItsBagelBot/internal/domain/rpc/billing"
+	"ItsBagelBot/pkg/bus"
+
+	"github.com/nats-io/nats.go"
+	"github.com/newrelic/go-agent/v3/newrelic"
+	"go.uber.org/zap"
+)
+
+// SubscribeBilling exposes the narrow private write surface used by the
+// transactions service after it has verified a Tebex webhook signature.
+func SubscribeBilling(nc *nats.Conn, repo *repository.Users, subject, invalidationPrefix, queueGroup string, app *newrelic.Application, log *zap.Logger) error {
+	return bus.QueueSubscribeJSON[billingrpc.ApplyRequest, billingrpc.ApplyReply](
+		nc, subject, queueGroup, 5*time.Second, app, log,
+		func(ctx context.Context, req billingrpc.ApplyRequest) billingrpc.ApplyReply {
+			applied, err := repo.ApplyBilling(ctx, req)
+			if err != nil {
+				return billingrpc.ApplyReply{Error: err.Error()}
+			}
+			if applied {
+				if err := invalidate.Publish(nc, invalidationPrefix, "status", fmt.Sprint(req.UserID)); err != nil {
+					log.Warn("billing cache invalidation publish failed", zap.Error(err))
+				}
+			}
+			return billingrpc.ApplyReply{Applied: applied}
+		},
+	)
+}

--- a/app/users/rpc/dashboard.go
+++ b/app/users/rpc/dashboard.go
@@ -260,7 +260,14 @@ func (d *dashboardRPC) handleStateGet(ctx context.Context, msg *nats.Msg) {
 		return
 	}
 
-	bus.Respond(msg, map[string]any{"active": view.IsActive, "status": view.Status})
+	bus.Respond(msg, map[string]any{
+		"active":                      view.IsActive,
+		"status":                      view.Status,
+		"expires_at":                  view.SubscriptionExpiresAt,
+		"source":                      view.SubscriptionSource,
+		"subscription_ref":            view.SubscriptionRef,
+		"subscription_cancel_pending": view.SubscriptionCancelPending,
+	})
 }
 
 // handleDeleteSelf removes the user and every delegation they own. Delegations

--- a/console/dashboard/src/lib/server/services.ts
+++ b/console/dashboard/src/lib/server/services.ts
@@ -396,6 +396,8 @@ export type BillingState = {
   expiresAt: string | null;
   // 'tebex' | 'admin' | '' — who granted the paid period.
   source: string;
+  subscriptionRef: string | null;
+  cancelPending: boolean;
 };
 
 // Billing-page variant of accountState: same state_get RPC but carrying the
@@ -404,11 +406,20 @@ export type BillingState = {
 export const billingState = defineRead({
   subject: `${SUB.dashboard}.state_get`,
   request: (userId: string) => ({ broadcaster_user_id: userId }),
-  map: (r: { active: boolean; status: string; expires_at?: string; source?: string }): BillingState => ({
+  map: (r: {
+    active: boolean;
+    status: string;
+    expires_at?: string;
+    source?: string;
+    subscription_ref?: string;
+    subscription_cancel_pending?: boolean;
+  }): BillingState => ({
     active: !!r.active,
     status: normalizeStatus(r.status),
     expiresAt: r.expires_at ?? null,
-    source: r.source ?? ''
+    source: r.source ?? '',
+    subscriptionRef: r.subscription_ref ?? null,
+    cancelPending: !!r.subscription_cancel_pending
   }),
   timeoutMs: READ_TIMEOUT_MS,
   cache: {
@@ -428,14 +439,25 @@ export const billingState = defineRead({
 // read budget.
 export type CheckoutBasket = { ident: string; checkoutUrl: string | null; recipientLogin: string | null };
 
+export async function billingPortalToken(): Promise<string | null> {
+  const r = await rpc<{ public_token?: string }>(`${SUB.transactions}.config_get`, {}, 3000);
+  return r.public_token ?? null;
+}
+
 export async function checkoutBasketCreate(
   userId: string,
   username: string,
-  recipientUsername?: string
+  recipientUsername?: string,
+  ipAddress?: string
 ): Promise<CheckoutBasket> {
   const r = await rpc<{ ident?: string; checkout_url?: string; recipient_login?: string }>(
     `${SUB.transactions}.basket_create`,
-    { user_id: userId, username, recipient_username: recipientUsername || undefined },
+    {
+      user_id: userId,
+      username,
+      recipient_username: recipientUsername || undefined,
+      ip_address: ipAddress || undefined
+    },
     16000
   );
   if (!r.ident) throw new Error('basket create returned no ident');

--- a/console/dashboard/src/routes/(app)/billing/+page.server.ts
+++ b/console/dashboard/src/routes/(app)/billing/+page.server.ts
@@ -1,12 +1,13 @@
 import type { Actions, PageServerLoad } from './$types';
 import { redirect, fail } from '@sveltejs/kit';
-import { billingState, checkoutBasketCreate, type BillingState } from '$lib/server/services';
+import { billingPortalToken, billingState, checkoutBasketCreate, type BillingState } from '$lib/server/services';
 import { RpcError } from '@bagel/shared/server/nats';
 import { env } from '$env/dynamic/private';
 
 type BillingLinks = {
   checkoutUrl: string | null;
   cancelUrl: string | null;
+  portalToken: string | null;
 };
 
 function optionalHttpsURL(value: string | undefined): string | null {
@@ -19,10 +20,12 @@ function optionalHttpsURL(value: string | undefined): string | null {
   }
 }
 
-function links(): BillingLinks {
+function links(portalToken: string | null = null): BillingLinks {
   return {
     checkoutUrl: optionalHttpsURL(env.TEBEX_PREMIUM_CHECKOUT_URL),
-    cancelUrl: optionalHttpsURL(env.TEBEX_CANCEL_URL)
+    cancelUrl: optionalHttpsURL(env.TEBEX_CANCEL_URL),
+    // Public project token used by Tebex.js's embedded Payment Portal.
+    portalToken: portalToken || env.TEBEX_PUBLIC_TOKEN || env.TEBEX_WEBSTORE_TOKEN || null
   };
 }
 
@@ -37,11 +40,14 @@ export const load: PageServerLoad = async ({ locals, url }) => {
         active: true,
         status: 'paid',
         expiresAt: new Date(Date.now() + 15 * 864e5).toISOString(),
-        source: 'tebex'
+        source: 'tebex',
+        subscriptionRef: 'tbx-r-demo',
+        cancelPending: false
       } as BillingState,
       links: {
         checkoutUrl: 'https://example.tebex.io/package/premium',
-        cancelUrl: 'https://example.tebex.io/account'
+        cancelUrl: 'https://example.tebex.io/account',
+        portalToken: 'demo-public-token'
       } satisfies BillingLinks,
       degraded: false,
       autostart
@@ -52,17 +58,20 @@ export const load: PageServerLoad = async ({ locals, url }) => {
   // Owner-only: billing is never part of a delegated section grant.
   if (!s || s.delegate_of) throw redirect(302, '/');
 
-  const accountResult = await billingState(s.user_id).then(
-    (value) => ({ status: 'fulfilled' as const, value }),
-    () => ({ status: 'rejected' as const })
-  );
+  const [accountResult, portalToken] = await Promise.all([
+    billingState(s.user_id).then(
+      (value) => ({ status: 'fulfilled' as const, value }),
+      () => ({ status: 'rejected' as const })
+    ),
+    billingPortalToken().catch(() => null)
+  ]);
 
   return {
     account:
       accountResult.status === 'fulfilled'
         ? accountResult.value
-        : ({ active: false, status: 'free', expiresAt: null, source: '' } as BillingState),
-    links: links(),
+        : ({ active: false, status: 'free', expiresAt: null, source: '', subscriptionRef: null, cancelPending: false } as BillingState),
+    links: links(portalToken),
     degraded: accountResult.status !== 'fulfilled',
     autostart
   };
@@ -73,7 +82,7 @@ export const actions: Actions = {
   // and hand the ident back so the page can launch the official Tebex.js
   // embedded checkout. If basket minting is down but a static hosted-checkout
   // URL is configured, fall back to the old 303 hand-off.
-  subscribe: async ({ locals }) => {
+  subscribe: async ({ locals, getClientAddress }) => {
     const s = locals.session;
     if (!s) return fail(401, { error: 'Not signed in.' });
     if (s.delegate_of || s.impersonator_id) {
@@ -93,7 +102,7 @@ export const actions: Actions = {
     }
 
     try {
-      const basket = await checkoutBasketCreate(s.user_id, s.login);
+      const basket = await checkoutBasketCreate(s.user_id, s.login, undefined, getClientAddress());
       return { ident: basket.ident, checkoutUrl: basket.checkoutUrl };
     } catch (err) {
       console.error('[billing] basket create failed:', err);
@@ -108,7 +117,7 @@ export const actions: Actions = {
   // the Twitch login and vets the recipient (registered, not banned, not
   // already premium); its error strings are user-facing, so surface them
   // verbatim on the gift form. The buyer's own plan does not gate gifting.
-  gift: async ({ locals, request }) => {
+  gift: async ({ locals, request, getClientAddress }) => {
     const s = locals.session;
     if (!s) return fail(401, { gift: true, error: 'Not signed in.' });
     if (s.delegate_of || s.impersonator_id) {
@@ -123,7 +132,7 @@ export const actions: Actions = {
     }
 
     try {
-      const basket = await checkoutBasketCreate(s.user_id, s.login, recipient);
+      const basket = await checkoutBasketCreate(s.user_id, s.login, recipient, getClientAddress());
       return {
         ident: basket.ident,
         checkoutUrl: basket.checkoutUrl,

--- a/console/dashboard/src/routes/(app)/billing/+page.svelte
+++ b/console/dashboard/src/routes/(app)/billing/+page.svelte
@@ -1,15 +1,15 @@
 <script lang="ts">
-  import { Icon, PageHead, Card, ConfirmDialog, toast } from '@bagel/shared';
+  import { Icon, PageHead, Card, toast } from '@bagel/shared';
   import { page } from '$app/state';
-  import { enhance } from '$app/forms';
+  import { applyAction, deserialize } from '$app/forms';
   import { invalidateAll, replaceState } from '$app/navigation';
-  import { onMount } from 'svelte';
+  import { onDestroy, onMount } from 'svelte';
   import type { BillingState } from '$lib/server/services';
 
   let { data, form } = $props();
 
   const account = $derived(data.account as BillingState);
-  const links = $derived(data.links as { checkoutUrl: string | null; cancelUrl: string | null });
+  const links = $derived(data.links as { checkoutUrl: string | null; cancelUrl: string | null; portalToken: string | null });
 
   const isVip = $derived(account.status === 'vip');
   const isPaid = $derived(account.status === 'paid' || isVip);
@@ -19,7 +19,7 @@
   // Basket minting happens server-side on click, so subscribing only needs a
   // free plan; the static checkoutUrl is just the hosted fallback.
   const canSubscribe = $derived(!isPaid);
-  const canCancel = $derived(!!links.cancelUrl && tebexPaid);
+  const canManage = $derived(tebexPaid && (!!links.portalToken || !!links.cancelUrl));
 
   // ── Tebex.js embedded checkout ──
   // The official script (js.tebex.io, loaded in <svelte:head>) exposes
@@ -27,10 +27,21 @@
   // opens the payment overlay without leaving the dashboard.
   type TebexGlobal = {
     checkout: {
-      init: (opts: { ident: string; theme?: 'light' | 'dark' }) => void;
-      launch: () => void;
-      close: () => void;
-      on: (event: 'payment:complete' | 'payment:error' | 'close', cb: () => void) => void;
+      init: (opts: {
+        ident?: string;
+        theme?: 'light' | 'dark' | 'auto' | 'default';
+        closeOnPaymentComplete?: boolean;
+        closeOnClickOutside?: boolean;
+        closeOnEsc?: boolean;
+        launchTimeout?: number;
+      }) => void;
+      launch: (ident?: () => Promise<string>) => Promise<void>;
+      close: () => Promise<void>;
+      on: (event: 'payment:complete' | 'payment:error' | 'close', cb: () => void) => () => void;
+    };
+    portal: {
+      init: (opts: { token: string; theme?: 'light' | 'dark' | 'auto' }) => void;
+      launch: () => Promise<void>;
     };
   };
   const tebexGlobal = () => (window as unknown as { Tebex?: TebexGlobal }).Tebex;
@@ -40,83 +51,118 @@
   let giftLaunching = $state(false);
   let giftRecipient = $state('');
 
-  // Shared enhance handler for both checkout forms (subscribe + gift): a
-  // successful action returns a basket ident to launch, the hosted-checkout
-  // fallback arrives as an external redirect, anything else releases the
-  // button and lets the form-error toast handle it.
-  function checkoutEnhance(setBusy: (busy: boolean) => void) {
-    return () => {
-      setBusy(true);
-      return async ({
-        result,
-        update
-      }: {
-        result: import('@sveltejs/kit').ActionResult;
-        update: () => Promise<void>;
-      }) => {
-        if (result.type === 'success' && result.data?.ident) {
-          if (result.data.recipientLogin) {
-            toast('ok', `Gifting premium to ${String(result.data.recipientLogin)} — complete the payment to send it.`);
-          }
-          await launchCheckout(
-            String(result.data.ident),
-            result.data.checkoutUrl ? String(result.data.checkoutUrl) : null,
-            setBusy
-          );
-          return;
-        }
-        if (result.type === 'redirect') {
-          // Hosted-checkout fallback is an external URL; goto() cannot take
-          // it, so navigate directly.
-          window.location.href = result.location;
-          return;
-        }
-        setBusy(false);
-        await update();
-      };
-    };
-  }
+  let checkoutUnsubscribers: Array<() => void> = [];
+  let checkoutFallback: string | null = null;
 
-  function waitForTebex(timeoutMs = 6000): Promise<TebexGlobal | null> {
-    return new Promise((resolve) => {
-      const started = Date.now();
-      const poll = () => {
-        const t = tebexGlobal();
-        if (t) return resolve(t);
-        if (Date.now() - started > timeoutMs) return resolve(null);
-        setTimeout(poll, 100);
-      };
-      poll();
+  onDestroy(() => checkoutUnsubscribers.splice(0).forEach((unsubscribe) => unsubscribe()));
+
+  async function submitAction(form: HTMLFormElement): Promise<import('@sveltejs/kit').ActionResult> {
+    const body = new URLSearchParams();
+    new FormData(form).forEach((value, key) => {
+      if (typeof value === 'string') body.append(key, value);
     });
+    const response = await fetch(form.action, {
+      method: 'POST',
+      headers: {
+        accept: 'application/json',
+        'content-type': 'application/x-www-form-urlencoded',
+        'x-sveltekit-action': 'true'
+      },
+      cache: 'no-store',
+      body
+    });
+    const result = deserialize(await response.text());
+    if (result.type === 'error') result.status = response.status;
+    return result;
   }
 
-  async function launchCheckout(ident: string, fallbackUrl: string | null, setBusy: (busy: boolean) => void) {
-    const tebex = await waitForTebex();
-    if (!tebex) {
-      // Script blocked or offline: hosted checkout still works.
-      if (fallbackUrl) {
-        window.location.href = fallbackUrl;
-        return;
+  async function createBasket(form: HTMLFormElement, setBusy: (busy: boolean) => void): Promise<string> {
+    const result = await submitAction(form);
+    if (result.type === 'success' && result.data?.ident) {
+      checkoutFallback = result.data.checkoutUrl ? String(result.data.checkoutUrl) : null;
+      if (result.data.recipientLogin) {
+        toast('ok', `Gifting premium to ${String(result.data.recipientLogin)} — complete the payment to send it.`);
       }
-      setBusy(false);
-      toast('err', 'Could not open checkout. Please try again.');
+      return String(result.data.ident);
+    }
+    if (result.type === 'redirect') {
+      window.location.href = result.location;
+      throw new Error('redirecting to hosted checkout');
+    }
+    setBusy(false);
+    await applyAction(result);
+    throw new Error('basket creation failed');
+  }
+
+  function bindCheckoutEvents(tebex: TebexGlobal, setBusy: (busy: boolean) => void) {
+    checkoutUnsubscribers.splice(0).forEach((unsubscribe) => unsubscribe());
+    checkoutUnsubscribers = [
+      tebex.checkout.on('payment:complete', () => {
+        toast('ok', 'Payment received — confirming your plan now.');
+        void pollForEntitlement();
+      }),
+      tebex.checkout.on('payment:error', () => {
+        toast('err', 'Payment did not go through. No charge was made.');
+      }),
+      tebex.checkout.on('close', () => setBusy(false))
+    ];
+  }
+
+  async function pollForEntitlement() {
+    for (const delay of [1000, 2000, 3000, 5000, 8000]) {
+      await new Promise((resolve) => setTimeout(resolve, delay));
+      await invalidateAll();
+      if (account.status !== 'free') return;
+    }
+  }
+
+  async function launchCheckout(form: HTMLFormElement, setBusy: (busy: boolean) => void) {
+    setBusy(true);
+    // Read synchronously inside the submit gesture. Tebex v1.11 can then open
+    // its mobile window before awaiting the basket callback.
+    const tebex = tebexGlobal();
+    if (!tebex) {
+      try {
+        await createBasket(form, setBusy);
+        if (checkoutFallback) window.location.href = checkoutFallback;
+      } catch {
+        // createBasket has already applied the form error or started redirecting.
+      }
       return;
     }
 
-    tebex.checkout.init({ ident, theme: 'dark' });
-    tebex.checkout.on('payment:complete', () => {
-      toast('ok', 'Payment received — it activates within a minute.');
-      tebex.checkout.close();
-      // The entitlement lands via the Tebex webhook; refetch shortly after.
-      setTimeout(() => void invalidateAll(), 1500);
+    checkoutFallback = null;
+    bindCheckoutEvents(tebex, setBusy);
+    tebex.checkout.init({
+      theme: 'dark',
+      closeOnPaymentComplete: true,
+      closeOnClickOutside: false,
+      closeOnEsc: true,
+      launchTimeout: 16000
     });
-    tebex.checkout.on('payment:error', () => {
-      toast('err', 'Payment did not go through. No charge was made.');
-    });
-    tebex.checkout.on('close', () => {
-      setBusy(false);
-    });
-    tebex.checkout.launch();
+    try {
+      // Tebex.js v1.11 opens the mobile window synchronously, then invokes this
+      // callback while its spinner is visible. Basket creation can therefore be
+      // asynchronous without browsers blocking the checkout popup.
+      await tebex.checkout.launch(() => createBasket(form, setBusy));
+    } catch {
+      if (checkoutFallback) window.location.href = checkoutFallback;
+      else setBusy(false);
+    }
+  }
+
+  async function launchPortal() {
+    const tebex = tebexGlobal();
+    if (!tebex || !links.portalToken) {
+      cancelForm?.requestSubmit();
+      return;
+    }
+    tebex.portal.init({ token: links.portalToken, theme: 'dark' });
+    try {
+      await tebex.portal.launch();
+    } catch {
+      cancelForm?.requestSubmit();
+    }
   }
 
   // Auto-open checkout when the pricing page sent the visitor here with
@@ -156,7 +202,6 @@
     if (form.error) toast('err', String(form.error));
   });
 
-  let cancelOpen = $state(false);
   let cancelForm = $state<HTMLFormElement | null>(null);
 
   const statusLabel = $derived(isVip ? 'VIP' : isPaid ? 'Premium' : 'Free');
@@ -164,7 +209,7 @@
 
 <svelte:head>
   <!-- Official Tebex.js — embedded checkout overlay (allowed by CSP script-src). -->
-  <script src="https://js.tebex.io/v/1.js" async></script>
+  <script src="https://js.tebex.io/v/1.js" defer></script>
 </svelte:head>
 
 <section class="screen active">
@@ -194,8 +239,8 @@
           </p>
         {:else if tebexPaid}
           <p class="hint">
-            Premium is active through Tebex{paidUntil ? ` until ${fmtDate(paidUntil)}` : ''}.
-            Use Tebex to manage or cancel the subscription.
+            {account.cancelPending ? 'Cancellation is scheduled' : 'Premium is active through Tebex'}{paidUntil ? ` until ${fmtDate(paidUntil)}` : ''}.
+            Use the Tebex Payment Portal to review payments or change the subscription.
           </p>
         {:else if isPaid}
           <p class="hint">Premium is active{paidUntil ? ` until ${fmtDate(paidUntil)}` : ''}.</p>
@@ -210,7 +255,10 @@
             method="POST"
             action="?/subscribe"
             bind:this={subscribeForm}
-            use:enhance={checkoutEnhance((busy) => (launching = busy))}
+            onsubmit={(event) => {
+              event.preventDefault();
+              void launchCheckout(event.currentTarget, (busy) => (launching = busy));
+            }}
           >
             <button class="btn primary" type="submit" disabled={launching}>
               <Icon name="heart" size={14} />
@@ -218,11 +266,11 @@
             </button>
           </form>
           <p class="hint tiny">Secure payment by Tebex, right here. Your plan updates after the payment lands.</p>
-        {:else if canCancel}
-          <button type="button" class="btn ghost danger" onclick={() => (cancelOpen = true)}>
-            Cancel subscription
+        {:else if canManage}
+          <button type="button" class="btn ghost" onclick={() => void launchPortal()}>
+            Manage subscription
           </button>
-          <p class="hint tiny">You will leave the dashboard and manage the subscription on Tebex.</p>
+          <p class="hint tiny">Opens Tebex’s secure Payment Portal.</p>
         {/if}
       </div>
     </div>
@@ -244,7 +292,10 @@
         class="gift-form"
         method="POST"
         action="?/gift"
-        use:enhance={checkoutEnhance((busy) => (giftLaunching = busy))}
+        onsubmit={(event) => {
+          event.preventDefault();
+          void launchCheckout(event.currentTarget, (busy) => (giftLaunching = busy));
+        }}
       >
         <input
           class="gift-input"
@@ -266,20 +317,6 @@
   </Card>
 </section>
 
-<!-- Cancel confirm: one confirmation before handing off to Tebex. -->
-<ConfirmDialog
-  open={cancelOpen}
-  title="Open Tebex subscription management?"
-  body={`You will leave ItsBagelBot and manage cancellation on Tebex. Premium stays active here until Tebex confirms the change${paidUntil ? ` or the period ends on ${fmtDate(paidUntil)}` : ''}.`}
-  confirmLabel="Continue to Tebex"
-  cancelLabel="Keep premium"
-  danger
-  onCancel={() => (cancelOpen = false)}
-  onConfirm={() => {
-    cancelForm?.requestSubmit();
-    cancelOpen = false;
-  }}
-/>
 <form method="POST" action="?/cancel" bind:this={cancelForm} hidden></form>
 
 <style>
@@ -316,7 +353,6 @@
     flex-shrink: 0;
   }
   .plan-actions .hint { text-align: right; }
-  .btn.danger { color: #e08f8f; }
 
   .gift-top {
     display: flex;

--- a/deploy/k8s/nats-auth.conf
+++ b/deploy/k8s/nats-auth.conf
@@ -198,6 +198,7 @@ accounts: {
       { service: "bagel.rpc.dashboard.>" }
       { service: "bagel.rpc.admin.user.>" }
       { service: "bagel.rpc.delegation.>" }
+      { service: "bagel.rpc.internal.billing.apply" }
       { service: "bagel.rpc.internal.projection.users.get" }
       { service: "bagel.rpc.internal.tokens.>" }
       { stream: "bagel.cache.invalidate.grant" }
@@ -267,6 +268,7 @@ accounts: {
     ]
     imports: [
       { service: { account: "USERS_RPC",         subject: "bagel.rpc.admin.user.get" } }
+      { service: { account: "USERS_RPC",         subject: "bagel.rpc.internal.billing.apply" } }
       { service: { account: "NOTIFICATIONS_RPC", subject: "bagel.rpc.admin.notifications.send" } }
     ]
   }

--- a/internal/domain/rpc/billing/billing.go
+++ b/internal/domain/rpc/billing/billing.go
@@ -1,0 +1,29 @@
+// Package billingrpc defines the private entitlement contract between the
+// transactions service (verified Tebex webhooks) and the users service (tier
+// owner). It is intentionally unavailable to dashboard/admin accounts.
+package billingrpc
+
+import "time"
+
+type Action string
+
+const (
+	ActionActivate        Action = "activate"
+	ActionCancelRequested Action = "cancel_requested"
+	ActionCancelAborted   Action = "cancel_aborted"
+	ActionRevoke          Action = "revoke"
+)
+
+type ApplyRequest struct {
+	UserID             uint64     `json:"user_id"`
+	EventID            string     `json:"event_id"`
+	Action             Action     `json:"action"`
+	OccurredAt         time.Time  `json:"occurred_at"`
+	ExpiresAt          *time.Time `json:"expires_at,omitempty"`
+	RecurringReference string     `json:"recurring_reference,omitempty"`
+}
+
+type ApplyReply struct {
+	Applied bool   `json:"applied"`
+	Error   string `json:"error,omitempty"`
+}

--- a/internal/domain/rpc/transactions/transactions.go
+++ b/internal/domain/rpc/transactions/transactions.go
@@ -13,6 +13,7 @@ type BasketCreateRequest struct {
 	UserID            string `json:"user_id"`
 	Username          string `json:"username,omitempty"`
 	RecipientUsername string `json:"recipient_username,omitempty"`
+	IPAddress         string `json:"ip_address,omitempty"`
 }
 
 type BasketCreateReply struct {
@@ -24,4 +25,9 @@ type BasketCreateReply struct {
 	// RecipientLogin echoes the resolved gift recipient (gift baskets only).
 	RecipientLogin string `json:"recipient_login,omitempty"`
 	Error          string `json:"error,omitempty"`
+}
+
+type ConfigReply struct {
+	PublicToken string `json:"public_token,omitempty"`
+	Error       string `json:"error,omitempty"`
 }

--- a/internal/domain/rpc/users/users.go
+++ b/internal/domain/rpc/users/users.go
@@ -16,16 +16,21 @@ type AdminRequest struct {
 	Search       string `json:"search"`
 	AccessToken  string `json:"access_token"`
 	RefreshToken string `json:"refresh_token"`
+	ExpiresAt    string `json:"expires_at,omitempty"`
 }
 
 // AdminUserView is a single user row in an admin reply.
 type AdminUserView struct {
-	ID        uint64    `json:"id"`
-	Username  string    `json:"username"`
-	IsActive  bool      `json:"is_active"`
-	Status    string    `json:"status"`
-	Banned    bool      `json:"banned"`
-	UpdatedAt time.Time `json:"updated_at"`
+	ID                        uint64     `json:"id"`
+	Username                  string     `json:"username"`
+	IsActive                  bool       `json:"is_active"`
+	Status                    string     `json:"status"`
+	Banned                    bool       `json:"banned"`
+	SubscriptionExpiresAt     *time.Time `json:"subscription_expires_at,omitempty"`
+	SubscriptionSource        string     `json:"subscription_source,omitempty"`
+	SubscriptionRef           *string    `json:"subscription_ref,omitempty"`
+	SubscriptionCancelPending bool       `json:"subscription_cancel_pending"`
+	UpdatedAt                 time.Time  `json:"updated_at"`
 }
 
 // AdminStats aggregates user counts for the admin overview.


### PR DESCRIPTION
## Summary
- use Tebex.js async basket launch and Payment Portal correctly
- synchronize verified Tebex webhook lifecycle events into user entitlements
- preserve cancellation access, revoke terminal/refunded/disputed subscriptions, and expire stale grants safely
- include customer identity/IP in Headless baskets and expose only the public portal token

## Verification
- `go test ./...`
- `bun run check && bun run build` (dashboard)
- `bun run check && bun run build` (admin)