### PR TITLE
feat(notifications): expire after read/peek + k3s cron cleanup

### DIFF
--- a/app/notifications/cleanup.go
+++ b/app/notifications/cleanup.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"context"
+	"time"
+
+	"go.uber.org/zap"
+
+	notificationsrpc "ItsBagelBot/internal/domain/rpc/notifications"
+	"ItsBagelBot/pkg/bus"
+	"ItsBagelBot/pkg/env"
+)
+
+// runCleanup is the one-shot cron entrypoint (`notifications cleanup`). It dials
+// NATS with the service's own RPC credentials and fires the internal cleanup
+// verb — a request/reply so the job surfaces the swept count and exits non-zero
+// on failure — then returns. Reusing the service image + creds means no extra
+// NATS account or image to maintain just for the janitor.
+func runCleanup(ctx context.Context, log *zap.Logger) error {
+	natsURL := env.Get("NATS_URL", "nats://127.0.0.1:4222")
+
+	nc, err := bus.Connect(bus.RPCURL(natsURL), serviceName+"-cleanup")
+	if err != nil {
+		return err
+	}
+	defer nc.Close()
+
+	subject := env.Get("NATS_NOTIFICATIONS_CLEANUP_SUBJECT", "bagel.rpc.internal.notifications.cleanup")
+
+	// RequestJSONTimeout already maps a {"error": ...} reply into a Go error, so
+	// a nil error here means the sweep succeeded.
+	reply, err := bus.RequestJSONTimeout[notificationsrpc.CleanupReply](
+		ctx, nc, subject, notificationsrpc.CleanupRequest{}, 30*time.Second)
+	if err != nil {
+		return err
+	}
+
+	log.Info("notification cleanup done", zap.Int("deleted", reply.Deleted))
+	return nil
+}

--- a/app/notifications/ent/migrate/schema.go
+++ b/app/notifications/ent/migrate/schema.go
@@ -45,6 +45,7 @@ var (
 		{Name: "id", Type: field.TypeInt, Increment: true},
 		{Name: "user_id", Type: field.TypeUint64},
 		{Name: "read_at", Type: field.TypeTime},
+		{Name: "expires_at", Type: field.TypeTime, Nullable: true},
 		{Name: "notification_reads", Type: field.TypeInt},
 	}
 	// NotificationReadsTable holds the schema information for the "notification_reads" table.
@@ -55,7 +56,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "notification_reads_notifications_reads",
-				Columns:    []*schema.Column{NotificationReadsColumns[3]},
+				Columns:    []*schema.Column{NotificationReadsColumns[4]},
 				RefColumns: []*schema.Column{NotificationsColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
@@ -64,7 +65,7 @@ var (
 			{
 				Name:    "notificationread_user_id_notification_reads",
 				Unique:  true,
-				Columns: []*schema.Column{NotificationReadsColumns[1], NotificationReadsColumns[3]},
+				Columns: []*schema.Column{NotificationReadsColumns[1], NotificationReadsColumns[4]},
 			},
 		},
 	}

--- a/app/notifications/ent/mutation.go
+++ b/app/notifications/ent/mutation.go
@@ -1073,6 +1073,7 @@ type NotificationReadMutation struct {
 	user_id             *uint64
 	adduser_id          *int64
 	read_at             *time.Time
+	expires_at          *time.Time
 	clearedFields       map[string]struct{}
 	notification        *int
 	clearednotification bool
@@ -1271,6 +1272,55 @@ func (m *NotificationReadMutation) ResetReadAt() {
 	m.read_at = nil
 }
 
+// SetExpiresAt sets the "expires_at" field.
+func (m *NotificationReadMutation) SetExpiresAt(t time.Time) {
+	m.expires_at = &t
+}
+
+// ExpiresAt returns the value of the "expires_at" field in the mutation.
+func (m *NotificationReadMutation) ExpiresAt() (r time.Time, exists bool) {
+	v := m.expires_at
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldExpiresAt returns the old "expires_at" field's value of the NotificationRead entity.
+// If the NotificationRead object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *NotificationReadMutation) OldExpiresAt(ctx context.Context) (v *time.Time, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldExpiresAt is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldExpiresAt requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldExpiresAt: %w", err)
+	}
+	return oldValue.ExpiresAt, nil
+}
+
+// ClearExpiresAt clears the value of the "expires_at" field.
+func (m *NotificationReadMutation) ClearExpiresAt() {
+	m.expires_at = nil
+	m.clearedFields[notificationread.FieldExpiresAt] = struct{}{}
+}
+
+// ExpiresAtCleared returns if the "expires_at" field was cleared in this mutation.
+func (m *NotificationReadMutation) ExpiresAtCleared() bool {
+	_, ok := m.clearedFields[notificationread.FieldExpiresAt]
+	return ok
+}
+
+// ResetExpiresAt resets all changes to the "expires_at" field.
+func (m *NotificationReadMutation) ResetExpiresAt() {
+	m.expires_at = nil
+	delete(m.clearedFields, notificationread.FieldExpiresAt)
+}
+
 // SetNotificationID sets the "notification" edge to the Notification entity by id.
 func (m *NotificationReadMutation) SetNotificationID(id int) {
 	m.notification = &id
@@ -1344,12 +1394,15 @@ func (m *NotificationReadMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *NotificationReadMutation) Fields() []string {
-	fields := make([]string, 0, 2)
+	fields := make([]string, 0, 3)
 	if m.user_id != nil {
 		fields = append(fields, notificationread.FieldUserID)
 	}
 	if m.read_at != nil {
 		fields = append(fields, notificationread.FieldReadAt)
+	}
+	if m.expires_at != nil {
+		fields = append(fields, notificationread.FieldExpiresAt)
 	}
 	return fields
 }
@@ -1363,6 +1416,8 @@ func (m *NotificationReadMutation) Field(name string) (ent.Value, bool) {
 		return m.UserID()
 	case notificationread.FieldReadAt:
 		return m.ReadAt()
+	case notificationread.FieldExpiresAt:
+		return m.ExpiresAt()
 	}
 	return nil, false
 }
@@ -1376,6 +1431,8 @@ func (m *NotificationReadMutation) OldField(ctx context.Context, name string) (e
 		return m.OldUserID(ctx)
 	case notificationread.FieldReadAt:
 		return m.OldReadAt(ctx)
+	case notificationread.FieldExpiresAt:
+		return m.OldExpiresAt(ctx)
 	}
 	return nil, fmt.Errorf("unknown NotificationRead field %s", name)
 }
@@ -1398,6 +1455,13 @@ func (m *NotificationReadMutation) SetField(name string, value ent.Value) error 
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetReadAt(v)
+		return nil
+	case notificationread.FieldExpiresAt:
+		v, ok := value.(time.Time)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetExpiresAt(v)
 		return nil
 	}
 	return fmt.Errorf("unknown NotificationRead field %s", name)
@@ -1443,7 +1507,11 @@ func (m *NotificationReadMutation) AddField(name string, value ent.Value) error 
 // ClearedFields returns all nullable fields that were cleared during this
 // mutation.
 func (m *NotificationReadMutation) ClearedFields() []string {
-	return nil
+	var fields []string
+	if m.FieldCleared(notificationread.FieldExpiresAt) {
+		fields = append(fields, notificationread.FieldExpiresAt)
+	}
+	return fields
 }
 
 // FieldCleared returns a boolean indicating if a field with the given name was
@@ -1456,6 +1524,11 @@ func (m *NotificationReadMutation) FieldCleared(name string) bool {
 // ClearField clears the value of the field with the given name. It returns an
 // error if the field is not defined in the schema.
 func (m *NotificationReadMutation) ClearField(name string) error {
+	switch name {
+	case notificationread.FieldExpiresAt:
+		m.ClearExpiresAt()
+		return nil
+	}
 	return fmt.Errorf("unknown NotificationRead nullable field %s", name)
 }
 
@@ -1468,6 +1541,9 @@ func (m *NotificationReadMutation) ResetField(name string) error {
 		return nil
 	case notificationread.FieldReadAt:
 		m.ResetReadAt()
+		return nil
+	case notificationread.FieldExpiresAt:
+		m.ResetExpiresAt()
 		return nil
 	}
 	return fmt.Errorf("unknown NotificationRead field %s", name)

--- a/app/notifications/ent/notificationread.go
+++ b/app/notifications/ent/notificationread.go
@@ -22,6 +22,8 @@ type NotificationRead struct {
 	UserID uint64 `json:"user_id,omitempty"`
 	// ReadAt holds the value of the "read_at" field.
 	ReadAt time.Time `json:"read_at,omitempty"`
+	// ExpiresAt holds the value of the "expires_at" field.
+	ExpiresAt *time.Time `json:"expires_at,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the NotificationReadQuery when eager-loading is set.
 	Edges              NotificationReadEdges `json:"edges"`
@@ -56,7 +58,7 @@ func (*NotificationRead) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case notificationread.FieldID, notificationread.FieldUserID:
 			values[i] = new(sql.NullInt64)
-		case notificationread.FieldReadAt:
+		case notificationread.FieldReadAt, notificationread.FieldExpiresAt:
 			values[i] = new(sql.NullTime)
 		case notificationread.ForeignKeys[0]: // notification_reads
 			values[i] = new(sql.NullInt64)
@@ -92,6 +94,13 @@ func (_m *NotificationRead) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field read_at", values[i])
 			} else if value.Valid {
 				_m.ReadAt = value.Time
+			}
+		case notificationread.FieldExpiresAt:
+			if value, ok := values[i].(*sql.NullTime); !ok {
+				return fmt.Errorf("unexpected type %T for field expires_at", values[i])
+			} else if value.Valid {
+				_m.ExpiresAt = new(time.Time)
+				*_m.ExpiresAt = value.Time
 			}
 		case notificationread.ForeignKeys[0]:
 			if value, ok := values[i].(*sql.NullInt64); !ok {
@@ -146,6 +155,11 @@ func (_m *NotificationRead) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("read_at=")
 	builder.WriteString(_m.ReadAt.Format(time.ANSIC))
+	builder.WriteString(", ")
+	if v := _m.ExpiresAt; v != nil {
+		builder.WriteString("expires_at=")
+		builder.WriteString(v.Format(time.ANSIC))
+	}
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/app/notifications/ent/notificationread/notificationread.go
+++ b/app/notifications/ent/notificationread/notificationread.go
@@ -18,6 +18,8 @@ const (
 	FieldUserID = "user_id"
 	// FieldReadAt holds the string denoting the read_at field in the database.
 	FieldReadAt = "read_at"
+	// FieldExpiresAt holds the string denoting the expires_at field in the database.
+	FieldExpiresAt = "expires_at"
 	// EdgeNotification holds the string denoting the notification edge name in mutations.
 	EdgeNotification = "notification"
 	// Table holds the table name of the notificationread in the database.
@@ -36,6 +38,7 @@ var Columns = []string{
 	FieldID,
 	FieldUserID,
 	FieldReadAt,
+	FieldExpiresAt,
 }
 
 // ForeignKeys holds the SQL foreign-keys that are owned by the "notification_reads"
@@ -80,6 +83,11 @@ func ByUserID(opts ...sql.OrderTermOption) OrderOption {
 // ByReadAt orders the results by the read_at field.
 func ByReadAt(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldReadAt, opts...).ToFunc()
+}
+
+// ByExpiresAt orders the results by the expires_at field.
+func ByExpiresAt(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldExpiresAt, opts...).ToFunc()
 }
 
 // ByNotificationField orders the results by notification field.

--- a/app/notifications/ent/notificationread/where.go
+++ b/app/notifications/ent/notificationread/where.go
@@ -65,6 +65,11 @@ func ReadAt(v time.Time) predicate.NotificationRead {
 	return predicate.NotificationRead(sql.FieldEQ(FieldReadAt, v))
 }
 
+// ExpiresAt applies equality check predicate on the "expires_at" field. It's identical to ExpiresAtEQ.
+func ExpiresAt(v time.Time) predicate.NotificationRead {
+	return predicate.NotificationRead(sql.FieldEQ(FieldExpiresAt, v))
+}
+
 // UserIDEQ applies the EQ predicate on the "user_id" field.
 func UserIDEQ(v uint64) predicate.NotificationRead {
 	return predicate.NotificationRead(sql.FieldEQ(FieldUserID, v))
@@ -143,6 +148,56 @@ func ReadAtLT(v time.Time) predicate.NotificationRead {
 // ReadAtLTE applies the LTE predicate on the "read_at" field.
 func ReadAtLTE(v time.Time) predicate.NotificationRead {
 	return predicate.NotificationRead(sql.FieldLTE(FieldReadAt, v))
+}
+
+// ExpiresAtEQ applies the EQ predicate on the "expires_at" field.
+func ExpiresAtEQ(v time.Time) predicate.NotificationRead {
+	return predicate.NotificationRead(sql.FieldEQ(FieldExpiresAt, v))
+}
+
+// ExpiresAtNEQ applies the NEQ predicate on the "expires_at" field.
+func ExpiresAtNEQ(v time.Time) predicate.NotificationRead {
+	return predicate.NotificationRead(sql.FieldNEQ(FieldExpiresAt, v))
+}
+
+// ExpiresAtIn applies the In predicate on the "expires_at" field.
+func ExpiresAtIn(vs ...time.Time) predicate.NotificationRead {
+	return predicate.NotificationRead(sql.FieldIn(FieldExpiresAt, vs...))
+}
+
+// ExpiresAtNotIn applies the NotIn predicate on the "expires_at" field.
+func ExpiresAtNotIn(vs ...time.Time) predicate.NotificationRead {
+	return predicate.NotificationRead(sql.FieldNotIn(FieldExpiresAt, vs...))
+}
+
+// ExpiresAtGT applies the GT predicate on the "expires_at" field.
+func ExpiresAtGT(v time.Time) predicate.NotificationRead {
+	return predicate.NotificationRead(sql.FieldGT(FieldExpiresAt, v))
+}
+
+// ExpiresAtGTE applies the GTE predicate on the "expires_at" field.
+func ExpiresAtGTE(v time.Time) predicate.NotificationRead {
+	return predicate.NotificationRead(sql.FieldGTE(FieldExpiresAt, v))
+}
+
+// ExpiresAtLT applies the LT predicate on the "expires_at" field.
+func ExpiresAtLT(v time.Time) predicate.NotificationRead {
+	return predicate.NotificationRead(sql.FieldLT(FieldExpiresAt, v))
+}
+
+// ExpiresAtLTE applies the LTE predicate on the "expires_at" field.
+func ExpiresAtLTE(v time.Time) predicate.NotificationRead {
+	return predicate.NotificationRead(sql.FieldLTE(FieldExpiresAt, v))
+}
+
+// ExpiresAtIsNil applies the IsNil predicate on the "expires_at" field.
+func ExpiresAtIsNil() predicate.NotificationRead {
+	return predicate.NotificationRead(sql.FieldIsNull(FieldExpiresAt))
+}
+
+// ExpiresAtNotNil applies the NotNil predicate on the "expires_at" field.
+func ExpiresAtNotNil() predicate.NotificationRead {
+	return predicate.NotificationRead(sql.FieldNotNull(FieldExpiresAt))
 }
 
 // HasNotification applies the HasEdge predicate on the "notification" edge.

--- a/app/notifications/ent/notificationread_create.go
+++ b/app/notifications/ent/notificationread_create.go
@@ -41,6 +41,20 @@ func (_c *NotificationReadCreate) SetNillableReadAt(v *time.Time) *NotificationR
 	return _c
 }
 
+// SetExpiresAt sets the "expires_at" field.
+func (_c *NotificationReadCreate) SetExpiresAt(v time.Time) *NotificationReadCreate {
+	_c.mutation.SetExpiresAt(v)
+	return _c
+}
+
+// SetNillableExpiresAt sets the "expires_at" field if the given value is not nil.
+func (_c *NotificationReadCreate) SetNillableExpiresAt(v *time.Time) *NotificationReadCreate {
+	if v != nil {
+		_c.SetExpiresAt(*v)
+	}
+	return _c
+}
+
 // SetNotificationID sets the "notification" edge to the Notification entity by ID.
 func (_c *NotificationReadCreate) SetNotificationID(id int) *NotificationReadCreate {
 	_c.mutation.SetNotificationID(id)
@@ -137,6 +151,10 @@ func (_c *NotificationReadCreate) createSpec() (*NotificationRead, *sqlgraph.Cre
 	if value, ok := _c.mutation.ReadAt(); ok {
 		_spec.SetField(notificationread.FieldReadAt, field.TypeTime, value)
 		_node.ReadAt = value
+	}
+	if value, ok := _c.mutation.ExpiresAt(); ok {
+		_spec.SetField(notificationread.FieldExpiresAt, field.TypeTime, value)
+		_node.ExpiresAt = &value
 	}
 	if nodes := _c.mutation.NotificationIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{

--- a/app/notifications/ent/notificationread_update.go
+++ b/app/notifications/ent/notificationread_update.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
@@ -46,6 +47,26 @@ func (_u *NotificationReadUpdate) SetNillableUserID(v *uint64) *NotificationRead
 // AddUserID adds value to the "user_id" field.
 func (_u *NotificationReadUpdate) AddUserID(v int64) *NotificationReadUpdate {
 	_u.mutation.AddUserID(v)
+	return _u
+}
+
+// SetExpiresAt sets the "expires_at" field.
+func (_u *NotificationReadUpdate) SetExpiresAt(v time.Time) *NotificationReadUpdate {
+	_u.mutation.SetExpiresAt(v)
+	return _u
+}
+
+// SetNillableExpiresAt sets the "expires_at" field if the given value is not nil.
+func (_u *NotificationReadUpdate) SetNillableExpiresAt(v *time.Time) *NotificationReadUpdate {
+	if v != nil {
+		_u.SetExpiresAt(*v)
+	}
+	return _u
+}
+
+// ClearExpiresAt clears the value of the "expires_at" field.
+func (_u *NotificationReadUpdate) ClearExpiresAt() *NotificationReadUpdate {
+	_u.mutation.ClearExpiresAt()
 	return _u
 }
 
@@ -124,6 +145,12 @@ func (_u *NotificationReadUpdate) sqlSave(ctx context.Context) (_node int, err e
 	if value, ok := _u.mutation.AddedUserID(); ok {
 		_spec.AddField(notificationread.FieldUserID, field.TypeUint64, value)
 	}
+	if value, ok := _u.mutation.ExpiresAt(); ok {
+		_spec.SetField(notificationread.FieldExpiresAt, field.TypeTime, value)
+	}
+	if _u.mutation.ExpiresAtCleared() {
+		_spec.ClearField(notificationread.FieldExpiresAt, field.TypeTime)
+	}
 	if _u.mutation.NotificationCleared() {
 		edge := &sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.M2O,
@@ -191,6 +218,26 @@ func (_u *NotificationReadUpdateOne) SetNillableUserID(v *uint64) *NotificationR
 // AddUserID adds value to the "user_id" field.
 func (_u *NotificationReadUpdateOne) AddUserID(v int64) *NotificationReadUpdateOne {
 	_u.mutation.AddUserID(v)
+	return _u
+}
+
+// SetExpiresAt sets the "expires_at" field.
+func (_u *NotificationReadUpdateOne) SetExpiresAt(v time.Time) *NotificationReadUpdateOne {
+	_u.mutation.SetExpiresAt(v)
+	return _u
+}
+
+// SetNillableExpiresAt sets the "expires_at" field if the given value is not nil.
+func (_u *NotificationReadUpdateOne) SetNillableExpiresAt(v *time.Time) *NotificationReadUpdateOne {
+	if v != nil {
+		_u.SetExpiresAt(*v)
+	}
+	return _u
+}
+
+// ClearExpiresAt clears the value of the "expires_at" field.
+func (_u *NotificationReadUpdateOne) ClearExpiresAt() *NotificationReadUpdateOne {
+	_u.mutation.ClearExpiresAt()
 	return _u
 }
 
@@ -298,6 +345,12 @@ func (_u *NotificationReadUpdateOne) sqlSave(ctx context.Context) (_node *Notifi
 	}
 	if value, ok := _u.mutation.AddedUserID(); ok {
 		_spec.AddField(notificationread.FieldUserID, field.TypeUint64, value)
+	}
+	if value, ok := _u.mutation.ExpiresAt(); ok {
+		_spec.SetField(notificationread.FieldExpiresAt, field.TypeTime, value)
+	}
+	if _u.mutation.ExpiresAtCleared() {
+		_spec.ClearField(notificationread.FieldExpiresAt, field.TypeTime)
 	}
 	if _u.mutation.NotificationCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/app/notifications/ent/schema/notification_read.go
+++ b/app/notifications/ent/schema/notification_read.go
@@ -21,6 +21,12 @@ func (NotificationRead) Fields() []ent.Field {
 		field.Uint64("user_id"),
 
 		field.Time("read_at").Default(time.Now).Immutable(),
+
+		// Per-user visibility cutoff. Once passed the notification drops out of
+		// this user's list even though the row (and the notification) still
+		// exist. A full read sets a short cutoff; a dropdown "peek" sets a longer
+		// reduced one. Nil means the read never lapses (legacy rows).
+		field.Time("expires_at").Optional().Nillable(),
 	}
 }
 

--- a/app/notifications/main.go
+++ b/app/notifications/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"ItsBagelBot/app/notifications/ent"
 	// Wire the ent schema runtime (field defaults/hooks); without this blank
@@ -28,6 +29,17 @@ func main() {
 
 	log := logger.New(env.Get("APP_ENV", "development")).Named(serviceName)
 	defer func() { _ = log.Sync() }()
+
+	// One-shot cron mode: `notifications cleanup` just fires the janitor verb at
+	// the running service and exits, so the k3s CronJob reuses this same image.
+	if len(os.Args) > 1 && os.Args[1] == "cleanup" {
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+		if err := runCleanup(ctx, log); err != nil {
+			log.Fatal("notification cleanup failed", zap.Error(err))
+		}
+		return
+	}
 
 	nrApp, err := monitor.New(serviceName, log)
 	if err != nil {
@@ -71,6 +83,14 @@ func main() {
 	queueGroup := "notifications-rpc"
 	invalidationPrefix := env.Get("NATS_CACHE_INVALIDATION_PREFIX", "bagel.cache.invalidate")
 
+	// TTL tiers (all Go durations). A send with no explicit expiry lives
+	// defaultTTL globally so the cron eventually sweeps it; a full read hides it
+	// from that user after fullReadTTL; opening the bell dropdown (peek) hides
+	// an unread one after the longer, reduced peekTTL.
+	defaultTTL := env.GetDuration("NOTIF_DEFAULT_TTL", 90*24*time.Hour)
+	fullReadTTL := env.GetDuration("NOTIF_FULL_READ_TTL", 24*time.Hour)
+	peekTTL := env.GetDuration("NOTIF_PEEK_TTL", 7*24*time.Hour)
+
 	// Cross-service lookup so an admin can target a direct notification by
 	// username, not just numeric id.
 	userGetSubject := env.Get("NATS_ADMIN_USER_SUBJECT_PREFIX", "bagel.rpc.admin.user") + ".get"
@@ -81,21 +101,37 @@ func main() {
 		InvalidationPrefix: invalidationPrefix,
 		UserGetSubject:     userGetSubject,
 		QueueGroup:         queueGroup,
+		DefaultTTL:         defaultTTL,
 	}
 	if err := rpc.SubscribeAdmin(nc, repo, adminCfg, nrApp, log); err != nil {
 		log.Fatal("failed to subscribe admin rpc", zap.Error(err))
 	}
 
 	userPrefix := env.Get("NATS_NOTIFICATIONS_SUBJECT_PREFIX", "bagel.rpc.notifications")
-	if err := rpc.SubscribeUser(nc, repo, rpc.UserConfig{Prefix: userPrefix, QueueGroup: queueGroup}, nrApp, log); err != nil {
+	userCfg := rpc.UserConfig{
+		Prefix:      userPrefix,
+		QueueGroup:  queueGroup,
+		FullReadTTL: fullReadTTL,
+		PeekTTL:     peekTTL,
+	}
+	if err := rpc.SubscribeUser(nc, repo, userCfg, nrApp, log); err != nil {
 		log.Fatal("failed to subscribe user rpc", zap.Error(err))
+	}
+
+	// Internal janitor verb driven by the k3s cron (see deploy/k8s). Not
+	// exported from the NATS account, so only a client with the service's own
+	// credentials can reach it.
+	cleanupSubject := env.Get("NATS_NOTIFICATIONS_CLEANUP_SUBJECT", "bagel.rpc.internal.notifications.cleanup")
+	if err := rpc.SubscribeMaintenance(nc, repo, cleanupSubject, queueGroup, nrApp, log); err != nil {
+		log.Fatal("failed to subscribe maintenance rpc", zap.Error(err))
 	}
 
 	health.Serve(env.Get("LISTEN_ADDR", ":8080"), nc.IsConnected)
 
 	log.Info("notifications service ready",
 		zap.String("admin_prefix", adminPrefix),
-		zap.String("user_prefix", userPrefix))
+		zap.String("user_prefix", userPrefix),
+		zap.String("cleanup_subject", cleanupSubject))
 
 	<-ctx.Done()
 

--- a/app/notifications/repository/notifications.go
+++ b/app/notifications/repository/notifications.go
@@ -7,6 +7,7 @@ import (
 	"ItsBagelBot/app/notifications/ent"
 	"ItsBagelBot/app/notifications/ent/notification"
 	"ItsBagelBot/app/notifications/ent/notificationread"
+	"ItsBagelBot/app/notifications/ent/predicate"
 	"ItsBagelBot/pkg/db"
 )
 
@@ -92,23 +93,45 @@ func (r *Notifications) CountForAdmin(ctx context.Context) (int, error) {
 	})
 }
 
+// visibleForUser matches notifications this user is allowed to see (broadcast or
+// directed at them) and whose global expiry has not passed at now. Shared by
+// ListForUser and MarkPeeked so both agree on the candidate set.
+func visibleForUser(userID uint64, now time.Time) predicate.Notification {
+	return notification.And(
+		notification.Or(
+			notification.ScopeEQ(notification.ScopeBroadcast),
+			notification.TargetUserIDEQ(userID),
+		),
+		notification.Or(
+			notification.ExpiresAtIsNil(),
+			notification.ExpiresAtGT(now),
+		),
+	)
+}
+
+// lapsedForUser matches notifications this user has already let expire: a read
+// row exists whose per-user cutoff (full read or dropdown peek) has passed.
+func lapsedForUser(userID uint64, now time.Time) predicate.Notification {
+	return notification.HasReadsWith(
+		notificationread.UserIDEQ(userID),
+		notificationread.ExpiresAtNotNil(),
+		notificationread.ExpiresAtLTE(now),
+	)
+}
+
 // ListForUser returns the broadcast + direct-to-user notifications this user
-// can see (newest first, expired rows excluded), plus the set of ids already
-// acknowledged by that user.
+// can see (newest first, globally- and per-user-expired rows excluded), plus
+// the set of ids already acknowledged by that user.
 func (r *Notifications) ListForUser(ctx context.Context, userID uint64, limit int) ([]*ent.Notification, map[int]bool, error) {
 	now := time.Now()
 
 	rows, err := db.WithQuery(ctx, func(ctx context.Context) ([]*ent.Notification, error) {
 		return r.client.Notification.Query().
 			Where(
-				notification.Or(
-					notification.ScopeEQ(notification.ScopeBroadcast),
-					notification.TargetUserIDEQ(userID),
-				),
-				notification.Or(
-					notification.ExpiresAtIsNil(),
-					notification.ExpiresAtGT(now),
-				),
+				visibleForUser(userID, now),
+				// Drop anything this user has already let lapse so the reduced
+				// peek / full-read cutoff actually hides it.
+				notification.Not(lapsedForUser(userID, now)),
 			).
 			Order(ent.Desc(notification.FieldCreatedAt)).
 			Limit(limit).
@@ -149,19 +172,140 @@ func (r *Notifications) ListForUser(ctx context.Context, userID uint64, limit in
 	return rows, read, nil
 }
 
-// MarkRead records that userID has acknowledged notificationID. Idempotent:
-// a repeat mark-read is a silent no-op rather than a unique-constraint error.
-func (r *Notifications) MarkRead(ctx context.Context, notificationID int, userID uint64) error {
-	err := db.WithExec(ctx, func(ctx context.Context) error {
-		return r.client.NotificationRead.Create().
+// MarkRead records (or refreshes) that userID has acknowledged notificationID
+// and sets the per-user visibility cutoff to expiresAt. Idempotent: a repeat
+// mark-read — or a full read after a dropdown peek — shortens the cutoff on the
+// existing row instead of erroring on the unique (user, notification) index.
+func (r *Notifications) MarkRead(ctx context.Context, notificationID int, userID uint64, expiresAt time.Time) error {
+	return db.WithExec(ctx, func(ctx context.Context) error {
+		err := r.client.NotificationRead.Create().
 			SetNotificationID(notificationID).
 			SetUserID(userID).
+			SetExpiresAt(expiresAt).
+			Exec(ctx)
+		if err == nil {
+			return nil
+		}
+		if !ent.IsConstraintError(err) {
+			return err
+		}
+		// Row already exists (earlier read or peek): pull the cutoff in.
+		_, updErr := r.client.NotificationRead.Update().
+			Where(
+				notificationread.UserIDEQ(userID),
+				notificationread.HasNotificationWith(notification.IDEQ(notificationID)),
+			).
+			SetExpiresAt(expiresAt).
+			Save(ctx)
+		return updErr
+	})
+}
+
+// MarkPeeked is the dropdown-open path: it inserts a read row carrying the
+// reduced peek cutoff for every notification this user can currently see that
+// has no read row yet. Rows already read (or peeked earlier) are left untouched
+// — a peek only ever shortens a notification's life for a user, never extends
+// it, so it must not overwrite an existing (shorter, full-read) cutoff. Returns
+// how many notifications were newly peeked.
+func (r *Notifications) MarkPeeked(ctx context.Context, userID uint64, expiresAt time.Time) (int, error) {
+	now := time.Now()
+
+	ids, err := db.WithQuery(ctx, func(ctx context.Context) ([]int, error) {
+		return r.client.Notification.Query().
+			Where(visibleForUser(userID, now)).
+			Limit(UserListLimit).
+			IDs(ctx)
+	})
+	if err != nil {
+		return 0, err
+	}
+	if len(ids) == 0 {
+		return 0, nil
+	}
+
+	readRows, err := db.WithQuery(ctx, func(ctx context.Context) ([]*ent.NotificationRead, error) {
+		return r.client.NotificationRead.Query().
+			Where(
+				notificationread.UserIDEQ(userID),
+				notificationread.HasNotificationWith(notification.IDIn(ids...)),
+			).
+			WithNotification().
+			All(ctx)
+	})
+	if err != nil {
+		return 0, err
+	}
+	already := make(map[int]bool, len(readRows))
+	for _, rr := range readRows {
+		if rr.Edges.Notification != nil {
+			already[rr.Edges.Notification.ID] = true
+		}
+	}
+
+	missing := make([]int, 0, len(ids))
+	for _, id := range ids {
+		if !already[id] {
+			missing = append(missing, id)
+		}
+	}
+	if len(missing) == 0 {
+		return 0, nil
+	}
+
+	builders := make([]*ent.NotificationReadCreate, len(missing))
+	for i, id := range missing {
+		builders[i] = r.client.NotificationRead.Create().
+			SetNotificationID(id).
+			SetUserID(userID).
+			SetExpiresAt(expiresAt)
+	}
+
+	// Fast path: one bulk insert. MySQL rejects the whole batch on a unique
+	// collision (a concurrent peek by the same user), so fall back to
+	// per-row inserts that skip the rows another writer already claimed.
+	err = db.WithExec(ctx, func(ctx context.Context) error {
+		return r.client.NotificationRead.CreateBulk(builders...).Exec(ctx)
+	})
+	if err == nil {
+		return len(missing), nil
+	}
+	if !ent.IsConstraintError(err) {
+		return 0, err
+	}
+
+	peeked := 0
+	for _, id := range missing {
+		insErr := db.WithExec(ctx, func(ctx context.Context) error {
+			return r.client.NotificationRead.Create().
+				SetNotificationID(id).
+				SetUserID(userID).
+				SetExpiresAt(expiresAt).
+				Exec(ctx)
+		})
+		if insErr == nil {
+			peeked++
+			continue
+		}
+		if !ent.IsConstraintError(insErr) {
+			return peeked, insErr
+		}
+	}
+	return peeked, nil
+}
+
+// DeleteExpired hard-deletes every notification whose global expiry has passed,
+// cascading its read receipts. This is the janitor the k3s cron drives; per-user
+// read cutoffs only hide rows (ListForUser filtering), so their storage is
+// reclaimed when the parent notification is swept here. Returns rows removed.
+func (r *Notifications) DeleteExpired(ctx context.Context, now time.Time) (int, error) {
+	return db.WithQuery(ctx, func(ctx context.Context) (int, error) {
+		return r.client.Notification.Delete().
+			Where(
+				notification.ExpiresAtNotNil(),
+				notification.ExpiresAtLTE(now),
+			).
 			Exec(ctx)
 	})
-	if err != nil && ent.IsConstraintError(err) {
-		return nil
-	}
-	return err
 }
 
 // Delete retracts a notification (cascades to its read receipts).

--- a/app/notifications/repository/notifications_test.go
+++ b/app/notifications/repository/notifications_test.go
@@ -7,6 +7,7 @@ import (
 
 	"ItsBagelBot/app/notifications/ent/enttest"
 	"ItsBagelBot/app/notifications/ent/notification"
+	"ItsBagelBot/app/notifications/ent/notificationread"
 	"ItsBagelBot/app/notifications/repository"
 
 	_ "github.com/mattn/go-sqlite3" // Required for the in-memory DB
@@ -64,8 +65,9 @@ func TestMarkReadIsIdempotentAndPerUser(t *testing.T) {
 	row, _, err := repo.Create(ctx, repository.CreateParams{RequestID: "read-1", Scope: notification.ScopeBroadcast, Title: "Heads up", Body: "Body", Level: notification.LevelInfo, CreatedBy: 1, CreatedByLogin: "itsmavey"})
 	require.NoError(t, err)
 
-	require.NoError(t, repo.MarkRead(ctx, row.ID, 1001))
-	require.NoError(t, repo.MarkRead(ctx, row.ID, 1001), "repeat mark-read must not error")
+	future := time.Now().Add(time.Hour)
+	require.NoError(t, repo.MarkRead(ctx, row.ID, 1001, future))
+	require.NoError(t, repo.MarkRead(ctx, row.ID, 1001, future), "repeat mark-read must not error")
 
 	_, read, err := repo.ListForUser(ctx, 1001, 50)
 	require.NoError(t, err)
@@ -106,7 +108,7 @@ func TestDeleteCascadesReads(t *testing.T) {
 
 	row, _, err := repo.Create(ctx, repository.CreateParams{RequestID: "delete-1", Scope: notification.ScopeBroadcast, Title: "Bye", Body: "Body", Level: notification.LevelInfo, CreatedBy: 1, CreatedByLogin: "itsmavey"})
 	require.NoError(t, err)
-	require.NoError(t, repo.MarkRead(ctx, row.ID, 1001))
+	require.NoError(t, repo.MarkRead(ctx, row.ID, 1001, time.Now().Add(time.Hour)))
 
 	require.NoError(t, repo.Delete(ctx, row.ID))
 
@@ -115,6 +117,96 @@ func TestDeleteCascadesReads(t *testing.T) {
 	admin, err := repo.ListForAdmin(ctx, 20, 0)
 	require.NoError(t, err)
 	assert.Empty(t, admin)
+}
+
+func TestMarkReadCutoffHidesAfterExpiry(t *testing.T) {
+	client := enttest.Open(t, "sqlite3", "file:notifreadcutoff?mode=memory&cache=shared&_fk=1")
+	t.Cleanup(func() { _ = client.Close() })
+
+	repo := repository.New(client)
+	ctx := context.Background()
+
+	row, _, err := repo.Create(ctx, repository.CreateParams{RequestID: "cutoff-1", Scope: notification.ScopeBroadcast, Title: "Heads up", Body: "Body", Level: notification.LevelInfo, CreatedBy: 1, CreatedByLogin: "itsmavey"})
+	require.NoError(t, err)
+
+	// A cutoff already in the past hides the row from that user immediately,
+	// while every other user still sees it (per-user, not global, expiry).
+	require.NoError(t, repo.MarkRead(ctx, row.ID, 1001, time.Now().Add(-time.Minute)))
+
+	rows, _, err := repo.ListForUser(ctx, 1001, 50)
+	require.NoError(t, err)
+	assert.Empty(t, rows, "a lapsed per-user cutoff must hide the notification")
+
+	rows, _, err = repo.ListForUser(ctx, 2002, 50)
+	require.NoError(t, err)
+	require.Len(t, rows, 1, "another user's cutoff must not hide it")
+}
+
+func TestMarkPeekedAcknowledgesWithoutClobberingFullRead(t *testing.T) {
+	client := enttest.Open(t, "sqlite3", "file:notifpeek?mode=memory&cache=shared&_fk=1")
+	t.Cleanup(func() { _ = client.Close() })
+
+	repo := repository.New(client)
+	ctx := context.Background()
+
+	a, _, err := repo.Create(ctx, repository.CreateParams{RequestID: "peek-a", Scope: notification.ScopeBroadcast, Title: "A", Body: "Body", Level: notification.LevelInfo, CreatedBy: 1, CreatedByLogin: "itsmavey"})
+	require.NoError(t, err)
+	b, _, err := repo.Create(ctx, repository.CreateParams{RequestID: "peek-b", Scope: notification.ScopeBroadcast, Title: "B", Body: "Body", Level: notification.LevelInfo, CreatedBy: 1, CreatedByLogin: "itsmavey"})
+	require.NoError(t, err)
+
+	// Full-read b first with a short cutoff, then peek. The peek must not extend
+	// b's cutoff, and must acknowledge the still-unread a.
+	shortCutoff := time.Now().Add(time.Minute)
+	require.NoError(t, repo.MarkRead(ctx, b.ID, 1001, shortCutoff))
+
+	peeked, err := repo.MarkPeeked(ctx, 1001, time.Now().Add(24*time.Hour))
+	require.NoError(t, err)
+	assert.Equal(t, 1, peeked, "only the unread notification is newly peeked")
+
+	_, read, err := repo.ListForUser(ctx, 1001, 50)
+	require.NoError(t, err)
+	assert.True(t, read[a.ID], "peek acknowledges the unread notification")
+	assert.True(t, read[b.ID])
+
+	bRead := client.NotificationRead.Query().
+		Where(
+			notificationread.UserIDEQ(1001),
+			notificationread.HasNotificationWith(notification.IDEQ(b.ID)),
+		).OnlyX(ctx)
+	assert.WithinDuration(t, shortCutoff, *bRead.ExpiresAt, time.Second,
+		"peek must not extend a full-read cutoff")
+
+	// A second peek is a no-op: everything already has a read row.
+	peeked, err = repo.MarkPeeked(ctx, 1001, time.Now().Add(24*time.Hour))
+	require.NoError(t, err)
+	assert.Equal(t, 0, peeked)
+}
+
+func TestDeleteExpiredSweepsGloballyExpired(t *testing.T) {
+	client := enttest.Open(t, "sqlite3", "file:notifsweep?mode=memory&cache=shared&_fk=1")
+	t.Cleanup(func() { _ = client.Close() })
+
+	repo := repository.New(client)
+	ctx := context.Background()
+
+	past := time.Now().Add(-time.Hour)
+	dead, _, err := repo.Create(ctx, repository.CreateParams{RequestID: "dead-1", Scope: notification.ScopeBroadcast, Title: "Dead", Body: "Body", Level: notification.LevelInfo, CreatedBy: 1, CreatedByLogin: "itsmavey", ExpiresAt: &past})
+	require.NoError(t, err)
+	require.NoError(t, repo.MarkRead(ctx, dead.ID, 1001, time.Now().Add(time.Hour)))
+
+	future := time.Now().Add(time.Hour)
+	_, _, err = repo.Create(ctx, repository.CreateParams{RequestID: "live-1", Scope: notification.ScopeBroadcast, Title: "Live", Body: "Body", Level: notification.LevelInfo, CreatedBy: 1, CreatedByLogin: "itsmavey", ExpiresAt: &future})
+	require.NoError(t, err)
+
+	// Never-expires row (nil global cutoff) must survive the sweep.
+	_, _, err = repo.Create(ctx, repository.CreateParams{RequestID: "keep-1", Scope: notification.ScopeBroadcast, Title: "Keep", Body: "Body", Level: notification.LevelInfo, CreatedBy: 1, CreatedByLogin: "itsmavey"})
+	require.NoError(t, err)
+
+	removed, err := repo.DeleteExpired(ctx, time.Now())
+	require.NoError(t, err)
+	assert.Equal(t, 1, removed, "only the globally-expired notification is swept")
+	assert.Equal(t, 2, client.Notification.Query().CountX(ctx))
+	assert.Equal(t, 0, client.NotificationRead.Query().CountX(ctx), "swept notification's reads cascade")
 }
 
 func TestCreateIsIdempotentByRequestID(t *testing.T) {

--- a/app/notifications/rpc/admin.go
+++ b/app/notifications/rpc/admin.go
@@ -23,7 +23,11 @@ type adminRPC struct {
 	nc                 *nats.Conn
 	invalidationPrefix string
 	userGetSubject     string
-	log                *zap.Logger
+	// defaultTTL bounds a notification's global life when the sender does not
+	// set an explicit expiry, so every send is eventually reachable by the
+	// cron janitor instead of living forever.
+	defaultTTL time.Duration
+	log        *zap.Logger
 }
 
 // AdminConfig carries the NATS wiring for the admin RPC surface.
@@ -32,6 +36,10 @@ type AdminConfig struct {
 	InvalidationPrefix string
 	UserGetSubject     string
 	QueueGroup         string
+	// DefaultTTL bounds a notification's global life when the sender does not
+	// set an explicit expiry, so every send is eventually reachable by the
+	// cron janitor instead of living forever.
+	DefaultTTL time.Duration
 }
 
 // SubscribeAdmin registers the admin-console verbs: compose/send a
@@ -42,6 +50,7 @@ func SubscribeAdmin(nc *nats.Conn, repo *repository.Notifications, cfg AdminConf
 		nc:                 nc,
 		invalidationPrefix: cfg.InvalidationPrefix,
 		userGetSubject:     cfg.UserGetSubject,
+		defaultTTL:         cfg.DefaultTTL,
 		log:                log,
 	}
 
@@ -107,6 +116,14 @@ func (a *adminRPC) send(ctx context.Context, req notificationsrpc.SendRequest) n
 			return notificationsrpc.SendReply{Error: err.Error()}
 		}
 		params.TargetUserID = &id
+	}
+
+	// Fall back to the default global TTL when the sender didn't pin an expiry,
+	// so the notification is eventually swept by the cron instead of living
+	// forever.
+	if params.ExpiresAt == nil && a.defaultTTL > 0 {
+		exp := time.Now().Add(a.defaultTTL)
+		params.ExpiresAt = &exp
 	}
 
 	row, created, err := a.repo.Create(ctx, params)

--- a/app/notifications/rpc/maintenance.go
+++ b/app/notifications/rpc/maintenance.go
@@ -1,0 +1,41 @@
+package rpc
+
+import (
+	"context"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/newrelic/go-agent/v3/newrelic"
+	"go.uber.org/zap"
+
+	"ItsBagelBot/app/notifications/repository"
+	notificationsrpc "ItsBagelBot/internal/domain/rpc/notifications"
+	"ItsBagelBot/pkg/bus"
+)
+
+type maintenanceRPC struct {
+	repo *repository.Notifications
+	log  *zap.Logger
+}
+
+// SubscribeMaintenance registers the internal janitor verb the k3s cron drives.
+// The subject is NOT exported from the NOTIFICATIONS_RPC account, so only a
+// client holding the notifications credentials (the cron reuses them) can reach
+// it. The queue group means exactly one replica runs the sweep per cron tick.
+func SubscribeMaintenance(nc *nats.Conn, repo *repository.Notifications, subject, queueGroup string, app *newrelic.Application, log *zap.Logger) error {
+	m := &maintenanceRPC{repo: repo, log: log}
+	return bus.QueueSubscribeJSON[notificationsrpc.CleanupRequest, notificationsrpc.CleanupReply](
+		nc, subject, queueGroup, 30*time.Second, app, log, m.cleanup)
+}
+
+func (m *maintenanceRPC) cleanup(ctx context.Context, _ notificationsrpc.CleanupRequest) notificationsrpc.CleanupReply {
+	deleted, err := m.repo.DeleteExpired(ctx, time.Now())
+	if err != nil {
+		m.log.Warn("notification cleanup failed", zap.Error(err))
+		return notificationsrpc.CleanupReply{Error: err.Error()}
+	}
+	if deleted > 0 {
+		m.log.Info("notification cleanup swept expired rows", zap.Int("deleted", deleted))
+	}
+	return notificationsrpc.CleanupReply{Deleted: deleted}
+}

--- a/app/notifications/rpc/user.go
+++ b/app/notifications/rpc/user.go
@@ -17,19 +17,30 @@ import (
 
 type userRPC struct {
 	repo *repository.Notifications
-	log  *zap.Logger
+	// fullReadTTL is how long a fully-read notification lingers for a user
+	// before it drops out of their list; peekTTL is the (longer) reduced life a
+	// dropdown peek grants an as-yet-unread one.
+	fullReadTTL time.Duration
+	peekTTL     time.Duration
+	log         *zap.Logger
 }
 
 // UserConfig carries the NATS wiring for the dashboard-facing RPC surface.
 type UserConfig struct {
 	Prefix     string
 	QueueGroup string
+	// FullReadTTL is how long a fully-read notification lingers for a user
+	// before it drops out of their list; PeekTTL is the (longer) reduced life a
+	// dropdown peek grants an as-yet-unread one.
+	FullReadTTL time.Duration
+	PeekTTL     time.Duration
 }
 
 // SubscribeUser registers the dashboard-facing verbs: list what a user can
-// see (broadcast + direct, newest first) and acknowledge one.
+// see (broadcast + direct, newest first), fully read one, and soft-acknowledge
+// (peek) all of them when the bell dropdown opens.
 func SubscribeUser(nc *nats.Conn, repo *repository.Notifications, cfg UserConfig, app *newrelic.Application, log *zap.Logger) error {
-	u := &userRPC{repo: repo, log: log}
+	u := &userRPC{repo: repo, fullReadTTL: cfg.FullReadTTL, peekTTL: cfg.PeekTTL, log: log}
 
 	if err := bus.QueueSubscribeJSON[notificationsrpc.UserListRequest, notificationsrpc.UserListReply](
 		nc, cfg.Prefix+".list", cfg.QueueGroup, 3*time.Second, app, log, u.list); err != nil {
@@ -37,6 +48,10 @@ func SubscribeUser(nc *nats.Conn, repo *repository.Notifications, cfg UserConfig
 	}
 	if err := bus.QueueSubscribeJSON[notificationsrpc.MarkReadRequest, notificationsrpc.MarkReadReply](
 		nc, cfg.Prefix+".mark_read", cfg.QueueGroup, 3*time.Second, app, log, u.markRead); err != nil {
+		return err
+	}
+	if err := bus.QueueSubscribeJSON[notificationsrpc.MarkPeekedRequest, notificationsrpc.MarkPeekedReply](
+		nc, cfg.Prefix+".mark_peeked", cfg.QueueGroup, 3*time.Second, app, log, u.markPeeked); err != nil {
 		return err
 	}
 	return nil
@@ -75,10 +90,26 @@ func (u *userRPC) markRead(ctx context.Context, req notificationsrpc.MarkReadReq
 	if err != nil {
 		return notificationsrpc.MarkReadReply{Error: "notification_id must be numeric"}
 	}
-	if err := u.repo.MarkRead(ctx, notifID, userID); err != nil {
+	if err := u.repo.MarkRead(ctx, notifID, userID, time.Now().Add(u.fullReadTTL)); err != nil {
 		return notificationsrpc.MarkReadReply{Error: err.Error()}
 	}
 	return notificationsrpc.MarkReadReply{}
+}
+
+// markPeeked soft-acknowledges every notification the user can currently see:
+// opening the bell dropdown counts as "seen", so unread items get the reduced
+// peek cutoff and the badge clears, while a later full read can still shorten an
+// item's life further.
+func (u *userRPC) markPeeked(ctx context.Context, req notificationsrpc.MarkPeekedRequest) notificationsrpc.MarkPeekedReply {
+	userID, err := parseUserID(req.UserID)
+	if err != nil {
+		return notificationsrpc.MarkPeekedReply{Error: err.Error()}
+	}
+	peeked, err := u.repo.MarkPeeked(ctx, userID, time.Now().Add(u.peekTTL))
+	if err != nil {
+		return notificationsrpc.MarkPeekedReply{Error: err.Error()}
+	}
+	return notificationsrpc.MarkPeekedReply{Peeked: peeked}
 }
 
 func parseUserID(s string) (uint64, error) {

--- a/console/dashboard/src/lib/server/services.ts
+++ b/console/dashboard/src/lib/server/services.ts
@@ -538,6 +538,16 @@ export const notificationMarkRead = defineWrite({
   after: (_result: unknown, userId: string) => invalidate(`notifications:${userId}`)
 });
 
+// Dropdown-open "peek": soft-acknowledge every notification the user can see,
+// shortening each unread one's per-user life to the reduced peek TTL and
+// clearing the unread badge. The notifications service picks the affected set,
+// so the request carries only the user id.
+export const notificationMarkPeeked = defineWrite({
+  subject: `${SUB.notifications}.mark_peeked`,
+  request: (userId: string) => ({ user_id: userId }),
+  after: (_result: unknown, userId: string) => invalidate(`notifications:${userId}`)
+});
+
 // Irreversibly delete the user's own account (and their owned delegations,
 // cleared server-side). The caller drops the session cookie after this resolves.
 // Custom error mapping (throw on !ok) doesn't fit defineWrite's result shape

--- a/console/dashboard/src/routes/(app)/+layout.svelte
+++ b/console/dashboard/src/routes/(app)/+layout.svelte
@@ -16,6 +16,13 @@
     queueMicrotask(() => markReadForm?.requestSubmit());
   }
 
+  // Opening the bell dropdown soft-acknowledges everything (server-side "peek");
+  // fired once per page by the bell so it only round-trips on the first open.
+  let peekForm = $state<HTMLFormElement | null>(null);
+  function peek() {
+    queueMicrotask(() => peekForm?.requestSubmit());
+  }
+
   // A stable section key drives active-state + the breadcrumb label; the label
   // itself is translated, so comparisons never break across languages.
   const path = $derived(page.url.pathname);
@@ -91,6 +98,7 @@
         unreadCount={data.unreadCount ?? 0}
         viewAllHref="/settings#notifications"
         onMarkRead={markRead}
+        onOpen={peek}
         title={t('bell.title')}
         viewAllLabel={t('bell.viewAll')}
         emptyLabel={t('bell.empty')}
@@ -106,6 +114,9 @@
 <form method="POST" action="/settings?/markRead" use:enhance bind:this={markReadForm} hidden>
   <input type="hidden" name="id" value={markReadId ?? ''} />
 </form>
+
+<!-- Hidden peek form: submitted once when the bell dropdown first opens. -->
+<form method="POST" action="/settings?/markPeeked" use:enhance bind:this={peekForm} hidden></form>
 
 <!-- One toast host for the whole app; pages push via the shared toast() store. -->
 <ToastHost />

--- a/console/dashboard/src/routes/(app)/settings/+page.server.ts
+++ b/console/dashboard/src/routes/(app)/settings/+page.server.ts
@@ -10,6 +10,7 @@ import {
   auditDashboardImpersonation,
   notificationsForUser,
   notificationMarkRead,
+  notificationMarkPeeked,
   type NotificationWire
 } from '$lib/server/services';
 import { ACCOUNT_DELETED_COOKIE, COOKIE, type Session } from '$lib/server/session';
@@ -100,6 +101,22 @@ export const actions: Actions = {
       return { ok: true, action: 'read' };
     } catch {
       return fail(502, { error: 'Could not update. Try again in a moment.' });
+    }
+  },
+
+  // markPeeked is the bell-dropdown-open path: soft-acknowledge everything the
+  // user can see. Best-effort — a failure just leaves the badge for next time,
+  // so it never surfaces an error to the glance-only bell.
+  markPeeked: async ({ locals }) => {
+    const s = locals.session;
+    if (env.DEMO === '1') return { ok: true, action: 'peeked' };
+    if (!s || s.delegate_of) return fail(403, { error: 'Not allowed.' });
+
+    try {
+      await notificationMarkPeeked(s.user_id);
+      return { ok: true, action: 'peeked' };
+    } catch {
+      return fail(502, { error: 'Could not update.' });
     }
   },
 

--- a/console/shared/components/NotificationBell.svelte
+++ b/console/shared/components/NotificationBell.svelte
@@ -21,6 +21,7 @@
     unreadCount = 0,
     viewAllHref,
     onMarkRead,
+    onOpen,
     emptyLabel = 'Nothing yet.',
     title = 'Notifications',
     viewAllLabel = 'View all →',
@@ -30,6 +31,10 @@
     unreadCount?: number;
     viewAllHref: string;
     onMarkRead?: (id: number) => void;
+    // Fired the first time the dropdown opens. The host uses it to "peek"
+    // (soft-acknowledge) every notification, so opening the bell counts as
+    // seeing them. Only hosts that track per-user read state pass this.
+    onOpen?: () => void;
     emptyLabel?: string;
     title?: string;
     viewAllLabel?: string;
@@ -37,6 +42,21 @@
   } = $props();
 
   let open = $state(false);
+  // Once a peek-capable host has been notified of an open, clear the badge
+  // optimistically so the count doesn't linger while the server round-trips.
+  let peeked = $state(false);
+
+  function toggle() {
+    open = !open;
+    if (open && onOpen && !peeked) {
+      peeked = true;
+      onOpen();
+    }
+  }
+
+  // Suppress the badge only for peek-capable hosts (dashboard); the admin bell
+  // has no per-user read state and keeps its badge behavior unchanged.
+  const showBadge = $derived(unreadCount > 0 && !(onOpen && peeked));
 </script>
 
 <svelte:window onkeydown={(e) => { if (e.key === 'Escape') open = false; }} />
@@ -48,10 +68,10 @@
     aria-label={title}
     aria-expanded={open}
     aria-haspopup="menu"
-    onclick={() => (open = !open)}
+    onclick={toggle}
   >
     <Icon name="bell" size={16} />
-    {#if unreadCount > 0}<span class="badge">{unreadCount > 9 ? '9+' : unreadCount}</span>{/if}
+    {#if showBadge}<span class="badge">{unreadCount > 9 ? '9+' : unreadCount}</span>{/if}
   </button>
 
   {#if open}

--- a/deploy/k8s/notifications.yaml
+++ b/deploy/k8s/notifications.yaml
@@ -147,3 +147,72 @@ spec:
   selector:
     matchLabels:
       app: notifications
+---
+# Janitor: fires the internal cleanup verb once per day so exactly one service
+# replica (queue group) hard-deletes globally-expired notifications; their
+# per-user read receipts cascade. Reuses the service image with the `cleanup`
+# arg and the service's own NATS creds (notifications-env), so no extra image or
+# NATS account is needed — the cleanup subject is internal to the
+# NOTIFICATIONS_RPC account and unreachable from anywhere else.
+#
+# Not Linkerd-injected: a meshed Job would hang on the lingering proxy, and NATS
+# is reachable un-meshed (no Server gates its port; `notifications` is outside
+# the default-deny NetworkPolicy). NATS auth is account creds, not mesh identity.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: notifications-cleanup
+  namespace: production
+spec:
+  schedule: "17 3 * * *" # daily, off the top of the hour
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 300
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 120
+      backoffLimit: 2
+      template:
+        metadata:
+          labels:
+            app: notifications-cleanup
+          annotations:
+            linkerd.io/inject: disabled
+        spec:
+          restartPolicy: OnFailure
+          tolerations:
+            - key: itsbagelbot.dev/pool
+              operator: Equal
+              value: worker-pool
+              effect: NoSchedule
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+            seccompProfile: {type: RuntimeDefault}
+          containers:
+            - name: cleanup
+              image: ghcr.io/adamousmer/itsbagelbot/notifications:main-1783103414-b9b8748aca7c@sha256:52d785d654387b0ec045d1bf42a3f220c77881cd07706a01f45436bf320d3fc5 # {"$imagepolicy": "flux-system:notifications"}
+              imagePullPolicy: IfNotPresent
+              args: ["cleanup"]
+              env:
+                - name: NATS_URL
+                  value: nats://nats:4222
+                - name: NATS_RPC_URL
+                  value: nats://nats-leaf-local:4222
+                - name: NATS_HUB_URL
+                  value: nats://nats:4222
+              envFrom:
+                - secretRef:
+                    name: notifications-env
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+                limits:
+                  cpu: 250m
+                  memory: 64Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities: {drop: ["ALL"]}

--- a/internal/domain/rpc/notifications/notifications.go
+++ b/internal/domain/rpc/notifications/notifications.go
@@ -83,3 +83,30 @@ type MarkReadRequest struct {
 type MarkReadReply struct {
 	Error string `json:"error,omitempty"`
 }
+
+// MarkPeekedRequest is the payload for the user-facing mark_peeked verb, fired
+// when the topbar bell dropdown is opened. It soft-acknowledges every
+// notification the user can currently see, shortening each one's per-user life
+// to the reduced peek TTL (a full read shortens it further still).
+type MarkPeekedRequest struct {
+	UserID string `json:"user_id"`
+}
+
+type MarkPeekedReply struct {
+	// Peeked is how many previously-unacknowledged notifications this call
+	// newly marked; 0 means everything was already read or peeked.
+	Peeked int    `json:"peeked"`
+	Error  string `json:"error,omitempty"`
+}
+
+// CleanupRequest is the payload for the internal maintenance cleanup verb the
+// k3s cron drives. It carries no arguments; the service sweeps whatever is
+// globally expired at handling time.
+type CleanupRequest struct{}
+
+type CleanupReply struct {
+	// Deleted is the number of globally-expired notifications swept (their read
+	// receipts cascade).
+	Deleted int    `json:"deleted"`
+	Error   string `json:"error,omitempty"`
+}


### PR DESCRIPTION
Notifications now age out instead of living forever, on three env-tunable TTL tiers (`NOTIF_DEFAULT_TTL` 90d / `NOTIF_PEEK_TTL` 7d / `NOTIF_FULL_READ_TTL` 24h).

## What
- **Per-user expiry**: `NotificationRead` gains an `expires_at` cutoff. A full read (`mark_read`) sets the short cutoff; a new `mark_peeked` verb — fired when the bell dropdown opens — soft-acknowledges every visible notification with the longer reduced cutoff (insert-if-absent, never extends a shorter full-read). `ListForUser` hides lapsed rows; the unread badge clears on peek.
- **Global default**: sends with no explicit expiry get the default global TTL, so broadcasts are eventually reclaimable.
- **Cron janitor**: new internal verb `bagel.rpc.internal.notifications.cleanup` (NOT exported from the `NOTIFICATIONS_RPC` account) hard-deletes globally-expired notifications; read receipts cascade. A daily `CronJob` reuses the service image with a `cleanup` arg + the service's own NATS creds to fire it, queue-grouped so one replica runs the sweep. Un-injected so the Job completes (meshed Jobs hang on the proxy; NATS is reachable un-meshed).
- **Dashboard bell** wired to peek on first open via `NotificationBell` `onOpen` + a hidden `markPeeked` form; badge clears optimistically. Admin bell untouched (no per-user read state).

## Verification
- `go build ./...`, `go vet`, `go test ./app/notifications/...` (incl. new peek / cutoff-hide / sweep tests), `gofmt` — all clean on top of current `main`.
- Rebased onto latest `main` (resolved the `AdminConfig`/`UserConfig`/`CreateParams` refactor).

No NATS ACL change needed (cleanup subject is internal to the notifications account). Deploy-gated as usual: DB column via `DB_AUTO_MIGRATE`; cron sweeps only once the new image ships.