### PR TITLE
chore(ci,build): loop ent-generate, tidy CI cache, gitignore, worker Containerfile

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,35 +18,27 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # 2. Install Go
+      # setup-go@v5 caches the module cache + build cache by default, keyed on
+      # go.sum, so no separate actions/cache step is needed.
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version: '1.26'
 
-      # 3. Cache dependencies (Makes subsequent runs faster)
-      - name: Cache Go modules
-        uses: actions/cache@v3
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
-      # 4. Install dependencies
       - name: Install dependencies
         run: go mod download
 
+      # Regenerate every service's Ent client. Discovered from app/*/ent/schema
+      # so adding a new Ent service needs no edit here.
       - name: Generate Ent clients
         run: |
-          go run -mod=mod entgo.io/ent/cmd/ent generate ./app/commands/ent/schema
-          go run -mod=mod entgo.io/ent/cmd/ent generate ./app/modules/ent/schema
-          go run -mod=mod entgo.io/ent/cmd/ent generate ./app/transactions/ent/schema
-          go run -mod=mod entgo.io/ent/cmd/ent generate ./app/users/ent/schema
-          go run -mod=mod entgo.io/ent/cmd/ent generate ./app/notifications/ent/schema
+          set -euo pipefail
+          for schema in app/*/ent/schema; do
+            echo "ent generate ./$schema"
+            go run -mod=mod entgo.io/ent/cmd/ent generate "./$schema"
+          done
 
-      # 5. Run the Tests
-      # -race detects race conditions (very good for concurrent bots)
-      # -v gives verbose output so you can see which test failed
+      # -race detects race conditions (good for a concurrent bot); -v names the
+      # failing test.
       - name: Run Tests
         run: go test -v -race ./...

--- a/.gitignore
+++ b/.gitignore
@@ -100,14 +100,3 @@ bustest
 /test_templ_templ.go
 /test_htmx.html
 /test-env.yaml
-/start_server.sh
-
-# Legacy build/deploy scripts (superseded by Flux GitOps; see deploy/flux/README.md)
-/build_all.sh
-/build_and_deploy_fixed.sh
-/build_dashboard_only.sh
-/build_local.sh
-/build_outgress.sh
-/build_users.sh
-/deploy_only.sh
-/update_manifests.sh

--- a/app/worker/Containerfile
+++ b/app/worker/Containerfile
@@ -1,7 +1,8 @@
-from docker.io/library/golang:1.26-bookworm AS build
+# worker (Go, root module) - build from the REPO ROOT:
+#   podman build -t itsbagelbot/worker -f app/worker/Containerfile .
+FROM docker.io/library/golang:1.26-bookworm AS build
 
 WORKDIR /src
-
 COPY go.mod go.sum ./
 RUN go mod download
 


### PR DESCRIPTION
Small chores reconciled onto current `main` (base == main, no reverts):
- **CI** (`.github/workflows/main.yml`): `setup-go@v5` caches modules by default → drop the manual `actions/cache` step; discover Ent schemas with a `app/*/ent/schema` loop instead of a hardcoded per-service list (new Ent services need no CI edit). `-race` tests unchanged.
- **.gitignore**: drop entries for the deprecated root build/deploy scripts (superseded by Flux GitOps).
- **app/worker/Containerfile**: add build-context note, uppercase `FROM`.

Part of the per-feature working-tree reconciliation.