### PR TITLE
chore(deploy): right-size fleet to 3 nodes (node3 decommissioned)

### DIFF
--- a/deploy/ansible/group_vars/all.yml
+++ b/deploy/ansible/group_vars/all.yml
@@ -27,7 +27,6 @@ tailscale_port: 41641                   # UDP listen port
 tailscale_direct_peers:
   - node1
   - node2
-  - node3
   - worker1
 
 # --- Node identity -----------------------------------------------------------

--- a/deploy/k8s/commands.yaml
+++ b/deploy/k8s/commands.yaml
@@ -21,7 +21,7 @@ metadata:
   annotations:
     secrets.doppler.com/reload: "true"
 spec:
-  replicas: 4 # one per node; 4 schedulable nodes incl worker1 (tolerates worker-pool)
+  replicas: 3 # one per node; 3 schedulable nodes incl worker1 (tolerates worker-pool); node3 decommissioned
   revisionHistoryLimit: 3
   minReadySeconds: 10
   strategy:

--- a/deploy/k8s/console-admin.yaml
+++ b/deploy/k8s/console-admin.yaml
@@ -36,7 +36,7 @@ metadata:
   annotations:
     secrets.doppler.com/reload: "true"
 spec:
-  replicas: 4 # +1; no worker toleration so it doubles on a normal node (soft spread), never worker1
+  replicas: 3 # no worker toleration: runs on the 2 normal nodes (soft spread), never worker1; node3 decommissioned
   revisionHistoryLimit: 3
   minReadySeconds: 10
   strategy:

--- a/deploy/k8s/modules.yaml
+++ b/deploy/k8s/modules.yaml
@@ -21,7 +21,7 @@ metadata:
   annotations:
     secrets.doppler.com/reload: "true"
 spec:
-  replicas: 4 # one per node; 4 schedulable nodes incl worker1 (tolerates worker-pool)
+  replicas: 3 # one per node; 3 schedulable nodes incl worker1 (tolerates worker-pool); node3 decommissioned
   revisionHistoryLimit: 3
   minReadySeconds: 10
   strategy:

--- a/deploy/k8s/outgress.yaml
+++ b/deploy/k8s/outgress.yaml
@@ -21,7 +21,7 @@ metadata:
   annotations:
     secrets.doppler.com/reload: "true"
 spec:
-  replicas: 4 # one per node; 4 schedulable nodes incl worker1 (tolerates worker-pool)
+  replicas: 3 # one per node; 3 schedulable nodes incl worker1 (tolerates worker-pool); node3 decommissioned
   revisionHistoryLimit: 3
   minReadySeconds: 10
   strategy:

--- a/deploy/k8s/projector.yaml
+++ b/deploy/k8s/projector.yaml
@@ -21,7 +21,7 @@ metadata:
   annotations:
     secrets.doppler.com/reload: "true"
 spec:
-  replicas: 4 # one per node; 4 schedulable nodes incl worker1 (tolerates worker-pool)
+  replicas: 3 # one per node; 3 schedulable nodes incl worker1 (tolerates worker-pool); node3 decommissioned
   revisionHistoryLimit: 3
   minReadySeconds: 10
   strategy:

--- a/deploy/k8s/transactions.yaml
+++ b/deploy/k8s/transactions.yaml
@@ -21,7 +21,7 @@ metadata:
   annotations:
     secrets.doppler.com/reload: "true"
 spec:
-  replicas: 4 # one per node; 4 schedulable nodes incl worker1 (tolerates worker-pool)
+  replicas: 3 # one per node; 3 schedulable nodes incl worker1 (tolerates worker-pool); node3 decommissioned
   revisionHistoryLimit: 3
   minReadySeconds: 10
   strategy:

--- a/deploy/k8s/users.yaml
+++ b/deploy/k8s/users.yaml
@@ -21,7 +21,7 @@ metadata:
   annotations:
     secrets.doppler.com/reload: "true"
 spec:
-  replicas: 4 # one per node; 4 schedulable nodes incl worker1 (tolerates worker-pool)
+  replicas: 3 # one per node; 3 schedulable nodes incl worker1 (tolerates worker-pool); node3 decommissioned
   revisionHistoryLimit: 3
   minReadySeconds: 10
   strategy:

--- a/deploy/k8s/worker.yaml
+++ b/deploy/k8s/worker.yaml
@@ -21,7 +21,7 @@ metadata:
   annotations:
     secrets.doppler.com/reload: "true"
 spec:
-  replicas: 4 # one per node; 4 schedulable nodes incl worker1 (tolerates worker-pool)
+  replicas: 3 # one per node; 3 schedulable nodes incl worker1 (tolerates worker-pool); node3 decommissioned
   revisionHistoryLimit: 3
   minReadySeconds: 10
   strategy:


### PR DESCRIPTION
node3 is permanently gone (node1/node2/worker1 remain). Scale the seven one-per-node services + console-admin from `replicas: 4` → `3`, and drop node3 from the ansible inventory.

Side benefit: frees CPU requests on the request-saturated node1 so the third valkey replica (`valkey-node-2`, already `replicas: 3`) can finally schedule — clearing the stuck valkey Flux Kustomization.

kustomize build validated; all 8 deployments confirmed at 3 in the built output.