### PR TITLE
fix(console): drop command draft on explicit editor close

### DIFF
--- a/console/dashboard/src/routes/(app)/commands/+page.svelte
+++ b/console/dashboard/src/routes/(app)/commands/+page.svelte
@@ -190,7 +190,11 @@
     if (restored) toast('info', t('commands.toastRestoreEdits'));
   }
 
+  // Explicit close (cancel / X / backdrop / Escape / collapse) drops the draft:
+  // the sessionStorage mirror exists only to survive a reload, so any deliberate
+  // exit discards work-in-progress. Save clears its own draft before landing here.
   function closeEditor() {
+    if (editorDraft) clearDraft(editorDraft.edit ? editorDraft.originalName : '', editorDraft.edit);
     expanded = null;
     editorDraft = null;
     serverErrors = null;


### PR DESCRIPTION
## Problem

The command editor mirrors work-in-progress to `sessionStorage` so a reload can't eat it. But `closeEditor()` never cleared that draft, so every explicit exit (Cancel button, X, backdrop click, Escape, row-collapse) left the draft behind. The row kept its **unsaved** chip and restored stale edits on reopen. Only save's success path cleared it.

## Fix

Drop the current editor's draft in `closeEditor()`, before nulling `editorDraft` so the `CommandEditor` `$effect` mirror can't re-persist during teardown.

Now:
- Cancel / X / backdrop / Escape / row-collapse → draft dropped
- Save success → draft cleared (unchanged)
- Failed save → editor stays open, draft intact (never hits `closeEditor`)
- **Reload** → never calls `closeEditor`, so `sessionStorage` survives and `loadDraft` restores on reopen

The draft mirror now serves its intended purpose only: surviving a page reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)