### PR TITLE
feat(console): shared-dashboards quick switch in account menu

### DIFF
--- a/console/dashboard/src/routes/(app)/+layout.server.ts
+++ b/console/dashboard/src/routes/(app)/+layout.server.ts
@@ -2,7 +2,7 @@ import { redirect, type Cookies } from '@sveltejs/kit';
 import { env } from '$env/dynamic/private';
 import type { LayoutServerLoad } from './$types';
 import { COOKIE, type Session } from '$lib/server/session';
-import { accountState, isBanned, notificationsForUser, type NotificationWire } from '$lib/server/services';
+import { accountState, isBanned, notificationsForUser, delegationAccess, type NotificationWire } from '$lib/server/services';
 import { RpcError } from '@bagel/shared/server/nats';
 import { demoNotifications } from '$lib/server/demo-notifications';
 
@@ -75,6 +75,26 @@ async function loadBellPeek(s: Session): Promise<{ unreadCount: number; notifica
   return { unreadCount, notifications };
 }
 
+// loadAuthorizedDashboards lists the boards shared with this user, for the
+// account-menu quick switch. Normal sessions only: /delegate/enter refuses a
+// delegate session, so a delegate must exit before switching boards.
+// Best-effort: an RPC blip just hides the list.
+async function loadAuthorizedDashboards(s: Session): Promise<{ href: string; name: string }[]> {
+  if (env.DEMO === '1') {
+    return [
+      { href: '/delegate/enter?owner=42', name: 'ferret_king' },
+      { href: '/delegate/enter?owner=77', name: 'bagel_queen' }
+    ];
+  }
+  if (s.delegate_of) return [];
+  try {
+    const grants = await delegationAccess(s.user_id);
+    return grants.map((g) => ({ href: `/delegate/enter?owner=${g.owner_user_id}`, name: g.owner_login }));
+  } catch {
+    return [];
+  }
+}
+
 export const load: LayoutServerLoad = async ({ locals, url, cookies }) => {
   let s = locals.session;
   if (!s && env.DEMO === '1') s = demo;
@@ -89,7 +109,10 @@ export const load: LayoutServerLoad = async ({ locals, url, cookies }) => {
   if (env.DEMO !== '1') await enforceAccountGates(s, url, cookies);
   enforceDelegateScope(s, url);
 
-  const { unreadCount, notifications } = await loadBellPeek(s);
+  const [{ unreadCount, notifications }, authorizedDashboards] = await Promise.all([
+    loadBellPeek(s),
+    loadAuthorizedDashboards(s)
+  ]);
 
   return {
     role: s.role,
@@ -100,6 +123,7 @@ export const load: LayoutServerLoad = async ({ locals, url, cookies }) => {
     delegateLogin: s.delegate_of ? s.delegate_login : undefined,
     sections: s.delegate_of ? (s.sections ?? []) : undefined,
     unreadCount,
-    bellNotifications: notifications.slice(0, BELL_PEEK)
+    bellNotifications: notifications.slice(0, BELL_PEEK),
+    authorizedDashboards
   };
 };

--- a/console/dashboard/src/routes/(app)/+layout.svelte
+++ b/console/dashboard/src/routes/(app)/+layout.svelte
@@ -75,6 +75,7 @@
   {crumb}
   accountName={data.displayName}
   accountRole={t('topbar.roleBroadcaster')}
+  dashboards={data.authorizedDashboards ?? []}
   {groups}
   mobileItems={items}
   offset={showBanner}

--- a/console/dashboard/src/routes/(app)/commands/+page.svelte
+++ b/console/dashboard/src/routes/(app)/commands/+page.svelte
@@ -5,6 +5,7 @@
     Icon,
     Card,
     PageHead,
+    Scroller,
     toast,
     normName,
     getI18n,
@@ -456,9 +457,9 @@
         {/if}
       </div>
       {#if editorDraft}
-        <div class="inspector-body" data-lenis-prevent>
+        <Scroller fill padding="16px" data-lenis-prevent>
           <CommandEditor bind:draft={editorDraft} {serverErrors} {busy} onCancel={closeEditor} onSubmit={saveSubmit} />
-        </div>
+        </Scroller>
       {:else}
         <div class="inspector-idle">
           <span class="idle-glyph"><Icon name="commands" size={18} /></span>
@@ -544,7 +545,6 @@
     letter-spacing: 0.02em;
     color: var(--bb-tan);
   }
-  .inspector-body { padding: 16px; overflow-y: auto; }
 
   .inspector-idle {
     padding: 34px 20px;

--- a/console/shared/components/AppShell.svelte
+++ b/console/shared/components/AppShell.svelte
@@ -5,14 +5,14 @@
   import type { Snippet } from 'svelte';
   import Topbar from './Topbar.svelte';
   import Dock from './Dock.svelte';
-  import type { NavGroupDef, NavLink } from '../lib/types';
+  import type { NavGroupDef, NavLink, DashboardLink } from '../lib/types';
   let {
     brandTitle = 'ItsBagelBot', brandSub, crumbRoot, crumb,
-    accountName, accountRole, groups, mobileItems,
+    accountName, accountRole, dashboards = [], groups, mobileItems,
     offset = false, banner, topActions, children
   }: {
     brandTitle?: string; brandSub: string; crumbRoot: string; crumb: string;
-    accountName: string; accountRole: string;
+    accountName: string; accountRole: string; dashboards?: DashboardLink[];
     groups: NavGroupDef[]; mobileItems: NavLink[];
     offset?: boolean; banner?: Snippet; topActions?: Snippet; children: Snippet;
   } = $props();
@@ -36,6 +36,7 @@
     {brandSub}
     {accountName}
     {accountRole}
+    {dashboards}
   />
   <main class="main">
     <div class="canvas">{@render children()}</div>

--- a/console/shared/components/Scroller.svelte
+++ b/console/shared/components/Scroller.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+  // A scroll region wearing the console's thin tan scrollbar instead of the
+  // browser's default chrome bar. Drop it anywhere a panel needs to scroll:
+  // the account menu's shared-dashboards list, the command inspector, and so on.
+  // Extra attributes (role, aria-*, data-lenis-prevent, …) pass straight through
+  // to the scrolling element.
+  import type { Snippet } from 'svelte';
+  import type { HTMLAttributes } from 'svelte/elements';
+
+  let {
+    maxHeight,
+    fill = false,
+    padding,
+    children,
+    ...rest
+  }: {
+    // Height cap before scrolling kicks in (e.g. '208px'). Omit to grow freely.
+    maxHeight?: string;
+    // Fill a flex parent and scroll the overflow (flex:1; min-height:0).
+    fill?: boolean;
+    // Inner padding kept inside the scroll region so the bar hugs the edge.
+    padding?: string;
+    children: Snippet;
+  } & HTMLAttributes<HTMLDivElement> = $props();
+
+  const style = $derived(
+    [maxHeight && `max-height:${maxHeight}`, padding && `padding:${padding}`]
+      .filter(Boolean)
+      .join(';') || undefined
+  );
+</script>
+
+<div class="scroller" class:fill {style} {...rest}>
+  {@render children()}
+</div>
+
+<style>
+  .scroller {
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    scrollbar-width: thin;
+    scrollbar-color: rgba(201, 168, 124, 0.35) transparent;
+  }
+  .scroller.fill { flex: 1; min-height: 0; }
+  .scroller::-webkit-scrollbar { width: 6px; }
+  .scroller::-webkit-scrollbar-thumb { background: rgba(201, 168, 124, 0.35); border-radius: 999px; }
+</style>

--- a/console/shared/components/Topbar.svelte
+++ b/console/shared/components/Topbar.svelte
@@ -4,6 +4,8 @@
   // operator. One thin ruled line, everything else is page.
   import type { Snippet } from 'svelte';
   import Icon from './Icon.svelte';
+  import Scroller from './Scroller.svelte';
+  import type { DashboardLink } from '../lib/types';
   import { getI18n } from '../lib/i18n/context';
 
   // Falls back to English when no i18n context is set (admin), so the label is
@@ -17,7 +19,8 @@
     brandTitle = 'ItsBagelBot',
     brandSub = '',
     accountName = '',
-    accountRole = ''
+    accountRole = '',
+    dashboards = []
   }: {
     root: string;
     crumb: string;
@@ -26,9 +29,13 @@
     brandSub?: string;
     accountName?: string;
     accountRole?: string;
+    // Boards shared with this user; renders a scrollable quick-switch list in
+    // the account menu. Empty (e.g. admin, or a user with no grants) hides it.
+    dashboards?: DashboardLink[];
   } = $props();
 
   const initial = $derived((accountName || '?').charAt(0).toUpperCase());
+  const dashInitial = (name: string) => (name || '?').charAt(0).toUpperCase();
 
   // Account menu: the avatar chip opens a small dropdown holding Log out —
   // sign-out lives here (not in the dock) so navigation stays uncrowded.
@@ -93,6 +100,24 @@
             <b>{accountName}</b>
             <i>{accountRole}</i>
           </div>
+          {#if dashboards.length}
+            <!-- Boards shared with this user; the Scroller caps the list so a
+                 long roster never runs the menu off-screen. Each row jumps into
+                 that owner's dashboard via the /delegate/enter link. -->
+            <div class="op-dash-group">
+              <div class="op-menu-section">{t('topbar.dashboards')}</div>
+              <Scroller maxHeight="208px" role="group" aria-label={t('topbar.dashboards')}>
+                <div class="op-dash-list">
+                  {#each dashboards as d (d.href)}
+                    <a class="op-dash" href={d.href} role="menuitem">
+                      <span class="dash-avatar">{dashInitial(d.name)}</span>
+                      <span class="dash-name">{d.name}</span>
+                    </a>
+                  {/each}
+                </div>
+              </Scroller>
+            </div>
+          {/if}
           <form method="POST" action="/auth/logout">
             <button type="submit" class="op-menu-item" role="menuitem">
               <Icon name="power" size={15} />
@@ -184,6 +209,36 @@
   .op-menu-head { display: flex; flex-direction: column; gap: 3px; padding: 6px 10px 10px; border-bottom: 1px solid var(--bb-border); margin-bottom: 6px; }
   .op-menu-head b { font-family: var(--bb-font-body); font-weight: 600; font-size: 13px; color: var(--bb-white); }
   .op-menu-head i { font-style: normal; font-family: var(--bb-font-display); font-weight: 700; font-size: 10px; color: var(--bb-tan); }
+
+  .op-menu-section {
+    padding: 2px 10px 4px;
+    font-family: var(--bb-font-mono); font-size: 9px; letter-spacing: 0.14em; text-transform: uppercase;
+    color: var(--bb-tan);
+  }
+  /* Ruled off from Log out below; the Scroller inside caps the height (~4.5 rows)
+     so a long roster never pushes Log out off-screen. */
+  .op-dash-group { margin-bottom: 6px; padding-bottom: 6px; border-bottom: 1px solid var(--bb-border); }
+  .op-dash-list { display: flex; flex-direction: column; gap: 2px; }
+  .op-dash {
+    display: flex; align-items: center; gap: 10px; width: 100%;
+    padding: 7px 10px; border-radius: var(--bb-radius-md, 10px);
+    text-decoration: none; cursor: pointer;
+    transition: background var(--bb-dur-fast, 180ms) ease;
+  }
+  .op-dash:hover { background: rgba(201, 168, 124, 0.1); }
+  /* Same gradient + first-letter mark as the account badge, scaled down. */
+  .dash-avatar {
+    width: 26px; height: 26px; border-radius: 50%; flex: none;
+    background: linear-gradient(135deg, var(--bb-green-light), var(--bb-tan));
+    display: flex; align-items: center; justify-content: center;
+    font-family: var(--bb-font-display); font-weight: 800; font-size: 11px; color: #0a0a0a;
+  }
+  .dash-name {
+    font-family: var(--bb-font-body); font-weight: 600; font-size: 13px; color: var(--bb-muted);
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis; min-width: 0;
+  }
+  .op-dash:hover .dash-name { color: var(--bb-white); }
+
   .op-menu form { display: flex; }
   .op-menu-item {
     display: flex; align-items: center; gap: 10px; width: 100%;

--- a/console/shared/lib/i18n/en.ts
+++ b/console/shared/lib/i18n/en.ts
@@ -44,7 +44,8 @@ export const en = {
   topbar: {
     roleBroadcaster: 'Broadcaster',
     notifications: 'Notifications',
-    logout: 'Log out'
+    logout: 'Log out',
+    dashboards: 'Shared dashboards'
   },
 
   banner: {

--- a/console/shared/lib/i18n/fr.ts
+++ b/console/shared/lib/i18n/fr.ts
@@ -43,7 +43,8 @@ export const fr = {
   topbar: {
     roleBroadcaster: 'Diffuseur',
     notifications: 'Notifications',
-    logout: 'Se déconnecter'
+    logout: 'Se déconnecter',
+    dashboards: 'Tableaux partagés'
   },
 
   banner: {

--- a/console/shared/lib/index.ts
+++ b/console/shared/lib/index.ts
@@ -34,6 +34,7 @@ export { default as RadioGroup } from '../components/RadioGroup.svelte';
 export { default as NotificationBell } from '../components/NotificationBell.svelte';
 export { default as SearchInput } from '../components/SearchInput.svelte';
 export { default as DataList } from '../components/DataList.svelte';
+export { default as Scroller } from '../components/Scroller.svelte';
 
 export { initLenis, magnetic, countUp } from './actions';
 export { icons, type IconName } from './icons';

--- a/console/shared/lib/types.ts
+++ b/console/shared/lib/types.ts
@@ -89,6 +89,16 @@ export interface NavGroupDef {
   items: NavLink[];
 }
 
+// A dashboard the signed-in user has been granted access to (a delegation
+// received). Rendered in the topbar account menu as a quick-switch link into
+// the owner's board via /delegate/enter.
+export interface DashboardLink {
+  // Full href to enter the board, e.g. /delegate/enter?owner=<id>.
+  href: string;
+  // Owner's Twitch login, shown as the row name + gradient-badge initial.
+  name: string;
+}
+
 // --- Module catalog -------------------------------------------------------
 // The user-facing modules the dashboard lets a broadcaster toggle/configure.
 // Core, hidden modules (the command processor, the live tracker, and the system


### PR DESCRIPTION
## What

Adds a **shared-dashboards quick switch** to the topbar account menu. Clicking the profile badge (the existing logout dropdown) now also lists every board that has been shared with the signed-in user. Each row shows the same gradient badge + first-letter mark as the account badge, and jumps into that owner's dashboard via the existing `/delegate/enter?owner=<id>` flow.

The list scrolls once it outgrows ~4.5 rows, so a long roster never pushes Log out off-screen.

## Scrollbar component

Extracts the console's thin tan scrollbar into a reusable `Scroller` shared component (`maxHeight`, `fill`, `padding` props; passes through `role` / `aria-*` / `data-lenis-prevent`). Used in two places:
- the account-menu dashboards list
- the command inspector panel (replacing the ad-hoc `.inspector-body` scroll region)

## How it loads

`authorizedDashboards` is fetched best-effort in the `(app)` layout loader for normal sessions only (a delegate must exit before switching boards, since `/delegate/enter` refuses a delegate session). An RPC blip just hides the list. Fetched in parallel with the notification bell peek via a `loadAuthorizedDashboards` helper.

## Verification

- DEMO preview: account menu renders the section with gradient badges + correct enter links; scroll engages past the cap; command inspector wears the same scrollbar with Lenis suppression intact.
- `svelte-check`: 0 errors on both dashboard and admin (only the pre-existing `line-clamp` warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)