### PR TITLE
docs: refresh infrastructure, admin, and system-overview docs

### DIFF
--- a/docs/src/content/docs/infrastructure/networking.md
+++ b/docs/src/content/docs/infrastructure/networking.md
@@ -56,7 +56,7 @@ flowchart LR
 
 ### ACL shape
 
-The policy is committed as code at `deploy/tailscale/policy.hujson` and pasted/applied to the admin
+The policy is committed as code at `deploy/infra/tailscale/policy.hujson` and pasted/applied to the admin
 console; it is **default-deny** (grants only). The posture in one sentence: **bare metal accepts only
 SSH from operator devices; everything Kubernetes-hosted is reached through Tailscale operator proxies.**
 

--- a/docs/src/content/docs/microservices/admin.md
+++ b/docs/src/content/docs/microservices/admin.md
@@ -105,10 +105,10 @@ The tailnet-only exposure is structural, not policy-on-top:
 1. **DNS**: the name is MagicDNS. It resolves only for tailnet members; there is no public DNS record of any
    kind, and the nodes' tailnet IPs appear in no public zone.
 2. **Data plane**: the `tailscale`-class Ingress attaches to the `ts-ingress` ProxyGroup
-   (`deploy/tailscale/proxies.yaml`), two proxy pods spread across node1/node2 that advertise the Tailscale
+   (`deploy/infra/tailscale/proxies.yaml`), two proxy pods spread across node1/node2 that advertise the Tailscale
    Service `svc:admin`. The path shares nothing with public ingress: no traefik route, no cloudflared
    hostname, no listener on any node interface.
-3. **Access control**: the tailnet policy (`deploy/tailscale/policy.hujson`) grants `svc:admin:443` to
+3. **Access control**: the tailnet policy (`deploy/infra/tailscale/policy.hujson`) grants `svc:admin:443` to
    operator devices only; bare metal accepts nothing but SSH from them.
 4. **TLS**: the proxy terminates HTTPS with an operator-provisioned Let's Encrypt certificate for the
    MagicDNS name; browsers show a normal padlock with no private CA to install.

--- a/docs/src/content/docs/reference/system-overview.md
+++ b/docs/src/content/docs/reference/system-overview.md
@@ -86,8 +86,9 @@ non-special, non-premium users is dropped before it reaches a lane.
 - **Mesh**: Linkerd native-sidecar.
 - **Delivery**: pull-based **Flux CD** from GHCR with digest-pinned images. The
   old root SSH build/deploy scripts are deprecated.
-- **NATS config**: `.conf` files are managed out-of-band via `apply-nats.sh`
-  (not Flux), hot-reloaded with `SIGHUP`.
+- **NATS config**: `.conf` files are Flux-managed via a kustomize
+  `configMapGenerator` in `deploy/k8s`; a git push hot-reloads them through the
+  `config-reloader` sidecar (`SIGHUP`), no pod restart.
 
 ## Targets
 


### PR DESCRIPTION
Documentation-only updates reconciled onto current `main` (base == main, no reverts):
- `infrastructure/networking.md`
- `microservices/admin.md`
- `reference/system-overview.md`

Part of the working-tree reconciliation (per-feature PRs). No code changes.