### PR TITLE
fix(dashboard): use identity.userId when seeding locale cookie

### DIFF
--- a/console/dashboard/src/routes/auth/callback/+server.ts
+++ b/console/dashboard/src/routes/auth/callback/+server.ts
@@ -157,7 +157,7 @@ export const GET: RequestHandler = async ({ url, cookies }) => {
     // language follows the user to a new browser/device. Best-effort: a new user
     // defaults to 'en', and an RPC blip just leaves detection to Accept-Language.
     try {
-      const saved = await userLocale(userId);
+      const saved = await userLocale(identity.userId);
       if (isLocale(saved)) {
         cookies.set(LOCALE_COOKIE, saved, {
           path: '/',


### PR DESCRIPTION
The auth callback (added in #176) referenced an undeclared `userId` when reading the saved account locale:

```ts
const saved = await userLocale(userId); // ReferenceError, swallowed by the surrounding try/catch
```

So locale-seeding from the account preference silently never ran (fell back to Accept-Language), and svelte-check failed with "Cannot find name 'userId'". Fixed to `identity.userId` (the field used everywhere else in the file).

**svelte-check:** now 0 errors on the dashboard.