### PR TITLE
feat(sesame): allow named built-in modules

### DIFF
--- a/app/sesame/engine/dispatch_test.go
+++ b/app/sesame/engine/dispatch_test.go
@@ -131,6 +131,17 @@ func TestBakedOutputRoutedByMiddleware(t *testing.T) {
 	assert.Equal(t, "hi", got[0].Text)
 }
 
+// TestNamedCoreCommandAlwaysRuns proves a named built-in (KindCore) command runs
+// with no ModuleView fetched and cannot be gated off by a missing toggle.
+func TestNamedCoreCommandAlwaysRuns(t *testing.T) {
+	sys := cmdEmit("system", module.KindCore, "sys", "ok")
+	pub := &fakePublisher{}
+	p := newPipelineWith(pub, fakeReader{}, sys)
+	require.NoError(t, p.Process(chatMsg(t, "standard", "!sys")))
+	require.Len(t, pub.got, 1)
+	assert.Equal(t, "ok", chatMessageText(t, pub.got[0].msg))
+}
+
 // --- integration: a command is gated by its owning module's enable state ---
 
 func TestOptInCommandGatedByModule(t *testing.T) {

--- a/app/sesame/engine/registry_test.go
+++ b/app/sesame/engine/registry_test.go
@@ -68,6 +68,14 @@ func TestNeedsModuleViewsForNamedCommand(t *testing.T) {
 	assert.True(t, reg.NeedsModuleViews(chatType))
 }
 
+func TestNamedCoreSkipsModuleViews(t *testing.T) {
+	// A named built-in (KindCore with a name) still skips the ModuleView fetch: it
+	// is always on and never toggled, so it must not force a projection read.
+	m := cmdModule("system", module.KindCore, "sys", module.RoleEveryone)
+	reg := NewRegistry(nil, m)
+	assert.False(t, reg.NeedsModuleViews(chatType))
+}
+
 func TestRegistryCommandIndex(t *testing.T) {
 	b := module.NewModule("", module.KindCore)
 	b.Command("ping").Everyone().Cooldown(5 * time.Second).Run(noRun)

--- a/app/sesame/module/builder.go
+++ b/app/sesame/module/builder.go
@@ -30,8 +30,10 @@ type Builder struct {
 // NewModule starts a module of the given name and kind. Deps are not passed
 // here: a command's Run and an event handler capture whatever services they need
 // by closure, which is what keeps this package free of runtime wiring. A core
-// module (KindCore) must use an empty name; a named module (KindDefault /
-// KindOptIn) must use a non-empty one. Build enforces this.
+// module (KindCore) is always on and never toggled or configured, so its name is
+// optional — empty for the classic unnamed built-ins, or set to give a named
+// built-in an identity. A named module (KindDefault / KindOptIn) must use a
+// non-empty name. Build enforces this.
 func NewModule(name string, kind Kind) *Builder {
 	return &Builder{name: name, kind: kind}
 }
@@ -100,14 +102,14 @@ func (b *Builder) Validate() error {
 	return b.validateCommands()
 }
 
-// validateKindName enforces the kind/name pairing: core modules have an empty
-// name, named modules a non-empty one.
+// validateKindName enforces the kind/name pairing. A named module (default or
+// opt-in) needs a non-empty name to key its ModuleView. A core module's name is
+// optional: empty for the classic unnamed built-ins, or set to give a named
+// built-in an identity — either way it is always on and never gets a ModuleView.
 func (b *Builder) validateKindName() error {
 	switch b.kind {
 	case KindCore:
-		if b.name != "" {
-			return fmt.Errorf("core module must have an empty name, got %q", b.name)
-		}
+		// name optional; always-on built-in, no ModuleView key.
 	case KindDefault, KindOptIn:
 		if b.name == "" {
 			return fmt.Errorf("%s module must have a non-empty name", b.kind)

--- a/app/sesame/module/builder_test.go
+++ b/app/sesame/module/builder_test.go
@@ -98,7 +98,7 @@ func TestValidateKindNamePairing(t *testing.T) {
 		wantErr bool
 	}{
 		{"core empty ok", func() *Builder { return NewModule("", KindCore) }, false},
-		{"core named bad", func() *Builder { return NewModule("x", KindCore) }, true},
+		{"core named ok", func() *Builder { return NewModule("system", KindCore) }, false},
 		{"default named ok", func() *Builder {
 			b := NewModule("greeter", KindDefault)
 			b.On("channel.chat.message", noopEvt)
@@ -157,7 +157,18 @@ func TestBuildPanicsOnInvalid(t *testing.T) {
 			t.Fatal("Build did not panic on an invalid module")
 		}
 	}()
-	NewModule("x", KindCore).Build() // core module with a name: must panic
+	NewModule("", KindDefault).Build() // named module with an empty name: must panic
+}
+
+// TestNamedCoreBuilds is the named built-in: a KindCore module may carry a name
+// (for identity) while staying always-on, never toggled or configured.
+func TestNamedCoreBuilds(t *testing.T) {
+	m := NewModule("system", KindCore)
+	m.Command("sys").Run(noopRun)
+	mod := m.Build()
+	if mod.Name != "system" || mod.Kind != KindCore {
+		t.Fatalf("named core: got name=%q kind=%v, want system/core", mod.Name, mod.Kind)
+	}
 }
 
 func TestDuplicateEventKeepsLast(t *testing.T) {

--- a/app/sesame/module/module.go
+++ b/app/sesame/module/module.go
@@ -22,8 +22,11 @@ import (
 type Kind int
 
 const (
-	// KindCore is always on, never listed to broadcasters, and immutable. A core
-	// module must have an empty Name (it has no ModuleView key).
+	// KindCore is always on, never listed to broadcasters, and immutable: it is
+	// never toggled or configured, and the engine skips the ModuleView check for
+	// it entirely (no projection fetch on its account). Its Name is optional —
+	// empty for the classic unnamed built-ins, or set to give a named built-in an
+	// identity (it still has no ModuleView key and no config).
 	KindCore Kind = iota
 	// KindDefault is a named module that ships enabled: it runs unless the
 	// broadcaster's ModuleView disables it.


### PR DESCRIPTION
## What

Lets a built-in module carry a **name** while staying always-on. Built-ins (`KindCore`) are always on, never toggled, never configured, and the engine already skips the ModuleView check for them — but the builder forced their name to be empty, so a built-in couldn't have an identity (for logs/listing).

```go
module.NewModule("system", module.KindCore)   // named, still always-on
// enabled() -> true (no check); NeedsModuleViews -> false (no projection fetch)
```

## Why it's a one-line-of-logic change

The engine's enable gate and view-fetch decision key on `Kind`, not `Name`:
- `enabled()` returns `true` immediately for `KindCore` and wires no config.
- `NeedsModuleViews` returns false for `KindCore`, so no `proj.Modules` read.

So only the builder's `validateKindName` needed to relax — `KindCore` may now have any name; named modules (`KindDefault`/`KindOptIn`) still require a non-empty one. A named built-in still gets **no ModuleView key and no config**, and can **never be toggled off**.

## Tests
- `builder_test`: named core builds; the panic test repointed to a still-invalid case (named module with empty name).
- `registry_test`: a named core command owner does **not** trigger `NeedsModuleViews`.
- `dispatch_test`: a named core command runs with no ModuleView fetched and can't be gated off.

Verified: `go build ./...`, `go test ./app/sesame/... ./internal/buildguard/` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)