### PR TITLE
fix(web): constrain nav logo bounding box

### DIFF
--- a/web/src/components/layout/Nav.astro
+++ b/web/src/components/layout/Nav.astro
@@ -320,6 +320,7 @@ const isActive = (href: string) =>
         align-items: center;
         gap: 10px;
         min-width: 0;
+        width: max-content;
         color: var(--white);
         text-decoration: none;
     }


### PR DESCRIPTION
Added max-content to the nav logo to prevent it from stretching to fill the grid cell.