### PR TITLE
refactor: clear remaining advisory Complex Method findings

### DIFF
--- a/console/admin/src/routes/(admin)/notifications/+page.server.ts
+++ b/console/admin/src/routes/(admin)/notifications/+page.server.ts
@@ -60,6 +60,43 @@ export const load: PageServerLoad = async ({ url }) => {
   }
 };
 
+type SendForm = {
+  scope: 'broadcast' | 'direct';
+  targetUserId: string;
+  targetUsername: string;
+  title: string;
+  body: string;
+  level: string;
+  expiresAtRaw: string;
+  target: string;
+};
+
+// parseSendForm trims/caps the compose fields and validates them. Returns the
+// parsed form, or { error } for the action to hand to fail(400).
+function parseSendForm(f: FormData): SendForm | { error: string } {
+  const scope = String(f.get('scope') ?? '').trim();
+  const targetUserId = String(f.get('target_user_id') ?? '').trim();
+  const targetUsername = String(f.get('target_username') ?? '').trim();
+  const title = String(f.get('title') ?? '')
+    .trim()
+    .slice(0, MAX_TITLE_LENGTH);
+  const body = String(f.get('body') ?? '')
+    .trim()
+    .slice(0, MAX_BODY_LENGTH);
+  const level = String(f.get('level') ?? 'info').trim();
+  const expiresAtRaw = String(f.get('expires_at') ?? '').trim();
+
+  if (scope !== 'broadcast' && scope !== 'direct') return { error: 'invalid scope' };
+  if (scope === 'direct' && !targetUserId && !targetUsername) {
+    return { error: 'target user id or username required' };
+  }
+  if (!title || !body) return { error: 'title and body are required' };
+  if (!LEVELS.has(level)) return { error: 'invalid level' };
+
+  const target = scope === 'direct' ? targetUserId || targetUsername : 'all users';
+  return { scope, targetUserId, targetUsername, title, body, level, expiresAtRaw, target };
+}
+
 // audit records a mutating action best-effort: a logging failure must never
 // block or fail the operator action it describes. Skipped in demo (synthetic
 // non-numeric actor id).
@@ -82,23 +119,9 @@ export const actions: Actions = {
     const admin = await requireAdmin(locals.session);
     if (!admin) return fail(403, { error: 'forbidden' });
 
-    const f = await request.formData();
-    const scope = String(f.get('scope') ?? '').trim();
-    const targetUserId = String(f.get('target_user_id') ?? '').trim();
-    const targetUsername = String(f.get('target_username') ?? '').trim();
-    const title = String(f.get('title') ?? '').trim().slice(0, MAX_TITLE_LENGTH);
-    const body = String(f.get('body') ?? '').trim().slice(0, MAX_BODY_LENGTH);
-    const level = String(f.get('level') ?? 'info').trim();
-    const expiresAtRaw = String(f.get('expires_at') ?? '').trim();
-
-    if (scope !== 'broadcast' && scope !== 'direct') return fail(400, { error: 'invalid scope' });
-    if (scope === 'direct' && !targetUserId && !targetUsername) {
-      return fail(400, { error: 'target user id or username required' });
-    }
-    if (!title || !body) return fail(400, { error: 'title and body are required' });
-    if (!LEVELS.has(level)) return fail(400, { error: 'invalid level' });
-
-    const target = scope === 'direct' ? targetUserId || targetUsername : 'all users';
+    const parsed = parseSendForm(await request.formData());
+    if ('error' in parsed) return fail(400, { error: parsed.error });
+    const { scope, targetUserId, targetUsername, title, body, level, expiresAtRaw, target } = parsed;
 
     if (isDemo()) {
       return { action: { ok: true, notice: `notification sent to ${target} (demo)` } };

--- a/console/dashboard/src/routes/(app)/+layout.server.ts
+++ b/console/dashboard/src/routes/(app)/+layout.server.ts
@@ -1,4 +1,4 @@
-import { redirect } from '@sveltejs/kit';
+import { redirect, type Cookies } from '@sveltejs/kit';
 import { env } from '$env/dynamic/private';
 import type { LayoutServerLoad } from './$types';
 import { COOKIE, type Session } from '$lib/server/session';
@@ -18,6 +18,63 @@ const demo: Session = {
   expires_at: Math.floor(Date.now() / 1000) + 3600
 };
 
+// enforceAccountGates bounces a session whose account was banned or deleted
+// after sign-in. Both checks fail open on a transport blip so an RPC outage
+// never locks the whole app out; only an authoritative "no such user"
+// (RpcError) wipes the cookie.
+async function enforceAccountGates(s: Session, url: URL, cookies: Cookies): Promise<void> {
+  // Defense in depth: bounce a session whose user was banned after sign-in.
+  if (await isBanned(s.user_id)) throw redirect(302, '/login?e=banned');
+
+  // Ghost-session gate: a session cookie stays cryptographically valid until
+  // it expires, so a browser that still holds one for a DELETED account (or
+  // one deleted from another device) could keep acting on the app — and its
+  // stale deletion cookies could bounce it through /goodbye on any action.
+  // accountState is fabric-cached, so this costs ~0 on the hot path.
+  try {
+    await accountState(s.user_id);
+  } catch (err) {
+    if (err instanceof RpcError) {
+      cookies.delete(COOKIE, { path: '/', secure: url.protocol === 'https:' });
+      throw redirect(302, '/login?e=signedout');
+    }
+    // Transient transport problem: keep the session, pages degrade instead.
+  }
+}
+
+// enforceDelegateScope keeps a delegate inside the sections they were granted.
+// Home, account (overview actions) and the share-management page are
+// owner-only; an out-of-scope path bounces to the first allowed section.
+function enforceDelegateScope(s: Session, url: URL): void {
+  if (!s.delegate_of) return;
+  const allowed = (s.sections ?? []).map((sec) => `/${sec}`);
+  const onAllowed = allowed.some((p) => url.pathname === p || url.pathname.startsWith(p + '/'));
+  if (!onAllowed) throw redirect(302, allowed[0] ?? '/login?e=link');
+}
+
+// loadBellPeek fetches the owner's notification bell, best-effort: an RPC blip
+// must never block the shell, so a failed fetch just shows an empty peek.
+// Delegates have no bell.
+async function loadBellPeek(s: Session): Promise<{ unreadCount: number; notifications: NotificationWire[] }> {
+  if (env.DEMO === '1') {
+    return {
+      notifications: demoNotifications,
+      unreadCount: demoNotifications.filter((n) => !n.read).length
+    };
+  }
+  if (s.delegate_of) return { unreadCount: 0, notifications: [] };
+
+  let unreadCount = 0;
+  let notifications: NotificationWire[] = [];
+  await notificationsForUser(s.user_id)
+    .then((r) => {
+      notifications = r.notifications;
+      unreadCount = r.unreadCount;
+    })
+    .catch(() => {});
+  return { unreadCount, notifications };
+}
+
 export const load: LayoutServerLoad = async ({ locals, url, cookies }) => {
   let s = locals.session;
   if (!s && env.DEMO === '1') s = demo;
@@ -29,56 +86,10 @@ export const load: LayoutServerLoad = async ({ locals, url, cookies }) => {
     throw redirect(302, next === '/' ? '/login' : `/login?next=${encodeURIComponent(next)}`);
   }
 
-  if (env.DEMO !== '1') {
-    // Defense in depth: bounce a session whose user was banned after sign-in.
-    // isBanned fails open so an RPC blip never locks out the whole app.
-    if (await isBanned(s.user_id)) throw redirect(302, '/login?e=banned');
+  if (env.DEMO !== '1') await enforceAccountGates(s, url, cookies);
+  enforceDelegateScope(s, url);
 
-    // Ghost-session gate: a session cookie stays cryptographically valid until
-    // it expires, so a browser that still holds one for a DELETED account (or
-    // one deleted from another device) could keep acting on the app — and its
-    // stale deletion cookies could bounce it through /goodbye on any action.
-    // accountState is fabric-cached, so this costs ~0 on the hot path; an
-    // RpcError means the users service itself answered "no such user"
-    // (transport failures throw plain errors and deliberately fail open).
-    try {
-      await accountState(s.user_id);
-    } catch (err) {
-      if (err instanceof RpcError) {
-        cookies.delete(COOKIE, { path: '/', secure: url.protocol === 'https:' });
-        throw redirect(302, '/login?e=signedout');
-      }
-      // Transient transport problem: keep the session, pages degrade instead.
-    }
-  }
-
-  // A delegate may only roam the sections they were granted. Home, account
-  // (overview actions) and the share-management page are owner-only. If the
-  // requested path is not under an allowed section, send them to the first one.
-  if (s.delegate_of) {
-    const sections = s.sections ?? [];
-    const allowed = sections.map((sec) => `/${sec}`);
-    const onAllowed = allowed.some((p) => url.pathname === p || url.pathname.startsWith(p + '/'));
-    if (!onAllowed) {
-      throw redirect(302, allowed[0] ?? '/login?e=link');
-    }
-  }
-
-  // Owner-only, best-effort: an RPC blip should never block the shell from
-  // rendering, so a failed fetch just shows an empty bell peek.
-  let unreadCount = 0;
-  let notifications: NotificationWire[] = [];
-  if (env.DEMO === '1') {
-    notifications = demoNotifications;
-    unreadCount = demoNotifications.filter((n) => !n.read).length;
-  } else if (!s.delegate_of) {
-    await notificationsForUser(s.user_id)
-      .then((r) => {
-        notifications = r.notifications;
-        unreadCount = r.unreadCount;
-      })
-      .catch(() => {});
-  }
+  const { unreadCount, notifications } = await loadBellPeek(s);
 
   return {
     role: s.role,

--- a/web/src/script/lightfield.js
+++ b/web/src/script/lightfield.js
@@ -36,23 +36,27 @@ function setupField(canvas) {
         }));
     }
 
+    // renderMote advances one mote and paints it, wrapping it around the
+    // viewport edges (up-and-out re-enters from the bottom at a fresh x).
+    function renderMote(m) {
+        m.y += m.vy;
+        m.x += m.vx;
+        if (m.y < -10) { m.y = h + 10; m.x = Math.random() * w; }
+        if (m.x < -10) m.x = w + 10; else if (m.x > w + 10) m.x = -10;
+        const col = m.warm < warmth ? "201, 168, 124" : "82, 183, 136";
+        ctx.beginPath();
+        ctx.arc(m.x, m.y, m.r, 0, Math.PI * 2);
+        ctx.fillStyle = `rgba(${col}, ${m.a.toFixed(3)})`;
+        ctx.fill();
+    }
+
     function draw() {
         if (!w || !h || !motes.length) build();
         if (!w || !h) return;
         ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
         ctx.clearRect(0, 0, w, h);
         ctx.globalCompositeOperation = "lighter";
-        for (const m of motes) {
-            m.y += m.vy;
-            m.x += m.vx;
-            if (m.y < -10) { m.y = h + 10; m.x = Math.random() * w; }
-            if (m.x < -10) m.x = w + 10; else if (m.x > w + 10) m.x = -10;
-            const col = m.warm < warmth ? "201, 168, 124" : "82, 183, 136";
-            ctx.beginPath();
-            ctx.arc(m.x, m.y, m.r, 0, Math.PI * 2);
-            ctx.fillStyle = `rgba(${col}, ${m.a.toFixed(3)})`;
-            ctx.fill();
-        }
+        for (const m of motes) renderMote(m);
         ctx.globalCompositeOperation = "source-over";
     }
 


### PR DESCRIPTION
Third and final CodeScene cleanup PR (after #173 config, #174 hand-written hotspots). Mops up the low-priority **advisory** Complex Method findings I deferred from #174. Behavior-preserving, no wire/DTO/route changes.

## admin notifications — `send` action
`(admin)/notifications/+page.server.ts`: extract `parseSendForm` (field trim/cap + validation) out of the `send` action. The action now just orchestrates parse → send → audit → reply. `SendForm.scope` is typed `'broadcast' | 'direct'` so the downstream `notificationSend` call stays fully typed.

## dashboard shell — `load`
`(app)/+layout.server.ts`: split the monolithic `load` into `enforceAccountGates` (ban + ghost-session), `enforceDelegateScope` (delegate section confinement), and `loadBellPeek` (best-effort bell fetch). `load` now reads as a linear gate list. All redirects and fail-open semantics preserved.

## web light-field — `draw`
`web/src/script/lightfield.js`: lift the per-mote advance+paint body into `renderMote`, leaving `draw` as frame setup + loop.

## Verification
`svelte-check` clean (0 errors) on both dashboard and admin consoles; `node --check` clean on lightfield.js.

🤖 Generated with [Claude Code](https://claude.com/claude-code)