### PR TITLE
Fix web transition WebGL lifecycle

### DIFF
--- a/web/src/components/home/Encryption.astro
+++ b/web/src/components/home/Encryption.astro
@@ -261,12 +261,15 @@ const t = useTranslations(lang);
     type EncryptionGeometryData = ReturnType<typeof buildEncryptionGeometryData>;
     type VirtualScrollData = { deltaX: number; deltaY: number; event: WheelEvent | TouchEvent };
     type EncryptionScrollAssist = (data: VirtualScrollData) => boolean | void;
+    type EncryptionCleanup = (event?: Event) => void;
     type WindowWithEncryptionAssist = Window & {
         __encryptionScrollAssist?: EncryptionScrollAssist;
         __itsbagelbotPreload?: {
             bootComplete?: boolean;
             preloadEncryption?: () => Promise<void>;
             encryptionData?: EncryptionGeometryData;
+            activeEncryption?: { id: number; cleanup: EncryptionCleanup; section?: HTMLElement };
+            nextEncryptionInstanceId?: number;
         };
     };
     type LenisController = {
@@ -301,10 +304,15 @@ const t = useTranslations(lang);
     const TAN = 0xc9a87c;
     const WHITE = 0xf0ece4;
 
+    function setupEncryption() {
     /* ─── dom ────────────────────────────────────────────────────── */
-    const canvas = document.getElementById('enc-canvas') as HTMLCanvasElement;
-    const section = document.getElementById('enc-section') as HTMLElement;
-    const pin = section.querySelector('.enc-pin') as HTMLElement;
+    const canvas = document.getElementById('enc-canvas') as HTMLCanvasElement | null;
+    const section = document.getElementById('enc-section') as HTMLElement | null;
+    if (!canvas || !section) return;
+
+    const pin = section.querySelector('.enc-pin') as HTMLElement | null;
+    if (!pin) return;
+
     const overlays = [0, 1, 2, 3].map(i => document.getElementById(`enc-ov-${i}`) as HTMLElement);
     const headings = overlays.map(el => el?.querySelector('.enc-h2') as HTMLElement | null);
     const paragraphs = overlays.map(el => el?.querySelector('.enc-p') as HTMLElement | null);
@@ -330,11 +338,16 @@ const t = useTranslations(lang);
     let destroyed = false;
     let loadObserver: IntersectionObserver | null = null;
     let initPromise: Promise<void> | null = null;
-    let cleanupScene: (() => void) | null = null;
+    let cleanupScene: ((deferGpuDispose?: boolean) => void) | null = null;
     const scrollController = lenis as LenisController;
     const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
     const assistedWindow = window as WindowWithEncryptionAssist;
     const preloadRegistry = (assistedWindow.__itsbagelbotPreload ??= {});
+    const previousActiveEncryption = preloadRegistry.activeEncryption;
+    if (previousActiveEncryption?.section === section) return;
+
+    const instanceId = (preloadRegistry.nextEncryptionInstanceId ?? 0) + 1;
+    preloadRegistry.nextEncryptionInstanceId = instanceId;
     const POST_BOOT_INIT_DELAY_MS = 960;
     const POST_BOOT_SCROLL_THRESHOLD = 36;
     let preloadModulesPromise: Promise<[
@@ -348,6 +361,15 @@ const t = useTranslations(lang);
         document.getElementById('loader-wrapper')?.getAttribute('aria-hidden') === 'true' ||
         !document.getElementById('loader-wrapper');
     let postBootStartTimer = 0;
+
+    function ownsActiveEncryption() {
+        return preloadRegistry.activeEncryption?.id === instanceId;
+    }
+
+    function isSectionNearViewport() {
+        const rect = section.getBoundingClientRect();
+        return rect.bottom >= -900 && rect.top <= window.innerHeight + 900;
+    }
 
     function preloadEncryptionModules() {
         if (!preloadModulesPromise) {
@@ -479,7 +501,7 @@ const t = useTranslations(lang);
             {UnrealBloomPass},
         ] = await preloadEncryptionModules();
 
-        if (destroyed) return;
+        if (destroyed || !ownsActiveEncryption() || !canvas.isConnected) return;
 
         const {
             WebGLRenderer, Scene, Group, PerspectiveCamera,
@@ -537,14 +559,16 @@ const t = useTranslations(lang);
         const coreGroup = new Group();
         world.add(coreGroup);
 
+        const coreOuterSource = new IcosahedronGeometry(1.6, 1);
         const coreOuter = new LineSegments(
-            new WireframeGeometry(new IcosahedronGeometry(1.6, 1)),
+            new WireframeGeometry(coreOuterSource),
             matCoreOuter,
         );
         coreGroup.add(coreOuter);
 
+        const coreInnerSource = new IcosahedronGeometry(0.8, 0);
         const coreInner = new LineSegments(
-            new EdgesGeometry(new IcosahedronGeometry(0.8, 0)),
+            new EdgesGeometry(coreInnerSource),
             matCoreInner,
         );
         coreGroup.add(coreInner);
@@ -563,6 +587,7 @@ const t = useTranslations(lang);
         ];
         const NODE_WIRES = NODE_GEOS.map(g => new WireframeGeometry(g));
         const NODE_DOT_GEO = new SphereGeometry(0.05, 6, 6);
+        const SOURCE_GEOS = [coreOuterSource, coreInnerSource, ...NODE_GEOS];
 
         const nodes: { group: Group; pos: Vector3 }[] = [];
         for (let i = 0; i < N_NODES; i++) {
@@ -1128,31 +1153,28 @@ const t = useTranslations(lang);
             refreshConnectorLayout();
         }
 
+        let disposed = false;
+        let gpuDisposed = false;
+        let disposeFallbackTimer = 0;
+        let removeAfterSwapDispose: (() => void) | null = null;
+        let bgFrame = 0;
+
         window.addEventListener('resize', resize);
         mediaQuery.addEventListener('change', resize);
         resize();
-        document.fonts?.ready.then(refreshConnectorLayout).catch(() => {});
+        document.fonts?.ready
+            .then(() => { if (!disposed) refreshConnectorLayout(); })
+            .catch(() => {});
 
         const timer = new Timer();
         timer.reset();
-        let disposed = false;
-        let bgFrame = 0;
 
-        cleanupScene = () => {
-            if (disposed) return;
-            disposed = true;
-
-            window.clearTimeout(snapTimer);
-            scrollController.off?.('virtual-scroll', onVirtualScroll);
-            window.removeEventListener('wheel', onWheel);
-            window.removeEventListener('touchend', onTouchEnd);
-            renderer.setAnimationLoop(null);
-            window.removeEventListener('scroll', onScroll);
-            window.removeEventListener('resize', resize);
-            document.removeEventListener('visibilitychange', onVisibilityChange);
-            mediaQuery.removeEventListener('change', resize);
-            obs.disconnect();
-            timer.dispose();
+        function disposeGpu() {
+            if (gpuDisposed) return;
+            gpuDisposed = true;
+            window.clearTimeout(disposeFallbackTimer);
+            removeAfterSwapDispose?.();
+            removeAfterSwapDispose = null;
 
             renderer.setEffects([]);
             renderPass.dispose();
@@ -1180,9 +1202,50 @@ const t = useTranslations(lang);
                 });
             });
 
-            NODE_GEOS.forEach((geometry) => geometry.dispose());
+            SOURCE_GEOS.forEach((geometry) => {
+                if (disposedGeometries.has(geometry)) return;
+                geometry.dispose();
+                disposedGeometries.add(geometry);
+            });
+
             renderer.dispose();
             renderer.forceContextLoss();
+            canvas.width = 0;
+            canvas.height = 0;
+        }
+
+        function scheduleGpuDisposeAfterSwap() {
+            const disposeAfterSwap = () => {
+                removeAfterSwapDispose = null;
+                requestAnimationFrame(disposeGpu);
+            };
+
+            document.addEventListener('astro:after-swap', disposeAfterSwap, {once: true});
+            removeAfterSwapDispose = () => document.removeEventListener('astro:after-swap', disposeAfterSwap);
+            disposeFallbackTimer = window.setTimeout(disposeGpu, 1400);
+        }
+
+        cleanupScene = (deferGpuDispose = false) => {
+            if (disposed) {
+                if (!deferGpuDispose) disposeGpu();
+                return;
+            }
+            disposed = true;
+
+            window.clearTimeout(snapTimer);
+            scrollController.off?.('virtual-scroll', onVirtualScroll);
+            window.removeEventListener('wheel', onWheel);
+            window.removeEventListener('touchend', onTouchEnd);
+            renderer.setAnimationLoop(null);
+            window.removeEventListener('scroll', onScroll);
+            window.removeEventListener('resize', resize);
+            document.removeEventListener('visibilitychange', onVisibilityChange);
+            mediaQuery.removeEventListener('change', resize);
+            obs.disconnect();
+            timer.dispose();
+
+            if (deferGpuDispose) scheduleGpuDisposeAfterSwap();
+            else disposeGpu();
         };
 
         renderer.setAnimationLoop((time) => {
@@ -1196,7 +1259,7 @@ const t = useTranslations(lang);
     }
 
     function startEncryption() {
-        if (initPromise) return;
+        if (destroyed || !ownsActiveEncryption() || initPromise) return;
         initPromise = initEncryption().catch((error: unknown) => {
             console.error('Encryption scene failed to load', error);
         });
@@ -1209,7 +1272,7 @@ const t = useTranslations(lang);
     }
 
     function maybeStartAfterBoot() {
-        if (destroyed || !pendingStart || !bootCompleted) return;
+        if (destroyed || !ownsActiveEncryption() || !pendingStart || !bootCompleted) return;
 
         if (window.scrollY >= POST_BOOT_SCROLL_THRESHOLD) {
             clearPostBootTimer();
@@ -1225,7 +1288,7 @@ const t = useTranslations(lang);
     }
 
     function requestEncryptionStart() {
-        if (destroyed) return;
+        if (destroyed || !ownsActiveEncryption()) return;
         pendingStart = true;
         void preloadEncryptionScene();
         maybeStartAfterBoot();
@@ -1242,7 +1305,7 @@ const t = useTranslations(lang);
         maybeStartAfterBoot();
     }
 
-    function cleanup() {
+    function cleanup(event?: Event) {
         if (destroyed) return;
         destroyed = true;
         clearPostBootTimer();
@@ -1254,7 +1317,10 @@ const t = useTranslations(lang);
         if (preloadRegistry.preloadEncryption === preloadEncryptionScene) {
             delete preloadRegistry.preloadEncryption;
         }
-        cleanupScene?.();
+        if (preloadRegistry.activeEncryption?.id === instanceId) {
+            delete preloadRegistry.activeEncryption;
+        }
+        cleanupScene?.(event?.type === 'astro:before-swap');
         cleanupScene = null;
         document.removeEventListener('itsbagelbot:loader-complete', onBootLoaderComplete);
         window.removeEventListener('scroll', onBootScroll);
@@ -1262,9 +1328,12 @@ const t = useTranslations(lang);
         window.removeEventListener('pagehide', cleanup);
     }
 
+    previousActiveEncryption?.cleanup(new Event('itsbagelbot:replace'));
+    preloadRegistry.activeEncryption = {id: instanceId, cleanup, section};
+
     loadObserver = new IntersectionObserver(
         ([entry]) => {
-            if (!entry.isIntersecting) return;
+            if (!entry.isIntersecting || !ownsActiveEncryption()) return;
             loadObserver?.disconnect();
             loadObserver = null;
             requestEncryptionStart();
@@ -1279,6 +1348,18 @@ const t = useTranslations(lang);
         maybeStartAfterBoot();
     }
 
+    requestAnimationFrame(() => {
+        if (!destroyed && ownsActiveEncryption() && isSectionNearViewport()) {
+            loadObserver?.disconnect();
+            loadObserver = null;
+            requestEncryptionStart();
+        }
+    });
+
     document.addEventListener('astro:before-swap', cleanup, {once: true});
     window.addEventListener('pagehide', cleanup, {once: true});
+    }
+
+    setupEncryption();
+    document.addEventListener('astro:page-load', setupEncryption);
 </script>

--- a/web/src/layouts/Layout.astro
+++ b/web/src/layouts/Layout.astro
@@ -32,6 +32,23 @@ basePath = basePath.replace(/\/+$/, '') || '/';
 const hasAlternates = LOCALIZED.has(basePath);
 const enHref = new URL(basePath, Astro.site).href;
 const frHref = new URL(basePath === '/' ? '/fr/' : `/fr${basePath}`, Astro.site).href;
+
+const devScriptSources = import.meta.env.DEV
+    ? " 'unsafe-inline' 'unsafe-eval'"
+    : "";
+const devConnectSources = import.meta.env.DEV
+    ? " ws://localhost:* ws://127.0.0.1:* http://localhost:* http://127.0.0.1:*"
+    : "";
+const contentSecurityPolicy = [
+    "default-src 'self'",
+    "img-src 'self' data:",
+    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+    "font-src 'self' https://fonts.gstatic.com",
+    `script-src 'self'${devScriptSources} https://static.cloudflareinsights.com`,
+    `connect-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com https://cloudflareinsights.com${devConnectSources}`,
+    "base-uri 'self'",
+    "form-action 'self'",
+].join('; ');
 ---
 
 
@@ -43,7 +60,7 @@ const frHref = new URL(basePath === '/' ? '/fr/' : `/fr${basePath}`, Astro.site)
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"/>
     <meta
         http-equiv="Content-Security-Policy"
-        content="default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; script-src 'self' https://static.cloudflareinsights.com; connect-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com https://cloudflareinsights.com; base-uri 'self'; form-action 'self'"
+        content={contentSecurityPolicy}
     />
     <meta name="referrer" content="strict-origin-when-cross-origin"/>
     <link rel="icon" type="image/png" href={logoImage.src}/>

--- a/web/src/script/decode.js
+++ b/web/src/script/decode.js
@@ -4,10 +4,9 @@
  * first time it scrolls into view its text scrambles, then resolves
  * character-by-character. Honors reduced-motion (shows final text instantly).
  *
- * The scramble is a first-impression flourish: it plays on the initial page
- * load, but on client-side navigations (Astro view transitions) the text is
- * resolved immediately. Running the per-frame scramble during a page
- * transition thrashed the main thread and made the transition stutter.
+ * The scramble plays whenever a fresh Astro page enters. In-flight work is
+ * cancelled before swaps so the outgoing page cannot keep animating against
+ * the incoming DOM.
  */
 
 const SCRAMBLE = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789#$%&*+-/<>";
@@ -62,18 +61,11 @@ function runDecode(el, text) {
     runningFrames.add(frameId);
 }
 
-// scramble=true animates on scroll-in; false resolves the text instantly
-// (used on navigations so nothing runs during the page transition).
-function setupDecode(el, scramble) {
+function setupDecode(el) {
     if (el.dataset.decodeReady === "true") return;
     el.dataset.decodeReady = "true";
 
     const text = (el.dataset.decode && el.dataset.decode.length ? el.dataset.decode : el.textContent) ?? "";
-
-    if (!scramble) {
-        el.textContent = text;
-        return;
-    }
 
     const observer = new IntersectionObserver(
         (entries) => {
@@ -91,14 +83,10 @@ function setupDecode(el, scramble) {
     observer.observe(el);
 }
 
-let firstLoad = true;
 function setup() {
-    document.querySelectorAll("[data-decode]").forEach((el) => setupDecode(el, firstLoad));
+    document.querySelectorAll("[data-decode]").forEach(setupDecode);
 }
 
 setup();
 document.addEventListener("astro:before-swap", cancelAll);
-document.addEventListener("astro:page-load", () => {
-    firstLoad = false;
-    setup();
-});
+document.addEventListener("astro:page-load", setup);

--- a/web/src/script/lightfield.js
+++ b/web/src/script/lightfield.js
@@ -5,14 +5,18 @@
  */
 
 const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
+const activeFieldCleanups = new Set();
 
 function setupField(canvas) {
     if (canvas.dataset.fieldReady === "true") return;
-    canvas.dataset.fieldReady = "true";
     if (reduceMotion.matches) return;
+    canvas.dataset.fieldReady = "true";
 
     const ctx = canvas.getContext("2d");
-    if (!ctx) return;
+    if (!ctx) {
+        canvas.removeAttribute("data-field-ready");
+        return;
+    }
 
     let w = 0, h = 0, motes = [];
     let dpr = Math.min(window.devicePixelRatio || 1, 2);
@@ -61,15 +65,34 @@ function setupField(canvas) {
     }
 
     let rafId = 0;
+    function stopLoop() {
+        if (!rafId) return;
+        cancelAnimationFrame(rafId);
+        rafId = 0;
+    }
+
     function loop() { draw(); rafId = requestAnimationFrame(loop); }
 
     const io = new IntersectionObserver(([e]) => {
         if (e.isIntersecting && !rafId) rafId = requestAnimationFrame(loop);
-        else if (!e.isIntersecting && rafId) { cancelAnimationFrame(rafId); rafId = 0; }
+        else if (!e.isIntersecting) stopLoop();
     }, { rootMargin: "150px" });
     io.observe(canvas);
 
-    window.addEventListener("resize", () => { dpr = Math.min(window.devicePixelRatio || 1, 2); build(); }, { passive: true });
+    const onResize = () => { dpr = Math.min(window.devicePixelRatio || 1, 2); build(); };
+    window.addEventListener("resize", onResize, { passive: true });
+
+    const cleanup = () => {
+        stopLoop();
+        io.disconnect();
+        window.removeEventListener("resize", onResize);
+        canvas.removeAttribute("data-field-ready");
+        canvas.width = 0;
+        canvas.height = 0;
+        activeFieldCleanups.delete(cleanup);
+    };
+    activeFieldCleanups.add(cleanup);
+
     build();
 }
 
@@ -77,5 +100,11 @@ function setup() {
     document.querySelectorAll("canvas[data-field]").forEach(setupField);
 }
 
+function cleanupAll() {
+    activeFieldCleanups.forEach((cleanup) => cleanup());
+}
+
 setup();
 document.addEventListener("astro:page-load", setup);
+document.addEventListener("astro:before-swap", cleanupAll);
+window.addEventListener("pagehide", cleanupAll);

--- a/web/src/script/scroll.js
+++ b/web/src/script/scroll.js
@@ -74,6 +74,35 @@ function stopRaf() {
     rafId = 0;
 }
 
+function stampCurrentHistoryPosition(left = 0, top = 0) {
+    if (!history.state) return;
+
+    history.scrollRestoration = 'manual';
+    history.replaceState({
+        ...history.state,
+        scrollX: left,
+        scrollY: top,
+    }, '');
+}
+
+function jumpToPageTop() {
+    lenis.resize?.();
+    lenis.scrollTo(0, {immediate: true, force: true});
+    window.scrollTo({left: 0, top: 0, behavior: 'instant'});
+    stampCurrentHistoryPosition(0, 0);
+    updateViewportHeight();
+    updateHeroProgress();
+}
+
+function resetRouteScroll() {
+    jumpToPageTop();
+
+    requestAnimationFrame(() => {
+        jumpToPageTop();
+        lenis.resize?.();
+    });
+}
+
 function onVisibilityChange() {
     if (document.hidden) {
         stopRaf();
@@ -88,6 +117,7 @@ function onVisibilityChange() {
 
 window.addEventListener('resize', updateViewportHeight, {passive: true});
 document.addEventListener('visibilitychange', onVisibilityChange);
+document.addEventListener('astro:after-swap', resetRouteScroll);
 document.addEventListener('itsbagelbot:loader-complete', () => {
     updateViewportHeight();
     updateHeroProgress();

--- a/web/tests/site.spec.js
+++ b/web/tests/site.spec.js
@@ -1,6 +1,44 @@
 import { test, expect } from '@playwright/test';
 
 test.describe('ItsBagelBot site', () => {
+    async function jumpDown(page) {
+        await page.evaluate(() => {
+            const maxScroll = Math.max(0, document.documentElement.scrollHeight - window.innerHeight);
+            const target = Math.min(Math.max(window.innerHeight * 1.4, 700), maxScroll);
+            window.lenis?.scrollTo?.(target, { immediate: true, force: true });
+            window.scrollTo({ top: target, behavior: 'instant' });
+        });
+        await page.waitForFunction(() => window.scrollY > 500);
+    }
+
+    async function expectPageTop(page) {
+        await page.waitForFunction(() => {
+            const lenis = window.lenis;
+            const lenisScroll = typeof lenis?.scroll === 'number' ? lenis.scroll : 0;
+            const lenisTarget = typeof lenis?.targetScroll === 'number' ? lenis.targetScroll : 0;
+            const savedScroll = typeof history.state?.scrollY === 'number' ? history.state.scrollY : 0;
+
+            return window.scrollY < 2 && lenisScroll < 2 && lenisTarget < 2 && savedScroll < 2;
+        });
+    }
+
+    async function expectEncryptionInitialized(page, previousId = 0) {
+        await page.waitForFunction((previousId) => {
+            const canvas = document.querySelector('#enc-canvas');
+            const active = window.__itsbagelbotPreload?.activeEncryption;
+            return Boolean(
+                canvas &&
+                active?.id > previousId &&
+                active.section === document.querySelector('#enc-section') &&
+                canvas.clientWidth > 0 &&
+                canvas.clientHeight > 0 &&
+                canvas.width >= canvas.clientWidth &&
+                canvas.height >= canvas.clientHeight &&
+                (canvas.width !== 300 || canvas.height !== 150)
+            );
+        }, previousId);
+    }
+
     test('home renders hero + Act II sections', async ({ page }) => {
         await page.goto('/');
 
@@ -103,7 +141,62 @@ test.describe('ItsBagelBot site', () => {
 
     test('active nav route is marked', async ({ page }) => {
         await page.goto('/pricing');
-        await expect(page.locator('nav .is-active')).toContainText('Pricing');
+        await expect(page.locator('nav a[aria-label="Pricing"].is-active')).toHaveCount(1);
+    });
+
+    test('client route changes always start at the top', async ({ page }) => {
+        await page.goto('/');
+        await jumpDown(page);
+
+        await page.locator('nav a[aria-label="Pricing"]').click();
+        await expect(page).toHaveURL(/\/pricing\/?$/);
+        await expectPageTop(page);
+
+        await jumpDown(page);
+        await page.locator('nav a[aria-label="Contact"]').click();
+        await expect(page).toHaveURL(/\/contact\/?$/);
+        await expectPageTop(page);
+
+        await page.goBack();
+        await expect(page).toHaveURL(/\/pricing\/?$/);
+        await expectPageTop(page);
+    });
+
+    test('decode text animates after client route swaps', async ({ page }) => {
+        await page.goto('/');
+
+        await page.locator('nav a[aria-label="Pricing"]').click();
+        await expect(page).toHaveURL(/\/pricing\/?$/);
+
+        await page.waitForFunction(() => {
+            const title = document.querySelector('.phero__title');
+            return Boolean(
+                title &&
+                title.dataset.decodeReady === 'true' &&
+                title.dataset.decode &&
+                title.textContent !== title.dataset.decode
+            );
+        });
+
+        await expect(page.locator('.phero__title')).toContainText('Free is the whole product.', { timeout: 3000 });
+    });
+
+    test('encryption scene boots again when returning home', async ({ page }) => {
+        await page.goto('/');
+
+        await expectEncryptionInitialized(page);
+
+        const firstSceneId = await page.evaluate(() => window.__itsbagelbotPreload.activeEncryption.id);
+
+        await page.locator('nav a[aria-label="Pricing"]').click();
+        await expect(page).toHaveURL(/\/pricing\/?$/);
+        await expect(page.locator('#enc-canvas')).toHaveCount(0);
+
+        await page.goBack();
+        await page.waitForFunction(() => location.pathname === '/');
+        await expectPageTop(page);
+
+        await expectEncryptionInitialized(page, firstSceneId);
     });
 });
 


### PR DESCRIPTION
## Summary
- reinitialize the encryption WebGL scene on Astro page-load after route swaps
- clean up WebGL/lightfield/scroll lifecycle state on transitions
- replay decode text on client-side page swaps
- allow Astro/Vite inline/HMR scripts only in dev CSP so normal dev loads start the scene

## Tests
- bun run build
- bunx playwright test