### PR TITLE
fix: bound outgress caches, align rate-limit token accounting

### DIFF
--- a/app/ingress/lib/ingress/conduit_manager.ex
+++ b/app/ingress/lib/ingress/conduit_manager.ex
@@ -46,8 +46,11 @@ defmodule Ingress.ConduitManager do
   def handle_info(:reconcile, state), do: {:noreply, reconcile(state)}
 
   defp reconcile(state) do
+    first_sync = is_nil(state.conduit_id)
+
     case ensure_conduit(state) do
       {:ok, conduit_id, applied_shard_count} ->
+        if first_sync, do: adopt_applied_count(applied_shard_count)
         desired = ShardScaler.desired()
         applied_shard_count = converge_shards(conduit_id, desired, applied_shard_count)
         Process.send_after(self(), :reconcile, @reconcile_interval_ms)
@@ -62,6 +65,20 @@ defmodule Ingress.ConduitManager do
 
   defp ensure_conduit(%{conduit_id: nil}), do: Api.ensure_conduit()
   defp ensure_conduit(%{conduit_id: id, applied_shard_count: count}), do: {:ok, id, count}
+
+  # Twitch's recorded shard count is the only survivor of a singleton failover
+  # or deploy: the scaler restarts at the config floor, so without adoption the
+  # first reconcile would shrink an autoscaled conduit and drop shard bindings
+  # until the autoscaler climbed back. Only raises the target (set_target
+  # clamps to max_shards); a count at or below the current desired changes
+  # nothing. Best-effort: an unreachable scaler just keeps its floor.
+  defp adopt_applied_count(applied) do
+    if applied > ShardScaler.desired() do
+      _ = ShardScaler.set_target(applied)
+    end
+
+    :ok
+  end
 
   # Converge the Conduit (Twitch side) and local ShardSession processes to
   # exactly `desired` shards. Grows or shrinks as needed.

--- a/app/outgress/internal/channels/registry.go
+++ b/app/outgress/internal/channels/registry.go
@@ -43,6 +43,15 @@ const (
 	pauseReadTimeout       = 750 * time.Millisecond
 )
 
+// The per-pod channel cache only needs the working set of channels this pod is
+// actively sending to; Valkey remains authoritative and NATS invalidation keeps
+// hits coherent. A short TTL lets channels that stop chatting leave memory
+// instead of sitting resident for a day.
+const (
+	channelCacheCapacity = 4096
+	channelCacheTTL      = 6 * time.Hour
+)
+
 var ErrPauseStateUnavailable = errors.New("outgress pause state is unavailable or stale")
 
 type pauseSnapshot struct {
@@ -74,14 +83,13 @@ type Registry struct {
 func New(client valkey.Client) *Registry {
 	return &Registry{
 		client: client,
-		cache:  cache.New[manage.Channel](10000, 24*time.Hour),
+		cache:  cache.New[manage.Channel](channelCacheCapacity, channelCacheTTL),
 	}
 }
 
 // StartInvalidationListener keeps the per-pod channel caches coherent. Valkey
 // is authoritative, but without this broadcast one replica can retain a stale
-// moderator status for the cache's full 24-hour TTL after another replica
-// refreshes it.
+// moderator status for the cache's full TTL after another replica refreshes it.
 func (r *Registry) StartInvalidationListener(nc *nats.Conn, prefix string, log *zap.Logger) error {
 	r.nc = nc
 	r.invalidatePrefix = prefix

--- a/app/outgress/internal/ratelimit/borrow.go
+++ b/app/outgress/internal/ratelimit/borrow.go
@@ -64,7 +64,9 @@ func NewPermitService(nc *nats.Conn, region, podID string, _ *BucketStore) (*Per
 	if region == "" || podID == "" {
 		return nil, errors.New("ratelimit: permit region and pod ID are required")
 	}
-	dedupe, err := theine.NewBuilder[string, cachedGrant](10_000).Build()
+	// Grants live for permitTTL (250ms), and each pod caps in-flight borrows at
+	// 64, so even a large fleet keeps well under this many live entries.
+	dedupe, err := theine.NewBuilder[string, cachedGrant](2048).Build()
 	if err != nil {
 		return nil, err
 	}

--- a/app/outgress/internal/twitch/broadcaster.go
+++ b/app/outgress/internal/twitch/broadcaster.go
@@ -1,6 +1,23 @@
 package twitch
 
-import "sync"
+import (
+	"sync"
+	"time"
+)
+
+// The token cache is bounded so a long tail of one-off broadcaster jobs cannot
+// grow the map for the life of the process. Evicting a Source is safe: the
+// refresh token lives in the users service, so a rebuilt Source resumes from
+// the stored grant on its next renewal.
+const (
+	maxBroadcasterSources = 2048
+	sourceIdleTTL         = time.Hour
+)
+
+type sourceEntry struct {
+	source   *Source
+	lastUsed time.Time
+}
 
 // BroadcasterTokens lazily builds and caches one user-token Source per
 // broadcaster id, so "send as the broadcaster" jobs reuse a single refreshing
@@ -10,12 +27,12 @@ import "sync"
 // that never authorized simply errors at send time).
 type BroadcasterTokens struct {
 	mu    sync.Mutex
-	cache map[string]*Source
+	cache map[string]*sourceEntry
 	build func(broadcasterID string) *Source
 }
 
 func NewBroadcasterTokens(build func(broadcasterID string) *Source) *BroadcasterTokens {
-	return &BroadcasterTokens{cache: make(map[string]*Source), build: build}
+	return &BroadcasterTokens{cache: make(map[string]*sourceEntry), build: build}
 }
 
 // Get returns the cached Source for a broadcaster, building it on first use.
@@ -25,10 +42,36 @@ func (b *BroadcasterTokens) Get(broadcasterID string) *Source {
 	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	if s, ok := b.cache[broadcasterID]; ok {
-		return s
+	now := time.Now()
+	if e, ok := b.cache[broadcasterID]; ok {
+		e.lastUsed = now
+		return e.source
+	}
+	if len(b.cache) >= maxBroadcasterSources {
+		b.evictLocked(now)
 	}
 	s := b.build(broadcasterID)
-	b.cache[broadcasterID] = s
+	b.cache[broadcasterID] = &sourceEntry{source: s, lastUsed: now}
 	return s
+}
+
+// evictLocked drops every source idle past sourceIdleTTL, falling back to the
+// least recently used one so an insert never grows the map past the cap. A
+// caller already holding an evicted *Source keeps using it safely; only the
+// cache slot is released.
+func (b *BroadcasterTokens) evictLocked(now time.Time) {
+	var oldestID string
+	var oldestUse time.Time
+	for id, e := range b.cache {
+		if now.Sub(e.lastUsed) >= sourceIdleTTL {
+			delete(b.cache, id)
+			continue
+		}
+		if oldestID == "" || e.lastUsed.Before(oldestUse) {
+			oldestID, oldestUse = id, e.lastUsed
+		}
+	}
+	if len(b.cache) >= maxBroadcasterSources && oldestID != "" {
+		delete(b.cache, oldestID)
+	}
 }

--- a/app/outgress/internal/worker/mod_status.go
+++ b/app/outgress/internal/worker/mod_status.go
@@ -17,6 +17,9 @@ const (
 	modCheckTimeout      = 15 * time.Second
 	modCheckErrorBackoff = 5 * time.Minute
 	maxConcurrentChecks  = 4
+	// backoffPruneAbove bounds the backoff map: entries for channels that never
+	// chat again would otherwise accumulate for the life of the process.
+	backoffPruneAbove = 1024
 )
 
 // ModVerifier keeps moderator discovery off the latency-sensitive chat path.
@@ -129,10 +132,18 @@ func (v *ModVerifier) verify(broadcasterID, botID string) {
 		<-v.slots
 		v.mu.Lock()
 		delete(v.pending, broadcasterID)
+		now := time.Now()
 		if failed {
-			v.backoff[broadcasterID] = time.Now().Add(modCheckErrorBackoff)
+			v.backoff[broadcasterID] = now.Add(modCheckErrorBackoff)
 		} else {
 			delete(v.backoff, broadcasterID)
+		}
+		if len(v.backoff) > backoffPruneAbove {
+			for id, until := range v.backoff {
+				if now.After(until) {
+					delete(v.backoff, id)
+				}
+			}
 		}
 		v.mu.Unlock()
 	}()

--- a/app/outgress/internal/worker/worker.go
+++ b/app/outgress/internal/worker/worker.go
@@ -17,6 +17,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"ItsBagelBot/app/outgress/internal/channels"
@@ -179,6 +180,21 @@ func (w *Worker) SetLiveWriter(lw *LiveWriter) { w.live = lw }
 
 func (w *Worker) SetModVerifier(v *ModVerifier) { w.modVerifier = v }
 
+// Shoutout targets are a small, fleet-shared keyspace, so the three lane
+// workers share one bounded cache instead of each holding a default-capacity
+// copy. Built lazily so importing the package does not spin cache machinery.
+var (
+	sharedUserIDs     *cache.Cache[string]
+	sharedUserIDsOnce sync.Once
+)
+
+func userIDCache() *cache.Cache[string] {
+	sharedUserIDsOnce.Do(func() {
+		sharedUserIDs = cache.New[string](1024, 10*time.Minute)
+	})
+	return sharedUserIDs
+}
+
 func New(log *zap.Logger, limiter ratelimit.Manager, registry *channels.Registry, tw *twitch.Client, botID, owner string, conduitResolver *conduit.Resolver, lane Lane) *Worker {
 	return &Worker{
 		log:      log,
@@ -189,7 +205,7 @@ func New(log *zap.Logger, limiter ratelimit.Manager, registry *channels.Registry
 		owner:    owner,
 		conduit:  conduitResolver,
 		lane:     lane,
-		userIDs:  cache.New[string](cache.DefaultCapacity, 10*time.Minute),
+		userIDs:  userIDCache(),
 	}
 }
 
@@ -473,6 +489,9 @@ func (w *Worker) processAnnounce(ctx context.Context, payload outgress.Message) 
 		return nil
 	}
 
+	// Announcements always execute on the app token; normalize before paying
+	// the rate bucket so accounting matches the token the call runs under.
+	payload.As = outgress.AsApp
 	if err := w.takeGeneralHelix(ctx, payload); err != nil {
 		return err
 	}
@@ -482,7 +501,6 @@ func (w *Worker) processAnnounce(ctx context.Context, payload outgress.Message) 
 		color = "primary"
 	}
 
-	payload.As = outgress.AsApp
 	payload.Method = http.MethodPost
 	payload.Endpoint = "/helix/chat/announcements?broadcaster_id=" +
 		url.QueryEscape(payload.BroadcasterID) + "&moderator_id=" + url.QueryEscape(mod)
@@ -548,11 +566,13 @@ func (w *Worker) processShoutout(ctx context.Context, payload outgress.Message) 
 		return nil
 	}
 
+	// Shoutouts always execute on the app token; normalize before paying the
+	// rate bucket so accounting matches the token the call runs under.
+	payload.As = outgress.AsApp
 	if err := w.takeGeneralHelix(ctx, payload); err != nil {
 		return err
 	}
 
-	payload.As = outgress.AsApp
 	payload.Method = http.MethodPost
 	payload.Endpoint = shoutoutEndpoint(payload.BroadcasterID, toID, mod)
 	payload.Payload = nil
@@ -969,11 +989,11 @@ func isPermanent(err error) bool {
 	return false
 }
 
-// takeGeneralHelix consumes one token from the general Helix budget, the
-// partition that backs ordinary api traffic.
-func generalHelixRequests(payload outgress.Message) (ratelimit.Request, ratelimit.Request) {
+// generalHelixRequests maps a message to the standard and shared bucket
+// requests for the token identity it will execute under, mirroring
+// twitch.ResolveIdentity so accounting and token selection cannot disagree.
+func generalHelixRequests(payload outgress.Message) (standard, shared ratelimit.Request) {
 	identity := twitch.ResolveIdentity(twitch.ParseIdentity(payload.As), payload.Endpoint)
-	var shared, standard ratelimit.Request
 	switch identity {
 	case twitch.IdentityBot:
 		shared = helixUserSpec.ForKey("ratelimit:helix:user:bot")
@@ -988,6 +1008,9 @@ func generalHelixRequests(payload outgress.Message) (ratelimit.Request, ratelimi
 	return standard, shared
 }
 
+// takeGeneralHelix consumes one token from the Helix budget backing the
+// message's token identity: the general app partition, the bot user budget,
+// or the target broadcaster's own user budget.
 func (w *Worker) takeGeneralHelix(ctx context.Context, payload outgress.Message) error {
 	standard, shared := generalHelixRequests(payload)
 	if w.lane == LaneStandard {

--- a/app/outgress/main.go
+++ b/app/outgress/main.go
@@ -178,7 +178,10 @@ func main() {
 	// hostname (the pod) is the dev fallback.
 	worker.SetNodeIdentity(cfg.RateRegion, env.Get("NODE_NAME", host))
 
-	buckets := ratelimit.NewBucketStore(10_000)
+	// Sized for the working set of lease buckets (active chat channels plus the
+	// fixed Helix buckets); DeleteExpired prunes idle channels every epoch and
+	// the store grows past the presize if a burst ever needs it.
+	buckets := ratelimit.NewBucketStore(2048)
 
 	permitSvc, err := ratelimit.NewPermitService(nc, cfg.RateRegion, host, buckets)
 	if err != nil {


### PR DESCRIPTION
## Rate limiter follow-ups (#232)

- **announce/shoutout bucket mismatch**: handlers charged the bucket from the wire `as` field, then forced `As=app` before executing. A producer sending `as:"bot"` paid `helix:user:bot` but ran on the app token. Now normalized before paying, matching the clip handler.
- **conduit failover shrink**: removing the ShardScaler live-conduit seed meant every deploy/Horde failover restarted the scaler at the config floor, so the first reconcile resized an autoscaled conduit down and dropped shard bindings until the autoscaler climbed back. ConduitManager now adopts Twitch's recorded shard count on first sync when it exceeds desired (no extra Helix call, never lowers the operator floor).

## Tighter in-process caching (RAM)

| Cache | Before | After |
|---|---|---|
| Shoutout login→id | 3 × 10k (one per lane worker) | 1 shared, 1024 entries |
| Broadcaster token sources | unbounded map | cap 2048, 1h idle eviction, LRU fallback |
| Channel registry | 10k entries / 24h TTL | 4096 / 6h (Valkey authoritative, NATS invalidation unchanged) |
| Permit dedupe | theine 10k | 2048 (250ms grant TTL, 64 in-flight borrows/pod) |
| Lease bucket store | xsync presize 10k | presize 2048, grows on demand |
| Mod-check backoff map | never pruned | sweep expired past 1024 entries |

No hot-path behavior change: hits stay lock-free, only bounds and eviction tightened.

## Verification

- `go build ./app/outgress/...` + `go vet` clean
- `go test ./app/outgress/... ./pkg/cache/...` all pass
- ingress: `mix compile --warnings-as-errors` clean, `mix test` 38/38 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)