### PR TITLE
fix: grant WORKER_RPC permission to mutate commands

### DIFF
--- a/deploy/k8s/nats-auth.conf
+++ b/deploy/k8s/nats-auth.conf
@@ -304,6 +304,7 @@ accounts: {
     imports: [
       { service: { account: "USERS_RPC",    subject: "bagel.rpc.internal.projection.users.get" } }
       { service: { account: "COMMANDS_RPC", subject: "bagel.rpc.internal.projection.commands.get" } }
+      { service: { account: "COMMANDS_RPC", subject: "bagel.rpc.commands.>" } }
       { service: { account: "MODULES_RPC",  subject: "bagel.rpc.internal.projection.modules.get" } }
       { service: { account: "PROJECTOR_RPC", subject: "bagel.rpc.broadcaster.live.get" } }
       { stream: { account: "USERS_RPC",     subject: "bagel.cache.invalidate.status" } }


### PR DESCRIPTION
This grants the WORKER_RPC account in NATS the ability to publish to `bagel.rpc.commands.>` so the sesame service can perform mutations (add/edit/delete) for custom commands without silently failing due to missing NATS ACL permissions.