### PR TITLE
feat(sesame): worker rewrite, deployed alongside worker

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -23,6 +23,7 @@ on:
           - transactions
           - users
           - worker
+          - sesame
           - twitch-ingress
           - console-dashboard
           - console-admin
@@ -114,6 +115,12 @@ jobs:
               "description": "ItsBagelBot Twitch event worker"
             },
             {
+              "image": "sesame",
+              "context": ".",
+              "containerfile": "app/sesame/Containerfile",
+              "description": "ItsBagelBot Twitch event worker (sesame rewrite)"
+            },
+            {
               "image": "twitch-ingress",
               "context": "app/ingress",
               "containerfile": "app/ingress/Containerfile",
@@ -148,6 +155,7 @@ jobs:
             add "transactions"
             add "users"
             add "worker"
+            add "sesame"
           }
 
           add_all_services() {
@@ -159,6 +167,7 @@ jobs:
             add "transactions"
             add "users"
             add "worker"
+            add "sesame"
             add "twitch-ingress"
             add "console-dashboard"
             add "console-admin"
@@ -203,6 +212,9 @@ jobs:
                 ;;
               app/worker/*)
                 add "worker"
+                ;;
+              app/sesame/*)
+                add "sesame"
                 ;;
               console/shared/*|console/bunfig.toml|console/bun.lock|console/package.json|console/tsconfig.base.json)
                 add "console-dashboard"

--- a/app/sesame/Containerfile
+++ b/app/sesame/Containerfile
@@ -1,0 +1,22 @@
+# sesame (Go, root module) - build from the REPO ROOT:
+#   podman build -t itsbagelbot/sesame -f app/sesame/Containerfile .
+FROM docker.io/library/golang:1.26-bookworm AS build
+
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY internal/domain internal/domain
+COPY internal/projection internal/projection
+COPY internal/utils internal/utils
+COPY pkg pkg
+COPY app/sesame app/sesame
+RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /sesame ./app/sesame
+
+# ---------------------------------------------------------------------------
+FROM gcr.io/distroless/static-debian12:nonroot
+
+COPY --from=build /sesame /sesame
+
+USER nonroot
+ENTRYPOINT ["/sesame"]

--- a/app/sesame/cmd/stage/main.go
+++ b/app/sesame/cmd/stage/main.go
@@ -1,0 +1,242 @@
+// Command stage drives the legacy worker pipeline and the new sesame engine with
+// the same fake chat/raid envelopes on both lanes and the same fake Valkey
+// (in-memory custom commands + module toggles), then prints their published
+// outgress messages side by side and flags MATCH / DIFF. It is a visual, runnable
+// version of the compare parity test — no real NATS or Valkey.
+//
+//	go run ./app/sesame/cmd/stage
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"ItsBagelBot/app/sesame/compare"
+	"ItsBagelBot/internal/projection"
+
+	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/bytedance/sonic"
+)
+
+type scenario struct {
+	name          string
+	msg           *message.Message
+	reader        compare.Reader
+	special       string
+	live          bool
+	greet         bool
+	timeSensitive bool // ping carries a live uptime; normalize it before comparing
+	divergent     bool // an intentional worker/sesame difference, not a failure
+	note          string
+}
+
+func main() {
+	// The fake Valkey: a broadcaster's custom command set (name -> definition),
+	// exactly what the projector would serve the pipeline from Valkey.
+	cmds := map[string]projection.Command{
+		"hi":    {Name: "hi", Response: "hello {sender}!", IsActive: true, Perm: "everyone"},
+		"ann":   {Name: "ann", Response: "/announce {sender}: {args}", IsActive: true, Perm: "everyone"},
+		"annb":  {Name: "annb", Response: "/announceblue {args}", IsActive: true, Perm: "everyone"},
+		"so":    {Name: "so", Response: "/shoutout @{touser}", IsActive: true, Perm: "everyone"},
+		"clear": {Name: "clear", Response: "/announce chat cleared", IsActive: true, Perm: "mod"},
+		"lurk":  {Name: "lurk", Aliases: []string{"afk"}, Response: "{sender} is now lurking", IsActive: true, Perm: "everyone"},
+	}
+	cmdReader := compare.Reader{Cmds: cmds}
+	shoutoutOn := compare.Reader{Mods: []projection.ModuleView{{Name: "shoutout", IsEnabled: true}}}
+
+	scenarios := []scenario{
+		{name: "baked !ping", msg: compare.ChatMsg("!ping", "9", "premium"), timeSensitive: true},
+		{name: "baked !itsbagelbot", msg: compare.ChatMsg("!itsbagelbot", "9", "standard")},
+		{name: "baked !source", msg: compare.ChatMsg("!source", "9", "premium")},
+		{name: "plain chat (no output)", msg: compare.ChatMsg("hello everyone how are you", "9", "standard")},
+
+		{name: "custom !hi (everyone)", msg: compare.ChatMsg("!hi", "9", "standard"), reader: cmdReader},
+		{name: "custom !ann -> /announce", msg: compare.ChatMsg("!ann hello world", "9", "premium"), reader: cmdReader},
+		{name: "custom !annb -> /announceblue", msg: compare.ChatMsg("!annb cold news", "9", "standard"), reader: cmdReader},
+		{name: "custom !so -> /shoutout", msg: compare.ChatMsg("!so @cooldude", "9", "premium"), reader: cmdReader},
+		{name: "custom alias !afk -> lurk", msg: compare.ChatMsg("!afk", "9", "standard"), reader: cmdReader},
+		{name: "custom !clear (mod-only) as viewer", msg: compare.ChatMsg("!clear", "9", "standard"), reader: cmdReader, note: "gated: viewer lacks mod"},
+		{name: "custom !clear (mod-only) as mod", msg: compare.ChatMsg("!clear", "9", "standard", "moderator"), reader: cmdReader},
+
+		{name: "bagel greet (special, live)", msg: compare.ChatMsg("hi chat", "1", "premium"), special: "1", live: true, greet: true},
+		{name: "bagel skipped (offline)", msg: compare.ChatMsg("hi chat", "1", "standard"), special: "1", live: false, greet: true},
+
+		{name: "raid -> shoutout (enabled)", msg: compare.RaidMsg("standard"), reader: shoutoutOn},
+
+		{name: "baked !announce (mod)", msg: compare.ChatMsg("!announce hi", "9", "standard", "moderator"), divergent: true,
+			note: "worker: baked command; sesame: announce is middleware (no baked cmd)"},
+	}
+
+	printHeader(cmds)
+
+	pass, fail, diverge := 0, 0, 0
+	for i, sc := range scenarios {
+		w, s := compare.ProcessBoth(sc.msg, sc.reader, sc.special, sc.live, sc.greet)
+		ok := equalCaptures(w, s, sc.timeSensitive)
+
+		status := "✅ MATCH"
+		switch {
+		case sc.divergent:
+			status = "⚠️  DIVERGENT (intentional)"
+			diverge++
+		case ok:
+			pass++
+		default:
+			status = "❌ DIFF"
+			fail++
+		}
+
+		fmt.Printf("▸ #%02d  %-34s %s\n", i+1, sc.name, laneOf(sc.msg))
+		fmt.Printf("    in    : %s\n", inputOf(sc.msg))
+		fmt.Printf("    worker: %s\n", render(w))
+		fmt.Printf("    sesame: %s\n", render(s))
+		if sc.note != "" {
+			fmt.Printf("    note  : %s\n", sc.note)
+		}
+		fmt.Printf("    %s\n\n", status)
+	}
+
+	fmt.Println(strings.Repeat("─", 70))
+	fmt.Printf(" %d MATCH   %d DIFF   %d intentional divergence\n", pass, fail, diverge)
+	fmt.Println(strings.Repeat("─", 70))
+	if fail > 0 {
+		os.Exit(1)
+	}
+}
+
+func printHeader(cmds map[string]projection.Command) {
+	fmt.Println(strings.Repeat("═", 70))
+	fmt.Println(" SESAME vs WORKER — staged side-by-side")
+	fmt.Println(" fake lanes (premium/standard) + fake Valkey (in-memory custom commands)")
+	fmt.Println(strings.Repeat("═", 70))
+	fmt.Println(" seeded custom commands (the fake Valkey):")
+	for _, name := range []string{"hi", "ann", "annb", "so", "lurk", "clear"} {
+		c := cmds[name]
+		perm := c.Perm
+		if perm == "" {
+			perm = "everyone"
+		}
+		alias := ""
+		if len(c.Aliases) > 0 {
+			alias = "  (alias: !" + strings.Join(c.Aliases, ", !") + ")"
+		}
+		fmt.Printf("   !%-7s [%-8s] %q%s\n", c.Name, perm, c.Response, alias)
+	}
+	fmt.Println(strings.Repeat("─", 70))
+}
+
+// render turns a pipeline's published messages into one readable line.
+func render(cs []compare.Captured) string {
+	if len(cs) == 0 {
+		return "(nothing)"
+	}
+	parts := make([]string, 0, len(cs))
+	for _, c := range cs {
+		parts = append(parts, one(c))
+	}
+	return strings.Join(parts, "  +  ")
+}
+
+func one(c compare.Captured) string {
+	lane := laneName(c.Subject)
+	switch c.Msg.Type {
+	case "announce":
+		return fmt.Sprintf("[%s] announce color=%s ch=%s %q", lane, c.Msg.Color, c.Msg.BroadcasterID, payloadMessage(c.Msg.Payload))
+	case "shoutout":
+		return fmt.Sprintf("[%s] shoutout to=%s ch=%s", lane, c.Msg.To, c.Msg.BroadcasterID)
+	default: // chat and everything else
+		return fmt.Sprintf("[%s] %s ch=%s %q", lane, c.Msg.Type, c.Msg.BroadcasterID, payloadMessage(c.Msg.Payload))
+	}
+}
+
+// equalCaptures compares two published sets; when timeSensitive it normalizes the
+// ping uptime tail so the two are comparable.
+func equalCaptures(w, s []compare.Captured, timeSensitive bool) bool {
+	if len(w) != len(s) {
+		return false
+	}
+	for i := range w {
+		if canon(w[i], timeSensitive) != canon(s[i], timeSensitive) {
+			return false
+		}
+	}
+	return true
+}
+
+func canon(c compare.Captured, timeSensitive bool) string {
+	msg := payloadMessage(c.Msg.Payload)
+	if timeSensitive {
+		if i := strings.Index(msg, "up for "); i >= 0 {
+			msg = msg[:i+len("up for ")] + "<uptime>"
+		}
+	}
+	return strings.Join([]string{c.Subject, c.Msg.Type, c.Msg.BroadcasterID, c.Msg.Color, c.Msg.To, msg}, "|")
+}
+
+func payloadMessage(payload []byte) string {
+	if len(payload) == 0 {
+		return ""
+	}
+	var inner struct {
+		Message string `json:"message"`
+	}
+	_ = sonic.Unmarshal(payload, &inner)
+	return inner.Message
+}
+
+// --- envelope readback for printing ---
+
+func laneOf(msg *message.Message) string  { return "lane=" + envField(msg, "lane") }
+func inputOf(msg *message.Message) string  { return describeInput(msg) }
+func laneName(subject string) string {
+	switch subject {
+	case compare.PremiumSubj:
+		return "premium"
+	case compare.StandardSubj:
+		return "standard"
+	default:
+		return subject
+	}
+}
+
+func describeInput(msg *message.Message) string {
+	typ := envField(msg, "type")
+	if typ == "channel.raid" {
+		return "channel.raid  raider=CoolStreamer viewers=42"
+	}
+	text := envField(msg, "text")
+	chatter := envField(msg, "chatter_user_id")
+	badges := envBadges(msg)
+	if badges != "" {
+		badges = "  badges=" + badges
+	}
+	return fmt.Sprintf("%q  chatter=%s%s", text, chatter, badges)
+}
+
+func envField(msg *message.Message, key string) string {
+	var m map[string]any
+	if err := sonic.Unmarshal(msg.Payload, &m); err != nil {
+		return ""
+	}
+	if v, ok := m[key].(string); ok {
+		return v
+	}
+	return ""
+}
+
+func envBadges(msg *message.Message) string {
+	var m struct {
+		Badges []struct {
+			SetID string `json:"set_id"`
+		} `json:"badges"`
+	}
+	if err := sonic.Unmarshal(msg.Payload, &m); err != nil {
+		return ""
+	}
+	ids := make([]string, 0, len(m.Badges))
+	for _, b := range m.Badges {
+		ids = append(ids, b.SetID)
+	}
+	return strings.Join(ids, ",")
+}

--- a/app/sesame/compare/compare_test.go
+++ b/app/sesame/compare/compare_test.go
@@ -1,0 +1,125 @@
+package compare
+
+import (
+	"strings"
+	"testing"
+
+	"ItsBagelBot/internal/domain/outgress"
+	"ItsBagelBot/internal/projection"
+
+	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/bytedance/sonic"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// custom returns a fake-Valkey Reader holding one everyone-perm "so" command.
+func custom(resp string) Reader {
+	return Reader{Cmds: map[string]projection.Command{
+		"so": {Name: "so", Response: resp, IsActive: true, Perm: "everyone"},
+	}}
+}
+
+// TestOutputParity feeds identical envelopes to both pipelines and asserts they
+// publish byte-identical outgress messages. One difference is intentional and
+// covered separately (TestAnnounceModelDiffers): worker ships !announce* as baked
+// commands, sesame treats announce as output middleware.
+func TestOutputParity(t *testing.T) {
+	shoutoutOn := Reader{Mods: []projection.ModuleView{{Name: "shoutout", IsEnabled: true}}}
+
+	type scenario struct {
+		name    string
+		msg     *message.Message
+		reader  Reader
+		special string
+		live    bool
+		greet   bool
+	}
+	scenarios := []scenario{
+		{name: "info itsbagelbot", msg: ChatMsg("!itsbagelbot", "9", "standard")},
+		{name: "info source premium", msg: ChatMsg("!source", "9", "premium")},
+		{name: "plain chat no output", msg: ChatMsg("just chatting here", "9", "standard")},
+		{name: "custom plain", msg: ChatMsg("!so", "9", "standard"), reader: custom("hello {sender}")},
+		{name: "custom announce", msg: ChatMsg("!so @bob hi there", "9", "premium"), reader: custom("/announce {user} says: {args}; to={target}")},
+		{name: "custom announce blue", msg: ChatMsg("!so cold news", "9", "standard"), reader: custom("/announceblue {args}")},
+		{name: "custom shoutout", msg: ChatMsg("!so @cooldude go", "9", "premium"), reader: custom("/shoutout @cooldude check them out")},
+		{name: "custom announce empty dropped", msg: ChatMsg("!so", "9", "standard"), reader: custom("/announce")},
+		{name: "bagel greet special first live", msg: ChatMsg("hi chat", "1", "premium"), special: "1", live: true, greet: true},
+		{name: "bagel skipped offline", msg: ChatMsg("hi chat", "1", "standard"), special: "1", live: false, greet: true},
+		{name: "raid shoutout default", msg: RaidMsg("standard"), reader: shoutoutOn},
+	}
+
+	for _, sc := range scenarios {
+		t.Run(sc.name, func(t *testing.T) {
+			w, s := ProcessBoth(sc.msg, sc.reader, sc.special, sc.live, sc.greet)
+			assert.Equal(t, w, s, "worker and sesame must publish identical outgress messages")
+		})
+	}
+}
+
+// TestPingParity checks !ping separately: the uptime string is time-dependent, so
+// it asserts identical Type/BroadcasterID/subject and the same fixed prefix.
+func TestPingParity(t *testing.T) {
+	w, s := ProcessBoth(ChatMsg("!ping", "9", "standard"), Reader{}, "", false, false)
+	require.Len(t, w, 1)
+	require.Len(t, s, 1)
+	assert.Equal(t, w[0].Subject, s[0].Subject)
+	assert.Equal(t, w[0].Msg.Type, s[0].Msg.Type)
+	assert.Equal(t, w[0].Msg.BroadcasterID, s[0].Msg.BroadcasterID)
+	assert.True(t, strings.Contains(chatText(t, w[0].Msg), "up for"))
+	assert.True(t, strings.Contains(chatText(t, s[0].Msg), "up for"))
+}
+
+// TestAnnounceModelDiffers documents the one intentional divergence.
+func TestAnnounceModelDiffers(t *testing.T) {
+	msg := ChatMsg("!announce hello", "9", "standard", "moderator")
+
+	wpub := &Pub{}
+	NewWorker(wpub, Reader{}, "", Live{}, Greet{}).Process(msg)
+	require.Len(t, wpub.Got, 1, "worker still ships !announce as a baked command")
+	assert.Equal(t, outgress.TypeAnnounce, wpub.Got[0].Msg.Type)
+
+	spub := &Pub{}
+	NewSesame(spub, Reader{}, "", Live{}, Greet{}).Process(msg)
+	assert.Empty(t, spub.Got, "sesame has no baked !announce; announce is middleware over a custom command")
+}
+
+func chatText(t *testing.T, m outgress.Message) string {
+	t.Helper()
+	var inner struct {
+		Message string `json:"message"`
+	}
+	require.NoError(t, sonic.Unmarshal(m.Payload, &inner))
+	return inner.Message
+}
+
+// --- timing, side by side ---
+
+func benchProcess(b *testing.B, p Processor, msg *message.Message) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := p.Process(msg); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkWorkerNoOutput(b *testing.B) {
+	benchProcess(b, NewWorker(&Pub{}, Reader{}, "", Live{}, Greet{}), ChatMsg("hello chat how is everyone", "9", "standard"))
+}
+func BenchmarkSesameNoOutput(b *testing.B) {
+	benchProcess(b, NewSesame(&Pub{}, Reader{}, "", Live{}, Greet{}), ChatMsg("hello chat how is everyone", "9", "standard"))
+}
+func BenchmarkWorkerInfoCommand(b *testing.B) {
+	benchProcess(b, NewWorker(&Pub{}, Reader{}, "", Live{}, Greet{}), ChatMsg("!source", "9", "standard"))
+}
+func BenchmarkSesameInfoCommand(b *testing.B) {
+	benchProcess(b, NewSesame(&Pub{}, Reader{}, "", Live{}, Greet{}), ChatMsg("!source", "9", "standard"))
+}
+func BenchmarkWorkerCustomAnnounce(b *testing.B) {
+	benchProcess(b, NewWorker(&Pub{}, custom("/announce {user}: {args}"), "", Live{}, Greet{}), ChatMsg("!so hi there", "9", "standard"))
+}
+func BenchmarkSesameCustomAnnounce(b *testing.B) {
+	benchProcess(b, NewSesame(&Pub{}, custom("/announce {user}: {args}"), "", Live{}, Greet{}), ChatMsg("!so hi there", "9", "standard"))
+}

--- a/app/sesame/compare/harness.go
+++ b/app/sesame/compare/harness.go
@@ -1,0 +1,185 @@
+// Package compare wires the legacy worker pipeline and the new sesame engine
+// against the SAME in-memory fakes so they can be driven with identical inputs
+// and their published outgress messages compared. It backs both the parity test
+// (compare_test.go) and the runnable stage (app/sesame/cmd/stage), which feeds
+// scripted chat/raid envelopes on the two lanes and prints worker vs sesame side
+// by side. Nothing here touches real NATS or Valkey: the Reader is the "fake
+// Valkey" (an in-memory custom-command set + module toggles), and the stores are
+// trivial fakes.
+package compare
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	sengine "ItsBagelBot/app/sesame/engine"
+	smods "ItsBagelBot/app/sesame/modules"
+	wmod "ItsBagelBot/app/worker/module"
+	wbuiltin "ItsBagelBot/app/worker/module/builtin"
+	wpipe "ItsBagelBot/app/worker/pipeline"
+	"ItsBagelBot/internal/domain/outgress"
+	"ItsBagelBot/internal/projection"
+
+	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/bytedance/sonic"
+	"go.uber.org/zap"
+)
+
+// Outgress lane subjects the pipelines publish on (fixed for the harness).
+const (
+	PremiumSubj  = "outgress.premium"
+	StandardSubj = "outgress.standard"
+)
+
+// Captured is one published outgress message plus the subject it rode.
+type Captured struct {
+	Subject string
+	Msg     outgress.Message
+}
+
+// Pub is a message.Publisher that records what was published.
+type Pub struct {
+	Got  []Captured
+	Fail error
+}
+
+func (p *Pub) Publish(subject string, msgs ...*message.Message) error {
+	if p.Fail != nil {
+		return p.Fail
+	}
+	for _, m := range msgs {
+		var om outgress.Message
+		_ = sonic.Unmarshal(m.Payload, &om)
+		p.Got = append(p.Got, Captured{Subject: subject, Msg: om})
+	}
+	return nil
+}
+func (p *Pub) Close() error { return nil }
+
+// Live is a fake live store; it reports IsLiveV and no-ops its writes. It
+// satisfies both wmod.LiveStore and sengine.LiveStore (identical method sets).
+type Live struct{ IsLiveV bool }
+
+func (f Live) IsLive(context.Context, uint64) (bool, error) { return f.IsLiveV, nil }
+func (f Live) SetLive(context.Context, uint64) error        { return nil }
+func (f Live) ClearLive(context.Context, uint64) error      { return nil }
+
+// Greet is a fake greet store; FirstGreet returns First.
+type Greet struct{ First bool }
+
+func (f Greet) FirstGreet(context.Context, uint64, string) (bool, error) { return f.First, nil }
+func (f Greet) ResetGreets(context.Context, uint64) error                { return nil }
+
+// Cooldown never gates. Satisfies both CooldownStore interfaces.
+type Cooldown struct{}
+
+func (Cooldown) Allow(context.Context, string, time.Duration) (bool, error) { return true, nil }
+
+// Reader is the fake Valkey: an in-memory user, module-toggle set, and custom
+// command set keyed by lowercased name (aliases resolved by scan).
+type Reader struct {
+	Usr  projection.User
+	Mods []projection.ModuleView
+	Cmds map[string]projection.Command
+}
+
+func (r Reader) User(context.Context, uint64) (projection.User, error) { return r.Usr, nil }
+func (r Reader) Modules(context.Context, uint64) ([]projection.ModuleView, error) {
+	return r.Mods, nil
+}
+func (r Reader) Command(_ context.Context, _ uint64, name string) (projection.Command, bool, error) {
+	n := strings.ToLower(name)
+	if c, ok := r.Cmds[n]; ok {
+		return c, true, nil
+	}
+	for _, c := range r.Cmds {
+		for _, a := range c.Aliases {
+			if strings.ToLower(a) == n {
+				return c, true, nil
+			}
+		}
+	}
+	return projection.Command{}, false, nil
+}
+
+// Processor is the shared surface: both pipelines take one decoded message.
+type Processor interface {
+	Process(*message.Message) error
+}
+
+// NewWorker builds the legacy worker pipeline with the given fakes.
+func NewWorker(pub message.Publisher, reader projection.Reader, special string, live wmod.LiveStore, greet wmod.GreetStore) Processor {
+	router := wmod.NewCommandRouter(reader, live, Cooldown{}, nil, zap.NewNop())
+	reg := wmod.NewRegistry(zap.NewNop(),
+		wbuiltin.NewBakedModule(wmod.NewSpecialSet(special), live, greet, zap.NewNop()),
+		router,
+		wbuiltin.NewLiveModule(live, greet, zap.NewNop()),
+		wbuiltin.NewShoutoutModule(zap.NewNop()),
+	)
+	router.Bind(reg)
+	return wpipe.NewPipeline(zap.NewNop(), pub, reader, reg, "", PremiumSubj, StandardSubj)
+}
+
+// NewSesame builds the sesame engine pipeline with the given fakes.
+func NewSesame(pub message.Publisher, reader projection.Reader, special string, live sengine.LiveStore, greet sengine.GreetStore) Processor {
+	d := sengine.Deps{
+		Proj:     reader,
+		Live:     live,
+		Greet:    greet,
+		Cooldown: Cooldown{},
+		Special:  sengine.NewSpecialSet(special),
+		Pub:      pub,
+		Log:      zap.NewNop(),
+	}
+	reg := sengine.NewRegistry(zap.NewNop(), smods.All(d)...)
+	return sengine.NewPipeline(d, reg, sengine.Config{OutgressPremium: PremiumSubj, OutgressStandard: StandardSubj})
+}
+
+// ChatMsg builds a channel.chat.message envelope on the given lane, with any
+// badge set_ids attached to the chatter (for perm gating).
+func ChatMsg(text, chatterID, lane string, badgeSetIDs ...string) *message.Message {
+	env := map[string]any{
+		"type":                "channel.chat.message",
+		"lane":                lane,
+		"broadcaster_user_id": "2",
+		"chatter_user_id":     chatterID,
+		"chatter_user_login":  "alice",
+		"text":                text,
+	}
+	if len(badgeSetIDs) > 0 {
+		badges := make([]map[string]string, 0, len(badgeSetIDs))
+		for _, id := range badgeSetIDs {
+			badges = append(badges, map[string]string{"set_id": id})
+		}
+		env["badges"] = badges
+	}
+	body, _ := sonic.Marshal(env)
+	return message.NewMessage("uuid", body)
+}
+
+// RaidMsg builds a channel.raid envelope on the given lane (receiving channel 2).
+func RaidMsg(lane string) *message.Message {
+	body, _ := sonic.Marshal(map[string]any{
+		"type": "channel.raid",
+		"lane": lane,
+		"event": map[string]any{
+			"from_broadcaster_user_login": "coolstreamer",
+			"from_broadcaster_user_name":  "CoolStreamer",
+			"to_broadcaster_user_id":      "2",
+			"viewers":                     42,
+		},
+	})
+	return message.NewMessage("uuid", body)
+}
+
+// ProcessBoth runs the same message through fresh worker and sesame pipelines
+// (fresh fakes each, so greet/live state does not leak between them) and returns
+// what each published.
+func ProcessBoth(msg *message.Message, reader projection.Reader, special string, live, greet bool) (worker, sesame []Captured) {
+	wp := &Pub{}
+	NewWorker(wp, reader, special, Live{live}, Greet{greet}).Process(msg)
+	sp := &Pub{}
+	NewSesame(sp, reader, special, Live{live}, Greet{greet}).Process(msg)
+	return wp.Got, sp.Got
+}

--- a/app/sesame/engine/cooldown_valkey.go
+++ b/app/sesame/engine/cooldown_valkey.go
@@ -1,0 +1,31 @@
+package engine
+
+import (
+	"context"
+	"time"
+
+	"github.com/valkey-io/valkey-go"
+)
+
+// ValkeyCooldown claims a cooldown with SET key 1 NX PX ttl: the first caller in
+// the window wins the key, everyone else sees it already set. It is one round trip
+// and correct across replicas, the same idiom outgress uses for its enroll lock.
+type ValkeyCooldown struct {
+	client valkey.Client
+}
+
+func NewValkeyCooldown(client valkey.Client) *ValkeyCooldown {
+	return &ValkeyCooldown{client: client}
+}
+
+func (c *ValkeyCooldown) Allow(ctx context.Context, key string, ttl time.Duration) (bool, error) {
+	res := c.client.Do(ctx, c.client.B().Set().Key(key).Value("1").Nx().PxMilliseconds(ttl.Milliseconds()).Build())
+	str, err := res.ToString()
+	if err != nil {
+		if valkey.IsValkeyNil(err) {
+			return false, nil // key already present: still cooling down
+		}
+		return false, err
+	}
+	return str == "OK", nil
+}

--- a/app/sesame/engine/deps.go
+++ b/app/sesame/engine/deps.go
@@ -1,0 +1,72 @@
+// Package engine is sesame's runtime: it takes the immutable module.Module
+// values a Builder produced, indexes them in a Registry, and runs the
+// interested ones for each message in the consumer's own goroutine. It owns the
+// per-message orchestration (decode, command dispatch, event handlers, publish)
+// and the shared command gate (permission, live-only, cooldown). The behavior
+// lives in the modules (app/sesame/modules); the engine only wires and runs
+// them.
+//
+// The command router is not a module here (as it was in the worker): dispatch is
+// an engine stage that reads the registry's command index directly, which
+// removes the worker's CommandRouter.Bind init-order footgun.
+package engine
+
+import (
+	"context"
+	"time"
+
+	"ItsBagelBot/internal/projection"
+
+	"github.com/ThreeDotsLabs/watermill/message"
+
+	"go.uber.org/zap"
+)
+
+// Deps is the bundle of runtime services a module fn captures by closure when it
+// builds its Module. main constructs it once and hands it to modules.All. Not
+// every module uses every field; unused ones are harmless.
+type Deps struct {
+	Proj     projection.Reader
+	Live     LiveStore
+	Greet    GreetStore
+	Cooldown CooldownStore
+	Special  *SpecialSet
+	Pub      message.Publisher
+	Log      *zap.Logger
+}
+
+// IsLiveChecker is the read-only slice of the live store: just "is this
+// broadcaster live?". The command gate's live-only check and the bagel greeter
+// depend on this narrow interface (ISP) rather than the full LiveStore.
+type IsLiveChecker interface {
+	IsLive(ctx context.Context, broadcasterID uint64) (bool, error)
+}
+
+// LiveStore answers and maintains a broadcaster's live state. Reads are served
+// from a cache fronting Valkey with a projector RPC fallback; writes flow from
+// the stream events the worker consumes.
+type LiveStore interface {
+	IsLiveChecker
+	SetLive(ctx context.Context, broadcasterID uint64) error
+	ClearLive(ctx context.Context, broadcasterID uint64) error
+}
+
+// GreetStore tracks which special users have already been greeted in the current
+// stream, so the bagel reply fires only on a user's first message per stream.
+type GreetStore interface {
+	FirstGreet(ctx context.Context, broadcasterID uint64, chatterID string) (bool, error)
+	ResetGreets(ctx context.Context, broadcasterID uint64) error
+}
+
+// CooldownStore gates an action behind a shared cooldown window. Allow returns
+// true when the caller may proceed (the window was free and is now claimed) and
+// false while a previous claim is still cooling down.
+type CooldownStore interface {
+	Allow(ctx context.Context, key string, ttl time.Duration) (bool, error)
+}
+
+// NoopCooldown never gates: every call is allowed. Used in tests and when no
+// cooldown backend is configured.
+type NoopCooldown struct{}
+
+func (NoopCooldown) Allow(context.Context, string, time.Duration) (bool, error) { return true, nil }

--- a/app/sesame/engine/dispatch.go
+++ b/app/sesame/engine/dispatch.go
@@ -1,0 +1,185 @@
+package engine
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"time"
+
+	"ItsBagelBot/app/sesame/module"
+	"ItsBagelBot/internal/domain/outgress"
+	"ItsBagelBot/internal/projection"
+
+	"go.uber.org/zap"
+)
+
+// dispatchCommand is the command stage the pipeline runs for every chat line. It
+// parses the "!command", looks it up first in the registry's bound command index
+// and then in the broadcaster's custom commands, applies the one shared gate
+// (permission, live-only, cooldown), and runs the winner. It is the folded-in
+// command router: unlike the worker it is not a module, so it reads the registry
+// directly and needs no Bind. A non-command line returns nil with no work.
+//
+// A baked command is first gated by its owning module's enable/premium state
+// (the same enabled() check event handlers pass), so a command on a disabled or
+// premium-only module never runs; that gate also wires the module's config into
+// the Context before the command runs. views is the broadcaster's ModuleView set
+// (nil when the chat path needs none, i.e. only core command owners).
+func (p *Pipeline) dispatchCommand(ctx context.Context, c *module.Context, views map[string]projection.ModuleView, emit module.Emit) error {
+	name, args, ok := parseCommand(c.Env.Text)
+	if !ok {
+		return nil
+	}
+	if bc, isBaked := p.registry.Command(name); isBaked {
+		if !p.enabled(bc.Owner, views, c) {
+			return nil
+		}
+		return p.runBaked(ctx, c, bc.Cmd, args, emit)
+	}
+	return p.runCustom(ctx, c, name, args, emit)
+}
+
+// runBaked gates and runs a command a module owns. Every output the command
+// emits is routed through the post-processing middleware (see emitCommand), so a
+// baked command can write "/announce ..." the same way a custom one does.
+func (p *Pipeline) runBaked(ctx context.Context, c *module.Context, cmd module.Command, args string, emit module.Emit) error {
+	pass, err := p.gate(ctx, c, cmd.Name, cmd.AllowedUserID, cmd.Perm, cmd.LiveOnly, cmd.Cooldown)
+	if err != nil || !pass {
+		return err
+	}
+	// Resolve the broadcaster's UI locale so baked commands can localize replies.
+	// Only for commands that actually run (past the gate); the read is cache
+	// fronted, and any miss leaves Locale empty (default language).
+	if u, uerr := p.proj.User(ctx, c.BroadcasterID); uerr == nil {
+		c.Locale = u.Locale
+	}
+	return cmd.Run(ctx, c, args, func(o *module.Output) { p.emitCommand(o, emit) })
+}
+
+// runCustom resolves a broadcaster's custom command, gates it with the same rule
+// as a baked command, then expands its response, translates any slash-verb, and
+// emits one chat line.
+func (p *Pipeline) runCustom(ctx context.Context, c *module.Context, name, args string, emit module.Emit) error {
+	cc, found, err := p.proj.Command(ctx, c.BroadcasterID, name)
+	if err != nil || !found || !cc.IsActive {
+		return err
+	}
+	if cc.Response == "" {
+		return nil
+	}
+
+	pass, err := p.gate(ctx, c, name, cc.AllowedUserID, module.ParsePerm(cc.Perm), cc.StreamOnlineOnly, time.Duration(cc.Cooldown)*time.Second)
+	if err != nil || !pass {
+		return err
+	}
+
+	p.log.Debug("command matched",
+		zap.String("command", name),
+		zap.String("regress", c.Regress.String()),
+		zap.Uint64("broadcaster_id", c.BroadcasterID),
+	)
+
+	sender := c.Env.ChatterUserLogin
+	touser := sender
+	if args != "" {
+		firstWord, _, _ := strings.Cut(args, " ")
+		touser = strings.TrimPrefix(firstWord, "@")
+	}
+
+	buf := GetBuf()
+	buf = expandCommand(buf, cc.Response, sender, sender, args, touser)
+	out := GetOutput()
+	out.Type = outgress.TypeChat
+	out.BroadcasterID = c.Env.BroadcasterUserID
+	out.Text = string(buf)
+	PutBuf(buf)
+
+	// Route the expanded response through the post-processing middleware. A
+	// response left with no payload (an "/announce" with no text, a "/shoutout"
+	// with no target) is dropped and not counted.
+	emitted := p.emitCommand(out, emit)
+	PutOutput(out)
+	if !emitted {
+		return nil
+	}
+
+	// Count the successful run. The reporter sums ticks locally and publishes one
+	// event per command per flush window, so chat spam never floods NATS. cc.Name
+	// is the canonical key (an alias lookup resolves to it), so alias invocations
+	// all count against the one command.
+	if p.uses != nil {
+		p.uses.Record(c.BroadcasterID, cc.Name)
+	}
+
+	return nil
+}
+
+// emitCommand is the command-output post-processing middleware. Every output a
+// command produces (baked or custom) passes through it before publish: Translate
+// routes a leading slash-verb to the right outgress action (/announce -> announce
+// with color, /shoutout -> shoutout; a plain line or /me stays chat), and an
+// action left empty (an /announce with no text, a /shoutout with no target) is
+// dropped so Twitch is never sent a call it would reject. It is deliberately not
+// gated: routing an output is not a privilege, so permission is the job of the
+// command that produced the output, not of the announce/shoutout verb. It
+// reports whether the output was actually emitted.
+func (p *Pipeline) emitCommand(o *module.Output, emit module.Emit) bool {
+	Translate(o)
+	if isEmptyAction(o) {
+		return false
+	}
+	emit(o)
+	return true
+}
+
+// gate applies the one shared command gate: permission (an explicit allowed user
+// overrides the role tier entirely), then live-only, then cooldown. It returns
+// (true, nil) only when every applicable check passes. It allocates nothing on
+// the hot path (the cooldown key is built into a pooled buffer).
+func (p *Pipeline) gate(ctx context.Context, c *module.Context, name, allowedUserID string, perm module.Role, liveOnly bool, cooldown time.Duration) (bool, error) {
+	// Permission: an explicit allowed user overrides the role tier entirely.
+	if allowedUserID != "" {
+		if c.Env.ChatterUserID != allowedUserID {
+			return false, nil
+		}
+	} else if !c.Chatter().Allows(perm) {
+		return false, nil
+	}
+
+	if liveOnly {
+		live, err := p.live.IsLive(ctx, c.BroadcasterID)
+		if err != nil {
+			return false, err
+		}
+		if !live {
+			return false, nil
+		}
+	}
+
+	if cooldown > 0 {
+		key := cooldownKey(c.BroadcasterID, name)
+		allowed, err := p.cooldown.Allow(ctx, key, cooldown)
+		if err != nil {
+			return false, err
+		}
+		if !allowed {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+// cooldownKey builds "cooldown:cmd:<broadcasterID>:<name>" into a pooled scratch
+// buffer, appending the id with strconv so the hot path does no fmt-style
+// allocation. The buffer is returned to the pool before the string is handed off.
+func cooldownKey(broadcasterID uint64, name string) string {
+	buf := GetBuf()
+	buf = append(buf, "cooldown:cmd:"...)
+	buf = strconv.AppendUint(buf, broadcasterID, 10)
+	buf = append(buf, ':')
+	buf = append(buf, name...)
+	key := string(buf)
+	PutBuf(buf)
+	return key
+}

--- a/app/sesame/engine/dispatch_test.go
+++ b/app/sesame/engine/dispatch_test.go
@@ -1,0 +1,167 @@
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"ItsBagelBot/app/sesame/module"
+	"ItsBagelBot/internal/domain/event/lane"
+	"ItsBagelBot/internal/domain/outgress"
+	"ItsBagelBot/internal/projection"
+
+	"github.com/bytedance/sonic"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// chatCtx builds a chat Context for the given text and optional badge role.
+func chatCtx(text, badgeRole string) *module.Context {
+	env := lane.Envelope{
+		Type:              chatType,
+		Text:              text,
+		BroadcasterUserID: "123",
+		ChatterUserID:     "999",
+		ChatterUserLogin:  "alice",
+	}
+	if badgeRole != "" {
+		env.Badges = []lane.Badge{{SetID: badgeRole}}
+	}
+	return &module.Context{Env: env, BroadcasterID: 123, Log: zap.NewNop()}
+}
+
+// collectDispatch runs the command stage and returns the emitted outputs.
+func collectDispatch(p *Pipeline, c *module.Context) []module.Output {
+	var got []module.Output
+	_ = p.dispatchCommand(context.Background(), c, nil, func(o *module.Output) { got = append(got, *o) })
+	return got
+}
+
+func chatMessageText(t *testing.T, m outgress.Message) string {
+	t.Helper()
+	var inner struct {
+		Message string `json:"message"`
+	}
+	require.NoError(t, sonic.Unmarshal(m.Payload, &inner))
+	return inner.Message
+}
+
+// --- custom (broadcaster-defined) command dispatch ---
+
+func customPipeline(resp, perm string) *Pipeline {
+	reg := NewRegistry(zap.NewNop()) // no baked commands
+	d := Deps{
+		Proj:     fakeReader{cmd: projection.Command{Name: "so", Response: resp, IsActive: true, Perm: perm}, cmdFound: true},
+		Live:     liveAlways{},
+		Cooldown: NoopCooldown{},
+		Pub:      &fakePublisher{},
+		Log:      zap.NewNop(),
+	}
+	return NewPipeline(d, reg, Config{OutgressPremium: premiumSubj, OutgressStandard: standardSubj})
+}
+
+func TestCustomAnnounceAllowedForEveryone(t *testing.T) {
+	p := customPipeline("/announce {user} says: {args}; target={target}", "everyone")
+	got := collectDispatch(p, chatCtx("!so @bob raid incoming", ""))
+	require.Len(t, got, 1)
+	assert.Equal(t, outgress.TypeAnnounce, got[0].Type)
+	assert.Equal(t, "primary", got[0].Color)
+	assert.Equal(t, "alice says: @bob raid incoming; target=bob", got[0].Text)
+}
+
+func TestCustomAnnounceEmptySkipped(t *testing.T) {
+	p := customPipeline("/announce", "everyone")
+	assert.Empty(t, collectDispatch(p, chatCtx("!so", "moderator")))
+}
+
+func TestCustomPlainChatStillEmits(t *testing.T) {
+	p := customPipeline("hello {sender}", "everyone")
+	got := collectDispatch(p, chatCtx("!so", ""))
+	require.Len(t, got, 1)
+	assert.Equal(t, outgress.TypeChat, got[0].Type)
+}
+
+// --- baked command dispatch + gate ---
+
+// cmdEmit builds a module owning one everyone-perm command that emits reply.
+func cmdEmit(name string, kind module.Kind, trigger, reply string) module.Module {
+	b := module.NewModule(name, kind)
+	b.Command(trigger).Everyone().Run(func(_ context.Context, c *module.Context, _ string, emit module.Emit) error {
+		emit(&module.Output{Type: outgress.TypeChat, BroadcasterID: c.Env.BroadcasterUserID, Text: reply})
+		return nil
+	})
+	return b.Build()
+}
+
+func TestBakedCommandRuns(t *testing.T) {
+	p := newPipelineWith(&fakePublisher{}, fakeReader{}, cmdEmit("", module.KindCore, "ping", "pong"))
+	got := collectDispatch(p, chatCtx("!ping", ""))
+	require.Len(t, got, 1)
+	assert.Equal(t, "pong", got[0].Text)
+}
+
+func TestBakedCommandPermGate(t *testing.T) {
+	// A mod-only command: an everyone chatter is gated out.
+	b := module.NewModule("", module.KindCore)
+	b.Command("clear").Mod().Run(func(_ context.Context, c *module.Context, _ string, emit module.Emit) error {
+		emit(&module.Output{Type: outgress.TypeChat, BroadcasterID: c.Env.BroadcasterUserID, Text: "ok"})
+		return nil
+	})
+	p := newPipelineWith(&fakePublisher{}, fakeReader{}, b.Build())
+
+	assert.Empty(t, collectDispatch(p, chatCtx("!clear", "")))             // everyone -> gated
+	require.Len(t, collectDispatch(p, chatCtx("!clear", "moderator")), 1) // mod -> runs
+}
+
+// TestBakedOutputRoutedByMiddleware proves announce is post-processing, not a
+// command: a baked command that writes "/announce hi" is routed to an announce
+// action by the shared middleware, exactly as a custom command would be.
+func TestBakedOutputRoutedByMiddleware(t *testing.T) {
+	b := module.NewModule("", module.KindCore)
+	b.Command("hype").Everyone().Run(func(_ context.Context, c *module.Context, _ string, emit module.Emit) error {
+		emit(&module.Output{Type: outgress.TypeChat, BroadcasterID: c.Env.BroadcasterUserID, Text: "/announce hi"})
+		return nil
+	})
+	p := newPipelineWith(&fakePublisher{}, fakeReader{}, b.Build())
+
+	got := collectDispatch(p, chatCtx("!hype", ""))
+	require.Len(t, got, 1)
+	assert.Equal(t, outgress.TypeAnnounce, got[0].Type)
+	assert.Equal(t, "primary", got[0].Color)
+	assert.Equal(t, "hi", got[0].Text)
+}
+
+// --- integration: a command is gated by its owning module's enable state ---
+
+func TestOptInCommandGatedByModule(t *testing.T) {
+	extra := cmdEmit("extra", module.KindOptIn, "hi", "yo")
+
+	// No ModuleView row: the opt-in module is off, so its command must not run.
+	pub := &fakePublisher{}
+	p := newPipelineWith(pub, fakeReader{}, extra)
+	require.NoError(t, p.Process(chatMsg(t, "standard", "!hi")))
+	assert.Empty(t, pub.got, "opt-in command must not run while its module is disabled")
+
+	// ModuleView enables it: the command now runs.
+	pub2 := &fakePublisher{}
+	p2 := newPipelineWith(pub2, fakeReader{modules: []projection.ModuleView{{Name: "extra", IsEnabled: true}}}, extra)
+	require.NoError(t, p2.Process(chatMsg(t, "standard", "!hi")))
+	require.Len(t, pub2.got, 1)
+	assert.Equal(t, "yo", chatMessageText(t, pub2.got[0].msg))
+}
+
+func TestDefaultCommandGatedByModule(t *testing.T) {
+	extra := cmdEmit("greet", module.KindDefault, "hey", "hello")
+
+	// No row: a default module ships enabled, so its command runs.
+	pub := &fakePublisher{}
+	p := newPipelineWith(pub, fakeReader{}, extra)
+	require.NoError(t, p.Process(chatMsg(t, "standard", "!hey")))
+	require.Len(t, pub.got, 1)
+
+	// Row disables it: the command must not run.
+	pub2 := &fakePublisher{}
+	p2 := newPipelineWith(pub2, fakeReader{modules: []projection.ModuleView{{Name: "greet", IsEnabled: false}}}, extra)
+	require.NoError(t, p2.Process(chatMsg(t, "standard", "!hey")))
+	assert.Empty(t, pub2.got)
+}

--- a/app/sesame/engine/expand.go
+++ b/app/sesame/engine/expand.go
@@ -1,0 +1,66 @@
+package engine
+
+// expand performs a single-pass {key} substitution over tmpl, appending the
+// result into dst and returning the grown slice. It allocates nothing of its
+// own: the caller passes a pooled scratch buffer (see GetBuf) as dst.
+//
+// Literal runs are copied verbatim. On a "{key}" span, repl is asked for the
+// key's value: if it returns ok, the value is appended; otherwise the literal
+// "{key}" (braces included) is preserved, so an unknown token is left untouched
+// rather than silently dropped. A '{' with no matching '}' is copied literally
+// through to the end.
+func expand(dst []byte, tmpl string, repl func(key string) (val string, ok bool)) []byte {
+	for i := 0; i < len(tmpl); {
+		c := tmpl[i]
+		if c != '{' {
+			dst = append(dst, c)
+			i++
+			continue
+		}
+		// Find the closing brace.
+		end := -1
+		for j := i + 1; j < len(tmpl); j++ {
+			if tmpl[j] == '}' {
+				end = j
+				break
+			}
+		}
+		if end < 0 {
+			// No closing brace: copy the rest literally.
+			dst = append(dst, tmpl[i:]...)
+			break
+		}
+		key := tmpl[i+1 : end]
+		if val, ok := repl(key); ok {
+			dst = append(dst, val...)
+		} else {
+			// Unknown token: keep it literal, braces and all.
+			dst = append(dst, tmpl[i:end+1]...)
+		}
+		i = end + 1
+	}
+	return dst
+}
+
+// expandCommand expands a custom-command response, supporting the {user},
+// {sender}, {args} and {touser} tokens. It is expand specialized for the
+// command path so the hot path needs no closure capture beyond the four
+// strings. {target} is the dashboard-facing name for {touser}; both are kept
+// as aliases so existing commands continue to work. dst should be a pooled
+// scratch buffer.
+func expandCommand(dst []byte, tmpl, user, sender, args, touser string) []byte {
+	return expand(dst, tmpl, func(key string) (string, bool) {
+		switch key {
+		case "user":
+			return user, true
+		case "sender":
+			return sender, true
+		case "args":
+			return args, true
+		case "touser", "target":
+			return touser, true
+		default:
+			return "", false
+		}
+	})
+}

--- a/app/sesame/engine/expand_test.go
+++ b/app/sesame/engine/expand_test.go
@@ -1,0 +1,57 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExpandCommand(t *testing.T) {
+	tests := []struct {
+		name string
+		tmpl string
+		want string
+	}{
+		{"no tokens", "plain text", "plain text"},
+		{"user token", "hi {user}", "hi alice"},
+		{"sender alias", "from {sender}", "from alice"},
+		{"args token", "you said {args}", "you said the rest here"},
+		{"touser token", "@{touser} pong", "@bob pong"},
+		{"target alias", "@{target} pong", "@bob pong"},
+		{"multiple tokens", "{user} -> {touser}: {args}", "alice -> bob: the rest here"},
+		{"unknown token preserved", "keep {whatever} intact", "keep {whatever} intact"},
+		// No closing brace anywhere after the first '{': the tail is copied literally.
+		{"unterminated brace literal", "dangling {user and {more", "dangling {user and {more"},
+		// First '}' closes the span; the {user} resolves, the trailing '{more' is literal.
+		{"first brace closes span", "{user} and {more", "alice and {more"},
+		{"adjacent tokens", "{user}{touser}", "alicebob"},
+		{"empty braces preserved", "a {} b", "a {} b"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := expandCommand(nil, tt.tmpl, "alice", "alice", "the rest here", "bob")
+			assert.Equal(t, tt.want, string(got))
+		})
+	}
+}
+
+func TestExpandGenericRepl(t *testing.T) {
+	repl := func(key string) (string, bool) {
+		switch key {
+		case "raider":
+			return "CoolStreamer", true
+		case "viewers":
+			return "42", true
+		default:
+			return "", false
+		}
+	}
+	got := expand(nil, "{raider} raided with {viewers}! {unknown}", repl)
+	assert.Equal(t, "CoolStreamer raided with 42! {unknown}", string(got))
+}
+
+func TestExpandAppendsIntoDst(t *testing.T) {
+	dst := []byte("prefix: ")
+	got := expandCommand(dst, "hi {user}", "alice", "alice", "", "alice")
+	assert.Equal(t, "prefix: hi alice", string(got))
+}

--- a/app/sesame/engine/greet_valkey.go
+++ b/app/sesame/engine/greet_valkey.go
@@ -1,0 +1,61 @@
+package engine
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/valkey-io/valkey-go"
+	"go.uber.org/zap"
+)
+
+// greetKeyPrefix is the per-broadcaster set of chatter ids already greeted in the
+// current stream session: bagel:greeted:<broadcaster_id>.
+const greetKeyPrefix = "bagel:greeted:"
+
+// ValkeyGreetStore backs GreetStore with a Valkey set. SADD's return count makes
+// the first-message check atomic: a new member returns 1, an existing one 0.
+type ValkeyGreetStore struct {
+	client valkey.Client
+	ttl    time.Duration // safety expiry so an abandoned set is reclaimed
+	log    *zap.Logger
+}
+
+func NewValkeyGreetStore(client valkey.Client, ttl time.Duration, log *zap.Logger) *ValkeyGreetStore {
+	if ttl <= 0 {
+		ttl = 12 * time.Hour
+	}
+	if log == nil {
+		log = zap.NewNop()
+	}
+	return &ValkeyGreetStore{client: client, ttl: ttl, log: log}
+}
+
+func greetKey(id uint64) string { return greetKeyPrefix + strconv.FormatUint(id, 10) }
+
+func (s *ValkeyGreetStore) FirstGreet(ctx context.Context, broadcasterID uint64, chatterID string) (bool, error) {
+	key := greetKey(broadcasterID)
+	added, err := s.client.Do(ctx, s.client.B().Sadd().Key(key).Member(chatterID).Build()).AsInt64()
+	if err != nil {
+		return false, err
+	}
+	if added > 0 {
+		// First greet this session: (re)arm the safety expiry. Fire-and-forget so
+		// the EXPIRE round-trip never lands on the response path of the chat message
+		// that won the SADD (the single Valkey master is transatlantic). The SADD
+		// already decided the greet; the TTL is only a janitorial backstop.
+		seconds := int64(s.ttl.Seconds())
+		go func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			if err := s.client.Do(ctx, s.client.B().Expire().Key(key).Seconds(seconds).Build()).Error(); err != nil {
+				s.log.Warn("greet: failed to re-arm greeted-set expiry", zap.String("key", key), zap.Error(err))
+			}
+		}()
+	}
+	return added > 0, nil
+}
+
+func (s *ValkeyGreetStore) ResetGreets(ctx context.Context, broadcasterID uint64) error {
+	return s.client.Do(ctx, s.client.B().Del().Key(greetKey(broadcasterID)).Build()).Error()
+}

--- a/app/sesame/engine/live_valkey.go
+++ b/app/sesame/engine/live_valkey.go
@@ -1,0 +1,250 @@
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+	"strings"
+	"time"
+
+	"ItsBagelBot/internal/domain/invalidate"
+	livekey "ItsBagelBot/internal/domain/live"
+	"ItsBagelBot/internal/domain/outgress"
+	projectorrpc "ItsBagelBot/internal/domain/rpc/projector"
+	"ItsBagelBot/pkg/bus"
+	"ItsBagelBot/pkg/cache"
+
+	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/nats-io/nats.go"
+	"github.com/valkey-io/valkey-go"
+	"go.uber.org/zap"
+)
+
+// recheckKeyPrefix guards the per-broadcaster Twitch re-check so that, when many
+// replicas all see the same key expire, only one fires the outgress job. It
+// deliberately sorts under the shared live: prefix; onExpired skips it.
+const recheckKeyPrefix = "live:recheck:"
+
+// LiveConfig wires the Valkey-backed live store.
+type LiveConfig struct {
+	// TTL bounds how long a live key survives without a refresh; on expiry the
+	// key-event watcher re-checks Twitch (via outgress) rather than letting the
+	// state silently drop, so a stream longer than TTL is re-confirmed.
+	TTL time.Duration
+	// CacheTTL is the in-process cache lifetime for the resolved live bool.
+	CacheTTL time.Duration
+	// ProjectorLiveSubject is the projector RPC asked on a cold Valkey key.
+	ProjectorLiveSubject string
+	// OutgressSystemSubject is the outgress system lane the re-check job rides.
+	OutgressSystemSubject string
+	// CacheInvalidatePrefix is the core-NATS prefix used to fan a live change to
+	// every replica (subject = prefix + ".live").
+	CacheInvalidatePrefix string
+	// KeyspaceDB is the Valkey db the key-event watcher listens on (default 0).
+	KeyspaceDB int
+}
+
+// ValkeyLiveStore is the default LiveStore. The same struct owns the read path
+// (cache -> Valkey -> projector RPC), the write path (stream events), the
+// fleet-wide invalidation, and the key-expiry re-check.
+type ValkeyLiveStore struct {
+	client valkey.Client
+	nc     *nats.Conn
+	pub    message.Publisher
+	cfg    LiveConfig
+	log    *zap.Logger
+
+	// cache is keyed by the broadcaster id itself, not the live: string key, so a
+	// cache hit (the hot path: every live-only command gate and bagel check)
+	// allocates nothing.
+	cache      *cache.Keyed[uint64, bool]
+	rpcTimeout time.Duration
+
+	invalidationSub *nats.Subscription
+}
+
+// NewValkeyLiveStore builds a live store. pub publishes the re-check job onto the
+// outgress system lane; nc carries the projector RPC and the invalidation fan-out.
+func NewValkeyLiveStore(client valkey.Client, nc *nats.Conn, pub message.Publisher, cfg LiveConfig, log *zap.Logger) *ValkeyLiveStore {
+	if cfg.CacheTTL <= 0 {
+		cfg.CacheTTL = 30 * time.Second
+	}
+	return &ValkeyLiveStore{
+		client:     client,
+		nc:         nc,
+		pub:        pub,
+		cfg:        cfg,
+		log:        log,
+		cache:      cache.NewKeyed[uint64, bool](cache.DefaultCapacity, cfg.CacheTTL, livekey.Key),
+		rpcTimeout: 1500 * time.Millisecond,
+	}
+}
+
+func liveKey(id uint64) string { return livekey.Key(id) }
+
+// IsLive resolves the broadcaster's live state: in-process cache, then the shared
+// Valkey key, then the projector on a cold key. A live answer learned from the
+// projector is written back so the key-expiry re-check applies to it.
+func (s *ValkeyLiveStore) IsLive(ctx context.Context, broadcasterID uint64) (bool, error) {
+	return s.cache.GetOrLoad(ctx, broadcasterID, func(ctx context.Context) (bool, error) {
+		val, err := s.client.Do(ctx, s.client.B().Get().Key(liveKey(broadcasterID)).Build()).ToString()
+		if err == nil {
+			return val == "1", nil
+		}
+		if !valkey.IsValkeyNil(err) {
+			return false, err
+		}
+
+		// Cold key: ask the projector. It returns its own projected state or, on
+		// its miss, escalates to Twitch and replies offline (eventual). Treat an
+		// RPC failure as offline so an outage never falsely greenlights.
+		reply, err := bus.RequestJSONTimeout[projectorrpc.LiveReply](
+			ctx, s.nc, s.cfg.ProjectorLiveSubject,
+			projectorrpc.LiveRequest{BroadcasterID: strconv.FormatUint(broadcasterID, 10)},
+			s.rpcTimeout,
+		)
+		if err != nil {
+			return false, nil
+		}
+		if reply.Live {
+			_ = s.setLiveKey(ctx, broadcasterID)
+		}
+		return reply.Live, nil
+	})
+}
+
+// SetLive marks the broadcaster live (on stream.online) and fans the change out.
+func (s *ValkeyLiveStore) SetLive(ctx context.Context, broadcasterID uint64) error {
+	if err := s.setLiveKey(ctx, broadcasterID); err != nil {
+		return err
+	}
+	s.cache.Set(broadcasterID, true)
+	s.broadcast(broadcasterID)
+	return nil
+}
+
+// ClearLive drops the broadcaster's live state (on stream.offline) = invalidate.
+func (s *ValkeyLiveStore) ClearLive(ctx context.Context, broadcasterID uint64) error {
+	if err := s.client.Do(ctx, s.client.B().Del().Key(liveKey(broadcasterID)).Build()).Error(); err != nil {
+		return err
+	}
+	s.cache.Invalidate(broadcasterID)
+	s.broadcast(broadcasterID)
+	return nil
+}
+
+func (s *ValkeyLiveStore) setLiveKey(ctx context.Context, broadcasterID uint64) error {
+	ttl := s.cfg.TTL
+	if ttl <= 0 {
+		ttl = 12 * time.Hour
+	}
+	return s.client.Do(ctx, s.client.B().Set().Key(liveKey(broadcasterID)).Value("1").ExSeconds(int64(ttl.Seconds())).Build()).Error()
+}
+
+// broadcast fans a live change to every replica so their in-process caches drop
+// the entry immediately, backing the short cache TTL.
+func (s *ValkeyLiveStore) broadcast(broadcasterID uint64) {
+	if s.nc == nil || s.cfg.CacheInvalidatePrefix == "" {
+		return
+	}
+	if err := invalidate.Publish(s.nc, s.cfg.CacheInvalidatePrefix, livekey.InvalidateScope, strconv.FormatUint(broadcasterID, 10)); err != nil {
+		s.log.Warn("live: failed to broadcast invalidation", zap.Uint64("broadcaster_id", broadcasterID), zap.Error(err))
+	}
+}
+
+// StartInvalidationListener subscribes to prefix+".live" so a live change made by
+// any replica (or by outgress after a re-check) drops this replica's cached bool.
+func (s *ValkeyLiveStore) StartInvalidationListener() {
+	if s.cfg.CacheInvalidatePrefix == "" {
+		return
+	}
+	subject := s.cfg.CacheInvalidatePrefix + "." + livekey.InvalidateScope
+	sub, err := s.nc.Subscribe(subject, func(msg *nats.Msg) {
+		var dto invalidate.DTO
+		if err := json.Unmarshal(msg.Data, &dto); err != nil {
+			return
+		}
+		id, err := strconv.ParseUint(dto.BroadcasterID, 10, 64)
+		if err != nil || id == 0 {
+			return
+		}
+		s.cache.Invalidate(id)
+	})
+	if err != nil {
+		s.log.Error("live: failed to subscribe to invalidation", zap.String("subject", subject), zap.Error(err))
+		return
+	}
+	s.invalidationSub = sub
+	s.log.Info("live: invalidation listener started", zap.String("subject", subject))
+}
+
+// StartExpiryWatcher subscribes to Valkey key-expiry notifications and, when a
+// live key expires, asks outgress (system lane) to re-check the stream against
+// Twitch. It runs until ctx is cancelled. Requires the Valkey server to have
+// notify-keyspace-events including expired-key events (Ex). Run in a goroutine.
+func (s *ValkeyLiveStore) StartExpiryWatcher(ctx context.Context) {
+	channel := "__keyevent@" + strconv.Itoa(s.cfg.KeyspaceDB) + "__:expired"
+	s.log.Info("live: expiry watcher starting", zap.String("channel", channel))
+
+	for ctx.Err() == nil {
+		err := s.client.Receive(ctx, s.client.B().Subscribe().Channel(channel).Build(), func(msg valkey.PubSubMessage) {
+			s.onExpired(ctx, msg.Message)
+		})
+		if ctx.Err() != nil {
+			return
+		}
+		s.log.Warn("live: expiry watcher dropped, reconnecting", zap.Error(err))
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(time.Second):
+		}
+	}
+}
+
+// onExpired handles one expired-key notification. It ignores everything that is
+// not a live key (and the recheck guard keys), dedups across replicas with an NX
+// guard, then publishes the re-check job.
+func (s *ValkeyLiveStore) onExpired(ctx context.Context, key string) {
+	if !strings.HasPrefix(key, livekey.KeyPrefix) || strings.HasPrefix(key, recheckKeyPrefix) {
+		return
+	}
+	idStr := strings.TrimPrefix(key, livekey.KeyPrefix)
+	id, err := strconv.ParseUint(idStr, 10, 64)
+	if err != nil || id == 0 {
+		return
+	}
+
+	// One replica per expiry fires the re-check.
+	got, err := s.client.Do(ctx, s.client.B().Set().Key(recheckKeyPrefix+idStr).Value("1").Nx().ExSeconds(10).Build()).ToString()
+	if err != nil || got != "OK" {
+		return
+	}
+
+	if err := s.requestRecheck(ctx, idStr); err != nil {
+		s.log.Warn("live: failed to publish re-check", zap.String("broadcaster_id", idStr), zap.Error(err))
+	}
+}
+
+// requestRecheck publishes a stream_status job onto the outgress system lane;
+// outgress resolves Twitch and writes the live key back with a fresh TTL.
+func (s *ValkeyLiveStore) requestRecheck(ctx context.Context, broadcasterID string) error {
+	body, err := json.Marshal(outgress.StreamStatusJob{BroadcasterID: broadcasterID})
+	if err != nil {
+		return err
+	}
+	return bus.PublishJSON(ctx, s.pub, s.cfg.OutgressSystemSubject, outgress.Message{
+		Type:          outgress.TypeStreamStatus,
+		BroadcasterID: broadcasterID,
+		Payload:       body,
+	})
+}
+
+// Close releases the invalidation subscription. The expiry watcher stops with its
+// context.
+func (s *ValkeyLiveStore) Close() {
+	if s.invalidationSub != nil {
+		_ = s.invalidationSub.Unsubscribe()
+	}
+	s.cache.Close()
+}

--- a/app/sesame/engine/parse.go
+++ b/app/sesame/engine/parse.go
@@ -1,0 +1,19 @@
+package engine
+
+import "strings"
+
+// parseCommand extracts the command name and argument string from chat text.
+// "!so @bob hi" -> ("so", "@bob hi", true). Non-commands (no leading '!', or a
+// bare "!") return ok=false. The name is lowercased; args are trimmed.
+func parseCommand(text string) (name, args string, ok bool) {
+	trimmed := strings.TrimLeft(text, " ")
+	if !strings.HasPrefix(trimmed, "!") {
+		return "", "", false
+	}
+	body := strings.TrimPrefix(trimmed, "!")
+	name, args, _ = strings.Cut(body, " ")
+	if name == "" {
+		return "", "", false
+	}
+	return strings.ToLower(name), strings.TrimSpace(args), true
+}

--- a/app/sesame/engine/parse_test.go
+++ b/app/sesame/engine/parse_test.go
@@ -1,0 +1,34 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseCommand(t *testing.T) {
+	tests := []struct {
+		name     string
+		text     string
+		wantName string
+		wantArgs string
+		wantOk   bool
+	}{
+		{"plain text is not a command", "hello world", "", "", false},
+		{"bare bang is not a command", "!", "", "", false},
+		{"name only", "!ping", "ping", "", true},
+		{"name and args", "!so @bob hi", "so", "@bob hi", true},
+		{"name lowercased", "!PING", "ping", "", true},
+		{"leading spaces tolerated", "   !ping", "ping", "", true},
+		{"args trimmed", "!so    spaced   ", "so", "spaced", true},
+		{"empty after trim still ok name", "!a b", "a", "b", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			name, args, ok := parseCommand(tt.text)
+			assert.Equal(t, tt.wantOk, ok)
+			assert.Equal(t, tt.wantName, name)
+			assert.Equal(t, tt.wantArgs, args)
+		})
+	}
+}

--- a/app/sesame/engine/pipeline.go
+++ b/app/sesame/engine/pipeline.go
@@ -1,0 +1,305 @@
+package engine
+
+import (
+	"ItsBagelBot/app/sesame/module"
+	"ItsBagelBot/internal/domain/outgress"
+	"ItsBagelBot/internal/projection"
+	"ItsBagelBot/pkg/bus"
+
+	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/bytedance/sonic"
+	"github.com/newrelic/go-agent/v3/newrelic"
+	"go.uber.org/zap"
+)
+
+// Config carries the per-service knobs the pipeline needs beyond its Deps: the
+// bot's own id (to skip its own chat), the two outgress lane subjects, and
+// whether to run the command-use counter.
+type Config struct {
+	BotID            string
+	OutgressPremium  string
+	OutgressStandard string
+	// CountUses starts the command-use reporter (a background flusher). Off in
+	// tests so they leak no goroutine and publish no counter events.
+	CountUses bool
+}
+
+// Pipeline is the per-message stage the consumer hands each decoded message to.
+// It is the single point every message flows through once the consumer has
+// handed it off: decode, dispatch a command if the line is one, run the event
+// handlers registered for the type, and publish what they emit. Command dispatch
+// is folded in here (it reads the registry's command index directly), so there
+// is no separate router module and no Bind step.
+//
+// Ack discipline mirrors the worker: Process returns nil (ack) once the emitted
+// requests are published; an infrastructure failure before publishing (a
+// ModuleView read) returns an error (nack) for redelivery; a single handler's
+// logic error, or a command gate's store error, is logged and skipped, never
+// nacked, so one misbehaving path cannot re-fire its siblings; a publish/marshal
+// failure on the emit path does nack.
+//
+// The hot path is allocation-free above the JSON decoder floor for a plain chat
+// line that emits nothing: the envelope and the module Context are pooled, and
+// the emit sink only builds an outgress message when a handler actually emits.
+type Pipeline struct {
+	log      *zap.Logger
+	pub      message.Publisher
+	proj     projection.Reader
+	registry *Registry
+
+	live     IsLiveChecker
+	cooldown CooldownStore
+	uses     *useReporter
+
+	botID            string
+	outgressPremium  string
+	outgressStandard string
+}
+
+// NewPipeline wires a Pipeline from the shared Deps, a pre-built registry, and
+// the per-service Config. It pulls its projection reader, live checker, cooldown
+// store, publisher and logger from d, so main constructs those once.
+func NewPipeline(d Deps, registry *Registry, cfg Config) *Pipeline {
+	p := &Pipeline{
+		log:              d.Log,
+		pub:              d.Pub,
+		proj:             d.Proj,
+		registry:         registry,
+		live:             d.Live,
+		cooldown:         d.Cooldown,
+		botID:            cfg.BotID,
+		outgressPremium:  cfg.OutgressPremium,
+		outgressStandard: cfg.OutgressStandard,
+	}
+	if cfg.CountUses && d.Pub != nil {
+		p.uses = newUseReporter(d.Pub, d.Log)
+	}
+	return p
+}
+
+// Close flushes and stops the command-use reporter. Safe when it was never
+// started (CountUses false).
+func (p *Pipeline) Close() {
+	if p.uses != nil {
+		p.uses.Close()
+	}
+}
+
+// chatType is the one EventSub type that carries command dispatch.
+const chatType = "channel.chat.message"
+
+// Process decodes one message, dispatches a command when the line is one, runs
+// the event handlers registered for the type, and publishes what they emit.
+func (p *Pipeline) Process(msg *message.Message) error {
+	ctx := msg.Context()
+
+	// Decode into a pooled envelope so the plain-chat path allocates nothing here.
+	env := GetEnvelope()
+	defer PutEnvelope(env)
+	if err := sonic.Unmarshal(msg.Payload, env); err != nil {
+		// A malformed envelope is poison: redelivering it forever helps no one, so
+		// drop it (ack) and move on.
+		p.log.Warn("dropping malformed envelope", zap.String("message_id", msg.UUID), zap.Error(err))
+		if txn := newrelic.FromContext(ctx); txn != nil {
+			txn.NoticeError(err)
+		}
+		return nil
+	}
+
+	isChat := env.Type == chatType
+
+	// The bot sees its own chat sends via EventSub; never react to them.
+	if p.botID != "" && isChat && env.ChatterUserID == p.botID {
+		return nil
+	}
+
+	// Event handlers registered for this type. Chat always runs (command dispatch
+	// is engine-internal, not a registered handler), so only non-chat types with
+	// no handler can bail out here with no work.
+	handlers := p.registry.For(env.Type)
+	if !isChat && len(handlers) == 0 {
+		return nil
+	}
+
+	broadcasterID, ok := env.BroadcasterID()
+	if !ok {
+		return nil
+	}
+
+	if txn := newrelic.FromContext(ctx); txn != nil {
+		txn.AddAttribute("event.type", env.Type)
+		txn.AddAttribute("event.broadcaster_id", broadcasterID)
+	}
+
+	regress := module.RegressFromLane(env.Lane)
+
+	// Resolve the broadcaster's module toggles + configs once, and only when a
+	// name-gated handler is registered for this type. Plain chat hits only core
+	// handlers, so this read is skipped entirely.
+	var views map[string]projection.ModuleView
+	if p.registry.NeedsModuleViews(env.Type) {
+		list, err := p.proj.Modules(ctx, broadcasterID)
+		if err != nil {
+			return err // infrastructure failure: nack
+		}
+		views = make(map[string]projection.ModuleView, len(list))
+		for _, v := range list {
+			views[v.Name] = v
+		}
+	}
+
+	mctx := GetContext()
+	defer PutContext(mctx)
+	mctx.Env = *env
+	mctx.Regress = regress
+	mctx.BroadcasterID = broadcasterID
+	mctx.Log = p.log
+
+	// emit is the sink command Run and event handlers hand their Outputs to. It
+	// builds and publishes inline onto the lane matching the regress status. The
+	// first publish or marshal failure is captured and short-circuits the rest:
+	// an infrastructure error must nack, and once one publish has failed there is
+	// no point attempting the siblings.
+	var emitErr error
+	emit := func(o *module.Output) {
+		if emitErr != nil || o == nil || o.Type == "" {
+			return
+		}
+		subject := p.outgressStandard
+		if regress.IsPremium() {
+			subject = p.outgressPremium
+		}
+		body, err := buildOutgress(o)
+		if err != nil {
+			emitErr = err
+			return
+		}
+		if err := bus.PublishRaw(ctx, p.pub, subject, body); err != nil {
+			emitErr = err
+		}
+	}
+
+	// Command dispatch stage: chat only, always on. A gate store error is logged
+	// and skipped like a handler error, never nacked.
+	if isChat {
+		if err := p.dispatchCommand(ctx, mctx, views, emit); err != nil {
+			p.log.Error("command dispatch failed",
+				zap.Uint64("broadcaster_id", broadcasterID), zap.Error(err))
+			if txn := newrelic.FromContext(ctx); txn != nil {
+				txn.NoticeError(err)
+			}
+		}
+	}
+
+	// Event handlers (the non-command path).
+	for _, m := range handlers {
+		if !p.enabled(m, views, mctx) {
+			continue
+		}
+		handle := m.Events[env.Type]
+		if handle == nil {
+			continue
+		}
+		if err := handle(ctx, mctx, emit); err != nil {
+			// Logic error: log and skip this module, do not nack (would re-fire the
+			// siblings that already succeeded on redelivery).
+			p.log.Error("module handler failed",
+				zap.String("module", moduleLabel(m)),
+				zap.String("type", env.Type),
+				zap.Uint64("broadcaster_id", broadcasterID),
+				zap.Error(err))
+			if txn := newrelic.FromContext(ctx); txn != nil {
+				txn.AddAttribute("module.failed", moduleLabel(m))
+				txn.NoticeError(err)
+			}
+			continue
+		}
+	}
+
+	// nil = ack; a publish/marshal failure on the emit path = nack.
+	return emitErr
+}
+
+// enabled applies the per-module enable gate and wires the module's config into
+// the context: a core module is always on; a KindDefault module runs unless its
+// ModuleView disables it; a KindOptIn module runs only when its ModuleView
+// enables it. There is no premium gate: premium vs standard is a routing lane
+// (see emit), not a feature switch, so every module is available on both.
+func (p *Pipeline) enabled(m module.Module, views map[string]projection.ModuleView, mctx *module.Context) bool {
+	switch m.Kind {
+	case module.KindCore:
+		mctx.Config = nil
+		return true
+	case module.KindDefault:
+		if mv, ok := views[m.Name]; ok {
+			if !mv.IsEnabled {
+				return false
+			}
+			mctx.Config = mv.Configs
+		} else {
+			mctx.Config = nil // ships enabled: no row means on, no config
+		}
+		return true
+	case module.KindOptIn:
+		mv, ok := views[m.Name]
+		if !ok || !mv.IsEnabled {
+			return false
+		}
+		mctx.Config = mv.Configs
+		return true
+	default:
+		return false
+	}
+}
+
+// buildOutgress translates a module Output into the marshaled bytes of the full
+// outgress.Message wire contract. The inner Payload is built from a small typed
+// struct rather than a map so sonic escapes emoji and quotes in the body
+// correctly. This runs only when a handler actually emits, so the allocation it
+// costs never touches the no-output plain-chat path.
+func buildOutgress(o *module.Output) ([]byte, error) {
+	var msg outgress.Message
+
+	switch o.Type {
+	case outgress.TypeChat:
+		payload, err := sonic.Marshal(struct {
+			BroadcasterID string `json:"broadcaster_id"`
+			Message       string `json:"message"`
+		}{o.BroadcasterID, o.Text})
+		if err != nil {
+			return nil, err
+		}
+		msg = outgress.Message{
+			Type:          outgress.TypeChat,
+			BroadcasterID: o.BroadcasterID,
+			Payload:       payload,
+		}
+	case outgress.TypeAnnounce:
+		payload, err := sonic.Marshal(struct {
+			Message string `json:"message"`
+		}{o.Text})
+		if err != nil {
+			return nil, err
+		}
+		msg = outgress.Message{
+			Type:          outgress.TypeAnnounce,
+			BroadcasterID: o.BroadcasterID,
+			Color:         o.Color,
+			Payload:       payload,
+		}
+	case outgress.TypeShoutout:
+		msg = outgress.Message{
+			Type:          outgress.TypeShoutout,
+			BroadcasterID: o.BroadcasterID,
+			To:            o.To,
+			Payload:       []byte("{}"),
+		}
+	default:
+		msg = outgress.Message{
+			Type:          o.Type,
+			BroadcasterID: o.BroadcasterID,
+		}
+	}
+
+	return sonic.Marshal(msg)
+}

--- a/app/sesame/engine/pipeline_bench_test.go
+++ b/app/sesame/engine/pipeline_bench_test.go
@@ -1,0 +1,85 @@
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"ItsBagelBot/app/sesame/module"
+
+	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/bytedance/sonic"
+)
+
+// benchChatBody builds a representative channel.chat.message envelope once, so the
+// benchmarks measure Process, not message construction.
+func benchChatBody() []byte {
+	body, err := sonic.Marshal(map[string]any{
+		"type":                chatType,
+		"lane":                "standard",
+		"broadcaster_user_id": "123",
+		"chatter_user_id":     "999",
+		"text":                "hello chat how is everyone",
+	})
+	if err != nil {
+		panic(err)
+	}
+	return body
+}
+
+// silentCore is a core chat handler that emits nothing: the true hot path.
+func silentCore() module.Module {
+	b := module.NewModule("", module.KindCore)
+	b.On(chatType, func(context.Context, *module.Context, module.Emit) error { return nil })
+	return b.Build()
+}
+
+// BenchmarkProcessNoOutput is the true hot path: a plain chat line that matches a
+// core handler which emits nothing. Everything per-message (envelope, context) is
+// pooled, so the only remaining allocations are the JSON decoder's internals.
+func BenchmarkProcessNoOutput(b *testing.B) {
+	p := newPipelineWith(&fakePublisher{}, fakeReader{}, silentCore())
+	msg := message.NewMessage("uuid", benchChatBody())
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := p.Process(msg); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkProcessChatEmit measures the emit path: a handler produces one chat
+// Output that is marshaled and published. Allocation here is expected and is the
+// cost the hot path above avoids.
+func BenchmarkProcessChatEmit(b *testing.B) {
+	p := newPipelineWith(&fakePublisher{}, fakeReader{}, emitModule("", module.KindCore, "pong"))
+	msg := message.NewMessage("uuid", benchChatBody())
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := p.Process(msg); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// TestProcessNoOutputAllocCeiling is a regression guard: the pooled no-output hot
+// path must stay at or below a small allocation ceiling (the decoder floor). The
+// ceiling is deliberately loose so normal decoder variance does not flake it; it
+// exists to catch a structural regression (un-pooling Context/Envelope), not to
+// assert an exact count.
+func TestProcessNoOutputAllocCeiling(t *testing.T) {
+	p := newPipelineWith(&fakePublisher{}, fakeReader{}, silentCore())
+	msg := message.NewMessage("uuid", benchChatBody())
+
+	avg := testing.AllocsPerRun(500, func() {
+		_ = p.Process(msg)
+	})
+
+	const ceiling = 12.0
+	if avg > ceiling {
+		t.Fatalf("no-output hot path allocates %.1f allocs/op, ceiling %.0f: pooling likely regressed", avg, ceiling)
+	}
+}

--- a/app/sesame/engine/pipeline_test.go
+++ b/app/sesame/engine/pipeline_test.go
@@ -1,0 +1,230 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"ItsBagelBot/app/sesame/module"
+	"ItsBagelBot/internal/domain/outgress"
+	"ItsBagelBot/internal/projection"
+
+	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/bytedance/sonic"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// --- shared test doubles (used across the engine test files) ---
+
+// captured is one published outgress message with the subject it rode.
+type captured struct {
+	subject string
+	msg     outgress.Message
+}
+
+type fakePublisher struct {
+	got     []captured
+	failErr error
+}
+
+func (p *fakePublisher) Publish(subject string, msgs ...*message.Message) error {
+	if p.failErr != nil {
+		return p.failErr
+	}
+	for _, m := range msgs {
+		var om outgress.Message
+		_ = sonic.Unmarshal(m.Payload, &om)
+		p.got = append(p.got, captured{subject: subject, msg: om})
+	}
+	return nil
+}
+
+func (p *fakePublisher) Close() error { return nil }
+
+// fakeReader is a configurable projection.Reader.
+type fakeReader struct {
+	user     projection.User
+	modules  []projection.ModuleView
+	modErr   error
+	cmd      projection.Command
+	cmdFound bool
+}
+
+func (r fakeReader) User(context.Context, uint64) (projection.User, error) { return r.user, nil }
+func (r fakeReader) Modules(context.Context, uint64) ([]projection.ModuleView, error) {
+	return r.modules, r.modErr
+}
+func (r fakeReader) Command(context.Context, uint64, string) (projection.Command, bool, error) {
+	return r.cmd, r.cmdFound, nil
+}
+
+// liveAlways is a LiveStore that reports live and no-ops its writes.
+type liveAlways struct{}
+
+func (liveAlways) IsLive(context.Context, uint64) (bool, error) { return true, nil }
+func (liveAlways) SetLive(context.Context, uint64) error        { return nil }
+func (liveAlways) ClearLive(context.Context, uint64) error      { return nil }
+
+const (
+	premiumSubj  = "outgress.premium"
+	standardSubj = "outgress.standard"
+)
+
+func newPipelineWith(pub message.Publisher, reader projection.Reader, mods ...module.Module) *Pipeline {
+	reg := NewRegistry(zap.NewNop(), mods...)
+	d := Deps{Proj: reader, Live: liveAlways{}, Cooldown: NoopCooldown{}, Pub: pub, Log: zap.NewNop()}
+	return NewPipeline(d, reg, Config{OutgressPremium: premiumSubj, OutgressStandard: standardSubj})
+}
+
+func chatMsg(t *testing.T, laneName, text string) *message.Message {
+	t.Helper()
+	body, err := sonic.Marshal(map[string]any{
+		"type":                chatType,
+		"lane":                laneName,
+		"broadcaster_user_id": "123",
+		"chatter_user_id":     "999",
+		"text":                text,
+	})
+	require.NoError(t, err)
+	return message.NewMessage("uuid-1", body)
+}
+
+// bareModule is a module with only a Kind/Name, for enabled() unit tests.
+func bareModule(name string, kind module.Kind) module.Module {
+	return module.NewModule(name, kind).Build()
+}
+
+// emitModule emits one fixed chat line on the chat event path. It fills a pooled
+// Output like a real handler.
+func emitModule(name string, kind module.Kind, text string) module.Module {
+	b := module.NewModule(name, kind)
+	b.On(chatType, func(_ context.Context, c *module.Context, emit module.Emit) error {
+		o := GetOutput()
+		defer PutOutput(o)
+		o.Type = outgress.TypeChat
+		o.BroadcasterID = c.Env.BroadcasterUserID
+		o.Text = text
+		emit(o)
+		return nil
+	})
+	return b.Build()
+}
+
+// errCore is a core module whose chat handler returns a logic error.
+func errCore() module.Module {
+	b := module.NewModule("", module.KindCore)
+	b.On(chatType, func(context.Context, *module.Context, module.Emit) error {
+		return errors.New("boom")
+	})
+	return b.Build()
+}
+
+// === enabled() gate tests ===
+
+func TestEnabledCoreModuleAlwaysRuns(t *testing.T) {
+	p := &Pipeline{}
+	mctx := &module.Context{Config: []byte("stale")}
+	assert.True(t, p.enabled(bareModule("", module.KindCore), nil, mctx))
+	assert.Nil(t, mctx.Config) // core modules carry no config
+}
+
+func TestEnabledDefaultModule(t *testing.T) {
+	p := &Pipeline{}
+	m := bareModule("feature", module.KindDefault)
+
+	// row present, enabled, with config -> runs and config is wired in
+	views := map[string]projection.ModuleView{"feature": {Name: "feature", IsEnabled: true, Configs: []byte(`{"x":1}`)}}
+	mctx := &module.Context{}
+	assert.True(t, p.enabled(m, views, mctx))
+	assert.Equal(t, []byte(`{"x":1}`), []byte(mctx.Config))
+
+	// row present, disabled -> skipped
+	off := map[string]projection.ModuleView{"feature": {Name: "feature", IsEnabled: false}}
+	assert.False(t, p.enabled(m, off, &module.Context{}))
+
+	// no row -> ships enabled (default on)
+	assert.True(t, p.enabled(m, nil, &module.Context{}))
+}
+
+func TestEnabledOptInModule(t *testing.T) {
+	p := &Pipeline{}
+	m := bareModule("shoutout", module.KindOptIn)
+
+	// no row -> off
+	assert.False(t, p.enabled(m, nil, &module.Context{}))
+
+	// row enabled -> on, config wired
+	on := map[string]projection.ModuleView{"shoutout": {Name: "shoutout", IsEnabled: true, Configs: []byte(`{"m":"hi"}`)}}
+	mctx := &module.Context{}
+	assert.True(t, p.enabled(m, on, mctx))
+	assert.Equal(t, []byte(`{"m":"hi"}`), []byte(mctx.Config))
+
+	// row disabled -> off
+	off := map[string]projection.ModuleView{"shoutout": {Name: "shoutout", IsEnabled: false}}
+	assert.False(t, p.enabled(m, off, &module.Context{}))
+}
+
+// === Process() tests ===
+
+func TestProcessMalformedEnvelopeDropped(t *testing.T) {
+	pub := &fakePublisher{}
+	p := newPipelineWith(pub, fakeReader{}, emitModule("", module.KindCore, "x"))
+	err := p.Process(message.NewMessage("uuid-bad", []byte("{not json")))
+	assert.NoError(t, err)   // ack, not nack
+	assert.Empty(t, pub.got) // nothing published
+}
+
+func TestProcessNoModuleAcks(t *testing.T) {
+	pub := &fakePublisher{}
+	p := newPipelineWith(pub, fakeReader{}) // empty registry
+	err := p.Process(chatMsg(t, "premium", "hi"))
+	assert.NoError(t, err)
+	assert.Empty(t, pub.got)
+}
+
+func TestProcessChatEmittedToStandardLane(t *testing.T) {
+	pub := &fakePublisher{}
+	p := newPipelineWith(pub, fakeReader{}, emitModule("", module.KindCore, "pong"))
+	err := p.Process(chatMsg(t, "standard", "hi"))
+	require.NoError(t, err)
+	require.Len(t, pub.got, 1)
+	assert.Equal(t, standardSubj, pub.got[0].subject)
+	assert.Equal(t, outgress.TypeChat, pub.got[0].msg.Type)
+	assert.Equal(t, "123", pub.got[0].msg.BroadcasterID)
+
+	var inner struct {
+		BroadcasterID string `json:"broadcaster_id"`
+		Message       string `json:"message"`
+	}
+	require.NoError(t, sonic.Unmarshal(pub.got[0].msg.Payload, &inner))
+	assert.Equal(t, "pong", inner.Message)
+	assert.Equal(t, "123", inner.BroadcasterID)
+}
+
+func TestProcessChatEmittedToPremiumLane(t *testing.T) {
+	pub := &fakePublisher{}
+	p := newPipelineWith(pub, fakeReader{}, emitModule("", module.KindCore, "pong"))
+	err := p.Process(chatMsg(t, "premium", "hi"))
+	require.NoError(t, err)
+	require.Len(t, pub.got, 1)
+	assert.Equal(t, premiumSubj, pub.got[0].subject)
+}
+
+func TestProcessModuleErrorSkippedNotNacked(t *testing.T) {
+	pub := &fakePublisher{}
+	// one failing module, one good module: error is logged+skipped, good still emits
+	p := newPipelineWith(pub, fakeReader{}, errCore(), emitModule("", module.KindCore, "still here"))
+	err := p.Process(chatMsg(t, "standard", "hi"))
+	assert.NoError(t, err) // logic error does NOT nack
+	require.Len(t, pub.got, 1)
+	assert.Equal(t, outgress.TypeChat, pub.got[0].msg.Type)
+}
+
+func TestProcessPublishErrorNacks(t *testing.T) {
+	pub := &fakePublisher{failErr: errors.New("broker down")}
+	p := newPipelineWith(pub, fakeReader{}, emitModule("", module.KindCore, "pong"))
+	err := p.Process(chatMsg(t, "standard", "hi"))
+	assert.Error(t, err) // publish failure DOES nack
+}

--- a/app/sesame/engine/pool.go
+++ b/app/sesame/engine/pool.go
@@ -1,0 +1,93 @@
+package engine
+
+import (
+	"sync"
+
+	"ItsBagelBot/app/sesame/module"
+	"ItsBagelBot/internal/domain/event/lane"
+)
+
+// The pipeline runs one Context, one Envelope, a handful of Outputs and a
+// scratch buffer per message on a hot path that fires for every chat line, so
+// each of those is pooled here. The pipeline owns the lifecycle: Get one, fill
+// it, use it within the message, then Put it back. Nothing pooled may be
+// retained past the message it was Got for.
+
+var ctxPool = sync.Pool{New: func() any { return new(module.Context) }}
+
+// GetContext returns a zeroed *module.Context from the pool, ready to fill.
+func GetContext() *module.Context {
+	c := ctxPool.Get().(*module.Context)
+	c.Reset()
+	return c
+}
+
+// PutContext returns a Context to the pool. The caller must not use c again.
+func PutContext(c *module.Context) {
+	if c == nil {
+		return
+	}
+	c.Reset()
+	ctxPool.Put(c)
+}
+
+var envPool = sync.Pool{New: func() any { return new(lane.Envelope) }}
+
+// GetEnvelope returns a reset *lane.Envelope from the pool. The Badges backing
+// array is retained (truncated to len 0) so decoding into it reuses capacity.
+func GetEnvelope() *lane.Envelope {
+	e := envPool.Get().(*lane.Envelope)
+	resetEnvelope(e)
+	return e
+}
+
+// PutEnvelope returns an Envelope to the pool. The caller must not use e again.
+func PutEnvelope(e *lane.Envelope) {
+	if e == nil {
+		return
+	}
+	resetEnvelope(e)
+	envPool.Put(e)
+}
+
+// resetEnvelope zeroes an Envelope's fields while keeping the Badges backing
+// array so it can be re-decoded into without a fresh allocation.
+func resetEnvelope(e *lane.Envelope) {
+	badges := e.Badges[:0]
+	*e = lane.Envelope{}
+	e.Badges = badges
+}
+
+var outPool = sync.Pool{New: func() any { return new(module.Output) }}
+
+// GetOutput returns a zeroed *module.Output from the pool, ready to fill.
+func GetOutput() *module.Output {
+	o := outPool.Get().(*module.Output)
+	*o = module.Output{}
+	return o
+}
+
+// PutOutput returns an Output to the pool. The caller must not use o again.
+func PutOutput(o *module.Output) {
+	if o == nil {
+		return
+	}
+	*o = module.Output{}
+	outPool.Put(o)
+}
+
+// bufPool hands out []byte scratch buffers for the zero-alloc template/key
+// builders. Buffers come back reset to length 0 with their capacity intact.
+var bufPool = sync.Pool{New: func() any { b := make([]byte, 0, 256); return &b }}
+
+// GetBuf returns a scratch buffer with len 0 (capacity retained).
+func GetBuf() []byte {
+	bp := bufPool.Get().(*[]byte)
+	return (*bp)[:0]
+}
+
+// PutBuf returns a scratch buffer to the pool. The caller must not use b again.
+func PutBuf(b []byte) {
+	b = b[:0]
+	bufPool.Put(&b)
+}

--- a/app/sesame/engine/registry.go
+++ b/app/sesame/engine/registry.go
@@ -1,0 +1,115 @@
+package engine
+
+import (
+	"ItsBagelBot/app/sesame/module"
+
+	"go.uber.org/zap"
+)
+
+// BoundCommand is a command together with the module that owns it. The pipeline
+// gates the command through its owner's enable/premium state before running it,
+// so a command on a disabled or premium-gated module never fires — commands and
+// event handlers share one gating model. The owner also carries the module's
+// config, which the pipeline wires into the Context so a command can read its
+// module's settings.
+type BoundCommand struct {
+	Cmd   module.Command
+	Owner module.Module
+}
+
+// Registry indexes the built modules by the EventSub type each handles on its
+// non-command path, and bakes a flat index of every command any module owns
+// (name and aliases alike), each bound to its owning module. It also precomputes
+// which event types need the broadcaster's ModuleView set fetched. It is built
+// once at startup and never mutated after, so lookups on the hot path are
+// lock-free.
+type Registry struct {
+	byEvent   map[string][]module.Module
+	commands  map[string]BoundCommand
+	needViews map[string]bool
+}
+
+// NewRegistry builds the event-type index and the bound-command index from the
+// given modules. A module is indexed under every type present in its Events map;
+// each command it owns is registered under its name and each alias, bound to the
+// module. The first registration of a trigger wins: a cross-module duplicate is
+// logged and ignored so a misconfigured module can never silently shadow
+// another's command. (Duplicates within a single module are already rejected by
+// Builder.Build.) An event type — or the chat command path — that has any
+// non-core module is flagged as needing ModuleView fetches. log may be nil
+// (duplicates are then silently ignored).
+func NewRegistry(log *zap.Logger, mods ...module.Module) *Registry {
+	r := &Registry{
+		byEvent:   make(map[string][]module.Module),
+		commands:  make(map[string]BoundCommand),
+		needViews: make(map[string]bool),
+	}
+	for _, m := range mods {
+		for evt := range m.Events {
+			r.byEvent[evt] = append(r.byEvent[evt], m)
+			if m.Kind != module.KindCore {
+				r.needViews[evt] = true
+			}
+		}
+		for _, cmd := range m.Commands {
+			r.bind(log, m, cmd, cmd.Name)
+			for _, alias := range cmd.Aliases {
+				r.bind(log, m, cmd, alias)
+			}
+			// A command owned by a named module must be gated by that module's
+			// ModuleView, so the chat path needs the view fetch.
+			if m.Kind != module.KindCore {
+				r.needViews[chatType] = true
+			}
+		}
+	}
+	return r
+}
+
+// bind registers cmd (owned by m) under trigger, first-wins.
+func (r *Registry) bind(log *zap.Logger, m module.Module, cmd module.Command, trigger string) {
+	if trigger == "" {
+		return
+	}
+	if existing, dup := r.commands[trigger]; dup {
+		if log != nil {
+			log.Warn("engine: duplicate command trigger ignored",
+				zap.String("trigger", trigger),
+				zap.String("module", moduleLabel(m)),
+				zap.String("kept_owner", moduleLabel(existing.Owner)),
+			)
+		}
+		return
+	}
+	r.commands[trigger] = BoundCommand{Cmd: cmd, Owner: m}
+}
+
+// For returns the modules registered for an event type, or nil when none are.
+// The returned slice is owned by the registry and must not be mutated.
+func (r *Registry) For(eventType string) []module.Module { return r.byEvent[eventType] }
+
+// NeedsModuleViews reports whether processing this event type must fetch the
+// broadcaster's ModuleView set: true when any event handler for the type, or any
+// command owner on the chat path, is name-gated (not core). Plain chat with only
+// core commands and handlers returns false, so the pipeline skips the projection
+// read entirely.
+func (r *Registry) NeedsModuleViews(eventType string) bool { return r.needViews[eventType] }
+
+// Command looks up a bound command by a lowercased trigger (name or alias).
+func (r *Registry) Command(name string) (BoundCommand, bool) {
+	bc, ok := r.commands[name]
+	return bc, ok
+}
+
+// Commands returns the bound-command index. The map is owned by the registry and
+// must be treated as read-only.
+func (r *Registry) Commands() map[string]BoundCommand { return r.commands }
+
+// moduleLabel names a module for logs: its Name, or "core" for the unnamed core
+// modules.
+func moduleLabel(m module.Module) string {
+	if m.Name != "" {
+		return m.Name
+	}
+	return "core"
+}

--- a/app/sesame/engine/registry_test.go
+++ b/app/sesame/engine/registry_test.go
@@ -1,0 +1,120 @@
+package engine
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"ItsBagelBot/app/sesame/module"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func noRun(context.Context, *module.Context, string, module.Emit) error { return nil }
+func noEvt(context.Context, *module.Context, module.Emit) error         { return nil }
+
+// evtModule builds a module that handles the given event types (no commands).
+func evtModule(name string, kind module.Kind, events ...string) module.Module {
+	b := module.NewModule(name, kind)
+	for _, e := range events {
+		b.On(e, noEvt)
+	}
+	return b.Build()
+}
+
+// cmdModule builds a module owning one command with the given trigger and perm.
+func cmdModule(name string, kind module.Kind, trigger string, perm module.Role) module.Module {
+	b := module.NewModule(name, kind)
+	c := b.Command(trigger)
+	switch perm {
+	case module.RoleBroadcaster:
+		c.Broadcaster()
+	case module.RoleModerator:
+		c.Mod()
+	default:
+		c.Everyone()
+	}
+	c.Run(noRun)
+	return b.Build()
+}
+
+func TestRegistryRouting(t *testing.T) {
+	core := evtModule("", module.KindCore, chatType)
+	named := evtModule("bagel", module.KindDefault, chatType, "stream.online")
+	reg := NewRegistry(nil, core, named)
+
+	assert.Len(t, reg.For(chatType), 2)
+	assert.Len(t, reg.For("stream.online"), 1)
+	assert.Empty(t, reg.For("channel.cheer"))
+}
+
+func TestNeedsModuleViews(t *testing.T) {
+	core := evtModule("", module.KindCore, chatType)
+	named := evtModule("bagel", module.KindDefault, "stream.online")
+	reg := NewRegistry(nil, core, named)
+
+	// Plain chat hits only the core module: no ModuleView fetch needed.
+	assert.False(t, reg.NeedsModuleViews(chatType))
+	// stream.online has a name-gated module: the pipeline must fetch views.
+	assert.True(t, reg.NeedsModuleViews("stream.online"))
+	assert.False(t, reg.NeedsModuleViews("unmapped"))
+}
+
+func TestNeedsModuleViewsForNamedCommand(t *testing.T) {
+	// A named module that owns a chat command forces the chat path to fetch views
+	// so the command can be gated by the module's enable flag.
+	named := cmdModule("extra", module.KindOptIn, "hi", module.RoleEveryone)
+	reg := NewRegistry(nil, named)
+	assert.True(t, reg.NeedsModuleViews(chatType))
+}
+
+func TestRegistryCommandIndex(t *testing.T) {
+	b := module.NewModule("", module.KindCore)
+	b.Command("ping").Everyone().Cooldown(5 * time.Second).Run(noRun)
+	b.Command("uptime").Mod().LiveOnly().Run(noRun)
+	reg := NewRegistry(nil, b.Build())
+
+	bc, ok := reg.Command("ping")
+	assert.True(t, ok)
+	assert.Equal(t, "ping", bc.Cmd.Name)
+	assert.Equal(t, 5*time.Second, bc.Cmd.Cooldown)
+
+	bc, ok = reg.Command("uptime")
+	assert.True(t, ok)
+	assert.True(t, bc.Cmd.LiveOnly)
+	assert.Equal(t, module.RoleModerator, bc.Cmd.Perm)
+
+	_, ok = reg.Command("nope")
+	assert.False(t, ok)
+
+	assert.Len(t, reg.Commands(), 2)
+}
+
+func TestRegistryAliasesIndexed(t *testing.T) {
+	b := module.NewModule("", module.KindCore)
+	b.Command("so").Aliases("shoutout").Run(noRun)
+	reg := NewRegistry(nil, b.Build())
+
+	bc, ok := reg.Command("so")
+	assert.True(t, ok)
+	assert.Equal(t, "so", bc.Cmd.Name)
+
+	bc, ok = reg.Command("shoutout") // alias resolves to the same command
+	assert.True(t, ok)
+	assert.Equal(t, "so", bc.Cmd.Name)
+
+	assert.Len(t, reg.Commands(), 2) // name + alias
+}
+
+func TestRegistryDuplicateCommandFirstWins(t *testing.T) {
+	first := cmdModule("a", module.KindDefault, "dup", module.RoleEveryone)
+	second := cmdModule("b", module.KindDefault, "dup", module.RoleBroadcaster)
+	reg := NewRegistry(nil, first, second)
+
+	bc, ok := reg.Command("dup")
+	assert.True(t, ok)
+	// First registration wins: the everyone perm and module "a" as owner.
+	assert.Equal(t, module.RoleEveryone, bc.Cmd.Perm)
+	assert.Equal(t, "a", bc.Owner.Name)
+	assert.Len(t, reg.Commands(), 1)
+}

--- a/app/sesame/engine/slash.go
+++ b/app/sesame/engine/slash.go
@@ -1,0 +1,101 @@
+package engine
+
+import (
+	"strings"
+
+	"ItsBagelBot/app/sesame/module"
+	"ItsBagelBot/internal/domain/outgress"
+)
+
+// Translate inspects out.Text for a leading slash-verb and, when it finds a
+// known one, rewrites the Output in place: it sets the outgress Type (and Color
+// or To where the verb carries one) and strips the verb prefix from Text. A
+// command author writes the verb the same way they would in chat (e.g.
+// "/announce hello"), and the engine turns it into the right outgress action.
+//
+// Recognized verbs:
+//
+//   - /announce[blue|green|orange|purple] -> TypeAnnounce, that color (plain
+//     /announce is "primary"); the verb is stripped from Text.
+//   - /shoutout <target> -> TypeShoutout; the first token (leading '@' stripped)
+//     becomes To and is removed from Text.
+//   - /me -> left as a plain chat line; the verb is NOT stripped (Twitch chat
+//     interprets the leading "/me" itself).
+//
+// Anything else is left unchanged.
+func Translate(out *module.Output) {
+	text := out.Text
+
+	// /announce family. Order matters: the colored variants are prefixes of the
+	// bare verb's namespace, so check the longer forms first.
+	if color, rest, ok := matchAnnounce(text); ok {
+		out.Type = outgress.TypeAnnounce
+		out.Color = color
+		out.Text = rest
+		return
+	}
+
+	// /shoutout <target>
+	if rest, ok := cutVerb(text, "/shoutout"); ok {
+		rest = strings.TrimLeft(rest, " ")
+		target, remainder, _ := strings.Cut(rest, " ")
+		target = strings.TrimPrefix(target, "@")
+		out.Type = outgress.TypeShoutout
+		out.To = target
+		out.Text = strings.TrimLeft(remainder, " ")
+		return
+	}
+
+	// /me is a plain passthrough: leave Type=chat and keep the verb in Text.
+}
+
+// isEmptyAction reports whether a translated output carries no usable payload, so
+// dispatch can skip emitting a call Twitch would reject: an /announce with no
+// message, a /shoutout with no target, or an empty chat line.
+func isEmptyAction(out *module.Output) bool {
+	switch out.Type {
+	case outgress.TypeAnnounce, outgress.TypeChat:
+		return out.Text == ""
+	case outgress.TypeShoutout:
+		return out.To == ""
+	default:
+		return false
+	}
+}
+
+// matchAnnounce reports whether text leads with an /announce verb. It returns
+// the announce color and the text with the verb (and one following space)
+// stripped.
+func matchAnnounce(text string) (color, rest string, ok bool) {
+	type variant struct {
+		verb  string
+		color string
+	}
+	// Longest verbs first so "/announceblue" is not mistaken for "/announce".
+	for _, v := range []variant{
+		{"/announceblue", "blue"},
+		{"/announcegreen", "green"},
+		{"/announceorange", "orange"},
+		{"/announcepurple", "purple"},
+		{"/announce", "primary"},
+	} {
+		if r, matched := cutVerb(text, v.verb); matched {
+			return v.color, r, true
+		}
+	}
+	return "", "", false
+}
+
+// cutVerb matches verb either as the whole string or as a "verb " prefix. On a
+// match it returns the remainder with the single separating space removed (empty
+// when the text was exactly the verb). A "verb" followed by a non-space (e.g.
+// "/announceblue" when matching "/announce") is not a match.
+func cutVerb(text, verb string) (rest string, ok bool) {
+	if text == verb {
+		return "", true
+	}
+	if strings.HasPrefix(text, verb+" ") {
+		return text[len(verb)+1:], true
+	}
+	return "", false
+}

--- a/app/sesame/engine/slash_test.go
+++ b/app/sesame/engine/slash_test.go
@@ -1,0 +1,52 @@
+package engine
+
+import (
+	"testing"
+
+	"ItsBagelBot/app/sesame/module"
+	"ItsBagelBot/internal/domain/outgress"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTranslate(t *testing.T) {
+	tests := []struct {
+		name      string
+		text      string
+		wantType  string
+		wantText  string
+		wantColor string
+		wantTo    string
+	}{
+		{"no verb unchanged", "just a normal line", outgress.TypeChat, "just a normal line", "", ""},
+		{"announce primary", "/announce hello there", outgress.TypeAnnounce, "hello there", "primary", ""},
+		{"announce bare verb only", "/announce", outgress.TypeAnnounce, "", "primary", ""},
+		{"announce blue", "/announceblue cold news", outgress.TypeAnnounce, "cold news", "blue", ""},
+		{"announce green", "/announcegreen go", outgress.TypeAnnounce, "go", "green", ""},
+		{"announce orange", "/announceorange warn", outgress.TypeAnnounce, "warn", "orange", ""},
+		{"announce purple", "/announcepurple royal", outgress.TypeAnnounce, "royal", "purple", ""},
+		{"shoutout strips target and at", "/shoutout @cooldude check them out", outgress.TypeShoutout, "check them out", "", "cooldude"},
+		{"shoutout target only", "/shoutout cooldude", outgress.TypeShoutout, "", "", "cooldude"},
+		{"me is plain passthrough not stripped", "/me waves", outgress.TypeChat, "/me waves", "", ""},
+		{"unknown slash unchanged", "/unknown thing", outgress.TypeChat, "/unknown thing", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := &module.Output{Type: outgress.TypeChat, Text: tt.text}
+			Translate(out)
+			assert.Equal(t, tt.wantType, out.Type)
+			assert.Equal(t, tt.wantText, out.Text)
+			assert.Equal(t, tt.wantColor, out.Color)
+			assert.Equal(t, tt.wantTo, out.To)
+		})
+	}
+}
+
+func TestIsEmptyAction(t *testing.T) {
+	assert.True(t, isEmptyAction(&module.Output{Type: outgress.TypeAnnounce, Text: ""}))
+	assert.False(t, isEmptyAction(&module.Output{Type: outgress.TypeAnnounce, Text: "hi"}))
+	assert.True(t, isEmptyAction(&module.Output{Type: outgress.TypeShoutout, To: ""}))
+	assert.False(t, isEmptyAction(&module.Output{Type: outgress.TypeShoutout, To: "bob"}))
+	assert.True(t, isEmptyAction(&module.Output{Type: outgress.TypeChat, Text: ""}))
+	assert.False(t, isEmptyAction(&module.Output{Type: outgress.TypeChat, Text: "hi"}))
+}

--- a/app/sesame/engine/special.go
+++ b/app/sesame/engine/special.go
@@ -1,0 +1,41 @@
+package engine
+
+import "strings"
+
+// SpecialSet is the set of special Twitch user ids (the bagel crew), parsed once
+// from the TWITCH_SPECIAL_USER_IDS Doppler secret (the same secret ingress uses
+// to lane them premium). Lookups are by the raw string id as it arrives on the
+// chat envelope.
+type SpecialSet struct {
+	ids map[string]struct{}
+}
+
+// NewSpecialSet parses a comma-separated list of user ids into a set. Blank
+// entries and surrounding whitespace are ignored.
+func NewSpecialSet(csv string) *SpecialSet {
+	s := &SpecialSet{ids: make(map[string]struct{})}
+	for _, raw := range strings.Split(csv, ",") {
+		id := strings.TrimSpace(raw)
+		if id != "" {
+			s.ids[id] = struct{}{}
+		}
+	}
+	return s
+}
+
+// Has reports whether id is a special user.
+func (s *SpecialSet) Has(id string) bool {
+	if s == nil || id == "" {
+		return false
+	}
+	_, ok := s.ids[id]
+	return ok
+}
+
+// Len returns how many special ids are configured.
+func (s *SpecialSet) Len() int {
+	if s == nil {
+		return 0
+	}
+	return len(s.ids)
+}

--- a/app/sesame/engine/use_reporter.go
+++ b/app/sesame/engine/use_reporter.go
@@ -1,0 +1,116 @@
+package engine
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"ItsBagelBot/internal/domain/event/data"
+	"ItsBagelBot/pkg/bus"
+
+	"github.com/ThreeDotsLabs/watermill/message"
+
+	"go.uber.org/zap"
+)
+
+const (
+	// useFlushInterval bounds the bus rate: a spammed zero-cooldown command
+	// costs one summed event per window instead of one per execution.
+	useFlushInterval = 5 * time.Second
+
+	// useMaxKeys caps the pending map. At the cap the reporter flushes early;
+	// if a flush is already running, further ticks for NEW keys are dropped
+	// (counters are loss-tolerant; protecting the worker's memory wins).
+	useMaxKeys = 1024
+)
+
+type useKey struct {
+	userID uint64
+	name   string
+}
+
+// useReporter aggregates command-use ticks per (broadcaster, command) and
+// publishes summed data.commands.used events on a flush window. It is the
+// worker-side rate limiter for the counter pipeline.
+type useReporter struct {
+	pub  message.Publisher
+	log  *zap.Logger
+	done chan struct{}
+
+	mu   sync.Mutex
+	pend map[useKey]uint64
+}
+
+func newUseReporter(pub message.Publisher, log *zap.Logger) *useReporter {
+	r := &useReporter{
+		pub:  pub,
+		log:  log,
+		done: make(chan struct{}),
+		pend: map[useKey]uint64{},
+	}
+	go func() {
+		ticker := time.NewTicker(useFlushInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				r.flush(context.Background())
+			case <-r.done:
+				return
+			}
+		}
+	}()
+	return r
+}
+
+// Record counts one execution. Never blocks the chat hot path: it takes a
+// short mutex, and at the map cap it either triggers an early flush or drops
+// the tick for a not-yet-tracked key.
+func (r *useReporter) Record(userID uint64, name string) {
+	if userID == 0 || name == "" {
+		return
+	}
+	key := useKey{userID: userID, name: name}
+
+	r.mu.Lock()
+	if _, tracked := r.pend[key]; !tracked && len(r.pend) >= useMaxKeys {
+		r.mu.Unlock()
+		go r.flush(context.Background())
+		return
+	}
+	r.pend[key]++
+	r.mu.Unlock()
+}
+
+// flush drains the pending sums and publishes one event per command.
+func (r *useReporter) flush(ctx context.Context) {
+	r.mu.Lock()
+	if len(r.pend) == 0 {
+		r.mu.Unlock()
+		return
+	}
+	pend := r.pend
+	r.pend = map[useKey]uint64{}
+	r.mu.Unlock()
+
+	for key, n := range pend {
+		if err := bus.PublishJSON(ctx, r.pub, data.SubjectCommandUsed, data.CommandUsedDTO{
+			UserID: key.userID,
+			Name:   key.name,
+			Count:  n,
+		}); err != nil {
+			r.log.Debug("failed to publish command uses",
+				zap.Uint64("broadcaster_id", key.userID),
+				zap.String("command", key.name),
+				zap.Uint64("count", n),
+				zap.Error(err),
+			)
+		}
+	}
+}
+
+// Close stops the ticker and flushes what is pending.
+func (r *useReporter) Close() {
+	close(r.done)
+	r.flush(context.Background())
+}

--- a/app/sesame/i18n/i18n.go
+++ b/app/sesame/i18n/i18n.go
@@ -1,0 +1,37 @@
+// Package i18n is a tiny, dependency-free catalog for sesame's built-in (system)
+// chat output. The broadcaster's locale rides the module Context
+// (module.Context.Locale), sourced from the Valkey user projection, so system
+// commands answer in the broadcaster's console language.
+//
+// It mirrors the console/site i18n set: add a locale here and to the users
+// service's supportedLocales map together. English is the source of truth and
+// every unknown locale or key falls back to it.
+package i18n
+
+// DefaultLocale is used when a message's locale is empty or unknown.
+const DefaultLocale = "en"
+
+// catalog[locale][key] -> template. Templates may carry fmt verbs (see T).
+var catalog = map[string]map[string]string{
+	"en": {
+		"ping": "Pong! ItsBagelBot has been up for %s",
+	},
+	"fr": {
+		"ping": "Pong ! ItsBagelBot est actif depuis %s",
+	},
+}
+
+// T returns the template for key in locale, falling back to English, then to
+// the key itself so a missing entry is visible rather than blank. The returned
+// string may contain fmt verbs; the caller applies fmt.Sprintf with the args.
+func T(locale, key string) string {
+	if m, ok := catalog[locale]; ok {
+		if s, ok := m[key]; ok {
+			return s
+		}
+	}
+	if s, ok := catalog[DefaultLocale][key]; ok {
+		return s
+	}
+	return key
+}

--- a/app/sesame/internal/config/config.go
+++ b/app/sesame/internal/config/config.go
@@ -1,0 +1,130 @@
+// Package config loads sesame's runtime settings from the environment.
+//
+// sesame sits between ingress and outgress: it drains the ingress premium and
+// standard lanes, runs each event through the engine pipeline, and publishes the
+// resulting actions onto the outgress lanes. Every knob is a plain env var with a
+// development-friendly default.
+//
+// Secret-provided vars (VALKEY_*, NATS_CACHE_INVALIDATION_PREFIX,
+// TWITCH_SPECIAL_USER_IDS, TWITCH_BOT_USER_ID) keep the exact names the worker
+// used, so the same Doppler config supplies them unchanged. Only the pod-tuning
+// knobs are renamed WORKER_* -> SESAME_* (set in sesame's own manifest).
+package config
+
+import (
+	"time"
+
+	"ItsBagelBot/pkg/env"
+)
+
+type Config struct {
+	NATSURL    string
+	NATSRPCURL string
+
+	// ConsumerName is the JetStream durable/queue group the subscriber binds. It
+	// defaults to "worker" so sesame reuses the worker's existing lane consumer:
+	// the lane consumers are DeliverAll, so a fresh durable would replay the whole
+	// stream, and reusing the group means rollout overlap load-balances across the
+	// shared DeliverGroup instead of double-processing. It is a genuine drop-in on
+	// the same lanes and the same pkg/bus consumer.
+	ConsumerName string
+
+	// Ingress lanes sesame consumes: premium and standard. Both carry every
+	// actionable event laned by broadcaster status, including the live
+	// (stream.online/offline) events ingress dual-publishes onto them.
+	PremiumSubject  string
+	StandardSubject string
+
+	// The one consumer drains both lanes into a shared, autoscaling pool of
+	// pipeline routines. PremiumReserve keeps a slice of the pool for premium so a
+	// standard flood never starves premium broadcasters.
+	MinRoutines    int
+	MaxRoutines    int
+	MaxConsumers   int
+	ScaleUpAfter   time.Duration
+	ScaleDownAfter time.Duration
+	PremiumReserve int
+
+	// Outgress lane subjects the pipeline publishes onto, chosen from the event's
+	// regress status (premium vs standard).
+	OutgressPremiumSubject  string
+	OutgressStandardSubject string
+	// OutgressSystemSubject is the outgress system lane (off the chat budget); the
+	// live key-expiry re-check publishes its Twitch Get Streams job here.
+	OutgressSystemSubject string
+
+	// ProjectionLiveSubject is the projector RPC the live store asks when its
+	// shared live key is cold.
+	ProjectionLiveSubject string
+
+	// SpecialUserIDs is the comma-separated list of special (bagel-crew) Twitch
+	// user ids, the same Doppler secret ingress uses to lane them premium.
+	SpecialUserIDs string
+
+	// BotUserID is the bot's own Twitch user id; the engine skips the bot's own
+	// chat messages so it never reacts to itself.
+	BotUserID string
+
+	// LiveTTL bounds how long a live key survives without a refresh.
+	LiveTTL time.Duration
+
+	// Projection RPC subjects: the contracts sesame uses to resolve the user,
+	// modules and commands for the broadcaster an event belongs to.
+	ProjectionUsersSubject    string
+	ProjectionModulesSubject  string
+	ProjectionCommandsSubject string
+
+	// CacheInvalidationPrefix is the NATS subject prefix sesame subscribes to for
+	// push invalidation of its in-process projection cache.
+	CacheInvalidationPrefix string
+
+	// Valkey holds the settings projection (user tier + modules) sesame reads on
+	// the hot path.
+	ValkeyAddr     string
+	ValkeyPassword string
+
+	ListenAddr string
+}
+
+func Load() *Config {
+	natsURL := env.Get("NATS_URL", "nats://127.0.0.1:4222")
+	return &Config{
+		NATSURL:    natsURL,
+		NATSRPCURL: env.Get("NATS_RPC_URL", natsURL),
+
+		ConsumerName: env.Get("SESAME_CONSUMER_NAME", "worker"),
+
+		PremiumSubject:  env.Get("NATS_INGRESS_PREMIUM_SUBJECT", "twitch.ingress.event.premium"),
+		StandardSubject: env.Get("NATS_INGRESS_STANDARD_SUBJECT", "twitch.ingress.event.standard"),
+
+		MinRoutines:    env.GetInt("SESAME_MIN_ROUTINES", 2),
+		MaxRoutines:    env.GetInt("SESAME_MAX_ROUTINES", 8),
+		MaxConsumers:   env.GetInt("SESAME_MAX_CONSUMERS", 3),
+		ScaleUpAfter:   env.GetDuration("SESAME_SCALE_UP_AFTER", 5*time.Second),
+		ScaleDownAfter: env.GetDuration("SESAME_SCALE_DOWN_AFTER", 30*time.Second),
+		PremiumReserve: env.GetInt("SESAME_PREMIUM_RESERVE_PERCENT", 25),
+
+		OutgressPremiumSubject:  env.Get("NATS_OUTGRESS_PREMIUM_SUBJECT", "twitch.outgress.premium"),
+		OutgressStandardSubject: env.Get("NATS_OUTGRESS_STANDARD_SUBJECT", "twitch.outgress.standard"),
+		OutgressSystemSubject:   env.Get("NATS_OUTGRESS_SYSTEM_SUBJECT", "twitch.outgress.system"),
+
+		ProjectionLiveSubject: env.Get("NATS_BROADCASTER_LIVE_SUBJECT", "bagel.rpc.broadcaster.live.get"),
+
+		SpecialUserIDs: env.Get("TWITCH_SPECIAL_USER_IDS", ""),
+
+		BotUserID: env.Get("TWITCH_BOT_USER_ID", ""),
+
+		LiveTTL: env.GetDuration("SESAME_LIVE_TTL", 12*time.Hour),
+
+		ProjectionUsersSubject:    env.Get("NATS_INTERNAL_PROJECTION_USERS_SUBJECT", "bagel.rpc.internal.projection.users.get"),
+		ProjectionModulesSubject:  env.Get("NATS_INTERNAL_PROJECTION_MODULES_SUBJECT", "bagel.rpc.internal.projection.modules.get"),
+		ProjectionCommandsSubject: env.Get("NATS_INTERNAL_PROJECTION_COMMANDS_SUBJECT", "bagel.rpc.internal.projection.commands.get"),
+
+		CacheInvalidationPrefix: env.Get("NATS_CACHE_INVALIDATION_PREFIX", "bagel.cache.invalidate"),
+
+		ValkeyAddr:     env.Get("VALKEY_ADDR", "127.0.0.1:6379"),
+		ValkeyPassword: env.Get("VALKEY_PASSWORD", ""),
+
+		ListenAddr: env.Get("LISTEN_ADDR", ":8080"),
+	}
+}

--- a/app/sesame/internal/consumer/consumer.go
+++ b/app/sesame/internal/consumer/consumer.go
@@ -1,0 +1,62 @@
+// Package consumer is sesame's ingress side: a single autoscaling consumer that
+// drains the premium and standard lanes and hands every message off to a pipeline
+// routine.
+//
+// The flow is NATS -> bus.ConsumeWeighted -> pool of pipeline routines. Both lanes
+// feed one shared routine pool that grows under load and shrinks when calm. The
+// premium lane reserves a slice of the pool (PremiumReserve) so a standard flood
+// can never starve premium broadcasters. The consumer does no processing of its
+// own; each in-flight message is run on a pool routine by the handler it was given
+// (the engine pipeline).
+package consumer
+
+import (
+	"context"
+
+	"ItsBagelBot/pkg/bus"
+
+	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/newrelic/go-agent/v3/newrelic"
+	"go.uber.org/zap"
+)
+
+// Handler is the per-message routine the consumer hands each event to. The engine
+// pipeline's Process satisfies it.
+type Handler func(*message.Message) error
+
+// Lanes names the two ingress subjects the consumer drains.
+type Lanes struct {
+	PremiumSubject  string
+	StandardSubject string
+}
+
+// Consumer drains the premium and standard lanes into one autoscaling pool.
+type Consumer struct {
+	sub            message.Subscriber
+	nrApp          *newrelic.Application
+	log            *zap.Logger
+	lanes          Lanes
+	policy         bus.ScalePolicy
+	premiumReserve int
+}
+
+// New builds a Consumer over one subscriber.
+func New(sub message.Subscriber, nrApp *newrelic.Application, lanes Lanes, policy bus.ScalePolicy, premiumReserve int, log *zap.Logger) *Consumer {
+	return &Consumer{
+		sub:            sub,
+		nrApp:          nrApp,
+		log:            log,
+		lanes:          lanes,
+		policy:         policy,
+		premiumReserve: premiumReserve,
+	}
+}
+
+// Start binds both lanes to handle and begins draining. It returns once the first
+// consumer is running; the pool and autoscaler stop when ctx is cancelled.
+func (c *Consumer) Start(ctx context.Context, handle Handler) error {
+	return bus.ConsumeWeighted(ctx, c.nrApp, []bus.WeightedLane{
+		{Sub: c.sub, Subject: c.lanes.PremiumSubject, Handle: handle, Reserve: c.premiumReserve},
+		{Sub: c.sub, Subject: c.lanes.StandardSubject, Handle: handle},
+	}, c.policy, c.log)
+}

--- a/app/sesame/main.go
+++ b/app/sesame/main.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"ItsBagelBot/app/sesame/engine"
+	"ItsBagelBot/app/sesame/internal/config"
+	"ItsBagelBot/app/sesame/internal/consumer"
+	"ItsBagelBot/app/sesame/modules"
+	"ItsBagelBot/internal/projection"
+	"ItsBagelBot/pkg/bus"
+	"ItsBagelBot/pkg/env"
+	"ItsBagelBot/pkg/health"
+	"ItsBagelBot/pkg/logger"
+	"ItsBagelBot/pkg/monitor"
+	pkg_valkey "ItsBagelBot/pkg/valkey"
+
+	"go.uber.org/zap"
+)
+
+const serviceName = "sesame"
+
+// projectionCacheTTL bounds how long a stale module/command/user view can linger
+// in sesame before the next read re-checks Valkey and the projector.
+const projectionCacheTTL = 30 * time.Second
+
+func main() {
+	log := logger.New(env.Get("APP_ENV", "development")).Named(serviceName)
+	defer func() { _ = log.Sync() }()
+
+	nrApp, err := monitor.New(serviceName, log)
+	if err != nil {
+		log.Fatal("failed to start new relic", zap.Error(err))
+	}
+	log = monitor.WrapLogger(log, nrApp)
+	defer monitor.Shutdown(nrApp)
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	cfg := config.Load()
+
+	if err := bus.EnsureStreams(ctx, cfg.NATSURL, bus.DataStreams, log); err != nil {
+		log.Fatal("failed to provision jetstream streams", zap.Error(err))
+	}
+
+	// Core connection drives the projector RPC fallback; JetStream pub/sub drives
+	// the lanes.
+	nc, err := bus.Connect(cfg.NATSRPCURL, serviceName)
+	if err != nil {
+		log.Fatal("failed to connect to nats", zap.Error(err))
+	}
+	defer nc.Close()
+
+	pub, err := bus.NewPublisher(cfg.NATSURL, log)
+	if err != nil {
+		log.Fatal("failed to connect publisher", zap.Error(err))
+	}
+	defer func() { _ = pub.Close() }()
+
+	// ConsumerName defaults to "worker" so sesame binds the worker's existing lane
+	// consumer (drop-in on the same lanes; no DeliverAll replay, rollout overlap
+	// load-balances instead of double-processing).
+	sub, err := bus.NewSubscriber(cfg.NATSURL, cfg.ConsumerName, log)
+	if err != nil {
+		log.Fatal("failed to connect subscriber", zap.Error(err))
+	}
+	defer func() { _ = sub.Close() }()
+
+	valkeyClient, err := pkg_valkey.NewClient(cfg.ValkeyAddr, cfg.ValkeyPassword)
+	if err != nil {
+		log.Fatal("failed to connect to valkey", zap.Error(err))
+	}
+	defer valkeyClient.Close()
+	valkeyStore := projection.NewStore(valkeyClient)
+
+	proj := projection.NewClient(valkeyStore, nc, projection.Subjects{
+		Users:    cfg.ProjectionUsersSubject,
+		Modules:  cfg.ProjectionModulesSubject,
+		Commands: cfg.ProjectionCommandsSubject,
+	}, projectionCacheTTL, log)
+	defer proj.Close()
+	proj.StartInvalidationListener(cfg.CacheInvalidationPrefix)
+
+	// Live status: a dedicated Valkey key (live:<id>) read through an in-process
+	// cache, written from the stream events sesame already consumes, with a
+	// projector RPC fallback on a cold key and a key-expiry re-check against Twitch
+	// (via the outgress system lane).
+	live := engine.NewValkeyLiveStore(valkeyClient, nc, pub, engine.LiveConfig{
+		TTL:                   cfg.LiveTTL,
+		CacheTTL:              projectionCacheTTL,
+		ProjectorLiveSubject:  cfg.ProjectionLiveSubject,
+		OutgressSystemSubject: cfg.OutgressSystemSubject,
+		CacheInvalidatePrefix: cfg.CacheInvalidationPrefix,
+		KeyspaceDB:            0,
+	}, log)
+	defer live.Close()
+	live.StartInvalidationListener()
+	go live.StartExpiryWatcher(ctx)
+
+	greet := engine.NewValkeyGreetStore(valkeyClient, cfg.LiveTTL, log)
+	cooldown := engine.NewValkeyCooldown(valkeyClient)
+	special := engine.NewSpecialSet(cfg.SpecialUserIDs)
+
+	// Deps is the bundle every module fn captures; main builds it once. modules.All
+	// returns the built modules (core commands + bagel, live tracker, opt-in
+	// shoutout), which the engine registry indexes. Adding a feature is a new file
+	// in app/sesame/modules plus one line in all.go — no wiring here.
+	deps := engine.Deps{
+		Proj:     proj,
+		Live:     live,
+		Greet:    greet,
+		Cooldown: cooldown,
+		Special:  special,
+		Pub:      pub,
+		Log:      log,
+	}
+	registry := engine.NewRegistry(log, modules.All(deps)...)
+
+	pipe := engine.NewPipeline(deps, registry, engine.Config{
+		BotID:            cfg.BotUserID,
+		OutgressPremium:  cfg.OutgressPremiumSubject,
+		OutgressStandard: cfg.OutgressStandardSubject,
+		CountUses:        true,
+	})
+	defer pipe.Close() // flushes pending use-counter ticks on shutdown
+
+	// One autoscaling consumer drains the premium and standard lanes into a shared
+	// pool of pipeline routines, with premium reserving a slice so it is never
+	// starved. Live events ride these same lanes, so there is no separate stream
+	// consumer.
+	cons := consumer.New(sub, nrApp,
+		consumer.Lanes{PremiumSubject: cfg.PremiumSubject, StandardSubject: cfg.StandardSubject},
+		bus.ScalePolicy{
+			MinRoutines:    cfg.MinRoutines,
+			MaxRoutines:    cfg.MaxRoutines,
+			MaxConsumers:   cfg.MaxConsumers,
+			ScaleUpAfter:   cfg.ScaleUpAfter,
+			ScaleDownAfter: cfg.ScaleDownAfter,
+		},
+		cfg.PremiumReserve,
+		log,
+	)
+	if err := cons.Start(ctx, pipe.Process); err != nil {
+		log.Fatal("failed to start consumer", zap.Error(err))
+	}
+
+	health.Serve(cfg.ListenAddr, nc.IsConnected)
+
+	log.Info("sesame ready",
+		zap.String("consumer_name", cfg.ConsumerName),
+		zap.String("premium_subject", cfg.PremiumSubject),
+		zap.String("standard_subject", cfg.StandardSubject),
+		zap.Int("min_routines", cfg.MinRoutines),
+		zap.Int("max_routines", cfg.MaxRoutines),
+		zap.Int("max_consumers", cfg.MaxConsumers),
+		zap.Int("premium_reserve_percent", cfg.PremiumReserve),
+		zap.Int("special_users", special.Len()),
+		zap.Duration("live_ttl", cfg.LiveTTL),
+	)
+
+	<-ctx.Done()
+
+	log.Info("sesame shutting down")
+}

--- a/app/sesame/module/builder.go
+++ b/app/sesame/module/builder.go
@@ -1,0 +1,184 @@
+package module
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Builder is the fluent authoring surface for one module. A module fn creates a
+// Builder with NewModule, declares its commands and event handlers, then calls
+// Build to get the immutable Module the engine consumes:
+//
+//	m := module.NewModule("", module.KindCore)
+//	m.Command("ping").Everyone().Run(pingRun)
+//	m.Command("announce").Mod().Run(announce(""))
+//	m.On("channel.chat.message", bagelGreet)
+//	return m.Build()
+//
+// The Builder holds *Command pointers while it is being assembled so the chained
+// CmdBuilder setters mutate the command in place; Build copies them into the
+// immutable Module. A Builder is single-use and not safe for concurrent use.
+type Builder struct {
+	name   string
+	kind   Kind
+	events map[string]EventHandler
+	cmds   []*Command
+}
+
+// NewModule starts a module of the given name and kind. Deps are not passed
+// here: a command's Run and an event handler capture whatever services they need
+// by closure, which is what keeps this package free of runtime wiring. A core
+// module (KindCore) must use an empty name; a named module (KindDefault /
+// KindOptIn) must use a non-empty one. Build enforces this.
+func NewModule(name string, kind Kind) *Builder {
+	return &Builder{name: name, kind: kind}
+}
+
+// On registers the module's non-command handler for one EventSub type (e.g.
+// "channel.chat.message", "channel.raid", "stream.online"). Registering the same
+// type twice keeps the last handler.
+func (b *Builder) On(eventType string, fn EventHandler) *Builder {
+	if b.events == nil {
+		b.events = make(map[string]EventHandler)
+	}
+	b.events[eventType] = fn
+	return b
+}
+
+// Command starts a command with the given trigger, returning a CmdBuilder to
+// chain its gates. The trigger is lowercased so it matches the engine's
+// case-insensitive lookup. The command is not complete until Run is called; a
+// CmdBuilder left without Run is reported by Build.
+func (b *Builder) Command(name string) *CmdBuilder {
+	c := &Command{Name: strings.ToLower(name), Perm: RoleEveryone}
+	b.cmds = append(b.cmds, c)
+	return &CmdBuilder{b: b, cmd: c}
+}
+
+// Build validates the assembled module and returns its immutable form. It panics
+// on a programmer error (bad kind/name pairing, empty or duplicate trigger, a
+// command with no Run): these are startup misconfigurations, not runtime data,
+// so failing loud at boot is the right behavior. Use Validate to check without
+// panicking.
+func (b *Builder) Build() Module {
+	if err := b.Validate(); err != nil {
+		panic("sesame/module: " + err.Error())
+	}
+
+	cmds := make([]Command, len(b.cmds))
+	for i, c := range b.cmds {
+		cmds[i] = *c
+	}
+
+	var events map[string]EventHandler
+	if len(b.events) > 0 {
+		events = make(map[string]EventHandler, len(b.events))
+		for k, v := range b.events {
+			events[k] = v
+		}
+	}
+
+	return Module{
+		Name:     b.name,
+		Kind:     b.kind,
+		Events:   events,
+		Commands: cmds,
+	}
+}
+
+// Validate reports the first problem with the assembled module, or nil when it
+// is well formed. Build calls it and panics on a non-nil result; tests and the
+// future registry can call it directly. It checks the kind/name pairing and,
+// across all of the module's commands, that every trigger (name or alias) is
+// non-empty, unique within the module, and backed by a Run.
+func (b *Builder) Validate() error {
+	switch b.kind {
+	case KindCore:
+		if b.name != "" {
+			return fmt.Errorf("core module must have an empty name, got %q", b.name)
+		}
+	case KindDefault, KindOptIn:
+		if b.name == "" {
+			return fmt.Errorf("%s module must have a non-empty name", b.kind)
+		}
+	default:
+		return fmt.Errorf("unknown module kind %d", int(b.kind))
+	}
+
+	// owner maps a trigger token to the command name that first claimed it, so a
+	// collision message can name both sides.
+	owner := make(map[string]string, len(b.cmds))
+	for _, c := range b.cmds {
+		if c.Name == "" {
+			return errors.New("command with an empty name")
+		}
+		if c.Run == nil {
+			return fmt.Errorf("command %q has no Run (chain .Run to finish it)", c.Name)
+		}
+		if prev, dup := owner[c.Name]; dup {
+			return fmt.Errorf("duplicate command trigger %q (already used by %q)", c.Name, prev)
+		}
+		owner[c.Name] = c.Name
+		for _, a := range c.Aliases {
+			if a == "" {
+				return fmt.Errorf("command %q has an empty alias", c.Name)
+			}
+			if prev, dup := owner[a]; dup {
+				return fmt.Errorf("alias %q of command %q collides with %q", a, c.Name, prev)
+			}
+			owner[a] = c.Name
+		}
+	}
+	return nil
+}
+
+// CmdBuilder chains a single command's gates. Every setter returns the same
+// CmdBuilder so they read as one line; Run is the terminal that finishes the
+// command. The setters mutate the *Command that Command already appended to the
+// parent Builder, so a command with no Run still exists as an incomplete entry
+// that Validate catches.
+type CmdBuilder struct {
+	b   *Builder
+	cmd *Command
+}
+
+// Everyone sets the command's minimum role to RoleEveryone (the default).
+func (c *CmdBuilder) Everyone() *CmdBuilder { c.cmd.Perm = RoleEveryone; return c }
+
+// Sub requires the chatter to be at least a subscriber.
+func (c *CmdBuilder) Sub() *CmdBuilder { c.cmd.Perm = RoleSubscriber; return c }
+
+// VIP requires the chatter to be at least a VIP.
+func (c *CmdBuilder) VIP() *CmdBuilder { c.cmd.Perm = RoleVIP; return c }
+
+// Mod requires the chatter to be at least a moderator (a lead moderator or the
+// broadcaster also satisfy it).
+func (c *CmdBuilder) Mod() *CmdBuilder { c.cmd.Perm = RoleModerator; return c }
+
+// Broadcaster restricts the command to the channel owner.
+func (c *CmdBuilder) Broadcaster() *CmdBuilder { c.cmd.Perm = RoleBroadcaster; return c }
+
+// Cooldown sets the shared per-command window; zero (the default) means none.
+func (c *CmdBuilder) Cooldown(d time.Duration) *CmdBuilder { c.cmd.Cooldown = d; return c }
+
+// LiveOnly gates the command to when the broadcaster is live.
+func (c *CmdBuilder) LiveOnly() *CmdBuilder { c.cmd.LiveOnly = true; return c }
+
+// AllowUser restricts the command to exactly one chatter id, overriding the role
+// gate entirely.
+func (c *CmdBuilder) AllowUser(id string) *CmdBuilder { c.cmd.AllowedUserID = id; return c }
+
+// Aliases adds extra triggers that resolve to this command. They are lowercased
+// to match the engine's lookup. Duplicates are rejected by Validate.
+func (c *CmdBuilder) Aliases(a ...string) *CmdBuilder {
+	for _, alias := range a {
+		c.cmd.Aliases = append(c.cmd.Aliases, strings.ToLower(alias))
+	}
+	return c
+}
+
+// Run sets the command's handler and finishes it. It is terminal: it returns
+// nothing so a command declaration cannot accidentally continue past it.
+func (c *CmdBuilder) Run(fn RunFunc) { c.cmd.Run = fn }

--- a/app/sesame/module/builder_test.go
+++ b/app/sesame/module/builder_test.go
@@ -1,0 +1,177 @@
+package module
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// noop is a valid RunFunc/EventHandler for tests that only care about assembly.
+func noopRun(context.Context, *Context, string, Emit) error { return nil }
+func noopEvt(context.Context, *Context, Emit) error         { return nil }
+
+func TestBuildAssemblesCommandsAndEvents(t *testing.T) {
+	m := NewModule("", KindCore)
+	m.Command("ping").Everyone().Run(noopRun)
+	m.Command("announce").Mod().Run(noopRun)
+	m.On("channel.chat.message", noopEvt)
+	mod := m.Build()
+
+	if mod.Name != "" || mod.Kind != KindCore {
+		t.Fatalf("got name=%q kind=%v, want core with empty name", mod.Name, mod.Kind)
+	}
+	if len(mod.Commands) != 2 {
+		t.Fatalf("got %d commands, want 2", len(mod.Commands))
+	}
+	if mod.Commands[0].Name != "ping" || mod.Commands[0].Perm != RoleEveryone {
+		t.Errorf("ping: got name=%q perm=%v", mod.Commands[0].Name, mod.Commands[0].Perm)
+	}
+	if mod.Commands[1].Name != "announce" || mod.Commands[1].Perm != RoleModerator {
+		t.Errorf("announce: got name=%q perm=%v", mod.Commands[1].Name, mod.Commands[1].Perm)
+	}
+	if _, ok := mod.Events["channel.chat.message"]; !ok {
+		t.Errorf("event handler not registered, events=%v", mod.Events)
+	}
+}
+
+func TestPermSettersMapToRoles(t *testing.T) {
+	cases := []struct {
+		name string
+		set  func(*CmdBuilder) *CmdBuilder
+		want Role
+	}{
+		{"everyone", (*CmdBuilder).Everyone, RoleEveryone},
+		{"sub", (*CmdBuilder).Sub, RoleSubscriber},
+		{"vip", (*CmdBuilder).VIP, RoleVIP},
+		{"mod", (*CmdBuilder).Mod, RoleModerator},
+		{"broadcaster", (*CmdBuilder).Broadcaster, RoleBroadcaster},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := NewModule("", KindCore)
+			tc.set(m.Command(tc.name)).Run(noopRun)
+			mod := m.Build()
+			if got := mod.Commands[0].Perm; got != tc.want {
+				t.Fatalf("got perm=%v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCommandOptionsLand(t *testing.T) {
+	m := NewModule("", KindCore)
+	m.Command("so").
+		Mod().
+		Cooldown(30 * time.Second).
+		LiveOnly().
+		AllowUser("12345").
+		Aliases("shoutout", "SO2").
+		Run(noopRun)
+	cmd := m.Build().Commands[0]
+
+	if cmd.Cooldown != 30*time.Second {
+		t.Errorf("cooldown: got %v", cmd.Cooldown)
+	}
+	if !cmd.LiveOnly {
+		t.Errorf("LiveOnly not set")
+	}
+	if cmd.AllowedUserID != "12345" {
+		t.Errorf("AllowedUserID: got %q", cmd.AllowedUserID)
+	}
+	if len(cmd.Aliases) != 2 || cmd.Aliases[0] != "shoutout" || cmd.Aliases[1] != "so2" {
+		t.Errorf("aliases not lowercased/stored: got %v", cmd.Aliases)
+	}
+}
+
+func TestTriggersLowercased(t *testing.T) {
+	m := NewModule("", KindCore)
+	m.Command("PiNg").Run(noopRun)
+	if got := m.Build().Commands[0].Name; got != "ping" {
+		t.Fatalf("command name not lowercased: got %q", got)
+	}
+}
+
+func TestValidateKindNamePairing(t *testing.T) {
+	cases := []struct {
+		name    string
+		build   func() *Builder
+		wantErr bool
+	}{
+		{"core empty ok", func() *Builder { return NewModule("", KindCore) }, false},
+		{"core named bad", func() *Builder { return NewModule("x", KindCore) }, true},
+		{"default named ok", func() *Builder {
+			b := NewModule("greeter", KindDefault)
+			b.On("channel.chat.message", noopEvt)
+			return b
+		}, false},
+		{"default empty bad", func() *Builder { return NewModule("", KindDefault) }, true},
+		{"optin empty bad", func() *Builder { return NewModule("", KindOptIn) }, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.build().Validate(); (err != nil) != tc.wantErr {
+				t.Fatalf("Validate() err=%v, wantErr=%v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateCommandWithoutRun(t *testing.T) {
+	m := NewModule("", KindCore)
+	m.Command("ping") // no .Run
+	if err := m.Validate(); err == nil {
+		t.Fatal("want error for command without Run, got nil")
+	}
+}
+
+func TestValidateDuplicateName(t *testing.T) {
+	m := NewModule("", KindCore)
+	m.Command("ping").Run(noopRun)
+	m.Command("ping").Run(noopRun)
+	if err := m.Validate(); err == nil {
+		t.Fatal("want error for duplicate command name, got nil")
+	}
+}
+
+func TestValidateAliasCollidesWithName(t *testing.T) {
+	m := NewModule("", KindCore)
+	m.Command("ping").Run(noopRun)
+	m.Command("pong").Aliases("ping").Run(noopRun)
+	if err := m.Validate(); err == nil {
+		t.Fatal("want error for alias colliding with a command name, got nil")
+	}
+}
+
+func TestValidateAliasCollidesWithAlias(t *testing.T) {
+	m := NewModule("", KindCore)
+	m.Command("a").Aliases("x").Run(noopRun)
+	m.Command("b").Aliases("x").Run(noopRun)
+	if err := m.Validate(); err == nil {
+		t.Fatal("want error for alias colliding with another alias, got nil")
+	}
+}
+
+func TestBuildPanicsOnInvalid(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("Build did not panic on an invalid module")
+		}
+	}()
+	NewModule("x", KindCore).Build() // core module with a name: must panic
+}
+
+func TestDuplicateEventKeepsLast(t *testing.T) {
+	var last int
+	first := func(context.Context, *Context, Emit) error { last = 1; return nil }
+	second := func(context.Context, *Context, Emit) error { last = 2; return nil }
+
+	m := NewModule("", KindCore)
+	m.On("channel.chat.message", first)
+	m.On("channel.chat.message", second)
+	mod := m.Build()
+
+	_ = mod.Events["channel.chat.message"](context.Background(), &Context{}, func(*Output) {})
+	if last != 2 {
+		t.Fatalf("On did not keep the last handler: last=%d", last)
+	}
+}

--- a/app/sesame/module/context.go
+++ b/app/sesame/module/context.go
@@ -1,0 +1,66 @@
+package module
+
+import (
+	"encoding/json"
+
+	"ItsBagelBot/internal/domain/event/lane"
+
+	"go.uber.org/zap"
+)
+
+// Context is the per-message state the engine builds and hands to each command
+// Run and event handler. It is confined to a single consumer goroutine, so its
+// lazily-computed fields need no synchronization. The engine pools it: it gets
+// one, fills it, runs the interested modules, then Resets and returns it.
+// Modules must not retain it past the call.
+type Context struct {
+	Env           lane.Envelope
+	Regress       Regress
+	BroadcasterID uint64
+	Log           *zap.Logger
+
+	// Locale is the broadcaster's console UI language ("en", "fr", …). The engine
+	// fills it (from the user projection) before running a command, so system
+	// replies can be localized. Empty means the default language.
+	Locale string
+
+	// Config is this module's raw configuration blob from its ModuleView; the
+	// engine sets it before calling a named module. Empty for core modules.
+	Config json.RawMessage
+
+	role    Role
+	roleSet bool
+}
+
+// Chatter returns the chatter's resolved role, parsed once from the event badges
+// and the broadcaster id. Non-chat events resolve to RoleEveryone.
+func (c *Context) Chatter() Role {
+	if !c.roleSet {
+		c.role = ParseRole(c.Env)
+		c.roleSet = true
+	}
+	return c.role
+}
+
+// Decode unmarshals the module's Config into out. A missing config is not an
+// error: out is left at its zero value.
+func (c *Context) Decode(out any) error {
+	if len(c.Config) == 0 {
+		return nil
+	}
+	return json.Unmarshal(c.Config, out)
+}
+
+// Reset zeroes the per-message fields so the Context can be reused from a pool.
+// The struct itself stays usable; only the values are cleared. The Log pointer
+// is left in place since the engine re-sets it per message anyway, but the lazy
+// role cache is cleared so it never leaks across messages.
+func (c *Context) Reset() {
+	c.Env = lane.Envelope{}
+	c.Regress = RegressStandard
+	c.BroadcasterID = 0
+	c.Locale = ""
+	c.Config = nil
+	c.role = RoleEveryone
+	c.roleSet = false
+}

--- a/app/sesame/module/module.go
+++ b/app/sesame/module/module.go
@@ -1,0 +1,118 @@
+// Package module is sesame's module authoring surface. A feature is declared as
+// one Module built by a fluent Builder: it names itself, declares its Kind
+// (core, default, or opt-in), lists the commands it owns, and registers any
+// non-command event handlers. The Builder produces an immutable Module value
+// that the sesame engine (a later layer) indexes and runs.
+//
+// This package is intentionally standalone: it holds only the authoring value
+// types and the Builder. It carries no runtime wiring (no pipeline, consumer,
+// projection, or Valkey), so a module fn captures whatever services it needs by
+// closure and this package never has to know about them. That keeps the
+// authoring surface small, cheap to import, and unit-testable on its own.
+package module
+
+import (
+	"context"
+	"time"
+)
+
+// Kind classifies a module's enable semantics, replacing the worker's magic
+// empty-name convention and its Defaulted optional interface with one explicit
+// field.
+type Kind int
+
+const (
+	// KindCore is always on, never listed to broadcasters, and immutable. A core
+	// module must have an empty Name (it has no ModuleView key).
+	KindCore Kind = iota
+	// KindDefault is a named module that ships enabled: it runs unless the
+	// broadcaster's ModuleView disables it.
+	KindDefault
+	// KindOptIn is a named module that ships disabled: it runs only when the
+	// broadcaster's ModuleView enables it.
+	KindOptIn
+)
+
+// String renders the kind for logs and errors.
+func (k Kind) String() string {
+	switch k {
+	case KindCore:
+		return "core"
+	case KindDefault:
+		return "default"
+	case KindOptIn:
+		return "opt-in"
+	default:
+		return "unknown"
+	}
+}
+
+// Output is one outgress action a module wants to take, in the module layer's
+// own minimal shape. The engine translates it onto an outgress.Message. It is
+// pooled by the caller: a module fills it, hands it to Emit, and must not retain
+// it afterwards.
+//
+//   - Type is the outgress message type (outgress.TypeChat, TypeAnnounce, ...).
+//   - BroadcasterID is the target channel (the raw string id).
+//   - Text is the message body.
+//   - Color is the announce color (primary/blue/green/orange/purple); empty
+//     unless Type is an announce.
+//   - To is the shoutout target (login or id); empty unless Type is a shoutout.
+type Output struct {
+	Type          string
+	BroadcasterID string
+	Text          string
+	Color         string
+	To            string
+}
+
+// Emit publishes one Output. The callee must not retain o past the call: the
+// engine may recycle it as soon as Emit returns.
+type Emit func(o *Output)
+
+// RunFunc executes a command after its gates pass, emitting any outputs. args is
+// the trimmed argument string after the command name.
+type RunFunc func(ctx context.Context, c *Context, args string, emit Emit) error
+
+// EventHandler runs a module's non-command path for one event of a registered
+// type and emits any outputs. Command dispatch never flows through here.
+type EventHandler func(ctx context.Context, c *Context, emit Emit) error
+
+// Command is one baked command a module owns. The engine gates and runs it
+// centrally, so the same permission/live/cooldown semantics apply to baked and
+// custom commands alike. Build normalizes Name and Aliases to lowercase so they
+// match the engine's case-insensitive lookup.
+type Command struct {
+	// Name is the lowercase trigger without the leading '!'.
+	Name string
+	// Aliases are extra lowercase triggers that resolve to this same command.
+	Aliases []string
+	// Perm is the minimum role required, unless AllowedUserID is set.
+	Perm Role
+	// Cooldown is the shared per-command window; zero means no cooldown.
+	Cooldown time.Duration
+	// LiveOnly gates the command to when the broadcaster is live.
+	LiveOnly bool
+	// AllowedUserID, when non-empty, restricts the command to exactly that
+	// chatter id and overrides Perm entirely.
+	AllowedUserID string
+	// Run executes the command after the gates pass.
+	Run RunFunc
+}
+
+// Module is the immutable artifact Build returns. The sesame engine indexes it:
+// each command goes into the flat command index, and each Events entry registers
+// the module under that EventSub type for its non-command path.
+//
+// There is deliberately no premium/feature gate here: premium vs standard is a
+// routing lane (it decides which outgress subject a reply rides), not a feature
+// switch. Every feature is available on both lanes.
+type Module struct {
+	Name     string
+	Kind     Kind
+	Events   map[string]EventHandler
+	Commands []Command
+	// Triggers is reserved: trigger-word matchers will land here so ingress can
+	// stop filtering to "!"-prefixed messages. Not populated yet.
+	// Triggers []Trigger
+}

--- a/app/sesame/module/permission.go
+++ b/app/sesame/module/permission.go
@@ -1,0 +1,72 @@
+package module
+
+import "ItsBagelBot/internal/domain/event/lane"
+
+// Role is a chatter's effective permission tier, ordered low to high so a gate
+// is a simple comparison. Twitch ships the lead-moderator badge instead of the
+// moderator badge, so lead_moderator ranks above moderator and satisfies any
+// gate a plain moderator would.
+type Role int
+
+const (
+	RoleEveryone Role = iota
+	RoleSubscriber
+	RoleVIP
+	RoleModerator
+	RoleLeadModerator
+	RoleBroadcaster
+)
+
+// badgeRoles maps a Twitch badge set_id onto the role it grants. Founders are
+// subscribers; sub-gifter and other cosmetic badges grant nothing.
+var badgeRoles = map[string]Role{
+	"broadcaster":    RoleBroadcaster,
+	"lead_moderator": RoleLeadModerator,
+	"moderator":      RoleModerator,
+	"vip":            RoleVIP,
+	"subscriber":     RoleSubscriber,
+	"founder":        RoleSubscriber,
+}
+
+// permRoles maps a command's stored perm string onto the minimum role required.
+var permRoles = map[string]Role{
+	"everyone":    RoleEveryone,
+	"sub":         RoleSubscriber,
+	"subscriber":  RoleSubscriber,
+	"vip":         RoleVIP,
+	"mod":         RoleModerator,
+	"moderator":   RoleModerator,
+	"lead_mod":    RoleLeadModerator,
+	"broadcaster": RoleBroadcaster,
+}
+
+// ParseRole resolves the chatter's highest role from the event badges, plus the
+// broadcaster shortcut: the channel owner always resolves to RoleBroadcaster
+// even if the badge is absent. Unknown badges contribute nothing.
+func ParseRole(env lane.Envelope) Role {
+	role := RoleEveryone
+	if env.ChatterUserID != "" && env.ChatterUserID == env.BroadcasterUserID {
+		role = RoleBroadcaster
+	}
+	for _, b := range env.Badges {
+		if r, ok := badgeRoles[b.SetID]; ok && r > role {
+			role = r
+		}
+	}
+	return role
+}
+
+// ParsePerm resolves a command's perm string to the minimum role required.
+// An empty or unknown value defaults to RoleEveryone.
+func ParsePerm(perm string) Role {
+	if perm == "" {
+		return RoleEveryone
+	}
+	if r, ok := permRoles[perm]; ok {
+		return r
+	}
+	return RoleEveryone
+}
+
+// Allows reports whether this role meets or exceeds the required role.
+func (r Role) Allows(required Role) bool { return r >= required }

--- a/app/sesame/module/regress.go
+++ b/app/sesame/module/regress.go
@@ -1,0 +1,39 @@
+package module
+
+// Regress is the lane an event arrived on. It is the worker's "regress status":
+// it records whether ingress decided this traffic was premium or standard, so
+// the pipeline can keep the same priority all the way out to outgress without
+// re-deciding it. Stream is the live lane and carries no priority of its own.
+type Regress int
+
+const (
+	RegressStandard Regress = iota
+	RegressPremium
+	RegressStream
+)
+
+func (r Regress) String() string {
+	switch r {
+	case RegressPremium:
+		return "premium"
+	case RegressStream:
+		return "stream"
+	default:
+		return "standard"
+	}
+}
+
+// RegressFromLane maps the ingress lane string onto the regress status.
+func RegressFromLane(lane string) Regress {
+	switch lane {
+	case "premium":
+		return RegressPremium
+	case "stream":
+		return RegressStream
+	default:
+		return RegressStandard
+	}
+}
+
+// IsPremium reports whether traffic on this regress should ride the premium lane.
+func (r Regress) IsPremium() bool { return r == RegressPremium }

--- a/app/sesame/modules/all.go
+++ b/app/sesame/modules/all.go
@@ -1,0 +1,18 @@
+package modules
+
+import (
+	"ItsBagelBot/app/sesame/engine"
+	"ItsBagelBot/app/sesame/module"
+)
+
+// All builds every module wired for the service, in registration order. Adding a
+// feature is writing its file and adding one line here. Core modules come first
+// so their reserved commands win the registry's first-wins de-dup over any named
+// module that might declare a clashing trigger.
+func All(d engine.Deps) []module.Module {
+	return []module.Module{
+		Core(d),
+		Live(d),
+		Shoutout(d),
+	}
+}

--- a/app/sesame/modules/all_test.go
+++ b/app/sesame/modules/all_test.go
@@ -1,0 +1,36 @@
+package modules
+
+import (
+	"testing"
+
+	"ItsBagelBot/app/sesame/engine"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// TestAllBuildsAndIndexes wires every shipped module through the registry, which
+// exercises Build validation and the first-wins de-dup for all of them at once —
+// the closest thing to what main does at startup.
+func TestAllBuildsAndIndexes(t *testing.T) {
+	d := engine.Deps{
+		Special: engine.NewSpecialSet(""),
+		Live:    &fakeLive{},
+		Greet:   &fakeGreet{},
+		Log:     zap.NewNop(),
+	}
+	mods := All(d)
+	require.NotEmpty(t, mods)
+
+	reg := engine.NewRegistry(zap.NewNop(), mods...)
+
+	// A representative reserved command is indexed.
+	_, ok := reg.Command("ping")
+	assert.True(t, ok)
+
+	// Chat and raid event handlers are registered.
+	assert.NotEmpty(t, reg.For("channel.chat.message"))
+	assert.NotEmpty(t, reg.For("channel.raid"))
+	assert.NotEmpty(t, reg.For("stream.online"))
+}

--- a/app/sesame/modules/core.go
+++ b/app/sesame/modules/core.go
@@ -1,0 +1,132 @@
+// Package modules holds sesame's shipped features, one file per module. Each is
+// a func that takes the engine Deps and returns a built module.Module; all() in
+// all.go lists them. A module declares its commands and event handlers with the
+// fluent module.Builder, and its command Runs and handlers capture whatever
+// services they need from Deps by closure.
+package modules
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"ItsBagelBot/app/sesame/engine"
+	"ItsBagelBot/app/sesame/i18n"
+	"ItsBagelBot/app/sesame/module"
+	"ItsBagelBot/internal/domain/outgress"
+
+	"go.uber.org/zap"
+)
+
+const (
+	bagelMessage = "🥯🥯🥯🥯🥯🥯"
+	bagelCount   = 3
+)
+
+// Core is the always-on core module of baked primitives. It is never listed on
+// the dashboard and cannot be toggled or reconfigured. It owns:
+//
+//   - the reserved info commands (!ping, !itsbagelbot, !source), which the
+//     registry indexes first so a custom or default command can never shadow
+//     their names;
+//   - the bagel greeting on the non-command chat path: a special user's first
+//     message on a live stream gets three bagels, once per stream.
+//
+// Announce is intentionally NOT a command here: it is output post-processing
+// middleware in the engine (a command whose text starts with "/announce" is
+// routed to an announce action). A broadcaster who wants an "!announce" command
+// makes a custom command with a "/announce {args}" response and gates that
+// command however they like.
+func Core(d engine.Deps) module.Module {
+	started := time.Now()
+
+	m := module.NewModule("", module.KindCore)
+
+	m.Command("ping").Everyone().Run(func(_ context.Context, c *module.Context, _ string, emit module.Emit) error {
+		emit(&module.Output{
+			Type:          outgress.TypeChat,
+			BroadcasterID: c.Env.BroadcasterUserID,
+			Text:          fmt.Sprintf(i18n.T(c.Locale, "ping"), humanizeUptime(time.Since(started))),
+		})
+		return nil
+	})
+
+	m.Command("itsbagelbot").Everyone().Run(chatLine("ItsBagelBot 🥯 → https://itsbagelbot.com"))
+	m.Command("source").Everyone().Run(chatLine("Source → https://github.com/AdamOusmer/ItsBagelBot"))
+
+	m.On("channel.chat.message", bagelGreet(d))
+
+	return m.Build()
+}
+
+// chatLine builds a RunFunc that emits one fixed chat line to the broadcaster.
+func chatLine(text string) module.RunFunc {
+	return func(_ context.Context, c *module.Context, _ string, emit module.Emit) error {
+		emit(&module.Output{
+			Type:          outgress.TypeChat,
+			BroadcasterID: c.Env.BroadcasterUserID,
+			Text:          text,
+		})
+		return nil
+	}
+}
+
+// bagelGreet is the non-command chat handler: any first message from a special
+// user while the stream is live yields three bagels. Errors are logged and
+// swallowed so a greet failure never blocks the message.
+func bagelGreet(d engine.Deps) module.EventHandler {
+	log := d.Log
+	if log == nil {
+		log = zap.NewNop()
+	}
+	return func(ctx context.Context, c *module.Context, emit module.Emit) error {
+		if !d.Special.Has(c.Env.ChatterUserID) {
+			return nil
+		}
+
+		live, err := d.Live.IsLive(ctx, c.BroadcasterID)
+		if err != nil {
+			log.Warn("core: live check failed for bagel", zap.Uint64("broadcaster_id", c.BroadcasterID), zap.Error(err))
+			return nil
+		}
+		if !live {
+			return nil
+		}
+
+		first, err := d.Greet.FirstGreet(ctx, c.BroadcasterID, c.Env.ChatterUserID)
+		if err != nil {
+			log.Warn("core: greet check failed", zap.Uint64("broadcaster_id", c.BroadcasterID), zap.Error(err))
+			return nil
+		}
+		if !first {
+			return nil
+		}
+
+		log.Debug("bagel greet",
+			zap.String("chatter_id", c.Env.ChatterUserID),
+			zap.Uint64("broadcaster_id", c.BroadcasterID),
+		)
+		for i := 0; i < bagelCount; i++ {
+			emit(&module.Output{
+				Type:          outgress.TypeChat,
+				BroadcasterID: c.Env.BroadcasterUserID,
+				Text:          bagelMessage,
+			})
+		}
+		return nil
+	}
+}
+
+func humanizeUptime(d time.Duration) string {
+	d = d.Round(time.Second)
+	h := int(d.Hours())
+	mn := int(d.Minutes()) % 60
+	s := int(d.Seconds()) % 60
+	if h > 0 {
+		return fmt.Sprintf("%dh %dm", h, mn)
+	}
+	if mn > 0 {
+		return fmt.Sprintf("%dm %ds", mn, s)
+	}
+	return fmt.Sprintf("%ds", s)
+}

--- a/app/sesame/modules/core_test.go
+++ b/app/sesame/modules/core_test.go
@@ -1,0 +1,146 @@
+package modules
+
+import (
+	"context"
+	"testing"
+
+	"ItsBagelBot/app/sesame/engine"
+	"ItsBagelBot/app/sesame/module"
+	"ItsBagelBot/internal/domain/event/lane"
+	"ItsBagelBot/internal/domain/outgress"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// --- test doubles ---
+
+type fakeLive struct {
+	live bool
+	err  error
+}
+
+func (f *fakeLive) IsLive(context.Context, uint64) (bool, error) { return f.live, f.err }
+func (f *fakeLive) SetLive(context.Context, uint64) error        { return nil }
+func (f *fakeLive) ClearLive(context.Context, uint64) error      { return nil }
+
+type fakeGreet struct {
+	first   bool
+	greeted []string
+	resetN  int
+}
+
+func (f *fakeGreet) FirstGreet(_ context.Context, _ uint64, id string) (bool, error) {
+	f.greeted = append(f.greeted, id)
+	return f.first, nil
+}
+func (f *fakeGreet) ResetGreets(context.Context, uint64) error { f.resetN++; return nil }
+
+type collector struct{ out []module.Output }
+
+func (c *collector) emit(o *module.Output) { c.out = append(c.out, *o) }
+
+func coreDeps(special *engine.SpecialSet, live engine.LiveStore, greet engine.GreetStore) engine.Deps {
+	return engine.Deps{Special: special, Live: live, Greet: greet, Log: zap.NewNop()}
+}
+
+func findCmd(t *testing.T, m module.Module, name string) module.Command {
+	t.Helper()
+	for _, c := range m.Commands {
+		if c.Name == name {
+			return c
+		}
+	}
+	t.Fatalf("command %q not declared", name)
+	return module.Command{}
+}
+
+func coreCtx(chatterID, text string) *module.Context {
+	return &module.Context{
+		Env: lane.Envelope{
+			Type:              "channel.chat.message",
+			BroadcasterUserID: "2",
+			ChatterUserID:     chatterID,
+			Text:              text,
+		},
+		Regress:       module.RegressPremium,
+		BroadcasterID: 2,
+		Log:           zap.NewNop(),
+	}
+}
+
+// --- commands ---
+
+func TestCorePing(t *testing.T) {
+	m := Core(coreDeps(engine.NewSpecialSet(""), &fakeLive{}, &fakeGreet{}))
+	cmd := findCmd(t, m, "ping")
+	assert.Equal(t, module.RoleEveryone, cmd.Perm)
+
+	var col collector
+	require.NoError(t, cmd.Run(context.Background(), coreCtx("9", "!ping"), "", col.emit))
+	require.Len(t, col.out, 1)
+	assert.Equal(t, outgress.TypeChat, col.out[0].Type)
+	assert.Equal(t, "2", col.out[0].BroadcasterID)
+	assert.Contains(t, col.out[0].Text, "up for")
+}
+
+func TestCoreInfoCommands(t *testing.T) {
+	m := Core(coreDeps(engine.NewSpecialSet(""), &fakeLive{}, &fakeGreet{}))
+	for name, want := range map[string]string{
+		"itsbagelbot": "https://itsbagelbot.com",
+		"source":      "https://github.com/AdamOusmer/ItsBagelBot",
+	} {
+		cmd := findCmd(t, m, name)
+		assert.Equal(t, module.RoleEveryone, cmd.Perm, name)
+		var col collector
+		require.NoError(t, cmd.Run(context.Background(), coreCtx("9", "!"+name), "", col.emit))
+		require.Len(t, col.out, 1, name)
+		assert.Equal(t, outgress.TypeChat, col.out[0].Type, name)
+		assert.Contains(t, col.out[0].Text, want, name)
+	}
+}
+
+// --- bagel greeting (non-command chat path) ---
+
+func bagelHandler(t *testing.T, m module.Module) module.EventHandler {
+	t.Helper()
+	h := m.Events["channel.chat.message"]
+	require.NotNil(t, h, "core module must handle channel.chat.message")
+	return h
+}
+
+func TestBagelGreetsSpecialFirstMessageWhenLive(t *testing.T) {
+	m := Core(coreDeps(engine.NewSpecialSet("1"), &fakeLive{live: true}, &fakeGreet{first: true}))
+	var col collector
+	require.NoError(t, bagelHandler(t, m)(context.Background(), coreCtx("1", "hello, not a command"), col.emit))
+	require.Len(t, col.out, bagelCount)
+	for _, o := range col.out {
+		assert.Equal(t, outgress.TypeChat, o.Type)
+		assert.Equal(t, "2", o.BroadcasterID)
+		assert.Equal(t, bagelMessage, o.Text)
+	}
+}
+
+func TestBagelIgnoresNonSpecial(t *testing.T) {
+	m := Core(coreDeps(engine.NewSpecialSet("999"), &fakeLive{live: true}, &fakeGreet{first: true}))
+	var col collector
+	require.NoError(t, bagelHandler(t, m)(context.Background(), coreCtx("1", "hi"), col.emit))
+	assert.Empty(t, col.out)
+}
+
+func TestBagelIgnoresWhenOffline(t *testing.T) {
+	greet := &fakeGreet{first: true}
+	m := Core(coreDeps(engine.NewSpecialSet("1"), &fakeLive{live: false}, greet))
+	var col collector
+	require.NoError(t, bagelHandler(t, m)(context.Background(), coreCtx("1", "hi"), col.emit))
+	assert.Empty(t, col.out)
+	assert.Empty(t, greet.greeted) // must not consume the first-greet slot
+}
+
+func TestBagelOncePerStream(t *testing.T) {
+	m := Core(coreDeps(engine.NewSpecialSet("1"), &fakeLive{live: true}, &fakeGreet{first: false}))
+	var col collector
+	require.NoError(t, bagelHandler(t, m)(context.Background(), coreCtx("1", "hi"), col.emit))
+	assert.Empty(t, col.out)
+}

--- a/app/sesame/modules/live.go
+++ b/app/sesame/modules/live.go
@@ -1,0 +1,66 @@
+package modules
+
+import (
+	"context"
+	"time"
+
+	"ItsBagelBot/app/sesame/engine"
+	"ItsBagelBot/app/sesame/module"
+
+	"go.uber.org/zap"
+)
+
+// liveWriteTimeout bounds each fire-and-forget live-state write so a stalled
+// transatlantic master cannot leak goroutines.
+const liveWriteTimeout = 5 * time.Second
+
+// Live keeps the worker's own live key in step with the stream lifecycle ingress
+// delivers on the lanes: stream.online marks the broadcaster live (and resets the
+// bagel greeted set for the new session), stream.offline clears it. It is a core
+// module and produces no outbound chat.
+//
+// Both writes are fire-and-forget on a Background-derived context (the consumer's
+// ctx is acked and may cancel the moment the handler returns), so the live-state
+// write to the geographically far master never blocks the consumer goroutine.
+// Failures are logged best-effort rather than returned: the pipeline swallows a
+// handler error without redelivery anyway, so returning it would buy nothing.
+func Live(d engine.Deps) module.Module {
+	log := d.Log
+	if log == nil {
+		log = zap.NewNop()
+	}
+
+	m := module.NewModule("", module.KindCore)
+
+	m.On("stream.online", func(_ context.Context, c *module.Context, _ module.Emit) error {
+		id := c.BroadcasterID
+		go func() {
+			wctx, cancel := context.WithTimeout(context.Background(), liveWriteTimeout)
+			defer cancel()
+			if err := d.Live.SetLive(wctx, id); err != nil {
+				log.Warn("live: failed to set live", zap.Uint64("broadcaster_id", id), zap.Error(err))
+			}
+			// New session: forget who has been greeted so the bagel reply fires again.
+			if err := d.Greet.ResetGreets(wctx, id); err != nil {
+				log.Warn("live: failed to reset greets", zap.Uint64("broadcaster_id", id), zap.Error(err))
+			}
+		}()
+		log.Debug("stream online", zap.Uint64("broadcaster_id", id))
+		return nil
+	})
+
+	m.On("stream.offline", func(_ context.Context, c *module.Context, _ module.Emit) error {
+		id := c.BroadcasterID
+		go func() {
+			wctx, cancel := context.WithTimeout(context.Background(), liveWriteTimeout)
+			defer cancel()
+			if err := d.Live.ClearLive(wctx, id); err != nil {
+				log.Warn("live: failed to clear live", zap.Uint64("broadcaster_id", id), zap.Error(err))
+			}
+		}()
+		log.Debug("stream offline", zap.Uint64("broadcaster_id", id))
+		return nil
+	})
+
+	return m.Build()
+}

--- a/app/sesame/modules/shoutout.go
+++ b/app/sesame/modules/shoutout.go
@@ -1,0 +1,75 @@
+package modules
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+	"strings"
+
+	"ItsBagelBot/app/sesame/engine"
+	"ItsBagelBot/app/sesame/module"
+	"ItsBagelBot/internal/domain/outgress"
+)
+
+// defaultShoutoutTemplate is used when the broadcaster has not set one. Tokens:
+// {raider} display name, {raider_login} login, {viewers} raid party size.
+const defaultShoutoutTemplate = "🥯 Huge shoutout to {raider} who raided with {viewers}! Go show some love → twitch.tv/{raider_login}"
+
+type shoutoutConfig struct {
+	Message string `json:"message"`
+}
+
+// raidEvent is the subset of the channel.raid EventSub payload we use.
+type raidEvent struct {
+	FromBroadcasterUserLogin string `json:"from_broadcaster_user_login"`
+	FromBroadcasterUserName  string `json:"from_broadcaster_user_name"`
+	ToBroadcasterUserID      string `json:"to_broadcaster_user_id"`
+	Viewers                  int    `json:"viewers"`
+}
+
+// Shoutout posts a shoutout when another channel raids in. It is a named, opt-in
+// module (KindOptIn): a broadcaster enables it on the dashboard and customizes
+// the message template via config. Off by default. It reads its template from the
+// module config the pipeline wires into the Context.
+func Shoutout(_ engine.Deps) module.Module {
+	m := module.NewModule("shoutout", module.KindOptIn)
+
+	m.On("channel.raid", func(_ context.Context, c *module.Context, emit module.Emit) error {
+		if len(c.Env.Event) == 0 {
+			return nil
+		}
+		var ev raidEvent
+		if err := json.Unmarshal(c.Env.Event, &ev); err != nil {
+			return err
+		}
+		if ev.FromBroadcasterUserLogin == "" {
+			return nil
+		}
+
+		tmpl := defaultShoutoutTemplate
+		var cfg shoutoutConfig
+		if err := c.Decode(&cfg); err == nil && cfg.Message != "" {
+			tmpl = cfg.Message
+		}
+
+		raider := ev.FromBroadcasterUserName
+		if raider == "" {
+			raider = ev.FromBroadcasterUserLogin
+		}
+		msg := strings.NewReplacer(
+			"{raider}", raider,
+			"{raider_login}", ev.FromBroadcasterUserLogin,
+			"{viewers}", strconv.Itoa(ev.Viewers),
+		).Replace(tmpl)
+
+		// The raid event names the receiving channel as to_broadcaster_user_id.
+		emit(&module.Output{
+			Type:          outgress.TypeChat,
+			BroadcasterID: ev.ToBroadcasterUserID,
+			Text:          msg,
+		})
+		return nil
+	})
+
+	return m.Build()
+}

--- a/app/sesame/modules/shoutout_test.go
+++ b/app/sesame/modules/shoutout_test.go
@@ -1,0 +1,65 @@
+package modules
+
+import (
+	"context"
+	"testing"
+
+	"ItsBagelBot/app/sesame/engine"
+	"ItsBagelBot/app/sesame/module"
+	"ItsBagelBot/internal/domain/event/lane"
+	"ItsBagelBot/internal/domain/outgress"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+const raidJSON = `{"from_broadcaster_user_login":"coolstreamer","from_broadcaster_user_name":"CoolStreamer","to_broadcaster_user_id":"2","viewers":42}`
+
+func raidCtx(config string) *module.Context {
+	c := &module.Context{
+		Env:           lane.Envelope{Type: "channel.raid", Event: []byte(raidJSON)},
+		BroadcasterID: 2,
+		Log:           zap.NewNop(),
+	}
+	if config != "" {
+		c.Config = []byte(config)
+	}
+	return c
+}
+
+func raidHandler(t *testing.T) module.EventHandler {
+	t.Helper()
+	m := Shoutout(engine.Deps{Log: zap.NewNop()})
+	assert.Equal(t, "shoutout", m.Name)
+	assert.Equal(t, module.KindOptIn, m.Kind)
+	h := m.Events["channel.raid"]
+	require.NotNil(t, h, "shoutout must handle channel.raid")
+	return h
+}
+
+func TestShoutoutDefaultTemplate(t *testing.T) {
+	var col collector
+	require.NoError(t, raidHandler(t)(context.Background(), raidCtx(""), col.emit))
+	require.Len(t, col.out, 1)
+	o := col.out[0]
+	assert.Equal(t, outgress.TypeChat, o.Type)
+	assert.Equal(t, "2", o.BroadcasterID) // the receiving channel
+	assert.Contains(t, o.Text, "CoolStreamer")
+	assert.Contains(t, o.Text, "42")
+	assert.Contains(t, o.Text, "coolstreamer")
+}
+
+func TestShoutoutCustomTemplate(t *testing.T) {
+	var col collector
+	require.NoError(t, raidHandler(t)(context.Background(), raidCtx(`{"message":"yo {raider} +{viewers}"}`), col.emit))
+	require.Len(t, col.out, 1)
+	assert.Equal(t, "yo CoolStreamer +42", col.out[0].Text)
+}
+
+func TestShoutoutIgnoresEmptyEvent(t *testing.T) {
+	c := &module.Context{Env: lane.Envelope{Type: "channel.raid"}, BroadcasterID: 2, Log: zap.NewNop()}
+	var col collector
+	require.NoError(t, raidHandler(t)(context.Background(), c, col.emit))
+	assert.Empty(t, col.out)
+}

--- a/deploy/flux/clusters/production/images/sesame.yaml
+++ b/deploy/flux/clusters/production/images/sesame.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageRepository
+metadata:
+  name: sesame
+  namespace: flux-system
+spec:
+  image: ghcr.io/adamousmer/itsbagelbot/sesame
+  interval: 5m
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: sesame
+  namespace: flux-system
+spec:
+  digestReflectionPolicy: Always
+  interval: 5m
+  imageRepositoryRef:
+    name: sesame
+  filterTags:
+    pattern: '^main-(?P<ts>[0-9]+)-[a-f0-9]{12}$'
+    extract: $ts
+  policy:
+    numerical:
+      order: asc

--- a/deploy/k8s/kustomization.yaml
+++ b/deploy/k8s/kustomization.yaml
@@ -13,6 +13,13 @@ resources:
   - transactions.yaml
   - users.yaml
   - worker.yaml
+  # sesame is the worker rewrite. It ships ALONGSIDE worker on purpose: it reuses
+  # worker's lane consumer group ("worker"), so the two share the DeliverGroup and
+  # messages load-balance across them — no double-processing, no gap. Once sesame is
+  # confirmed healthy, the worker-deletion PR removes worker.yaml (apps Kustomization
+  # has prune=true, so dropping it prunes the worker Deployment/PDB/DopplerSecret)
+  # along with app/worker/ and images/worker.yaml.
+  - sesame.yaml
   - twitch-ingress.yaml
   - network-policies.yaml
   - linkerd-auth.yaml

--- a/deploy/k8s/sesame.yaml
+++ b/deploy/k8s/sesame.yaml
@@ -1,0 +1,171 @@
+# sesame replaces the worker: same lanes, same pkg/bus consumer group ("worker"),
+# same Doppler secret values. It reuses the worker's Doppler service token
+# (worker-doppler-token, created out-of-band and never pruned), so sesame-env
+# holds the identical secrets the worker read (VALKEY_*, NATS_CACHE_INVALIDATION_PREFIX,
+# TWITCH_SPECIAL_USER_IDS). Only the k8s secret name differs.
+apiVersion: secrets.doppler.com/v1alpha1
+kind: DopplerSecret
+metadata:
+  name: sesame-env
+  namespace: production
+spec:
+  host: https://api.doppler.com
+  tokenSecret:
+    name: worker-doppler-token
+  managedSecret:
+    name: sesame-env
+    namespace: production
+    type: Opaque
+  resyncSeconds: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sesame
+  namespace: production
+  annotations:
+    secrets.doppler.com/reload: "true"
+spec:
+  replicas: 4 # one per node; 4 schedulable nodes incl worker1 (tolerates worker-pool)
+  revisionHistoryLimit: 3
+  minReadySeconds: 10
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: sesame
+  template:
+    metadata:
+      labels:
+        app: sesame
+      annotations:
+        linkerd.io/inject: enabled
+        config.linkerd.io/proxy-cpu-request: 5m
+        config.linkerd.io/proxy-cpu-limit: 1000m
+        config.linkerd.io/proxy-memory-request: 16Mi
+        config.linkerd.io/proxy-memory-limit: 128Mi
+        config.linkerd.io/skip-outbound-ports: 6379,26379
+    spec:
+      tolerations:
+        - key: itsbagelbot.dev/pool
+          operator: Equal
+          value: worker-pool
+          effect: NoSchedule
+        - key: node.kubernetes.io/unreachable
+          operator: Exists
+          effect: NoExecute
+          tolerationSeconds: 60
+        - key: node.kubernetes.io/not-ready
+          operator: Exists
+          effect: NoExecute
+          tolerationSeconds: 60
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: sesame
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        seccompProfile: {type: RuntimeDefault}
+      containers:
+        - name: sesame
+          image: ghcr.io/adamousmer/itsbagelbot/sesame:main # {"$imagepolicy": "flux-system:sesame"}
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: NATS_HOST
+              value: nats
+            # Apps connect only to the node-local leaf cluster; the hub is reached
+            # over the leafnode link for JetStream. No hub in the server list.
+            - name: NATS_URL
+              value: nats://nats-leaf:4222
+            - name: NATS_RPC_URL
+              value: nats://nats-leaf:4222
+            - name: NATS_LEAF_URL
+              value: nats://nats-leaf:4222
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: GOMEMLIMIT
+              value: 512MiB
+            # Reuse the worker's shared lane consumer so this is a true drop-in:
+            # no DeliverAll replay, and rollout overlap load-balances instead of
+            # double-processing.
+            - name: SESAME_CONSUMER_NAME
+              value: worker
+            - name: SESAME_MIN_ROUTINES
+              value: "4"
+            - name: SESAME_MAX_ROUTINES
+              value: "25"
+            - name: SESAME_MAX_CONSUMERS
+              value: "4"
+            - name: SESAME_SCALE_UP_AFTER
+              value: 2s
+            - name: SESAME_SCALE_DOWN_AFTER
+              value: 45s
+            - name: SESAME_PREMIUM_RESERVE_PERCENT
+              value: "25"
+            # Live status: dedicated Valkey key with a TTL backstop; on expiry sesame
+            # re-checks the stream against Twitch via the outgress system lane,
+            # falling back to the projector live RPC on a cold key.
+            - name: SESAME_LIVE_TTL
+              value: 12h
+            - name: NATS_OUTGRESS_SYSTEM_SUBJECT
+              value: twitch.outgress.system
+            - name: NATS_BROADCASTER_LIVE_SUBJECT
+              value: bagel.rpc.broadcaster.live.get
+          envFrom:
+            # sesame-env (Doppler) carries VALKEY_*, NATS_CACHE_INVALIDATION_PREFIX,
+            # and TWITCH_SPECIAL_USER_IDS — the same values the worker read.
+            - secretRef:
+                name: sesame-env
+          ports:
+            - containerPort: 8080
+          resources:
+            requests:
+              cpu: 250m
+              memory: 256Mi
+            limits:
+              cpu: "2"
+              memory: 768Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities: {drop: ["ALL"]}
+          lifecycle:
+            preStop:
+              httpGet:
+                path: /drain
+                port: 8080
+          livenessProbe:
+            httpGet: {path: /healthz, port: 8080}
+            periodSeconds: 30
+          readinessProbe:
+            httpGet: {path: /readyz, port: 8080}
+            periodSeconds: 10
+          startupProbe:
+            httpGet: {path: /healthz, port: 8080}
+            failureThreshold: 18
+            periodSeconds: 5
+      terminationGracePeriodSeconds: 45
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: sesame
+  namespace: production
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: sesame


### PR DESCRIPTION
## What

Replaces the worker's behaviour layer with **app/sesame**, a cleaner authoring model, and wires the Flux deploy to run it **alongside** the worker (cutover, not hard swap).

### Engine / authoring
- One file per module under `app/sesame/modules`; commands declared with a fluent builder (`module.NewModule(...).Command("ping").Everyone().Run(fn)`), registered from a central `modules.All()` list — no `init()` globals, no `CommandRouter.Bind` init-order footgun.
- `Kind` (core/default/opt-in) replaces the empty-`Name()` magic and the `Defaulted`/`PremiumOnly` interfaces.
- **No premium feature gate** — premium vs standard is only a routing lane (which outgress subject a reply rides).
- **Announce/shoutout/me are output post-processing middleware** over a command's text, not commands. A command is gated only by the command that emits it (there is no baked `!announce` anymore; a broadcaster uses a custom command with a `/announce {args}` response).
- Commands are bound to their owning module and gated by that module's enable state (unified command + event-handler gating).
- Pooled zero-alloc pipeline + weighted-lane consumer preserved (no-output chat ~6 allocs/op, at the sonic-decode floor).

### Drop-in deploy (coexist, then remove worker)
- Reuses the worker's **lane consumer group** (`SESAME_CONSUMER_NAME=worker`): both share the `DeliverGroup` and load-balance — no double-processing, and no `DeliverAll` replay storm from a fresh durable.
- Reuses the worker's **Doppler service token** (`worker-doppler-token`) → `sesame-env` holds the identical secret values.
- `deploy/k8s/kustomization.yaml` adds `sesame.yaml` **alongside** `worker.yaml`. Worker source, `worker.yaml` and `images/worker.yaml` are removed in a **follow-up PR** once sesame is confirmed healthy.

### Verification
- Parity harness `app/sesame/compare` asserts byte-identical outgress vs the worker across baked/custom/bagel/raid on both lanes.
- Runnable stage: `go run ./app/sesame/cmd/stage` prints worker-vs-sesame side by side (14/14 match; announce is the one intentional divergence).

### Overlap caveat
While both run, `!announce` is inconsistent (worker emits it; sesame treats announce as middleware). Everything else is byte-identical. Resolves when the worker is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)