### PR TITLE
feat(modules): channel alerts + built-in clip command

### DIFF
--- a/app/outgress/internal/twitch/eventsub.go
+++ b/app/outgress/internal/twitch/eventsub.go
@@ -32,7 +32,7 @@ type SubSpec struct {
 //     401. They drive the live-event subsystem (go-live cache prewarm and the
 //     mod-status re-verify), so every channel must carry them.
 func ChannelSubscriptions(broadcasterID, botID string) []SubSpec {
-	specs := make([]SubSpec, 0, 9)
+	specs := make([]SubSpec, 0, 10)
 
 	if botID != "" {
 		specs = append(specs,
@@ -46,6 +46,10 @@ func ChannelSubscriptions(broadcasterID, botID string) []SubSpec {
 		SubSpec{"channel.subscription.message", "1", map[string]string{"broadcaster_user_id": broadcasterID}},
 		SubSpec{"channel.cheer", "1", map[string]string{"broadcaster_user_id": broadcasterID}},
 		SubSpec{"channel.follow", "2", map[string]string{"broadcaster_user_id": broadcasterID, "moderator_user_id": broadcasterID}},
+		// Condition keys off the receiving channel: a raid is "to" this broadcaster,
+		// not "from" them, so to_broadcaster_user_id is what makes this channel's
+		// raid handlers (shoutout, alerts) actually fire.
+		SubSpec{"channel.raid", "1", map[string]string{"to_broadcaster_user_id": broadcasterID}},
 		SubSpec{"channel.update", "2", map[string]string{"broadcaster_user_id": broadcasterID}},
 		// Authorized by the conduit app token alone (broadcaster_user_id only,
 		// no user scope, no 401 risk). These deliver go-live/go-offline, which
@@ -164,3 +168,4 @@ func statusError(res *http.Response, op string) error {
 	body, _ := io.ReadAll(io.LimitReader(res.Body, 2048))
 	return &StatusError{Status: res.StatusCode, Op: op, Body: string(body)}
 }
+

--- a/app/outgress/internal/worker/worker.go
+++ b/app/outgress/internal/worker/worker.go
@@ -320,6 +320,13 @@ func (w *Worker) Process(msg *message.Message) error {
 		return w.processShoutout(ctx, payload)
 	}
 
+	// Clip needs broadcaster_id in the query string, and — uniquely — reads the
+	// Create Clip response to post the clip URL back to chat, so it gets its own
+	// handler.
+	if payload.Type == outgress.TypeClip {
+		return w.processClip(ctx, payload)
+	}
+
 	// Only "chat" pays the chat rate buckets; every other Helix call pays the
 	// general bucket.
 	if payload.Type == outgress.TypeChat {
@@ -1088,4 +1095,123 @@ const maxResponseDrain = 64 << 10
 func drainResponse(res *http.Response) {
 	_, _ = io.CopyN(io.Discard, res.Body, maxResponseDrain+1)
 	_ = res.Body.Close()
+}
+
+// clipMeta is the metadata sesame threads on a TypeClip message: the title the
+// viewer typed and their login. The Create Clip call needs neither
+// (broadcaster_id rides the query, no body); they compose the chat reply posted
+// with the clip URL.
+type clipMeta struct {
+	Title   string `json:"title"`
+	Clipper string `json:"clipper"`
+}
+
+// clipCreateReply is the subset of the Helix Create Clip response we read.
+type clipCreateReply struct {
+	Data []struct {
+		ID      string `json:"id"`
+		EditURL string `json:"edit_url"`
+	} `json:"data"`
+}
+
+// processClip creates a clip on the broadcaster's channel and posts the public
+// clip URL back to chat. The Create Clip response (and thus the URL) is visible
+// only here, so this is the one place that can surface it.
+//
+// Redelivery safety: once the clip is created (2xx) this returns nil no matter
+// what happens to the reply — re-running the message would create a DUPLICATE
+// clip, far worse than a missing reply line. Only failures BEFORE the clip
+// exists (rate bucket, transport, 429, 5xx) return an error to redeliver.
+func (w *Worker) processClip(ctx context.Context, payload outgress.Message) error {
+	var meta clipMeta
+	if len(payload.Payload) > 0 {
+		_ = sonic.Unmarshal(payload.Payload, &meta)
+	}
+
+	if err := w.takeGeneralHelix(ctx); err != nil {
+		return err // no clip created yet: safe to redeliver
+	}
+
+	// broadcaster_id rides the query string; the Create Clip call takes no body.
+	endpoint := "/helix/clips?broadcaster_id=" + url.QueryEscape(payload.BroadcasterID)
+	res, err := w.twitch.ExecuteAs(ctx, twitch.ParseIdentity(outgress.AsBroadcaster),
+		payload.BroadcasterID, http.MethodPost, endpoint, nil)
+	if err != nil {
+		w.log.Error("clip create failed",
+			zap.String("broadcaster_id", payload.BroadcasterID), zap.Error(err))
+		return err // no clip: redeliver
+	}
+	defer drainResponse(res)
+
+	switch {
+	case res.StatusCode == http.StatusTooManyRequests:
+		w.log.Warn("twitch rate limited clip create",
+			zap.String("broadcaster_id", payload.BroadcasterID),
+			zap.Duration("retry_after", twitch.RetryAfter(res)))
+		return fmt.Errorf("twitch 429 on clip create")
+	case res.StatusCode >= 500:
+		return fmt.Errorf("twitch server error on clip create: %d", res.StatusCode)
+	case res.StatusCode >= 400:
+		body, _ := io.ReadAll(io.LimitReader(res.Body, 2048))
+		w.log.Error("dropping clip: twitch rejected create",
+			zap.Int("status", res.StatusCode),
+			zap.String("broadcaster_id", payload.BroadcasterID),
+			zap.String("body", string(body)))
+		if txn := newrelic.FromContext(ctx); txn != nil {
+			txn.NoticeError(fmt.Errorf("twitch rejected clip create: %d %s", res.StatusCode, string(body)))
+		}
+		return nil // permanent: don't redeliver
+	}
+
+	// Clip now exists. From here on never return an error (see the doc comment).
+	var reply clipCreateReply
+	if err := json.NewDecoder(io.LimitReader(res.Body, 4096)).Decode(&reply); err != nil ||
+		len(reply.Data) == 0 || reply.Data[0].ID == "" {
+		w.log.Warn("clip created but response unparseable; skipping reply",
+			zap.String("broadcaster_id", payload.BroadcasterID), zap.Error(err))
+		return nil
+	}
+
+	clipURL := "https://clips.twitch.tv/" + reply.Data[0].ID
+	if err := w.sendClipReply(ctx, payload.BroadcasterID, meta, clipURL); err != nil {
+		w.log.Warn("clip created but reply chat failed",
+			zap.String("broadcaster_id", payload.BroadcasterID), zap.Error(err))
+	}
+	return nil
+}
+
+// sendClipReply posts the chat line announcing a freshly created clip through
+// the normal chat path (rate buckets, sender-id injection). Its error is only
+// for the caller to log; the clip already exists, so the caller must not
+// redeliver on a reply failure.
+func (w *Worker) sendClipReply(ctx context.Context, broadcasterID string, meta clipMeta, clipURL string) error {
+	body, err := sonic.Marshal(struct {
+		BroadcasterID string `json:"broadcaster_id"`
+		Message       string `json:"message"`
+	}{broadcasterID, clipReplyText(meta, clipURL)})
+	if err != nil {
+		return err
+	}
+	return w.processChat(ctx, outgress.Message{
+		Type:          outgress.TypeChat,
+		BroadcasterID: broadcasterID,
+		Payload:       body,
+	})
+}
+
+// clipReplyText composes the chat line for a new clip: it names the clipper,
+// echoes the title they typed (when any), and links the public clip URL.
+func clipReplyText(meta clipMeta, clipURL string) string {
+	who := meta.Clipper
+	title := strings.TrimSpace(meta.Title)
+	switch {
+	case who != "" && title != "":
+		return "🎬 " + who + " clipped: " + title + " → " + clipURL
+	case who != "":
+		return "🎬 " + who + " made a clip → " + clipURL
+	case title != "":
+		return "🎬 Clip: " + title + " → " + clipURL
+	default:
+		return "🎬 New clip → " + clipURL
+	}
 }

--- a/app/sesame/engine/dispatch.go
+++ b/app/sesame/engine/dispatch.go
@@ -30,7 +30,7 @@ func (p *Pipeline) dispatchCommand(ctx context.Context, c *module.Context, views
 	if !ok {
 		return nil
 	}
-	if bc, isBaked := p.registry.Command(name); isBaked {
+	if bc, _, isBaked := p.registry.ResolveCommand(name); isBaked {
 		if !p.enabled(bc.Owner, views, c) {
 			return nil
 		}

--- a/app/sesame/engine/parse.go
+++ b/app/sesame/engine/parse.go
@@ -17,3 +17,15 @@ func parseCommand(text string) (name, args string, ok bool) {
 	}
 	return strings.ToLower(name), strings.TrimSpace(args), true
 }
+
+
+// splitTrailingDigits splits a run of trailing ASCII digits off the end of s.
+// "clip30" -> ("clip", "30"); "clip" -> ("clip", ""). It is used by the command
+// resolver to match a numeric-suffix trigger like !clip30.
+func splitTrailingDigits(s string) (base, digits string) {
+	i := len(s)
+	for i > 0 && s[i-1] >= '0' && s[i-1] <= '9' {
+		i--
+	}
+	return s[:i], s[i:]
+}

--- a/app/sesame/engine/pipeline.go
+++ b/app/sesame/engine/pipeline.go
@@ -333,6 +333,23 @@ func buildOutgress(o *module.Output) ([]byte, error) {
 			To:            o.To,
 			Payload:       []byte("{}"),
 		}
+	case outgress.TypeClip:
+		// The Create Clip call itself needs no body (broadcaster_id rides the
+		// query string, added by outgress). This payload is metadata outgress
+		// reads to compose the reply it posts with the clip URL: the title the
+		// viewer typed and their login.
+		payload, err := sonic.Marshal(struct {
+			Title   string `json:"title,omitempty"`
+			Clipper string `json:"clipper,omitempty"`
+		}{o.Text, o.To})
+		if err != nil {
+			return nil, err
+		}
+		msg = outgress.Message{
+			Type:          outgress.TypeClip,
+			BroadcasterID: o.BroadcasterID,
+			Payload:       payload,
+		}
 	default:
 		msg = outgress.Message{
 			Type:          o.Type,

--- a/app/sesame/engine/registry.go
+++ b/app/sesame/engine/registry.go
@@ -112,6 +112,27 @@ func (r *Registry) Command(name string) (BoundCommand, bool) {
 	return bc, ok
 }
 
+// ResolveCommand resolves a chat trigger to a bound command. It first tries an
+// exact match; on a miss it strips a trailing run of digits and retries the
+// base, matching only when that base command opted into a numeric suffix
+// (Command.NumericSuffix). "clip30" resolves to "clip" with num="30"; an exact
+// hit returns num="". The digits are returned for the caller's information but
+// are not the command's argument string. This lets a built-in like !clip accept
+// an inline number without registering every !clipN variant.
+func (r *Registry) ResolveCommand(name string) (bc BoundCommand, num string, ok bool) {
+	if bc, ok := r.commands[name]; ok {
+		return bc, "", true
+	}
+	base, digits := splitTrailingDigits(name)
+	if digits == "" || base == "" {
+		return BoundCommand{}, "", false
+	}
+	if bc, ok := r.commands[base]; ok && bc.Cmd.NumericSuffix {
+		return bc, digits, true
+	}
+	return BoundCommand{}, "", false
+}
+
 // Commands returns the bound-command index. The map is owned by the registry and
 // must be treated as read-only.
 func (r *Registry) Commands() map[string]BoundCommand { return r.commands }

--- a/app/sesame/engine/registry_test.go
+++ b/app/sesame/engine/registry_test.go
@@ -126,3 +126,47 @@ func TestRegistryDuplicateCommandFirstWins(t *testing.T) {
 	assert.Equal(t, "a", bc.Owner.Name)
 	assert.Len(t, reg.Commands(), 1)
 }
+
+func TestSplitTrailingDigits(t *testing.T) {
+	cases := []struct{ in, base, digits string }{
+		{"clip30", "clip", "30"},
+		{"clip", "clip", ""},
+		{"clip0", "clip", "0"},
+		{"30", "", "30"},
+		{"", "", ""},
+	}
+	for _, c := range cases {
+		base, digits := splitTrailingDigits(c.in)
+		assert.Equal(t, c.base, base, "base of %q", c.in)
+		assert.Equal(t, c.digits, digits, "digits of %q", c.in)
+	}
+}
+
+func TestResolveCommandNumericSuffix(t *testing.T) {
+	b := module.NewModule("", module.KindCore)
+	b.Command("clip").Everyone().NumericSuffix().Run(noRun)
+	b.Command("ping").Everyone().Run(noRun) // no numeric suffix
+	reg := NewRegistry(nil, b.Build())
+
+	// Exact match: no digits absorbed.
+	bc, num, ok := reg.ResolveCommand("clip")
+	assert.True(t, ok)
+	assert.Equal(t, "", num)
+	assert.Equal(t, "clip", bc.Cmd.Name)
+
+	// Numeric suffix resolves to the base and reports the digits.
+	bc, num, ok = reg.ResolveCommand("clip30")
+	assert.True(t, ok)
+	assert.Equal(t, "30", num)
+	assert.Equal(t, "clip", bc.Cmd.Name)
+
+	// A command without NumericSuffix does not absorb a trailing number.
+	_, _, ok = reg.ResolveCommand("ping5")
+	assert.False(t, ok)
+
+	// Unknown trigger and digits-only both miss.
+	_, _, ok = reg.ResolveCommand("nope")
+	assert.False(t, ok)
+	_, _, ok = reg.ResolveCommand("30")
+	assert.False(t, ok)
+}

--- a/app/sesame/module/builder.go
+++ b/app/sesame/module/builder.go
@@ -196,6 +196,11 @@ func (c *CmdBuilder) Cooldown(d time.Duration) *CmdBuilder { c.cmd.Cooldown = d;
 // LiveOnly gates the command to when the broadcaster is live.
 func (c *CmdBuilder) LiveOnly() *CmdBuilder { c.cmd.LiveOnly = true; return c }
 
+// NumericSuffix lets the trigger match with a trailing run of digits typed
+// inline: "!clip30" resolves to the "clip" command. The digits are stripped and
+// discarded (they are not the argument string). See Registry.ResolveCommand.
+func (c *CmdBuilder) NumericSuffix() *CmdBuilder { c.cmd.NumericSuffix = true; return c }
+
 // AllowUser restricts the command to exactly one chatter id, overriding the role
 // gate entirely.
 func (c *CmdBuilder) AllowUser(id string) *CmdBuilder { c.cmd.AllowedUserID = id; return c }

--- a/app/sesame/module/module.go
+++ b/app/sesame/module/module.go
@@ -99,6 +99,11 @@ type Command struct {
 	// AllowedUserID, when non-empty, restricts the command to exactly that
 	// chatter id and overrides Perm entirely.
 	AllowedUserID string
+	// NumericSuffix lets the trigger absorb a trailing run of digits typed
+	// inline (e.g. "!clip30" resolves to "clip"). The digits are not passed to
+	// the command; they only widen what matches this trigger. Used by built-ins
+	// like !clip that accept an inline number.
+	NumericSuffix bool
 	// Run executes the command after the gates pass.
 	Run RunFunc
 }

--- a/app/sesame/modules/alerts.go
+++ b/app/sesame/modules/alerts.go
@@ -1,0 +1,236 @@
+package modules
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+	"strings"
+
+	"ItsBagelBot/app/sesame/engine"
+	"ItsBagelBot/app/sesame/module"
+	"ItsBagelBot/internal/domain/outgress"
+)
+
+// Default chat templates for each alert. Tokens are documented per handler below.
+const (
+	defaultFollowTemplate = "🥯 Thanks for the follow, {user}!"
+	defaultSubTemplate    = "🥯 {user} just subscribed! Welcome to the sub squad!"
+	defaultCheerTemplate  = "🥯 {user} cheered {bits} bits! Thanks for the support!"
+	defaultRaidTemplate   = "🥯 {user} is raiding with {viewers} viewers!"
+)
+
+// alertsConfig holds the broadcaster's per-alert enable flags and customized
+// templates. Each *Enabled is a dashboard toggle stored as "on"/"off"; empty
+// (no stored value) means default-on, so a freshly enabled module fires every
+// alert until the broadcaster turns one off. Each *Message empty falls back to
+// that alert's default template.
+type alertsConfig struct {
+	FollowEnabled string `json:"followEnabled"`
+	FollowMessage string `json:"followMessage"`
+	SubEnabled    string `json:"subEnabled"`
+	SubMessage    string `json:"subMessage"`
+	CheerEnabled  string `json:"cheerEnabled"`
+	CheerMessage  string `json:"cheerMessage"`
+	RaidEnabled   string `json:"raidEnabled"`
+	RaidMessage   string `json:"raidMessage"`
+}
+
+// alertOn reports whether a sub-alert toggle is on. Only an explicit "off"
+// disables it; empty (never set) and "on" both fire, so each alert defaults on.
+func alertOn(v string) bool { return v != "off" }
+
+// followEvent is the subset of the channel.follow EventSub payload we use.
+type followEvent struct {
+	UserName          string `json:"user_name"`
+	UserLogin         string `json:"user_login"`
+	BroadcasterUserID string `json:"broadcaster_user_id"`
+}
+
+// subscribeEvent is the subset of the channel.subscribe EventSub payload we use.
+type subscribeEvent struct {
+	UserName          string `json:"user_name"`
+	UserLogin         string `json:"user_login"`
+	BroadcasterUserID string `json:"broadcaster_user_id"`
+	Tier              string `json:"tier"`
+}
+
+// cheerEvent is the subset of the channel.cheer EventSub payload we use. A
+// cheer left anonymous by the chatter carries no user identity.
+type cheerEvent struct {
+	IsAnonymous       bool   `json:"is_anonymous"`
+	UserName          string `json:"user_name"`
+	UserLogin         string `json:"user_login"`
+	BroadcasterUserID string `json:"broadcaster_user_id"`
+	Bits              int    `json:"bits"`
+}
+
+// Alerts posts a chat line on channel.follow, channel.subscribe, channel.cheer
+// and channel.raid. It is a named, default-on module (KindDefault): it ships
+// enabled and runs unless the broadcaster disables the whole module on the
+// dashboard. Each alert has its own enable toggle and message template, wired in
+// from the module config the pipeline sets on the Context. Raid is a separate
+// alert from the Shoutout module: Shoutout points chat at the raider's channel,
+// this just announces the raid happened.
+func Alerts(_ engine.Deps) module.Module {
+	m := module.NewModule("alerts", module.KindDefault)
+
+	m.On("channel.follow", func(_ context.Context, c *module.Context, emit module.Emit) error {
+		var cfg alertsConfig
+		_ = c.Decode(&cfg)
+		if !alertOn(cfg.FollowEnabled) {
+			return nil
+		}
+		if len(c.Env.Event) == 0 {
+			return nil
+		}
+		var ev followEvent
+		if err := json.Unmarshal(c.Env.Event, &ev); err != nil {
+			return err
+		}
+		if ev.UserLogin == "" {
+			return nil
+		}
+
+		tmpl := cfg.FollowMessage
+		if tmpl == "" {
+			tmpl = defaultFollowTemplate
+		}
+
+		emit(&module.Output{
+			Type:          outgress.TypeChat,
+			BroadcasterID: ev.BroadcasterUserID,
+			Text:          expandUserTokens(tmpl, displayName(ev.UserName, ev.UserLogin), ev.UserLogin),
+		})
+		return nil
+	})
+
+	m.On("channel.subscribe", func(_ context.Context, c *module.Context, emit module.Emit) error {
+		var cfg alertsConfig
+		_ = c.Decode(&cfg)
+		if !alertOn(cfg.SubEnabled) {
+			return nil
+		}
+		if len(c.Env.Event) == 0 {
+			return nil
+		}
+		var ev subscribeEvent
+		if err := json.Unmarshal(c.Env.Event, &ev); err != nil {
+			return err
+		}
+		if ev.UserLogin == "" {
+			return nil
+		}
+
+		tmpl := cfg.SubMessage
+		if tmpl == "" {
+			tmpl = defaultSubTemplate
+		}
+
+		msg := strings.NewReplacer(
+			"{user}", displayName(ev.UserName, ev.UserLogin),
+			"{user_login}", ev.UserLogin,
+			"{tier}", ev.Tier,
+		).Replace(tmpl)
+
+		emit(&module.Output{
+			Type:          outgress.TypeChat,
+			BroadcasterID: ev.BroadcasterUserID,
+			Text:          msg,
+		})
+		return nil
+	})
+
+	m.On("channel.cheer", func(_ context.Context, c *module.Context, emit module.Emit) error {
+		var cfg alertsConfig
+		_ = c.Decode(&cfg)
+		if !alertOn(cfg.CheerEnabled) {
+			return nil
+		}
+		if len(c.Env.Event) == 0 {
+			return nil
+		}
+		var ev cheerEvent
+		if err := json.Unmarshal(c.Env.Event, &ev); err != nil {
+			return err
+		}
+		if ev.BroadcasterUserID == "" {
+			return nil
+		}
+
+		tmpl := cfg.CheerMessage
+		if tmpl == "" {
+			tmpl = defaultCheerTemplate
+		}
+
+		cheerer := "An anonymous cheerer"
+		login := ev.UserLogin
+		if !ev.IsAnonymous {
+			cheerer = displayName(ev.UserName, ev.UserLogin)
+		}
+
+		msg := strings.NewReplacer(
+			"{user}", cheerer,
+			"{user_login}", login,
+			"{bits}", strconv.Itoa(ev.Bits),
+		).Replace(tmpl)
+
+		emit(&module.Output{
+			Type:          outgress.TypeChat,
+			BroadcasterID: ev.BroadcasterUserID,
+			Text:          msg,
+		})
+		return nil
+	})
+
+	m.On("channel.raid", func(_ context.Context, c *module.Context, emit module.Emit) error {
+		var cfg alertsConfig
+		_ = c.Decode(&cfg)
+		if !alertOn(cfg.RaidEnabled) {
+			return nil
+		}
+		if len(c.Env.Event) == 0 {
+			return nil
+		}
+		var ev raidEvent
+		if err := json.Unmarshal(c.Env.Event, &ev); err != nil {
+			return err
+		}
+		if ev.FromBroadcasterUserLogin == "" {
+			return nil
+		}
+
+		tmpl := cfg.RaidMessage
+		if tmpl == "" {
+			tmpl = defaultRaidTemplate
+		}
+
+		msg := strings.NewReplacer(
+			"{user}", displayName(ev.FromBroadcasterUserName, ev.FromBroadcasterUserLogin),
+			"{user_login}", ev.FromBroadcasterUserLogin,
+			"{viewers}", strconv.Itoa(ev.Viewers),
+		).Replace(tmpl)
+
+		emit(&module.Output{
+			Type:          outgress.TypeChat,
+			BroadcasterID: ev.ToBroadcasterUserID,
+			Text:          msg,
+		})
+		return nil
+	})
+
+	return m.Build()
+}
+
+// displayName prefers the EventSub display name, falling back to the login
+// when Twitch omits it.
+func displayName(name, login string) string {
+	if name != "" {
+		return name
+	}
+	return login
+}
+
+// expandUserTokens replaces {user} and {user_login} in tmpl.
+func expandUserTokens(tmpl, user, login string) string {
+	return strings.NewReplacer("{user}", user, "{user_login}", login).Replace(tmpl)
+}

--- a/app/sesame/modules/alerts_test.go
+++ b/app/sesame/modules/alerts_test.go
@@ -1,0 +1,154 @@
+package modules
+
+import (
+	"context"
+	"testing"
+
+	"ItsBagelBot/app/sesame/engine"
+	"ItsBagelBot/app/sesame/module"
+	"ItsBagelBot/internal/domain/event/lane"
+	"ItsBagelBot/internal/domain/outgress"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+const (
+	followJSON    = `{"user_name":"CoolViewer","user_login":"coolviewer","broadcaster_user_id":"2"}`
+	subscribeJSON = `{"user_name":"CoolViewer","user_login":"coolviewer","broadcaster_user_id":"2","tier":"1000"}`
+	cheerJSON     = `{"is_anonymous":false,"user_name":"CoolViewer","user_login":"coolviewer","broadcaster_user_id":"2","bits":100}`
+	anonCheerJSON = `{"is_anonymous":true,"broadcaster_user_id":"2","bits":50}`
+)
+
+func alertsCtx(eventType, payload, config string) *module.Context {
+	c := &module.Context{
+		Env:           lane.Envelope{Type: eventType, Event: []byte(payload)},
+		BroadcasterID: 2,
+		Log:           zap.NewNop(),
+	}
+	if config != "" {
+		c.Config = []byte(config)
+	}
+	return c
+}
+
+func alertsHandler(t *testing.T, eventType string) module.EventHandler {
+	t.Helper()
+	m := Alerts(engine.Deps{Log: zap.NewNop()})
+	assert.Equal(t, "alerts", m.Name)
+	assert.Equal(t, module.KindDefault, m.Kind)
+	h := m.Events[eventType]
+	require.NotNil(t, h, "alerts must handle %s", eventType)
+	return h
+}
+
+func TestAlertsFollowDefaultTemplate(t *testing.T) {
+	var col collector
+	require.NoError(t, alertsHandler(t, "channel.follow")(context.Background(), alertsCtx("channel.follow", followJSON, ""), col.emit))
+	require.Len(t, col.out, 1)
+	o := col.out[0]
+	assert.Equal(t, outgress.TypeChat, o.Type)
+	assert.Equal(t, "2", o.BroadcasterID)
+	assert.Contains(t, o.Text, "CoolViewer")
+}
+
+func TestAlertsFollowCustomTemplate(t *testing.T) {
+	var col collector
+	cfg := `{"followMessage":"welcome {user} ({user_login})"}`
+	require.NoError(t, alertsHandler(t, "channel.follow")(context.Background(), alertsCtx("channel.follow", followJSON, cfg), col.emit))
+	require.Len(t, col.out, 1)
+	assert.Equal(t, "welcome CoolViewer (coolviewer)", col.out[0].Text)
+}
+
+func TestAlertsFollowIgnoresEmptyEvent(t *testing.T) {
+	var col collector
+	require.NoError(t, alertsHandler(t, "channel.follow")(context.Background(), alertsCtx("channel.follow", "", ""), col.emit))
+	assert.Empty(t, col.out)
+}
+
+func TestAlertsSubDefaultTemplate(t *testing.T) {
+	var col collector
+	require.NoError(t, alertsHandler(t, "channel.subscribe")(context.Background(), alertsCtx("channel.subscribe", subscribeJSON, ""), col.emit))
+	require.Len(t, col.out, 1)
+	assert.Contains(t, col.out[0].Text, "CoolViewer")
+}
+
+func TestAlertsSubCustomTemplate(t *testing.T) {
+	var col collector
+	cfg := `{"subMessage":"{user} sub'd at tier {tier}"}`
+	require.NoError(t, alertsHandler(t, "channel.subscribe")(context.Background(), alertsCtx("channel.subscribe", subscribeJSON, cfg), col.emit))
+	require.Len(t, col.out, 1)
+	assert.Equal(t, "CoolViewer sub'd at tier 1000", col.out[0].Text)
+}
+
+func TestAlertsCheerDefaultTemplate(t *testing.T) {
+	var col collector
+	require.NoError(t, alertsHandler(t, "channel.cheer")(context.Background(), alertsCtx("channel.cheer", cheerJSON, ""), col.emit))
+	require.Len(t, col.out, 1)
+	assert.Contains(t, col.out[0].Text, "CoolViewer")
+	assert.Contains(t, col.out[0].Text, "100")
+}
+
+func TestAlertsCheerAnonymous(t *testing.T) {
+	var col collector
+	require.NoError(t, alertsHandler(t, "channel.cheer")(context.Background(), alertsCtx("channel.cheer", anonCheerJSON, ""), col.emit))
+	require.Len(t, col.out, 1)
+	assert.Contains(t, col.out[0].Text, "anonymous")
+	assert.Contains(t, col.out[0].Text, "50")
+}
+
+func TestAlertsRaidDefaultTemplate(t *testing.T) {
+	var col collector
+	require.NoError(t, alertsHandler(t, "channel.raid")(context.Background(), alertsCtx("channel.raid", raidJSON, ""), col.emit))
+	require.Len(t, col.out, 1)
+	o := col.out[0]
+	assert.Equal(t, "2", o.BroadcasterID) // the receiving channel
+	assert.Contains(t, o.Text, "CoolStreamer")
+	assert.Contains(t, o.Text, "42")
+}
+
+func TestAlertsRaidCustomTemplate(t *testing.T) {
+	var col collector
+	cfg := `{"raidMessage":"raid! {user} +{viewers}"}`
+	require.NoError(t, alertsHandler(t, "channel.raid")(context.Background(), alertsCtx("channel.raid", raidJSON, cfg), col.emit))
+	require.Len(t, col.out, 1)
+	assert.Equal(t, "raid! CoolStreamer +42", col.out[0].Text)
+}
+
+func TestAlertsFollowDisabled(t *testing.T) {
+	var col collector
+	cfg := `{"followEnabled":"off"}`
+	require.NoError(t, alertsHandler(t, "channel.follow")(context.Background(), alertsCtx("channel.follow", followJSON, cfg), col.emit))
+	assert.Empty(t, col.out)
+}
+
+func TestAlertsSubDisabled(t *testing.T) {
+	var col collector
+	cfg := `{"subEnabled":"off"}`
+	require.NoError(t, alertsHandler(t, "channel.subscribe")(context.Background(), alertsCtx("channel.subscribe", subscribeJSON, cfg), col.emit))
+	assert.Empty(t, col.out)
+}
+
+func TestAlertsCheerDisabled(t *testing.T) {
+	var col collector
+	cfg := `{"cheerEnabled":"off"}`
+	require.NoError(t, alertsHandler(t, "channel.cheer")(context.Background(), alertsCtx("channel.cheer", cheerJSON, cfg), col.emit))
+	assert.Empty(t, col.out)
+}
+
+func TestAlertsRaidDisabled(t *testing.T) {
+	var col collector
+	cfg := `{"raidEnabled":"off"}`
+	require.NoError(t, alertsHandler(t, "channel.raid")(context.Background(), alertsCtx("channel.raid", raidJSON, cfg), col.emit))
+	assert.Empty(t, col.out)
+}
+
+func TestAlertsEnabledOnAndBlankBothFire(t *testing.T) {
+	// "on" and an absent flag both fire (default-on); only "off" suppresses.
+	for _, cfg := range []string{`{"followEnabled":"on"}`, `{}`, ``} {
+		var col collector
+		require.NoError(t, alertsHandler(t, "channel.follow")(context.Background(), alertsCtx("channel.follow", followJSON, cfg), col.emit))
+		require.Len(t, col.out, 1, "cfg=%q should fire", cfg)
+	}
+}

--- a/app/sesame/modules/all.go
+++ b/app/sesame/modules/all.go
@@ -14,5 +14,7 @@ func All(d engine.Deps) []module.Module {
 		Core(d),
 		Live(d),
 		Shoutout(d),
+		Alerts(d),
+		Clip(d),
 	}
 }

--- a/app/sesame/modules/clip.go
+++ b/app/sesame/modules/clip.go
@@ -1,0 +1,92 @@
+package modules
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"ItsBagelBot/app/sesame/engine"
+	"ItsBagelBot/app/sesame/module"
+	"ItsBagelBot/internal/domain/outgress"
+
+	"go.uber.org/zap"
+)
+
+// clipCooldown is the shared per-channel window on !clip so a single viewer (or
+// the whole chat) cannot spam clip creation and blow the broadcaster's Helix
+// budget. Twitch also rate-limits clip creation server-side; this is the polite
+// first line.
+const clipCooldown = 15 * time.Second
+
+// clipModuleName is the modules-service key that stores the per-broadcaster
+// on/off state for the built-in !clip command. It is deliberately NOT in the
+// dashboard MODULE_CATALOG (so it never shows on the modules page); it surfaces
+// on the commands page as a built-in command instead. Absent row means on.
+const clipModuleName = "clip"
+
+// Clip owns the built-in !clip command. It is a core module (always indexed, no
+// per-message ModuleView fetch on the hot chat path), but the command is
+// toggleable per broadcaster: clipRun reads the "clip" module toggle lazily,
+// only when !clip is actually typed, so a channel that never clips pays nothing.
+//
+// It is live-only: Twitch's Create Clip API rejects an offline channel, so the
+// command gate skips it when the broadcaster is not streaming.
+//
+// !clip <title> and !clip<N> <title> both work: N is an inline number the
+// trigger absorbs (NumericSuffix). Twitch's Create Clip API cannot set a clip
+// title or a custom duration (clips are a fixed recent window, titled later on
+// Twitch's edit page), so <title> and N are cosmetic on Twitch's side; the title
+// is echoed back in the chat reply outgress posts with the clip URL.
+func Clip(d engine.Deps) module.Module {
+	log := d.Log
+	if log == nil {
+		log = zap.NewNop()
+	}
+
+	m := module.NewModule("", module.KindCore)
+	m.Command("clip").Everyone().LiveOnly().NumericSuffix().Cooldown(clipCooldown).Run(clipRun(d, log))
+	return m.Build()
+}
+
+// clipRun creates a clip for the broadcaster when the built-in is enabled. It
+// emits one TypeClip outgress action carrying the title and the clipper's login;
+// outgress creates the clip and posts the resulting public URL (with the title)
+// back to chat, since the Create Clip response — and thus the URL — is only
+// visible to outgress, never here.
+func clipRun(d engine.Deps, log *zap.Logger) module.RunFunc {
+	return func(ctx context.Context, c *module.Context, args string, emit module.Emit) error {
+		if !clipEnabled(ctx, d, c.BroadcasterID, log) {
+			return nil
+		}
+		emit(&module.Output{
+			Type:          outgress.TypeClip,
+			BroadcasterID: c.Env.BroadcasterUserID,
+			Text:          strings.TrimSpace(args), // clip title, echoed in the reply
+			To:            c.Env.ChatterUserLogin,   // the clipper, named in the reply
+		})
+		return nil
+	}
+}
+
+// clipEnabled reports whether the broadcaster has the built-in clip command on.
+// The toggle lives in the modules service under clipModuleName; a missing row
+// means default-on (the built-in ships enabled). Read lazily here, not on the
+// hot chat path. On a projection error it fails open (allows the clip): a
+// transient read blip should not silently swallow a viewer's clip.
+func clipEnabled(ctx context.Context, d engine.Deps, broadcasterID uint64, log *zap.Logger) bool {
+	if d.Proj == nil {
+		return true
+	}
+	views, err := d.Proj.Modules(ctx, broadcasterID)
+	if err != nil {
+		log.Warn("clip: module state read failed, allowing",
+			zap.Uint64("broadcaster_id", broadcasterID), zap.Error(err))
+		return true
+	}
+	for _, v := range views {
+		if v.Name == clipModuleName {
+			return v.IsEnabled
+		}
+	}
+	return true
+}

--- a/app/sesame/modules/clip_test.go
+++ b/app/sesame/modules/clip_test.go
@@ -1,0 +1,94 @@
+package modules
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"ItsBagelBot/app/sesame/engine"
+	"ItsBagelBot/app/sesame/module"
+	"ItsBagelBot/internal/domain/event/lane"
+	"ItsBagelBot/internal/domain/outgress"
+	"ItsBagelBot/internal/projection"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// clipReader is a minimal projection.Reader stub for the clip toggle read.
+type clipReader struct {
+	modules []projection.ModuleView
+	err     error
+}
+
+func (r clipReader) User(context.Context, uint64) (projection.User, error) {
+	return projection.User{}, nil
+}
+func (r clipReader) Modules(context.Context, uint64) ([]projection.ModuleView, error) {
+	return r.modules, r.err
+}
+func (r clipReader) Command(context.Context, uint64, string) (projection.Command, bool, error) {
+	return projection.Command{}, false, nil
+}
+
+func clipCommand(t *testing.T, d engine.Deps) module.Command {
+	t.Helper()
+	m := Clip(d)
+	for _, cmd := range m.Commands {
+		if cmd.Name == "clip" {
+			return cmd
+		}
+	}
+	t.Fatal("clip command not found")
+	return module.Command{}
+}
+
+func clipCtx() *module.Context {
+	return &module.Context{
+		Env: lane.Envelope{
+			Type:              "channel.chat.message",
+			BroadcasterUserID: "5",
+			ChatterUserLogin:  "viewer",
+		},
+		BroadcasterID: 5,
+		Log:           zap.NewNop(),
+	}
+}
+
+func TestClipCommandShape(t *testing.T) {
+	cmd := clipCommand(t, engine.Deps{Log: zap.NewNop()})
+	assert.True(t, cmd.NumericSuffix, "clip must accept a numeric suffix")
+	assert.Equal(t, clipCooldown, cmd.Cooldown)
+	assert.Equal(t, module.RoleEveryone, cmd.Perm)
+	assert.True(t, cmd.LiveOnly, "clip must be live-only: Twitch rejects clips on an offline channel")
+}
+
+func TestClipEmitsWhenEnabled(t *testing.T) {
+	// No stored row => default-on.
+	cmd := clipCommand(t, engine.Deps{Proj: clipReader{}, Log: zap.NewNop()})
+	var col collector
+	require.NoError(t, cmd.Run(context.Background(), clipCtx(), "Sick play", col.emit))
+	require.Len(t, col.out, 1)
+	o := col.out[0]
+	assert.Equal(t, outgress.TypeClip, o.Type)
+	assert.Equal(t, "5", o.BroadcasterID)
+	assert.Equal(t, "Sick play", o.Text)   // title echoed
+	assert.Equal(t, "viewer", o.To)         // clipper for the reply
+}
+
+func TestClipSuppressedWhenDisabled(t *testing.T) {
+	reader := clipReader{modules: []projection.ModuleView{{Name: "clip", IsEnabled: false}}}
+	cmd := clipCommand(t, engine.Deps{Proj: reader, Log: zap.NewNop()})
+	var col collector
+	require.NoError(t, cmd.Run(context.Background(), clipCtx(), "x", col.emit))
+	assert.Empty(t, col.out, "disabled clip must emit nothing")
+}
+
+func TestClipFailsOpenOnReadError(t *testing.T) {
+	reader := clipReader{err: errors.New("boom")}
+	cmd := clipCommand(t, engine.Deps{Proj: reader, Log: zap.NewNop()})
+	var col collector
+	require.NoError(t, cmd.Run(context.Background(), clipCtx(), "", col.emit))
+	require.Len(t, col.out, 1, "a projection blip should not swallow the clip")
+}

--- a/console/dashboard/src/lib/components/commands/BuiltinInspector.svelte
+++ b/console/dashboard/src/lib/components/commands/BuiltinInspector.svelte
@@ -1,0 +1,175 @@
+<script lang="ts">
+  // Inspector pane for a built-in command. Built-ins have no editable response,
+  // so this is intentionally read-only: it shows what the command does, example
+  // usage, a preview of the chat line the bot posts, and a single on/off toggle.
+  // The toggle posts to ?/toggleBuiltin (built-in state lives in the modules
+  // service) via the page's shared optimistic toggle handler.
+  import { enhance } from '$app/forms';
+  import type { SubmitFunction } from '@sveltejs/kit';
+  import {
+    Icon,
+    getI18n,
+    PERM_LABELS,
+    type CommandView,
+    type BuiltinCommandDef,
+    type Perm
+  } from '@bagel/shared';
+
+  let {
+    command,
+    def,
+    toggleSubmit
+  }: {
+    command: CommandView;
+    def: BuiltinCommandDef;
+    toggleSubmit: SubmitFunction;
+  } = $props();
+
+  const { t } = getI18n();
+  const c = $derived(command);
+</script>
+
+<div class="builtin">
+  <div class="row toprow">
+    <div class="row-text">
+      <span class="row-label">{t('builtinInspector.enabled')}</span>
+      <span class="row-help">{t('builtinInspector.enabledHelp')}</span>
+    </div>
+    <form method="POST" action="?/toggleBuiltin" use:enhance={toggleSubmit}>
+      <input type="hidden" name="name" value={c.name} />
+      <input type="hidden" name="is_active" value={c.is_active ? '' : 'on'} />
+      <button
+        class="toggle {c.is_active ? 'on' : ''}"
+        type="submit"
+        aria-label={t('commandRow.toggleAria', { name: c.name })}
+      ></button>
+    </form>
+  </div>
+
+  <p class="desc">{def.description}</p>
+
+  <div class="block">
+    <span class="block-h">{t('builtinInspector.usage')}</span>
+    <ul class="usage">
+      {#each def.usage as u}<li><code>{u}</code></li>{/each}
+    </ul>
+  </div>
+
+  <div class="block">
+    <span class="block-h">{t('builtinInspector.preview')}</span>
+    <div class="preview">
+      <span class="bot"><Icon name="commands" size={12} /> bot</span>
+      <span class="msg">{def.preview}</span>
+    </div>
+  </div>
+
+  <div class="meta-row">
+    <span class="meta-item">{t('builtinInspector.access')}: {PERM_LABELS[(c.perm ?? def.defaultPerm) as Perm]}</span>
+    <span class="meta-item">{t('builtinInspector.cooldown')}: {c.cooldown ?? def.defaultCooldown}s</span>
+  </div>
+</div>
+
+<style>
+  .builtin {
+    padding: 4px 2px 2px;
+    font-family: var(--bb-font-body);
+  }
+
+  .row {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    padding: 4px 2px 16px;
+    border-bottom: 1px solid var(--glass-border);
+  }
+  .row-text {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+  }
+  .row-label {
+    font-family: var(--bb-font-display);
+    font-weight: 700;
+    font-size: 15px;
+    color: var(--bb-white);
+  }
+  .row-help {
+    font-size: 12.5px;
+    color: var(--bb-muted);
+  }
+  .row form {
+    margin-left: auto;
+  }
+
+  .desc {
+    margin: 14px 0;
+    font-size: 13px;
+    line-height: 1.6;
+    color: var(--bb-muted);
+  }
+
+  .block {
+    margin-bottom: 16px;
+  }
+  .block-h {
+    display: block;
+    margin-bottom: 8px;
+    font-size: 11px;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--bb-muted);
+  }
+
+  .usage {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .usage code {
+    font-family: var(--bb-font-mono);
+    font-size: 12.5px;
+    color: var(--bb-tan-light);
+    background: rgba(201, 168, 124, 0.08);
+    border: 1px solid var(--glass-border);
+    border-radius: 6px;
+    padding: 4px 8px;
+  }
+
+  .preview {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    padding: 10px 12px;
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid var(--glass-border);
+    border-radius: var(--bb-radius-md, 10px);
+  }
+  .preview .bot {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    flex: none;
+    font-family: var(--bb-font-mono);
+    font-size: 11.5px;
+    color: var(--bb-tan-light);
+  }
+  .preview .msg {
+    font-size: 13px;
+    color: var(--bb-white);
+    line-height: 1.5;
+  }
+
+  .meta-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px 16px;
+  }
+  .meta-item {
+    font-family: var(--bb-font-mono);
+    font-size: 11.5px;
+    color: var(--bb-muted);
+  }
+</style>

--- a/console/dashboard/src/lib/components/commands/CommandRow.svelte
+++ b/console/dashboard/src/lib/components/commands/CommandRow.svelte
@@ -66,6 +66,9 @@
         {#if c.stream_online_only}
           <span class="lock" title={t('commandRow.liveOnly')}><Icon name="pulse" size={11} /></span>
         {/if}
+        {#if c.builtin}
+          <span class="builtin-tag" title={t('commandRow.builtinTitle')}>{t('commandRow.builtin')}</span>
+        {/if}
         {#if unsaved}
           <span class="unsaved" title={t('commandRow.unsavedTitle')}>{t('commandRow.unsaved')}</span>
         {/if}
@@ -86,7 +89,7 @@
     <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
     <span class="row-act" onclick={(e) => e.stopPropagation()}>
       <!-- Toggle: silent upsert that flips is_active, preserving config -->
-      <form method="POST" action="?/toggle" use:enhance={toggleSubmit}>
+      <form method="POST" action={c.builtin ? '?/toggleBuiltin' : '?/toggle'} use:enhance={toggleSubmit}>
         <input type="hidden" name="name" value={c.name} />
         {#each c.aliases ?? [] as a}<input type="hidden" name="aliases" value={a} />{/each}
         <input type="hidden" name="response" value={c.response} />
@@ -97,9 +100,15 @@
         <input type="hidden" name="is_active" value={c.is_active ? '' : 'on'} />
         <button class="toggle {c.is_active ? 'on' : ''}" type="submit" aria-label={t('commandRow.toggleAria', { name: c.name })}></button>
       </form>
-      <button class="mini" type="button" aria-label={t('commandRow.deleteAria', { name: c.name })} onclick={onDelete}>
-        <Icon name="trash" size={15} />
-      </button>
+      {#if !c.builtin}
+        <button class="mini" type="button" aria-label={t('commandRow.deleteAria', { name: c.name })} onclick={onDelete}>
+          <Icon name="trash" size={15} />
+        </button>
+      {:else}
+        <!-- Built-ins can't be deleted; hold the delete slot so the toggle stays
+             column-aligned with the deletable custom rows. -->
+        <span class="mini-spacer" aria-hidden="true"></span>
+      {/if}
     </span>
   </div>
 </div>
@@ -158,6 +167,19 @@
     padding: 1px 8px;
   }
 
+  .builtin-tag {
+    margin-left: 8px;
+    font-family: var(--bb-font-display);
+    font-weight: 700;
+    font-size: 9.5px;
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+    color: var(--bb-green-glow, #7fd4a3);
+    border: 1px solid rgba(82, 183, 136, 0.4);
+    border-radius: var(--bb-radius-pill, 100px);
+    padding: 1px 8px;
+  }
+
   .aliases { display: flex; flex-wrap: wrap; gap: 4px; }
   .alias-tag {
     font-family: var(--bb-font-mono);
@@ -191,6 +213,7 @@
 
   .state { min-width: 0; }
   .row-act { display: inline-flex; align-items: center; gap: 6px; }
+  .mini-spacer { width: 28px; height: 28px; flex: none; }
 
   @media (max-width: 760px) {
     .trow {
@@ -220,5 +243,6 @@
       min-height: 44px;
     }
     .mini { min-width: 44px; min-height: 44px; }
+    .mini-spacer { width: 44px; height: 44px; }
   }
 </style>

--- a/console/dashboard/src/lib/components/commands/drafts.ts
+++ b/console/dashboard/src/lib/components/commands/drafts.ts
@@ -15,6 +15,10 @@ export interface CommandDraft {
   allowed_user_id: string;
   stream_online_only: boolean;
   is_active: boolean;
+  // Set for a built-in command: the inspector renders a read-only preview +
+  // toggle instead of the editable form. Built-ins are never persisted as
+  // drafts.
+  builtin?: boolean;
 }
 
 const PREFIX = 'bb-cmd-draft:';

--- a/console/dashboard/src/routes/(app)/commands/+page.server.ts
+++ b/console/dashboard/src/routes/(app)/commands/+page.server.ts
@@ -1,7 +1,7 @@
 import type { Actions, PageServerLoad } from './$types';
 import type { CommandView, Perm } from '@bagel/shared';
-import { PERMS, normName, validateCommand, firstError } from '@bagel/shared';
-import { listCommands, upsertCommand, deleteCommand } from '$lib/server/commands-store';
+import { PERMS, normName, validateCommand, firstError, BUILTIN_COMMANDS, BUILTIN_NAMES, builtinDef } from '@bagel/shared';
+import { listCommands, upsertCommand, deleteCommand, listModules, upsertModule } from '$lib/server/commands-store';
 import { auditDashboardImpersonation } from '$lib/server/services';
 import type { Session } from '$lib/server/session';
 import { env } from '$env/dynamic/private';
@@ -33,15 +33,45 @@ const sample: CommandView[] = [
   { name: 'followage', response: "@{user} you've followed for {followage} 🥯", perm: 'sub', cooldown: 15, uses: '177', is_active: true }
 ];
 
+// builtinViews turns the built-in catalog into command rows, reading each
+// built-in's on/off state from the modules service (key = the built-in id). A
+// missing module row means the catalog default. These render read-only on the
+// commands page with a toggle + preview.
+function builtinViews(modules: { name: string; is_enabled: boolean }[]): CommandView[] {
+  const byName = new Map(modules.map((m) => [m.name, m]));
+  return BUILTIN_COMMANDS.map((def) => {
+    const row = byName.get(def.id);
+    return {
+      name: def.id,
+      response: def.summary,
+      is_active: row ? row.is_enabled : def.defaultActive,
+      perm: def.defaultPerm,
+      cooldown: def.defaultCooldown,
+      stream_online_only: def.liveOnly,
+      builtin: true
+    } satisfies CommandView;
+  });
+}
+
+// mergeCommands lists built-ins first, then the user's custom commands with any
+// name colliding with a built-in dropped (built-ins reserve their trigger).
+function mergeCommands(custom: CommandView[], modules: { name: string; is_enabled: boolean }[]): CommandView[] {
+  const builtins = builtinViews(modules);
+  const customs = custom.filter((c) => !BUILTIN_NAMES.has(c.name));
+  return [...builtins, ...customs];
+}
+
 export const load: PageServerLoad = async ({ locals }) => {
   gateCommands(locals.session);
   const uid = effectiveId(locals.session);
-  if (env.DEMO === '1') return { commands: sample };
+  if (env.DEMO === '1') return { commands: mergeCommands(sample, []) };
   try {
-    return { commands: await listCommands(uid) };
+    const [custom, modules] = await Promise.all([listCommands(uid), listModules(uid).catch(() => [])]);
+    return { commands: mergeCommands(custom, modules) };
   } catch {
     // Don't show fabricated rows in production; surface a degraded state.
-    return { commands: [] as CommandView[], degraded: true };
+    // Built-ins still render (their defaults) so the list is never empty.
+    return { commands: mergeCommands([], []), degraded: true };
   }
 };
 
@@ -207,5 +237,43 @@ export const actions: Actions = {
     auditDashboardImpersonation(locals.session, 'command:delete', name);
 
     return { ok: true, action: 'deleted', name, commands };
+  },
+
+  // Toggle a built-in command on/off. Built-in state lives in the modules
+  // service (key = the built-in id), not the commands service, so this is a
+  // separate path from the custom-command toggle. Returns the rebuilt built-in
+  // row so the optimistic UI reconciles the same way it does for custom rows.
+  toggleBuiltin: async ({ request, locals }) => {
+    gateCommands(locals.session);
+    const uid = effectiveId(locals.session);
+    if (env.DEMO !== '1' && !locals.session) {
+      return fail(401, { ok: false, error: 'Not signed in.' });
+    }
+
+    const f = await request.formData();
+    const name = normName(String(f.get('name') ?? ''));
+    const def = builtinDef(name);
+    if (!def) return fail(400, { ok: false, error: 'Unknown built-in command.' });
+    const isActive = f.get('is_active') === 'on';
+
+    const view: CommandView = {
+      name: def.id,
+      response: def.summary,
+      is_active: isActive,
+      perm: def.defaultPerm,
+      cooldown: def.defaultCooldown,
+      stream_online_only: def.liveOnly,
+      builtin: true
+    };
+
+    if (env.DEMO === '1') {
+      return { ok: true, action: 'updated', name, commands: [view], silent: true };
+    }
+
+    const { error } = await upsertModule(uid, def.id, isActive);
+    if (error) return fail(400, { ok: false, error });
+
+    auditDashboardImpersonation(locals.session, 'command:builtin_toggle', `${name}=${isActive}`);
+    return { ok: true, action: 'updated', name, commands: [view], silent: true };
   }
 };

--- a/console/dashboard/src/routes/(app)/commands/+page.svelte
+++ b/console/dashboard/src/routes/(app)/commands/+page.svelte
@@ -9,6 +9,7 @@
     toast,
     normName,
     getI18n,
+    builtinDef,
     type CommandView,
     type CommandErrors,
     type Perm
@@ -16,6 +17,7 @@
   import type { SaveState } from '@bagel/shared/components/SaveStatus.svelte';
   import CommandRow from '$lib/components/commands/CommandRow.svelte';
   import CommandEditor from '$lib/components/commands/CommandEditor.svelte';
+  import BuiltinInspector from '$lib/components/commands/BuiltinInspector.svelte';
   import { loadDraft, clearDraft, hasDraft, type CommandDraft } from '$lib/components/commands/drafts';
 
   let { data } = $props();
@@ -110,16 +112,37 @@
   }
 
   // --- Filters ---------------------------------------------------------------
-  const filters = ['All', 'Active', 'Disabled'] as const;
+  const filters = ['All', 'Active', 'Disabled', 'Built-in', 'Custom'] as const;
   // Internal keys drive the filter logic; only the display label is translated.
   const filterLabel = (f: (typeof filters)[number]) =>
-    f === 'Active' ? t('commands.filterActive') : f === 'Disabled' ? t('commands.filterDisabled') : t('commands.filterAll');
+    f === 'Active'
+      ? t('commands.filterActive')
+      : f === 'Disabled'
+        ? t('commands.filterDisabled')
+        : f === 'Built-in'
+          ? t('commands.filterBuiltin')
+          : f === 'Custom'
+            ? t('commands.filterCustom')
+            : t('commands.filterAll');
   let active = $state<(typeof filters)[number]>('All');
   let search = $state('');
 
   const rows = $derived(
     items
-      .filter((c) => (active === 'Disabled' ? !c.is_active : active === 'Active' ? c.is_active : true))
+      .filter((c) => {
+        switch (active) {
+          case 'Active':
+            return c.is_active;
+          case 'Disabled':
+            return !c.is_active;
+          case 'Built-in':
+            return !!c.builtin;
+          case 'Custom':
+            return !c.builtin;
+          default:
+            return true;
+        }
+      })
       .filter((c) => {
         const q = search.toLowerCase();
         return (
@@ -128,7 +151,8 @@
           c.response.toLowerCase().includes(q)
         );
       })
-      .toSorted((a, b) => a.name.localeCompare(b.name))
+      // Built-ins float to the top, then alphabetical within each group.
+      .toSorted((a, b) => Number(!!b.builtin) - Number(!!a.builtin) || a.name.localeCompare(b.name))
   );
 
   // --- Inline editor ----------------------------------------------------------
@@ -166,7 +190,8 @@
       cooldown: c.cooldown ?? 0,
       allowed_user_id: c.allowed_user_id ?? '',
       stream_online_only: c.stream_online_only === true,
-      is_active: c.is_active
+      is_active: c.is_active,
+      builtin: c.builtin === true
     };
   }
 
@@ -184,6 +209,13 @@
       return;
     }
     serverErrors = null;
+    // Built-ins have no editable draft: the inspector is a read-only preview +
+    // toggle, so skip the sessionStorage draft machinery entirely.
+    if (c.builtin) {
+      editorDraft = { ...blankDraft(), edit: true, name: c.name, originalName: c.name, is_active: c.is_active, builtin: true };
+      expanded = c.name;
+      return;
+    }
     const restored = loadDraft(c.name, true);
     editorDraft = restored ?? fromView(c);
     expanded = c.name;
@@ -346,6 +378,11 @@
 
   const activeCount = $derived(items.filter((c) => c.is_active).length);
 
+  // The command currently loaded in the inspector (built-in path reads it live).
+  const selectedCmd = $derived(
+    expanded && expanded !== NEW ? items.find((c) => c.name === expanded) : undefined
+  );
+
   // --- Keyboard control: "/" jumps to search, "n" starts a new command,
   // Escape closes the inspector. Ignored while typing in any field. ---
   let searchInput = $state<HTMLInputElement | null>(null);
@@ -462,7 +499,14 @@
       </div>
       {#if editorDraft}
         <Scroller fill padding="16px" data-lenis-prevent>
-          <CommandEditor bind:draft={editorDraft} {serverErrors} {busy} onCancel={closeEditor} onSubmit={saveSubmit} />
+          {#if editorDraft.builtin && selectedCmd}
+            {@const def = builtinDef(selectedCmd.name)}
+            {#if def}
+              <BuiltinInspector command={selectedCmd} {def} toggleSubmit={toggleSubmit(selectedCmd)} />
+            {/if}
+          {:else}
+            <CommandEditor bind:draft={editorDraft} {serverErrors} {busy} onCancel={closeEditor} onSubmit={saveSubmit} />
+          {/if}
         </Scroller>
       {:else}
         <div class="inspector-idle">

--- a/console/dashboard/src/routes/(app)/modules/[id]/+page.svelte
+++ b/console/dashboard/src/routes/(app)/modules/[id]/+page.svelte
@@ -72,27 +72,44 @@
       </div>
 
       {#each def.fields as field (field.key)}
-        <label class="field">
-          <span>{field.label}</span>
-          {#if field.type === 'textarea'}
-            <textarea
-              class="resp-area"
-              name={`cfg.${field.key}`}
-              rows="3"
-              placeholder={field.placeholder ?? ''}
-              bind:value={config[field.key]}
-            ></textarea>
-          {:else}
-            <input
-              class="search"
-              type={field.type === 'number' ? 'number' : 'text'}
-              name={`cfg.${field.key}`}
-              placeholder={field.placeholder ?? ''}
-              bind:value={config[field.key]}
-            />
-          {/if}
-          {#if field.help}<small>{field.help}</small>{/if}
-        </label>
+        {#if field.type === 'toggle'}
+          <div class="row subrow">
+            <div class="row-text">
+              <span class="row-label sm">{field.label}</span>
+              {#if field.help}<span class="row-help">{field.help}</span>{/if}
+            </div>
+            <input type="hidden" name={`cfg.${field.key}`} value={config[field.key] === 'off' ? 'off' : 'on'} />
+            <button
+              class="toggle {config[field.key] === 'off' ? '' : 'on'}"
+              type="button"
+              aria-label="Toggle {field.label}"
+              onclick={() =>
+                (config = { ...config, [field.key]: config[field.key] === 'off' ? 'on' : 'off' })}
+            ></button>
+          </div>
+        {:else}
+          <label class="field">
+            <span>{field.label}</span>
+            {#if field.type === 'textarea'}
+              <textarea
+                class="resp-area"
+                name={`cfg.${field.key}`}
+                rows="3"
+                placeholder={field.placeholder ?? ''}
+                bind:value={config[field.key]}
+              ></textarea>
+            {:else}
+              <input
+                class="search"
+                type={field.type === 'number' ? 'number' : 'text'}
+                name={`cfg.${field.key}`}
+                placeholder={field.placeholder ?? ''}
+                bind:value={config[field.key]}
+              />
+            {/if}
+            {#if field.help}<small>{field.help}</small>{/if}
+          </label>
+        {/if}
       {/each}
 
       <div class="actions">
@@ -126,6 +143,8 @@
   .row-label { font-family: var(--bb-font-display); font-weight: 700; font-size: 15px; color: var(--bb-white); }
   .row-help { font-family: var(--bb-font-body); font-size: 12.5px; color: var(--bb-muted); }
   .row .toggle { margin-left: auto; }
+  .subrow { border-top: 1px solid var(--glass-border); }
+  .row-label.sm { font-size: 13.5px; }
 
   .field { display: flex; flex-direction: column; gap: 6px; padding: 16px 20px 0; }
   .field > span { font-family: var(--bb-font-body); font-size: 12.5px; color: var(--bb-muted); }

--- a/console/shared/lib/i18n/en.ts
+++ b/console/shared/lib/i18n/en.ts
@@ -273,6 +273,8 @@ export const en = {
     filterAll: 'All',
     filterActive: 'Active',
     filterDisabled: 'Disabled',
+    filterBuiltin: 'Built-in',
+    filterCustom: 'Custom',
     keysSearch: 'search',
     keysNew: 'new',
     searchPlaceholder: 'Search name, alias, response…',
@@ -387,6 +389,17 @@ export const en = {
     cooldown: 'Cooldown',
     uses: 'Uses',
     toggleAria: 'Toggle !{name}',
-    deleteAria: 'Delete !{name}'
+    deleteAria: 'Delete !{name}',
+    builtin: 'Built-in',
+    builtinTitle: 'Built-in command: toggle only, no editable response'
+  },
+
+  builtinInspector: {
+    enabled: 'Enabled',
+    enabledHelp: 'Turn this built-in command on or off for your channel.',
+    usage: 'Usage',
+    preview: 'Preview',
+    access: 'Access',
+    cooldown: 'Cooldown'
   }
 } satisfies MessageTree;

--- a/console/shared/lib/i18n/fr.ts
+++ b/console/shared/lib/i18n/fr.ts
@@ -272,6 +272,8 @@ export const fr = {
     filterAll: 'Toutes',
     filterActive: 'Actives',
     filterDisabled: 'Désactivées',
+    filterBuiltin: 'Intégrées',
+    filterCustom: 'Personnalisées',
     keysSearch: 'rechercher',
     keysNew: 'nouvelle',
     searchPlaceholder: 'Rechercher nom, alias, réponse…',
@@ -386,6 +388,17 @@ export const fr = {
     cooldown: 'Délai',
     uses: 'Utilisations',
     toggleAria: 'Basculer !{name}',
-    deleteAria: 'Supprimer !{name}'
+    deleteAria: 'Supprimer !{name}',
+    builtin: 'Intégrée',
+    builtinTitle: 'Commande intégrée : activation seulement, pas de réponse modifiable'
+  },
+
+  builtinInspector: {
+    enabled: 'Activée',
+    enabledHelp: 'Activez ou désactivez cette commande intégrée pour votre chaîne.',
+    usage: 'Utilisation',
+    preview: 'Aperçu',
+    access: 'Accès',
+    cooldown: 'Délai'
   }
 } satisfies MessageTree;

--- a/console/shared/lib/types.ts
+++ b/console/shared/lib/types.ts
@@ -30,7 +30,62 @@ export interface CommandView {
   // Lifetime execution counter. The backend sends a number; older sample data
   // used human-formatted strings ('1.2k'), so both are accepted for display.
   uses?: number | string;
+  // When true this is a built-in command: its behavior is baked into the bot,
+  // it has no editable response, and its on/off state is stored in the modules
+  // service (not the commands service). The dashboard renders it read-only with
+  // a toggle + preview. See BUILTIN_COMMANDS.
+  builtin?: boolean;
 }
+
+// --- Built-in command catalog --------------------------------------------
+// Built-in commands are behaviors baked into the bot (not user text). They show
+// on the commands page alongside custom commands, flagged builtin, but they
+// cannot be renamed, deleted, or given a custom response — only toggled on/off.
+// Their per-user on/off state lives in the modules service under `id` (a missing
+// row means defaultActive). Adding one is a row here + the matching sesame
+// built-in module. They are deliberately NOT in MODULE_CATALOG (never shown on
+// the modules page).
+
+export interface BuiltinCommandDef {
+  // id is both the chat trigger and the modules-service key for the toggle.
+  id: string;
+  label: string;
+  // summary is shown in the command row where a custom command shows its
+  // response (built-ins have no response).
+  summary: string;
+  description: string; // longer copy for the inspector
+  // usage lists example invocations shown in the inspector.
+  usage: string[];
+  // preview is a mock of the chat line the bot posts, for the inspector.
+  preview: string;
+  defaultActive: boolean;
+  defaultPerm: Perm;
+  defaultCooldown: number; // seconds
+  // liveOnly commands run only while the broadcaster is streaming.
+  liveOnly: boolean;
+}
+
+export const BUILTIN_COMMANDS: readonly BuiltinCommandDef[] = [
+  {
+    id: 'clip',
+    label: 'Clip',
+    summary: 'Built-in · clips the last moments of the stream and posts the link.',
+    description:
+      'Viewers create a clip of the recent stream. The bot replies in chat with the clip link. Type !clip <title>, or add a number like !clip30 <title> — the number is accepted but Twitch fixes the clip length, so it is cosmetic. Only works while you are live.',
+    usage: ['!clip <title>', '!clip30 <title>'],
+    preview: '🎬 viewer clipped: That was insane → clips.twitch.tv/AbCdEf',
+    defaultActive: true,
+    defaultPerm: 'everyone',
+    defaultCooldown: 15,
+    liveOnly: true
+  }
+];
+
+export function builtinDef(id: string): BuiltinCommandDef | undefined {
+  return BUILTIN_COMMANDS.find((b) => b.id === id);
+}
+
+export const BUILTIN_NAMES: ReadonlySet<string> = new Set(BUILTIN_COMMANDS.map((b) => b.id));
 
 export interface AdminUser {
   user_id: string;
@@ -105,7 +160,7 @@ export interface DashboardLink {
 // module that owns !ping/!itsbagelbot and the bagel greeting) are deliberately
 // NOT listed here: they are always on and never shown.
 
-export type ModuleFieldType = 'text' | 'textarea' | 'number';
+export type ModuleFieldType = 'text' | 'textarea' | 'number' | 'toggle';
 
 export interface ModuleField {
   // key is the JSON property written into the module's Configs blob.
@@ -151,6 +206,69 @@ export const MODULE_CATALOG: readonly ModuleDef[] = [
         type: 'textarea',
         placeholder: '🥯 Huge shoutout to {raider} who raided with {viewers}! → twitch.tv/{raider_login}',
         help: 'Tokens: {raider}, {raider_login}, {viewers}. Leave blank to use the default.'
+      }
+    ]
+  },
+  {
+    id: 'alerts',
+    label: 'Chat Alerts',
+    tagline: 'Announce follows, subs, cheers and raids in chat.',
+    description:
+      'The bot posts a chat line when someone follows, subscribes, cheers, or raids. Turn each alert on or off and customize its message. New alerts default on.',
+    icon: 'bell',
+    defaultEnabled: true,
+    fields: [
+      {
+        key: 'followEnabled',
+        label: 'Follow alert',
+        type: 'toggle',
+        help: 'Post a chat line when someone follows.'
+      },
+      {
+        key: 'followMessage',
+        label: 'Follow message',
+        type: 'textarea',
+        placeholder: '🥯 Thanks for the follow, {user}!',
+        help: 'Tokens: {user}, {user_login}. Leave blank to use the default.'
+      },
+      {
+        key: 'subEnabled',
+        label: 'Subscribe alert',
+        type: 'toggle',
+        help: 'Post a chat line when someone subscribes.'
+      },
+      {
+        key: 'subMessage',
+        label: 'Subscribe message',
+        type: 'textarea',
+        placeholder: '🥯 {user} just subscribed! Welcome to the sub squad!',
+        help: 'Tokens: {user}, {user_login}, {tier}. Leave blank to use the default.'
+      },
+      {
+        key: 'cheerEnabled',
+        label: 'Cheer alert',
+        type: 'toggle',
+        help: 'Post a chat line when someone cheers bits.'
+      },
+      {
+        key: 'cheerMessage',
+        label: 'Cheer message',
+        type: 'textarea',
+        placeholder: '🥯 {user} cheered {bits} bits! Thanks for the support!',
+        help: 'Tokens: {user}, {user_login}, {bits}. Leave blank to use the default.'
+      },
+      {
+        key: 'raidEnabled',
+        label: 'Raid alert',
+        type: 'toggle',
+        help: 'Post a chat line when another channel raids in.'
+      },
+      {
+        key: 'raidMessage',
+        label: 'Raid message',
+        type: 'textarea',
+        placeholder: '🥯 {user} is raiding with {viewers} viewers!',
+        help: 'Tokens: {user}, {user_login}, {viewers}. Leave blank to use the default.'
       }
     ]
   }


### PR DESCRIPTION
## Summary

Two chat features and their dashboard surfaces.

### Chat Alerts — sesame `alerts` module (KindDefault, ships enabled)
- Posts a chat line on `channel.follow` / `channel.subscribe` / `channel.cheer` / `channel.raid`.
- Each sub-alert has its own on/off toggle and message template (module config), default-on until turned off.
- Adds the `channel.raid` EventSub subscription in outgress — it was never created, so the existing **Shoutout** raid handler couldn't fire either.
- Dashboard: **Chat Alerts** in the module catalog, with a new `toggle` field type for the per-sub switches.

### Built-in `!clip` command — sesame `clip` (core module, ships enabled)
- `!clip <title>` and `!clip<N> <title>` both route to clip via a new numeric-suffix matcher (`Command.NumericSuffix` + `Registry.ResolveCommand`). `N` is cosmetic: Twitch's Create Clip API fixes clip length and can't set a title.
- Per-user on/off is stored in the **modules service** (key `clip`) and read **lazily** — only when `!clip` is typed — so the hot chat path pays no extra fetch. Disabled = command fully dead.
- outgress `processClip`: adds `broadcaster_id` to the query, creates the clip as the broadcaster, and posts the **public clip URL + echoed title** back to chat. Redelivery-safe: never returns an error once the clip exists (no duplicate clips).
- Dashboard: built-ins render in the normal commands list with a **Built-in** badge, `Active` / `Built-in` / `Custom` filters, and a read-only inspector (toggle + clip preview, no response editor). Toggle persists via the modules service. Row toggles stay column-aligned when the delete action is absent.

## Notes
- Clip creation needs the broadcaster's `clips:edit` grant (outgress calls as broadcaster); missing scope → Twitch 4xx, dropped + logged, same as other broadcaster-auth calls.
- Built-in toggle state lives in the modules service (not the commands DB) because the commands schema requires a non-empty `response`.

## Testing
- Go: `go build` + `go test ./app/sesame/...` + `./app/outgress/...` green; added alerts, clip, and numeric-suffix resolver tests.
- Dashboard: `svelte-check` 0 errors; browser-verified the module toggles, built-in row/filters/inspector, clip toggle round-trip, and toggle alignment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)