### PR TITLE
Update premium price display

### DIFF
--- a/console/dashboard/src/routes/(app)/billing/+page.svelte
+++ b/console/dashboard/src/routes/(app)/billing/+page.svelte
@@ -273,8 +273,7 @@
         <span class="plan-eyebrow">{t('billing.upgrade')}</span>
         <div class="plan-headline">{t('billing.premium')}</div>
         <div class="plan-price">
-          <span class="plan-cur">$</span>
-          <span class="plan-amt">5</span>
+          <span class="plan-amt">7$</span>
           <span class="plan-per">{t('billing.perMonth')}</span>
         </div>
         <p class="plan-desc">{t('billing.premiumDesc')}</p>
@@ -556,14 +555,6 @@
     align-items: baseline;
     gap: 3px;
     margin-bottom: 12px;
-  }
-  .plan-cur {
-    font-family: var(--bb-font-display);
-    font-weight: 800;
-    font-size: 1.5rem;
-    color: var(--bb-tan-light);
-    align-self: flex-start;
-    margin-top: 6px;
   }
   .plan-amt {
     font-family: var(--bb-font-display);

--- a/console/shared/lib/i18n/en.ts
+++ b/console/shared/lib/i18n/en.ts
@@ -220,7 +220,7 @@ export const en = {
     priorityLane: 'Priority lane',
     upgrade: 'Upgrade',
     premium: 'Premium',
-    perMonth: '/month',
+    perMonth: 'CAD +tx /month',
     premiumDesc: 'Keeps the servers warm and bumps you to the front of the queue when chat gets loud.',
     premiumFeat1: 'Everything in Free, obviously',
     premiumFeat2: 'Your messages jump to the front of the line',

--- a/console/shared/lib/i18n/fr.ts
+++ b/console/shared/lib/i18n/fr.ts
@@ -219,7 +219,7 @@ export const fr = {
     priorityLane: 'File prioritaire',
     upgrade: 'Améliorer',
     premium: 'Premium',
-    perMonth: '/mois',
+    perMonth: 'CAD +tx /mois',
     premiumDesc: 'Garde les serveurs au chaud et vous fait passer en tête de file quand le chat s\'emballe.',
     premiumFeat1: 'Tout ce qui est dans Gratuit, évidemment',
     premiumFeat2: 'Vos messages passent devant tout le monde',

--- a/web/src/components/pricing/Tiers.astro
+++ b/web/src/components/pricing/Tiers.astro
@@ -70,8 +70,7 @@ const enterpriseFeatures = [
                 <span class="tier__badge">{t('tier.premiumBadge')}</span>
                 <span class="tier__name">{t('tier.premium')}</span>
                 <div class="tier__price">
-                    <span class="tier__prefix" aria-hidden="true">$</span>
-                    <span class="tier__amount" data-count-up data-target="5">0</span>
+                    <span class="tier__amount" data-count-up data-target="7" data-suffix="$">0$</span>
                     <span class="tier__suffix">{t('tier.premiumSuffix')}</span>
                 </div>
                 <p class="tier__desc">
@@ -400,8 +399,9 @@ const enterpriseFeatures = [
     /* Price count-up when the amount scrolls into view */
     function runCountUp(el: HTMLElement) {
         const target = parseInt(el.dataset.target ?? '0', 10);
+        const suffix = el.dataset.suffix ?? '';
         if (target === 0 || window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
-            el.textContent = String(target);
+            el.textContent = `${target}${suffix}`;
             return;
         }
         const duration = 900;
@@ -409,7 +409,7 @@ const enterpriseFeatures = [
         function tick(now: number) {
             const progress = Math.min((now - startTime) / duration, 1);
             const eased = progress === 1 ? 1 : 1 - Math.pow(2, -10 * progress);
-            el.textContent = String(Math.round(eased * target));
+            el.textContent = `${Math.round(eased * target)}${suffix}`;
             if (progress < 1) requestAnimationFrame(tick);
         }
         requestAnimationFrame(tick);

--- a/web/src/i18n/ui.ts
+++ b/web/src/i18n/ui.ts
@@ -77,7 +77,7 @@ const en = {
 
   'tier.premium': 'Premium',
   'tier.premiumBadge': 'The tip jar, with perks',
-  'tier.premiumSuffix': '/month',
+  'tier.premiumSuffix': 'CAD +tx /month',
   'tier.premiumDesc': 'Keeps the servers warm and bumps you to the front of the queue when chat gets loud.',
   'tier.chipIn': 'Chip in',
   'tier.premiumFeat1': 'Everything in Free, obviously',
@@ -299,7 +299,7 @@ const fr: Partial<Record<UIKey, string>> = {
 
   'tier.premium': 'Premium',
   'tier.premiumBadge': 'La cagnotte, avec des avantages',
-  'tier.premiumSuffix': '/mois',
+  'tier.premiumSuffix': 'CAD +tx /mois',
   'tier.premiumDesc': 'Garde les serveurs au chaud et vous fait passer en tête de file quand le chat s\'emballe.',
   'tier.chipIn': 'Participer',
   'tier.premiumFeat1': 'Tout ce qui est dans Gratuit, évidemment',

--- a/web/src/pages/terms.astro
+++ b/web/src/pages/terms.astro
@@ -59,7 +59,7 @@ const sections = [
 
         <Fragment slot="payments">
             <p>
-                Free tier has no cost and no limitations. Premium ($5/month) can be canceled anytime. Enterprise
+                Free tier has no cost and no limitations. Premium (7$ CAD +tx/month) can be canceled anytime. Enterprise
                 pricing is custom and outlined in separate agreements.
             </p>
         </Fragment>


### PR DESCRIPTION
## Summary
- update premium price displays to 7$ CAD +tx on the marketing pricing page and dashboard billing page
- update English/French billing suffixes and Terms payment copy
- keep the marketing count-up animation rendering the trailing dollar sign correctly

## Tests
- bun run build (web)
- bun run --filter dashboard check (console; passes with existing CommandRow.svelte line-clamp warning)