### PR TITLE
One-time single-month purchases for subscribe and gift

### DIFF
--- a/app/transactions/rpc/checkout.go
+++ b/app/transactions/rpc/checkout.go
@@ -62,6 +62,8 @@ func (c *checkoutRPC) basketCreate(ctx context.Context, req transactionsrpc.Bask
 			IPAddress:     validIPv4(req.IPAddress),
 			GiftedByID:    buyerID,
 			GiftedByLogin: req.Username,
+			// A gift is one paid month, never a recurring charge on the buyer.
+			PackageType: "single",
 		}
 		recipientLogin = view.Username
 	}

--- a/app/transactions/tebex/client.go
+++ b/app/transactions/tebex/client.go
@@ -155,6 +155,9 @@ type BasketSpec struct {
 	IPAddress     string
 	GiftedByID    uint64
 	GiftedByLogin string
+	// PackageType overrides Config.PackageType for this basket ("single" buys
+	// one period one-time, "subscription" auto-renews). Empty uses the config.
+	PackageType string
 }
 
 // CreateBasket mints a basket and adds the premium package. The recipient's
@@ -194,10 +197,15 @@ func (c *Client) CreateBasket(ctx context.Context, spec BasketSpec) (Basket, err
 		return Basket{}, errors.New("create basket: response missing ident")
 	}
 
+	packageType := c.cfg.PackageType
+	if spec.PackageType != "" {
+		packageType = spec.PackageType
+	}
+
 	addPackage := map[string]any{
 		"package_id": c.cfg.PackageID,
 		"quantity":   1,
-		"type":       c.cfg.PackageType,
+		"type":       packageType,
 	}
 
 	var updated basketData

--- a/app/transactions/tebex/client_test.go
+++ b/app/transactions/tebex/client_test.go
@@ -162,7 +162,7 @@ func TestCreateBasketWithoutPrivateKeyOmitsAuthenticatedIP(t *testing.T) {
 }
 
 func TestCreateBasketGiftCarriesAttribution(t *testing.T) {
-	var createBody map[string]any
+	var createBody, packageBody map[string]any
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /api/accounts/token-123/baskets", func(w http.ResponseWriter, r *http.Request) {
@@ -177,6 +177,9 @@ func TestCreateBasketGiftCarriesAttribution(t *testing.T) {
 		})
 	})
 	mux.HandleFunc("POST /api/baskets/bkt-gift/packages", func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&packageBody); err != nil {
+			t.Fatalf("decode package body: %v", err)
+		}
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"data": map[string]any{
 				"ident": "bkt-gift",
@@ -190,6 +193,7 @@ func TestCreateBasketGiftCarriesAttribution(t *testing.T) {
 		Username:      "recipient",
 		GiftedByID:    804932984,
 		GiftedByLogin: "mavey",
+		PackageType:   "single",
 	})
 	if err != nil {
 		t.Fatalf("CreateBasket: %v", err)
@@ -204,6 +208,9 @@ func TestCreateBasketGiftCarriesAttribution(t *testing.T) {
 	}
 	if custom["gifted_by_login"] != "mavey" {
 		t.Errorf("custom.gifted_by_login = %v, want mavey", custom["gifted_by_login"])
+	}
+	if packageBody["type"] != "single" {
+		t.Errorf("type = %v, want the per-basket single override", packageBody["type"])
 	}
 }
 

--- a/app/transactions/web/server.go
+++ b/app/transactions/web/server.go
@@ -296,12 +296,21 @@ func (s *Server) applyBilling(ctx context.Context, event tebexEvent, payment rec
 	if err != nil {
 		return fmt.Errorf("invalid webhook date: %w", err)
 	}
+	expiresAt := payment.ExpiresAt
+	if action == billingrpc.ActionActivate && expiresAt == nil {
+		// One-time purchases (single-month buys, gifts) can arrive without any
+		// expiry on the payment subject, but a paid month must still run out —
+		// an activation without expiry would never be revoked by the safety
+		// net. Default to one month from the payment event.
+		fallback := occurredAt.AddDate(0, 1, 0)
+		expiresAt = &fallback
+	}
 	return s.cfg.ApplyBilling(ctx, billingrpc.ApplyRequest{
 		UserID:             payment.UserID,
 		EventID:            event.ID,
 		Action:             action,
 		OccurredAt:         occurredAt,
-		ExpiresAt:          payment.ExpiresAt,
+		ExpiresAt:          expiresAt,
 		RecurringReference: payment.RecurringReference,
 	})
 }

--- a/app/transactions/web/server_test.go
+++ b/app/transactions/web/server_test.go
@@ -85,6 +85,10 @@ func TestPaymentCompletedActivatesAndStoresProcessedState(t *testing.T) {
 	require.Len(t, store.changes, 1)
 	assert.Equal(t, billingrpc.ActionActivate, store.changes[0].Action)
 	assert.Equal(t, uint64(1001), store.changes[0].UserID)
+	// No expiry on the payment subject (one-time purchase): the activation
+	// must still carry one, defaulted to a month after the event.
+	require.NotNil(t, store.changes[0].ExpiresAt)
+	assert.Equal(t, "2026-08-02", store.changes[0].ExpiresAt.UTC().Format("2006-01-02"))
 	require.Len(t, store.events, 1)
 	assert.Equal(t, repository.WebhookProcessed, store.events[0].Status)
 	assert.Equal(t, "tbx-1234", store.events[0].TransactionID)


### PR DESCRIPTION
## Changes
- Gift baskets always add the premium package as `type: single` — a gift is one paid month, never a recurring charge on the buyer's card.
- Self-subscribe package type stays env-driven; `TEBEX_PACKAGE_TYPE=single` is now set in the transactions prod config, so the Subscribe flow is also a one-time month. Flipping back to recurring later = change that env, no deploy.
- Activations now default the entitlement expiry to one month after the payment event when the Tebex payment subject carries no expiry — a one-time purchase without expiry would otherwise stay premium forever (the expiry safety net keys off that date).

## Test plan
- `go build` / `go vet` / `go test ./app/transactions/...` green; new assertions: gift basket sends `type: single`, expiry defaults to +1 month on payment.completed without expiry data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)