### PR TITLE
Fix Twitch rate-limit accounting and ingress conduit spam

### DIFF
--- a/app/ingress/lib/ingress/conduit_manager.ex
+++ b/app/ingress/lib/ingress/conduit_manager.ex
@@ -9,10 +9,9 @@ defmodule Ingress.ConduitManager do
   `Ingress.ShardScaler`), then converges the running `Ingress.ShardSession`
   processes to match — starting missing shards and stopping excess ones.
 
-  Reconciliation repeats periodically: it heals shards whose supervisor gave
-  up, re-asserts the Conduit size against Twitch (the one external source of
-  truth we cannot avoid reconciling with), and shrinks when the scaler's
-  desired count drops below the current session count.
+  Reconciliation repeats periodically to heal local shards whose supervisor
+  gave up. Twitch is updated only when the internally-owned desired shard count
+  changes; stable reconciliation ticks never spend Helix quota.
   """
 
   use GenServer
@@ -32,7 +31,7 @@ defmodule Ingress.ConduitManager do
 
   @impl true
   def init(_) do
-    {:ok, %{conduit_id: nil}, {:continue, :reconcile}}
+    {:ok, %{conduit_id: nil, applied_shard_count: nil}, {:continue, :reconcile}}
   end
 
   @impl true
@@ -48,11 +47,11 @@ defmodule Ingress.ConduitManager do
 
   defp reconcile(state) do
     case ensure_conduit(state) do
-      {:ok, conduit_id} ->
+      {:ok, conduit_id, applied_shard_count} ->
         desired = ShardScaler.desired()
-        converge_shards(conduit_id, desired)
+        applied_shard_count = converge_shards(conduit_id, desired, applied_shard_count)
         Process.send_after(self(), :reconcile, @reconcile_interval_ms)
-        %{state | conduit_id: conduit_id}
+        %{state | conduit_id: conduit_id, applied_shard_count: applied_shard_count}
 
       {:error, reason} ->
         Logger.error("conduit reconcile failed: #{inspect(reason)}")
@@ -62,29 +61,38 @@ defmodule Ingress.ConduitManager do
   end
 
   defp ensure_conduit(%{conduit_id: nil}), do: Api.ensure_conduit()
-  defp ensure_conduit(%{conduit_id: id}), do: {:ok, id}
+  defp ensure_conduit(%{conduit_id: id, applied_shard_count: count}), do: {:ok, id, count}
 
   # Converge the Conduit (Twitch side) and local ShardSession processes to
   # exactly `desired` shards. Grows or shrinks as needed.
   #
   # Order of operations:
-  #   1. Resize the Conduit on Twitch's side so it accepts exactly `desired`
-  #      shard bindings. update_conduit/2 works both directions.
+  #   1. If `desired` changed, resize the Conduit on Twitch's side so it
+  #      accepts exactly that many shard bindings.
   #   2. Stop sessions for shard IDs >= desired (the Conduit no longer has
   #      slots for them; stopping is safe because :transient restart means a
   #      deliberate shutdown will not restart the session).
   #   3. Start any missing sessions for shard IDs 0..(desired-1).
-  defp converge_shards(conduit_id, desired) when desired > 0 do
-    case Api.update_conduit(conduit_id, desired) do
-      :ok ->
-        Logger.debug("conduit resized to #{desired} shards")
-
-      {:error, reason} ->
-        Logger.warning("conduit resize to #{desired} failed: #{inspect(reason)}")
-    end
+  defp converge_shards(conduit_id, desired, applied) when desired > 0 do
+    applied = maybe_resize_conduit(conduit_id, desired, applied)
 
     stop_excess_shards(desired)
     start_missing_shards(conduit_id, desired)
+    applied
+  end
+
+  defp maybe_resize_conduit(_conduit_id, desired, desired), do: desired
+
+  defp maybe_resize_conduit(conduit_id, desired, applied) do
+    case Api.update_conduit(conduit_id, desired) do
+      :ok ->
+        Logger.info("conduit resized to #{desired} shards")
+        desired
+
+      {:error, reason} ->
+        Logger.warning("conduit resize to #{desired} failed: #{inspect(reason)}")
+        applied
+    end
   end
 
   # Stop ShardSession processes for shard IDs >= desired. We look them up in

--- a/app/ingress/lib/ingress/shard_scaler.ex
+++ b/app/ingress/lib/ingress/shard_scaler.ex
@@ -42,8 +42,6 @@ defmodule Ingress.ShardScaler do
   require Logger
 
   alias Ingress.Config
-  alias Ingress.Twitch.Api
-
   # --- tunables ---------------------------------------------------------------
 
   # How often the autoscaler evaluates load.
@@ -117,9 +115,10 @@ defmodule Ingress.ShardScaler do
 
   @impl true
   def init(_) do
-    # Seed target from the live conduit's shard_count so we do not race the
-    # ConduitManager on boot with a stale env value.
-    target = seed_target()
+    # The scaler is the source of truth. ConduitManager performs the one
+    # startup read needed to locate the pinned conduit and applies this target
+    # only when Twitch's recorded count differs.
+    target = Config.conduit_shard_count()
     Logger.info("shard_scaler started: target=#{target} on #{node()}")
     schedule_autoscale()
     {:ok, %{target: target, autoscale: true, low_ticks: 0, last_sample: nil}}
@@ -185,19 +184,6 @@ defmodule Ingress.ShardScaler do
 
       [] ->
         {:error, :not_running}
-    end
-  end
-
-  # Seed from the live conduit if reachable; fall back to the env value so
-  # the first reconcile does not needlessly resize.
-  defp seed_target do
-    case Api.list_conduits() do
-      {:ok, [%{"shard_count" => n} | _]} when is_integer(n) and n > 0 ->
-        Logger.info("shard_scaler: seeded target from conduit shard_count=#{n}")
-        n
-
-      _ ->
-        Config.conduit_shard_count()
     end
   end
 

--- a/app/ingress/lib/ingress/twitch/api.ex
+++ b/app/ingress/lib/ingress/twitch/api.ex
@@ -22,20 +22,20 @@ defmodule Ingress.Twitch.Api do
   first existing conduit for this client is reused, and one is created when
   none exists.
   """
-  @spec ensure_conduit() :: {:ok, String.t()} | {:error, term()}
+  @spec ensure_conduit() :: {:ok, String.t(), pos_integer()} | {:error, term()}
   def ensure_conduit do
     desired = Config.conduit_shard_count()
 
     with {:ok, conduits} <- list_conduits() do
       case pick_conduit(conduits) do
         {:ok, nil} ->
-          create_conduit(desired)
+          with {:ok, id} <- create_conduit(desired), do: {:ok, id, desired}
 
         {:ok, %{"id" => id, "shard_count" => count}} when count < desired ->
-          with :ok <- update_conduit(id, desired), do: {:ok, id}
+          with :ok <- update_conduit(id, desired), do: {:ok, id, desired}
 
-        {:ok, %{"id" => id}} ->
-          {:ok, id}
+        {:ok, %{"id" => id, "shard_count" => count}} ->
+          {:ok, id, count}
 
         {:error, reason} ->
           {:error, reason}

--- a/app/outgress/internal/ratelimit/borrow.go
+++ b/app/outgress/internal/ratelimit/borrow.go
@@ -182,13 +182,15 @@ func (ps *PermitService) respond(req micro.Request, reply BorrowReply) {
 }
 
 var (
-	profileChatShared       = NewSpec(20, 20.0/30.0)
-	profileChatStandard     = NewSpec(10, 10.0/30.0)
-	profileChatModShared    = NewSpec(100, 100.0/30.0)
-	profileChatModStandard  = NewSpec(50, 50.0/30.0)
-	profileHelixShared      = NewSpec(700, 700.0/60.0)
-	profileHelixStandard    = NewSpec(350, 350.0/60.0)
-	profileHelixSystemShare = NewSpec(100, 100.0/60.0)
+	profileChatShared        = NewSpec(20, 20.0/30.0)
+	profileChatStandard      = NewSpec(10, 10.0/30.0)
+	profileChatModShared     = NewSpec(100, 100.0/30.0)
+	profileChatModStandard   = NewSpec(50, 50.0/30.0)
+	profileHelixShared       = NewSpec(700, 700.0/60.0)
+	profileHelixStandard     = NewSpec(350, 350.0/60.0)
+	profileHelixSystemShare  = NewSpec(100, 100.0/60.0)
+	profileHelixUserShared   = NewSpec(800, 800.0/60.0)
+	profileHelixUserStandard = NewSpec(400, 400.0/60.0)
 )
 
 func specsForProfile(profile uint8) (shared, standard Spec, ok bool) {
@@ -201,6 +203,8 @@ func specsForProfile(profile uint8) (shared, standard Spec, ok bool) {
 		return profileHelixShared, profileHelixStandard, true
 	case profileHelixSystem:
 		return profileHelixSystemShare, Spec{}, true
+	case profileHelixUser:
+		return profileHelixUserShared, profileHelixUserStandard, true
 	default:
 		return Spec{}, Spec{}, false
 	}

--- a/app/outgress/internal/ratelimit/lease_manager.go
+++ b/app/outgress/internal/ratelimit/lease_manager.go
@@ -37,7 +37,7 @@ type activePlan struct {
 	members     []Member
 	selfIndex   int
 	selfPodID   string
-	shares      [profileHelixSystem + 1]selfShare
+	shares      [profileHelixUser + 1]selfShare
 }
 
 type LeaseManager struct {
@@ -103,7 +103,7 @@ func (m *LeaseManager) ActivatePlan(plan Plan, serverNow, localNow time.Time, gu
 	if selfIndex >= 0 {
 		ap.selfPodID = canonical.Members[selfIndex].PodID
 		members := len(canonical.Members)
-		for profile := profileChat; profile <= profileHelixSystem; profile++ {
+		for profile := profileChat; profile <= profileHelixUser; profile++ {
 			shared, standard, ok := specsForProfile(profile)
 			if !ok {
 				continue
@@ -126,6 +126,7 @@ func (m *LeaseManager) ActivatePlan(plan Plan, serverNow, localNow time.Time, gu
 		}
 	}
 	m.plan.Store(ap)
+	m.primeFixedBuckets(localNow, ap)
 	if m.local != nil {
 		// Keep the immediately previous incarnation so an unchanged holder can
 		// renew without losing its token balance. Older idle buckets are safe to
@@ -133,6 +134,38 @@ func (m *LeaseManager) ActivatePlan(plan Plan, serverNow, localNow time.Time, gu
 		m.local.DeleteExpired(localNow.Add(-2 * notAfter.Sub(notBefore)).UnixNano())
 	}
 	return nil
+}
+
+// primeFixedBuckets creates the fleet-wide Helix buckets as soon as a lease
+// plan activates and renews them every epoch. Unlike per-channel chat buckets,
+// these sparse control buckets must remain resident: creating them on the first
+// EventSub operation would start them empty and expose only the 10% emergency
+// partition to an operation that needs a larger burst.
+func (m *LeaseManager) primeFixedBuckets(now time.Time, plan *activePlan) {
+	if m.local == nil || plan.selfIndex < 0 {
+		return
+	}
+	for _, fixed := range []struct {
+		id      BucketID
+		profile uint8
+	}{
+		{BucketID{Scope: "helix:app"}, profileHelixGeneral},
+		{BucketID{Scope: "helix:system"}, profileHelixSystem},
+		{BucketID{Scope: "helix:user:bot"}, profileHelixUser},
+	} {
+		share := &plan.shares[fixed.profile]
+		if !share.valid {
+			continue
+		}
+		bucket, _ := m.configuredBucket(now, plan, fixed.id, plan.selfPodID, share)
+		if bucket.Generation() != plan.generation || bucket.Holder() != plan.selfPodID {
+			bucket.Update(now, plan.epoch, plan.generation, plan.selfPodID,
+				plan.notBefore, plan.notAfter, share.sharedRate, share.sharedBurst,
+				share.standardRate, share.standardBurst)
+		} else {
+			bucket.Renew(plan.epoch, plan.notBefore, plan.notAfter)
+		}
+	}
 }
 
 func (m *LeaseManager) Allow(ctx context.Context, req Request) (bool, error) {

--- a/app/outgress/internal/ratelimit/lease_manager_test.go
+++ b/app/outgress/internal/ratelimit/lease_manager_test.go
@@ -51,6 +51,58 @@ func TestLocalSharesPreserveGlobalBudget(t *testing.T) {
 	}
 }
 
+func TestFixedSystemBucketWarmsBeforeFirstBurst(t *testing.T) {
+	store := NewBucketStore(16)
+	manager := NewLeaseManager(nil, store, nil, WithLeaseIdentity("local", "pod-a"))
+	plan, now := activeTestPlan(t, []Member{{PodID: "pod-a", Region: "local"}}, 31)
+	if err := manager.ActivatePlan(plan, now, now, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	// No system request has arrived yet. The plan activation must still have
+	// created the bucket so its leased share can refill while the lane is idle.
+	later := now.Add(time.Minute)
+	req := profileHelixSystemShare.ForKey("ratelimit:helix:system")
+	for i := 0; i < 20; i++ {
+		allowed, err := manager.allowAt(context.Background(), &req, later)
+		if err != nil || !allowed {
+			t.Fatalf("system request %d denied after warmup: allowed=%v err=%v", i+1, allowed, err)
+		}
+	}
+}
+
+func TestFixedHelixBucketsRenewWithoutTraffic(t *testing.T) {
+	store := NewBucketStore(16)
+	manager := NewLeaseManager(nil, store, nil, WithLeaseIdentity("local", "pod-a"))
+	base := time.Now()
+	var original *LocalBucket
+
+	for epoch := uint64(1); epoch <= 5; epoch++ {
+		now := base.Add(time.Duration(epoch-1) * 30 * time.Second)
+		plan := Plan{
+			Version: planVersion, Epoch: epoch, Generation: 32,
+			ValidFromMS:  now.Add(-time.Second).UnixMilli(),
+			ValidUntilMS: now.Add(29 * time.Second).UnixMilli(),
+			Members:      []Member{{PodID: "pod-a", Region: "local"}},
+		}
+		if err := plan.ComputeDigest(); err != nil {
+			t.Fatal(err)
+		}
+		if err := manager.ActivatePlan(plan, now, now, 0); err != nil {
+			t.Fatal(err)
+		}
+		bucket, ok := store.Load(BucketID{Scope: "helix:system"})
+		if !ok {
+			t.Fatalf("fixed system bucket missing at epoch %d", epoch)
+		}
+		if original == nil {
+			original = bucket
+		} else if bucket != original {
+			t.Fatalf("fixed system bucket was evicted and recreated at epoch %d", epoch)
+		}
+	}
+}
+
 func TestGenerationChangeStartsSameHolderEmpty(t *testing.T) {
 	bucket := NewLocalBucket()
 	start := time.Now()

--- a/app/outgress/internal/ratelimit/valkey.go
+++ b/app/outgress/internal/ratelimit/valkey.go
@@ -165,6 +165,7 @@ const (
 	profileChatMod
 	profileHelixGeneral
 	profileHelixSystem
+	profileHelixUser
 )
 
 func detectProfile(capacity int, refill float64) uint8 {
@@ -179,6 +180,8 @@ func detectProfile(capacity int, refill float64) uint8 {
 		return profileHelixSystem
 	case 700:
 		return profileHelixGeneral
+	case 800:
+		return profileHelixUser
 	default:
 		return profileUnknown
 	}

--- a/app/outgress/internal/twitch/client.go
+++ b/app/outgress/internal/twitch/client.go
@@ -120,6 +120,25 @@ func ParseIdentity(s string) Identity {
 	}
 }
 
+// ResolveIdentity returns the token bucket identity used for a request. An
+// explicit wire identity wins; automatic routing mirrors sourceFor so rate
+// limiting and token selection cannot disagree.
+func ResolveIdentity(id Identity, endpoint string) Identity {
+	if id != IdentityAuto {
+		return id
+	}
+	path := endpoint
+	if i := strings.IndexByte(path, '?'); i >= 0 {
+		path = path[:i]
+	}
+	for _, prefix := range userScopedPrefixes {
+		if strings.HasPrefix(path, prefix) {
+			return IdentityBot
+		}
+	}
+	return IdentityApp
+}
+
 // Do executes one Helix request under the app token (chat sends, conduit
 // EventSub management, general reads). The caller owns the response body.
 func (c *Client) Do(ctx context.Context, method, endpoint string, body []byte) (*http.Response, error) {
@@ -154,7 +173,7 @@ func (c *Client) sourceFor(endpoint string) *Source {
 // sourceForIdentity resolves the token a job runs under. An explicit identity
 // wins; IdentityAuto falls back to endpoint-based routing.
 func (c *Client) sourceForIdentity(id Identity, broadcasterID, endpoint string) *Source {
-	switch id {
+	switch ResolveIdentity(id, endpoint) {
 	case IdentityApp:
 		return c.app
 	case IdentityBot:
@@ -162,7 +181,7 @@ func (c *Client) sourceForIdentity(id Identity, broadcasterID, endpoint string) 
 	case IdentityBroadcaster:
 		return c.broadcasters.Get(broadcasterID)
 	default:
-		return c.sourceFor(endpoint)
+		return c.app
 	}
 }
 

--- a/app/outgress/internal/worker/worker.go
+++ b/app/outgress/internal/worker/worker.go
@@ -36,8 +36,8 @@ import (
 )
 
 // Twitch enforces the chat limits per channel (20 messages per 30s, 100 when
-// the bot moderates the channel) and one Helix budget per app token (800 per
-// minute, shared by every endpoint the app calls).
+// the bot moderates the channel), one Helix budget for app-access requests,
+// and a separate budget per client ID + user for user-access requests.
 //
 // That 800/min budget is partitioned so the lanes cannot starve each other:
 //
@@ -63,18 +63,21 @@ const (
 	helixWindow          = 60.0
 	helixSystemReserve   = 100.0
 	helixGeneralCapacity = helixCapacity - helixSystemReserve
+	helixUserCapacity    = 800.0
 )
 
 // Stable bucket parameters are formatted once at process initialization. Chat
 // keys remain per-broadcaster, but their numeric Lua arguments do not.
 var (
-	chatSpec            = ratelimit.NewSpec(chatCapacity, chatCapacity/chatWindow)
-	chatStandardSpec    = ratelimit.NewSpec(chatCapacity/2, chatCapacity/chatWindow/2)
-	chatModSpec         = ratelimit.NewSpec(chatModCapacity, chatModCapacity/chatWindow)
-	chatModStandardSpec = ratelimit.NewSpec(chatModCapacity/2, chatModCapacity/chatWindow/2)
-	helixGeneralSpec    = ratelimit.NewSpec(helixGeneralCapacity, helixGeneralCapacity/helixWindow)
-	helixStandardSpec   = ratelimit.NewSpec(helixGeneralCapacity/2, helixGeneralCapacity/helixWindow/2)
-	helixSystemSpec     = ratelimit.NewSpec(helixSystemReserve, helixSystemReserve/helixWindow)
+	chatSpec              = ratelimit.NewSpec(chatCapacity, chatCapacity/chatWindow)
+	chatStandardSpec      = ratelimit.NewSpec(chatCapacity/2, chatCapacity/chatWindow/2)
+	chatModSpec           = ratelimit.NewSpec(chatModCapacity, chatModCapacity/chatWindow)
+	chatModStandardSpec   = ratelimit.NewSpec(chatModCapacity/2, chatModCapacity/chatWindow/2)
+	helixGeneralSpec      = ratelimit.NewSpec(helixGeneralCapacity, helixGeneralCapacity/helixWindow)
+	helixStandardSpec     = ratelimit.NewSpec(helixGeneralCapacity/2, helixGeneralCapacity/helixWindow/2)
+	helixSystemSpec       = ratelimit.NewSpec(helixSystemReserve, helixSystemReserve/helixWindow)
+	helixUserSpec         = ratelimit.NewSpec(helixUserCapacity, helixUserCapacity/helixWindow)
+	helixUserStandardSpec = ratelimit.NewSpec(helixUserCapacity/2, helixUserCapacity/helixWindow/2)
 )
 
 // nodeRegion and nodeName label every transaction so Twitch external-segment
@@ -443,7 +446,7 @@ func withField(body []byte, field, value string) []byte {
 }
 
 func (w *Worker) processAPI(ctx context.Context, payload outgress.Message) error {
-	if err := w.takeGeneralHelix(ctx); err != nil {
+	if err := w.takeGeneralHelix(ctx, payload); err != nil {
 		return err
 	}
 
@@ -470,7 +473,7 @@ func (w *Worker) processAnnounce(ctx context.Context, payload outgress.Message) 
 		return nil
 	}
 
-	if err := w.takeGeneralHelix(ctx); err != nil {
+	if err := w.takeGeneralHelix(ctx, payload); err != nil {
 		return err
 	}
 
@@ -545,7 +548,7 @@ func (w *Worker) processShoutout(ctx context.Context, payload outgress.Message) 
 		return nil
 	}
 
-	if err := w.takeGeneralHelix(ctx); err != nil {
+	if err := w.takeGeneralHelix(ctx, payload); err != nil {
 		return err
 	}
 
@@ -968,10 +971,26 @@ func isPermanent(err error) bool {
 
 // takeGeneralHelix consumes one token from the general Helix budget, the
 // partition that backs ordinary api traffic.
-func (w *Worker) takeGeneralHelix(ctx context.Context) error {
-	shared := helixGeneralSpec.ForKey("ratelimit:helix:app")
+func generalHelixRequests(payload outgress.Message) (ratelimit.Request, ratelimit.Request) {
+	identity := twitch.ResolveIdentity(twitch.ParseIdentity(payload.As), payload.Endpoint)
+	var shared, standard ratelimit.Request
+	switch identity {
+	case twitch.IdentityBot:
+		shared = helixUserSpec.ForKey("ratelimit:helix:user:bot")
+		standard = helixUserStandardSpec.ForKey("ratelimit:helix:user:bot:standard")
+	case twitch.IdentityBroadcaster:
+		shared = helixUserSpec.ForDynamicKey("ratelimit:helix:user:", "helix:user", payload.BroadcasterID)
+		standard = helixUserStandardSpec.ForDynamicKey("ratelimit:helix:user:standard:", "helix:user:standard", payload.BroadcasterID)
+	default:
+		shared = helixGeneralSpec.ForKey("ratelimit:helix:app")
+		standard = helixStandardSpec.ForKey("ratelimit:helix:app:standard")
+	}
+	return standard, shared
+}
+
+func (w *Worker) takeGeneralHelix(ctx context.Context, payload outgress.Message) error {
+	standard, shared := generalHelixRequests(payload)
 	if w.lane == LaneStandard {
-		standard := helixStandardSpec.ForKey("ratelimit:helix:app:standard")
 		return w.takeOrdered(ctx, standard, shared)
 	}
 	return w.take(ctx, shared)
@@ -1128,7 +1147,8 @@ func (w *Worker) processClip(ctx context.Context, payload outgress.Message) erro
 		_ = sonic.Unmarshal(payload.Payload, &meta)
 	}
 
-	if err := w.takeGeneralHelix(ctx); err != nil {
+	payload.As = outgress.AsBroadcaster
+	if err := w.takeGeneralHelix(ctx, payload); err != nil {
 		return err // no clip created yet: safe to redeliver
 	}
 

--- a/app/outgress/internal/worker/worker_test.go
+++ b/app/outgress/internal/worker/worker_test.go
@@ -74,6 +74,48 @@ func TestCloudBotChatActionsUseAppToken(t *testing.T) {
 	}
 }
 
+func TestGeneralHelixRequestsUseTokenSpecificBuckets(t *testing.T) {
+	tests := []struct {
+		name       string
+		message    outgress.Message
+		sharedKey  string
+		sharedPref string
+		scope      string
+		value      string
+	}{
+		{
+			name:      "app token",
+			message:   outgress.Message{As: outgress.AsApp, Endpoint: "/helix/users"},
+			sharedKey: "ratelimit:helix:app",
+		},
+		{
+			name:      "bot user token",
+			message:   outgress.Message{As: outgress.AsBot, Endpoint: "/helix/moderation/bans"},
+			sharedKey: "ratelimit:helix:user:bot",
+		},
+		{
+			name:      "auto-routed bot user token",
+			message:   outgress.Message{Endpoint: "/helix/moderation/channels?first=100"},
+			sharedKey: "ratelimit:helix:user:bot",
+		},
+		{
+			name:       "broadcaster user token",
+			message:    outgress.Message{As: outgress.AsBroadcaster, BroadcasterID: "123", Endpoint: "/helix/clips"},
+			sharedPref: "ratelimit:helix:user:", scope: "helix:user", value: "123",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, shared := generalHelixRequests(tc.message)
+			if shared.Key != tc.sharedKey || shared.DynamicPrefix != tc.sharedPref ||
+				shared.Bucket.Scope != tc.scope || shared.Bucket.Value != tc.value {
+				t.Fatalf("shared request = %+v", shared)
+			}
+		})
+	}
+}
+
 func TestWithField(t *testing.T) {
 	tests := []struct {
 		name  string


### PR DESCRIPTION
## Summary
- stop ingress from polling and PATCHing an unchanged conduit every 30 seconds
- prewarm and retain fixed Helix lease buckets
- account app, bot-user, and broadcaster-user access tokens in separate Twitch buckets

## Verification
- `mix test` (38 tests)
- `go test ./...`
- `go test -race ./app/outgress/internal/ratelimit ./app/outgress/internal/twitch ./app/outgress/internal/worker`