### PR TITLE
refactor: cut CodeScene complexity in hand-written hotspots

### DIFF
--- a/app/commands/main.go
+++ b/app/commands/main.go
@@ -3,9 +3,12 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
+
+	"github.com/newrelic/go-agent/v3/newrelic"
 
 	"ItsBagelBot/app/commands/ent"
 	// Wire the ent schema runtime (field defaults like updated_at, and the name
@@ -29,6 +32,77 @@ import (
 )
 
 const serviceName = "commands"
+
+// registerConsumers wires the event subscriptions onto repo: cache
+// invalidation fans out to every instance (broadcast), while use-counter and
+// account-deletion events are handled once per event (grouped).
+func registerConsumers(ctx context.Context, nrApp *newrelic.Application, repo *repository.Commands, broadcast, grouped message.Subscriber, log *zap.Logger) error {
+	// Use-counter events from the worker: exactly one instance sums each event
+	// (queue group), the repo batches them and flushes uses = uses + n.
+	subs := []struct {
+		name    string
+		sub     message.Subscriber
+		subject string
+		handle  func(*message.Message) error
+	}{
+		{"command changes", broadcast, data.SubjectCommandChanged, invalidateOnChange(repo)},
+		{"command used events", grouped, data.SubjectCommandUsed, recordUse(repo, log)},
+		{"user deleted events", grouped, data.SubjectUserDeleted, deleteAllForUser(repo, log)},
+	}
+	for _, s := range subs {
+		if err := bus.Consume(ctx, nrApp, s.sub, s.subject, s.handle, log); err != nil {
+			return fmt.Errorf("subscribe to %s: %w", s.name, err)
+		}
+	}
+	return nil
+}
+
+// invalidateOnChange drops the cached view of the changed user.
+func invalidateOnChange(repo *repository.Commands) func(*message.Message) error {
+	return func(msg *message.Message) error {
+		var dto data.CommandChangedDTO
+		if err := json.Unmarshal(msg.Payload, &dto); err != nil {
+			return err
+		}
+		repo.Invalidate(dto.UserID)
+		return nil
+	}
+}
+
+// recordUse folds a worker use-counter event into the repo's accumulator. A
+// malformed payload is dropped (nil), not retried.
+func recordUse(repo *repository.Commands, log *zap.Logger) func(*message.Message) error {
+	return func(msg *message.Message) error {
+		var dto data.CommandUsedDTO
+		if err := json.Unmarshal(msg.Payload, &dto); err != nil {
+			log.Warn("commands: bad command_used payload", zap.Error(err))
+			return nil
+		}
+		repo.RecordUse(dto.UserID, dto.Name, dto.Count)
+		return nil
+	}
+}
+
+// deleteAllForUser removes every command of a deleted account. Malformed or
+// invalid payloads are dropped; a DB failure is returned for retry.
+func deleteAllForUser(repo *repository.Commands, log *zap.Logger) func(*message.Message) error {
+	return func(msg *message.Message) error {
+		var dto data.UserDeletedDTO
+		if err := json.Unmarshal(msg.Payload, &dto); err != nil {
+			log.Warn("commands: bad user_deleted payload", zap.Error(err))
+			return nil
+		}
+		if err := validate.UserID(dto.UserID); err != nil {
+			log.Warn("commands: invalid user_id in user_deleted", zap.Error(err))
+			return nil
+		}
+		if err := repo.DeleteAllForUser(msg.Context(), dto.UserID); err != nil {
+			return err
+		}
+		log.Info("commands: deleted all for user", zap.Uint64("user_id", dto.UserID))
+		return nil
+	}
+}
 
 func main() {
 
@@ -94,19 +168,6 @@ func main() {
 	}
 	defer func() { _ = broadcast.Close() }()
 
-	if err := bus.Consume(ctx, nrApp, broadcast, data.SubjectCommandChanged, func(msg *message.Message) error {
-
-		var dto data.CommandChangedDTO
-		if err := json.Unmarshal(msg.Payload, &dto); err != nil {
-			return err
-		}
-
-		repo.Invalidate(dto.UserID)
-		return nil
-	}, log); err != nil {
-		log.Fatal("failed to subscribe to command changes", zap.Error(err))
-	}
-
 	// Durable group subscription: exactly one instance handles the delete so
 	// rows are not redundantly removed, and any instance failure is retried.
 	grouped, err := bus.NewSubscriber(natsURL, serviceName, log)
@@ -115,43 +176,8 @@ func main() {
 	}
 	defer func() { _ = grouped.Close() }()
 
-	// Use-counter events from the worker: exactly one instance sums each event
-	// (queue group), the repo batches them and flushes uses = uses + n.
-	if err := bus.Consume(ctx, nrApp, grouped, data.SubjectCommandUsed, func(msg *message.Message) error {
-
-		var dto data.CommandUsedDTO
-		if err := json.Unmarshal(msg.Payload, &dto); err != nil {
-			log.Warn("commands: bad command_used payload", zap.Error(err))
-			return nil
-		}
-
-		repo.RecordUse(dto.UserID, dto.Name, dto.Count)
-		return nil
-	}, log); err != nil {
-		log.Fatal("failed to subscribe to command used events", zap.Error(err))
-	}
-
-	if err := bus.Consume(ctx, nrApp, grouped, data.SubjectUserDeleted, func(msg *message.Message) error {
-
-		var dto data.UserDeletedDTO
-		if err := json.Unmarshal(msg.Payload, &dto); err != nil {
-			log.Warn("commands: bad user_deleted payload", zap.Error(err))
-			return nil
-		}
-
-		if err := validate.UserID(dto.UserID); err != nil {
-			log.Warn("commands: invalid user_id in user_deleted", zap.Error(err))
-			return nil
-		}
-
-		if err := repo.DeleteAllForUser(msg.Context(), dto.UserID); err != nil {
-			return err
-		}
-
-		log.Info("commands: deleted all for user", zap.Uint64("user_id", dto.UserID))
-		return nil
-	}, log); err != nil {
-		log.Fatal("failed to subscribe to user deleted events", zap.Error(err))
+	if err := registerConsumers(ctx, nrApp, repo, broadcast, grouped, log); err != nil {
+		log.Fatal("failed to subscribe to events", zap.Error(err))
 	}
 
 	projectionSubject := env.Get("NATS_INTERNAL_PROJECTION_COMMANDS_SUBJECT", "bagel.rpc.internal.projection.commands.get")

--- a/app/commands/repository/commands.go
+++ b/app/commands/repository/commands.go
@@ -159,43 +159,70 @@ func (r *Commands) List(ctx context.Context, userID uint64) ([]CommandView, erro
 	})
 }
 
+// CommandSpec is the caller-editable state of one command, as accepted by
+// Upsert and Rename. Name and Aliases arrive raw from the console and are
+// normalized before validation.
+type CommandSpec struct {
+	Name             string
+	Aliases          []string
+	Response         string
+	IsActive         bool
+	StreamOnlineOnly bool
+	Perm             string
+	Cooldown         uint
+	AllowedUserID    uint64
+}
+
+func (s *CommandSpec) normalize() {
+	s.Name = normalizeName(s.Name)
+	s.Aliases = normalizeAliases(s.Aliases)
+}
+
+func (s *CommandSpec) validate() error {
+	if err := validate.CommandName(s.Name); err != nil {
+		return err
+	}
+	if err := validate.CommandAliases(s.Aliases); err != nil {
+		return err
+	}
+	if err := validate.CommandResponse(s.Response); err != nil {
+		return err
+	}
+	if err := validate.Perm(s.Perm); err != nil {
+		return err
+	}
+	return validate.Cooldown(s.Cooldown)
+}
+
+// dto renders the spec as a full-state change event for userID.
+func (s *CommandSpec) dto(userID uint64) data.CommandChangedDTO {
+	return data.CommandChangedDTO{
+		UserID:           userID,
+		Name:             s.Name,
+		Aliases:          s.Aliases,
+		Response:         s.Response,
+		IsActive:         s.IsActive,
+		StreamOnlineOnly: s.StreamOnlineOnly,
+		Perm:             s.Perm,
+		Cooldown:         s.Cooldown,
+		AllowedUserID:    s.AllowedUserID,
+	}
+}
+
 // Upsert validates and queues a command create or edit. Consecutive edits of
 // the same command coalesce into the latest state before the next flush.
-func (r *Commands) Upsert(userID uint64, name string, aliases []string, response string, isActive bool, streamOnlineOnly bool, perm string, cooldown uint, allowedUserID uint64) error {
+func (r *Commands) Upsert(userID uint64, spec CommandSpec) error {
 
-	name = normalizeName(name)
-	aliases = normalizeAliases(aliases)
+	spec.normalize()
 
 	if err := validate.UserID(userID); err != nil {
 		return err
 	}
-	if err := validate.CommandName(name); err != nil {
-		return err
-	}
-	if err := validate.CommandAliases(aliases); err != nil {
-		return err
-	}
-	if err := validate.CommandResponse(response); err != nil {
-		return err
-	}
-	if err := validate.Perm(perm); err != nil {
-		return err
-	}
-	if err := validate.Cooldown(cooldown); err != nil {
+	if err := spec.validate(); err != nil {
 		return err
 	}
 
-	r.batcher.Add(commandKey{userID: userID, name: name}, data.CommandChangedDTO{
-		UserID:           userID,
-		Name:             name,
-		Aliases:          aliases,
-		Response:         response,
-		IsActive:         isActive,
-		StreamOnlineOnly: streamOnlineOnly,
-		Perm:             perm,
-		Cooldown:         cooldown,
-		AllowedUserID:    allowedUserID,
-	})
+	r.batcher.Add(commandKey{userID: userID, name: spec.Name}, spec.dto(userID))
 
 	return nil
 }
@@ -206,11 +233,10 @@ func (r *Commands) Upsert(userID uint64, name string, aliases []string, response
 // can't be represented as a queued edit of the old key. Emits a delete for the
 // old name and a change for the new so name-keyed consumers (projector, bot)
 // drop the stale entry and pick up the renamed command.
-func (r *Commands) Rename(ctx context.Context, userID uint64, oldName, newName string, aliases []string, response string, isActive bool, streamOnlineOnly bool, perm string, cooldown uint, allowedUserID uint64) error {
+func (r *Commands) Rename(ctx context.Context, userID uint64, oldName string, spec CommandSpec) error {
 
 	oldName = normalizeName(oldName)
-	newName = normalizeName(newName)
-	aliases = normalizeAliases(aliases)
+	spec.normalize()
 
 	if err := validate.UserID(userID); err != nil {
 		return err
@@ -218,38 +244,11 @@ func (r *Commands) Rename(ctx context.Context, userID uint64, oldName, newName s
 	if err := validate.CommandName(oldName); err != nil {
 		return err
 	}
-	if err := validate.CommandName(newName); err != nil {
-		return err
-	}
-	if err := validate.CommandAliases(aliases); err != nil {
-		return err
-	}
-	if err := validate.CommandResponse(response); err != nil {
-		return err
-	}
-	if err := validate.Perm(perm); err != nil {
-		return err
-	}
-	if err := validate.Cooldown(cooldown); err != nil {
+	if err := spec.validate(); err != nil {
 		return err
 	}
 
-	updated, err := db.WithQuery(ctx, func(ctx context.Context) (int, error) {
-		return r.client.Commands.Update().
-			Where(
-				commands.UserIDEQ(userID),
-				commands.NameEQ(oldName),
-			).
-			SetName(newName).
-			SetAliases(aliases).
-			SetResponse(response).
-			SetIsActive(isActive).
-			SetStreamOnlineOnly(streamOnlineOnly).
-			SetPerm(perm).
-			SetCooldown(cooldown).
-			SetAllowedUserID(allowedUserID).
-			Save(ctx)
-	})
+	updated, err := r.renameRow(ctx, userID, oldName, spec)
 	if err != nil {
 		return err
 	}
@@ -257,7 +256,7 @@ func (r *Commands) Rename(ctx context.Context, userID uint64, oldName, newName s
 	// Old row absent (already renamed/deleted elsewhere): fall back to a plain
 	// write of the new command so the edit is not lost.
 	if updated == 0 {
-		return r.Upsert(userID, newName, aliases, response, isActive, streamOnlineOnly, perm, cooldown, allowedUserID)
+		return r.Upsert(userID, spec)
 	}
 
 	r.Invalidate(userID)
@@ -272,23 +271,35 @@ func (r *Commands) Rename(ctx context.Context, userID uint64, oldName, newName s
 
 	// The rename preserved the row, so its uses counter survives; carry it on
 	// the event so the projection doesn't regress it to zero.
-	changed := data.CommandChangedDTO{
-		UserID:           userID,
-		Name:             newName,
-		Aliases:          aliases,
-		Response:         response,
-		IsActive:         isActive,
-		StreamOnlineOnly: streamOnlineOnly,
-		Perm:             perm,
-		Cooldown:         cooldown,
-		AllowedUserID:    allowedUserID,
-	}
-	if states, serr := r.rowStates(ctx, []commandKey{{userID: userID, name: newName}}); serr == nil {
-		if s, ok := states[commandKey{userID: userID, name: newName}]; ok {
+	changed := spec.dto(userID)
+	key := commandKey{userID: userID, name: spec.Name}
+	if states, serr := r.rowStates(ctx, []commandKey{key}); serr == nil {
+		if s, ok := states[key]; ok {
 			changed.Uses = s.Uses
 		}
 	}
 	return bus.PublishJSON(ctx, r.pub, data.SubjectCommandChanged, changed)
+}
+
+// renameRow rewrites the old row's key and payload in one UPDATE, returning
+// the number of rows hit (0 = old name no longer exists).
+func (r *Commands) renameRow(ctx context.Context, userID uint64, oldName string, spec CommandSpec) (int, error) {
+	return db.WithQuery(ctx, func(ctx context.Context) (int, error) {
+		return r.client.Commands.Update().
+			Where(
+				commands.UserIDEQ(userID),
+				commands.NameEQ(oldName),
+			).
+			SetName(spec.Name).
+			SetAliases(spec.Aliases).
+			SetResponse(spec.Response).
+			SetIsActive(spec.IsActive).
+			SetStreamOnlineOnly(spec.StreamOnlineOnly).
+			SetPerm(spec.Perm).
+			SetCooldown(spec.Cooldown).
+			SetAllowedUserID(spec.AllowedUserID).
+			Save(ctx)
+	})
 }
 
 // Delete removes a command immediately and announces it.
@@ -375,21 +386,42 @@ func (r *Commands) RecordUse(userID uint64, name string, count uint64) {
 // pipeline as an edit, so nothing downstream needs a special counter path.
 func (r *Commands) flushUses(ctx context.Context) {
 
-	r.usesMu.Lock()
-	if len(r.usesPend) == 0 {
-		r.usesMu.Unlock()
+	pend := r.drainPendingUses()
+	if len(pend) == 0 {
 		return
 	}
-	pend := r.usesPend
-	r.usesPend = map[commandKey]uint64{}
-	r.usesMu.Unlock()
 
 	txn := r.app.StartTransaction("flush command uses")
 	defer txn.End()
 	ctx = newrelic.NewContext(ctx, txn)
 
+	keys, err := r.persistUses(ctx, txn, pend)
+	if err != nil {
+		txn.NoticeError(err)
+		return
+	}
+
+	r.publishUseEvents(ctx, txn, keys)
+}
+
+// drainPendingUses swaps out the accumulator under the lock.
+func (r *Commands) drainPendingUses() map[commandKey]uint64 {
+	r.usesMu.Lock()
+	defer r.usesMu.Unlock()
+	if len(r.usesPend) == 0 {
+		return nil
+	}
+	pend := r.usesPend
+	r.usesPend = map[commandKey]uint64{}
+	return pend
+}
+
+// persistUses applies uses = uses + n per key and returns the keys that
+// landed. A single missing/deleted row must not drop the whole window, so
+// per-row failures are logged and skipped.
+func (r *Commands) persistUses(ctx context.Context, txn *newrelic.Transaction, pend map[commandKey]uint64) ([]commandKey, error) {
 	keys := make([]commandKey, 0, len(pend))
-	if err := db.WithExec(ctx, func(ctx context.Context) error {
+	err := db.WithExec(ctx, func(ctx context.Context) error {
 		for key, n := range pend {
 			_, err := r.client.Commands.Update().
 				Where(
@@ -399,8 +431,6 @@ func (r *Commands) flushUses(ctx context.Context) {
 				AddUses(int64(n)). //nolint:gosec // n is a small per-window count
 				Save(ctx)
 			if err != nil {
-				// Keep counting the rest; a single missing/deleted row must not
-				// drop the whole window.
 				txn.NoticeError(err)
 				r.log.Warn("failed to persist command uses",
 					zap.Uint64("user_id", key.userID),
@@ -412,11 +442,13 @@ func (r *Commands) flushUses(ctx context.Context) {
 			keys = append(keys, key)
 		}
 		return nil
-	}); err != nil {
-		txn.NoticeError(err)
-		return
-	}
+	})
+	return keys, err
+}
 
+// publishUseEvents reloads the flushed rows and publishes ordinary change
+// events built from DB truth, invalidating each affected user's cache once.
+func (r *Commands) publishUseEvents(ctx context.Context, txn *newrelic.Transaction, keys []commandKey) {
 	states, err := r.rowStates(ctx, keys)
 	if err != nil {
 		txn.NoticeError(err)

--- a/app/commands/repository/commands_test.go
+++ b/app/commands/repository/commands_test.go
@@ -29,13 +29,25 @@ func setup(t *testing.T) (*ent.Client, *bustest.Publisher, *repository.Commands)
 	return client, pub, repository.NewCommands(client, pub, nil, zap.NewNop())
 }
 
+// spec builds a CommandSpec with the fields these tests vary.
+func spec(name, response string, streamOnlineOnly bool, cooldown uint) repository.CommandSpec {
+	return repository.CommandSpec{
+		Name:             name,
+		Response:         response,
+		IsActive:         true,
+		StreamOnlineOnly: streamOnlineOnly,
+		Perm:             "everyone",
+		Cooldown:         cooldown,
+	}
+}
+
 func TestUpsertCoalescesEdits(t *testing.T) {
 	client, pub, repo := setup(t)
 	ctx := context.Background()
 
-	repo.Upsert(1001, "!hello", nil, "draft one", true, false, "everyone", 0, 0)
-	repo.Upsert(1001, "!hello", nil, "draft two", true, false, "everyone", 0, 0)
-	repo.Upsert(1001, "!hello", nil, "final wording", true, true, "everyone", 0, 0)
+	repo.Upsert(1001, spec("!hello", "draft one", false, 0))
+	repo.Upsert(1001, spec("!hello", "draft two", false, 0))
+	repo.Upsert(1001, spec("!hello", "final wording", true, 0))
 
 	repo.Close(ctx) // deterministic flush
 
@@ -51,7 +63,7 @@ func TestDeleteIsImmediateAndAnnounced(t *testing.T) {
 	client, pub, repo := setup(t)
 	ctx := context.Background()
 
-	repo.Upsert(1001, "!hello", nil, "hi chat", true, false, "everyone", 0, 0)
+	repo.Upsert(1001, spec("!hello", "hi chat", false, 0))
 	repo.Close(ctx)
 
 	repo2 := repository.NewCommands(client, pub, nil, zap.NewNop())
@@ -73,7 +85,7 @@ func TestRenameUpdatesRowInPlace(t *testing.T) {
 	client, pub, repo := setup(t)
 	ctx := context.Background()
 
-	repo.Upsert(1001, "!old", nil, "the response", true, false, "everyone", 7, 0)
+	repo.Upsert(1001, spec("!old", "the response", false, 7))
 	repo.Close(ctx)
 	originalID := client.Commands.Query().FirstX(ctx).ID
 
@@ -82,7 +94,7 @@ func TestRenameUpdatesRowInPlace(t *testing.T) {
 
 	baseline := len(pub.On(data.SubjectCommandChanged)) // the create flush above
 
-	require.NoError(t, repo2.Rename(ctx, 1001, "!old", "!new", nil, "the response", true, true, "everyone", 7, 0))
+	require.NoError(t, repo2.Rename(ctx, 1001, "!old", spec("!new", "the response", true, 7)))
 
 	// Exactly one row, same primary key (updated in place, not deleted+recreated).
 	rows := client.Commands.Query().AllX(ctx)
@@ -111,7 +123,7 @@ func TestRenameMissingRowFallsBackToCreate(t *testing.T) {
 	client, _, repo := setup(t)
 	ctx := context.Background()
 
-	require.NoError(t, repo.Rename(ctx, 1001, "!ghost", "!new", nil, "resp", true, true, "everyone", 0, 0))
+	require.NoError(t, repo.Rename(ctx, 1001, "!ghost", spec("!new", "resp", true, 0)))
 	repo.Close(ctx) // flush the fallback upsert
 
 	rows := client.Commands.Query().AllX(ctx)

--- a/app/commands/rpc/dashboard.go
+++ b/app/commands/rpc/dashboard.go
@@ -77,14 +77,25 @@ func (d *dashboardRPC) handleUpsert(ctx context.Context, req commandsrpc.Dashboa
 		allowedUserID = parsed
 	}
 
+	spec := repository.CommandSpec{
+		Name:             req.Name,
+		Aliases:          req.Aliases,
+		Response:         req.Response,
+		IsActive:         req.IsActive,
+		StreamOnlineOnly: req.StreamOnlineOnly,
+		Perm:             req.Perm,
+		Cooldown:         req.Cooldown,
+		AllowedUserID:    allowedUserID,
+	}
+
 	// A rename updates the existing row's name field in place; a plain edit or
 	// create goes through the write-behind upsert.
 	rename := req.OriginalName != "" && req.OriginalName != req.Name
 	var opErr error
 	if rename {
-		opErr = d.repo.Rename(ctx, id, req.OriginalName, req.Name, req.Aliases, req.Response, req.IsActive, req.StreamOnlineOnly, req.Perm, req.Cooldown, allowedUserID)
+		opErr = d.repo.Rename(ctx, id, req.OriginalName, spec)
 	} else {
-		opErr = d.repo.Upsert(id, req.Name, req.Aliases, req.Response, req.IsActive, req.StreamOnlineOnly, req.Perm, req.Cooldown, allowedUserID)
+		opErr = d.repo.Upsert(id, spec)
 	}
 	if opErr != nil {
 		// Validation/conflict error: return it.

--- a/app/notifications/main.go
+++ b/app/notifications/main.go
@@ -76,12 +76,18 @@ func main() {
 	userGetSubject := env.Get("NATS_ADMIN_USER_SUBJECT_PREFIX", "bagel.rpc.admin.user") + ".get"
 
 	adminPrefix := env.Get("NATS_ADMIN_NOTIFICATIONS_SUBJECT_PREFIX", "bagel.rpc.admin.notifications")
-	if err := rpc.SubscribeAdmin(nc, repo, adminPrefix, invalidationPrefix, userGetSubject, queueGroup, nrApp, log); err != nil {
+	adminCfg := rpc.AdminConfig{
+		Prefix:             adminPrefix,
+		InvalidationPrefix: invalidationPrefix,
+		UserGetSubject:     userGetSubject,
+		QueueGroup:         queueGroup,
+	}
+	if err := rpc.SubscribeAdmin(nc, repo, adminCfg, nrApp, log); err != nil {
 		log.Fatal("failed to subscribe admin rpc", zap.Error(err))
 	}
 
 	userPrefix := env.Get("NATS_NOTIFICATIONS_SUBJECT_PREFIX", "bagel.rpc.notifications")
-	if err := rpc.SubscribeUser(nc, repo, userPrefix, queueGroup, nrApp, log); err != nil {
+	if err := rpc.SubscribeUser(nc, repo, rpc.UserConfig{Prefix: userPrefix, QueueGroup: queueGroup}, nrApp, log); err != nil {
 		log.Fatal("failed to subscribe user rpc", zap.Error(err))
 	}
 

--- a/app/notifications/repository/notifications.go
+++ b/app/notifications/repository/notifications.go
@@ -24,37 +24,42 @@ func New(client *ent.Client) *Notifications {
 	return &Notifications{client: client}
 }
 
-// Create records a notification. targetUserID is nil for scope=broadcast.
-func (r *Notifications) Create(
-	ctx context.Context,
-	requestID string,
-	scope notification.Scope,
-	targetUserID *uint64,
-	title, body string,
-	level notification.Level,
-	createdBy uint64,
-	createdByLogin string,
-	expiresAt *time.Time,
-) (*ent.Notification, bool, error) {
+// CreateParams describes one notification to record. TargetUserID is nil for
+// scope=broadcast; RequestID (when set) deduplicates redelivered sends.
+type CreateParams struct {
+	RequestID      string
+	Scope          notification.Scope
+	TargetUserID   *uint64
+	Title          string
+	Body           string
+	Level          notification.Level
+	CreatedBy      uint64
+	CreatedByLogin string
+	ExpiresAt      *time.Time
+}
+
+// Create records a notification. The bool reports whether a new row was
+// inserted (false = an earlier delivery of the same RequestID won).
+func (r *Notifications) Create(ctx context.Context, p CreateParams) (*ent.Notification, bool, error) {
 	row, err := db.WithQuery(ctx, func(ctx context.Context) (*ent.Notification, error) {
 		q := r.client.Notification.Create().
-			SetScope(scope).
-			SetTitle(title).
-			SetBody(body).
-			SetLevel(level).
-			SetCreatedBy(createdBy).
-			SetCreatedByLogin(createdByLogin).
-			SetNillableTargetUserID(targetUserID).
-			SetNillableExpiresAt(expiresAt)
-		if requestID != "" {
-			q.SetRequestID(requestID)
+			SetScope(p.Scope).
+			SetTitle(p.Title).
+			SetBody(p.Body).
+			SetLevel(p.Level).
+			SetCreatedBy(p.CreatedBy).
+			SetCreatedByLogin(p.CreatedByLogin).
+			SetNillableTargetUserID(p.TargetUserID).
+			SetNillableExpiresAt(p.ExpiresAt)
+		if p.RequestID != "" {
+			q.SetRequestID(p.RequestID)
 		}
 		return q.Save(ctx)
 	})
 	if err == nil {
 		return row, true, nil
 	}
-	if !ent.IsConstraintError(err) || requestID == "" {
+	if !ent.IsConstraintError(err) || p.RequestID == "" {
 		return nil, false, err
 	}
 
@@ -62,7 +67,7 @@ func (r *Notifications) Create(
 	// row as success so every RPC delivery produces the same reply without a
 	// second insert or cache invalidation.
 	row, lookupErr := db.WithQuery(ctx, func(ctx context.Context) (*ent.Notification, error) {
-		return r.client.Notification.Query().Where(notification.RequestIDEQ(requestID)).Only(ctx)
+		return r.client.Notification.Query().Where(notification.RequestIDEQ(p.RequestID)).Only(ctx)
 	})
 	if lookupErr != nil {
 		return nil, false, lookupErr

--- a/app/notifications/repository/notifications_test.go
+++ b/app/notifications/repository/notifications_test.go
@@ -21,7 +21,7 @@ func TestBroadcastVisibleToEveryUser(t *testing.T) {
 	repo := repository.New(client)
 	ctx := context.Background()
 
-	_, _, err := repo.Create(ctx, "broadcast-1", notification.ScopeBroadcast, nil, "Maintenance", "Downtime tonight", notification.LevelWarning, 1, "itsmavey", nil)
+	_, _, err := repo.Create(ctx, repository.CreateParams{RequestID: "broadcast-1", Scope: notification.ScopeBroadcast, Title: "Maintenance", Body: "Downtime tonight", Level: notification.LevelWarning, CreatedBy: 1, CreatedByLogin: "itsmavey"})
 	require.NoError(t, err)
 
 	rows, read, err := repo.ListForUser(ctx, 1001, 50)
@@ -42,7 +42,7 @@ func TestDirectNotificationScopedToTarget(t *testing.T) {
 	ctx := context.Background()
 
 	target := uint64(1001)
-	_, _, err := repo.Create(ctx, "direct-1", notification.ScopeDirect, &target, "Welcome", "Thanks for subscribing", notification.LevelInfo, 1, "itsmavey", nil)
+	_, _, err := repo.Create(ctx, repository.CreateParams{RequestID: "direct-1", Scope: notification.ScopeDirect, TargetUserID: &target, Title: "Welcome", Body: "Thanks for subscribing", Level: notification.LevelInfo, CreatedBy: 1, CreatedByLogin: "itsmavey"})
 	require.NoError(t, err)
 
 	rows, _, err := repo.ListForUser(ctx, 1001, 50)
@@ -61,7 +61,7 @@ func TestMarkReadIsIdempotentAndPerUser(t *testing.T) {
 	repo := repository.New(client)
 	ctx := context.Background()
 
-	row, _, err := repo.Create(ctx, "read-1", notification.ScopeBroadcast, nil, "Heads up", "Body", notification.LevelInfo, 1, "itsmavey", nil)
+	row, _, err := repo.Create(ctx, repository.CreateParams{RequestID: "read-1", Scope: notification.ScopeBroadcast, Title: "Heads up", Body: "Body", Level: notification.LevelInfo, CreatedBy: 1, CreatedByLogin: "itsmavey"})
 	require.NoError(t, err)
 
 	require.NoError(t, repo.MarkRead(ctx, row.ID, 1001))
@@ -84,11 +84,11 @@ func TestExpiredNotificationExcluded(t *testing.T) {
 	ctx := context.Background()
 
 	past := time.Now().Add(-time.Hour)
-	_, _, err := repo.Create(ctx, "expired-1", notification.ScopeBroadcast, nil, "Expired", "Body", notification.LevelInfo, 1, "itsmavey", &past)
+	_, _, err := repo.Create(ctx, repository.CreateParams{RequestID: "expired-1", Scope: notification.ScopeBroadcast, Title: "Expired", Body: "Body", Level: notification.LevelInfo, CreatedBy: 1, CreatedByLogin: "itsmavey", ExpiresAt: &past})
 	require.NoError(t, err)
 
 	future := time.Now().Add(time.Hour)
-	_, _, err = repo.Create(ctx, "live-1", notification.ScopeBroadcast, nil, "Still live", "Body", notification.LevelInfo, 1, "itsmavey", &future)
+	_, _, err = repo.Create(ctx, repository.CreateParams{RequestID: "live-1", Scope: notification.ScopeBroadcast, Title: "Still live", Body: "Body", Level: notification.LevelInfo, CreatedBy: 1, CreatedByLogin: "itsmavey", ExpiresAt: &future})
 	require.NoError(t, err)
 
 	rows, _, err := repo.ListForUser(ctx, 1001, 50)
@@ -104,7 +104,7 @@ func TestDeleteCascadesReads(t *testing.T) {
 	repo := repository.New(client)
 	ctx := context.Background()
 
-	row, _, err := repo.Create(ctx, "delete-1", notification.ScopeBroadcast, nil, "Bye", "Body", notification.LevelInfo, 1, "itsmavey", nil)
+	row, _, err := repo.Create(ctx, repository.CreateParams{RequestID: "delete-1", Scope: notification.ScopeBroadcast, Title: "Bye", Body: "Body", Level: notification.LevelInfo, CreatedBy: 1, CreatedByLogin: "itsmavey"})
 	require.NoError(t, err)
 	require.NoError(t, repo.MarkRead(ctx, row.ID, 1001))
 
@@ -124,11 +124,11 @@ func TestCreateIsIdempotentByRequestID(t *testing.T) {
 	repo := repository.New(client)
 	ctx := context.Background()
 
-	first, created, err := repo.Create(ctx, "send-123", notification.ScopeBroadcast, nil, "Once", "Body", notification.LevelInfo, 1, "itsmavey", nil)
+	first, created, err := repo.Create(ctx, repository.CreateParams{RequestID: "send-123", Scope: notification.ScopeBroadcast, Title: "Once", Body: "Body", Level: notification.LevelInfo, CreatedBy: 1, CreatedByLogin: "itsmavey"})
 	require.NoError(t, err)
 	assert.True(t, created)
 
-	duplicate, created, err := repo.Create(ctx, "send-123", notification.ScopeBroadcast, nil, "Once", "Body", notification.LevelInfo, 1, "itsmavey", nil)
+	duplicate, created, err := repo.Create(ctx, repository.CreateParams{RequestID: "send-123", Scope: notification.ScopeBroadcast, Title: "Once", Body: "Body", Level: notification.LevelInfo, CreatedBy: 1, CreatedByLogin: "itsmavey"})
 	require.NoError(t, err)
 	assert.False(t, created)
 	assert.Equal(t, first.ID, duplicate.ID)

--- a/app/notifications/rpc/admin.go
+++ b/app/notifications/rpc/admin.go
@@ -26,39 +26,49 @@ type adminRPC struct {
 	log                *zap.Logger
 }
 
+// AdminConfig carries the NATS wiring for the admin RPC surface.
+type AdminConfig struct {
+	Prefix             string
+	InvalidationPrefix string
+	UserGetSubject     string
+	QueueGroup         string
+}
+
 // SubscribeAdmin registers the admin-console verbs: compose/send a
 // notification, list the sent history, and retract one.
-func SubscribeAdmin(nc *nats.Conn, repo *repository.Notifications, prefix, invalidationPrefix, userGetSubject, queueGroup string, app *newrelic.Application, log *zap.Logger) error {
+func SubscribeAdmin(nc *nats.Conn, repo *repository.Notifications, cfg AdminConfig, app *newrelic.Application, log *zap.Logger) error {
 	a := &adminRPC{
 		repo:               repo,
 		nc:                 nc,
-		invalidationPrefix: invalidationPrefix,
-		userGetSubject:     userGetSubject,
+		invalidationPrefix: cfg.InvalidationPrefix,
+		userGetSubject:     cfg.UserGetSubject,
 		log:                log,
 	}
 
 	if err := bus.QueueSubscribeJSON[notificationsrpc.SendRequest, notificationsrpc.SendReply](
-		a.nc, prefix+".send", queueGroup, 5*time.Second, app, log, a.send); err != nil {
+		a.nc, cfg.Prefix+".send", cfg.QueueGroup, 5*time.Second, app, log, a.send); err != nil {
 		return err
 	}
 	if err := bus.QueueSubscribeJSON[notificationsrpc.ListAdminRequest, notificationsrpc.ListAdminReply](
-		a.nc, prefix+".list", queueGroup, 3*time.Second, app, log, a.list); err != nil {
+		a.nc, cfg.Prefix+".list", cfg.QueueGroup, 3*time.Second, app, log, a.list); err != nil {
 		return err
 	}
 	if err := bus.QueueSubscribeJSON[notificationsrpc.DeleteRequest, notificationsrpc.DeleteReply](
-		a.nc, prefix+".delete", queueGroup, 3*time.Second, app, log, a.delete); err != nil {
+		a.nc, cfg.Prefix+".delete", cfg.QueueGroup, 3*time.Second, app, log, a.delete); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (a *adminRPC) send(ctx context.Context, req notificationsrpc.SendRequest) notificationsrpc.SendReply {
+// parseSendRequest validates the compose form fields and renders them as
+// repository parameters (target resolution happens separately: it needs I/O).
+func parseSendRequest(req notificationsrpc.SendRequest) (repository.CreateParams, error) {
 	scope := notification.Scope(req.Scope)
 	if err := notification.ScopeValidator(scope); err != nil {
-		return notificationsrpc.SendReply{Error: "scope must be broadcast or direct"}
+		return repository.CreateParams{}, fmt.Errorf("scope must be broadcast or direct")
 	}
 	if req.Title == "" || req.Body == "" {
-		return notificationsrpc.SendReply{Error: "title and body are required"}
+		return repository.CreateParams{}, fmt.Errorf("title and body are required")
 	}
 
 	level := notification.Level(req.Level)
@@ -66,56 +76,80 @@ func (a *adminRPC) send(ctx context.Context, req notificationsrpc.SendRequest) n
 		level = notification.LevelInfo
 	}
 	if err := notification.LevelValidator(level); err != nil {
-		return notificationsrpc.SendReply{Error: "level must be info, success, warning or critical"}
+		return repository.CreateParams{}, fmt.Errorf("level must be info, success, warning or critical")
 	}
 	actorID, err := strconv.ParseUint(req.ActorID, 10, 64)
 	if err != nil {
-		return notificationsrpc.SendReply{Error: "actor_id must be numeric"}
+		return repository.CreateParams{}, fmt.Errorf("actor_id must be numeric")
 	}
-	var target *uint64
-	if scope == notification.ScopeDirect {
+
+	return repository.CreateParams{
+		RequestID:      req.RequestID,
+		Scope:          scope,
+		Title:          req.Title,
+		Body:           req.Body,
+		Level:          level,
+		CreatedBy:      actorID,
+		CreatedByLogin: req.ActorLogin,
+		ExpiresAt:      req.ExpiresAt,
+	}, nil
+}
+
+func (a *adminRPC) send(ctx context.Context, req notificationsrpc.SendRequest) notificationsrpc.SendReply {
+	params, err := parseSendRequest(req)
+	if err != nil {
+		return notificationsrpc.SendReply{Error: err.Error()}
+	}
+
+	if params.Scope == notification.ScopeDirect {
 		id, err := a.resolveTarget(ctx, req.TargetUserID, req.TargetUsername)
 		if err != nil {
 			return notificationsrpc.SendReply{Error: err.Error()}
 		}
-		target = &id
+		params.TargetUserID = &id
 	}
 
-	row, created, err := a.repo.Create(ctx, req.RequestID, scope, target, req.Title, req.Body, level, actorID, req.ActorLogin, req.ExpiresAt)
+	row, created, err := a.repo.Create(ctx, params)
 	if err != nil {
 		return notificationsrpc.SendReply{Error: err.Error()}
 	}
 
 	if created {
-		a.invalidate(target)
+		a.invalidate(params.TargetUserID)
 		a.log.Info("admin notification sent",
-			zap.String("scope", req.Scope), zap.Int("id", row.ID), zap.Uint64("actor", actorID))
+			zap.String("scope", req.Scope), zap.Int("id", row.ID), zap.Uint64("actor", params.CreatedBy))
 	} else {
 		a.log.Warn("duplicate admin notification suppressed",
-			zap.String("scope", req.Scope), zap.Int("id", row.ID), zap.Uint64("actor", actorID))
+			zap.String("scope", req.Scope), zap.Int("id", row.ID), zap.Uint64("actor", params.CreatedBy))
 	}
 
 	view := viewOf(row, false)
 	return notificationsrpc.SendReply{Notification: &view}
 }
 
-func (a *adminRPC) list(ctx context.Context, req notificationsrpc.ListAdminRequest) notificationsrpc.ListAdminReply {
-	pageSize := req.Limit
+// clampAdminPage bounds the requested page/limit to the admin window and
+// returns the fetch limit (one extra row probes for a following page).
+func clampAdminPage(req notificationsrpc.ListAdminRequest) (page, pageSize, fetchLimit int) {
+	pageSize = req.Limit
 	if pageSize <= 0 || pageSize > repository.AdminPageSize {
 		pageSize = repository.AdminPageSize
 	}
-	page := req.Page
+	page = req.Page
 	if page < 1 {
 		page = 1
 	}
 	if page > repository.AdminMaxPages {
 		page = repository.AdminMaxPages
 	}
-
-	fetchLimit := pageSize
+	fetchLimit = pageSize
 	if page < repository.AdminMaxPages {
 		fetchLimit++
 	}
+	return page, pageSize, fetchLimit
+}
+
+func (a *adminRPC) list(ctx context.Context, req notificationsrpc.ListAdminRequest) notificationsrpc.ListAdminReply {
+	page, pageSize, fetchLimit := clampAdminPage(req)
 	rows, err := a.repo.ListForAdmin(ctx, fetchLimit, (page-1)*pageSize)
 	if err != nil {
 		return notificationsrpc.ListAdminReply{Error: err.Error()}

--- a/app/notifications/rpc/user.go
+++ b/app/notifications/rpc/user.go
@@ -20,17 +20,23 @@ type userRPC struct {
 	log  *zap.Logger
 }
 
+// UserConfig carries the NATS wiring for the dashboard-facing RPC surface.
+type UserConfig struct {
+	Prefix     string
+	QueueGroup string
+}
+
 // SubscribeUser registers the dashboard-facing verbs: list what a user can
 // see (broadcast + direct, newest first) and acknowledge one.
-func SubscribeUser(nc *nats.Conn, repo *repository.Notifications, prefix, queueGroup string, app *newrelic.Application, log *zap.Logger) error {
+func SubscribeUser(nc *nats.Conn, repo *repository.Notifications, cfg UserConfig, app *newrelic.Application, log *zap.Logger) error {
 	u := &userRPC{repo: repo, log: log}
 
 	if err := bus.QueueSubscribeJSON[notificationsrpc.UserListRequest, notificationsrpc.UserListReply](
-		nc, prefix+".list", queueGroup, 3*time.Second, app, log, u.list); err != nil {
+		nc, cfg.Prefix+".list", cfg.QueueGroup, 3*time.Second, app, log, u.list); err != nil {
 		return err
 	}
 	if err := bus.QueueSubscribeJSON[notificationsrpc.MarkReadRequest, notificationsrpc.MarkReadReply](
-		nc, prefix+".mark_read", queueGroup, 3*time.Second, app, log, u.markRead); err != nil {
+		nc, cfg.Prefix+".mark_read", cfg.QueueGroup, 3*time.Second, app, log, u.markRead); err != nil {
 		return err
 	}
 	return nil

--- a/app/worker/main.go
+++ b/app/worker/main.go
@@ -20,6 +20,10 @@ import (
 	"ItsBagelBot/pkg/monitor"
 	pkg_valkey "ItsBagelBot/pkg/valkey"
 
+	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/valkey-io/valkey-go"
+
 	"go.uber.org/zap"
 )
 
@@ -28,6 +32,51 @@ const serviceName = "worker"
 // projectionCacheTTL bounds how long a stale module/command/user view can
 // linger in the worker before the next read re-checks Valkey and the projector.
 const projectionCacheTTL = 30 * time.Second
+
+// buildRegistry assembles the pluggable behavior set. Core modules (the baked
+// primitives, the command router, the live tracker) are always on and never
+// shown on the dashboard; the baked module owns the immutable commands plus
+// the bagel greeting, and the command router does all command dispatch (baked
+// + custom) behind one set of gates. Named modules (shoutout) are toggled +
+// configured per broadcaster. Adding a feature is registering a module here.
+// The returned router must be Closed by the caller (it flushes pending
+// use-counter ticks on shutdown).
+func buildRegistry(cfg *config.Config, valkeyClient valkey.Client, proj *projection.Client, live *module.ValkeyLiveStore, pub message.Publisher, special *module.SpecialSet, log *zap.Logger) (*module.Registry, *module.CommandRouter) {
+	greet := module.NewValkeyGreetStore(valkeyClient, cfg.LiveTTL, log)
+	cooldown := module.NewValkeyCooldown(valkeyClient)
+
+	router := module.NewCommandRouter(proj, live, cooldown, pub, log)
+	registry := module.NewRegistry(log,
+		builtin.NewBakedModule(special, live, greet, log),
+		router,
+		builtin.NewLiveModule(live, greet, log),
+		builtin.NewShoutoutModule(log),
+	)
+	// The router resolves baked commands through the registry's baked index, so
+	// it must be bound after the registry is built (before the first message).
+	router.Bind(registry)
+	return registry, router
+}
+
+// startConsumer launches the autoscaling consumer that drains the premium and
+// standard lanes into a shared pool of pipeline routines, with premium
+// reserving a slice so it is never starved. Live events ride these same lanes
+// (ingress dual-publishes them), so there is no separate stream consumer.
+func startConsumer(ctx context.Context, cfg *config.Config, sub message.Subscriber, nrApp *newrelic.Application, process consumer.Handler, log *zap.Logger) error {
+	cons := consumer.New(sub, nrApp,
+		consumer.Lanes{PremiumSubject: cfg.PremiumSubject, StandardSubject: cfg.StandardSubject},
+		bus.ScalePolicy{
+			MinRoutines:    cfg.MinRoutines,
+			MaxRoutines:    cfg.MaxRoutines,
+			MaxConsumers:   cfg.MaxConsumers,
+			ScaleUpAfter:   cfg.ScaleUpAfter,
+			ScaleDownAfter: cfg.ScaleDownAfter,
+		},
+		cfg.PremiumReserve,
+		log,
+	)
+	return cons.Start(ctx, process)
+}
 
 func main() {
 
@@ -102,28 +151,10 @@ func main() {
 	live.StartInvalidationListener()
 	go live.StartExpiryWatcher(ctx)
 
-	greet := module.NewValkeyGreetStore(valkeyClient, cfg.LiveTTL, log)
-	cooldown := module.NewValkeyCooldown(valkeyClient)
 	special := module.NewSpecialSet(cfg.SpecialUserIDs)
 
-	// The module registry is the pluggable behavior set. Core modules (the baked
-	// primitives, the command router, the live tracker) are always on and never
-	// shown on the dashboard; the baked module owns the immutable commands plus
-	// the bagel greeting, and the command router does all command dispatch
-	// (baked + custom) behind one set of gates. Named modules (shoutout) are
-	// toggled + configured per broadcaster. Adding a feature is registering a
-	// module here.
-	router := module.NewCommandRouter(proj, live, cooldown, pub, log)
+	registry, router := buildRegistry(cfg, valkeyClient, proj, live, pub, special, log)
 	defer router.Close() // flushes pending use-counter ticks on shutdown
-	registry := module.NewRegistry(log,
-		builtin.NewBakedModule(special, live, greet, log),
-		router,
-		builtin.NewLiveModule(live, greet, log),
-		builtin.NewShoutoutModule(log),
-	)
-	// The router resolves baked commands through the registry's baked index, so
-	// it must be bound after the registry is built (before the first message).
-	router.Bind(registry)
 
 	pipe := pipeline.NewPipeline(
 		log,
@@ -135,23 +166,7 @@ func main() {
 		cfg.OutgressStandardSubject,
 	)
 
-	// One autoscaling consumer drains the premium and standard lanes into a
-	// shared pool of pipeline routines, with premium reserving a slice so it is
-	// never starved. Live events ride these same lanes (ingress dual-publishes
-	// them), so there is no separate stream consumer here.
-	cons := consumer.New(sub, nrApp,
-		consumer.Lanes{PremiumSubject: cfg.PremiumSubject, StandardSubject: cfg.StandardSubject},
-		bus.ScalePolicy{
-			MinRoutines:    cfg.MinRoutines,
-			MaxRoutines:    cfg.MaxRoutines,
-			MaxConsumers:   cfg.MaxConsumers,
-			ScaleUpAfter:   cfg.ScaleUpAfter,
-			ScaleDownAfter: cfg.ScaleDownAfter,
-		},
-		cfg.PremiumReserve,
-		log,
-	)
-	if err := cons.Start(ctx, pipe.Process); err != nil {
+	if err := startConsumer(ctx, cfg, sub, nrApp, pipe.Process, log); err != nil {
 		log.Fatal("failed to start consumer", zap.Error(err))
 	}
 

--- a/console/dashboard/src/routes/(app)/settings/+page.server.ts
+++ b/console/dashboard/src/routes/(app)/settings/+page.server.ts
@@ -12,7 +12,7 @@ import {
   notificationMarkRead,
   type NotificationWire
 } from '$lib/server/services';
-import { ACCOUNT_DELETED_COOKIE, COOKIE } from '$lib/server/session';
+import { ACCOUNT_DELETED_COOKIE, COOKIE, type Session } from '$lib/server/session';
 import { demoNotifications } from '$lib/server/demo-notifications';
 import { env } from '$env/dynamic/private';
 
@@ -20,6 +20,25 @@ const SECTIONS = ['commands'] as const;
 
 function tokenLabel(token: string): string {
   return token.length <= 8 ? 'token=redacted' : `token=${token.slice(0, 8)}...`;
+}
+
+// ownerAction wraps the shared shape of the delegation actions: owner-only
+// guard, form parse, and a 502 failure when the backing RPC is down.
+function ownerAction<R>(
+  failMsg: string,
+  run: (s: Session, form: FormData) => Promise<R>
+) {
+  return async ({ request, locals }: { request: Request; locals: App.Locals }) => {
+    const s = locals.session;
+    if (!s || s.delegate_of) return fail(403, { error: 'Not allowed.' });
+
+    const form = await request.formData();
+    try {
+      return await run(s, form);
+    } catch {
+      return fail(502, { error: failMsg });
+    }
+  };
 }
 
 export const load: PageServerLoad = async ({ locals }) => {
@@ -106,63 +125,39 @@ export const actions: Actions = {
     throw redirect(302, '/goodbye');
   },
 
-  create: async ({ request, locals }) => {
-    const s = locals.session;
-    if (!s || s.delegate_of) return fail(403, { error: 'Not allowed.' });
-
-    const f = await request.formData();
+  create: ownerAction('Could not create link.', async (s, f) => {
     const sections = SECTIONS.filter((sec) => f.get(sec) === 'on');
     if (sections.length === 0) return fail(400, { error: 'Pick at least one section.' });
 
-    try {
-      const token = await delegationCreate(s.user_id, s.login, sections);
-      auditDashboardImpersonation(s, 'delegation:create', `sections=${sections.join(',')}`);
-      return {
-        ok: true,
-        action: 'created',
-        createdGrant: {
-          token,
-          sections,
-          delegate_login: '',
-          consumed: false
-        }
-      };
-    } catch {
-      return fail(502, { error: 'Could not create link.' });
-    }
-  },
+    const token = await delegationCreate(s.user_id, s.login, sections);
+    auditDashboardImpersonation(s, 'delegation:create', `sections=${sections.join(',')}`);
+    return {
+      ok: true,
+      action: 'created',
+      createdGrant: {
+        token,
+        sections,
+        delegate_login: '',
+        consumed: false
+      }
+    };
+  }),
 
-  revoke: async ({ request, locals }) => {
-    const s = locals.session;
-    if (!s || s.delegate_of) return fail(403, { error: 'Not allowed.' });
-
-    const f = await request.formData();
+  revoke: ownerAction('Could not revoke link.', async (s, f) => {
     const token = String(f.get('token') ?? '');
     if (!token) return fail(400, { error: 'Missing token.' });
 
-    try {
-      await delegationRevoke(s.user_id, token);
-      auditDashboardImpersonation(s, 'delegation:revoke', tokenLabel(token));
-      return { ok: true, action: 'revoked' };
-    } catch {
-      return fail(502, { error: 'Could not revoke link.' });
-    }
-  },
+    await delegationRevoke(s.user_id, token);
+    auditDashboardImpersonation(s, 'delegation:revoke', tokenLabel(token));
+    return { ok: true, action: 'revoked' };
+  }),
 
-  optOut: async ({ request, locals }) => {
-    const s = locals.session;
-    if (!s || s.delegate_of) return fail(403, { error: 'Not allowed.' });
-
-    const f = await request.formData();
+  optOut: ownerAction('Could not leave dashboard.', async (s, f) => {
     const ownerId = String(f.get('owner_user_id') ?? '');
     if (!ownerId) return fail(400, { error: 'Missing dashboard.' });
 
-    try {
-      await delegationOptOut(s.user_id, ownerId);
-      auditDashboardImpersonation(s, 'delegation:opt_out', `owner=${ownerId}`);
-      return { ok: true, action: 'opted_out' };
-    } catch {
-      return fail(502, { error: 'Could not leave dashboard.' });
-    }
-  }
+    await delegationOptOut(s.user_id, ownerId);
+    auditDashboardImpersonation(s, 'delegation:opt_out', `owner=${ownerId}`);
+    return { ok: true, action: 'opted_out' };
+  })
 };

--- a/console/dashboard/src/routes/auth/callback/+server.ts
+++ b/console/dashboard/src/routes/auth/callback/+server.ts
@@ -1,4 +1,5 @@
 import type { RequestHandler } from './$types';
+import type { Cookies } from '@sveltejs/kit';
 import { redirect } from '@sveltejs/kit';
 import { decodeIdToken, OAuth2RequestError } from 'arctic';
 import { twitch, safeNextPath, fetchAccountEmail } from '$lib/server/oauth';
@@ -9,6 +10,107 @@ import { env } from '$env/dynamic/private';
 
 const DASHBOARD = env.NATS_DASHBOARD_SUBJECT_PREFIX ?? 'bagel.rpc.dashboard';
 const SESSION_TTL = 7 * 24 * 3600;
+
+type IdTokenClaims = {
+  sub: string;
+  preferred_username: string;
+  aud?: string | string[];
+  iss?: string;
+  nonce?: string;
+  // Twitch may include granted scope; best-effort check.
+  scope?: string;
+};
+
+type Identity = { userId: string; login: string; displayName: string };
+
+// verifyClaims rejects a forged or substituted id_token. Throws a redirect on
+// any failed guard.
+function verifyClaims(claims: IdTokenClaims, storedNonce: string | undefined): void {
+  // Validate aud == client id and iss == Twitch.
+  // arctic's Twitch.createAuthorizationURL does not accept a nonce param,
+  // so we appended it manually in the login route and verify it here.
+  // This guards against id_token substitution attacks.
+  const clientId = env.TWITCH_CLIENT_ID ?? '';
+  const audOk = Array.isArray(claims.aud) ? claims.aud.includes(clientId) : claims.aud === clientId;
+  const issOk = claims.iss === 'https://id.twitch.tv/oauth2';
+  if (!audOk || !issOk) throw redirect(302, '/login?e=state');
+
+  // Nonce check: stored nonce must match claim (replay / token-swap guard).
+  if (storedNonce && claims.nonce !== storedNonce) throw redirect(302, '/login?e=state');
+
+  // Bot-account guard: the bot reauthorizes through the admin bot flow, not
+  // here. If the bot account ever lands on this broadcaster callback, refuse to
+  // mint a streamer session (which would drop it onto the user dashboard) and
+  // skip the grant save. claims.sub is the Twitch user id; ADMIN_BOT_USER_ID is
+  // the same env the admin flow uses to pin the bot's id. No-op if unset.
+  const botId = env.ADMIN_BOT_USER_ID ?? '';
+  if (botId && claims.sub === botId) throw redirect(302, '/login?e=bot');
+
+  // Best-effort scope check: if Twitch echoes the granted scope, ensure
+  // openid is present. Don't hard-fail on absent scope field.
+  if (claims.scope && !claims.scope.includes('openid')) throw redirect(302, '/login?e=scope');
+}
+
+function setSessionCookie(cookies: Cookies, url: URL, session: Parameters<typeof seal>[0]): void {
+  cookies.set(COOKIE, seal(session), {
+    path: '/',
+    httpOnly: true,
+    secure: url.protocol === 'https:',
+    sameSite: 'lax',
+    maxAge: SESSION_TTL
+  });
+}
+
+function streamerSession(id: Identity) {
+  return {
+    user_id: id.userId,
+    login: id.login,
+    display_name: id.displayName,
+    role: 'streamer' as const,
+    expires_at: Math.floor(Date.now() / 1000) + SESSION_TTL
+  };
+}
+
+// Delegated accept flow: if a pending share token rode in on a cookie, bind
+// it to this user now. Single-use — consume always deletes the cookie, and a
+// delegate session is sealed only on success. On any failure we redirect to
+// /login?e=link instead of issuing a normal owner session. No-op without the
+// cookie; when it consumes, it throws the final redirect itself.
+async function acceptPendingDelegation(cookies: Cookies, url: URL, id: Identity): Promise<void> {
+  const pending = cookies.get('pending_delegation');
+  if (!pending) return;
+
+  cookies.delete('pending_delegation', { path: '/' });
+  const result = await delegationConsume(pending, id.userId, id.login);
+  if (!result.ok) throw redirect(302, '/login?e=link');
+
+  setSessionCookie(cookies, url, {
+    ...streamerSession(id),
+    delegate_of: result.owner_user_id,
+    delegate_login: result.owner_login,
+    sections: result.sections ?? []
+  });
+  throw redirect(302, '/');
+}
+
+// Register the user BEFORE sealing a session. The (app) layout's
+// ghost-session gate treats a missing user row as a deleted account and
+// wipes the cookie, so minting a session for a row that failed to land
+// is an instant sign-out loop. If the upsert cannot land, refuse the
+// session and let the user retry the flow.
+async function registerUser(id: Identity, email: string | null): Promise<void> {
+  try {
+    await rpc(`${DASHBOARD}.upsert_user`, {
+      user_id: id.userId,
+      username: id.login,
+      display_name: id.displayName,
+      ...(email ? { email } : {})
+    });
+  } catch (err: unknown) {
+    console.error('[callback] upsert_user failed, refusing session:', err);
+    throw redirect(302, '/login?e=retry');
+  }
+}
 
 export const GET: RequestHandler = async ({ url, cookies }) => {
   const code = url.searchParams.get('code');
@@ -27,119 +129,28 @@ export const GET: RequestHandler = async ({ url, cookies }) => {
 
   try {
     const tokens = await twitch().validateAuthorizationCode(code);
-    const claims = decodeIdToken(tokens.idToken()!) as {
-      sub: string;
-      preferred_username: string;
-      aud?: string | string[];
-      iss?: string;
-      nonce?: string;
-      // Twitch may include granted scope; best-effort check.
-      scope?: string;
+    const claims = decodeIdToken(tokens.idToken()!) as IdTokenClaims;
+    verifyClaims(claims, storedNonce);
+
+    const identity: Identity = {
+      userId: claims.sub,
+      login: claims.preferred_username.toLowerCase(),
+      displayName: claims.preferred_username
     };
-
-    // Validate aud == client id and iss == Twitch.
-    // arctic's Twitch.createAuthorizationURL does not accept a nonce param,
-    // so we appended it manually in the login route and verify it here.
-    // This guards against id_token substitution attacks.
-    const clientId = env.TWITCH_CLIENT_ID ?? '';
-    const audOk = Array.isArray(claims.aud)
-      ? claims.aud.includes(clientId)
-      : claims.aud === clientId;
-    const issOk = claims.iss === 'https://id.twitch.tv/oauth2';
-    if (!audOk || !issOk) throw redirect(302, '/login?e=state');
-
-    // Nonce check: stored nonce must match claim (replay / token-swap guard).
-    if (storedNonce && claims.nonce !== storedNonce) throw redirect(302, '/login?e=state');
-
-    // Bot-account guard: the bot reauthorizes through the admin bot flow, not
-    // here. If the bot account ever lands on this broadcaster callback, refuse to
-    // mint a streamer session (which would drop it onto the user dashboard) and
-    // skip the grant save. claims.sub is the Twitch user id; ADMIN_BOT_USER_ID is
-    // the same env the admin flow uses to pin the bot's id. No-op if unset.
-    const botId = env.ADMIN_BOT_USER_ID ?? '';
-    if (botId && claims.sub === botId) throw redirect(302, '/login?e=bot');
-
-    // Best-effort scope check: if Twitch echoes the granted scope, ensure
-    // openid is present. Don't hard-fail on absent scope field.
-    if (claims.scope && !claims.scope.includes('openid')) throw redirect(302, '/login?e=scope');
-
-    const userId = claims.sub;
-    const login = claims.preferred_username.toLowerCase();
-    const displayName = claims.preferred_username;
 
     // Platform ban gate: a banned user must not get a session. isBanned fails
     // open (treats an RPC blip as not-banned) so an outage never locks out
     // every login; the admin panel re-bans authoritatively.
-    if (await isBanned(userId)) throw redirect(302, '/login?e=banned');
+    if (await isBanned(identity.userId)) throw redirect(302, '/login?e=banned');
 
-    // Delegated accept flow: if a pending share token rode in on a cookie, bind
-    // it to this user now. Single-use — consume always deletes the cookie, and a
-    // delegate session is sealed only on success. On any failure we fall through
-    // to /login?e=link instead of issuing a normal owner session.
-    const pending = cookies.get('pending_delegation');
-    if (pending) {
-      cookies.delete('pending_delegation', { path: '/' });
-      const result = await delegationConsume(pending, userId, login);
-      if (!result.ok) throw redirect(302, '/login?e=link');
+    await acceptPendingDelegation(cookies, url, identity);
 
-      const value = seal({
-        user_id: userId,
-        login,
-        display_name: displayName,
-        role: 'streamer',
-        expires_at: Math.floor(Date.now() / 1000) + SESSION_TTL,
-        delegate_of: result.owner_user_id,
-        delegate_login: result.owner_login,
-        sections: result.sections ?? []
-      });
-      cookies.set(COOKIE, value, {
-        path: '/',
-        httpOnly: true,
-        secure: url.protocol === 'https:',
-        sameSite: 'lax',
-        maxAge: SESSION_TTL
-      });
-      throw redirect(302, '/');
-    }
-
-    // Register the user BEFORE sealing a session. The (app) layout's
-    // ghost-session gate treats a missing user row as a deleted account and
-    // wipes the cookie, so minting a session for a row that failed to land
-    // is an instant sign-out loop. If the upsert cannot land, refuse the
-    // session and let the user retry the flow.
     // Real account email (user:read:email consent). Null on any failure —
     // capture is best-effort and the users service stores it encrypted.
     const email = await fetchAccountEmail(tokens.accessToken());
+    await registerUser(identity, email);
 
-    let registered = false;
-    try {
-      await rpc(`${DASHBOARD}.upsert_user`, {
-        user_id: userId,
-        username: login,
-        display_name: displayName,
-        ...(email ? { email } : {})
-      });
-      registered = true;
-    } catch (err: unknown) {
-      console.error('[callback] upsert_user failed, refusing session:', err);
-    }
-    if (!registered) throw redirect(302, '/login?e=retry');
-
-    const value = seal({
-      user_id: userId,
-      login: login,
-      display_name: displayName,
-      role: 'streamer',
-      expires_at: Math.floor(Date.now() / 1000) + SESSION_TTL
-    });
-
-    cookies.set(COOKIE, value, {
-      path: '/',
-      httpOnly: true,
-      secure: url.protocol === 'https:',
-      sameSite: 'lax',
-      maxAge: SESSION_TTL
-    });
+    setSessionCookie(cookies, url, streamerSession(identity));
 
     // Persist the OAuth grant (access + refresh) after the user row exists —
     // the token row references it. Grant failure stays non-fatal: the session
@@ -147,7 +158,7 @@ export const GET: RequestHandler = async ({ url, cookies }) => {
     // and the home needs-attention strip surfaces that. The user can re-auth
     // to retry.
     try {
-      await saveGrant(userId, tokens.accessToken(), tokens.refreshToken());
+      await saveGrant(identity.userId, tokens.accessToken(), tokens.refreshToken());
     } catch (err: unknown) {
       console.error('[callback] grant_save failed (non-fatal):', err);
     }


### PR DESCRIPTION
Second of two CodeScene cleanup PRs (first: #173 silences generated ent code). This one refactors the genuinely-complex **hand-written** files CodeScene flagged across #143/#144/#148. Behavior-preserving: no wire formats, DTOs, or RPC subjects change; existing tests pass unchanged (call sites updated to the new signatures).

## commands repository (`app/commands/repository/commands.go`)
Was the worst offender — critical *Bumpy Road Ahead* in `flushUses`, *Complex Method* on `Rename`, plus 9-10 positional-arg signatures.
- Introduce `CommandSpec` (name/aliases/response/flags/perm/cooldown/allowed) with `normalize()` + `validate()` + `dto()`. `Upsert(userID, spec)` and `Rename(ctx, userID, oldName, spec)` replace the long positional lists and the duplicated 6-validator chains → clears *Excess Number of Function Arguments*.
- Split `flushUses` → `drainPendingUses` / `persistUses` / `publishUseEvents`; extract `renameRow` → clears the critical *Bumpy Road*.

## notifications (`app/notifications/...`)
- `repository.Create` now takes a `CreateParams` struct (was 9 positional args).
- `admin.go`: extract `parseSendRequest` (form validation) and `clampAdminPage` (paging math) out of `send`/`list`; fold `SubscribeAdmin`'s 8 params into `AdminConfig`, `SubscribeUser`'s into `UserConfig`.

## dashboard auth callback (`auth/callback/+server.ts`)
Flagged in #144 and #149. Extract `verifyClaims` (aud/iss/nonce/bot/scope), `setSessionCookie` (deduped the repeated cookie block), `streamerSession`, `acceptPendingDelegation`, `registerUser`. **All 11 redirects and every security guard preserved** (verified: state/nonce/aud/iss/bot/scope/ban gates all intact, redirect parity 11↔11).

## settings actions (`(app)/settings/+page.server.ts`)
Extract an `ownerAction` wrapper (owner-guard + formData + 502-on-failure) so `create`/`revoke`/`optOut` stop repeating the same scaffolding → clears *Code Duplication*. Generic over the return type so SvelteKit still infers `ActionData`.

## main() wiring (`app/commands/main.go`, `app/worker/main.go`)
Lift inline consume handlers and subscription/registry/consumer wiring into named funcs (`registerConsumers` + handler constructors; `buildRegistry` + `startConsumer`) → clears *Complex Method* (hotspot decline) and *Large Method* on `main`.

## Verification
`go build/vet/test` for commands, notifications, worker all green in an isolated worktree at HEAD; `svelte-check` clean (0 errors) on the two dashboard files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)