### PR TITLE
Add animated error pages

### DIFF
--- a/console/shared/components/ErrorView.svelte
+++ b/console/shared/components/ErrorView.svelte
@@ -1,15 +1,45 @@
 <script lang="ts">
   import { page } from '$app/state';
-  import Icon from './Icon.svelte';
+  import LightField from './LightField.svelte';
 
   let { appName, loginHref = '/login' }: { appName: string; loginHref?: string } = $props();
 
-  const isTransient = $derived(page.status === 503 || page.status === 500);
-  const isNotFound = $derived(page.status === 404);
-  const isAuth = $derived(page.status === 401 || page.status === 403);
+  const view = $derived.by(() => {
+    if (page.status === 404) return {
+      eyebrow: 'Lost in the crumbs',
+      title: 'This page wandered off.',
+      description: "We looked under every sesame seed, but the page you're after isn't here.",
+      action: 'home' as const
+    };
+    if (page.status === 401 || page.status === 403) return {
+      eyebrow: 'Behind the counter',
+      title: 'This one is staff only.',
+      description: `Sign in with an account that has access to the ${appName.toLowerCase()}.`,
+      action: 'login' as const
+    };
+    if (page.status === 500 || page.status === 503) return {
+      eyebrow: 'A little overbaked',
+      title: 'Something went sideways.',
+      description: 'A tray tipped over behind the scenes. Give us a moment, then try the page again.',
+      action: 'retry' as const
+    };
+    return {
+      eyebrow: 'An unexpected detour',
+      title: 'We hit a rough patch.',
+      description: page.error?.message ?? 'Something unexpected happened while loading this page.',
+      action: 'retry' as const
+    };
+  });
+
+  const homeLabel = $derived(appName === 'Dashboard' ? 'Back to dashboard' : `Back to ${appName.toLowerCase()}`);
 
   function retry() {
     window.location.reload();
+  }
+
+  function goBack() {
+    if (window.history.length > 1) window.history.back();
+    else window.location.assign('/');
   }
 </script>
 
@@ -17,126 +47,239 @@
   <title>{page.status} — ItsBagelBot {appName}</title>
 </svelte:head>
 
-<main class="error-shell">
-  <div class="panel">
-    <div class="status-icon">
-      {#if isTransient}
-        <Icon name="pulse" size={24} />
-      {:else if isNotFound}
-        <Icon name="search" size={24} />
-      {:else if isAuth}
-        <Icon name="moderation" size={24} />
+<main class="error-scene" aria-labelledby="error-title">
+  <LightField />
+  <div class="glow" aria-hidden="true"></div>
+
+  <div class="orbit-wrap" aria-hidden="true">
+    <span class="orbit one"></span>
+    <span class="orbit two"></span>
+  </div>
+
+  <div class="content">
+    <p class="eyebrow"><span>{page.status}</span> · {view.eyebrow}</p>
+    <p class="code" aria-hidden="true">{page.status}</p>
+    <h1 id="error-title">{view.title}</h1>
+    <p class="description">{view.description}</p>
+
+    <div class="actions">
+      {#if view.action === 'retry'}
+        <button class="error-action primary" type="button" onclick={retry}>Try again</button>
+      {:else if view.action === 'login'}
+        <a class="error-action primary" href={loginHref}>Sign in</a>
       {:else}
-        <Icon name="activity" size={24} />
+        <a class="error-action primary" href="/">{homeLabel}</a>
       {/if}
+      <button class="error-action quiet" type="button" onclick={goBack}>Go back</button>
     </div>
 
-    <div class="error-code">{page.status}</div>
-
-    {#if isTransient}
-      <div class="name">Back in a moment</div>
-      <p class="lede">The {appName.toLowerCase()} console is updating. This should resolve in a few seconds.</p>
-      <button class="err-btn" onclick={retry}>Retry</button>
-    {:else if isNotFound}
-      <div class="name">Page not found</div>
-      <p class="lede">The page you're looking for doesn't exist.</p>
-      <a href="/" class="err-btn">Go home</a>
-    {:else if isAuth}
-      <div class="name">Access denied</div>
-      <p class="lede">You don't have permission to view this page.</p>
-      <a href={loginHref} class="err-btn">Sign in</a>
-    {:else}
-      <div class="name">Something went wrong</div>
-      <p class="lede">{page.error?.message ?? 'An unexpected error occurred.'}</p>
-      <button class="err-btn" onclick={retry}>Retry</button>
-    {/if}
+    <p class="aside">The oven is still warm. Everything else is right where you left it.</p>
   </div>
 </main>
 
 <style>
-  .error-shell {
-    min-height: 100vh;
+  .error-scene {
+    position: relative;
+    isolation: isolate;
+    overflow: hidden;
+    display: grid;
+    place-items: center;
+    min-height: 100svh;
+    padding: 72px 24px;
+    text-align: center;
+    background: var(--bb-black, #0a0a0a);
+  }
+
+  .glow {
+    position: absolute;
+    z-index: -1;
+    left: 50%;
+    top: 48%;
+    width: min(920px, 110vw);
+    aspect-ratio: 1.35;
+    translate: -50% -50%;
+    border-radius: 50%;
+    background:
+      radial-gradient(circle at 48% 44%, rgba(201, 168, 124, 0.16), transparent 34%),
+      radial-gradient(circle at 54% 58%, rgba(82, 183, 136, 0.09), transparent 58%);
+    filter: blur(18px);
+    animation: error-glow 7s ease-in-out infinite;
+    pointer-events: none;
+  }
+
+  .orbit-wrap {
+    position: absolute;
+    z-index: -1;
+    left: 50%;
+    top: 47%;
+    width: min(650px, 82vw);
+    aspect-ratio: 1;
+    translate: -50% -50%;
+    pointer-events: none;
+    opacity: 0;
+    animation: orbit-in 1.2s 100ms var(--bb-ease-out-expo) forwards;
+  }
+
+  .orbit {
+    position: absolute;
+    inset: 8%;
+    border: 1px solid rgba(201, 168, 124, 0.13);
+    border-radius: 50%;
+    transform: rotate(-18deg) scaleY(0.46);
+  }
+  .orbit::after {
+    content: '';
+    position: absolute;
+    top: 48%;
+    left: -4px;
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: var(--bb-tan-light);
+    box-shadow: 0 0 16px rgba(224, 196, 154, 0.8);
+  }
+  .orbit.one { animation: orbit-one 18s linear infinite; }
+  .orbit.two {
+    inset: 18%;
+    border-color: rgba(82, 183, 136, 0.13);
+    transform: rotate(38deg) scaleY(0.58);
+    animation: orbit-two 23s linear infinite reverse;
+  }
+  .orbit.two::after {
+    left: auto;
+    right: -3px;
+    background: var(--bb-green-glow);
+    box-shadow: 0 0 16px rgba(82, 183, 136, 0.75);
+  }
+
+  .content {
+    position: relative;
+    z-index: 2;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: min(100%, 760px);
+  }
+  .eyebrow {
+    margin: 0 0 18px;
+    color: var(--bb-green-glow);
+    font-family: var(--bb-font-mono);
+    font-size: clamp(0.68rem, 1.6vw, 0.78rem);
+    line-height: 1.4;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    text-shadow: 0 0 16px rgba(82, 183, 136, 0.45);
+    opacity: 0;
+    animation: error-rise 720ms 100ms var(--bb-ease-out-expo) forwards;
+  }
+  .eyebrow span { color: var(--bb-tan-light); }
+  .code {
+    margin: 0 0 -0.18em;
+    color: transparent;
+    font-family: var(--bb-font-display);
+    font-size: clamp(6.8rem, 24vw, 13.5rem);
+    font-weight: 800;
+    line-height: 0.72;
+    letter-spacing: -0.08em;
+    -webkit-text-stroke: 1px rgba(201, 168, 124, 0.28);
+    text-shadow: 0 0 60px rgba(201, 168, 124, 0.08);
+    opacity: 0;
+    animation: code-in 1s 20ms var(--bb-ease-out-expo) forwards, code-breathe 6s 1.1s ease-in-out infinite;
+  }
+  h1 {
+    max-width: 13ch;
+    margin: 0;
+    color: var(--bb-white);
+    font-family: var(--bb-font-display);
+    font-size: clamp(2.2rem, 6.5vw, 4.5rem);
+    font-weight: 800;
+    line-height: 0.98;
+    letter-spacing: -0.035em;
+    text-shadow: 0 3px 18px rgba(0, 0, 0, 0.9), 0 0 38px rgba(201, 168, 124, 0.16);
+    opacity: 0;
+    animation: error-rise 780ms 260ms var(--bb-ease-out-expo) forwards;
+  }
+  .description {
+    max-width: 49ch;
+    margin: 24px 0 0;
+    color: #aaa197;
+    font-family: var(--bb-font-body);
+    font-size: clamp(0.98rem, 1.8vw, 1.12rem);
+    line-height: 1.7;
+    opacity: 0;
+    animation: error-rise 780ms 390ms var(--bb-ease-out-expo) forwards;
+  }
+  .actions {
     display: flex;
     align-items: center;
     justify-content: center;
-    padding: 24px;
-    /* fallback background if not rendered inside the main app layout */
-    background: var(--bb-bg-1, #0f0f13);
+    gap: 12px;
+    margin-top: 34px;
+    opacity: 0;
+    animation: error-rise 780ms 500ms var(--bb-ease-out-expo) forwards;
   }
-  .panel {
-    width: 100%;
-    max-width: 420px;
-    padding: 44px 40px 40px;
-    text-align: center;
-    background: var(--glass-fill, rgba(255, 255, 255, 0.055));
-    border: 1px solid var(--glass-border, rgba(255, 255, 255, 0.14));
-    border-radius: 8px 8px;
-    backdrop-filter: blur(var(--glass-blur, 26px)) saturate(var(--glass-sat, 180%));
-    -webkit-backdrop-filter: blur(var(--glass-blur, 26px)) saturate(var(--glass-sat, 180%));
-    box-shadow: var(--glass-rim), var(--glass-shadow);
-  }
-  .status-icon {
+  .error-action {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 48px;
-    height: 48px;
-    border-radius: 8px;
-    background: rgba(255, 255, 255, 0.05);
-    color: var(--bb-tan, #c9a87c);
-    border: 1px solid var(--glass-border, rgba(255, 255, 255, 0.14));
-    margin-bottom: 16px;
-  }
-  .status-icon :global(svg) {
-    stroke: currentColor;
-    fill: none;
-    stroke-width: 1.7;
-  }
-  .error-code {
-    font-family: var(--bb-font-display, system-ui);
-    font-size: 3.5rem;
-    font-weight: 800;
-    line-height: 1;
-    color: var(--bb-tan, #c9a87c);
-    letter-spacing: -2px;
-    margin-bottom: 12px;
-  }
-  .name {
-    font-family: var(--bb-font-display, system-ui);
+    min-height: 48px;
+    padding: 0 22px;
+    border: 1px solid transparent;
+    border-radius: var(--bb-radius-sm, 6px);
+    font-family: var(--bb-font-display);
+    font-size: 0.88rem;
     font-weight: 700;
-    font-size: 22px;
-    letter-spacing: -0.01em;
-    color: var(--bb-white, #fff);
-  }
-  .lede {
-    font-family: var(--bb-font-body, system-ui);
-    font-size: 14px;
-    line-height: 1.55;
-    color: var(--bb-muted, #888899);
-    margin: 12px 0 24px;
-  }
-  .err-btn {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    gap: 0.4rem;
-    width: 100%;
-    font-family: var(--bb-font-mono, ui-monospace, monospace);
-    font-size: 11px;
-    letter-spacing: 0.12em;
-    text-transform: uppercase;
-    padding: 12px 20px;
-    border-radius: var(--bb-radius-pill, 999px);
-    cursor: pointer;
-    white-space: nowrap;
     text-decoration: none;
-    color: var(--bb-white, #fff);
-    background: var(--ui-accent, var(--bb-green, #2d6a4f));
-    border: 1px solid var(--ui-accent-light, var(--bb-green-light, #40916c));
-    transition: all var(--bb-dur-base, 240ms) var(--bb-ease-out-back, ease);
+    cursor: pointer;
+    transition: transform 320ms var(--bb-ease-out-expo), background 220ms ease, border-color 220ms ease, box-shadow 320ms ease;
   }
-  .err-btn:hover {
-    background: var(--ui-accent-light, var(--bb-green-light, #40916c));
-    box-shadow: 0 0 24px rgba(82, 183, 136, 0.32);
+  .error-action.primary { background: var(--bb-tan); color: var(--bb-black); }
+  .error-action.primary:hover,
+  .error-action.primary:focus-visible {
+    background: var(--bb-tan-light);
+    transform: translateY(-2px);
+    box-shadow: 0 10px 32px rgba(201, 168, 124, 0.22);
+  }
+  .error-action.quiet {
+    background: rgba(10, 10, 10, 0.32);
+    border-color: rgba(201, 168, 124, 0.3);
+    color: var(--bb-tan-light);
+  }
+  .error-action.quiet:hover,
+  .error-action.quiet:focus-visible {
+    border-color: rgba(201, 168, 124, 0.58);
+    background: rgba(201, 168, 124, 0.08);
+    transform: translateY(-2px);
+  }
+  .aside {
+    margin: 32px 0 0;
+    color: var(--bb-muted);
+    font-family: var(--bb-font-mono);
+    font-size: 0.68rem;
+    line-height: 1.6;
+    letter-spacing: 0.08em;
+    opacity: 0;
+    animation: error-rise 780ms 610ms var(--bb-ease-out-expo) forwards;
+  }
+
+  @keyframes error-rise { from { opacity: 0; transform: translateY(18px); } to { opacity: 1; transform: translateY(0); } }
+  @keyframes code-in { from { opacity: 0; transform: scale(0.92); filter: blur(8px); } to { opacity: 1; transform: scale(1); filter: blur(0); } }
+  @keyframes code-breathe { 50% { text-shadow: 0 0 80px rgba(201, 168, 124, 0.16); } }
+  @keyframes error-glow { 50% { opacity: 0.72; transform: scale(1.06); } }
+  @keyframes orbit-in { to { opacity: 1; } }
+  @keyframes orbit-one { to { transform: rotate(342deg) scaleY(0.46); } }
+  @keyframes orbit-two { to { transform: rotate(398deg) scaleY(0.58); } }
+  @media (max-width: 520px) {
+    .error-scene { padding-inline: 20px; }
+    .orbit-wrap { width: 110vw; }
+    .actions { width: 100%; flex-direction: column; }
+    .error-action { width: min(100%, 300px); }
+    .aside { max-width: 33ch; }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .glow, .orbit-wrap, .orbit, .eyebrow, .code, h1, .description, .actions, .aside { animation: none; }
+    .orbit-wrap, .eyebrow, .code, h1, .description, .actions, .aside { opacity: 1; }
+    .error-action:hover { transform: none; }
   }
 </style>

--- a/console/shared/components/LightField.svelte
+++ b/console/shared/components/LightField.svelte
@@ -1,0 +1,107 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+
+  let canvas: HTMLCanvasElement;
+
+  onMount(() => {
+    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
+    if (reduceMotion.matches) return;
+
+    const context = canvas.getContext('2d');
+    if (!context) return;
+    const ctx = context;
+
+    type Mote = { x: number; y: number; r: number; vx: number; vy: number; alpha: number; warm: boolean };
+    let width = 0;
+    let height = 0;
+    let dpr = Math.min(window.devicePixelRatio || 1, 2);
+    let motes: Mote[] = [];
+    let frame = 0;
+    let visible = true;
+
+    function build() {
+      width = canvas.clientWidth;
+      height = canvas.clientHeight;
+      if (!width || !height) return;
+      canvas.width = Math.round(width * dpr);
+      canvas.height = Math.round(height * dpr);
+      const count = width < 700 ? 40 : 70;
+      motes = Array.from({ length: count }, () => ({
+        x: Math.random() * width,
+        y: Math.random() * height,
+        r: 0.6 + Math.random() * 2,
+        vy: -(0.05 + Math.random() * 0.2),
+        vx: (Math.random() - 0.5) * 0.1,
+        alpha: 0.12 + Math.random() * 0.45,
+        warm: Math.random() < 0.7
+      }));
+    }
+
+    function draw() {
+      if (!width || !height) build();
+      if (!width || !height) return;
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      ctx.clearRect(0, 0, width, height);
+      ctx.globalCompositeOperation = 'lighter';
+
+      for (const mote of motes) {
+        mote.y += mote.vy;
+        mote.x += mote.vx;
+        if (mote.y < -10) { mote.y = height + 10; mote.x = Math.random() * width; }
+        if (mote.x < -10) mote.x = width + 10;
+        else if (mote.x > width + 10) mote.x = -10;
+        const color = mote.warm ? '201, 168, 124' : '82, 183, 136';
+        ctx.beginPath();
+        ctx.arc(mote.x, mote.y, mote.r, 0, Math.PI * 2);
+        ctx.fillStyle = `rgba(${color}, ${mote.alpha.toFixed(3)})`;
+        ctx.fill();
+      }
+
+      ctx.globalCompositeOperation = 'source-over';
+    }
+
+    function loop() {
+      draw();
+      frame = requestAnimationFrame(loop);
+    }
+
+    const observer = new IntersectionObserver(([entry]) => {
+      visible = entry.isIntersecting;
+      cancelAnimationFrame(frame);
+      frame = visible ? requestAnimationFrame(loop) : 0;
+    }, { rootMargin: '150px' });
+
+    const resize = () => {
+      dpr = Math.min(window.devicePixelRatio || 1, 2);
+      build();
+    };
+
+    build();
+    observer.observe(canvas);
+    window.addEventListener('resize', resize, { passive: true });
+
+    return () => {
+      cancelAnimationFrame(frame);
+      observer.disconnect();
+      window.removeEventListener('resize', resize);
+    };
+  });
+</script>
+
+<canvas bind:this={canvas} class="light-field" aria-hidden="true"></canvas>
+
+<style>
+  .light-field {
+    position: absolute;
+    z-index: -1;
+    inset: 0;
+    display: block;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .light-field { display: none; }
+  }
+</style>

--- a/console/shared/lib/index.ts
+++ b/console/shared/lib/index.ts
@@ -23,6 +23,7 @@ export { default as CardHead } from '../components/CardHead.svelte';
 export { default as Chip } from '../components/Chip.svelte';
 export { default as MiniButton } from '../components/MiniButton.svelte';
 export { default as ErrorView } from '../components/ErrorView.svelte';
+export { default as LightField } from '../components/LightField.svelte';
 export { default as ToastHost } from '../components/ToastHost.svelte';
 export { default as SaveStatus } from '../components/SaveStatus.svelte';
 export { default as FieldError } from '../components/FieldError.svelte';

--- a/web/src/components/errors/ErrorScene.astro
+++ b/web/src/components/errors/ErrorScene.astro
@@ -1,0 +1,292 @@
+---
+import HomeLightField from '../home/HomeLightField.astro';
+
+interface Props {
+    status: number;
+    eyebrow: string;
+    title: string;
+    description: string;
+    actionLabel?: string;
+    actionHref?: string;
+}
+
+const {
+    status,
+    eyebrow,
+    title,
+    description,
+    actionLabel = 'Back to home',
+    actionHref = '/',
+} = Astro.props;
+---
+
+<section class="error-scene" aria-labelledby="error-title">
+    <HomeLightField />
+    <div class="error-scene__glow" aria-hidden="true"></div>
+
+    <div class="error-scene__orbit" aria-hidden="true">
+        <span class="orbit orbit--one"></span>
+        <span class="orbit orbit--two"></span>
+    </div>
+
+    <div class="error-scene__content">
+        <p class="error-scene__eyebrow"><span>{status}</span> · {eyebrow}</p>
+        <p class="error-scene__code" aria-hidden="true">{status}</p>
+        <h1 id="error-title">{title}</h1>
+        <p class="error-scene__description">{description}</p>
+
+        <div class="error-scene__actions">
+            <a class="error-action error-action--primary" href={actionHref}>{actionLabel}</a>
+            <button class="error-action error-action--quiet" type="button" data-error-back>Go back</button>
+        </div>
+
+        <p class="error-scene__aside">The oven is still warm. Everything else is right where you left it.</p>
+    </div>
+</section>
+
+<script>
+    document.addEventListener('click', (event) => {
+        const target = event.target;
+        if (!(target instanceof Element) || !target.closest('[data-error-back]')) return;
+        if (window.history.length > 1) window.history.back();
+        else window.location.assign('/');
+    });
+</script>
+
+<style>
+    .error-scene {
+        position: relative;
+        isolation: isolate;
+        overflow: hidden;
+        display: grid;
+        place-items: center;
+        min-height: 100svh;
+        max-width: none;
+        margin: 0;
+        padding: calc(var(--nav-offset, 76px) + 70px) 24px 84px;
+        text-align: center;
+    }
+
+    .error-scene__glow {
+        position: absolute;
+        z-index: -1;
+        left: 50%;
+        top: 48%;
+        width: min(920px, 110vw);
+        aspect-ratio: 1.35;
+        translate: -50% -50%;
+        border-radius: 50%;
+        background:
+            radial-gradient(circle at 48% 44%, rgba(201, 168, 124, 0.16), transparent 34%),
+            radial-gradient(circle at 54% 58%, rgba(82, 183, 136, 0.09), transparent 58%);
+        filter: blur(18px);
+        animation: errorGlow 7s ease-in-out infinite;
+        pointer-events: none;
+    }
+
+    .error-scene__orbit {
+        position: absolute;
+        z-index: -1;
+        left: 50%;
+        top: 47%;
+        width: min(650px, 82vw);
+        aspect-ratio: 1;
+        translate: -50% -50%;
+        pointer-events: none;
+        opacity: 0;
+        animation: orbitIn 1.2s 100ms var(--ease-out-expo) forwards;
+    }
+
+    .orbit {
+        position: absolute;
+        inset: 8%;
+        border: 1px solid rgba(201, 168, 124, 0.13);
+        border-radius: 50%;
+        transform: rotate(-18deg) scaleY(0.46);
+    }
+
+    .orbit::after {
+        content: "";
+        position: absolute;
+        top: 48%;
+        left: -4px;
+        width: 7px;
+        height: 7px;
+        border-radius: 50%;
+        background: var(--tan-light);
+        box-shadow: 0 0 16px rgba(224, 196, 154, 0.8);
+    }
+
+    .orbit--one { animation: orbitOne 18s linear infinite; }
+    .orbit--two {
+        inset: 18%;
+        border-color: rgba(82, 183, 136, 0.13);
+        transform: rotate(38deg) scaleY(0.58);
+        animation: orbitTwo 23s linear infinite reverse;
+    }
+    .orbit--two::after {
+        left: auto;
+        right: -3px;
+        background: var(--green-glow);
+        box-shadow: 0 0 16px rgba(82, 183, 136, 0.75);
+    }
+
+    .error-scene__content {
+        position: relative;
+        z-index: 2;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        width: min(100%, 760px);
+    }
+
+    .error-scene__eyebrow {
+        margin: 0 0 18px;
+        color: var(--green-glow);
+        font-family: var(--font-mono);
+        font-size: clamp(0.68rem, 1.6vw, 0.78rem);
+        letter-spacing: 0.2em;
+        text-transform: uppercase;
+        text-shadow: 0 0 16px rgba(82, 183, 136, 0.45);
+        opacity: 0;
+        animation: errorRise 720ms 100ms var(--ease-out-expo) forwards;
+    }
+    .error-scene__eyebrow span { color: var(--tan-light); }
+
+    .error-scene__code {
+        margin: 0 0 -0.18em;
+        color: transparent;
+        font-family: var(--font-display);
+        font-size: clamp(6.8rem, 24vw, 13.5rem);
+        font-weight: 800;
+        line-height: 0.72;
+        letter-spacing: -0.08em;
+        -webkit-text-stroke: 1px rgba(201, 168, 124, 0.28);
+        text-shadow: 0 0 60px rgba(201, 168, 124, 0.08);
+        opacity: 0;
+        animation: codeIn 1s 20ms var(--ease-out-expo) forwards, codeBreathe 6s 1.1s ease-in-out infinite;
+    }
+
+    h1 {
+        max-width: 13ch;
+        margin: 0;
+        color: var(--white);
+        font-family: var(--font-display);
+        font-size: clamp(2.2rem, 6.5vw, 4.5rem);
+        font-weight: 800;
+        line-height: 0.98;
+        letter-spacing: -0.035em;
+        text-shadow: 0 3px 18px rgba(0, 0, 0, 0.9), 0 0 38px rgba(201, 168, 124, 0.16);
+        opacity: 0;
+        animation: errorRise 780ms 260ms var(--ease-out-expo) forwards;
+    }
+
+    .error-scene__description {
+        max-width: 49ch;
+        margin: 24px 0 0;
+        color: #aaa197;
+        font-family: var(--font-body);
+        font-size: clamp(0.98rem, 1.8vw, 1.12rem);
+        line-height: 1.7;
+        opacity: 0;
+        animation: errorRise 780ms 390ms var(--ease-out-expo) forwards;
+    }
+
+    .error-scene__actions {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 12px;
+        margin-top: 34px;
+        opacity: 0;
+        animation: errorRise 780ms 500ms var(--ease-out-expo) forwards;
+    }
+
+    .error-action {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 48px;
+        padding: 0 22px;
+        border: 1px solid transparent;
+        border-radius: var(--radius-sm, 6px);
+        font-family: var(--font-display);
+        font-size: 0.88rem;
+        font-weight: 700;
+        text-decoration: none;
+        cursor: pointer;
+        transition: transform 320ms var(--ease-out-expo), background 220ms ease, border-color 220ms ease, box-shadow 320ms ease;
+    }
+    .error-action--primary { background: var(--tan); color: var(--black); }
+    .error-action--primary:hover,
+    .error-action--primary:focus-visible {
+        background: var(--tan-light);
+        transform: translateY(-2px);
+        box-shadow: 0 10px 32px rgba(201, 168, 124, 0.22);
+    }
+    .error-action--quiet {
+        background: rgba(10, 10, 10, 0.32);
+        border-color: rgba(201, 168, 124, 0.3);
+        color: var(--tan-light);
+    }
+    .error-action--quiet:hover,
+    .error-action--quiet:focus-visible {
+        border-color: rgba(201, 168, 124, 0.58);
+        background: rgba(201, 168, 124, 0.08);
+        transform: translateY(-2px);
+    }
+
+    .error-scene__aside {
+        margin: 32px 0 0;
+        color: var(--muted);
+        font-family: var(--font-mono);
+        font-size: 0.68rem;
+        line-height: 1.6;
+        letter-spacing: 0.08em;
+        opacity: 0;
+        animation: errorRise 780ms 610ms var(--ease-out-expo) forwards;
+    }
+
+    @keyframes errorRise {
+        from { opacity: 0; transform: translateY(18px); }
+        to { opacity: 1; transform: translateY(0); }
+    }
+    @keyframes codeIn {
+        from { opacity: 0; transform: scale(0.92); filter: blur(8px); }
+        to { opacity: 1; transform: scale(1); filter: blur(0); }
+    }
+    @keyframes codeBreathe { 50% { text-shadow: 0 0 80px rgba(201, 168, 124, 0.16); } }
+    @keyframes errorGlow { 50% { opacity: 0.72; transform: scale(1.06); } }
+    @keyframes orbitIn { to { opacity: 1; } }
+    @keyframes orbitOne { to { transform: rotate(342deg) scaleY(0.46); } }
+    @keyframes orbitTwo { to { transform: rotate(398deg) scaleY(0.58); } }
+    @media (max-width: 520px) {
+        .error-scene { padding-inline: 20px; }
+        .error-scene__orbit { width: 110vw; }
+        .error-scene__actions { width: 100%; flex-direction: column; }
+        .error-action { width: min(100%, 300px); }
+        .error-scene__aside { max-width: 33ch; }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        .error-scene__glow,
+        .error-scene__orbit,
+        .orbit,
+        .error-scene__eyebrow,
+        .error-scene__code,
+        h1,
+        .error-scene__description,
+        .error-scene__actions,
+        .error-scene__aside {
+            animation: none;
+        }
+        .error-scene__orbit,
+        .error-scene__eyebrow,
+        .error-scene__code,
+        h1,
+        .error-scene__description,
+        .error-scene__actions,
+        .error-scene__aside { opacity: 1; }
+        .error-action:hover { transform: none; }
+    }
+</style>

--- a/web/src/pages/404.astro
+++ b/web/src/pages/404.astro
@@ -1,0 +1,16 @@
+---
+import Layout from '../layouts/Layout.astro';
+import ErrorScene from '../components/errors/ErrorScene.astro';
+---
+
+<Layout
+    title="404 — Page not found | ItsBagelBot"
+    description="This ItsBagelBot page could not be found."
+>
+    <ErrorScene
+        status={404}
+        eyebrow="Lost in the crumbs"
+        title="This page wandered off."
+        description="We looked under every sesame seed, but the page you're after isn't here."
+    />
+</Layout>

--- a/web/src/pages/500.astro
+++ b/web/src/pages/500.astro
@@ -1,0 +1,17 @@
+---
+import Layout from '../layouts/Layout.astro';
+import ErrorScene from '../components/errors/ErrorScene.astro';
+---
+
+<Layout
+    title="500 — Something went wrong | ItsBagelBot"
+    description="ItsBagelBot hit an unexpected error."
+>
+    <ErrorScene
+        status={500}
+        eyebrow="A little overbaked"
+        title="Something went sideways."
+        description="A tray tipped over behind the scenes. Give us a moment, then try the page again."
+        actionLabel="Back to safety"
+    />
+</Layout>


### PR DESCRIPTION
## Summary
- add branded Astro 404 and 500 pages for the marketing site
- replace the shared dashboard/admin error view with the matching Svelte design
- add a lightweight reusable 2D canvas mote field with responsive and reduced-motion support

## Verification
- `web`: `bun run build`
- `console/dashboard`: `bun run check`
- `console/dashboard`: `bun run build`
- `console/admin`: `bun run check`
- `console/admin`: `bun run build`
- verified 404 status handling and desktop/mobile rendering in the in-app browser