### PR TITLE
fix(web,console): iOS safe-area coverage + mobile card responsiveness

### DIFF
--- a/console/admin/src/app.html
+++ b/console/admin/src/app.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <link rel="icon" href="%sveltekit.assets%/logo.png" />
   %sveltekit.head%
 </head>

--- a/console/dashboard/src/app.html
+++ b/console/dashboard/src/app.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <link rel="icon" href="%sveltekit.assets%/logo.png" />
   %sveltekit.head%
 </head>

--- a/console/shared/components/Dock.svelte
+++ b/console/shared/components/Dock.svelte
@@ -280,6 +280,23 @@
 
   @media (max-width: 760px) {
     .dock { padding: 0 8px calc(8px + env(safe-area-inset-bottom)); }
+    /* Full-bleed veil behind the pill: fades the scrolling page out and paints
+       the canvas colour solid across the home-indicator strip, so nothing shows
+       through the gaps around the floating dock. */
+    .dock::before {
+      content: "";
+      position: absolute;
+      inset: -22px 0 0;
+      background: linear-gradient(
+        to top,
+        var(--bb-bg-0) 0%,
+        var(--bb-bg-0) 46%,
+        rgba(10, 10, 10, 0.72) 72%,
+        transparent 100%
+      );
+      pointer-events: none;
+      z-index: -1;
+    }
     .dock-inner { width: 100%; justify-content: space-around; }
     .dock-item { min-width: 0; flex: 1; padding: 8px 6px 7px; }
     .group-wrap { flex: 1; }

--- a/console/shared/components/Topbar.svelte
+++ b/console/shared/components/Topbar.svelte
@@ -72,12 +72,14 @@
   .topbar {
     position: sticky; top: 0; z-index: 40;
     display: flex; align-items: center; gap: 14px;
-    padding: 9px 16px;
+    /* Top padding carries the notch inset so the strip's ink paints the safe
+       area; the row itself stays at its normal height below it. */
+    padding: calc(9px + env(safe-area-inset-top, 0px)) max(16px, env(safe-area-inset-right, 0px)) 9px max(16px, env(safe-area-inset-left, 0px));
     background: rgba(10, 10, 10, 0.85);
     border-bottom: 1px solid var(--rule, rgba(240, 236, 228, 0.1));
   }
   @media (min-width: 761px) {
-    .topbar { gap: 20px; padding: 9px var(--gutter); }
+    .topbar { gap: 20px; padding: calc(9px + env(safe-area-inset-top, 0px)) var(--gutter) 9px; }
   }
 
   .station { display: flex; align-items: center; gap: 9px; text-decoration: none; flex: none; }

--- a/console/shared/styles/app.css
+++ b/console/shared/styles/app.css
@@ -350,7 +350,13 @@ kbd.hint {
 @media (max-width: 1100px) { .mod-grid { grid-template-columns: 1fr; } }
 
 @media (max-width: 760px) {
-  .stat-grid { grid-template-columns: 1fr 1fr; }
+  /* Tighten the page gutter so cards get the width back on phones. */
+  :root { --gutter: 16px; }
+  .stat-grid { grid-template-columns: 1fr 1fr; gap: 10px; }
+  .stat { padding: 16px; }
+  .stat .ico { margin-bottom: 12px; }
+  .stat .value { font-size: clamp(24px, 7vw, 34px); }
+  .grid-2, .mod-grid { gap: 14px; }
   .thead { display: none; }
   .trow { grid-template-columns: 1fr auto; gap: 8px; }
   .trow .resp, .trow .cd, .trow .perm-cell { display: none; }

--- a/web/src/components/layout/MobileMenu.astro
+++ b/web/src/components/layout/MobileMenu.astro
@@ -35,7 +35,7 @@ const { links, ctaHref = "#", ctaLabel = "Add to Twitch" } = Astro.props;
     .mobile-menu {
         display: none;
         position: fixed;
-        inset: var(--nav-height, 76px) 0 0;
+        inset: var(--nav-offset, 76px) 0 0;
         padding: 16px;
         background: rgba(10, 10, 10, 0.72);
         backdrop-filter: blur(22px);
@@ -122,7 +122,7 @@ const { links, ctaHref = "#", ctaLabel = "Add to Twitch" } = Astro.props;
         display: flex;
         flex-direction: column;
         gap: 16px;
-        margin-bottom: clamp(56px, 8vh, 86px);
+        margin-bottom: calc(clamp(56px, 8vh, 86px) + env(safe-area-inset-bottom, 0px));
         padding-top: 24px;
         border-top: 1px solid rgba(201, 168, 124, 0.15);
     }
@@ -177,7 +177,7 @@ const { links, ctaHref = "#", ctaLabel = "Add to Twitch" } = Astro.props;
         }
 
         .mobile-menu__footer {
-            margin-bottom: clamp(64px, 9vh, 92px);
+            margin-bottom: calc(clamp(64px, 9vh, 92px) + env(safe-area-inset-bottom, 0px));
         }
     }
 

--- a/web/src/components/layout/Nav.astro
+++ b/web/src/components/layout/Nav.astro
@@ -285,8 +285,12 @@ const isActive = (href: string) =>
         top: 0;
         left: 0;
         width: 100%;
-        height: var(--nav-height, 76px);
-        padding: 0 max(24px, 4vw);
+        /* Grow up into the notch so the blurred bar paints the safe area; the
+           top padding pushes the button row back down to its normal band. */
+        height: calc(var(--nav-height, 76px) + env(safe-area-inset-top, 0px));
+        padding-top: env(safe-area-inset-top, 0px);
+        padding-bottom: 0;
+        padding-inline: max(24px, 4vw, env(safe-area-inset-left, 0px), env(safe-area-inset-right, 0px));
         border-bottom: var(--border) 1px solid;
         z-index: 50;
         backdrop-filter: blur(12px);
@@ -351,7 +355,7 @@ const isActive = (href: string) =>
 
     @media (max-width: 1120px) {
         .site-nav {
-            padding-inline: 28px;
+            padding-inline: max(28px, env(safe-area-inset-left, 0px), env(safe-area-inset-right, 0px));
         }
 
         .site-nav__inner {
@@ -375,7 +379,7 @@ const isActive = (href: string) =>
 
     @media (max-width: 1023px) {
         .site-nav {
-            padding-inline: 24px;
+            padding-inline: max(24px, env(safe-area-inset-left, 0px), env(safe-area-inset-right, 0px));
         }
 
         .site-nav__inner {
@@ -391,7 +395,7 @@ const isActive = (href: string) =>
 
     @media (max-width: 420px) {
         .site-nav {
-            padding-inline: 18px;
+            padding-inline: max(18px, env(safe-area-inset-left, 0px), env(safe-area-inset-right, 0px));
         }
 
         .logo span {

--- a/web/src/components/legal/LegalShell.astro
+++ b/web/src/components/legal/LegalShell.astro
@@ -107,7 +107,7 @@ const { updated, sections } = Astro.props;
         .lshell__toc {
             display: block;
             position: sticky;
-            top: calc(var(--nav-height, 76px) + 32px);
+            top: calc(var(--nav-offset, 76px) + 32px);
             align-self: start;
         }
     }
@@ -174,7 +174,7 @@ const { updated, sections } = Astro.props;
         margin-bottom: 48px;
     }
 
-    .lshell__block { scroll-margin-top: calc(var(--nav-height, 76px) + 24px); }
+    .lshell__block { scroll-margin-top: calc(var(--nav-offset, 76px) + 24px); }
 
     .lshell__block h2 {
         font-family: var(--font-display, "Syne", sans-serif);

--- a/web/src/components/pricing/Tiers.astro
+++ b/web/src/components/pricing/Tiers.astro
@@ -224,6 +224,11 @@ const enterpriseFeatures = [
         z-index: 1;
     }
 
+    /* The badge straddles the top of the card body (its positioned ancestor),
+       so the premium card drops its content down to clear it — otherwise the
+       ribbon sits on top of the "Premium" title. */
+    .tier--premium :global(.card__body) { padding-top: 22px; }
+
     .tier__name {
         display: block;
         font-family: var(--font-display, "Syne", sans-serif);

--- a/web/src/components/ui/PageHero.astro
+++ b/web/src/components/ui/PageHero.astro
@@ -33,7 +33,7 @@ const { eyebrow, title, description } = Astro.props;
         justify-content: center;
         text-align: center;
         min-height: clamp(56vh, 70vh, 80vh);
-        padding: calc(var(--nav-height, 76px) + 80px) 24px 80px;
+        padding: calc(var(--nav-offset, 76px) + 80px) 24px 80px;
         max-width: none;
         margin: 0;
     }
@@ -124,6 +124,6 @@ const { eyebrow, title, description } = Astro.props;
     }
 
     @media (max-width: 640px) {
-        .phero { min-height: 60vh; padding: calc(var(--nav-height, 68px) + 56px) 20px 56px; }
+        .phero { min-height: 60vh; padding: calc(var(--nav-offset, 68px) + 56px) 20px 56px; }
     }
 </style>

--- a/web/src/layouts/Layout.astro
+++ b/web/src/layouts/Layout.astro
@@ -24,7 +24,7 @@ const {
 
 <head>
     <meta charset="UTF-8"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"/>
     <meta
         http-equiv="Content-Security-Policy"
         content="default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; script-src 'self' https://static.cloudflareinsights.com; connect-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com https://cloudflareinsights.com; base-uri 'self'; form-action 'self'"

--- a/web/src/styles/style.css
+++ b/web/src/styles/style.css
@@ -17,6 +17,9 @@
     --font-hand: "Caveat", cursive;
 
     --nav-height: 76px;
+    /* Visual nav band (--nav-height) plus the iOS notch inset above it. Fixed
+       nav grows into the safe area; content offsets clear the whole thing. */
+    --nav-offset: calc(var(--nav-height) + env(safe-area-inset-top, 0px));
     --ease-out-expo: cubic-bezier(0.16, 1, 0.3, 1);
     --ease-out-back: cubic-bezier(0.34, 1.56, 0.64, 1);
 


### PR DESCRIPTION
Isolated mobile-responsiveness pass for the marketing site and the console (admin + dashboard). CSS-only + one viewport meta per app; no logic changes.

## Web
- **Notch coverage:** `viewport-fit=cover`; the fixed top nav grows up into the safe area (`height += env(safe-area-inset-top)`, top padding carries the inset) so the blurred bar paints behind the notch while the button row stays in its normal band. New `--nav-offset` token feeds content offsets (`PageHero`, `LegalShell`, `MobileMenu`).
- **Mobile menu:** footer/CTA lifts clear of the home indicator.
- **Bug fix:** the premium pricing badge ("the tip jar, with perks") straddles `.card__body` (its positioned ancestor), so it was sitting on top of the "Premium" title at every width. Content now drops to clear it.

## Console (admin + dashboard, shared components)
- **Notch coverage:** `viewport-fit=cover`; `Topbar` carries the notch inset the same way.
- **Home indicator:** the floating `Dock` can't be full-bleed, so a mobile-only full-width veil behind it fades page content to the canvas colour across the home-indicator strip (nothing shows through the gaps).
- **Cards:** tighter page gutter on phones (28→16px), `stat-grid`/grid gaps, clamped numerals. Verified no horizontal overflow on the overview and users routes.

## Verification
Verified in-browser at a 375px viewport with simulated notch/home-indicator insets (emulators report zero insets): nav/topbar bars paint the safe area with content below the notch line; the Dock veil masks scrolling content; pricing badge clears the title; no horizontal overflow. The console changes are orthogonal CSS additions that also apply to the streamer dashboard via the shared components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)