### PR TITLE
fix: add missing delegate props to destructuring

### DIFF
--- a/console/shared/components/AppShell.svelte
+++ b/console/shared/components/AppShell.svelte
@@ -9,7 +9,8 @@
   let {
     brandTitle = 'ItsBagelBot', brandSub, crumbRoot, crumb,
     accountName, accountRole, dashboards = [], groups, mobileItems,
-    offset = false, logoSrc = '/logo.png', isPremium = false, banner, topActions, children
+    offset = false, logoSrc = '/logo.png', isPremium = false, banner, topActions, children,
+    isDelegate = false, delegateExitHref = '', delegateExitLabel = ''
   }: {
     brandTitle?: string; brandSub: string; crumbRoot: string; crumb: string;
     accountName: string; accountRole: string; dashboards?: DashboardLink[];

--- a/console/shared/components/Topbar.svelte
+++ b/console/shared/components/Topbar.svelte
@@ -23,7 +23,10 @@
     accountRole = '',
     dashboards = [],
     logoSrc = '/logo.png',
-    isPremium = false
+    isPremium = false,
+    isDelegate = false,
+    delegateExitHref = '',
+    delegateExitLabel = ''
   }: {
     root: string;
     crumb: string;


### PR DESCRIPTION
Fixes 500 errors caused by missing variables in AppShell and Topbar destructuring.