### PR TITLE
feat(users): count gifts a user has sent (gifts_sent column)

### DIFF
--- a/app/transactions/web/server.go
+++ b/app/transactions/web/server.go
@@ -316,6 +316,10 @@ func (s *Server) applyBilling(ctx context.Context, event tebexEvent, payment rec
 		OccurredAt:         occurredAt,
 		ExpiresAt:          expiresAt,
 		RecurringReference: payment.RecurringReference,
+		// Non-zero only on a gift payment (gifts are one-time "single" packages,
+		// so this is set on the initial payment.completed and never on renewals);
+		// lets the users service count the gift against the buyer.
+		GifterID: payment.GiftedByID,
 	})
 }
 

--- a/app/users/ent/migrate/schema.go
+++ b/app/users/ent/migrate/schema.go
@@ -144,6 +144,7 @@ var (
 		{Name: "subscription_cancel_pending", Type: field.TypeBool, Default: false},
 		{Name: "billing_event_at", Type: field.TypeTime, Nullable: true},
 		{Name: "billing_event_id", Type: field.TypeString, Nullable: true},
+		{Name: "gifts_sent", Type: field.TypeUint32, Default: 0},
 		{Name: "created_at", Type: field.TypeTime},
 		{Name: "updated_at", Type: field.TypeTime},
 	}

--- a/app/users/ent/mutation.go
+++ b/app/users/ent/mutation.go
@@ -3046,6 +3046,8 @@ type UserMutation struct {
 	subscription_cancel_pending *bool
 	billing_event_at            *time.Time
 	billing_event_id            *string
+	gifts_sent                  *uint32
+	addgifts_sent               *int32
 	created_at                  *time.Time
 	updated_at                  *time.Time
 	clearedFields               map[string]struct{}
@@ -3694,6 +3696,62 @@ func (m *UserMutation) ResetBillingEventID() {
 	delete(m.clearedFields, user.FieldBillingEventID)
 }
 
+// SetGiftsSent sets the "gifts_sent" field.
+func (m *UserMutation) SetGiftsSent(u uint32) {
+	m.gifts_sent = &u
+	m.addgifts_sent = nil
+}
+
+// GiftsSent returns the value of the "gifts_sent" field in the mutation.
+func (m *UserMutation) GiftsSent() (r uint32, exists bool) {
+	v := m.gifts_sent
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldGiftsSent returns the old "gifts_sent" field's value of the User entity.
+// If the User object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *UserMutation) OldGiftsSent(ctx context.Context) (v uint32, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldGiftsSent is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldGiftsSent requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldGiftsSent: %w", err)
+	}
+	return oldValue.GiftsSent, nil
+}
+
+// AddGiftsSent adds u to the "gifts_sent" field.
+func (m *UserMutation) AddGiftsSent(u int32) {
+	if m.addgifts_sent != nil {
+		*m.addgifts_sent += u
+	} else {
+		m.addgifts_sent = &u
+	}
+}
+
+// AddedGiftsSent returns the value that was added to the "gifts_sent" field in this mutation.
+func (m *UserMutation) AddedGiftsSent() (r int32, exists bool) {
+	v := m.addgifts_sent
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// ResetGiftsSent resets all changes to the "gifts_sent" field.
+func (m *UserMutation) ResetGiftsSent() {
+	m.gifts_sent = nil
+	m.addgifts_sent = nil
+}
+
 // SetCreatedAt sets the "created_at" field.
 func (m *UserMutation) SetCreatedAt(t time.Time) {
 	m.created_at = &t
@@ -3854,7 +3912,7 @@ func (m *UserMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *UserMutation) Fields() []string {
-	fields := make([]string, 0, 15)
+	fields := make([]string, 0, 16)
 	if m.username != nil {
 		fields = append(fields, user.FieldUsername)
 	}
@@ -3893,6 +3951,9 @@ func (m *UserMutation) Fields() []string {
 	}
 	if m.billing_event_id != nil {
 		fields = append(fields, user.FieldBillingEventID)
+	}
+	if m.gifts_sent != nil {
+		fields = append(fields, user.FieldGiftsSent)
 	}
 	if m.created_at != nil {
 		fields = append(fields, user.FieldCreatedAt)
@@ -3934,6 +3995,8 @@ func (m *UserMutation) Field(name string) (ent.Value, bool) {
 		return m.BillingEventAt()
 	case user.FieldBillingEventID:
 		return m.BillingEventID()
+	case user.FieldGiftsSent:
+		return m.GiftsSent()
 	case user.FieldCreatedAt:
 		return m.CreatedAt()
 	case user.FieldUpdatedAt:
@@ -3973,6 +4036,8 @@ func (m *UserMutation) OldField(ctx context.Context, name string) (ent.Value, er
 		return m.OldBillingEventAt(ctx)
 	case user.FieldBillingEventID:
 		return m.OldBillingEventID(ctx)
+	case user.FieldGiftsSent:
+		return m.OldGiftsSent(ctx)
 	case user.FieldCreatedAt:
 		return m.OldCreatedAt(ctx)
 	case user.FieldUpdatedAt:
@@ -4077,6 +4142,13 @@ func (m *UserMutation) SetField(name string, value ent.Value) error {
 		}
 		m.SetBillingEventID(v)
 		return nil
+	case user.FieldGiftsSent:
+		v, ok := value.(uint32)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetGiftsSent(v)
+		return nil
 	case user.FieldCreatedAt:
 		v, ok := value.(time.Time)
 		if !ok {
@@ -4098,13 +4170,21 @@ func (m *UserMutation) SetField(name string, value ent.Value) error {
 // AddedFields returns all numeric fields that were incremented/decremented during
 // this mutation.
 func (m *UserMutation) AddedFields() []string {
-	return nil
+	var fields []string
+	if m.addgifts_sent != nil {
+		fields = append(fields, user.FieldGiftsSent)
+	}
+	return fields
 }
 
 // AddedField returns the numeric value that was incremented/decremented on a field
 // with the given name. The second boolean return value indicates that this field
 // was not set, or was not defined in the schema.
 func (m *UserMutation) AddedField(name string) (ent.Value, bool) {
+	switch name {
+	case user.FieldGiftsSent:
+		return m.AddedGiftsSent()
+	}
 	return nil, false
 }
 
@@ -4113,6 +4193,13 @@ func (m *UserMutation) AddedField(name string) (ent.Value, bool) {
 // type.
 func (m *UserMutation) AddField(name string, value ent.Value) error {
 	switch name {
+	case user.FieldGiftsSent:
+		v, ok := value.(int32)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.AddGiftsSent(v)
+		return nil
 	}
 	return fmt.Errorf("unknown User numeric field %s", name)
 }
@@ -4211,6 +4298,9 @@ func (m *UserMutation) ResetField(name string) error {
 		return nil
 	case user.FieldBillingEventID:
 		m.ResetBillingEventID()
+		return nil
+	case user.FieldGiftsSent:
+		m.ResetGiftsSent()
 		return nil
 	case user.FieldCreatedAt:
 		m.ResetCreatedAt()

--- a/app/users/ent/runtime.go
+++ b/app/users/ent/runtime.go
@@ -109,12 +109,16 @@ func init() {
 	userDescSubscriptionCancelPending := userFields[11].Descriptor()
 	// user.DefaultSubscriptionCancelPending holds the default value on creation for the subscription_cancel_pending field.
 	user.DefaultSubscriptionCancelPending = userDescSubscriptionCancelPending.Default.(bool)
+	// userDescGiftsSent is the schema descriptor for gifts_sent field.
+	userDescGiftsSent := userFields[14].Descriptor()
+	// user.DefaultGiftsSent holds the default value on creation for the gifts_sent field.
+	user.DefaultGiftsSent = userDescGiftsSent.Default.(uint32)
 	// userDescCreatedAt is the schema descriptor for created_at field.
-	userDescCreatedAt := userFields[14].Descriptor()
+	userDescCreatedAt := userFields[15].Descriptor()
 	// user.DefaultCreatedAt holds the default value on creation for the created_at field.
 	user.DefaultCreatedAt = userDescCreatedAt.Default.(func() time.Time)
 	// userDescUpdatedAt is the schema descriptor for updated_at field.
-	userDescUpdatedAt := userFields[15].Descriptor()
+	userDescUpdatedAt := userFields[16].Descriptor()
 	// user.DefaultUpdatedAt holds the default value on creation for the updated_at field.
 	user.DefaultUpdatedAt = userDescUpdatedAt.Default.(func() time.Time)
 	// user.UpdateDefaultUpdatedAt holds the default value on update for the updated_at field.

--- a/app/users/ent/schema/user.go
+++ b/app/users/ent/schema/user.go
@@ -56,6 +56,12 @@ func (User) Fields() []ent.Field {
 		field.Time("billing_event_at").Optional().Nillable(),
 		field.String("billing_event_id").Optional().Nillable(),
 
+		// Number of premium gifts this user has paid for (as the gifter). Bumped
+		// once per gift when the payment lands, on the idempotent billing-apply
+		// path so Tebex webhook retries never double-count. Existing rows get 0
+		// on migration.
+		field.Uint32("gifts_sent").Default(0),
+
 		field.Time("created_at").Default(time.Now),
 
 		field.Time("updated_at").

--- a/app/users/ent/user.go
+++ b/app/users/ent/user.go
@@ -43,6 +43,8 @@ type User struct {
 	BillingEventAt *time.Time `json:"billing_event_at,omitempty"`
 	// BillingEventID holds the value of the "billing_event_id" field.
 	BillingEventID *string `json:"billing_event_id,omitempty"`
+	// GiftsSent holds the value of the "gifts_sent" field.
+	GiftsSent uint32 `json:"gifts_sent,omitempty"`
 	// CreatedAt holds the value of the "created_at" field.
 	CreatedAt time.Time `json:"created_at,omitempty"`
 	// UpdatedAt holds the value of the "updated_at" field.
@@ -80,7 +82,7 @@ func (*User) scanValues(columns []string) ([]any, error) {
 			values[i] = new([]byte)
 		case user.FieldIsActive, user.FieldBanned, user.FieldSubscriptionCancelPending:
 			values[i] = new(sql.NullBool)
-		case user.FieldID:
+		case user.FieldID, user.FieldGiftsSent:
 			values[i] = new(sql.NullInt64)
 		case user.FieldUsername, user.FieldEmail, user.FieldStatus, user.FieldLocale, user.FieldSubscriptionSource, user.FieldSubscriptionRef, user.FieldBillingEventID:
 			values[i] = new(sql.NullString)
@@ -189,6 +191,12 @@ func (_m *User) assignValues(columns []string, values []any) error {
 				_m.BillingEventID = new(string)
 				*_m.BillingEventID = value.String
 			}
+		case user.FieldGiftsSent:
+			if value, ok := values[i].(*sql.NullInt64); !ok {
+				return fmt.Errorf("unexpected type %T for field gifts_sent", values[i])
+			} else if value.Valid {
+				_m.GiftsSent = uint32(value.Int64)
+			}
 		case user.FieldCreatedAt:
 			if value, ok := values[i].(*sql.NullTime); !ok {
 				return fmt.Errorf("unexpected type %T for field created_at", values[i])
@@ -286,6 +294,9 @@ func (_m *User) String() string {
 		builder.WriteString("billing_event_id=")
 		builder.WriteString(*v)
 	}
+	builder.WriteString(", ")
+	builder.WriteString("gifts_sent=")
+	builder.WriteString(fmt.Sprintf("%v", _m.GiftsSent))
 	builder.WriteString(", ")
 	builder.WriteString("created_at=")
 	builder.WriteString(_m.CreatedAt.Format(time.ANSIC))

--- a/app/users/ent/user/user.go
+++ b/app/users/ent/user/user.go
@@ -41,6 +41,8 @@ const (
 	FieldBillingEventAt = "billing_event_at"
 	// FieldBillingEventID holds the string denoting the billing_event_id field in the database.
 	FieldBillingEventID = "billing_event_id"
+	// FieldGiftsSent holds the string denoting the gifts_sent field in the database.
+	FieldGiftsSent = "gifts_sent"
 	// FieldCreatedAt holds the string denoting the created_at field in the database.
 	FieldCreatedAt = "created_at"
 	// FieldUpdatedAt holds the string denoting the updated_at field in the database.
@@ -74,6 +76,7 @@ var Columns = []string{
 	FieldSubscriptionCancelPending,
 	FieldBillingEventAt,
 	FieldBillingEventID,
+	FieldGiftsSent,
 	FieldCreatedAt,
 	FieldUpdatedAt,
 }
@@ -105,6 +108,8 @@ var (
 	DefaultSubscriptionSource string
 	// DefaultSubscriptionCancelPending holds the default value on creation for the "subscription_cancel_pending" field.
 	DefaultSubscriptionCancelPending bool
+	// DefaultGiftsSent holds the default value on creation for the "gifts_sent" field.
+	DefaultGiftsSent uint32
 	// DefaultCreatedAt holds the default value on creation for the "created_at" field.
 	DefaultCreatedAt func() time.Time
 	// DefaultUpdatedAt holds the default value on creation for the "updated_at" field.
@@ -206,6 +211,11 @@ func ByBillingEventAt(opts ...sql.OrderTermOption) OrderOption {
 // ByBillingEventID orders the results by the billing_event_id field.
 func ByBillingEventID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldBillingEventID, opts...).ToFunc()
+}
+
+// ByGiftsSent orders the results by the gifts_sent field.
+func ByGiftsSent(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldGiftsSent, opts...).ToFunc()
 }
 
 // ByCreatedAt orders the results by the created_at field.

--- a/app/users/ent/user/where.go
+++ b/app/users/ent/user/where.go
@@ -115,6 +115,11 @@ func BillingEventID(v string) predicate.User {
 	return predicate.User(sql.FieldEQ(FieldBillingEventID, v))
 }
 
+// GiftsSent applies equality check predicate on the "gifts_sent" field. It's identical to GiftsSentEQ.
+func GiftsSent(v uint32) predicate.User {
+	return predicate.User(sql.FieldEQ(FieldGiftsSent, v))
+}
+
 // CreatedAt applies equality check predicate on the "created_at" field. It's identical to CreatedAtEQ.
 func CreatedAt(v time.Time) predicate.User {
 	return predicate.User(sql.FieldEQ(FieldCreatedAt, v))
@@ -733,6 +738,46 @@ func BillingEventIDEqualFold(v string) predicate.User {
 // BillingEventIDContainsFold applies the ContainsFold predicate on the "billing_event_id" field.
 func BillingEventIDContainsFold(v string) predicate.User {
 	return predicate.User(sql.FieldContainsFold(FieldBillingEventID, v))
+}
+
+// GiftsSentEQ applies the EQ predicate on the "gifts_sent" field.
+func GiftsSentEQ(v uint32) predicate.User {
+	return predicate.User(sql.FieldEQ(FieldGiftsSent, v))
+}
+
+// GiftsSentNEQ applies the NEQ predicate on the "gifts_sent" field.
+func GiftsSentNEQ(v uint32) predicate.User {
+	return predicate.User(sql.FieldNEQ(FieldGiftsSent, v))
+}
+
+// GiftsSentIn applies the In predicate on the "gifts_sent" field.
+func GiftsSentIn(vs ...uint32) predicate.User {
+	return predicate.User(sql.FieldIn(FieldGiftsSent, vs...))
+}
+
+// GiftsSentNotIn applies the NotIn predicate on the "gifts_sent" field.
+func GiftsSentNotIn(vs ...uint32) predicate.User {
+	return predicate.User(sql.FieldNotIn(FieldGiftsSent, vs...))
+}
+
+// GiftsSentGT applies the GT predicate on the "gifts_sent" field.
+func GiftsSentGT(v uint32) predicate.User {
+	return predicate.User(sql.FieldGT(FieldGiftsSent, v))
+}
+
+// GiftsSentGTE applies the GTE predicate on the "gifts_sent" field.
+func GiftsSentGTE(v uint32) predicate.User {
+	return predicate.User(sql.FieldGTE(FieldGiftsSent, v))
+}
+
+// GiftsSentLT applies the LT predicate on the "gifts_sent" field.
+func GiftsSentLT(v uint32) predicate.User {
+	return predicate.User(sql.FieldLT(FieldGiftsSent, v))
+}
+
+// GiftsSentLTE applies the LTE predicate on the "gifts_sent" field.
+func GiftsSentLTE(v uint32) predicate.User {
+	return predicate.User(sql.FieldLTE(FieldGiftsSent, v))
 }
 
 // CreatedAtEQ applies the EQ predicate on the "created_at" field.

--- a/app/users/ent/user_create.go
+++ b/app/users/ent/user_create.go
@@ -179,6 +179,20 @@ func (_c *UserCreate) SetNillableBillingEventID(v *string) *UserCreate {
 	return _c
 }
 
+// SetGiftsSent sets the "gifts_sent" field.
+func (_c *UserCreate) SetGiftsSent(v uint32) *UserCreate {
+	_c.mutation.SetGiftsSent(v)
+	return _c
+}
+
+// SetNillableGiftsSent sets the "gifts_sent" field if the given value is not nil.
+func (_c *UserCreate) SetNillableGiftsSent(v *uint32) *UserCreate {
+	if v != nil {
+		_c.SetGiftsSent(*v)
+	}
+	return _c
+}
+
 // SetCreatedAt sets the "created_at" field.
 func (_c *UserCreate) SetCreatedAt(v time.Time) *UserCreate {
 	_c.mutation.SetCreatedAt(v)
@@ -287,6 +301,10 @@ func (_c *UserCreate) defaults() {
 		v := user.DefaultSubscriptionCancelPending
 		_c.mutation.SetSubscriptionCancelPending(v)
 	}
+	if _, ok := _c.mutation.GiftsSent(); !ok {
+		v := user.DefaultGiftsSent
+		_c.mutation.SetGiftsSent(v)
+	}
 	if _, ok := _c.mutation.CreatedAt(); !ok {
 		v := user.DefaultCreatedAt()
 		_c.mutation.SetCreatedAt(v)
@@ -342,6 +360,9 @@ func (_c *UserCreate) check() error {
 	}
 	if _, ok := _c.mutation.SubscriptionCancelPending(); !ok {
 		return &ValidationError{Name: "subscription_cancel_pending", err: errors.New(`ent: missing required field "User.subscription_cancel_pending"`)}
+	}
+	if _, ok := _c.mutation.GiftsSent(); !ok {
+		return &ValidationError{Name: "gifts_sent", err: errors.New(`ent: missing required field "User.gifts_sent"`)}
 	}
 	if _, ok := _c.mutation.CreatedAt(); !ok {
 		return &ValidationError{Name: "created_at", err: errors.New(`ent: missing required field "User.created_at"`)}
@@ -432,6 +453,10 @@ func (_c *UserCreate) createSpec() (*User, *sqlgraph.CreateSpec) {
 	if value, ok := _c.mutation.BillingEventID(); ok {
 		_spec.SetField(user.FieldBillingEventID, field.TypeString, value)
 		_node.BillingEventID = &value
+	}
+	if value, ok := _c.mutation.GiftsSent(); ok {
+		_spec.SetField(user.FieldGiftsSent, field.TypeUint32, value)
+		_node.GiftsSent = value
 	}
 	if value, ok := _c.mutation.CreatedAt(); ok {
 		_spec.SetField(user.FieldCreatedAt, field.TypeTime, value)

--- a/app/users/ent/user_update.go
+++ b/app/users/ent/user_update.go
@@ -233,6 +233,27 @@ func (_u *UserUpdate) ClearBillingEventID() *UserUpdate {
 	return _u
 }
 
+// SetGiftsSent sets the "gifts_sent" field.
+func (_u *UserUpdate) SetGiftsSent(v uint32) *UserUpdate {
+	_u.mutation.ResetGiftsSent()
+	_u.mutation.SetGiftsSent(v)
+	return _u
+}
+
+// SetNillableGiftsSent sets the "gifts_sent" field if the given value is not nil.
+func (_u *UserUpdate) SetNillableGiftsSent(v *uint32) *UserUpdate {
+	if v != nil {
+		_u.SetGiftsSent(*v)
+	}
+	return _u
+}
+
+// AddGiftsSent adds value to the "gifts_sent" field.
+func (_u *UserUpdate) AddGiftsSent(v int32) *UserUpdate {
+	_u.mutation.AddGiftsSent(v)
+	return _u
+}
+
 // SetCreatedAt sets the "created_at" field.
 func (_u *UserUpdate) SetCreatedAt(v time.Time) *UserUpdate {
 	_u.mutation.SetCreatedAt(v)
@@ -420,6 +441,12 @@ func (_u *UserUpdate) sqlSave(ctx context.Context) (_node int, err error) {
 	}
 	if _u.mutation.BillingEventIDCleared() {
 		_spec.ClearField(user.FieldBillingEventID, field.TypeString)
+	}
+	if value, ok := _u.mutation.GiftsSent(); ok {
+		_spec.SetField(user.FieldGiftsSent, field.TypeUint32, value)
+	}
+	if value, ok := _u.mutation.AddedGiftsSent(); ok {
+		_spec.AddField(user.FieldGiftsSent, field.TypeUint32, value)
 	}
 	if value, ok := _u.mutation.CreatedAt(); ok {
 		_spec.SetField(user.FieldCreatedAt, field.TypeTime, value)
@@ -696,6 +723,27 @@ func (_u *UserUpdateOne) ClearBillingEventID() *UserUpdateOne {
 	return _u
 }
 
+// SetGiftsSent sets the "gifts_sent" field.
+func (_u *UserUpdateOne) SetGiftsSent(v uint32) *UserUpdateOne {
+	_u.mutation.ResetGiftsSent()
+	_u.mutation.SetGiftsSent(v)
+	return _u
+}
+
+// SetNillableGiftsSent sets the "gifts_sent" field if the given value is not nil.
+func (_u *UserUpdateOne) SetNillableGiftsSent(v *uint32) *UserUpdateOne {
+	if v != nil {
+		_u.SetGiftsSent(*v)
+	}
+	return _u
+}
+
+// AddGiftsSent adds value to the "gifts_sent" field.
+func (_u *UserUpdateOne) AddGiftsSent(v int32) *UserUpdateOne {
+	_u.mutation.AddGiftsSent(v)
+	return _u
+}
+
 // SetCreatedAt sets the "created_at" field.
 func (_u *UserUpdateOne) SetCreatedAt(v time.Time) *UserUpdateOne {
 	_u.mutation.SetCreatedAt(v)
@@ -913,6 +961,12 @@ func (_u *UserUpdateOne) sqlSave(ctx context.Context) (_node *User, err error) {
 	}
 	if _u.mutation.BillingEventIDCleared() {
 		_spec.ClearField(user.FieldBillingEventID, field.TypeString)
+	}
+	if value, ok := _u.mutation.GiftsSent(); ok {
+		_spec.SetField(user.FieldGiftsSent, field.TypeUint32, value)
+	}
+	if value, ok := _u.mutation.AddedGiftsSent(); ok {
+		_spec.AddField(user.FieldGiftsSent, field.TypeUint32, value)
 	}
 	if value, ok := _u.mutation.CreatedAt(); ok {
 		_spec.SetField(user.FieldCreatedAt, field.TypeTime, value)

--- a/app/users/repository/billing.go
+++ b/app/users/repository/billing.go
@@ -98,6 +98,16 @@ func (r *Users) ApplyBilling(ctx context.Context, req billingrpc.ApplyRequest) (
 	if err != nil || updated == 0 {
 		return false, err
 	}
+	// A first-time gift activation bumps the gifter's counter. Idempotent: a
+	// replay of the same event returns early above, so this runs exactly once
+	// per gift. Best-effort: a counter failure must never fail the already
+	// applied entitlement (that would make Tebex retry and re-apply), so its
+	// error is intentionally dropped.
+	if req.Action == billingrpc.ActionActivate && req.GifterID != 0 && req.GifterID != req.UserID {
+		_ = db.WithExec(ctx, func(ctx context.Context) error {
+			return r.client.User.Update().Where(user.IDEQ(req.GifterID)).AddGiftsSent(1).Exec(ctx)
+		})
+	}
 	if err := r.publishChanged(ctx, req.UserID); err != nil {
 		return false, err
 	}

--- a/app/users/repository/users_test.go
+++ b/app/users/repository/users_test.go
@@ -180,6 +180,46 @@ func TestApplyBillingLifecycleIsMonotonicAndProtectsAdminGrants(t *testing.T) {
 	assert.False(t, applied, "Tebex must not revoke an operator grant")
 }
 
+func TestApplyBillingCountsGiftForGifterIdempotently(t *testing.T) {
+	client, _, repo := setup(t)
+	ctx := context.Background()
+	require.NoError(t, repo.Register(ctx, 4001, "Gifter", "gifter@example.com"))
+	require.NoError(t, repo.Register(ctx, 4002, "Recipient", "recipient@example.com"))
+
+	when := time.Date(2026, 7, 3, 12, 0, 0, 0, time.UTC)
+	expires := when.AddDate(0, 1, 0)
+	gift := billingrpc.ApplyRequest{
+		UserID: 4002, EventID: "evt-gift-1", Action: billingrpc.ActionActivate,
+		OccurredAt: when, ExpiresAt: &expires, GifterID: 4001,
+	}
+
+	applied, err := repo.ApplyBilling(ctx, gift)
+	require.NoError(t, err)
+	assert.True(t, applied)
+
+	rv, err := repo.Get(ctx, 4002)
+	require.NoError(t, err)
+	assert.Equal(t, "paid", rv.Status, "recipient still gets premium")
+
+	g := client.User.GetX(ctx, 4001)
+	assert.Equal(t, uint32(1), g.GiftsSent, "gifter counter bumped once")
+
+	// A Tebex retry of the exact same webhook must not double-count.
+	_, err = repo.ApplyBilling(ctx, gift)
+	require.NoError(t, err)
+	g = client.User.GetX(ctx, 4001)
+	assert.Equal(t, uint32(1), g.GiftsSent, "webhook retry must not double-count")
+
+	// A self-purchase (no gifter) must not bump the counter.
+	_, err = repo.ApplyBilling(ctx, billingrpc.ApplyRequest{
+		UserID: 4001, EventID: "evt-self", Action: billingrpc.ActionActivate,
+		OccurredAt: when.Add(time.Hour), ExpiresAt: &expires, GifterID: 0,
+	})
+	require.NoError(t, err)
+	g = client.User.GetX(ctx, 4001)
+	assert.Equal(t, uint32(1), g.GiftsSent, "self-purchase must not bump the counter")
+}
+
 func TestApplyBillingCancellationAndEnd(t *testing.T) {
 	_, _, repo := setup(t)
 	ctx := context.Background()

--- a/internal/domain/rpc/billing/billing.go
+++ b/internal/domain/rpc/billing/billing.go
@@ -21,6 +21,10 @@ type ApplyRequest struct {
 	OccurredAt         time.Time  `json:"occurred_at"`
 	ExpiresAt          *time.Time `json:"expires_at,omitempty"`
 	RecurringReference string     `json:"recurring_reference,omitempty"`
+	// GifterID is the buyer when this activation is a gift to UserID; zero for a
+	// self-purchase or renewal. When set (and this is a first-time activation),
+	// the users service bumps the gifter's gifts_sent counter idempotently.
+	GifterID uint64 `json:"gifter_id,omitempty"`
 }
 
 type ApplyReply struct {


### PR DESCRIPTION
Adds a **`gifts_sent`** `uint32` column (default 0) to the users table — the count of premium gifts a user has paid for.

## How it's counted (idempotent, no double-count)
- `billingrpc.ApplyRequest` gains `GifterID` (the buyer; 0 for self-purchase/renewal).
- The transactions webhook sets `GifterID = payment.GiftedByID` on the recipient's activation (gifts are one-time `single` packages → set on `payment.completed`, never on renewals).
- `users.ApplyBilling` bumps the gifter's counter (`AddGiftsSent(1)`) **only on a first-time apply** — event replays return early on the billing-event-id dedupe, so **Tebex webhook retries never double-count**. Best-effort: a counter failure never fails the already-applied entitlement.

## Migration
Additive (ent auto-migrate adds the column); **existing rows get 0**.

## Tests
`TestApplyBillingCountsGiftForGifterIdempotently`: gift bumps the gifter to 1, a retry stays 1, a self-purchase doesn't bump. Full `app/users` + `app/transactions` suites + vet green.