### PR TITLE
Fix impersonated and Sesame locale handling

### DIFF
--- a/app/sesame/engine/pipeline.go
+++ b/app/sesame/engine/pipeline.go
@@ -190,6 +190,16 @@ func (p *Pipeline) Process(msg *message.Message) (err error) {
 		p.dispatch(ctx, mctx, views, emit)
 	}
 	if len(handlers) > 0 {
+		// Event handlers can emit localized system text too (for example the
+		// stream-online bagel announcement). Command dispatch resolves locale for
+		// baked commands, but non-command events never pass through that path.
+		// Reuse the value when dispatch already populated it and otherwise load it
+		// from the projected user before invoking handlers.
+		if mctx.Locale == "" {
+			if u, uerr := p.proj.User(ctx, broadcasterID); uerr == nil {
+				mctx.Locale = u.Locale
+			}
+		}
 		p.runHandlers(ctx, views, mctx, emit)
 	}
 

--- a/app/sesame/engine/pipeline_test.go
+++ b/app/sesame/engine/pipeline_test.go
@@ -112,6 +112,19 @@ func emitModule(name string, kind module.Kind, text string) module.Module {
 	return b.Build()
 }
 
+func emitLocaleModule(eventType string) module.Module {
+	b := module.NewModule("", module.KindCore)
+	b.On(eventType, func(_ context.Context, c *module.Context, emit module.Emit) error {
+		emit(&module.Output{
+			Type:          outgress.TypeChat,
+			BroadcasterID: c.Env.BroadcasterUserID,
+			Text:          c.Locale,
+		})
+		return nil
+	})
+	return b.Build()
+}
+
 // errCore is a core module whose chat handler returns a logic error.
 func errCore() module.Module {
 	b := module.NewModule("", module.KindCore)
@@ -174,6 +187,21 @@ func TestProcessMalformedEnvelopeDropped(t *testing.T) {
 	err := p.Process(message.NewMessage("uuid-bad", []byte("{not json")))
 	assert.NoError(t, err)   // ack, not nack
 	assert.Empty(t, pub.got) // nothing published
+}
+
+func TestProcessLoadsLocaleForEventHandlers(t *testing.T) {
+	pub := &fakePublisher{}
+	p := newPipelineWith(pub, fakeReader{user: projection.User{Locale: "fr"}}, emitLocaleModule("stream.online"))
+	body, err := sonic.Marshal(map[string]any{
+		"type":                "stream.online",
+		"lane":                "standard",
+		"broadcaster_user_id": "123",
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, p.Process(message.NewMessage("uuid-locale", body)))
+	require.Len(t, pub.got, 1)
+	assert.Equal(t, "fr", chatMessageText(t, pub.got[0].msg))
 }
 
 func TestProcessNoModuleAcks(t *testing.T) {

--- a/console/dashboard/src/hooks.server.ts
+++ b/console/dashboard/src/hooks.server.ts
@@ -55,10 +55,15 @@ export const handle: Handle = async ({ event, resolve }) => {
 
   // Resolve the UI locale once per request: query parameter wins (if just set), else
   // the explicit switcher cookie, else the browser's Accept-Language, else English.
-  const locale = detectLocale({
-    cookie: queryLang || event.cookies.get(LOCALE_COOKIE),
-    accept: event.request.headers.get('accept-language')
-  });
+  // Admin view-as sessions are always rendered in English. Their language
+  // control edits the target account preference; it must not translate the
+  // administrative UI itself.
+  const locale = event.locals.session?.impersonator_id
+    ? 'en'
+    : detectLocale({
+        cookie: queryLang || event.cookies.get(LOCALE_COOKIE),
+        accept: event.request.headers.get('accept-language')
+      });
   event.locals.locale = locale;
 
   // New Relic: name the web transaction by SvelteKit route (not the raw URL, so

--- a/console/dashboard/src/lib/components/LangSwitch.svelte
+++ b/console/dashboard/src/lib/components/LangSwitch.svelte
@@ -4,7 +4,9 @@
   import { page } from '$app/state';
   import { getI18n, LOCALES, type Locale } from '@bagel/shared';
 
+  let { selected }: { selected?: Locale } = $props();
   const i18n = getI18n();
+  const active = $derived(selected ?? i18n.locale);
   const next = $derived(page.url.pathname + page.url.search);
   const short = (l: Locale) => l.toUpperCase();
 </script>
@@ -17,8 +19,8 @@
       name="to"
       value={l}
       class="lang-opt"
-      class:active={l === i18n.locale}
-      aria-pressed={l === i18n.locale}
+      class:active={l === active}
+      aria-pressed={l === active}
       title={i18n.t(`lang.${l}`)}
     >{short(l)}</button>
   {/each}

--- a/console/dashboard/src/routes/(app)/settings/+page.server.ts
+++ b/console/dashboard/src/routes/(app)/settings/+page.server.ts
@@ -12,6 +12,7 @@ import {
   notificationsForUser,
   notificationMarkRead,
   notificationMarkPeeked,
+  userLocale,
   type NotificationWire
 } from '$lib/server/services';
 import { ACCOUNT_DELETED_COOKIE, COOKIE, type Session } from '$lib/server/session';
@@ -57,6 +58,7 @@ export const load: PageServerLoad = async ({ locals }) => {
       received: [{ owner_user_id: '42', owner_login: 'ferret_king', sections: ['commands'] }],
       grantableSections: [...SECTIONS],
       notifications: demoNotifications,
+      savedLocale: 'en' as const,
       degraded: false
     };
   }
@@ -72,10 +74,11 @@ export const load: PageServerLoad = async ({ locals }) => {
   let notifications: NotificationWire[] = [];
   let degraded = false;
 
-  const [givenResult, receivedResult, notifResult] = await Promise.allSettled([
+  const [givenResult, receivedResult, notifResult, localeResult] = await Promise.allSettled([
     delegationList(self),
     delegationAccess(self),
-    notificationsForUser(self)
+    notificationsForUser(self),
+    userLocale(self)
   ]);
 
   if (givenResult.status === 'fulfilled') given = givenResult.value;
@@ -85,7 +88,12 @@ export const load: PageServerLoad = async ({ locals }) => {
   // Notifications are a nice-to-have section; a failed fetch just shows empty.
   if (notifResult.status === 'fulfilled') notifications = notifResult.value.notifications;
 
-  return { given, received, grantableSections: [...SECTIONS], notifications, degraded };
+  const savedLocale = localeResult.status === 'fulfilled' && (localeResult.value === 'en' || localeResult.value === 'fr')
+    ? localeResult.value
+    : 'en';
+  if (localeResult.status === 'rejected') degraded = true;
+
+  return { given, received, grantableSections: [...SECTIONS], notifications, savedLocale, degraded };
 };
 
 export const actions: Actions = {

--- a/console/dashboard/src/routes/(app)/settings/+page.svelte
+++ b/console/dashboard/src/routes/(app)/settings/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Icon, Modal, PageHead, Card, ConfirmDialog, EmptyState, toast, getI18n } from '@bagel/shared';
+  import { Icon, Modal, PageHead, Card, ConfirmDialog, EmptyState, toast, getI18n, type Locale } from '@bagel/shared';
   import { page } from '$app/state';
   import { enhance } from '$app/forms';
   import CheckButton from '$lib/components/CheckButton.svelte';
@@ -11,6 +11,7 @@
   const { t } = getI18n();
 
   const notifications = $derived((data.notifications ?? []) as NotificationWire[]);
+  const savedLocale = $derived((data.savedLocale ?? 'en') as Locale);
   const levelLabel = (l: string) => l.charAt(0).toUpperCase() + l.slice(1);
 
   const createdGrant = $derived(form?.createdGrant as DelegationGrant | undefined);
@@ -91,7 +92,7 @@
         <b>{t('settings.language')}</b>
         <p class="hint">{t('settings.languageHint')}</p>
       </div>
-      <LangSwitch />
+      <LangSwitch selected={savedLocale} />
     </div>
     <div class="row">
       <div>

--- a/console/dashboard/src/routes/auth/impersonate/+server.ts
+++ b/console/dashboard/src/routes/auth/impersonate/+server.ts
@@ -6,12 +6,11 @@ import type { RequestHandler } from './$types';
 import { redirect } from '@sveltejs/kit';
 import { verifyViewAs } from '@bagel/shared/server/impersonation';
 import { COOKIE, seal } from '$lib/server/session';
-import { isLocale, LOCALE_COOKIE } from '@bagel/shared/i18n';
-import { userLocale } from '$lib/server/services';
+import { LOCALE_COOKIE } from '@bagel/shared/i18n';
 
 const SESSION_TTL = 3600; // 1h — shorter than a normal login.
 
-export const GET: RequestHandler = async ({ url, cookies }) => {
+export const GET: RequestHandler = ({ url, cookies }) => {
   const token = url.searchParams.get('t') ?? '';
   const p = verifyViewAs(token);
   if (!p) throw redirect(302, '/login?e=imp');
@@ -34,20 +33,16 @@ export const GET: RequestHandler = async ({ url, cookies }) => {
     maxAge: SESSION_TTL
   });
 
-  try {
-    const saved = await userLocale(p.sub);
-    if (isLocale(saved)) {
-      cookies.set(LOCALE_COOKIE, saved, {
-        path: '/',
-        httpOnly: true,
-        secure: url.protocol === 'https:',
-        sameSite: 'lax',
-        maxAge: 60 * 60 * 24 * 365
-      });
-    }
-  } catch (err) {
-    /* best-effort */
-  }
+  // Impersonation is an admin surface: keep its chrome in English regardless
+  // of the target account's preference. The Settings switch still writes the
+  // target's saved locale through /lang.
+  cookies.set(LOCALE_COOKIE, 'en', {
+    path: '/',
+    httpOnly: true,
+    secure: url.protocol === 'https:',
+    sameSite: 'lax',
+    maxAge: 60 * 60 * 24 * 365
+  });
 
   throw redirect(302, '/');
 };

--- a/console/dashboard/src/routes/lang/+server.ts
+++ b/console/dashboard/src/routes/lang/+server.ts
@@ -14,7 +14,8 @@ export const POST: RequestHandler = async ({ request, url, cookies, locals }) =>
   const next = String(form.get('next') ?? '/');
 
   if (isLocale(to)) {
-    cookies.set(LOCALE_COOKIE, to, {
+    const s = locals.session;
+    cookies.set(LOCALE_COOKIE, s?.impersonator_id ? 'en' : to, {
       path: '/',
       maxAge: 60 * 60 * 24 * 365,
       sameSite: 'lax',
@@ -22,11 +23,11 @@ export const POST: RequestHandler = async ({ request, url, cookies, locals }) =>
       secure: url.protocol === 'https:'
     });
 
-    // Persist to the account — but not while an admin is impersonating (the
-    // cookie already flips the current view; writing would change the *target*
-    // user's saved preference).
-    const s = locals.session;
-    if (s?.user_id && !s.impersonator_id) {
+    // The session user is always the account whose dashboard is being viewed.
+    // During impersonation that is deliberately the target user, so persist the
+    // choice there as well; the impersonator id is audit metadata, not the owner
+    // of this preference.
+    if (s?.user_id) {
       await setLocale(s.user_id, to);
     }
   }


### PR DESCRIPTION
Keeps admin impersonation in English while persisting the target locale, displays the stored target preference, and loads projected locale for Sesame event-handler i18n. Verified with Go tests and Svelte check.