### PR TITLE
Offer both one-month and monthly subscribe buttons

### DIFF
--- a/app/transactions/rpc/checkout.go
+++ b/app/transactions/rpc/checkout.go
@@ -45,7 +45,15 @@ func (c *checkoutRPC) basketCreate(ctx context.Context, req transactionsrpc.Bask
 		return transactionsrpc.BasketCreateReply{Error: "user_id must be numeric"}
 	}
 
-	spec := tebex.BasketSpec{UserID: buyerID, Username: req.Username, IPAddress: validIPv4(req.IPAddress)}
+	packageType := ""
+	switch req.PackageType {
+	case "", "single", "subscription":
+		packageType = req.PackageType
+	default:
+		return transactionsrpc.BasketCreateReply{Error: "package_type must be single or subscription"}
+	}
+
+	spec := tebex.BasketSpec{UserID: buyerID, Username: req.Username, IPAddress: validIPv4(req.IPAddress), PackageType: packageType}
 	recipientLogin := ""
 
 	if recipient := normalizeLogin(req.RecipientUsername); recipient != "" {

--- a/console/dashboard/src/lib/server/services.ts
+++ b/console/dashboard/src/lib/server/services.ts
@@ -439,11 +439,14 @@ export const billingState = defineRead({
 // read budget.
 export type CheckoutBasket = { ident: string; checkoutUrl: string | null; recipientLogin: string | null };
 
+export type CheckoutPackageType = 'single' | 'subscription';
+
 export async function checkoutBasketCreate(
   userId: string,
   username: string,
   recipientUsername?: string,
-  ipAddress?: string
+  ipAddress?: string,
+  packageType?: CheckoutPackageType
 ): Promise<CheckoutBasket> {
   const r = await rpc<{ ident?: string; checkout_url?: string; recipient_login?: string }>(
     `${SUB.transactions}.basket_create`,
@@ -451,7 +454,8 @@ export async function checkoutBasketCreate(
       user_id: userId,
       username,
       recipient_username: recipientUsername || undefined,
-      ip_address: ipAddress || undefined
+      ip_address: ipAddress || undefined,
+      package_type: packageType || undefined
     },
     16000
   );

--- a/console/dashboard/src/routes/(app)/billing/+page.server.ts
+++ b/console/dashboard/src/routes/(app)/billing/+page.server.ts
@@ -73,12 +73,17 @@ export const actions: Actions = {
   // required because it carries our custom user_id for webhook attribution; do
   // not fall back to a static package URL that could charge without attributing
   // the resulting entitlement.
-  subscribe: async ({ locals, getClientAddress }) => {
+  subscribe: async ({ locals, request, getClientAddress }) => {
     const s = locals.session;
     if (!s) return fail(401, { error: 'Not signed in.' });
     if (s.delegate_of || s.impersonator_id) {
       return fail(403, { error: 'Only the account owner can subscribe.' });
     }
+
+    // 'monthly' = auto-renewing subscription, anything else = one paid month.
+    // Recurring billing only ever happens on an explicit monthly choice.
+    const form = await request.formData();
+    const packageType = form.get('plan') === 'monthly' ? 'subscription' : 'single';
 
     // Never send an already-premium user to Tebex: a staff-granted period,
     // active Tebex entitlement, or VIP grant must run out before a new charge is
@@ -94,7 +99,7 @@ export const actions: Actions = {
 
     let checkoutUrl: string | null = null;
     try {
-      const basket = await checkoutBasketCreate(s.user_id, s.login, undefined, getClientAddress());
+      const basket = await checkoutBasketCreate(s.user_id, s.login, undefined, getClientAddress(), packageType);
       checkoutUrl = optionalHttpsURL(basket.checkoutUrl ?? undefined);
     } catch (err) {
       console.error('[billing] basket create failed:', err);

--- a/console/dashboard/src/routes/(app)/billing/+page.svelte
+++ b/console/dashboard/src/routes/(app)/billing/+page.svelte
@@ -169,19 +169,39 @@
 
       <div class="plan-actions">
         {#if canSubscribe}
-          <form
-            method="POST"
-            action="?/subscribe"
-            bind:this={subscribeForm}
-            onsubmit={() => {
-              launching = true;
-            }}
-          >
-            <button class="btn primary" type="submit" disabled={launching}>
-              <Icon name="heart" size={14} />
-              {launching ? 'Opening checkout…' : 'Subscribe'}
-            </button>
-          </form>
+          <!-- Two ways to pay, both one click: an auto-renewing monthly
+               subscription or a single month with no renewal. The plan rides
+               in a hidden input (never a button value: submit-time state
+               changes can drop the submitter from the form data). -->
+          <div class="plan-buttons">
+            <form
+              method="POST"
+              action="?/subscribe"
+              bind:this={subscribeForm}
+              onsubmit={() => {
+                launching = true;
+              }}
+            >
+              <input type="hidden" name="plan" value="monthly" />
+              <button class="btn primary" type="submit" disabled={launching}>
+                <Icon name="heart" size={14} />
+                {launching ? 'Opening checkout…' : 'Subscribe monthly'}
+              </button>
+            </form>
+            <form
+              method="POST"
+              action="?/subscribe"
+              onsubmit={() => {
+                launching = true;
+              }}
+            >
+              <input type="hidden" name="plan" value="once" />
+              <button class="btn ghost" type="submit" disabled={launching}>
+                {launching ? 'Opening checkout…' : 'Buy one month'}
+              </button>
+            </form>
+          </div>
+          <p class="hint tiny">Monthly renews automatically until cancelled. One month is a single charge, no renewal.</p>
           <p class="hint tiny">Redirects to Tebex’s secure hosted checkout. Your plan updates after the payment lands.</p>
         {:else if canManage}
           <form method="POST" action="?/cancel">
@@ -283,6 +303,11 @@
     gap: 8px;
     flex-shrink: 0;
   }
+  .plan-buttons {
+    display: flex;
+    gap: 10px;
+    align-items: center;
+  }
   .plan-actions .hint { text-align: right; }
 
   .gift-top {
@@ -345,6 +370,9 @@
     .plan-top { flex-direction: column; }
     .plan-actions { align-items: stretch; width: 100%; }
     .plan-actions .hint { text-align: left; }
+    .plan-buttons { flex-direction: column; align-items: stretch; }
+    .plan-buttons form { width: 100%; }
+    .plan-buttons .btn { width: 100%; justify-content: center; }
     .gift-top { flex-direction: column; }
     .gift-side { align-items: stretch; width: 100%; }
     .gift-form { width: 100%; flex-wrap: wrap; }

--- a/internal/domain/rpc/transactions/transactions.go
+++ b/internal/domain/rpc/transactions/transactions.go
@@ -14,6 +14,10 @@ type BasketCreateRequest struct {
 	Username          string `json:"username,omitempty"`
 	RecipientUsername string `json:"recipient_username,omitempty"`
 	IPAddress         string `json:"ip_address,omitempty"`
+	// PackageType selects how the buyer pays: "single" (one month, one charge)
+	// or "subscription" (auto-renews monthly). Empty falls back to the
+	// service's configured default. Gifts are always "single" regardless.
+	PackageType string `json:"package_type,omitempty"`
 }
 
 type BasketCreateReply struct {


### PR DESCRIPTION
## Changes
- `basket_create` accepts `package_type` (`single` | `subscription`, validated; anything else errors).
- Billing page: **Subscribe monthly** (auto-renews) and **Buy one month** (single charge) side by side; hint explains the difference. The choice rides in a hidden input, never a button value — submit-time state changes can drop the submitter from form data (same class of bug as the gift field).
- Recurring billing only happens on an explicit monthly choice; a missing/unknown plan resolves to a single month. Gifts stay hardcoded `single`.
- Pricing-page autostart (`?subscribe=1`) submits the monthly form.

## Test plan
- `go build`/`vet`/`test ./app/transactions/...` green; `svelte-check` 1009 files 0 errors; `bun run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)