### PR TITLE
feat(ingress): chat guard suite (squash, flood-shed, size, passthrough flag)

### DIFF
--- a/app/ingress/lib/ingress/application.ex
+++ b/app/ingress/lib/ingress/application.ex
@@ -10,6 +10,11 @@ defmodule Ingress.Application do
       them to surviving nodes when a node leaves.
     * `Ingress.BroadcasterCache` - in-process ETS cache over the broadcaster
       status NATS RPC (the ingress never reads the database directly).
+    * `Ingress.Squash` - coalesces identical non-command chat into one
+      `channel.chat.message.duplicates` cohort, so duplicates keep their
+      reputation/campaign signal without one bus event each.
+    * `Ingress.FloodShed` - per-channel rate cap for distinct plain chat (the
+      load guard that replaces the old `!` filter's implicit ceiling).
     * `Ingress.Dispatcher` - bounded async notification filtering and NATS
       publish workers so shard socket processes never do that work inline.
     * `Ingress.Twitch.AppToken` - cached app access token for Helix calls.
@@ -63,6 +68,8 @@ defmodule Ingress.Application do
       nats_bus_connection(),
       Ingress.NatsFailback,
       Ingress.BroadcasterCache,
+      Ingress.Squash,
+      Ingress.FloodShed,
       {Task.Supervisor, name: Ingress.Dispatcher.TaskSupervisor},
       Ingress.Dispatcher,
       Ingress.Twitch.AppToken,

--- a/app/ingress/lib/ingress/config.ex
+++ b/app/ingress/lib/ingress/config.ex
@@ -44,6 +44,41 @@ defmodule Ingress.Config do
   def broadcaster_cache_ttl_ms,
     do: Application.get_env(:ingress, :broadcaster_cache_ttl_ms, 300_000)
 
+  # How long identical non-command chat is coalesced before the cohort is
+  # flushed (see Ingress.Squash).
+  def squash_window_ms,
+    do: Application.get_env(:ingress, :squash_window_ms, 2_000)
+
+  # A cohort this large flushes early instead of waiting for the window, to
+  # bound the event size under a raid.
+  def squash_max_senders,
+    do: Application.get_env(:ingress, :squash_max_senders, 500)
+
+  # How often the squash sweep runs; keep it well under the window so cohorts
+  # flush promptly after their window closes.
+  def squash_sweep_ms,
+    do: Application.get_env(:ingress, :squash_sweep_ms, 500)
+
+  # Feature flag for the lifted `!` filter. While false (the default), plain
+  # non-command chat is dropped exactly as before, so the guards can ship dark;
+  # flip it true once the worker's automod is ready to consume all chat.
+  def chat_passthrough_enabled?,
+    do: Application.get_env(:ingress, :chat_passthrough_enabled, false)
+
+  # Size guard: chat text past this many bytes is malformed/abuse and dropped.
+  # A well-formed Twitch line is <= 500 chars; the ceiling is generous.
+  def max_chat_text_bytes,
+    do: Application.get_env(:ingress, :max_chat_text_bytes, 4_096)
+
+  # Per-channel plain-chat rate cap (messages per second) before shedding; see
+  # Ingress.FloodShed. Identical lines are squashed first, so this caps distinct
+  # plain chat only.
+  def flood_shed_per_sec,
+    do: Application.get_env(:ingress, :flood_shed_per_sec, 40)
+
+  def flood_shed_sweep_ms,
+    do: Application.get_env(:ingress, :flood_shed_sweep_ms, 2_000)
+
   def dispatcher_max_running,
     do: Application.get_env(:ingress, :dispatcher_max_running, 64)
 

--- a/app/ingress/lib/ingress/flood_shed.ex
+++ b/app/ingress/lib/ingress/flood_shed.ex
@@ -1,0 +1,76 @@
+defmodule Ingress.FloodShed do
+  @moduledoc """
+  Per-channel rate cap for plain chat, the load guard that replaces the old `!`
+  filter's implicit ceiling.
+
+  With `!` lifted, every chat line flows. `Ingress.Squash` collapses identical
+  lines (emote spam, copypasta, unsalted raids), so those never reach here. What
+  remains is DISTINCT plain chat: a hate raid that salts each message, or a
+  genuine flood. This caps that at `flood_shed_per_sec` messages per channel per
+  second; anything over is shed, which still leaves the worker dozens of distinct
+  senders a second, more than enough for the automod to see the raid and drive
+  Shield Mode, while NATS and the worker never drown.
+
+  Commands and special users never reach here (they are published directly), so
+  a legitimate `!followage` is never shed and the cooldown gates command abuse.
+
+  A fixed per-second window keyed by `{broadcaster_id, unix_second}` is
+  incremented with an atomic, lock-free `:ets.update_counter` from the calling
+  process; the GenServer only owns the table and sweeps stale buckets. Per-pod
+  state is sufficient: a channel's chat is owned by one shard on one node.
+  """
+
+  use GenServer
+
+  alias Ingress.Config
+
+  @table __MODULE__.Buckets
+
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: Keyword.get(opts, :name, __MODULE__))
+  end
+
+  @doc """
+  True when the channel is under its per-second budget (publish); false when it
+  is over (shed). Fails open (`true`) when the table is absent so a missing
+  guard never drops traffic.
+  """
+  @spec allow?(String.t()) :: boolean()
+  def allow?(broadcaster_id) do
+    key = {broadcaster_id, System.system_time(:second)}
+    :ets.update_counter(@table, key, {2, 1}, {key, 0}) <= limit()
+  rescue
+    ArgumentError -> true
+  end
+
+  @impl true
+  def init(opts) do
+    :ets.new(@table, [
+      :set,
+      :public,
+      :named_table,
+      write_concurrency: true,
+      read_concurrency: true
+    ])
+
+    :persistent_term.put(
+      {__MODULE__, :limit},
+      Keyword.get(opts, :per_sec) || Config.flood_shed_per_sec()
+    )
+
+    sweep_ms = Keyword.get(opts, :sweep_ms) || Config.flood_shed_sweep_ms()
+    Process.send_after(self(), :sweep, sweep_ms)
+    {:ok, %{sweep_ms: sweep_ms}}
+  end
+
+  @impl true
+  def handle_info(:sweep, state) do
+    # Keep the current and previous second; drop everything older.
+    cutoff = System.system_time(:second) - 1
+    :ets.select_delete(@table, [{{{:_, :"$1"}, :_}, [{:<, :"$1", cutoff}], [true]}])
+    Process.send_after(self(), :sweep, state.sweep_ms)
+    {:noreply, state}
+  end
+
+  defp limit, do: :persistent_term.get({__MODULE__, :limit}, 40)
+end

--- a/app/ingress/lib/ingress/pipeline.ex
+++ b/app/ingress/lib/ingress/pipeline.ex
@@ -17,15 +17,25 @@ defmodule Ingress.Pipeline do
   Every published event carries its `type` in the payload so consumers filter
   there, not on the subject.
 
-  For `channel.chat.message` there are exactly three outcomes:
+  For `channel.chat.message` there are three outcomes:
 
     1. The chatter is one of the special user IDs (from secrets): publish to
        the **premium** lane, always, even when the broadcaster is on the free
        tier.
-    2. The message text starts with `!`: publish to the lane matching the
-       **broadcaster's** status (premium or standard), looked up through
-       `Ingress.BroadcasterCache`.
-    3. Anything else: drop.
+    2. The message text starts with `!` (a command): publish to the lane
+       matching the **broadcaster's** status, looked up through
+       `Ingress.BroadcasterCache`. Commands are never squashed - a repeated
+       command is a legitimate second invocation the worker gates by cooldown.
+    3. Anything else (plain chat): gated behind the `chat_passthrough_enabled`
+       flag. While it is off (the default) plain chat is dropped exactly as
+       before, so the guards ship dark; flip it on once the worker's automod is
+       ready. When on, it is published under two guards: identical lines are
+       coalesced by `Ingress.Squash` into one `channel.chat.message.duplicates`
+       cohort (keeping the full reputation/campaign signal), and the surviving
+       distinct lines are rate-capped per channel by `Ingress.FloodShed`.
+
+  A size guard drops oversized/malformed chat text (`max_chat_text_bytes`)
+  before any routing.
 
   Every other EventSub type rides the premium/standard lanes, routed by the
   event's broadcaster status. Events without an extractable broadcaster
@@ -34,9 +44,9 @@ defmodule Ingress.Pipeline do
 
   require Logger
 
-  alias Ingress.{BroadcasterCache, Config, Metrics, Nats}
+  alias Ingress.{BroadcasterCache, Config, FloodShed, Metrics, Nats, Squash}
 
-  @type decision :: :special | :command | :drop
+  @type decision :: :special | :command | :chat
 
   @type lane :: :premium | :standard | :stream | :drop
 
@@ -49,6 +59,18 @@ defmodule Ingress.Pipeline do
 
       {:publish_many, publishes} ->
         Enum.each(publishes, fn {subject, message} -> publish_one(subject, message) end)
+
+      :squash ->
+        Metrics.count("Squashed")
+        :squash
+
+      :shed ->
+        Metrics.count("Shed")
+        :shed
+
+      :oversized ->
+        Metrics.count("Oversized")
+        :oversized
 
       :drop ->
         Metrics.count("Dropped")
@@ -96,17 +118,17 @@ defmodule Ingress.Pipeline do
   def route(%{"subscription" => %{"type" => "channel.chat.message"}, "event" => event}, meta) do
     text = get_in(event, ["message", "text"]) || ""
 
-    case decide(text, event["chatter_user_id"], Config.special_user_ids()) do
-      :drop ->
-        :drop
+    cond do
+      # Size guard: a well-formed Twitch chat line is <= 500 chars; anything far
+      # past that is malformed or abuse and is dropped before any further work.
+      oversized?(text) ->
+        :oversized
 
-      :special ->
-        chat_message(:premium, event, text, meta)
-
-      :command ->
-        case BroadcasterCache.lane(event["broadcaster_user_id"]) do
-          :drop -> :drop
-          lane -> chat_message(lane, event, text, meta)
+      true ->
+        case decide(text, event["chatter_user_id"], Config.special_user_ids()) do
+          :special -> chat_message(:premium, event, text, meta)
+          :command -> broadcaster_lane_publish(event, text, meta)
+          :chat -> plain_chat(event, text, meta)
         end
     end
   end
@@ -149,7 +171,7 @@ defmodule Ingress.Pipeline do
     cond do
       chatter_id != nil and chatter_id in special_user_ids -> :special
       String.starts_with?(String.trim_leading(text), "!") -> :command
-      true -> :drop
+      true -> :chat
     end
   end
 
@@ -171,6 +193,72 @@ defmodule Ingress.Pipeline do
       shard_id: meta.shard_id,
       msg_id: meta.msg_id,
       received_at: meta.ts
+    }
+  end
+
+  # Commands (and their like): publish to the broadcaster's own lane, unless the
+  # broadcaster is dropped (banned). Never squashed or shed, so a legitimate
+  # repeated command still runs (the worker gates abuse by cooldown).
+  defp broadcaster_lane_publish(event, text, meta) do
+    case BroadcasterCache.lane(event["broadcaster_user_id"]) do
+      :drop -> :drop
+      lane -> chat_message(lane, event, text, meta)
+    end
+  end
+
+  # Plain (non-command) chat. The `!` lift is gated behind a flag so the code
+  # ships dark: when disabled, plain chat keeps the pre-lift behaviour and is
+  # dropped, and the flag is flipped only once the worker's automod is ready to
+  # consume the volume. When enabled, identical lines are squashed into a cohort
+  # (Ingress.Squash) and the surviving distinct lines are rate-capped per channel
+  # (Ingress.FloodShed) before publishing.
+  defp plain_chat(event, text, meta) do
+    broadcaster_id = event["broadcaster_user_id"]
+
+    cond do
+      not Config.chat_passthrough_enabled?() ->
+        :drop
+
+      true ->
+        case BroadcasterCache.lane(broadcaster_id) do
+          :drop ->
+            :drop
+
+          lane ->
+            case Squash.observe(cohort_base(lane, event, text), sender_entry(event, meta)) do
+              :buffered -> :squash
+              :first -> flood_gated_publish(broadcaster_id, lane, event, text, meta)
+            end
+        end
+    end
+  end
+
+  defp flood_gated_publish(broadcaster_id, lane, event, text, meta) do
+    if FloodShed.allow?(broadcaster_id) do
+      chat_message(lane, event, text, meta)
+    else
+      :shed
+    end
+  end
+
+  defp oversized?(text), do: byte_size(text) > Config.max_chat_text_bytes()
+
+  defp cohort_base(lane, event, text) do
+    %{
+      broadcaster_user_id: event["broadcaster_user_id"],
+      broadcaster_user_login: event["broadcaster_user_login"],
+      lane: lane,
+      text: text
+    }
+  end
+
+  defp sender_entry(event, meta) do
+    %{
+      chatter_user_id: event["chatter_user_id"],
+      chatter_user_login: event["chatter_user_login"],
+      msg_id: meta.msg_id,
+      ts: meta.ts,
+      badges: event["badges"]
     }
   end
 

--- a/app/ingress/lib/ingress/squash.ex
+++ b/app/ingress/lib/ingress/squash.ex
@@ -1,0 +1,173 @@
+defmodule Ingress.Squash do
+  @moduledoc """
+  Coalesces identical non-command chat so the worker keeps the full reputation
+  and campaign signal at a fraction of the event count.
+
+  The `!` filter is gone, so every chat line now flows to the worker for the
+  automod. A raid or copypasta means the same text lands on a channel from many
+  chatters (or one chatter repeating). Dropping those duplicates would blind the
+  worker's per-user reputation and cross-user campaign detection, and forwarding
+  each is wasteful. So instead:
+
+    * the FIRST occurrence of a `{broadcaster, trimmed-text}` is published
+      immediately as a normal `channel.chat.message` (zero added latency for the
+      common unique message, and an instant content look for the automod);
+    * every later identical line within the window is buffered as just its
+      SENDER, and the window is flushed into ONE
+      `channel.chat.message.duplicates` cohort event carrying every duplicate
+      sender. `M` distinct users on identical text is exactly the campaign
+      primitive, delivered pre-assembled.
+
+  Commands (`!followage`, custom commands with integrations) and special users
+  never reach here: a repeated command is a legitimate second invocation the
+  worker gates with its own cooldown, so those are published individually.
+
+  Per-pod state is sufficient: a channel's chat is owned by one shard on one
+  node, so its duplicates land on the same table. The first-check is an atomic
+  `:ets.insert_new` from the calling process (lock-free, no GenServer hop on the
+  unique-message hot path); only actual duplicates cast to the GenServer, which
+  accumulates senders and flushes on the sweep or a size cap.
+  """
+
+  use GenServer
+  require Logger
+
+  alias Ingress.{Config, Metrics, Nats}
+
+  @keys_table __MODULE__.Keys
+
+  @type base :: %{
+          broadcaster_user_id: String.t(),
+          broadcaster_user_login: String.t() | nil,
+          lane: :premium | :standard,
+          text: String.t()
+        }
+  @type sender :: %{
+          chatter_user_id: String.t() | nil,
+          chatter_user_login: String.t() | nil,
+          msg_id: String.t() | nil,
+          ts: term(),
+          badges: term()
+        }
+
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: Keyword.get(opts, :name, __MODULE__))
+  end
+
+  @doc """
+  Records one plain-chat line. Returns `:first` when this is the opening
+  occurrence in the window (the caller publishes it normally), or `:buffered`
+  when it is a duplicate (the caller drops it; it will re-surface inside the
+  cohort event).
+  """
+  @spec observe(base(), sender(), GenServer.server()) :: :first | :buffered
+  def observe(base, sender, server \\ __MODULE__) do
+    key = {base.broadcaster_user_id, String.trim(base.text)}
+
+    if :ets.insert_new(@keys_table, {key, now_ms() + window_ms()}) do
+      :first
+    else
+      GenServer.cast(server, {:dup, key, base, sender})
+      :buffered
+    end
+  rescue
+    # Table missing (Squash not started, e.g. in a unit test that exercises the
+    # pipeline alone): fail open and publish rather than lose the message.
+    ArgumentError -> :first
+  end
+
+  @impl true
+  def init(opts) do
+    :ets.new(@keys_table, [
+      :set,
+      :public,
+      :named_table,
+      read_concurrency: true,
+      write_concurrency: true
+    ])
+
+    :persistent_term.put(
+      {__MODULE__, :window_ms},
+      Keyword.get(opts, :window_ms) || Config.squash_window_ms()
+    )
+
+    state = %{
+      cohorts: %{},
+      max_senders: Keyword.get(opts, :max_senders) || Config.squash_max_senders(),
+      sweep_ms: Keyword.get(opts, :sweep_ms) || Config.squash_sweep_ms(),
+      publish: Keyword.get(opts, :publish, &Nats.publish/2)
+    }
+
+    Process.send_after(self(), :sweep, state.sweep_ms)
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_cast({:dup, key, base, sender}, state) do
+    cohorts =
+      Map.update(state.cohorts, key, %{base: base, senders: [sender], count: 1}, fn c ->
+        %{c | senders: [sender | c.senders], count: c.count + 1}
+      end)
+
+    cohort = Map.fetch!(cohorts, key)
+
+    # A cohort that hits the cap flushes early: bounds the event size and hands
+    # the worker a raid cohort without waiting for the window to close.
+    if cohort.count >= state.max_senders do
+      emit(cohort, state)
+      :ets.delete(@keys_table, key)
+      {:noreply, %{state | cohorts: Map.delete(cohorts, key)}}
+    else
+      {:noreply, %{state | cohorts: cohorts}}
+    end
+  end
+
+  @impl true
+  def handle_info(:sweep, state) do
+    now = now_ms()
+    # Every key whose window has closed. Keys with no cohort are unique messages
+    # (first published, no duplicates) and are just cleaned up; keys with a
+    # cohort are flushed into one event.
+    expired = :ets.select(@keys_table, [{{:"$1", :"$2"}, [{:"=<", :"$2", now}], [:"$1"]}])
+
+    cohorts =
+      Enum.reduce(expired, state.cohorts, fn key, acc ->
+        :ets.delete(@keys_table, key)
+
+        case Map.pop(acc, key) do
+          {nil, acc} -> acc
+          {cohort, acc} -> emit(cohort, state) && acc
+        end
+      end)
+
+    Process.send_after(self(), :sweep, state.sweep_ms)
+    {:noreply, %{state | cohorts: cohorts}}
+  end
+
+  # Build and publish the cohort event onto the broadcaster's lane. It carries
+  # only the DUPLICATE senders; the first occurrence already rode a normal
+  # channel.chat.message, so the worker aggregates the two by text (and dedups
+  # by msg_id) with no double count.
+  defp emit(%{base: base, senders: senders, count: count}, state) do
+    distinct = senders |> Enum.map(& &1.chatter_user_id) |> Enum.uniq() |> length()
+
+    message = %{
+      type: "channel.chat.message.duplicates",
+      lane: base.lane,
+      broadcaster_user_id: base.broadcaster_user_id,
+      broadcaster_user_login: base.broadcaster_user_login,
+      text: base.text,
+      senders: Enum.reverse(senders),
+      count: count,
+      distinct_users: distinct
+    }
+
+    Metrics.count("Cohorts/Emitted")
+    Metrics.count("Cohorts/Senders", count)
+    state.publish.(Config.lane_subject(base.lane), message)
+    true
+  end
+
+  defp window_ms, do: :persistent_term.get({__MODULE__, :window_ms}, 2_000)
+  defp now_ms, do: System.monotonic_time(:millisecond)
+end

--- a/app/ingress/test/ingress_test.exs
+++ b/app/ingress/test/ingress_test.exs
@@ -22,16 +22,16 @@ defmodule Ingress.PipelineTest do
       assert Pipeline.decide("   !points", "555", @special) == :command
     end
 
-    test "plain chatter from a regular user is dropped" do
-      assert Pipeline.decide("just chatting", "555", @special) == :drop
+    test "plain chatter from a regular user is chat (published, then squashed)" do
+      assert Pipeline.decide("just chatting", "555", @special) == :chat
     end
 
-    test "empty text from an unknown user is dropped" do
-      assert Pipeline.decide("", nil, @special) == :drop
+    test "empty text from an unknown user is chat" do
+      assert Pipeline.decide("", nil, @special) == :chat
     end
 
     test "bang in the middle of the message is not a command" do
-      assert Pipeline.decide("nice play!", "555", @special) == :drop
+      assert Pipeline.decide("nice play!", "555", @special) == :chat
     end
   end
 
@@ -110,6 +110,16 @@ defmodule Ingress.PipelineTest do
       assert {:publish, _subject, %{badges: ^badges}} =
                Pipeline.route(notification("channel.chat.message", event), @meta)
     end
+
+    test "oversized chat text is dropped before routing" do
+      event = %{
+        "broadcaster_user_id" => "77",
+        "chatter_user_id" => "555",
+        "message" => %{"text" => String.duplicate("a", 5_000)}
+      }
+
+      assert :oversized = Pipeline.route(notification("channel.chat.message", event), @meta)
+    end
   end
 
   describe "broadcaster_id/1" do
@@ -136,9 +146,7 @@ defmodule Ingress.BroadcasterCacheTest do
   defp start_cache(loader, opts \\ []) do
     name = :"cache_#{System.unique_integer([:positive])}"
 
-    start_supervised!(
-      {BroadcasterCache, [name: name, table: name, loader: loader] ++ opts}
-    )
+    start_supervised!({BroadcasterCache, [name: name, table: name, loader: loader] ++ opts})
 
     name
   end
@@ -272,5 +280,134 @@ defmodule Ingress.CacheInvalidatorTest do
   test "garbage bodies are ignored without crashing the consumer" do
     assert :ok = CacheInvalidator.request(%{body: ""})
     assert :ok = CacheInvalidator.request(%{body: "   "})
+  end
+end
+
+defmodule Ingress.SquashTest do
+  use ExUnit.Case, async: false
+
+  alias Ingress.Squash
+
+  defp start_squash(opts) do
+    test = self()
+    publish = fn subject, msg -> send(test, {:published, subject, msg}) end
+    start_supervised!({Squash, [publish: publish] ++ opts})
+    :ok
+  end
+
+  defp base(text, lane \\ :standard),
+    do: %{broadcaster_user_id: "77", broadcaster_user_login: "chan", lane: lane, text: text}
+
+  defp sender(id),
+    do: %{chatter_user_id: id, chatter_user_login: "u#{id}", msg_id: "m#{id}", ts: 0, badges: nil}
+
+  test "the first identical line is :first, the rest are :buffered" do
+    start_squash(window_ms: 10_000, sweep_ms: 10_000)
+    assert Squash.observe(base("gg"), sender("1")) == :first
+    assert Squash.observe(base("gg"), sender("2")) == :buffered
+    assert Squash.observe(base("gg"), sender("3")) == :buffered
+  end
+
+  test "distinct text opens distinct windows (both :first)" do
+    start_squash(window_ms: 10_000, sweep_ms: 10_000)
+    assert Squash.observe(base("aaa"), sender("1")) == :first
+    assert Squash.observe(base("bbb"), sender("1")) == :first
+  end
+
+  test "the window flushes one cohort carrying every duplicate sender in order" do
+    start_squash(window_ms: 20, sweep_ms: 10)
+    assert Squash.observe(base("spam", :premium), sender("1")) == :first
+    assert Squash.observe(base("spam", :premium), sender("2")) == :buffered
+    assert Squash.observe(base("spam", :premium), sender("3")) == :buffered
+
+    assert_receive {:published, "twitch.ingress.event.premium", cohort}, 500
+    assert cohort.type == "channel.chat.message.duplicates"
+    assert cohort.text == "spam"
+    assert cohort.count == 2
+    assert cohort.distinct_users == 2
+    assert Enum.map(cohort.senders, & &1.chatter_user_id) == ["2", "3"]
+  end
+
+  test "a cohort at the size cap flushes early without waiting for the window" do
+    start_squash(window_ms: 60_000, sweep_ms: 60_000, max_senders: 2)
+    assert Squash.observe(base("flood"), sender("1")) == :first
+    assert Squash.observe(base("flood"), sender("2")) == :buffered
+    assert Squash.observe(base("flood"), sender("3")) == :buffered
+
+    assert_receive {:published, _subject, cohort}, 500
+    assert cohort.count == 2
+  end
+
+  test "observe fails open to :first when the table is absent" do
+    # No Squash started: the pipeline must never lose a message.
+    assert Squash.observe(base("x"), sender("1")) == :first
+  end
+end
+
+defmodule Ingress.PipelineGuardsTest do
+  # async: false - mutates the shared :chat_passthrough_enabled app env.
+  use ExUnit.Case, async: false
+
+  alias Ingress.Pipeline
+
+  @meta %{shard_id: 0, msg_id: "m1", ts: "2026-06-10T00:00:00Z"}
+
+  setup do
+    start_supervised!({Ingress.BroadcasterCache, [loader: fn _id -> {:ok, :standard} end]})
+    on_exit(fn -> Application.delete_env(:ingress, :chat_passthrough_enabled) end)
+    :ok
+  end
+
+  defp plain_chat do
+    %{
+      "subscription" => %{"type" => "channel.chat.message"},
+      "event" => %{
+        "broadcaster_user_id" => "77",
+        "chatter_user_id" => "555",
+        "message" => %{"text" => "just chatting"}
+      }
+    }
+  end
+
+  test "plain chat is dropped while the passthrough flag is off (ships dark)" do
+    Application.put_env(:ingress, :chat_passthrough_enabled, false)
+    assert :drop = Pipeline.route(plain_chat(), @meta)
+  end
+
+  test "plain chat publishes when the passthrough flag is on (guards fail open)" do
+    Application.put_env(:ingress, :chat_passthrough_enabled, true)
+
+    assert {:publish, "twitch.ingress.event.standard",
+            %{type: "channel.chat.message", text: "just chatting"}} =
+             Pipeline.route(plain_chat(), @meta)
+  end
+end
+
+defmodule Ingress.FloodShedTest do
+  use ExUnit.Case, async: false
+
+  alias Ingress.FloodShed
+
+  test "allows up to the per-second limit, then sheds" do
+    start_supervised!({FloodShed, [per_sec: 3, sweep_ms: 60_000]})
+
+    assert FloodShed.allow?("c1")
+    assert FloodShed.allow?("c1")
+    assert FloodShed.allow?("c1")
+    refute FloodShed.allow?("c1")
+    refute FloodShed.allow?("c1")
+  end
+
+  test "the budget is per channel" do
+    start_supervised!({FloodShed, [per_sec: 1, sweep_ms: 60_000]})
+
+    assert FloodShed.allow?("a")
+    refute FloodShed.allow?("a")
+    # A different channel has its own budget.
+    assert FloodShed.allow?("b")
+  end
+
+  test "fails open when not started so a missing guard never drops traffic" do
+    assert FloodShed.allow?("nope")
   end
 end


### PR DESCRIPTION
Ingress-side guards + safety measures so the `!` filter can be lifted (all chat flows to the worker's automod) without drowning NATS/the worker or losing signal.

## Guards (in `Ingress.Pipeline.route/2`)
- **Size guard** — text over `max_chat_text_bytes` (4096) dropped before routing.
- **`chat_passthrough_enabled` flag (default false)** — the `!` lift ships dark. Plain chat keeps the pre-lift drop until the flag is flipped, so this is a **no-op deploy**.
- **`Ingress.Squash`** — identical non-command chat coalesces: first publishes immediately, duplicates fold into one `channel.chat.message.duplicates` cohort carrying every sender (`count`, `distinct_users`). Keeps per-user reputation + cross-user campaign signal at a fraction of the event count.
- **`Ingress.FloodShed`** — per-channel per-second cap on distinct plain chat (atomic `:ets.update_counter`), the load guard replacing the `!` filter's implicit ceiling.
- Commands + special users are never squashed or shed (a legit duplicated `!followage`/integration/`!enter` still runs; worker cooldown gates abuse). Command-raid load backstopped by the existing Dispatcher bounded-queue.

Each guard is a small ETS+GenServer+sweep module (mirrors `BroadcasterCache`) and **fails open** — a missing guard never drops traffic. Per-pod state is sufficient (a channel's shard is one node).

## Worker-side follow-up (automod phase)
sesame must consume `channel.chat.message.duplicates` (per sender: reputation + campaign). Until then it safely ignores the unknown type (ack + drop). No msg_id redelivery dedup needed (EventSub-over-websocket doesn't redeliver; squash covers content dups).

## Enabling
Safe to merge/deploy as-is (flag off). Flip `chat_passthrough_enabled: true` once the worker consumes the cohort and flood-shed is tuned.

42 tests pass (`mix test`), formatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)