### PR TITLE
feat(mail): support email templates + DMARC/BIMI email auth

### DIFF
--- a/deploy/dns/bimi-add-vmc.sh
+++ b/deploy/dns/bimi-add-vmc.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env sh
+# Add the a=<VMC> tag to the live BIMI record once a Verified Mark Certificate
+# is hosted. Run AFTER web/public/vmc.pem is deployed and reachable. Looks the
+# record up by name so there is no hardcoded record id. Idempotent: re-running
+# just re-sets the same content.
+#
+#   sh deploy/dns/bimi-add-vmc.sh
+#
+# Token comes from Doppler (project cloudflared, config prd); never printed.
+set -eu
+
+ZONE=21c8bf01d6c33a5a1bc78eda7b23f84d
+NAME=default._bimi.itsbagelbot.com
+SVG=https://itsbagelbot.com/bimi.svg
+VMC=https://itsbagelbot.com/vmc.pem
+
+# Refuse to wire up a VMC that is not actually reachable, an unreachable a=
+# breaks BIMI evaluation instead of just leaving it unbranded.
+code=$(curl -s -o /dev/null -w '%{http_code}' -I "$VMC")
+if [ "$code" != "200" ]; then
+  echo "vmc.pem not reachable at $VMC (HTTP $code). Deploy it first." >&2
+  exit 1
+fi
+
+doppler run -p cloudflared -c prd -- sh -c '
+  set -eu
+  id=$(curl -s -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+    "https://api.cloudflare.com/client/v4/zones/'"$ZONE"'/dns_records?type=TXT&name='"$NAME"'" \
+    | python3 -c "import sys,json;r=json.load(sys.stdin)[\"result\"];print(r[0][\"id\"]) if r else exit(\"BIMI record not found\")")
+  curl -s -X PATCH -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" -H "Content-Type: application/json" \
+    "https://api.cloudflare.com/client/v4/zones/'"$ZONE"'/dns_records/$id" \
+    --data "{\"content\":\"v=BIMI1; l='"$SVG"'; a='"$VMC"';\"}" \
+    | python3 -c "import sys,json;d=json.load(sys.stdin);print(\"ok:\",d[\"success\"],d.get(\"result\",{}).get(\"content\") or d.get(\"errors\"))"
+'

--- a/deploy/dns/email-auth.md
+++ b/deploy/dns/email-auth.md
@@ -1,0 +1,88 @@
+# Email authentication (SPF / DKIM / DMARC / BIMI)
+
+Records for `itsbagelbot.com`, Cloudflare zone `21c8bf01d6c33a5a1bc78eda7b23f84d`.
+Two senders: **Zoho** (human support mail, `@itsbagelbot.com`) and **Resend**
+(transactional, via the `send.` subdomain). This file is the source of truth for
+what the zone should contain, the zone itself is edited through the Cloudflare
+API using the `CLOUDFLARE_API_TOKEN` in Doppler project `cloudflared`, config
+`prd`. There is no DNS-as-code apply step, the records are managed by hand.
+
+## Current state (all live)
+
+| Record | Name | Value | Owner |
+| --- | --- | --- | --- |
+| MX | `itsbagelbot.com` | `mx.zohocloud.ca` (10), `mx2` (20), `mx3` (50) | Zoho |
+| SPF | `itsbagelbot.com` TXT | `v=spf1 include:zohocloud.ca ~all` | Zoho |
+| DKIM | `zmail._domainkey` TXT | `v=DKIM1; k=rsa; p=…` | Zoho |
+| MX | `send.itsbagelbot.com` | `feedback-smtp.us-east-1.amazonses.com` (10) | Resend |
+| SPF | `send.itsbagelbot.com` TXT | `v=spf1 include:amazonses.com ~all` | Resend |
+| DKIM | `resend._domainkey` TXT | `p=…` | Resend |
+| DMARC | `_dmarc.itsbagelbot.com` TXT | `v=DMARC1; p=quarantine; sp=quarantine; adkim=r; aspf=r; pct=100; rua=mailto:dmarc@itsbagelbot.com; ruf=mailto:dmarc@itsbagelbot.com; fo=1` | shared |
+| BIMI | `default._bimi.itsbagelbot.com` TXT | `v=BIMI1; l=https://itsbagelbot.com/bimi.svg;` | shared |
+
+### Alignment (why quarantine is safe)
+
+DMARC passes if SPF **or** DKIM aligns. Both senders DKIM-sign with
+`d=itsbagelbot.com`, so both align regardless of the envelope path:
+
+- **Zoho**: From `@itsbagelbot.com`; SPF `include:zohocloud.ca` aligns, DKIM
+  `zmail` (d=root) aligns. Passes.
+- **Resend**: envelope MAIL FROM is `send.itsbagelbot.com` (relaxed SPF aligns),
+  and DKIM `resend` (d=root) aligns strictly. Passes on DKIM even if SPF is
+  treated strict.
+
+`sp=quarantine` covers spoofed subdomains. It does not affect Resend: Resend's
+visible From is the root domain, governed by `p=`, not `sp=`.
+
+## Open items to reach "fully enforced + branded"
+
+### 1. `dmarc@itsbagelbot.com` mailbox  — REQUIRED
+
+Aggregate (`rua`) and forensic (`ruf`) reports are sent here. Create the mailbox
+or an alias/catch-all in Zoho, otherwise every report bounces and you get zero
+visibility. Same-domain `rua`, so no external authorization record is needed.
+
+### 2. Ramp DMARC to `p=reject`  — after ~2 weeks of clean reports
+
+Once reports confirm no legitimate source is failing, raise the policy. One
+call (looks the record up by name, no hardcoded id):
+
+```sh
+ZONE=21c8bf01d6c33a5a1bc78eda7b23f84d
+doppler run -p cloudflared -c prd -- sh -c '
+  id=$(curl -s -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+    "https://api.cloudflare.com/client/v4/zones/'"$ZONE"'/dns_records?type=TXT&name=_dmarc.itsbagelbot.com" \
+    | python3 -c "import sys,json;print(json.load(sys.stdin)[\"result\"][0][\"id\"])")
+  curl -s -X PATCH -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" -H "Content-Type: application/json" \
+    "https://api.cloudflare.com/client/v4/zones/'"$ZONE"'/dns_records/$id" \
+    --data "{\"content\":\"v=DMARC1; p=reject; sp=reject; adkim=r; aspf=r; pct=100; rua=mailto:dmarc@itsbagelbot.com; ruf=mailto:dmarc@itsbagelbot.com; fo=1\"}"
+'
+```
+
+### 3. BIMI logo must be live  — ships with the next web deploy
+
+`l=` points at `https://itsbagelbot.com/bimi.svg`. The file is
+[`web/public/bimi.svg`](../../web/public/bimi.svg) (SVG Tiny PS: `baseProfile=
+tiny-ps`, one `<title>`, square viewBox, no CSS/script/external refs). It goes
+live when the web image builds and Flux rolls it. Until then the URL 404s and
+clients fall back to the normal avatar (no harm). Verify after deploy:
+
+```sh
+curl -sI https://itsbagelbot.com/bimi.svg | grep -i content-type   # want image/svg+xml
+```
+
+### 4. VMC (Verified Mark Certificate)  — required for Gmail / Apple / Yahoo
+
+The bare `l=` record is valid and some clients (Fastmail, La Poste) render it
+once the SVG is live. **Gmail, Apple Mail and Yahoo only show the logo when the
+record also carries `a=` pointing at a VMC.** A VMC is a paid certificate
+(~$1k+/yr, DigiCert or Entrust) issued against a **registered trademark** of the
+logo (a Common Mark Certificate / CMC is the trademark-free alternative Apple
+accepts, still paid). Steps:
+
+1. Register the ItsBagelBot logo as a trademark (or gather CMC prior-use
+   evidence). This is the long pole, months.
+2. Buy the VMC from DigiCert/Entrust using the exact SVG in `web/public/bimi.svg`.
+3. Host the issued PEM at `https://itsbagelbot.com/vmc.pem` (drop it in
+   `web/public/vmc.pem`, deploy).
+4. Add the `a=` tag: run [`bimi-add-vmc.sh`](bimi-add-vmc.sh).

--- a/mail/README.md
+++ b/mail/README.md
@@ -1,0 +1,99 @@
+# Support email templates
+
+Paste-ready email templates for the support team. Same look as the
+transactional emails the bot sends (the Premium gift email), so a hand-written
+support reply and an automated receipt feel like they came from the same place.
+
+These are **static files for humans**, not code. Nothing here is wired into a
+service. You copy the file, fill it in, and paste it into whatever tool sends
+the mail (Resend dashboard, Gmail with an HTML-paste add-on, a help desk).
+
+## Files
+
+| File | Use |
+| --- | --- |
+| `support-email.html` | The template. Copy it, replace every `[[ ... ]]`, paste as the **HTML** body. |
+| `support-email.txt`  | Plain-text twin. Paste as the **plain-text** body so text-only clients get a clean version. |
+| `example-filled.html` | The template with everything filled in. Open in a browser to see the finished look. Do **not** send this one. |
+| `received.html` / `received.txt` | Ready-to-send auto-acknowledgment: confirms the message landed, states open hours (10am–5pm most active days), and links the Discord for faster replies. Fire it on receipt. Only edit the hours line if the window changes. |
+
+## Recognising us / anti-phishing
+
+Support mail is a prime phishing target, so every template carries the same two
+fixed pieces. **Do not edit, personalise, or remove them.** Their whole value is
+that they are identical on every email, so users learn the pattern.
+
+1. **Verified-sender strip** (header, under the wordmark): a green `✓ Official
+   ItsBagelBot email · itsbagelbot.com`. This is the at-a-glance "it's really
+   us" cue. Same tick, same wording, same place, always.
+2. **Anti-phishing footer**: "ItsBagelBot will never ask for your password,
+   payment or card details, or login and verification codes by email. We only
+   send from @itsbagelbot.com..." with a Discord link to verify anything
+   suspicious.
+
+Together with the locked visual identity (logo + wordmark, the tan→green accent
+bar, the bagel-stamp signature) these give the mail a look that is easy to
+recognise and awkward to fake convincingly.
+
+### The strip is not real authentication, the domain is
+
+A tick in the body proves nothing on its own, anyone can copy pixels. What
+actually stops spoofing is the sending domain, set up on the DNS / Resend side.
+Full state and runbook: [`deploy/dns/email-auth.md`](../deploy/dns/email-auth.md).
+
+- **SPF, DKIM, DMARC** on `itsbagelbot.com` — live. DKIM is set for both Zoho
+  and Resend, both aligned. DMARC is at `p=quarantine; pct=100` (spoofed
+  `@itsbagelbot.com` goes to spam); ramp to `p=reject` after ~2 weeks of clean
+  reports.
+- **BIMI** — record live at `default._bimi.itsbagelbot.com`, logo at
+  [`web/public/bimi.svg`](../web/public/bimi.svg). Goes live on the next web
+  deploy; Gmail/Apple then show the logo **once a VMC is added** (paid cert,
+  needs a trademark — see the runbook).
+- **One consistent From identity**, e.g. `ItsBagelBot Support
+  <support@itsbagelbot.com>`, and a matching subject prefix such as
+  `[ItsBagelBot]`. Consistency is what trains recognition.
+
+Still owed by you: create the `dmarc@itsbagelbot.com` mailbox so reports land,
+then ramp DMARC to reject and buy the VMC. All in the runbook.
+
+## Sending a reply
+
+1. Open `support-email.html` and `support-email.txt`.
+2. Replace every `[[ ... ]]` marker with your copy. The marker text says what
+   goes there.
+3. Delete the blocks you do not need. The **note callout**, the **status line**,
+   and the **button** each have a `OPTIONAL` banner comment marking where they
+   start and end. Remove the whole block, banners included.
+4. In your sender, set the HTML body from `support-email.html` and the
+   plain-text body from `support-email.txt`. Always send both.
+5. Send yourself a test first. Check it on a phone too.
+
+## Design (do not "tidy up")
+
+Email clients are not browsers. The rules that keep this rendering right:
+
+- **Table layout + inline styles only.** No `<div>` grids, no external or
+  `<style>`-block CSS (the one `@import` for the webfont is the exception, and
+  clients that drop it just fall back to Arial/Helvetica).
+- **One remote image, the logo.** Many clients block images by default, so the
+  design has to still read with images off. Do not add more.
+- **Colours and fonts are locked** to the site's system. They match
+  `web/src/styles/style.css` and `app/transactions/mail/gift_template.go`:
+
+  | Token | Value |
+  | --- | --- |
+  | Canvas | `#0a0a0a` |
+  | Card | `#111110` |
+  | Border | `#2b241b` |
+  | Tan (accent) | `#c9a87c` |
+  | Tan light | `#e0c49a` |
+  | Text | `#f0ece4` / body `#a89f92` |
+  | Muted | `#888077` |
+  | Green (done) | `#52b788` |
+  | Display font | Syne |
+  | Body font | DM Sans |
+  | Label / mono | DM Mono |
+  | Signature | Caveat |
+
+If the styling ever changes on the site or in the gift email, update these
+files to match so support mail does not drift.

--- a/mail/example-filled.html
+++ b/mail/example-filled.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="color-scheme" content="dark">
+<meta name="supported-color-schemes" content="dark">
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Syne:wght@700;800&family=Caveat:wght@600&display=swap');
+</style>
+<title>ItsBagelBot Support</title>
+</head>
+<!--
+  EXAMPLE  ·  the support-email.html template with every placeholder filled in.
+  Open this file in a browser to see the finished look. Do not send this one,
+  copy support-email.html and fill it for the real reply.
+-->
+<body style="margin:0;padding:0;background-color:#0a0a0a;">
+
+<div style="display:none;max-height:0;overflow:hidden;mso-hide:all;">We re-linked your Twitch account, Premium is back.</div>
+
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#0a0a0a" style="background-color:#0a0a0a;background-image:url(&quot;data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)' opacity='0.055'/%3E%3C/svg%3E&quot;);">
+<tr><td align="center" style="padding:40px 16px 48px;">
+
+  <table role="presentation" width="560" cellpadding="0" cellspacing="0" border="0" style="width:560px;max-width:100%;">
+
+    <tr><td align="center" style="padding:0 0 14px;">
+      <img src="https://itsbagelbot.com/logo.png" width="52" height="52" alt="" style="display:inline-block;width:52px;height:52px;vertical-align:middle;">
+      <span style="font-family:'Syne','Avenir Next','Helvetica Neue',Arial,sans-serif;font-size:20px;font-weight:800;letter-spacing:0.01em;color:#f0ece4;vertical-align:middle;padding-left:12px;">ItsBagelBot</span>
+    </td></tr>
+
+    <tr><td align="center" style="padding:0 0 26px;">
+      <span style="font-family:'DM Mono',Menlo,Consolas,monospace;font-size:11px;letter-spacing:1.5px;text-transform:uppercase;color:#52b788;">&#10003;&nbsp; Official ItsBagelBot email &middot; itsbagelbot.com</span>
+    </td></tr>
+
+    <tr><td style="background-color:#111110;border:1px solid #2b241b;border-radius:16px;overflow:hidden;">
+      <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+
+        <tr><td height="3" bgcolor="#c9a87c" style="height:3px;background:linear-gradient(90deg,#c9a87c,#52b788);font-size:0;line-height:0;">&nbsp;</td></tr>
+
+        <tr><td style="padding:40px 40px 36px;">
+
+          <div style="font-family:'DM Mono',Menlo,Consolas,monospace;font-size:11px;letter-spacing:3px;text-transform:uppercase;color:#c9a87c;padding-bottom:18px;">
+            Support &middot; Reply
+          </div>
+
+          <div style="font-family:'Syne','Avenir Next','Helvetica Neue',Arial,sans-serif;font-size:30px;line-height:1.15;font-weight:800;color:#f0ece4;padding-bottom:16px;">
+            We sorted&nbsp;that out.
+          </div>
+
+          <div style="font-family:'DM Sans','Helvetica Neue',Arial,sans-serif;font-size:15px;line-height:1.65;color:#a89f92;padding-bottom:20px;">
+            Thanks for the heads up. Your Twitch login had come unlinked, which is
+            why <strong style="color:#e0c49a;font-weight:600;">Premium looked missing</strong>.
+            We re-linked it and confirmed the subscription is live again. Nothing
+            you need to do on your end.
+          </div>
+
+          <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="margin:0 0 24px;">
+            <tr><td style="background-color:#0d0d0c;border:1px solid #2b241b;border-left:3px solid #c9a87c;border-radius:8px;padding:16px 18px;">
+              <div style="font-family:'DM Mono',Menlo,Consolas,monospace;font-size:10px;letter-spacing:2px;text-transform:uppercase;color:#c9a87c;padding-bottom:9px;">Ticket</div>
+              <div style="font-family:'DM Sans','Helvetica Neue',Arial,sans-serif;font-size:15px;line-height:1.6;color:#d8d0c4;">#4821 &middot; Premium not showing after re-subscribe</div>
+            </td></tr>
+          </table>
+
+          <div style="font-family:'DM Mono',Menlo,Consolas,monospace;font-size:12px;letter-spacing:0.5px;color:#52b788;padding-bottom:26px;">
+            Resolved on your account now
+          </div>
+
+          <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+            <tr><td height="1" style="height:1px;background-color:#2b241b;font-size:0;line-height:0;">&nbsp;</td></tr>
+          </table>
+
+          <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin-top:30px;">
+            <tr><td bgcolor="#c9a87c" style="border-radius:100px;">
+              <a href="https://itsbagelbot.com/dashboard" style="display:inline-block;padding:13px 30px;font-family:'DM Sans','Helvetica Neue',Arial,sans-serif;font-size:14px;font-weight:700;color:#0a0a0a;text-decoration:none;border-radius:100px;">
+                Open your dashboard &rarr;
+              </a>
+            </td></tr>
+          </table>
+
+          <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="margin-top:36px;">
+            <tr>
+              <td valign="middle">
+                <span style="display:inline-block;">
+                  <span style="font-family:'Caveat',cursive;font-size:26px;font-weight:600;line-height:1;color:#e0c49a;">the ItsBagelBot support team</span>
+                  <span style="display:block;height:2px;margin-top:8px;border-radius:2px;background-color:#c9a87c;background-image:linear-gradient(90deg,rgba(201,168,124,0.7),rgba(82,183,136,0.5));font-size:0;line-height:0;">&nbsp;</span>
+                </span>
+              </td>
+              <td valign="middle" align="right" width="66">
+                <div style="display:inline-block;width:55px;height:55px;line-height:55px;text-align:center;font-size:24px;border:1.5px dashed rgba(201,168,124,0.4);border-radius:50%;transform:rotate(8deg);">&#129391;</div>
+              </td>
+            </tr>
+          </table>
+
+        </td></tr>
+      </table>
+    </td></tr>
+
+    <tr><td style="padding:30px 8px 0;">
+      <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+        <tr><td height="1" style="height:1px;background-color:#2b241b;font-size:0;line-height:0;">&nbsp;</td></tr>
+      </table>
+      <div style="padding:16px 14px 0;font-family:'DM Sans','Helvetica Neue',Arial,sans-serif;font-size:12px;line-height:1.7;color:#888077;text-align:center;">
+        <span style="color:#c9a87c;font-weight:600;">&#128274; Staying safe.</span>
+        ItsBagelBot will never ask for your password, payment or card details, or login and verification codes by email. We only send from <span style="color:#a89f92;">@itsbagelbot.com</span>. If a message asks for any of that, it isn't us. Ignore it and reach the real team on <a href="https://discord.gg/SZ2remwSDv" style="color:#c9a87c;text-decoration:none;">Discord</a>.
+      </div>
+    </td></tr>
+
+    <tr><td align="center" style="padding:18px 20px 0;font-family:'DM Sans','Helvetica Neue',Arial,sans-serif;font-size:12px;line-height:1.7;color:#888077;">
+      Sent by ItsBagelBot support in reply to your message. Just reply to reach us again.<br>
+      <a href="https://itsbagelbot.com" style="color:#c9a87c;text-decoration:none;">itsbagelbot.com</a>
+    </td></tr>
+
+  </table>
+
+</td></tr>
+</table>
+</body>
+</html>

--- a/mail/received.html
+++ b/mail/received.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="color-scheme" content="dark">
+<meta name="supported-color-schemes" content="dark">
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Syne:wght@700;800&family=Caveat:wght@600&display=swap');
+</style>
+<title>ItsBagelBot Support</title>
+</head>
+<!--
+  "We got your message" auto-acknowledgment.
+  Send this the moment a support message lands, before a human replies.
+  Filled and ready. The only thing worth editing is the hours line if the
+  support window ever changes. Design matches support-email.html.
+-->
+<body style="margin:0;padding:0;background-color:#0a0a0a;">
+
+<div style="display:none;max-height:0;overflow:hidden;mso-hide:all;">Got it, your message is with the support team.</div>
+
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#0a0a0a" style="background-color:#0a0a0a;background-image:url(&quot;data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)' opacity='0.055'/%3E%3C/svg%3E&quot;);">
+<tr><td align="center" style="padding:40px 16px 48px;">
+
+  <table role="presentation" width="560" cellpadding="0" cellspacing="0" border="0" style="width:560px;max-width:100%;">
+
+    <tr><td align="center" style="padding:0 0 14px;">
+      <img src="https://itsbagelbot.com/logo.png" width="52" height="52" alt="" style="display:inline-block;width:52px;height:52px;vertical-align:middle;">
+      <span style="font-family:'Syne','Avenir Next','Helvetica Neue',Arial,sans-serif;font-size:20px;font-weight:800;letter-spacing:0.01em;color:#f0ece4;vertical-align:middle;padding-left:12px;">ItsBagelBot</span>
+    </td></tr>
+
+    <tr><td align="center" style="padding:0 0 26px;">
+      <span style="font-family:'DM Mono',Menlo,Consolas,monospace;font-size:11px;letter-spacing:1.5px;text-transform:uppercase;color:#52b788;">&#10003;&nbsp; Official ItsBagelBot email &middot; itsbagelbot.com</span>
+    </td></tr>
+
+    <tr><td style="background-color:#111110;border:1px solid #2b241b;border-radius:16px;overflow:hidden;">
+      <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+
+        <tr><td height="3" bgcolor="#c9a87c" style="height:3px;background:linear-gradient(90deg,#c9a87c,#52b788);font-size:0;line-height:0;">&nbsp;</td></tr>
+
+        <tr><td style="padding:40px 40px 36px;">
+
+          <div style="font-family:'DM Mono',Menlo,Consolas,monospace;font-size:11px;letter-spacing:3px;text-transform:uppercase;color:#c9a87c;padding-bottom:18px;">
+            Support &middot; Received
+          </div>
+
+          <div style="font-family:'Syne','Avenir Next','Helvetica Neue',Arial,sans-serif;font-size:30px;line-height:1.15;font-weight:800;color:#f0ece4;padding-bottom:16px;">
+            Got it. It's in the&nbsp;queue.
+          </div>
+
+          <div style="font-family:'DM Sans','Helvetica Neue',Arial,sans-serif;font-size:15px;line-height:1.65;color:#a89f92;padding-bottom:20px;">
+            Your message reached the support team, no need to send it again. A
+            real person will read it and get back to you. Replies come during our
+            open hours, so hang tight.
+          </div>
+
+          <!-- open hours callout -->
+          <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="margin:0 0 24px;">
+            <tr><td style="background-color:#0d0d0c;border:1px solid #2b241b;border-left:3px solid #c9a87c;border-radius:8px;padding:16px 18px;">
+              <div style="font-family:'DM Mono',Menlo,Consolas,monospace;font-size:10px;letter-spacing:2px;text-transform:uppercase;color:#c9a87c;padding-bottom:9px;">Open hours</div>
+              <div style="font-family:'DM Sans','Helvetica Neue',Arial,sans-serif;font-size:15px;line-height:1.6;color:#d8d0c4;">10am &ndash; 5pm on our most active days. Messages sent outside those hours are answered when we're back.</div>
+            </td></tr>
+          </table>
+
+          <!-- faster-reply nudge -->
+          <div style="font-family:'DM Sans','Helvetica Neue',Arial,sans-serif;font-size:15px;line-height:1.65;color:#a89f92;padding-bottom:26px;">
+            Need a faster answer? Our Discord is usually the quickest way to reach
+            someone.
+          </div>
+
+          <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+            <tr><td height="1" style="height:1px;background-color:#2b241b;font-size:0;line-height:0;">&nbsp;</td></tr>
+          </table>
+
+          <!-- Discord CTA -->
+          <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin-top:30px;">
+            <tr><td bgcolor="#c9a87c" style="border-radius:100px;">
+              <a href="https://discord.gg/SZ2remwSDv" style="display:inline-block;padding:13px 30px;font-family:'DM Sans','Helvetica Neue',Arial,sans-serif;font-size:14px;font-weight:700;color:#0a0a0a;text-decoration:none;border-radius:100px;">
+                Join the Discord &rarr;
+              </a>
+            </td></tr>
+          </table>
+
+          <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="margin-top:36px;">
+            <tr>
+              <td valign="middle">
+                <span style="display:inline-block;">
+                  <span style="font-family:'Caveat',cursive;font-size:26px;font-weight:600;line-height:1;color:#e0c49a;">the ItsBagelBot support team</span>
+                  <span style="display:block;height:2px;margin-top:8px;border-radius:2px;background-color:#c9a87c;background-image:linear-gradient(90deg,rgba(201,168,124,0.7),rgba(82,183,136,0.5));font-size:0;line-height:0;">&nbsp;</span>
+                </span>
+              </td>
+              <td valign="middle" align="right" width="66">
+                <div style="display:inline-block;width:55px;height:55px;line-height:55px;text-align:center;font-size:24px;border:1.5px dashed rgba(201,168,124,0.4);border-radius:50%;transform:rotate(8deg);">&#129391;</div>
+              </td>
+            </tr>
+          </table>
+
+        </td></tr>
+      </table>
+    </td></tr>
+
+    <tr><td style="padding:30px 8px 0;">
+      <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+        <tr><td height="1" style="height:1px;background-color:#2b241b;font-size:0;line-height:0;">&nbsp;</td></tr>
+      </table>
+      <div style="padding:16px 14px 0;font-family:'DM Sans','Helvetica Neue',Arial,sans-serif;font-size:12px;line-height:1.7;color:#888077;text-align:center;">
+        <span style="color:#c9a87c;font-weight:600;">&#128274; Staying safe.</span>
+        ItsBagelBot will never ask for your password, payment or card details, or login and verification codes by email. We only send from <span style="color:#a89f92;">@itsbagelbot.com</span>. If a message asks for any of that, it isn't us. Ignore it and reach the real team on <a href="https://discord.gg/SZ2remwSDv" style="color:#c9a87c;text-decoration:none;">Discord</a>.
+      </div>
+    </td></tr>
+
+    <tr><td align="center" style="padding:18px 20px 0;font-family:'DM Sans','Helvetica Neue',Arial,sans-serif;font-size:12px;line-height:1.7;color:#888077;">
+      Automatic confirmation that we received your message. No need to reply to this one.<br>
+      <a href="https://itsbagelbot.com" style="color:#c9a87c;text-decoration:none;">itsbagelbot.com</a>
+    </td></tr>
+
+  </table>
+
+</td></tr>
+</table>
+</body>
+</html>

--- a/mail/received.txt
+++ b/mail/received.txt
@@ -1,0 +1,25 @@
+[ Official ItsBagelBot email - itsbagelbot.com ]
+
+Support received
+
+Got it. It's in the queue.
+
+Your message reached the support team, no need to send it again. A real person
+will read it and get back to you. Replies come during our open hours, so hang
+tight.
+
+Open hours: 10am - 5pm on our most active days. Messages sent outside those
+hours are answered when we're back.
+
+Need a faster answer? Our Discord is usually the quickest way to reach someone:
+https://discord.gg/SZ2remwSDv
+
+the ItsBagelBot support team
+
+Staying safe: ItsBagelBot will never ask for your password, payment or card
+details, or login and verification codes by email. We only send from
+@itsbagelbot.com. If a message asks for any of that, it isn't us. Ignore it and
+reach the real team on Discord: https://discord.gg/SZ2remwSDv
+
+Automatic confirmation that we received your message. No need to reply to this one.
+https://itsbagelbot.com

--- a/mail/support-email.html
+++ b/mail/support-email.html
@@ -1,0 +1,170 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="color-scheme" content="dark">
+<meta name="supported-color-schemes" content="dark">
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Syne:wght@700;800&family=Caveat:wght@600&display=swap');
+</style>
+<!-- EDIT: browser/tab title. Most inboxes ignore it; harmless to leave. -->
+<title>ItsBagelBot Support</title>
+</head>
+<!--
+  ==========================================================================
+  ItsBagelBot support email  ·  paste-ready template
+  --------------------------------------------------------------------------
+  Mirrors the transactional gift email (app/transactions/mail/gift_template.go)
+  and the marketing design system (web/src/styles/style.css): near-black
+  canvas with fractal-noise grain, warm tan accents, green for "done" states,
+  pill button, 16px card, Syne display type, Caveat signature.
+
+  HOW TO USE
+    1. Find every [[ ... ]] marker below and replace it with your copy.
+    2. Delete any optional block whose banner comment says so (the note
+       callout and the button are both optional).
+    3. Paste the whole file into your sender (Resend dashboard "HTML",
+       Gmail via a paste-HTML add-on, or your help desk's raw-HTML editor).
+    4. Also paste support-email.txt as the plain-text alternative so
+       text-only clients get a clean version.
+
+  RULES (email clients are picky, do not "clean this up"):
+    - Keep the table layout and inline styles. No external CSS, no <div> grids.
+    - Do not add remote images beyond the logo; many clients block them.
+    - Fonts load via @import with system fallbacks. If a client strips the
+       webfont the layout still holds, it just uses Arial/Helvetica.
+  ==========================================================================
+-->
+<body style="margin:0;padding:0;background-color:#0a0a0a;">
+
+<!-- EDIT: preheader = the grey preview line shown in the inbox list, next to
+     the subject. Keep it short. It is hidden inside the email body itself. -->
+<div style="display:none;max-height:0;overflow:hidden;mso-hide:all;">[[PREHEADER — one-line inbox preview, e.g. We looked into your Premium question.]]</div>
+
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#0a0a0a" style="background-color:#0a0a0a;background-image:url(&quot;data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)' opacity='0.055'/%3E%3C/svg%3E&quot;);">
+<tr><td align="center" style="padding:40px 16px 48px;">
+
+  <table role="presentation" width="560" cellpadding="0" cellspacing="0" border="0" style="width:560px;max-width:100%;">
+
+    <!-- logo + wordmark, centered -->
+    <tr><td align="center" style="padding:0 0 14px;">
+      <img src="https://itsbagelbot.com/logo.png" width="52" height="52" alt="" style="display:inline-block;width:52px;height:52px;vertical-align:middle;">
+      <span style="font-family:'Syne','Avenir Next','Helvetica Neue',Arial,sans-serif;font-size:20px;font-weight:800;letter-spacing:0.01em;color:#f0ece4;vertical-align:middle;padding-left:12px;">ItsBagelBot</span>
+    </td></tr>
+
+    <!-- verified-sender strip. Ships on EVERY ItsBagelBot email, unchanged, so
+         recipients learn to recognise it at a glance: green tick + our domain.
+         Do not personalise or remove it. -->
+    <tr><td align="center" style="padding:0 0 26px;">
+      <span style="font-family:'DM Mono',Menlo,Consolas,monospace;font-size:11px;letter-spacing:1.5px;text-transform:uppercase;color:#52b788;">&#10003;&nbsp; Official ItsBagelBot email &middot; itsbagelbot.com</span>
+    </td></tr>
+
+    <!-- card -->
+    <tr><td style="background-color:#111110;border:1px solid #2b241b;border-radius:16px;overflow:hidden;">
+      <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+
+        <!-- accent bar -->
+        <tr><td height="3" bgcolor="#c9a87c" style="height:3px;background:linear-gradient(90deg,#c9a87c,#52b788);font-size:0;line-height:0;">&nbsp;</td></tr>
+
+        <tr><td style="padding:40px 40px 36px;">
+
+          <!-- EDIT: eyebrow / kicker. Small uppercase label above the heading. -->
+          <div style="font-family:'DM Mono',Menlo,Consolas,monospace;font-size:11px;letter-spacing:3px;text-transform:uppercase;color:#c9a87c;padding-bottom:18px;">
+            [[EYEBROW — e.g. Support &middot; Reply]]
+          </div>
+
+          <!-- EDIT: headline. One short line. Use &nbsp; between the last two
+               words to stop an ugly single word wrapping alone. -->
+          <div style="font-family:'Syne','Avenir Next','Helvetica Neue',Arial,sans-serif;font-size:30px;line-height:1.15;font-weight:800;color:#f0ece4;padding-bottom:16px;">
+            [[HEADING — e.g. We sorted&nbsp;that out.]]
+          </div>
+
+          <!-- EDIT: body. Write to the customer. Duplicate this whole <div>
+               for each extra paragraph. <a> links use the tan style shown. -->
+          <div style="font-family:'DM Sans','Helvetica Neue',Arial,sans-serif;font-size:15px;line-height:1.65;color:#a89f92;padding-bottom:20px;">
+            [[BODY PARAGRAPH — plain sentences. Bold with
+            <strong style="color:#e0c49a;font-weight:600;">this span</strong>,
+            link with
+            <a href="https://example.com" style="color:#c9a87c;text-decoration:underline;">a tan link</a>.]]
+          </div>
+
+          <!-- ============ OPTIONAL: highlight / note callout ============
+               Use to surface an order id, steps, or a quote. DELETE this
+               whole comment + table if you do not need it. -->
+          <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="margin:0 0 24px;">
+            <tr><td style="background-color:#0d0d0c;border:1px solid #2b241b;border-left:3px solid #c9a87c;border-radius:8px;padding:16px 18px;">
+              <div style="font-family:'DM Mono',Menlo,Consolas,monospace;font-size:10px;letter-spacing:2px;text-transform:uppercase;color:#c9a87c;padding-bottom:9px;">[[NOTE LABEL — e.g. Your order]]</div>
+              <div style="font-family:'DM Sans','Helvetica Neue',Arial,sans-serif;font-size:15px;line-height:1.6;color:#d8d0c4;">[[NOTE BODY — the highlighted detail.]]</div>
+            </td></tr>
+          </table>
+          <!-- ============ /OPTIONAL note callout ============ -->
+
+          <!-- ============ OPTIONAL: status line ============
+               Green "done" line, matches the gift email's "Active now".
+               DELETE if not relevant. -->
+          <div style="font-family:'DM Mono',Menlo,Consolas,monospace;font-size:12px;letter-spacing:0.5px;color:#52b788;padding-bottom:26px;">
+            [[STATUS — e.g. Resolved on your account now]]
+          </div>
+          <!-- ============ /OPTIONAL status line ============ -->
+
+          <!-- divider -->
+          <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+            <tr><td height="1" style="height:1px;background-color:#2b241b;font-size:0;line-height:0;">&nbsp;</td></tr>
+          </table>
+
+          <!-- ============ OPTIONAL: call-to-action button ============
+               DELETE this whole comment + table if the email needs no button. -->
+          <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin-top:30px;">
+            <tr><td bgcolor="#c9a87c" style="border-radius:100px;">
+              <a href="[[CTA URL — https://...]]" style="display:inline-block;padding:13px 30px;font-family:'DM Sans','Helvetica Neue',Arial,sans-serif;font-size:14px;font-weight:700;color:#0a0a0a;text-decoration:none;border-radius:100px;">
+                [[CTA LABEL — e.g. Open your dashboard &rarr;]]
+              </a>
+            </td></tr>
+          </table>
+          <!-- ============ /OPTIONAL call-to-action button ============ -->
+
+          <!-- sign-off: handwritten signature + bagel stamp, from the site's
+               story section. EDIT only the name line if you want. -->
+          <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="margin-top:36px;">
+            <tr>
+              <td valign="middle">
+                <span style="display:inline-block;">
+                  <span style="font-family:'Caveat',cursive;font-size:26px;font-weight:600;line-height:1;color:#e0c49a;">the ItsBagelBot support team</span>
+                  <span style="display:block;height:2px;margin-top:8px;border-radius:2px;background-color:#c9a87c;background-image:linear-gradient(90deg,rgba(201,168,124,0.7),rgba(82,183,136,0.5));font-size:0;line-height:0;">&nbsp;</span>
+                </span>
+              </td>
+              <td valign="middle" align="right" width="66">
+                <div style="display:inline-block;width:55px;height:55px;line-height:55px;text-align:center;font-size:24px;border:1.5px dashed rgba(201,168,124,0.4);border-radius:50%;transform:rotate(8deg);">&#129391;</div>
+              </td>
+            </tr>
+          </table>
+
+        </td></tr>
+      </table>
+    </td></tr>
+
+    <!-- anti-phishing notice. Ships on EVERY email, unchanged. Do not water
+         it down: it is the line that protects users from spoofed mail. -->
+    <tr><td style="padding:30px 8px 0;">
+      <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+        <tr><td height="1" style="height:1px;background-color:#2b241b;font-size:0;line-height:0;">&nbsp;</td></tr>
+      </table>
+      <div style="padding:16px 14px 0;font-family:'DM Sans','Helvetica Neue',Arial,sans-serif;font-size:12px;line-height:1.7;color:#888077;text-align:center;">
+        <span style="color:#c9a87c;font-weight:600;">&#128274; Staying safe.</span>
+        ItsBagelBot will never ask for your password, payment or card details, or login and verification codes by email. We only send from <span style="color:#a89f92;">@itsbagelbot.com</span>. If a message asks for any of that, it isn't us. Ignore it and reach the real team on <a href="https://discord.gg/SZ2remwSDv" style="color:#c9a87c;text-decoration:none;">Discord</a>.
+      </div>
+    </td></tr>
+
+    <!-- footer. EDIT the reason line if you like; keep the site link. -->
+    <tr><td align="center" style="padding:18px 20px 0;font-family:'DM Sans','Helvetica Neue',Arial,sans-serif;font-size:12px;line-height:1.7;color:#888077;">
+      Sent by ItsBagelBot support in reply to your message. Just reply to reach us again.<br>
+      <a href="https://itsbagelbot.com" style="color:#c9a87c;text-decoration:none;">itsbagelbot.com</a>
+    </td></tr>
+
+  </table>
+
+</td></tr>
+</table>
+</body>
+</html>

--- a/mail/support-email.txt
+++ b/mail/support-email.txt
@@ -1,0 +1,24 @@
+[ Official ItsBagelBot email - itsbagelbot.com ]
+
+[[EYEBROW — e.g. Support reply]]
+
+[[HEADING — e.g. We sorted that out.]]
+
+[[BODY — write to the customer in plain sentences. Blank line between
+paragraphs. No markup, this is the text-only version.]]
+
+[[OPTIONAL NOTE — LABEL: the highlighted detail. Delete if unused.]]
+
+[[OPTIONAL STATUS — e.g. Resolved on your account now. Delete if unused.]]
+
+[[OPTIONAL CTA LABEL]]: [[CTA URL — https://...   Delete both if unused.]]
+
+the ItsBagelBot support team
+
+Staying safe: ItsBagelBot will never ask for your password, payment or card
+details, or login and verification codes by email. We only send from
+@itsbagelbot.com. If a message asks for any of that, it isn't us. Ignore it and
+reach the real team on Discord: https://discord.gg/SZ2remwSDv
+
+Sent by ItsBagelBot support in reply to your message. Just reply to reach us again.
+https://itsbagelbot.com

--- a/web/public/bimi.svg
+++ b/web/public/bimi.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- BIMI logo. SVG Tiny Portable/Secure (baseProfile tiny-ps): required for
+     Brand Indicators for Message Identification. Deliberately constrained vs
+     favicon.svg: no <style>, no class/style attrs, no media queries, no
+     scripts or external refs, exactly one <title>, square viewBox. Solid tan
+     fill so it reads inside the circular avatar clients crop it to, matching
+     the tan pill buttons in the emails. Mark scaled to 0.8 and centred so the
+     circle crop never clips it. Keep under 32KB. -->
+<svg version="1.2" baseProfile="tiny-ps" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <title>ItsBagelBot</title>
+  <rect width="128" height="128" fill="#c9a87c"/>
+  <g transform="translate(12.8 12.8) scale(0.8)">
+    <path fill="#0a0a0a" d="M50.4 78.5a75.1 75.1 0 0 0-28.5 6.9l24.2-65.7c.7-2 1.9-3.2 3.4-3.2h29c1.5 0 2.7 1.2 3.4 3.2l24.2 65.7s-11.6-7-28.5-7L67 45.5c-.4-1.7-1.6-2.8-2.9-2.8-1.3 0-2.5 1.1-2.9 2.7L50.4 78.5Zm-1.1 28.2Zm-4.2-20.2c-2 6.6-.6 15.8 4.2 20.2a17.5 17.5 0 0 1 .2-.7 5.5 5.5 0 0 1 5.7-4.5c2.8.1 4.3 1.5 4.7 4.7.2 1.1.2 2.3.2 3.5v.4c0 2.7.7 5.2 2.2 7.4a13 13 0 0 0 5.7 4.9v-.3l-.2-.3c-1.8-5.6-.5-9.5 4.4-12.8l1.5-1a73 73 0 0 0 3.2-2.2 16 16 0 0 0 6.8-11.4c.3-2 .1-4-.6-6l-.8.6-1.6 1a37 37 0 0 1-22.4 2.7c-5-.7-9.7-2-13.2-6.2Z"/>
+  </g>
+</svg>


### PR DESCRIPTION
## What

Adds support-team email templates, wires up email authentication (DMARC/BIMI) so mail is recognisable and hard to spoof.

### `/mail` — support templates
Paste-ready HTML + plain-text templates matching the transactional gift email design (`app/transactions/mail/gift_template.go`). For humans pasting into Resend/Gmail/help desk, not code.
- `support-email.html` / `.txt` — the fill-in-the-blanks template.
- `received.html` / `.txt` — "message received" auto-ack: confirms receipt, open hours 10am–5pm most active days, Discord for faster replies.
- `example-filled.html` — rendered reference.
- Every template carries the same **verified-sender strip** (green ✓ header) + **anti-phishing footer** (never asks for passwords/payment/codes, only sends from @itsbagelbot.com).

### Email auth
- `web/public/bimi.svg` — SVG Tiny PS BIMI logo (validated: baseProfile tiny-ps, one title, square viewBox, no CSS/script/external refs, circle-crop safe).
- `deploy/dns/email-auth.md` — runbook: full SPF/DKIM/DMARC/BIMI state for Zoho + Resend, alignment rationale, ramp + VMC steps.
- `deploy/dns/bimi-add-vmc.sh` — one-command VMC wiring once purchased.

## Already applied live (Cloudflare API)
- DMARC `_dmarc` → `p=quarantine; sp=quarantine; pct=100; rua/ruf=dmarc@itsbagelbot.com`. Both senders verified aligned via DKIM (d=root), so no legit mail is quarantined.
- BIMI `default._bimi` → `v=BIMI1; l=https://itsbagelbot.com/bimi.svg;`.

## Merging this
Merge → web image builds → `https://itsbagelbot.com/bimi.svg` goes live (currently 404, harmless until then).

## Still owed (external, cannot be automated)
1. Create `dmarc@itsbagelbot.com` mailbox in Zoho (else reports bounce).
2. Ramp DMARC to `p=reject` after ~2 weeks of clean reports.
3. Buy VMC (trademark-gated) for Gmail/Apple to render the logo, then run `bimi-add-vmc.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)