### PR TITLE
chore(newrelic): trim nrk8s kubelet CPU to free node1 for valkey HA

### DIFF
--- a/deploy/flux/clusters/production/newrelic.yaml
+++ b/deploy/flux/clusters/production/newrelic.yaml
@@ -177,6 +177,18 @@ spec:
       # out-of-band). valkey-core-secret is Doppler-managed and carries the key
       # VALKEY_CORE_PASSWORD verbatim (NOT renamed to valkey-password).
       kubelet:
+        # CPU trim. node1 is a 2-core node and was request-saturated (~96%),
+        # which kept the third valkey replica from scheduling (HA needs one
+        # valkey pod per node). The chart default 100m for this kubelet
+        # integration container is far above its real usage; drop it to 25m so
+        # node1 keeps headroom. Memory is left generous so the integration is
+        # never OOM-killed; no CPU limit so it is never throttled.
+        resources:
+          requests:
+            cpu: 25m
+            memory: 150M
+          limits:
+            memory: 300M
         extraVolumes:
           - name: valkey-core-secret
             secret:


### PR DESCRIPTION
node1 (2 cores) was ~96% CPU-*requested* (though ~15% used), which kept `valkey-node-2` unschedulable — HA wants one valkey pod per node. Trim the newrelic nrk8s-kubelet integration container from the chart-default 100m to 25m (memory kept generous, no CPU limit → never throttled). Frees ~75m/node of pure over-provisioning; monitoring only, no app impact.

Pairs with #184 (fleet right-sized to 3 nodes).