### PR TITLE
Cursor bounding box on the gift username field

### DIFF
--- a/console/dashboard/src/routes/(app)/billing/+page.svelte
+++ b/console/dashboard/src/routes/(app)/billing/+page.svelte
@@ -248,6 +248,7 @@
             class="gift-input"
             type="text"
             name="recipient"
+            data-cursor
             placeholder="Twitch username"
             autocomplete="off"
             spellcheck="false"


### PR DESCRIPTION
The custom cursor ring morphs onto `a, button, .search, [data-cursor]`; the gift recipient input had no marker, so hovering it kept the small ring instead of the bounding-box highlight. Adds `data-cursor` to the field.

Test plan: `svelte-check` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)