### PR TITLE
Fix sesame dedup pipeline

### DIFF
--- a/app/sesame/engine/deps.go
+++ b/app/sesame/engine/deps.go
@@ -30,6 +30,7 @@ type Deps struct {
 	Live     LiveStore
 	Greet    GreetStore
 	Cooldown CooldownStore
+	Dedup    DedupStore
 	Special  *SpecialSet
 	Pub      message.Publisher
 	Log      *zap.Logger
@@ -65,8 +66,22 @@ type CooldownStore interface {
 	Allow(ctx context.Context, key string, ttl time.Duration) (bool, error)
 }
 
+// DedupStore folds replicated ingress deliveries by claiming an EventSub id for
+// long enough that overlapping publishers cannot re-run the same notification.
+type DedupStore interface {
+	Claim(ctx context.Context, key string) (bool, error)
+	Release(ctx context.Context, key string) error
+}
+
 // NoopCooldown never gates: every call is allowed. Used in tests and when no
 // cooldown backend is configured.
 type NoopCooldown struct{}
 
 func (NoopCooldown) Allow(context.Context, string, time.Duration) (bool, error) { return true, nil }
+
+// NoopDedup never folds deliveries. It keeps tests and alternate embeddings
+// working when no shared dedup backend is configured.
+type NoopDedup struct{}
+
+func (NoopDedup) Claim(context.Context, string) (bool, error) { return true, nil }
+func (NoopDedup) Release(context.Context, string) error       { return nil }

--- a/app/sesame/engine/pipeline.go
+++ b/app/sesame/engine/pipeline.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"fmt"
 
 	"ItsBagelBot/app/sesame/module"
 	"ItsBagelBot/internal/domain/event/lane"
@@ -52,6 +53,7 @@ type Pipeline struct {
 
 	live     IsLiveChecker
 	cooldown CooldownStore
+	dedup    DedupStore
 	uses     *useReporter
 
 	botID            string
@@ -70,9 +72,13 @@ func NewPipeline(d Deps, registry *Registry, cfg Config) *Pipeline {
 		registry:         registry,
 		live:             d.Live,
 		cooldown:         d.Cooldown,
+		dedup:            d.Dedup,
 		botID:            cfg.BotID,
 		outgressPremium:  cfg.OutgressPremium,
 		outgressStandard: cfg.OutgressStandard,
+	}
+	if p.dedup == nil {
+		p.dedup = NoopDedup{}
 	}
 	if cfg.CountUses && d.Pub != nil {
 		p.uses = newUseReporter(d.Pub, d.Log)
@@ -95,7 +101,7 @@ const chatType = "channel.chat.message"
 // the event handlers registered for the type, and publishes what they emit. It
 // reads as a short sequence of guards and stages; the loops and the failure
 // bookkeeping live in the helpers below.
-func (p *Pipeline) Process(msg *message.Message) error {
+func (p *Pipeline) Process(msg *message.Message) (err error) {
 	ctx := msg.Context()
 
 	// Decode into a pooled envelope so the plain-chat path allocates nothing here.
@@ -122,6 +128,27 @@ func (p *Pipeline) Process(msg *message.Message) error {
 		return nil
 	}
 	traceEvent(ctx, env.Type, broadcasterID)
+
+	var dedupKey string
+	if env.EventID != "" {
+		dedupKey = fmt.Sprintf("sesame:dedup:%d:%s", broadcasterID, env.EventID)
+		claimed, claimErr := p.dedup.Claim(ctx, dedupKey)
+		if claimErr != nil {
+			p.log.Warn("dedup claim failed; processing event", zap.String("dedup_key", dedupKey), zap.Error(claimErr))
+			notice(ctx, claimErr)
+		} else if !claimed {
+			return nil
+		} else {
+			defer func() {
+				if err != nil {
+					if relErr := p.dedup.Release(ctx, dedupKey); relErr != nil {
+						p.log.Warn("dedup release failed", zap.String("dedup_key", dedupKey), zap.Error(relErr))
+						notice(ctx, relErr)
+					}
+				}
+			}()
+		}
+	}
 
 	views, err := p.moduleViews(ctx, env.Type, broadcasterID)
 	if err != nil {

--- a/app/sesame/main.go
+++ b/app/sesame/main.go
@@ -80,6 +80,7 @@ func main() {
 		Live:     live,
 		Greet:    engine.NewValkeyGreetStore(valkeyClient, cfg.LiveTTL, log),
 		Cooldown: engine.NewValkeyCooldown(valkeyClient),
+		Dedup:    engine.NewValkeyDedup(valkeyClient, 10*time.Minute),
 		Special:  engine.NewSpecialSet(cfg.SpecialUserIDs),
 		Pub:      pub,
 		Log:      log,

--- a/internal/domain/event/lane/lane.go
+++ b/internal/domain/event/lane/lane.go
@@ -26,8 +26,9 @@ type Badge struct {
 //   - every other type, including stream.online/offline, nests the raw EventSub
 //     `event` object.
 type Envelope struct {
-	Type string `json:"type"`
-	Lane string `json:"lane"`
+	Type    string `json:"type"`
+	Lane    string `json:"lane"`
+	EventID string `json:"event_id,omitempty"`
 
 	// Flattened chat fields (only set for channel.chat.message).
 	BroadcasterUserID    string  `json:"broadcaster_user_id,omitempty"`

--- a/test.go
+++ b/test.go
@@ -1,14 +1,19 @@
+//go:build ignore
+
 package main
+
 import (
 	"encoding/json"
 	"fmt"
 )
+
 type raidEvent struct {
 	FromBroadcasterUserLogin string `json:"from_broadcaster_user_login"`
 	FromBroadcasterUserName  string `json:"from_broadcaster_user_name"`
 	ToBroadcasterUserID      string `json:"to_broadcaster_user_id"`
 	Viewers                  int    `json:"viewers"`
 }
+
 func main() {
 	payload := `{"from_broadcaster_user_id":"1234","from_broadcaster_user_login":"jtv","from_broadcaster_user_name":"JTV","to_broadcaster_user_id":"5678","to_broadcaster_user_login":"twitch","to_broadcaster_user_name":"Twitch","viewers":9000}`
 	var ev raidEvent


### PR DESCRIPTION
## Summary
- add EventSub event_id to lane envelopes
- wire DedupStore through sesame engine dependencies and pipeline processing
- configure Valkey-backed dedup in sesame main
- exclude root scratch utility from normal Go package builds

## Verification
- go test ./app/sesame/engine
- go test ./...
- go test -v -race ./...