### PR TITLE
feat: add external API gateway and Sesame integrations

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -114,6 +114,12 @@ jobs:
               "description": "ItsBagelBot Twitch event worker (sesame)"
             },
             {
+              "image": "gateway",
+              "context": ".",
+              "containerfile": "app/gateway/Containerfile",
+              "description": "ItsBagelBot external API gateway"
+            },
+            {
               "image": "twitch-ingress",
               "context": "app/ingress",
               "containerfile": "app/ingress/Containerfile",
@@ -148,6 +154,7 @@ jobs:
             add "transactions"
             add "users"
             add "sesame"
+            add "gateway"
           }
 
           add_all_services() {
@@ -159,6 +166,7 @@ jobs:
             add "transactions"
             add "users"
             add "sesame"
+            add "gateway"
             add "twitch-ingress"
             add "console-dashboard"
             add "console-admin"
@@ -203,6 +211,9 @@ jobs:
                 ;;
               app/sesame/*)
                 add "sesame"
+                ;;
+              app/gateway/*)
+                add "gateway"
                 ;;
               console/shared/*|console/bunfig.toml|console/bun.lock|console/package.json|console/tsconfig.base.json)
                 add "console-dashboard"

--- a/app/gateway/Containerfile
+++ b/app/gateway/Containerfile
@@ -1,0 +1,21 @@
+# gateway (Go, root module) - build from the REPO ROOT:
+#   podman build -t itsbagelbot/gateway -f app/gateway/Containerfile .
+FROM docker.io/library/golang:1.26-bookworm AS build
+
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY internal/domain internal/domain
+COPY internal/utils internal/utils
+COPY pkg pkg
+COPY app/gateway app/gateway
+RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /gateway ./app/gateway
+
+# ---------------------------------------------------------------------------
+FROM gcr.io/distroless/static-debian12:nonroot
+
+COPY --from=build /gateway /gateway
+
+USER nonroot
+ENTRYPOINT ["/gateway"]

--- a/app/gateway/internal/config/config.go
+++ b/app/gateway/internal/config/config.go
@@ -1,0 +1,59 @@
+// Package config loads the gateway's runtime settings from the environment.
+//
+// The gateway is the fleet's one door to external API systems: sesame asks it
+// over NATS RPC, it fetches from the upstream (urchin.gg Coral, MCSR Ranked)
+// and caches replies in Valkey. Providers with no credentials configured are
+// skipped at boot, so a missing key degrades to "provider offline", never a
+// crash loop.
+package config
+
+import (
+	"ItsBagelBot/pkg/env"
+)
+
+type Config struct {
+	NATSURL    string
+	NATSRPCURL string
+
+	// SubjectPrefix is the NATS prefix every provider endpoint subscribes
+	// under: "<prefix>.<provider>.<endpoint>".
+	SubjectPrefix string
+
+	// Valkey holds the reply cache and the mcsr stream-session snapshots.
+	ValkeyAddr     string
+	ValkeyPassword string
+
+	// Urchin (Coral) provider. APIKey empty = provider disabled.
+	UrchinBaseURL string
+	UrchinAPIKey  string
+
+	// MCSR Ranked provider. The public API needs no key; APIKey optionally
+	// unlocks expanded rate limits. Enabled unless MCSR_ENABLED=false.
+	McsrBaseURL string
+	McsrAPIKey  string
+	McsrEnabled bool
+
+	ListenAddr string
+}
+
+func Load() *Config {
+	natsURL := env.Get("NATS_URL", "nats://127.0.0.1:4222")
+	return &Config{
+		NATSURL:    natsURL,
+		NATSRPCURL: env.Get("NATS_RPC_URL", natsURL),
+
+		SubjectPrefix: env.Get("NATS_GATEWAY_SUBJECT_PREFIX", "bagel.rpc.gateway"),
+
+		ValkeyAddr:     env.Get("VALKEY_ADDR", "127.0.0.1:6379"),
+		ValkeyPassword: env.Get("VALKEY_PASSWORD", ""),
+
+		UrchinBaseURL: env.Get("URCHIN_BASE_URL", "https://api.urchin.gg"),
+		UrchinAPIKey:  env.Get("URCHIN_API_KEY", ""),
+
+		McsrBaseURL: env.Get("MCSR_BASE_URL", "https://api.mcsrranked.com"),
+		McsrAPIKey:  env.Get("MCSR_API_KEY", ""),
+		McsrEnabled: env.GetBool("MCSR_ENABLED", true),
+
+		ListenAddr: env.Get("LISTEN_ADDR", ":8080"),
+	}
+}

--- a/app/gateway/internal/core/cache.go
+++ b/app/gateway/internal/core/cache.go
@@ -1,0 +1,136 @@
+// Package core holds the gateway's provider-neutral runtime pieces: the
+// Valkey-backed reply cache and the outbound HTTP fetcher. Providers compose
+// these; core knows nothing about any specific external API.
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/valkey-io/valkey-go"
+	"golang.org/x/sync/singleflight"
+)
+
+// Store is the byte-level cache surface Cache runs on. Valkey in production;
+// tests substitute an in-memory map.
+type Store interface {
+	// Get returns the cached bytes and whether the key existed.
+	Get(ctx context.Context, key string) ([]byte, bool, error)
+	// Set writes val under key for ttl.
+	Set(ctx context.Context, key string, val []byte, ttl time.Duration) error
+	// Del removes key.
+	Del(ctx context.Context, key string) error
+}
+
+// ValkeyStore implements Store on the fleet's Valkey client (node-local reads,
+// Sentinel-routed writes).
+type ValkeyStore struct{ c valkey.Client }
+
+func NewValkeyStore(c valkey.Client) *ValkeyStore { return &ValkeyStore{c: c} }
+
+func (s *ValkeyStore) Get(ctx context.Context, key string) ([]byte, bool, error) {
+	res := s.c.Do(ctx, s.c.B().Get().Key(key).Build())
+	if err := res.Error(); err != nil {
+		if valkey.IsValkeyNil(err) {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	b, err := res.AsBytes()
+	if err != nil {
+		return nil, false, err
+	}
+	return b, true, nil
+}
+
+func (s *ValkeyStore) Set(ctx context.Context, key string, val []byte, ttl time.Duration) error {
+	return s.c.Do(ctx, s.c.B().Set().Key(key).Value(valkey.BinaryString(val)).Ex(ttl).Build()).Error()
+}
+
+func (s *ValkeyStore) Del(ctx context.Context, key string) error {
+	return s.c.Do(ctx, s.c.B().Del().Key(key).Build()).Error()
+}
+
+// Cache is the shared reply cache every provider endpoint reads through. It
+// stores marshaled JSON replies in the Store under
+// "gateway:<provider>:<endpoint>:<key>" and collapses concurrent misses for
+// the same key through singleflight, so a chat spike on one player costs one
+// upstream call.
+type Cache struct {
+	store Store
+	sf    singleflight.Group
+}
+
+func NewCache(store Store) *Cache { return &Cache{store: store} }
+
+// Key builds the canonical cache key for one endpoint lookup.
+func Key(provider, endpoint, id string) string {
+	return "gateway:" + provider + ":" + endpoint + ":" + id
+}
+
+// Cached returns the cached T under key, or runs fetch to fill it for ttl.
+// Only successful fetches are cached: an upstream failure is returned to this
+// caller and the next request retries. A Store read/write error degrades to a
+// direct fetch rather than failing the lookup — the cache is an optimization,
+// never a dependency.
+func Cached[T any](ctx context.Context, c *Cache, key string, ttl time.Duration, fetch func(context.Context) (T, error)) (T, error) {
+	var zero T
+	if b, ok, err := c.store.Get(ctx, key); err == nil && ok {
+		var v T
+		if err := json.Unmarshal(b, &v); err == nil {
+			return v, nil
+		}
+		// Poison entry (shape drift after a deploy): drop it and refetch.
+		_ = c.store.Del(ctx, key)
+	}
+
+	res, err, _ := c.sf.Do(key, func() (any, error) {
+		// A previous flight may have filled the key while we queued.
+		if b, ok, gerr := c.store.Get(ctx, key); gerr == nil && ok {
+			var v T
+			if uerr := json.Unmarshal(b, &v); uerr == nil {
+				return v, nil
+			}
+		}
+		v, ferr := fetch(ctx)
+		if ferr != nil {
+			return nil, ferr
+		}
+		if b, merr := json.Marshal(v); merr == nil {
+			_ = c.store.Set(ctx, key, b, ttl)
+		}
+		return v, nil
+	})
+	if err != nil {
+		return zero, err
+	}
+	v, ok := res.(T)
+	if !ok {
+		return zero, fmt.Errorf("cache %s: unexpected value type %T", key, res)
+	}
+	return v, nil
+}
+
+// GetJSON reads a raw (non-fetching) entry, for provider-owned state like the
+// mcsr stream-start snapshot.
+func (c *Cache) GetJSON(ctx context.Context, key string, out any) (bool, error) {
+	b, ok, err := c.store.Get(ctx, key)
+	if err != nil || !ok {
+		return false, err
+	}
+	if err := json.Unmarshal(b, out); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// SetJSON writes a raw entry for ttl.
+func (c *Cache) SetJSON(ctx context.Context, key string, v any, ttl time.Duration) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	return c.store.Set(ctx, key, b, ttl)
+}

--- a/app/gateway/internal/core/cache_test.go
+++ b/app/gateway/internal/core/cache_test.go
@@ -1,0 +1,141 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// memStore is an in-memory Store for tests (TTL ignored beyond storage).
+type memStore struct {
+	mu sync.Mutex
+	m  map[string][]byte
+}
+
+func newMemStore() *memStore { return &memStore{m: map[string][]byte{}} }
+
+func (s *memStore) Get(_ context.Context, key string) ([]byte, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	b, ok := s.m[key]
+	return b, ok, nil
+}
+
+func (s *memStore) Set(_ context.Context, key string, val []byte, _ time.Duration) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.m[key] = val
+	return nil
+}
+
+func (s *memStore) Del(_ context.Context, key string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.m, key)
+	return nil
+}
+
+type payload struct {
+	Name string `json:"name"`
+	N    int    `json:"n"`
+}
+
+func TestCachedMissFillsThenHits(t *testing.T) {
+	c := NewCache(newMemStore())
+	var fetches atomic.Int32
+	fetch := func(context.Context) (payload, error) {
+		fetches.Add(1)
+		return payload{Name: "x", N: 7}, nil
+	}
+
+	got, err := Cached(context.Background(), c, "k", time.Minute, fetch)
+	require.NoError(t, err)
+	assert.Equal(t, payload{Name: "x", N: 7}, got)
+
+	got, err = Cached(context.Background(), c, "k", time.Minute, fetch)
+	require.NoError(t, err)
+	assert.Equal(t, payload{Name: "x", N: 7}, got)
+	assert.Equal(t, int32(1), fetches.Load(), "second read must come from cache")
+}
+
+func TestCachedErrorNotCached(t *testing.T) {
+	c := NewCache(newMemStore())
+	var fetches atomic.Int32
+	boom := errors.New("boom")
+
+	_, err := Cached(context.Background(), c, "k", time.Minute, func(context.Context) (payload, error) {
+		fetches.Add(1)
+		return payload{}, boom
+	})
+	require.ErrorIs(t, err, boom)
+
+	got, err := Cached(context.Background(), c, "k", time.Minute, func(context.Context) (payload, error) {
+		fetches.Add(1)
+		return payload{Name: "ok"}, nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "ok", got.Name)
+	assert.Equal(t, int32(2), fetches.Load(), "a failed fetch must be retried, never cached")
+}
+
+func TestCachedPoisonEntryRefetched(t *testing.T) {
+	st := newMemStore()
+	require.NoError(t, st.Set(context.Background(), "k", []byte("{not json"), time.Minute))
+	c := NewCache(st)
+
+	got, err := Cached(context.Background(), c, "k", time.Minute, func(context.Context) (payload, error) {
+		return payload{Name: "fresh"}, nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "fresh", got.Name)
+}
+
+func TestCachedSingleflightCollapses(t *testing.T) {
+	c := NewCache(newMemStore())
+	var fetches atomic.Int32
+	release := make(chan struct{})
+
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = Cached(context.Background(), c, "k", time.Minute, func(context.Context) (payload, error) {
+				fetches.Add(1)
+				<-release
+				return payload{Name: "one"}, nil
+			})
+		}()
+	}
+	// Give the goroutines a moment to pile onto the flight, then release.
+	time.Sleep(50 * time.Millisecond)
+	close(release)
+	wg.Wait()
+
+	assert.Equal(t, int32(1), fetches.Load(), "concurrent misses must share one fetch")
+}
+
+func TestSnapshotRoundTrip(t *testing.T) {
+	c := NewCache(newMemStore())
+	require.NoError(t, c.SetJSON(context.Background(), "snap", payload{Name: "s", N: 3}, time.Hour))
+
+	var got payload
+	ok, err := c.GetJSON(context.Background(), "snap", &got)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, payload{Name: "s", N: 3}, got)
+
+	ok, err = c.GetJSON(context.Background(), "missing", &got)
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestKey(t *testing.T) {
+	assert.Equal(t, "gateway:urchin:daily:techno", Key("urchin", "daily", "techno"))
+}

--- a/app/gateway/internal/core/http.go
+++ b/app/gateway/internal/core/http.go
@@ -1,0 +1,91 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// maxBody bounds an upstream response read. The largest legitimate payload the
+// gateway handles is a full Hypixel profile (a few hundred KB); anything past
+// this is a misbehaving upstream, not data.
+const maxBody = 4 << 20 // 4 MiB
+
+// UpstreamError is a non-2xx answer from an external API, kept as a typed
+// error so providers can map well-known statuses (404 -> "player not found")
+// to user-facing reply errors instead of infrastructure failures.
+type UpstreamError struct {
+	Status int
+	// Message is the upstream's own error text when it sent a JSON
+	// {"error": "..."} body, empty otherwise.
+	Message string
+}
+
+func (e *UpstreamError) Error() string {
+	if e.Message != "" {
+		return fmt.Sprintf("upstream %d: %s", e.Status, e.Message)
+	}
+	return fmt.Sprintf("upstream status %d", e.Status)
+}
+
+// HTTPClient is the outbound fetcher a provider dials its API with: one base
+// URL, a fixed header set (API keys), and a bounded per-request timeout.
+type HTTPClient struct {
+	base    string
+	headers map[string]string
+	hc      *http.Client
+}
+
+// NewHTTPClient builds a fetcher for base (scheme + host, no trailing slash).
+// headers are attached to every request; timeout bounds each call.
+func NewHTTPClient(base string, headers map[string]string, timeout time.Duration) *HTTPClient {
+	if timeout <= 0 {
+		timeout = 10 * time.Second
+	}
+	return &HTTPClient{base: base, headers: headers, hc: &http.Client{Timeout: timeout}}
+}
+
+// GetJSON fetches base+path?query and decodes the JSON body into out. A non-2xx
+// status returns an *UpstreamError carrying the upstream's own error message
+// when it sent one.
+func (c *HTTPClient) GetJSON(ctx context.Context, path string, query url.Values, out any) error {
+	u := c.base + path
+	if len(query) > 0 {
+		u += "?" + query.Encode()
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "ItsBagelBot-gateway/1.0")
+	for k, v := range c.headers {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := c.hc.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxBody))
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		var envelope struct {
+			Error string `json:"error"`
+		}
+		_ = json.Unmarshal(body, &envelope)
+		return &UpstreamError{Status: resp.StatusCode, Message: envelope.Error}
+	}
+
+	return json.Unmarshal(body, out)
+}

--- a/app/gateway/internal/provider/provider.go
+++ b/app/gateway/internal/provider/provider.go
@@ -1,0 +1,35 @@
+// Package provider defines the gateway's pluggable external-API surface. One
+// Provider wraps one external system (urchin, mcsr, ...) and declares the RPC
+// endpoints it answers; main subscribes each endpoint at
+// "<prefix>.<provider>.<endpoint>" with the shared queue group. Adding an
+// external system is a new package under internal/providers plus one line in
+// main — the same shape as sesame's module registry.
+package provider
+
+import (
+	"context"
+	"time"
+
+	gatewayrpc "ItsBagelBot/internal/domain/rpc/gateway"
+)
+
+// Endpoint is one RPC verb a provider answers. Handle returns the reply value
+// to marshal back; it must embed the conventional {"error": ""} envelope and
+// report user-facing failures (player not found) there rather than panicking
+// or returning nothing.
+type Endpoint struct {
+	// Name is the last subject token ("daily", "user", "session_start", ...).
+	Name string
+	// Timeout bounds one handler run; zero means the bus default (5s).
+	Timeout time.Duration
+	// Handle answers one request.
+	Handle func(ctx context.Context, req gatewayrpc.Request) any
+}
+
+// Provider is one external API system.
+type Provider interface {
+	// Name is the subject token identifying the system ("urchin", "mcsr").
+	Name() string
+	// Endpoints lists the verbs the provider answers.
+	Endpoints() []Endpoint
+}

--- a/app/gateway/internal/providers/mcsr/mcsr.go
+++ b/app/gateway/internal/providers/mcsr/mcsr.go
@@ -1,0 +1,279 @@
+// Package mcsr is the gateway provider for the MCSR Ranked public API: a
+// player's current ranked standing, plus the per-channel stream-session delta
+// sesame's !session command shows.
+//
+// The session flow is snapshot-based: when a stream goes online sesame calls
+// session_start, which stores the player's standing under the broadcaster's
+// channel id. A later session call diffs the live standing against that
+// snapshot, so "this stream" means exactly the live session — the value the
+// dashboard module page promises.
+package mcsr
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"ItsBagelBot/app/gateway/internal/core"
+	"ItsBagelBot/app/gateway/internal/provider"
+	gatewayrpc "ItsBagelBot/internal/domain/rpc/gateway"
+
+	"go.uber.org/zap"
+)
+
+const (
+	// userTTL keeps chat spam off the MCSR API (500 req / 10 min fleet-wide)
+	// while staying fresh enough that a finished match shows within a minute.
+	userTTL = time.Minute
+	// snapshotTTL outlives any plausible single stream; Twitch caps broadcasts
+	// at 48h.
+	snapshotTTL = 49 * time.Hour
+
+	httpTimeout    = 10 * time.Second
+	handlerTimeout = 15 * time.Second
+)
+
+// Config carries the provider's environment. APIKey is optional: MCSR grants
+// expanded rate limits to keyed clients via the Private-Key header.
+type Config struct {
+	BaseURL string
+	APIKey  string
+}
+
+// Provider implements provider.Provider for the MCSR Ranked API.
+type Provider struct {
+	http  *core.HTTPClient
+	cache *core.Cache
+	log   *zap.Logger
+}
+
+// New builds the mcsr provider.
+func New(cfg Config, cache *core.Cache, log *zap.Logger) *Provider {
+	base := strings.TrimSuffix(cfg.BaseURL, "/")
+	if base == "" {
+		base = "https://api.mcsrranked.com"
+	}
+	var headers map[string]string
+	if cfg.APIKey != "" {
+		headers = map[string]string{"Private-Key": cfg.APIKey}
+	}
+	return &Provider{
+		http:  core.NewHTTPClient(base, headers, httpTimeout),
+		cache: cache,
+		log:   log,
+	}
+}
+
+func (p *Provider) Name() string { return "mcsr" }
+
+func (p *Provider) Endpoints() []provider.Endpoint {
+	return []provider.Endpoint{
+		{Name: "user", Timeout: handlerTimeout, Handle: p.user},
+		{Name: "session_start", Timeout: handlerTimeout, Handle: p.sessionStart},
+		{Name: "session", Timeout: handlerTimeout, Handle: p.session},
+	}
+}
+
+// --- upstream shapes -----------------------------------------------------------
+
+// userResponse is the /users/{identifier} envelope subset the gateway reads.
+// eloRate/eloRank are null for an unrated player. statistics.season maps a
+// category name to per-queue counters; the ranked queue is the one MCSR Ranked
+// is about.
+type userResponse struct {
+	Status string `json:"status"`
+	Data   struct {
+		UUID       string `json:"uuid"`
+		Nickname   string `json:"nickname"`
+		EloRate    *int   `json:"eloRate"`
+		EloRank    *int   `json:"eloRank"`
+		Country    string `json:"country"`
+		Statistics struct {
+			Season map[string]struct {
+				Ranked *int64 `json:"ranked"`
+			} `json:"season"`
+		} `json:"statistics"`
+	} `json:"data"`
+}
+
+// snapshot is the stream-start standing stored per channel.
+type snapshot struct {
+	Account  string `json:"account"`
+	Nickname string `json:"nickname"`
+	Elo      int    `json:"elo"`
+	Wins     int    `json:"wins"`
+	Loses    int    `json:"loses"`
+	Played   int    `json:"played"`
+	AtUnix   int64  `json:"at_unix"`
+}
+
+func snapshotKey(channelID string) string { return core.Key("mcsr", "session", channelID) }
+
+// friendlyError maps an upstream failure onto a user-facing reply error, or
+// returns "" for an infrastructure failure. The MCSR API answers 400 for "data
+// not found" and 401 for wrong parameters.
+func friendlyError(err error) string {
+	var ue *core.UpstreamError
+	if errors.As(err, &ue) {
+		switch ue.Status {
+		case 400, 401, 404:
+			return "player not found"
+		case 429:
+			return "MCSR Ranked API is busy, try again in a minute"
+		}
+	}
+	return ""
+}
+
+// fetchUser loads a player's live standing straight from the API.
+func (p *Provider) fetchUser(ctx context.Context, account string) (gatewayrpc.McsrUserReply, error) {
+	var resp userResponse
+	if err := p.http.GetJSON(ctx, "/users/"+strings.TrimSpace(account), nil, &resp); err != nil {
+		return gatewayrpc.McsrUserReply{}, err
+	}
+	d := resp.Data
+
+	season := func(cat string) int {
+		if s, ok := d.Statistics.Season[cat]; ok && s.Ranked != nil {
+			return int(*s.Ranked)
+		}
+		return 0
+	}
+	bestTime := int64(0)
+	if s, ok := d.Statistics.Season["bestTime"]; ok && s.Ranked != nil {
+		bestTime = *s.Ranked
+	}
+
+	reply := gatewayrpc.McsrUserReply{
+		Nickname:   d.Nickname,
+		UUID:       d.UUID,
+		Elo:        -1,
+		Rank:       -1,
+		Country:    d.Country,
+		Wins:       season("wins"),
+		Loses:      season("loses"),
+		Played:     season("playedMatches"),
+		BestTimeMS: bestTime,
+	}
+	if d.EloRate != nil {
+		reply.Elo = *d.EloRate
+	}
+	if d.EloRank != nil {
+		reply.Rank = *d.EloRank
+	}
+	return reply, nil
+}
+
+// cachedUser is fetchUser behind the shared 60s cache.
+func (p *Provider) cachedUser(ctx context.Context, account string) (gatewayrpc.McsrUserReply, error) {
+	key := core.Key(p.Name(), "user", strings.ToLower(strings.TrimSpace(account)))
+	return core.Cached(ctx, p.cache, key, userTTL, func(ctx context.Context) (gatewayrpc.McsrUserReply, error) {
+		return p.fetchUser(ctx, account)
+	})
+}
+
+// --- endpoints ------------------------------------------------------------------
+
+func (p *Provider) user(ctx context.Context, req gatewayrpc.Request) any {
+	account := strings.TrimSpace(req.Account)
+	if account == "" {
+		return gatewayrpc.McsrUserReply{Error: "missing account"}
+	}
+	reply, err := p.cachedUser(ctx, account)
+	if err != nil {
+		if msg := friendlyError(err); msg != "" {
+			return gatewayrpc.McsrUserReply{Nickname: account, Error: msg}
+		}
+		p.log.Warn("mcsr user fetch failed", zap.String("account", account), zap.Error(err))
+		return gatewayrpc.McsrUserReply{Nickname: account, Error: "stats lookup failed"}
+	}
+	return reply
+}
+
+// sessionStart snapshots the player's live standing for the channel. It
+// fetches fresh (not through the 60s cache): the snapshot is the session
+// baseline, so it must not predate the stream by a stale cache window.
+func (p *Provider) sessionStart(ctx context.Context, req gatewayrpc.Request) any {
+	account := strings.TrimSpace(req.Account)
+	if account == "" || req.ChannelID == "" {
+		return gatewayrpc.McsrSnapshotReply{Error: "missing account or channel"}
+	}
+	user, err := p.fetchUser(ctx, account)
+	if err != nil {
+		if msg := friendlyError(err); msg != "" {
+			return gatewayrpc.McsrSnapshotReply{Error: msg}
+		}
+		p.log.Warn("mcsr snapshot fetch failed", zap.String("account", account), zap.Error(err))
+		return gatewayrpc.McsrSnapshotReply{Error: "stats lookup failed"}
+	}
+	if err := p.writeSnapshot(ctx, req.ChannelID, account, user); err != nil {
+		p.log.Warn("mcsr snapshot write failed", zap.String("channel_id", req.ChannelID), zap.Error(err))
+		return gatewayrpc.McsrSnapshotReply{Error: "snapshot store failed"}
+	}
+	return gatewayrpc.McsrSnapshotReply{Nickname: user.Nickname, Elo: user.Elo}
+}
+
+func (p *Provider) writeSnapshot(ctx context.Context, channelID, account string, user gatewayrpc.McsrUserReply) error {
+	return p.cache.SetJSON(ctx, snapshotKey(channelID), snapshot{
+		Account:  strings.ToLower(account),
+		Nickname: user.Nickname,
+		Elo:      user.Elo,
+		Wins:     user.Wins,
+		Loses:    user.Loses,
+		Played:   user.Played,
+		AtUnix:   time.Now().Unix(),
+	}, snapshotTTL)
+}
+
+// session answers the delta since the channel's stream-start snapshot. Without
+// a usable snapshot (none stored, or it tracks a different account) it takes
+// one now and reports HasSnapshot=false so the caller can say "tracking from
+// now".
+func (p *Provider) session(ctx context.Context, req gatewayrpc.Request) any {
+	account := strings.TrimSpace(req.Account)
+	if account == "" || req.ChannelID == "" {
+		return gatewayrpc.McsrSessionReply{Error: "missing account or channel"}
+	}
+
+	user, err := p.cachedUser(ctx, account)
+	if err != nil {
+		if msg := friendlyError(err); msg != "" {
+			return gatewayrpc.McsrSessionReply{Nickname: account, Error: msg}
+		}
+		p.log.Warn("mcsr session fetch failed", zap.String("account", account), zap.Error(err))
+		return gatewayrpc.McsrSessionReply{Nickname: account, Error: "stats lookup failed"}
+	}
+
+	var snap snapshot
+	ok, err := p.cache.GetJSON(ctx, snapshotKey(req.ChannelID), &snap)
+	if err != nil {
+		p.log.Warn("mcsr snapshot read failed", zap.String("channel_id", req.ChannelID), zap.Error(err))
+	}
+	if !ok || snap.Account != strings.ToLower(account) {
+		if werr := p.writeSnapshot(ctx, req.ChannelID, account, user); werr != nil {
+			p.log.Warn("mcsr snapshot write failed", zap.String("channel_id", req.ChannelID), zap.Error(werr))
+		}
+		return gatewayrpc.McsrSessionReply{
+			Nickname:    user.Nickname,
+			Elo:         user.Elo,
+			HasSnapshot: false,
+			SinceUnix:   time.Now().Unix(),
+		}
+	}
+
+	reply := gatewayrpc.McsrSessionReply{
+		Nickname:    user.Nickname,
+		Elo:         user.Elo,
+		Wins:        user.Wins - snap.Wins,
+		Loses:       user.Loses - snap.Loses,
+		Played:      user.Played - snap.Played,
+		SinceUnix:   snap.AtUnix,
+		HasSnapshot: true,
+	}
+	// Elo change only means something when both ends are rated.
+	if user.Elo >= 0 && snap.Elo >= 0 {
+		reply.EloChange = user.Elo - snap.Elo
+	}
+	return reply
+}

--- a/app/gateway/internal/providers/mcsr/mcsr_test.go
+++ b/app/gateway/internal/providers/mcsr/mcsr_test.go
@@ -1,0 +1,193 @@
+package mcsr
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"ItsBagelBot/app/gateway/internal/core"
+	gatewayrpc "ItsBagelBot/internal/domain/rpc/gateway"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// memStore is an in-memory core.Store for tests.
+type memStore struct {
+	mu sync.Mutex
+	m  map[string][]byte
+}
+
+func newMemStore() *memStore { return &memStore{m: map[string][]byte{}} }
+
+func (s *memStore) Get(_ context.Context, key string) ([]byte, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	b, ok := s.m[key]
+	return b, ok, nil
+}
+func (s *memStore) Set(_ context.Context, key string, val []byte, _ time.Duration) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.m[key] = val
+	return nil
+}
+func (s *memStore) Del(_ context.Context, key string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.m, key)
+	return nil
+}
+
+func userBody(elo int, wins, loses, played int) string {
+	i := strconv.Itoa
+	return `{
+		"status": "success",
+		"data": {
+			"uuid": "u1", "nickname": "Feinberg",
+			"eloRate": ` + i(elo) + `, "eloRank": 12, "country": "us",
+			"statistics": {
+				"season": {
+					"wins": {"ranked": ` + i(wins) + `, "casual": 1},
+					"loses": {"ranked": ` + i(loses) + `, "casual": 0},
+					"playedMatches": {"ranked": ` + i(played) + `, "casual": 1},
+					"bestTime": {"ranked": 543210, "casual": null}
+				}
+			}
+		}
+	}`
+}
+
+// newTestProvider serves handler as the MCSR API and returns the provider plus
+// its backing store (so tests can evict the 60s user cache to simulate time).
+func newTestProvider(t *testing.T, handler http.Handler) (*Provider, *memStore) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	st := newMemStore()
+	return New(Config{BaseURL: srv.URL}, core.NewCache(st), zap.NewNop()), st
+}
+
+func endpoint(t *testing.T, p *Provider, name string) func(context.Context, gatewayrpc.Request) any {
+	t.Helper()
+	for _, ep := range p.Endpoints() {
+		if ep.Name == name {
+			return ep.Handle
+		}
+	}
+	t.Fatalf("endpoint %q not declared", name)
+	return nil
+}
+
+func TestUserParsing(t *testing.T) {
+	p, _ := newTestProvider(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/users/Feinberg", r.URL.Path)
+		_, _ = w.Write([]byte(userBody(1650, 40, 20, 61)))
+	}))
+
+	reply := endpoint(t, p, "user")(context.Background(), gatewayrpc.Request{Account: "Feinberg"}).(gatewayrpc.McsrUserReply)
+	require.Empty(t, reply.Error)
+	assert.Equal(t, "Feinberg", reply.Nickname)
+	assert.Equal(t, 1650, reply.Elo)
+	assert.Equal(t, 12, reply.Rank)
+	assert.Equal(t, 40, reply.Wins)
+	assert.Equal(t, 20, reply.Loses)
+	assert.Equal(t, 61, reply.Played)
+	assert.Equal(t, int64(543210), reply.BestTimeMS)
+}
+
+func TestUserUnrated(t *testing.T) {
+	body := `{"status":"success","data":{"uuid":"u1","nickname":"New","eloRate":null,"eloRank":null,"country":null,"statistics":{"season":{}}}}`
+	p, _ := newTestProvider(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+
+	reply := endpoint(t, p, "user")(context.Background(), gatewayrpc.Request{Account: "New"}).(gatewayrpc.McsrUserReply)
+	require.Empty(t, reply.Error)
+	assert.Equal(t, -1, reply.Elo)
+	assert.Equal(t, -1, reply.Rank)
+}
+
+func TestUserNotFound(t *testing.T) {
+	p, _ := newTestProvider(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest) // MCSR answers 400 for data not found
+		_, _ = w.Write([]byte(`{"status":"error","data":null}`))
+	}))
+
+	reply := endpoint(t, p, "user")(context.Background(), gatewayrpc.Request{Account: "ghost"}).(gatewayrpc.McsrUserReply)
+	assert.Equal(t, "player not found", reply.Error)
+}
+
+// TestSessionFlow drives the full snapshot lifecycle: session_start stores the
+// baseline, the player wins games, session reports the delta.
+func TestSessionFlow(t *testing.T) {
+	var mu sync.Mutex
+	elo, wins, loses, played := 1650, 40, 20, 61
+	p, st := newTestProvider(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		mu.Lock()
+		body := userBody(elo, wins, loses, played)
+		mu.Unlock()
+		_, _ = w.Write([]byte(body))
+	}))
+
+	start := endpoint(t, p, "session_start")(context.Background(), gatewayrpc.Request{Account: "Feinberg", ChannelID: "77"}).(gatewayrpc.McsrSnapshotReply)
+	require.Empty(t, start.Error)
+	assert.Equal(t, 1650, start.Elo)
+
+	// The player plays: +24 elo, 3 wins, 1 loss. Evict the 60s user cache so
+	// the session read refetches, as it would after the TTL.
+	mu.Lock()
+	elo, wins, loses, played = 1674, 43, 21, 65
+	mu.Unlock()
+	require.NoError(t, st.Del(context.Background(), core.Key("mcsr", "user", "feinberg")))
+
+	sess := endpoint(t, p, "session")(context.Background(), gatewayrpc.Request{Account: "Feinberg", ChannelID: "77"}).(gatewayrpc.McsrSessionReply)
+	require.Empty(t, sess.Error)
+	assert.True(t, sess.HasSnapshot)
+	assert.Equal(t, 1674, sess.Elo)
+	assert.Equal(t, 24, sess.EloChange)
+	assert.Equal(t, 3, sess.Wins)
+	assert.Equal(t, 1, sess.Loses)
+	assert.Equal(t, 4, sess.Played)
+}
+
+func TestSessionWithoutSnapshotStartsTracking(t *testing.T) {
+	p, _ := newTestProvider(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(userBody(1650, 40, 20, 61)))
+	}))
+
+	sess := endpoint(t, p, "session")(context.Background(), gatewayrpc.Request{Account: "Feinberg", ChannelID: "77"}).(gatewayrpc.McsrSessionReply)
+	require.Empty(t, sess.Error)
+	assert.False(t, sess.HasSnapshot)
+
+	// The call itself planted a snapshot: the next session read has a baseline.
+	sess = endpoint(t, p, "session")(context.Background(), gatewayrpc.Request{Account: "Feinberg", ChannelID: "77"}).(gatewayrpc.McsrSessionReply)
+	assert.True(t, sess.HasSnapshot)
+	assert.Zero(t, sess.EloChange)
+}
+
+// A snapshot for another account must not produce a bogus delta.
+func TestSessionAccountSwitchResetsBaseline(t *testing.T) {
+	p, _ := newTestProvider(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(userBody(1650, 40, 20, 61)))
+	}))
+
+	start := endpoint(t, p, "session_start")(context.Background(), gatewayrpc.Request{Account: "OldAcc", ChannelID: "77"}).(gatewayrpc.McsrSnapshotReply)
+	require.Empty(t, start.Error)
+
+	sess := endpoint(t, p, "session")(context.Background(), gatewayrpc.Request{Account: "Feinberg", ChannelID: "77"}).(gatewayrpc.McsrSessionReply)
+	assert.False(t, sess.HasSnapshot, "different account must reset the baseline")
+}
+
+func TestMissingChannel(t *testing.T) {
+	p, _ := newTestProvider(t, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Error("no upstream call expected")
+	}))
+	reply := endpoint(t, p, "session")(context.Background(), gatewayrpc.Request{Account: "x"}).(gatewayrpc.McsrSessionReply)
+	assert.Equal(t, "missing account or channel", reply.Error)
+}

--- a/app/gateway/internal/providers/urchin/urchin.go
+++ b/app/gateway/internal/providers/urchin/urchin.go
@@ -1,0 +1,374 @@
+// Package urchin is the gateway provider for the urchin.gg Coral API: Hypixel
+// Bed Wars stats (daily/weekly/monthly session deltas, lifetime stats) and the
+// Urchin cheater blacklist (sniper score, tags).
+//
+// Every endpoint takes the player as Request.Account (a Minecraft username or
+// UUID; Coral resolves usernames through Mojang) and answers a typed
+// gatewayrpc reply. A well-known upstream failure (404/400 player not found)
+// becomes a reply-level Error, not an RPC failure, so sesame can chat it back.
+package urchin
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/url"
+	"strings"
+	"time"
+
+	"ItsBagelBot/app/gateway/internal/core"
+	"ItsBagelBot/app/gateway/internal/provider"
+	gatewayrpc "ItsBagelBot/internal/domain/rpc/gateway"
+
+	"go.uber.org/zap"
+)
+
+// Cache TTLs. Session deltas move while the player is online, so they stay
+// short; lifetime stats and blacklist state can lag a little. The uuid
+// resolution never changes for a username short of a Mojang rename, so it is
+// cached long.
+const (
+	sessionTTL = 2 * time.Minute
+	statsTTL   = 10 * time.Minute
+	sniperTTL  = 10 * time.Minute
+	tagsTTL    = 10 * time.Minute
+	uuidTTL    = 24 * time.Hour
+
+	// profileCacheAge is passed as Coral's max_cache_age so it serves its own
+	// stored Hypixel snapshot instead of hitting Hypixel per lookup.
+	profileCacheAge = "10m"
+
+	httpTimeout = 10 * time.Second
+	// handlerTimeout leaves headroom over one upstream call plus the uuid
+	// resolution hop the sniper endpoint needs.
+	handlerTimeout = 15 * time.Second
+)
+
+// Config carries the provider's environment: the Coral base URL and the API
+// key every request authenticates with.
+type Config struct {
+	BaseURL string
+	APIKey  string
+}
+
+// Provider implements provider.Provider for the Coral API.
+type Provider struct {
+	http  *core.HTTPClient
+	cache *core.Cache
+	key   string
+	log   *zap.Logger
+}
+
+// New builds the urchin provider. cfg.APIKey must be non-empty (main skips the
+// provider entirely when it is not configured).
+func New(cfg Config, cache *core.Cache, log *zap.Logger) *Provider {
+	base := strings.TrimSuffix(cfg.BaseURL, "/")
+	if base == "" {
+		base = "https://api.urchin.gg"
+	}
+	return &Provider{
+		http:  core.NewHTTPClient(base, map[string]string{"X-API-Key": cfg.APIKey}, httpTimeout),
+		cache: cache,
+		key:   cfg.APIKey,
+		log:   log,
+	}
+}
+
+func (p *Provider) Name() string { return "urchin" }
+
+func (p *Provider) Endpoints() []provider.Endpoint {
+	return []provider.Endpoint{
+		{Name: "daily", Timeout: handlerTimeout, Handle: p.session("daily")},
+		{Name: "weekly", Timeout: handlerTimeout, Handle: p.session("weekly")},
+		{Name: "monthly", Timeout: handlerTimeout, Handle: p.session("monthly")},
+		{Name: "stats", Timeout: handlerTimeout, Handle: p.stats},
+		{Name: "sniper", Timeout: handlerTimeout, Handle: p.sniper},
+		{Name: "tags", Timeout: handlerTimeout, Handle: p.tags},
+	}
+}
+
+// accountKey normalizes the player identifier for cache keys so "Player" and
+// "player" share an entry.
+func accountKey(account string) string { return strings.ToLower(strings.TrimSpace(account)) }
+
+// friendlyError maps an upstream failure onto a user-facing reply error, or
+// returns "" for an infrastructure failure the caller should propagate.
+func friendlyError(err error) string {
+	var ue *core.UpstreamError
+	if errors.As(err, &ue) {
+		switch ue.Status {
+		case 400, 404:
+			if ue.Message != "" {
+				return ue.Message
+			}
+			return "player not found"
+		case 429:
+			return "stats service is busy, try again in a minute"
+		}
+	}
+	return ""
+}
+
+// --- session deltas (daily / weekly / monthly) -------------------------------
+
+// sessionResponse is the Coral SessionDeltaResponse subset the gateway reads.
+// Delta is the recursive diff of the Hypixel player object: unchanged fields
+// omitted, changed numeric stats as bare numbers, non-numeric changes as
+// {old,new} objects.
+type sessionResponse struct {
+	UUID        string          `json:"uuid"`
+	DisplayName *string         `json:"displayname"`
+	From        int64           `json:"from"`
+	Delta       json.RawMessage `json:"delta"`
+}
+
+// sessionDelta is the Bed Wars slice of the diff. Fields use json.RawMessage +
+// numDelta because a stat can surface as a bare number or, for a returning
+// player diffed against a partial snapshot, as an {old,new} object we skip.
+type sessionDelta struct {
+	Stats struct {
+		Bedwars map[string]json.RawMessage `json:"Bedwars"`
+	} `json:"stats"`
+	Achievements map[string]json.RawMessage `json:"achievements"`
+}
+
+// numDelta reads a numeric session diff. Bare numbers are true period deltas;
+// the {old,new} object form means the baseline was missing (a lifetime total
+// would masquerade as a period gain), so it reads as 0.
+func numDelta(raw json.RawMessage) int64 {
+	if len(raw) == 0 {
+		return 0
+	}
+	var n json.Number
+	if err := json.Unmarshal(raw, &n); err != nil {
+		return 0
+	}
+	f, err := n.Float64()
+	if err != nil {
+		return 0
+	}
+	return int64(f)
+}
+
+func (p *Provider) session(period string) func(context.Context, gatewayrpc.Request) any {
+	return func(ctx context.Context, req gatewayrpc.Request) any {
+		account := strings.TrimSpace(req.Account)
+		if account == "" {
+			return gatewayrpc.UrchinSessionReply{Error: "missing account"}
+		}
+		key := core.Key(p.Name(), period, accountKey(account))
+		reply, err := core.Cached(ctx, p.cache, key, sessionTTL, func(ctx context.Context) (gatewayrpc.UrchinSessionReply, error) {
+			return p.fetchSession(ctx, period, account)
+		})
+		if err != nil {
+			if msg := friendlyError(err); msg != "" {
+				return gatewayrpc.UrchinSessionReply{Player: account, Error: msg}
+			}
+			p.log.Warn("urchin session fetch failed", zap.String("period", period), zap.String("account", account), zap.Error(err))
+			return gatewayrpc.UrchinSessionReply{Player: account, Error: "stats lookup failed"}
+		}
+		return reply
+	}
+}
+
+func (p *Provider) fetchSession(ctx context.Context, period, account string) (gatewayrpc.UrchinSessionReply, error) {
+	var resp sessionResponse
+	q := url.Values{"player": {account}}
+	if err := p.http.GetJSON(ctx, "/v3/player/sessions/"+period, q, &resp); err != nil {
+		return gatewayrpc.UrchinSessionReply{}, err
+	}
+
+	reply := gatewayrpc.UrchinSessionReply{
+		Player:    displayOr(resp.DisplayName, account),
+		SinceUnix: resp.From / 1000, // Coral timestamps are Unix milliseconds
+	}
+	if len(resp.Delta) > 0 {
+		var d sessionDelta
+		if err := json.Unmarshal(resp.Delta, &d); err == nil {
+			bw := d.Stats.Bedwars
+			reply.Wins = numDelta(bw["wins_bedwars"])
+			reply.Losses = numDelta(bw["losses_bedwars"])
+			reply.FinalKills = numDelta(bw["final_kills_bedwars"])
+			reply.FinalDeaths = numDelta(bw["final_deaths_bedwars"])
+			reply.BedsBroken = numDelta(bw["beds_broken_bedwars"])
+			reply.GamesPlayed = numDelta(bw["games_played_bedwars"])
+			reply.Levels = numDelta(d.Achievements["bedwars_level"])
+		}
+	}
+	return reply, nil
+}
+
+// --- lifetime stats -----------------------------------------------------------
+
+// profileResponse is the Coral PlayerStatsResponse subset the gateway reads:
+// the resolved name plus the raw Hypixel player object.
+type profileResponse struct {
+	Username    string  `json:"username"`
+	DisplayName *string `json:"displayname"`
+	Hypixel     struct {
+		Achievements struct {
+			BedwarsLevel int64 `json:"bedwars_level"`
+		} `json:"achievements"`
+		Stats struct {
+			Bedwars struct {
+				Wins        int64 `json:"wins_bedwars"`
+				Losses      int64 `json:"losses_bedwars"`
+				FinalKills  int64 `json:"final_kills_bedwars"`
+				FinalDeaths int64 `json:"final_deaths_bedwars"`
+				BedsBroken  int64 `json:"beds_broken_bedwars"`
+			} `json:"Bedwars"`
+		} `json:"stats"`
+	} `json:"hypixel"`
+}
+
+func (p *Provider) stats(ctx context.Context, req gatewayrpc.Request) any {
+	account := strings.TrimSpace(req.Account)
+	if account == "" {
+		return gatewayrpc.UrchinStatsReply{Error: "missing account"}
+	}
+	key := core.Key(p.Name(), "stats", accountKey(account))
+	reply, err := core.Cached(ctx, p.cache, key, statsTTL, func(ctx context.Context) (gatewayrpc.UrchinStatsReply, error) {
+		var resp profileResponse
+		q := url.Values{"player": {account}, "max_cache_age": {profileCacheAge}}
+		if err := p.http.GetJSON(ctx, "/v3/player/profile", q, &resp); err != nil {
+			return gatewayrpc.UrchinStatsReply{}, err
+		}
+		name := displayOr(resp.DisplayName, resp.Username)
+		if name == "" {
+			name = account
+		}
+		bw := resp.Hypixel.Stats.Bedwars
+		return gatewayrpc.UrchinStatsReply{
+			Player:      name,
+			Stars:       resp.Hypixel.Achievements.BedwarsLevel,
+			Wins:        bw.Wins,
+			Losses:      bw.Losses,
+			FinalKills:  bw.FinalKills,
+			FinalDeaths: bw.FinalDeaths,
+			BedsBroken:  bw.BedsBroken,
+		}, nil
+	})
+	if err != nil {
+		if msg := friendlyError(err); msg != "" {
+			return gatewayrpc.UrchinStatsReply{Player: account, Error: msg}
+		}
+		p.log.Warn("urchin stats fetch failed", zap.String("account", account), zap.Error(err))
+		return gatewayrpc.UrchinStatsReply{Player: account, Error: "stats lookup failed"}
+	}
+	return reply
+}
+
+// --- blacklist: tags + sniper score -------------------------------------------
+
+// tagsResponse is the Coral PlayerTagsResponse subset the gateway reads. It is
+// also the uuid resolver for the sniper endpoint (it accepts a username and
+// echoes the canonical uuid, without needing the Player Data permission the
+// dedicated /v3/resolve endpoint requires).
+type tagsResponse struct {
+	UUID        string  `json:"uuid"`
+	DisplayName *string `json:"displayname"`
+	Tags        []struct {
+		TagType string `json:"tag_type"`
+		Reason  string `json:"reason"`
+	} `json:"tags"`
+}
+
+func (p *Provider) fetchTags(ctx context.Context, account string) (tagsResponse, error) {
+	var resp tagsResponse
+	return resp, p.http.GetJSON(ctx, "/v3/player/tags", url.Values{"player": {account}}, &resp)
+}
+
+func (p *Provider) tags(ctx context.Context, req gatewayrpc.Request) any {
+	account := strings.TrimSpace(req.Account)
+	if account == "" {
+		return gatewayrpc.UrchinTagsReply{Error: "missing account"}
+	}
+	key := core.Key(p.Name(), "tags", accountKey(account))
+	reply, err := core.Cached(ctx, p.cache, key, tagsTTL, func(ctx context.Context) (gatewayrpc.UrchinTagsReply, error) {
+		resp, err := p.fetchTags(ctx, account)
+		if err != nil {
+			return gatewayrpc.UrchinTagsReply{}, err
+		}
+		out := gatewayrpc.UrchinTagsReply{
+			Player: displayOr(resp.DisplayName, account),
+			Tags:   make([]gatewayrpc.UrchinTag, 0, len(resp.Tags)),
+		}
+		for _, t := range resp.Tags {
+			out.Tags = append(out.Tags, gatewayrpc.UrchinTag{Type: t.TagType, Reason: t.Reason})
+		}
+		return out, nil
+	})
+	if err != nil {
+		if msg := friendlyError(err); msg != "" {
+			return gatewayrpc.UrchinTagsReply{Player: account, Error: msg}
+		}
+		p.log.Warn("urchin tags fetch failed", zap.String("account", account), zap.Error(err))
+		return gatewayrpc.UrchinTagsReply{Player: account, Error: "tags lookup failed"}
+	}
+	return reply
+}
+
+// cubelifyResponse is the Coral CubelifyResponse subset the gateway reads.
+type cubelifyResponse struct {
+	Score struct {
+		Value float64 `json:"value"`
+		Mode  string  `json:"mode"`
+	} `json:"score"`
+	Tags []json.RawMessage `json:"tags"`
+}
+
+// resolveUUID turns a username into the canonical uuid via the tags endpoint,
+// cached for a day.
+func (p *Provider) resolveUUID(ctx context.Context, account string) (string, error) {
+	key := core.Key(p.Name(), "uuid", accountKey(account))
+	return core.Cached(ctx, p.cache, key, uuidTTL, func(ctx context.Context) (string, error) {
+		resp, err := p.fetchTags(ctx, account)
+		if err != nil {
+			return "", err
+		}
+		return resp.UUID, nil
+	})
+}
+
+func (p *Provider) sniper(ctx context.Context, req gatewayrpc.Request) any {
+	account := strings.TrimSpace(req.Account)
+	if account == "" {
+		return gatewayrpc.UrchinSniperReply{Error: "missing account"}
+	}
+	key := core.Key(p.Name(), "sniper", accountKey(account))
+	reply, err := core.Cached(ctx, p.cache, key, sniperTTL, func(ctx context.Context) (gatewayrpc.UrchinSniperReply, error) {
+		uuid, err := p.resolveUUID(ctx, account)
+		if err != nil {
+			return gatewayrpc.UrchinSniperReply{}, err
+		}
+		// The cubelify endpoint authenticates via the key query parameter (it is
+		// built for the overlay); the client's X-API-Key header rides along too.
+		var resp cubelifyResponse
+		q := url.Values{"uuid": {uuid}, "key": {p.key}, "name": {account}}
+		if err := p.http.GetJSON(ctx, "/v3/cubelify", q, &resp); err != nil {
+			return gatewayrpc.UrchinSniperReply{}, err
+		}
+		return gatewayrpc.UrchinSniperReply{
+			Player:   account,
+			Score:    resp.Score.Value,
+			Mode:     resp.Score.Mode,
+			TagCount: len(resp.Tags),
+		}, nil
+	})
+	if err != nil {
+		if msg := friendlyError(err); msg != "" {
+			return gatewayrpc.UrchinSniperReply{Player: account, Error: msg}
+		}
+		p.log.Warn("urchin sniper fetch failed", zap.String("account", account), zap.Error(err))
+		return gatewayrpc.UrchinSniperReply{Player: account, Error: "score lookup failed"}
+	}
+	return reply
+}
+
+// displayOr prefers the API's display name when present and non-empty.
+func displayOr(display *string, fallback string) string {
+	if display != nil && *display != "" {
+		return *display
+	}
+	return fallback
+}

--- a/app/gateway/internal/providers/urchin/urchin_test.go
+++ b/app/gateway/internal/providers/urchin/urchin_test.go
@@ -1,0 +1,212 @@
+package urchin
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"ItsBagelBot/app/gateway/internal/core"
+	gatewayrpc "ItsBagelBot/internal/domain/rpc/gateway"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// memStore is an in-memory core.Store for tests.
+type memStore struct {
+	mu sync.Mutex
+	m  map[string][]byte
+}
+
+func newMemStore() *memStore { return &memStore{m: map[string][]byte{}} }
+
+func (s *memStore) Get(_ context.Context, key string) ([]byte, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	b, ok := s.m[key]
+	return b, ok, nil
+}
+func (s *memStore) Set(_ context.Context, key string, val []byte, _ time.Duration) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.m[key] = val
+	return nil
+}
+func (s *memStore) Del(_ context.Context, key string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.m, key)
+	return nil
+}
+
+func newTestProvider(t *testing.T, handler http.Handler) *Provider {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return New(Config{BaseURL: srv.URL, APIKey: "test-key"}, core.NewCache(newMemStore()), zap.NewNop())
+}
+
+func endpoint(t *testing.T, p *Provider, name string) func(context.Context, gatewayrpc.Request) any {
+	t.Helper()
+	for _, ep := range p.Endpoints() {
+		if ep.Name == name {
+			return ep.Handle
+		}
+	}
+	t.Fatalf("endpoint %q not declared", name)
+	return nil
+}
+
+const sessionBody = `{
+	"uuid": "abc",
+	"displayname": "§7Techno",
+	"from": 1720000000000,
+	"from_readable": "today",
+	"delta": {
+		"stats": {"Bedwars": {
+			"wins_bedwars": 5,
+			"losses_bedwars": 2,
+			"final_kills_bedwars": 21,
+			"final_deaths_bedwars": 3,
+			"beds_broken_bedwars": 9,
+			"games_played_bedwars": 8,
+			"Experience": 4870.5
+		}},
+		"achievements": {"bedwars_level": 1}
+	}
+}`
+
+func TestDailySessionParsing(t *testing.T) {
+	var gotKey, gotPlayer string
+	p := newTestProvider(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/v3/player/sessions/daily", r.URL.Path)
+		gotKey = r.Header.Get("X-API-Key")
+		gotPlayer = r.URL.Query().Get("player")
+		_, _ = w.Write([]byte(sessionBody))
+	}))
+
+	reply := endpoint(t, p, "daily")(context.Background(), gatewayrpc.Request{Account: "Techno"}).(gatewayrpc.UrchinSessionReply)
+	require.Empty(t, reply.Error)
+	assert.Equal(t, "test-key", gotKey)
+	assert.Equal(t, "Techno", gotPlayer)
+	assert.Equal(t, "§7Techno", reply.Player)
+	assert.Equal(t, int64(1720000000), reply.SinceUnix)
+	assert.Equal(t, int64(5), reply.Wins)
+	assert.Equal(t, int64(2), reply.Losses)
+	assert.Equal(t, int64(21), reply.FinalKills)
+	assert.Equal(t, int64(3), reply.FinalDeaths)
+	assert.Equal(t, int64(9), reply.BedsBroken)
+	assert.Equal(t, int64(8), reply.GamesPlayed)
+	assert.Equal(t, int64(1), reply.Levels)
+}
+
+func TestSessionObjectDeltaSkipped(t *testing.T) {
+	// A returning player diffed against a partial snapshot surfaces totals as
+	// {old:null,new:N}; those must read 0, not the lifetime total.
+	body := `{"uuid":"abc","from":0,"from_readable":"x","delta":{"stats":{"Bedwars":{"wins_bedwars":{"old":null,"new":5000}}}}}`
+	p := newTestProvider(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+
+	reply := endpoint(t, p, "weekly")(context.Background(), gatewayrpc.Request{Account: "x"}).(gatewayrpc.UrchinSessionReply)
+	require.Empty(t, reply.Error)
+	assert.Zero(t, reply.Wins)
+}
+
+func TestSessionCachesReply(t *testing.T) {
+	var hits int
+	p := newTestProvider(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits++
+		_, _ = w.Write([]byte(sessionBody))
+	}))
+	h := endpoint(t, p, "daily")
+
+	_ = h(context.Background(), gatewayrpc.Request{Account: "Techno"})
+	// Same player, case-insensitive: served from cache.
+	_ = h(context.Background(), gatewayrpc.Request{Account: "techno"})
+	assert.Equal(t, 1, hits)
+}
+
+func TestPlayerNotFoundIsReplyError(t *testing.T) {
+	p := newTestProvider(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"player not found"}`))
+	}))
+
+	reply := endpoint(t, p, "daily")(context.Background(), gatewayrpc.Request{Account: "ghost"}).(gatewayrpc.UrchinSessionReply)
+	assert.Equal(t, "player not found", reply.Error)
+}
+
+func TestStatsParsing(t *testing.T) {
+	body := `{
+		"uuid": "abc", "username": "Techno", "displayname": "Techno", "slim": false, "tags": [],
+		"hypixel": {
+			"achievements": {"bedwars_level": 402},
+			"stats": {"Bedwars": {
+				"wins_bedwars": 1000, "losses_bedwars": 100,
+				"final_kills_bedwars": 5000, "final_deaths_bedwars": 500,
+				"beds_broken_bedwars": 2000
+			}}
+		}
+	}`
+	p := newTestProvider(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/v3/player/profile", r.URL.Path)
+		assert.NotEmpty(t, r.URL.Query().Get("max_cache_age"))
+		_, _ = w.Write([]byte(body))
+	}))
+
+	reply := endpoint(t, p, "stats")(context.Background(), gatewayrpc.Request{Account: "Techno"}).(gatewayrpc.UrchinStatsReply)
+	require.Empty(t, reply.Error)
+	assert.Equal(t, int64(402), reply.Stars)
+	assert.Equal(t, int64(1000), reply.Wins)
+	assert.Equal(t, int64(5000), reply.FinalKills)
+}
+
+func TestSniperResolvesUUIDThenScores(t *testing.T) {
+	p := newTestProvider(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v3/player/tags":
+			_, _ = w.Write([]byte(`{"uuid":"deadbeef","displayname":"Aim","tags":[]}`))
+		case "/v3/cubelify":
+			assert.Equal(t, "deadbeef", r.URL.Query().Get("uuid"))
+			assert.Equal(t, "test-key", r.URL.Query().Get("key"))
+			_, _ = w.Write([]byte(`{"score":{"value":7.5,"mode":"warn"},"tags":[{"icon":"x","color":1,"tooltip":"t"}]}`))
+		default:
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+	}))
+
+	reply := endpoint(t, p, "sniper")(context.Background(), gatewayrpc.Request{Account: "Aim"}).(gatewayrpc.UrchinSniperReply)
+	require.Empty(t, reply.Error)
+	assert.Equal(t, 7.5, reply.Score)
+	assert.Equal(t, "warn", reply.Mode)
+	assert.Equal(t, 1, reply.TagCount)
+}
+
+func TestTagsParsing(t *testing.T) {
+	body := `{"uuid":"abc","displayname":"Sus","tags":[
+		{"tag_type":"cheater","reason":"bhop","added_by":1,"added_on":0,"hide_username":false},
+		{"tag_type":"sniper","reason":"","added_by":1,"added_on":0,"hide_username":false}
+	]}`
+	p := newTestProvider(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+
+	reply := endpoint(t, p, "tags")(context.Background(), gatewayrpc.Request{Account: "Sus"}).(gatewayrpc.UrchinTagsReply)
+	require.Empty(t, reply.Error)
+	require.Len(t, reply.Tags, 2)
+	assert.Equal(t, gatewayrpc.UrchinTag{Type: "cheater", Reason: "bhop"}, reply.Tags[0])
+	assert.Equal(t, gatewayrpc.UrchinTag{Type: "sniper"}, reply.Tags[1])
+}
+
+func TestMissingAccount(t *testing.T) {
+	p := newTestProvider(t, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Error("no upstream call expected")
+	}))
+	reply := endpoint(t, p, "daily")(context.Background(), gatewayrpc.Request{}).(gatewayrpc.UrchinSessionReply)
+	assert.Equal(t, "missing account", reply.Error)
+}

--- a/app/gateway/main.go
+++ b/app/gateway/main.go
@@ -1,0 +1,136 @@
+// gateway is the fleet's external-API gateway: sesame (and any future caller)
+// requests third-party data over NATS RPC and the gateway fetches, normalizes
+// and caches it in Valkey. External systems plug in as providers
+// (app/gateway/internal/providers/*); adding one is a new package plus one
+// line in buildProviders.
+package main
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"ItsBagelBot/app/gateway/internal/config"
+	"ItsBagelBot/app/gateway/internal/core"
+	"ItsBagelBot/app/gateway/internal/provider"
+	"ItsBagelBot/app/gateway/internal/providers/mcsr"
+	"ItsBagelBot/app/gateway/internal/providers/urchin"
+	gatewayrpc "ItsBagelBot/internal/domain/rpc/gateway"
+	"ItsBagelBot/pkg/bus"
+	"ItsBagelBot/pkg/env"
+	"ItsBagelBot/pkg/health"
+	"ItsBagelBot/pkg/logger"
+	"ItsBagelBot/pkg/monitor"
+	pkg_valkey "ItsBagelBot/pkg/valkey"
+
+	"github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/nats-io/nats.go"
+	"go.uber.org/zap"
+)
+
+const serviceName = "gateway"
+
+// queueGroup load-balances each endpoint across gateway replicas.
+const queueGroup = "gateway-rpc"
+
+func main() {
+	log := logger.New(env.Get("APP_ENV", "development")).Named(serviceName)
+	defer func() { _ = log.Sync() }()
+
+	nrApp, err := monitor.New(serviceName, log)
+	if err != nil {
+		log.Fatal("failed to start new relic", zap.Error(err))
+	}
+	log = monitor.WrapLogger(log, nrApp)
+	defer monitor.Shutdown(nrApp)
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	cfg := config.Load()
+
+	valkeyClient, err := pkg_valkey.NewClient(cfg.ValkeyAddr, cfg.ValkeyPassword)
+	if err != nil {
+		log.Fatal("failed to connect to valkey", zap.Error(err))
+	}
+	defer valkeyClient.Close()
+
+	nc, err := bus.Connect(cfg.NATSRPCURL, serviceName)
+	if err != nil {
+		log.Fatal("failed to connect to nats", zap.Error(err))
+	}
+	defer nc.Close()
+
+	cache := core.NewCache(core.NewValkeyStore(valkeyClient))
+
+	providers := buildProviders(cfg, cache, log)
+	if len(providers) == 0 {
+		log.Warn("no providers configured; gateway will answer nothing")
+	}
+	if err := subscribeProviders(nc, cfg.SubjectPrefix, providers, nrApp, log); err != nil {
+		log.Fatal("failed to subscribe provider endpoints", zap.Error(err))
+	}
+
+	health.Serve(cfg.ListenAddr, nc.IsConnected)
+
+	names := make([]string, 0, len(providers))
+	for _, p := range providers {
+		names = append(names, p.Name())
+	}
+	log.Info("gateway ready",
+		zap.String("subject_prefix", cfg.SubjectPrefix),
+		zap.Strings("providers", names),
+	)
+
+	<-ctx.Done()
+
+	log.Info("gateway shutting down")
+}
+
+// buildProviders wires every configured provider. A provider missing its
+// credentials is skipped with a warning: its subjects then simply time out at
+// the caller, the same failure mode as the upstream being down.
+func buildProviders(cfg *config.Config, cache *core.Cache, log *zap.Logger) []provider.Provider {
+	var providers []provider.Provider
+
+	if cfg.UrchinAPIKey != "" {
+		providers = append(providers, urchin.New(urchin.Config{
+			BaseURL: cfg.UrchinBaseURL,
+			APIKey:  cfg.UrchinAPIKey,
+		}, cache, log))
+	} else {
+		log.Warn("urchin provider disabled: URCHIN_API_KEY not set")
+	}
+
+	if cfg.McsrEnabled {
+		providers = append(providers, mcsr.New(mcsr.Config{
+			BaseURL: cfg.McsrBaseURL,
+			APIKey:  cfg.McsrAPIKey,
+		}, cache, log))
+	} else {
+		log.Warn("mcsr provider disabled: MCSR_ENABLED=false")
+	}
+
+	return providers
+}
+
+// subscribeProviders registers every endpoint of every provider on the RPC
+// connection, queue-grouped so replicas share the load.
+func subscribeProviders(nc *nats.Conn, prefix string, providers []provider.Provider, nrApp *newrelic.Application, log *zap.Logger) error {
+	for _, p := range providers {
+		for _, ep := range p.Endpoints() {
+			subject := gatewayrpc.Subject(prefix, p.Name(), ep.Name)
+			handle := ep.Handle
+			err := bus.QueueSubscribeJSON(nc, subject, queueGroup, ep.Timeout, nrApp, log,
+				func(ctx context.Context, req gatewayrpc.Request) any {
+					return handle(ctx, req)
+				})
+			if err != nil {
+				return err
+			}
+			log.Debug("gateway endpoint registered", zap.String("subject", subject))
+		}
+	}
+	return nil
+}

--- a/app/sesame/engine/deps.go
+++ b/app/sesame/engine/deps.go
@@ -43,6 +43,7 @@ type Deps struct {
 	Special  *SpecialSet
 	Pub      message.Publisher
 	Commands CommandManager
+	Gateway  GatewayCaller
 	Log      *zap.Logger
 }
 

--- a/app/sesame/engine/dispatch.go
+++ b/app/sesame/engine/dispatch.go
@@ -20,21 +20,25 @@ import (
 // command router: unlike the worker it is not a module, so it reads the registry
 // directly and needs no Bind. A non-command line returns nil with no work.
 //
-// A baked command is first gated by its owning module's enable/premium state
-// (the same enabled() check event handlers pass), so a command on a disabled or
-// premium-only module never runs; that gate also wires the module's config into
-// the Context before the command runs. views is the broadcaster's ModuleView set
-// (nil when the chat path needs none, i.e. only core command owners).
+// A baked command is first gated by its owning module's enable state (the same
+// enabled() check event handlers pass), so a command on a disabled module never
+// runs — the trigger instead falls through to the broadcaster's custom
+// commands, so an opt-in module can ship friendly triggers without reserving
+// them fleet-wide. The gate also wires the module's config into the Context
+// before the command runs. views is the broadcaster's ModuleView set (nil when
+// the chat path needs none, i.e. only core command owners).
 func (p *Pipeline) dispatchCommand(ctx context.Context, c *module.Context, views map[string]projection.ModuleView, emit module.Emit) error {
 	name, args, ok := parseCommand(c.Env.Text)
 	if !ok {
 		return nil
 	}
 	if bc, _, isBaked := p.registry.ResolveCommand(name); isBaked {
-		if !p.enabled(bc.Owner, views, c) {
-			return nil
+		if p.enabled(bc.Owner, views, c) {
+			return p.runBaked(ctx, c, bc.Cmd, args, emit)
 		}
-		return p.runBaked(ctx, c, bc.Cmd, args, emit)
+		// The owner module is off: fall through to the broadcaster's custom
+		// commands so an opt-in module's trigger (e.g. !daily) never reserves the
+		// name on channels that did not enable it.
 	}
 	return p.runCustom(ctx, c, name, args, emit)
 }

--- a/app/sesame/engine/dispatch_test.go
+++ b/app/sesame/engine/dispatch_test.go
@@ -113,6 +113,32 @@ func TestBakedCommandPermGate(t *testing.T) {
 	require.Len(t, collectDispatch(p, chatCtx("!clear", "moderator")), 1) // mod -> runs
 }
 
+// TestBakedDisabledFallsThroughToCustom proves a disabled opt-in module's
+// trigger does not reserve the name: the broadcaster's custom command with the
+// same trigger still answers.
+func TestBakedDisabledFallsThroughToCustom(t *testing.T) {
+	reader := fakeReader{cmd: projection.Command{Name: "daily", Response: "custom daily", IsActive: true, Perm: "everyone"}, cmdFound: true}
+	p := newPipelineWith(&fakePublisher{}, reader, cmdEmit("urchin", module.KindOptIn, "daily", "baked daily"))
+
+	// nil views = the opt-in module is not enabled for this broadcaster.
+	got := collectDispatch(p, chatCtx("!daily", ""))
+	require.Len(t, got, 1)
+	assert.Equal(t, "custom daily", got[0].Text)
+}
+
+// TestBakedEnabledWinsOverCustom is the counterpart: with the module enabled,
+// the baked command answers and the custom one is shadowed.
+func TestBakedEnabledWinsOverCustom(t *testing.T) {
+	reader := fakeReader{cmd: projection.Command{Name: "daily", Response: "custom daily", IsActive: true, Perm: "everyone"}, cmdFound: true}
+	p := newPipelineWith(&fakePublisher{}, reader, cmdEmit("urchin", module.KindOptIn, "daily", "baked daily"))
+
+	views := map[string]projection.ModuleView{"urchin": {Name: "urchin", IsEnabled: true}}
+	var got []module.Output
+	require.NoError(t, p.dispatchCommand(context.Background(), chatCtx("!daily", ""), views, func(o *module.Output) { got = append(got, *o) }))
+	require.Len(t, got, 1)
+	assert.Equal(t, "baked daily", got[0].Text)
+}
+
 // TestBakedOutputRoutedByMiddleware proves announce is post-processing, not a
 // command: a baked command that writes "/announce hi" is routed to an announce
 // action by the shared middleware, exactly as a custom command would be.

--- a/app/sesame/engine/gateway_rpc.go
+++ b/app/sesame/engine/gateway_rpc.go
@@ -1,0 +1,67 @@
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	gatewayrpc "ItsBagelBot/internal/domain/rpc/gateway"
+	"ItsBagelBot/pkg/bus"
+
+	"github.com/nats-io/nats.go"
+)
+
+const gatewayRPCTimeout = 8 * time.Second
+
+// GatewayCaller is the external-data surface modules pull third-party stats
+// through (the urchin and mcsr modules). One generic Call keeps Deps flat while
+// each module keeps its replies typed: it passes the gatewayrpc reply struct it
+// expects as out.
+type GatewayCaller interface {
+	Call(ctx context.Context, provider, endpoint string, req gatewayrpc.Request, out any) error
+}
+
+// GatewayRPC implements GatewayCaller over NATS request/reply against the
+// gateway service.
+type GatewayRPC struct {
+	nc     *nats.Conn
+	prefix string // e.g. "bagel.rpc.gateway"
+}
+
+// NewGatewayRPC returns a GatewayCaller for the gateway service. prefix is the
+// subject prefix the gateway subscribes under (default "bagel.rpc.gateway").
+func NewGatewayRPC(nc *nats.Conn, prefix string) *GatewayRPC {
+	return &GatewayRPC{nc: nc, prefix: prefix}
+}
+
+// Call requests one gateway endpoint and decodes the reply into out. A reply
+// carrying the conventional {"error": "..."} envelope (player not found, ...)
+// is returned as a bus.RPCReplyError so a module can chat the message back;
+// any other failure (timeout, no responder) is an infrastructure error.
+func (g *GatewayRPC) Call(ctx context.Context, provider, endpoint string, req gatewayrpc.Request, out any) error {
+	subject := gatewayrpc.Subject(g.prefix, provider, endpoint)
+
+	ctx, cancel := context.WithTimeout(ctx, gatewayRPCTimeout)
+	defer cancel()
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("rpc %s marshal request: %w", subject, err)
+	}
+	msg, err := g.nc.RequestWithContext(ctx, subject, body)
+	if err != nil {
+		return fmt.Errorf("rpc %s request: %w", subject, err)
+	}
+
+	var envelope struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(msg.Data, &envelope); err == nil && envelope.Error != "" {
+		return bus.RPCReplyError{Subject: subject, Message: envelope.Error}
+	}
+	if err := json.Unmarshal(msg.Data, out); err != nil {
+		return fmt.Errorf("rpc %s unmarshal reply: %w", subject, err)
+	}
+	return nil
+}

--- a/app/sesame/internal/config/config.go
+++ b/app/sesame/internal/config/config.go
@@ -83,6 +83,11 @@ type Config struct {
 	// manage custom commands from chat (the !cmd module).
 	CommandsDashboardPrefix string
 
+	// GatewayRPCPrefix is the NATS subject prefix the gateway service (external
+	// API proxy + cache) subscribes to; the urchin/mcsr modules append
+	// ".<provider>.<endpoint>".
+	GatewayRPCPrefix string
+
 	// Valkey holds the settings projection (user tier + modules) sesame reads on
 	// the hot path.
 	ValkeyAddr     string
@@ -128,6 +133,8 @@ func Load() *Config {
 		CacheInvalidationPrefix: env.Get("NATS_CACHE_INVALIDATION_PREFIX", "bagel.cache.invalidate"),
 
 		CommandsDashboardPrefix: env.Get("NATS_COMMANDS_DASHBOARD_PREFIX", "bagel.rpc.commands"),
+
+		GatewayRPCPrefix: env.Get("NATS_GATEWAY_SUBJECT_PREFIX", "bagel.rpc.gateway"),
 
 		ValkeyAddr:     env.Get("VALKEY_ADDR", "127.0.0.1:6379"),
 		ValkeyPassword: env.Get("VALKEY_PASSWORD", ""),

--- a/app/sesame/main.go
+++ b/app/sesame/main.go
@@ -84,6 +84,7 @@ func main() {
 		Special:  engine.NewSpecialSet(cfg.SpecialUserIDs),
 		Pub:      pub,
 		Commands: engine.NewCommandsRPC(nc, cfg.CommandsDashboardPrefix),
+		Gateway:  engine.NewGatewayRPC(nc, cfg.GatewayRPCPrefix),
 		Log:      log,
 	}
 	registry := engine.NewRegistry(log, modules.All(deps)...)

--- a/app/sesame/modules/all.go
+++ b/app/sesame/modules/all.go
@@ -17,5 +17,7 @@ func All(d engine.Deps) []module.Module {
 		Shoutout(d),
 		Alerts(d),
 		Clip(d),
+		Urchin(d),
+		Mcsr(d),
 	}
 }

--- a/app/sesame/modules/external.go
+++ b/app/sesame/modules/external.go
@@ -1,0 +1,87 @@
+package modules
+
+import (
+	"errors"
+	"strconv"
+	"strings"
+
+	"ItsBagelBot/app/sesame/module"
+	"ItsBagelBot/internal/domain/outgress"
+	"ItsBagelBot/pkg/bus"
+)
+
+// Shared helpers for the external-stats modules (urchin, mcsr): both resolve a
+// linked account the same way, chat upstream reply errors the same way, and
+// format the same kinds of numbers.
+
+// resolveAccount picks the account a stats command targets, in priority order:
+// an explicit argument typed after the command (first word, '@' stripped), the
+// module's configured linked account, then the broadcaster's own Twitch login
+// (the "default linked account per user" — most streamers use the same handle).
+func resolveAccount(args, linked, broadcasterLogin string) string {
+	if first, _, _ := strings.Cut(strings.TrimSpace(args), " "); first != "" {
+		return strings.TrimPrefix(first, "@")
+	}
+	if linked = strings.TrimSpace(linked); linked != "" {
+		return linked
+	}
+	return broadcasterLogin
+}
+
+// chatReplyError turns a gateway reply-level failure (player not found, rate
+// limited) into a chat line so the viewer gets an answer instead of silence.
+// It reports whether the error was handled; an infrastructure error (timeout,
+// no responder) returns false and should be propagated for logging.
+func chatReplyError(c *module.Context, emit module.Emit, account string, err error) bool {
+	var re bus.RPCReplyError
+	if !errors.As(err, &re) {
+		return false
+	}
+	emit(&module.Output{
+		Type:          outgress.TypeChat,
+		BroadcasterID: c.Env.BroadcasterUserID,
+		Text:          account + ": " + re.Message,
+	})
+	return true
+}
+
+// ratio renders kills/deaths style ratios with two decimals; a zero
+// denominator counts as one so a flawless run shows the raw numerator.
+func ratio(num, den int64) string {
+	if den == 0 {
+		den = 1
+	}
+	return strconv.FormatFloat(float64(num)/float64(den), 'f', 2, 64)
+}
+
+// signed renders a delta with an explicit sign so "gained 12" and "lost 12"
+// never read the same ("+12", "-12", "±0").
+func signed(n int) string {
+	switch {
+	case n > 0:
+		return "+" + strconv.Itoa(n)
+	case n < 0:
+		return strconv.Itoa(n)
+	default:
+		return "±0"
+	}
+}
+
+// orDefault returns tmpl unless it is blank, then def.
+func orDefault(tmpl, def string) string {
+	if strings.TrimSpace(tmpl) == "" {
+		return def
+	}
+	return tmpl
+}
+
+// i64 renders an int64 for template tokens.
+func i64(n int64) string { return strconv.FormatInt(n, 10) }
+
+// trimScore renders a float score without trailing zero noise (7.50 -> 7.5,
+// 3.00 -> 3).
+func trimScore(f float64) string {
+	s := strconv.FormatFloat(f, 'f', 2, 64)
+	s = strings.TrimRight(s, "0")
+	return strings.TrimSuffix(s, ".")
+}

--- a/app/sesame/modules/mcsr.go
+++ b/app/sesame/modules/mcsr.go
@@ -1,0 +1,211 @@
+package modules
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"ItsBagelBot/app/sesame/engine"
+	"ItsBagelBot/app/sesame/module"
+	gatewayrpc "ItsBagelBot/internal/domain/rpc/gateway"
+	"ItsBagelBot/internal/domain/outgress"
+
+	"go.uber.org/zap"
+)
+
+// mcsrModuleName is the ModuleView key; the console MODULE_CATALOG entry and
+// the dashboard module page use the same id.
+const mcsrModuleName = "mcsr"
+
+// mcsrCooldown is the shared per-command window; the gateway caches upstream
+// replies (the MCSR API allows 500 requests / 10 min fleet-wide), so this only
+// shields chat from spam.
+const mcsrCooldown = 10 * time.Second
+
+// mcsrSnapshotTimeout bounds the fire-and-forget stream-start snapshot call.
+const mcsrSnapshotTimeout = 10 * time.Second
+
+const (
+	defaultMcsrEloTemplate     = "🏆 {player}: {elo} elo · rank #{rank} · {wins}W {losses}L this season"
+	defaultMcsrSessionTemplate = "📈 {player} this stream: {elochange} elo ({elo} now) · {wins}W {losses}L in {matches} matches"
+)
+
+// mcsrConfig is the module's dashboard configuration. Account is the linked
+// default MCSR Ranked account (blank = the broadcaster's own Twitch login).
+// Toggle/message semantics match the urchin module.
+type mcsrConfig struct {
+	Account string `json:"account"`
+
+	EloEnabled     string `json:"eloEnabled"`
+	EloMessage     string `json:"eloMessage"`
+	SessionEnabled string `json:"sessionEnabled"`
+	SessionMessage string `json:"sessionMessage"`
+}
+
+// Mcsr owns the MCSR Ranked commands backed by the gateway service. It is a
+// named, opt-in module (KindOptIn): off by default, enabled on the dashboard
+// with a linked account.
+//
+// Commands: !elo (current rating + season record), !session (elo and record
+// since the stream started). The session baseline is snapshotted when
+// stream.online arrives — the gateway stores the player's standing keyed by
+// this channel — so "this stream" is exactly the live session's duration.
+func Mcsr(d engine.Deps) module.Module {
+	log := d.Log
+	if log == nil {
+		log = zap.NewNop()
+	}
+
+	m := module.NewModule(mcsrModuleName, module.KindOptIn)
+	m.Command("elo").Everyone().Cooldown(mcsrCooldown).Aliases("mcsr", "ranked").
+		Run(mcsrEloRun(d))
+	m.Command("session").Everyone().Cooldown(mcsrCooldown).Aliases("mcsrsession").
+		Run(mcsrSessionRun(d))
+
+	// Snapshot the linked account's standing the moment the stream goes online.
+	// The pipeline only runs this when the module is enabled, and it wires the
+	// module config in, so the snapshot targets the linked account. Fire and
+	// forget on a Background-derived context (the consumer's ctx is acked and
+	// may cancel the moment the handler returns), mirroring the live module's
+	// write discipline.
+	m.On("stream.online", func(_ context.Context, c *module.Context, _ module.Emit) error {
+		if d.Gateway == nil {
+			return nil
+		}
+		var cfg mcsrConfig
+		_ = c.Decode(&cfg)
+		account := resolveAccount("", cfg.Account, c.Env.BroadcasterUserLogin)
+		channelID := strconv.FormatUint(c.BroadcasterID, 10)
+		go func() {
+			wctx, cancel := context.WithTimeout(context.Background(), mcsrSnapshotTimeout)
+			defer cancel()
+			var reply gatewayrpc.McsrSnapshotReply
+			if err := d.Gateway.Call(wctx, "mcsr", "session_start", gatewayrpc.Request{Account: account, ChannelID: channelID}, &reply); err != nil {
+				log.Warn("mcsr: stream-start snapshot failed",
+					zap.String("channel_id", channelID), zap.String("account", account), zap.Error(err))
+				return
+			}
+			log.Debug("mcsr: stream-start snapshot stored",
+				zap.String("channel_id", channelID), zap.String("account", account), zap.Int("elo", reply.Elo))
+		}()
+		return nil
+	})
+
+	return m.Build()
+}
+
+// mcsrEloRun answers !elo with the player's current standing. Template tokens:
+// {player} {elo} {rank} {wins} {losses} {matches} {country}.
+func mcsrEloRun(d engine.Deps) module.RunFunc {
+	return func(ctx context.Context, c *module.Context, args string, emit module.Emit) error {
+		var cfg mcsrConfig
+		_ = c.Decode(&cfg)
+		if !alertOn(cfg.EloEnabled) || d.Gateway == nil {
+			return nil
+		}
+
+		account := resolveAccount(args, cfg.Account, c.Env.BroadcasterUserLogin)
+		var reply gatewayrpc.McsrUserReply
+		if err := d.Gateway.Call(ctx, "mcsr", "user", gatewayrpc.Request{Account: account}, &reply); err != nil {
+			if chatReplyError(c, emit, account, err) {
+				return nil
+			}
+			return err
+		}
+
+		tmpl := orDefault(cfg.EloMessage, defaultMcsrEloTemplate)
+		msg := module.ExpandString(tmpl, func(key string) (string, bool) {
+			switch key {
+			case "player":
+				return reply.Nickname, true
+			case "elo":
+				return mcsrElo(reply.Elo), true
+			case "rank":
+				return mcsrRank(reply.Rank), true
+			case "wins":
+				return strconv.Itoa(reply.Wins), true
+			case "losses":
+				return strconv.Itoa(reply.Loses), true
+			case "matches":
+				return strconv.Itoa(reply.Played), true
+			case "country":
+				return reply.Country, true
+			default:
+				return module.ParseDynamic(key)
+			}
+		})
+		emit(&module.Output{Type: outgress.TypeChat, BroadcasterID: c.Env.BroadcasterUserID, Text: msg})
+		return nil
+	}
+}
+
+// mcsrSessionRun answers !session with the delta since the stream-start
+// snapshot. Template tokens: {player} {elo} {elochange} {wins} {losses}
+// {matches}. Without a baseline (module enabled mid-stream) the gateway starts
+// tracking now and the reply says so instead of faking a zero delta.
+func mcsrSessionRun(d engine.Deps) module.RunFunc {
+	return func(ctx context.Context, c *module.Context, args string, emit module.Emit) error {
+		var cfg mcsrConfig
+		_ = c.Decode(&cfg)
+		if !alertOn(cfg.SessionEnabled) || d.Gateway == nil {
+			return nil
+		}
+
+		account := resolveAccount(args, cfg.Account, c.Env.BroadcasterUserLogin)
+		req := gatewayrpc.Request{Account: account, ChannelID: strconv.FormatUint(c.BroadcasterID, 10)}
+		var reply gatewayrpc.McsrSessionReply
+		if err := d.Gateway.Call(ctx, "mcsr", "session", req, &reply); err != nil {
+			if chatReplyError(c, emit, account, err) {
+				return nil
+			}
+			return err
+		}
+
+		if !reply.HasSnapshot {
+			emit(&module.Output{
+				Type:          outgress.TypeChat,
+				BroadcasterID: c.Env.BroadcasterUserID,
+				Text:          "📈 " + reply.Nickname + ": session tracking just started (" + mcsrElo(reply.Elo) + " elo) — ask again after a match!",
+			})
+			return nil
+		}
+
+		tmpl := orDefault(cfg.SessionMessage, defaultMcsrSessionTemplate)
+		msg := module.ExpandString(tmpl, func(key string) (string, bool) {
+			switch key {
+			case "player":
+				return reply.Nickname, true
+			case "elo":
+				return mcsrElo(reply.Elo), true
+			case "elochange":
+				return signed(reply.EloChange), true
+			case "wins":
+				return strconv.Itoa(reply.Wins), true
+			case "losses":
+				return strconv.Itoa(reply.Loses), true
+			case "matches":
+				return strconv.Itoa(reply.Played), true
+			default:
+				return module.ParseDynamic(key)
+			}
+		})
+		emit(&module.Output{Type: outgress.TypeChat, BroadcasterID: c.Env.BroadcasterUserID, Text: msg})
+		return nil
+	}
+}
+
+// mcsrElo renders an elo value, naming the unrated sentinel.
+func mcsrElo(elo int) string {
+	if elo < 0 {
+		return "unrated"
+	}
+	return strconv.Itoa(elo)
+}
+
+// mcsrRank renders a leaderboard rank, dashing the unranked sentinel.
+func mcsrRank(rank int) string {
+	if rank < 0 {
+		return "—"
+	}
+	return strconv.Itoa(rank)
+}

--- a/app/sesame/modules/mcsr.go
+++ b/app/sesame/modules/mcsr.go
@@ -26,8 +26,8 @@ const mcsrCooldown = 10 * time.Second
 const mcsrSnapshotTimeout = 10 * time.Second
 
 const (
-	defaultMcsrEloTemplate     = "🏆 {player}: {elo} elo · rank #{rank} · {wins}W {losses}L this season"
-	defaultMcsrSessionTemplate = "📈 {player} this stream: {elochange} elo ({elo} now) · {wins}W {losses}L in {matches} matches"
+	defaultMcsrEloTemplate     = "{player}: {elo} elo · rank #{rank} · {wins}W {losses}L this season"
+	defaultMcsrSessionTemplate = "{player} this stream: {elochange} elo ({elo} now) · {wins}W {losses}L in {matches} matches"
 )
 
 // mcsrConfig is the module's dashboard configuration. Account is the linked
@@ -144,14 +144,18 @@ func mcsrEloRun(d engine.Deps) module.RunFunc {
 // {matches}. Without a baseline (module enabled mid-stream) the gateway starts
 // tracking now and the reply says so instead of faking a zero delta.
 func mcsrSessionRun(d engine.Deps) module.RunFunc {
-	return func(ctx context.Context, c *module.Context, args string, emit module.Emit) error {
+	return func(ctx context.Context, c *module.Context, _ string, emit module.Emit) error {
 		var cfg mcsrConfig
 		_ = c.Decode(&cfg)
 		if !alertOn(cfg.SessionEnabled) || d.Gateway == nil {
 			return nil
 		}
 
-		account := resolveAccount(args, cfg.Account, c.Env.BroadcasterUserLogin)
+		// !session is always the linked account, never a typed argument: the
+		// baseline snapshot is stored per channel and keyed to the linked
+		// account, so honoring an arbitrary player would clobber the streamer's
+		// stream-start baseline. Per-player lookups go through !elo instead.
+		account := resolveAccount("", cfg.Account, c.Env.BroadcasterUserLogin)
 		req := gatewayrpc.Request{Account: account, ChannelID: strconv.FormatUint(c.BroadcasterID, 10)}
 		var reply gatewayrpc.McsrSessionReply
 		if err := d.Gateway.Call(ctx, "mcsr", "session", req, &reply); err != nil {
@@ -165,7 +169,7 @@ func mcsrSessionRun(d engine.Deps) module.RunFunc {
 			emit(&module.Output{
 				Type:          outgress.TypeChat,
 				BroadcasterID: c.Env.BroadcasterUserID,
-				Text:          "📈 " + reply.Nickname + ": session tracking just started (" + mcsrElo(reply.Elo) + " elo) — ask again after a match!",
+				Text:          reply.Nickname + ": session tracking just started (" + mcsrElo(reply.Elo) + " elo), ask again after a match!",
 			})
 			return nil
 		}

--- a/app/sesame/modules/mcsr_test.go
+++ b/app/sesame/modules/mcsr_test.go
@@ -36,7 +36,7 @@ func TestMcsrEloDefaultTemplate(t *testing.T) {
 	var col collector
 	require.NoError(t, cmd.Run(context.Background(), mcsrCtx(""), "", col.emit))
 	require.Len(t, col.out, 1)
-	assert.Equal(t, "🏆 Feinberg: 1650 elo · rank #12 · 40W 20L this season", col.out[0].Text)
+	assert.Equal(t, "Feinberg: 1650 elo · rank #12 · 40W 20L this season", col.out[0].Text)
 }
 
 func TestMcsrEloUnrated(t *testing.T) {
@@ -63,10 +63,24 @@ func TestMcsrSessionWithSnapshot(t *testing.T) {
 	var col collector
 	require.NoError(t, cmd.Run(context.Background(), mcsrCtx(`{"account":"Feinberg"}`), "", col.emit))
 	require.Len(t, col.out, 1)
-	assert.Equal(t, "📈 Feinberg this stream: +24 elo (1660 now) · 3W 1L in 4 matches", col.out[0].Text)
+	assert.Equal(t, "Feinberg this stream: +24 elo (1660 now) · 3W 1L in 4 matches", col.out[0].Text)
 
 	// The session request is scoped to this channel.
 	assert.Equal(t, "2", gw.lastCall(t).req.ChannelID)
+	assert.Equal(t, "Feinberg", gw.lastCall(t).req.Account)
+}
+
+// !session ignores a typed player argument so a viewer cannot retarget (and
+// clobber) the streamer's per-channel baseline; it always uses the linked
+// account.
+func TestMcsrSessionIgnoresArgument(t *testing.T) {
+	gw := &fakeGateway{replies: map[string]any{
+		"mcsr.session": gatewayrpc.McsrSessionReply{Nickname: "Feinberg", HasSnapshot: true},
+	}}
+	cmd := findCmd(t, mcsrModule(gw), "session")
+
+	var col collector
+	require.NoError(t, cmd.Run(context.Background(), mcsrCtx(`{"account":"Feinberg"}`), "SomeoneElse", col.emit))
 	assert.Equal(t, "Feinberg", gw.lastCall(t).req.Account)
 }
 

--- a/app/sesame/modules/mcsr_test.go
+++ b/app/sesame/modules/mcsr_test.go
@@ -1,0 +1,130 @@
+package modules
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"ItsBagelBot/app/sesame/engine"
+	"ItsBagelBot/app/sesame/module"
+	"ItsBagelBot/internal/domain/event/lane"
+	gatewayrpc "ItsBagelBot/internal/domain/rpc/gateway"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func mcsrModule(gw engine.GatewayCaller) module.Module {
+	return Mcsr(engine.Deps{Gateway: gw, Log: zap.NewNop()})
+}
+
+func mcsrCtx(config string) *module.Context {
+	c := urchinCtx(config) // same envelope shape
+	return c
+}
+
+func TestMcsrEloDefaultTemplate(t *testing.T) {
+	gw := &fakeGateway{replies: map[string]any{
+		"mcsr.user": gatewayrpc.McsrUserReply{Nickname: "Feinberg", Elo: 1650, Rank: 12, Wins: 40, Loses: 20},
+	}}
+	m := mcsrModule(gw)
+	assert.Equal(t, "mcsr", m.Name)
+	assert.Equal(t, module.KindOptIn, m.Kind)
+	cmd := findCmd(t, m, "elo")
+
+	var col collector
+	require.NoError(t, cmd.Run(context.Background(), mcsrCtx(""), "", col.emit))
+	require.Len(t, col.out, 1)
+	assert.Equal(t, "🏆 Feinberg: 1650 elo · rank #12 · 40W 20L this season", col.out[0].Text)
+}
+
+func TestMcsrEloUnrated(t *testing.T) {
+	gw := &fakeGateway{replies: map[string]any{
+		"mcsr.user": gatewayrpc.McsrUserReply{Nickname: "Newbie", Elo: -1, Rank: -1},
+	}}
+	cmd := findCmd(t, mcsrModule(gw), "elo")
+
+	var col collector
+	require.NoError(t, cmd.Run(context.Background(), mcsrCtx(""), "", col.emit))
+	require.Len(t, col.out, 1)
+	assert.Contains(t, col.out[0].Text, "unrated elo")
+	assert.Contains(t, col.out[0].Text, "#—")
+}
+
+func TestMcsrSessionWithSnapshot(t *testing.T) {
+	gw := &fakeGateway{replies: map[string]any{
+		"mcsr.session": gatewayrpc.McsrSessionReply{
+			Nickname: "Feinberg", Elo: 1660, EloChange: 24, Wins: 3, Loses: 1, Played: 4, HasSnapshot: true,
+		},
+	}}
+	cmd := findCmd(t, mcsrModule(gw), "session")
+
+	var col collector
+	require.NoError(t, cmd.Run(context.Background(), mcsrCtx(`{"account":"Feinberg"}`), "", col.emit))
+	require.Len(t, col.out, 1)
+	assert.Equal(t, "📈 Feinberg this stream: +24 elo (1660 now) · 3W 1L in 4 matches", col.out[0].Text)
+
+	// The session request is scoped to this channel.
+	assert.Equal(t, "2", gw.lastCall(t).req.ChannelID)
+	assert.Equal(t, "Feinberg", gw.lastCall(t).req.Account)
+}
+
+func TestMcsrSessionWithoutSnapshot(t *testing.T) {
+	gw := &fakeGateway{replies: map[string]any{
+		"mcsr.session": gatewayrpc.McsrSessionReply{Nickname: "Feinberg", Elo: 1650, HasSnapshot: false},
+	}}
+	cmd := findCmd(t, mcsrModule(gw), "session")
+
+	var col collector
+	require.NoError(t, cmd.Run(context.Background(), mcsrCtx(""), "", col.emit))
+	require.Len(t, col.out, 1)
+	assert.Contains(t, col.out[0].Text, "session tracking just started")
+}
+
+func TestMcsrSessionToggleOff(t *testing.T) {
+	gw := &fakeGateway{replies: map[string]any{"mcsr.session": gatewayrpc.McsrSessionReply{}}}
+	cmd := findCmd(t, mcsrModule(gw), "session")
+
+	var col collector
+	require.NoError(t, cmd.Run(context.Background(), mcsrCtx(`{"sessionEnabled":"off"}`), "", col.emit))
+	assert.Empty(t, col.out)
+	assert.Empty(t, gw.calls)
+}
+
+func TestMcsrStreamOnlineSnapshots(t *testing.T) {
+	done := make(chan struct{})
+	gw := &fakeGateway{
+		replies: map[string]any{"mcsr.session_start": gatewayrpc.McsrSnapshotReply{Nickname: "Feinberg", Elo: 1650}},
+		done:    done,
+	}
+	m := mcsrModule(gw)
+	h := m.Events["stream.online"]
+	require.NotNil(t, h, "mcsr must handle stream.online")
+
+	c := &module.Context{
+		Env: lane.Envelope{
+			Type:                 "stream.online",
+			BroadcasterUserID:    "2",
+			BroadcasterUserLogin: "streamer",
+		},
+		BroadcasterID: 2,
+		Log:           zap.NewNop(),
+		Config:        []byte(`{"account":"Feinberg"}`),
+	}
+	var col collector
+	require.NoError(t, h(context.Background(), c, col.emit))
+	assert.Empty(t, col.out, "snapshot handler must not chat")
+
+	// The snapshot call is fire-and-forget on its own goroutine.
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("stream.online never called the gateway")
+	}
+	call := gw.lastCall(t)
+	assert.Equal(t, "mcsr", call.provider)
+	assert.Equal(t, "session_start", call.endpoint)
+	assert.Equal(t, "Feinberg", call.req.Account)
+	assert.Equal(t, "2", call.req.ChannelID)
+}

--- a/app/sesame/modules/urchin.go
+++ b/app/sesame/modules/urchin.go
@@ -1,0 +1,301 @@
+package modules
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"ItsBagelBot/app/sesame/engine"
+	"ItsBagelBot/app/sesame/module"
+	gatewayrpc "ItsBagelBot/internal/domain/rpc/gateway"
+	"ItsBagelBot/internal/domain/outgress"
+
+	"go.uber.org/zap"
+)
+
+// urchinModuleName is the ModuleView key; the console MODULE_CATALOG entry and
+// the dashboard module page use the same id.
+const urchinModuleName = "urchin"
+
+// urchinCooldown is the shared per-command window; the gateway caches upstream
+// replies, so this only shields chat from command spam, not the API.
+const urchinCooldown = 10 * time.Second
+
+// Default reply templates. The broadcaster customizes them per command on the
+// module page; blank falls back to these.
+const (
+	defaultUrchinDailyTemplate   = "🛏 {player} today: {wins}W {losses}L · {finals} finals · {beds} beds · {fkdr} FKDR"
+	defaultUrchinWeeklyTemplate  = "🛏 {player} this week: {wins}W {losses}L · {finals} finals · {beds} beds · {fkdr} FKDR"
+	defaultUrchinMonthlyTemplate = "🛏 {player} this month: {wins}W {losses}L · {finals} finals · {beds} beds · {fkdr} FKDR"
+	defaultUrchinStatsTemplate   = "🛏 {player}: {stars}✫ · {wins} wins · {finals} finals · {fkdr} FKDR · {beds} beds broken"
+	defaultUrchinSniperTemplate  = "🎯 {player} urchin score: {score}"
+	defaultUrchinTagsTemplate    = "🏷️ {player}: {tags}"
+)
+
+// urchinConfig is the module's dashboard configuration. Account is the linked
+// default account (blank = the broadcaster's own Twitch login). Each *Enabled
+// is a per-command toggle stored "on"/"off" — empty means on, matching the
+// alerts module's semantics — and each *Message is a customized template
+// (blank = default).
+type urchinConfig struct {
+	Account string `json:"account"`
+
+	DailyEnabled   string `json:"dailyEnabled"`
+	DailyMessage   string `json:"dailyMessage"`
+	WeeklyEnabled  string `json:"weeklyEnabled"`
+	WeeklyMessage  string `json:"weeklyMessage"`
+	MonthlyEnabled string `json:"monthlyEnabled"`
+	MonthlyMessage string `json:"monthlyMessage"`
+	StatsEnabled   string `json:"statsEnabled"`
+	StatsMessage   string `json:"statsMessage"`
+	SniperEnabled  string `json:"sniperEnabled"`
+	SniperMessage  string `json:"sniperMessage"`
+	TagsEnabled    string `json:"tagsEnabled"`
+	TagsMessage    string `json:"tagsMessage"`
+}
+
+// Urchin owns the Hypixel Bed Wars stats commands backed by the urchin.gg
+// Coral API through the gateway service. It is a named, opt-in module
+// (KindOptIn): off by default, enabled on the dashboard, where the broadcaster
+// links a default Minecraft account and can toggle or re-template each
+// command. Viewers can always target another player explicitly: "!daily
+// somePlayer".
+//
+// Commands: !daily / !weekly / !monthly (Bed Wars session deltas), !bwstats
+// (lifetime stats), !sniper (Urchin/Cubelify overlay score), !tags (active
+// blacklist tags).
+func Urchin(d engine.Deps) module.Module {
+	log := d.Log
+	if log == nil {
+		log = zap.NewNop()
+	}
+
+	m := module.NewModule(urchinModuleName, module.KindOptIn)
+	m.Command("daily").Everyone().Cooldown(urchinCooldown).Aliases("bwdaily").
+		Run(urchinSessionRun(d, "daily"))
+	m.Command("weekly").Everyone().Cooldown(urchinCooldown).Aliases("bwweekly").
+		Run(urchinSessionRun(d, "weekly"))
+	m.Command("monthly").Everyone().Cooldown(urchinCooldown).Aliases("bwmonthly").
+		Run(urchinSessionRun(d, "monthly"))
+	m.Command("bwstats").Everyone().Cooldown(urchinCooldown).Aliases("bedwars").
+		Run(urchinStatsRun(d))
+	m.Command("sniper").Everyone().Cooldown(urchinCooldown).Aliases("urchin").
+		Run(urchinSniperRun(d))
+	m.Command("tags").Everyone().Cooldown(urchinCooldown).Aliases("bwtags").
+		Run(urchinTagsRun(d))
+	return m.Build()
+}
+
+// urchinToggle returns one command's (enabled, template, default) triple from
+// the decoded config.
+func urchinToggle(cfg urchinConfig, endpoint string) (enabled bool, tmpl string) {
+	switch endpoint {
+	case "daily":
+		return alertOn(cfg.DailyEnabled), orDefault(cfg.DailyMessage, defaultUrchinDailyTemplate)
+	case "weekly":
+		return alertOn(cfg.WeeklyEnabled), orDefault(cfg.WeeklyMessage, defaultUrchinWeeklyTemplate)
+	case "monthly":
+		return alertOn(cfg.MonthlyEnabled), orDefault(cfg.MonthlyMessage, defaultUrchinMonthlyTemplate)
+	case "stats":
+		return alertOn(cfg.StatsEnabled), orDefault(cfg.StatsMessage, defaultUrchinStatsTemplate)
+	case "sniper":
+		return alertOn(cfg.SniperEnabled), orDefault(cfg.SniperMessage, defaultUrchinSniperTemplate)
+	case "tags":
+		return alertOn(cfg.TagsEnabled), orDefault(cfg.TagsMessage, defaultUrchinTagsTemplate)
+	default:
+		return false, ""
+	}
+}
+
+// urchinSessionRun answers !daily / !weekly / !monthly with the period's Bed
+// Wars delta. Template tokens: {player} {wins} {losses} {finals} {finaldeaths}
+// {beds} {games} {levels} {fkdr}.
+func urchinSessionRun(d engine.Deps, endpoint string) module.RunFunc {
+	return func(ctx context.Context, c *module.Context, args string, emit module.Emit) error {
+		var cfg urchinConfig
+		_ = c.Decode(&cfg)
+		enabled, tmpl := urchinToggle(cfg, endpoint)
+		if !enabled || d.Gateway == nil {
+			return nil
+		}
+
+		account := resolveAccount(args, cfg.Account, c.Env.BroadcasterUserLogin)
+		var reply gatewayrpc.UrchinSessionReply
+		if err := d.Gateway.Call(ctx, "urchin", endpoint, gatewayrpc.Request{Account: account}, &reply); err != nil {
+			if chatReplyError(c, emit, account, err) {
+				return nil
+			}
+			return err
+		}
+
+		msg := module.ExpandString(tmpl, func(key string) (string, bool) {
+			switch key {
+			case "player":
+				return reply.Player, true
+			case "wins":
+				return i64(reply.Wins), true
+			case "losses":
+				return i64(reply.Losses), true
+			case "finals":
+				return i64(reply.FinalKills), true
+			case "finaldeaths":
+				return i64(reply.FinalDeaths), true
+			case "beds":
+				return i64(reply.BedsBroken), true
+			case "games":
+				return i64(reply.GamesPlayed), true
+			case "levels":
+				return i64(reply.Levels), true
+			case "fkdr":
+				return ratio(reply.FinalKills, reply.FinalDeaths), true
+			default:
+				return module.ParseDynamic(key)
+			}
+		})
+		emit(&module.Output{Type: outgress.TypeChat, BroadcasterID: c.Env.BroadcasterUserID, Text: msg})
+		return nil
+	}
+}
+
+// urchinStatsRun answers !bwstats with lifetime Bed Wars stats. Template
+// tokens: {player} {stars} {wins} {losses} {finals} {finaldeaths} {beds}
+// {fkdr} {wlr}.
+func urchinStatsRun(d engine.Deps) module.RunFunc {
+	return func(ctx context.Context, c *module.Context, args string, emit module.Emit) error {
+		var cfg urchinConfig
+		_ = c.Decode(&cfg)
+		enabled, tmpl := urchinToggle(cfg, "stats")
+		if !enabled || d.Gateway == nil {
+			return nil
+		}
+
+		account := resolveAccount(args, cfg.Account, c.Env.BroadcasterUserLogin)
+		var reply gatewayrpc.UrchinStatsReply
+		if err := d.Gateway.Call(ctx, "urchin", "stats", gatewayrpc.Request{Account: account}, &reply); err != nil {
+			if chatReplyError(c, emit, account, err) {
+				return nil
+			}
+			return err
+		}
+
+		msg := module.ExpandString(tmpl, func(key string) (string, bool) {
+			switch key {
+			case "player":
+				return reply.Player, true
+			case "stars":
+				return i64(reply.Stars), true
+			case "wins":
+				return i64(reply.Wins), true
+			case "losses":
+				return i64(reply.Losses), true
+			case "finals":
+				return i64(reply.FinalKills), true
+			case "finaldeaths":
+				return i64(reply.FinalDeaths), true
+			case "beds":
+				return i64(reply.BedsBroken), true
+			case "fkdr":
+				return ratio(reply.FinalKills, reply.FinalDeaths), true
+			case "wlr":
+				return ratio(reply.Wins, reply.Losses), true
+			default:
+				return module.ParseDynamic(key)
+			}
+		})
+		emit(&module.Output{Type: outgress.TypeChat, BroadcasterID: c.Env.BroadcasterUserID, Text: msg})
+		return nil
+	}
+}
+
+// urchinSniperRun answers !sniper with the Urchin (Cubelify overlay) score.
+// Template tokens: {player} {score} {mode} {tagcount}.
+func urchinSniperRun(d engine.Deps) module.RunFunc {
+	return func(ctx context.Context, c *module.Context, args string, emit module.Emit) error {
+		var cfg urchinConfig
+		_ = c.Decode(&cfg)
+		enabled, tmpl := urchinToggle(cfg, "sniper")
+		if !enabled || d.Gateway == nil {
+			return nil
+		}
+
+		account := resolveAccount(args, cfg.Account, c.Env.BroadcasterUserLogin)
+		var reply gatewayrpc.UrchinSniperReply
+		if err := d.Gateway.Call(ctx, "urchin", "sniper", gatewayrpc.Request{Account: account}, &reply); err != nil {
+			if chatReplyError(c, emit, account, err) {
+				return nil
+			}
+			return err
+		}
+
+		msg := module.ExpandString(tmpl, func(key string) (string, bool) {
+			switch key {
+			case "player":
+				return reply.Player, true
+			case "score":
+				return trimScore(reply.Score), true
+			case "mode":
+				return reply.Mode, true
+			case "tagcount":
+				return i64(int64(reply.TagCount)), true
+			default:
+				return module.ParseDynamic(key)
+			}
+		})
+		emit(&module.Output{Type: outgress.TypeChat, BroadcasterID: c.Env.BroadcasterUserID, Text: msg})
+		return nil
+	}
+}
+
+// urchinTagsRun answers !tags with the player's active blacklist tags.
+// Template tokens: {player} {tags} {tagcount}.
+func urchinTagsRun(d engine.Deps) module.RunFunc {
+	return func(ctx context.Context, c *module.Context, args string, emit module.Emit) error {
+		var cfg urchinConfig
+		_ = c.Decode(&cfg)
+		enabled, tmpl := urchinToggle(cfg, "tags")
+		if !enabled || d.Gateway == nil {
+			return nil
+		}
+
+		account := resolveAccount(args, cfg.Account, c.Env.BroadcasterUserLogin)
+		var reply gatewayrpc.UrchinTagsReply
+		if err := d.Gateway.Call(ctx, "urchin", "tags", gatewayrpc.Request{Account: account}, &reply); err != nil {
+			if chatReplyError(c, emit, account, err) {
+				return nil
+			}
+			return err
+		}
+
+		msg := module.ExpandString(tmpl, func(key string) (string, bool) {
+			switch key {
+			case "player":
+				return reply.Player, true
+			case "tags":
+				return formatUrchinTags(reply.Tags), true
+			case "tagcount":
+				return i64(int64(len(reply.Tags))), true
+			default:
+				return module.ParseDynamic(key)
+			}
+		})
+		emit(&module.Output{Type: outgress.TypeChat, BroadcasterID: c.Env.BroadcasterUserID, Text: msg})
+		return nil
+	}
+}
+
+// formatUrchinTags renders the tag list for chat: "cheater (bhop), sniper", or
+// "no tags — clean" when the player has none.
+func formatUrchinTags(tags []gatewayrpc.UrchinTag) string {
+	if len(tags) == 0 {
+		return "no tags — clean"
+	}
+	parts := make([]string, 0, len(tags))
+	for _, t := range tags {
+		if t.Reason != "" {
+			parts = append(parts, t.Type+" ("+t.Reason+")")
+		} else {
+			parts = append(parts, t.Type)
+		}
+	}
+	return strings.Join(parts, ", ")
+}

--- a/app/sesame/modules/urchin.go
+++ b/app/sesame/modules/urchin.go
@@ -24,12 +24,12 @@ const urchinCooldown = 10 * time.Second
 // Default reply templates. The broadcaster customizes them per command on the
 // module page; blank falls back to these.
 const (
-	defaultUrchinDailyTemplate   = "🛏 {player} today: {wins}W {losses}L · {finals} finals · {beds} beds · {fkdr} FKDR"
-	defaultUrchinWeeklyTemplate  = "🛏 {player} this week: {wins}W {losses}L · {finals} finals · {beds} beds · {fkdr} FKDR"
-	defaultUrchinMonthlyTemplate = "🛏 {player} this month: {wins}W {losses}L · {finals} finals · {beds} beds · {fkdr} FKDR"
-	defaultUrchinStatsTemplate   = "🛏 {player}: {stars}✫ · {wins} wins · {finals} finals · {fkdr} FKDR · {beds} beds broken"
-	defaultUrchinSniperTemplate  = "🎯 {player} urchin score: {score}"
-	defaultUrchinTagsTemplate    = "🏷️ {player}: {tags}"
+	defaultUrchinDailyTemplate   = "{player} today: {wins}W {losses}L · {finals} finals · {beds} beds · {fkdr} FKDR"
+	defaultUrchinWeeklyTemplate  = "{player} this week: {wins}W {losses}L · {finals} finals · {beds} beds · {fkdr} FKDR"
+	defaultUrchinMonthlyTemplate = "{player} this month: {wins}W {losses}L · {finals} finals · {beds} beds · {fkdr} FKDR"
+	defaultUrchinStatsTemplate   = "{player}: {stars} stars · {wins} wins · {finals} finals · {fkdr} FKDR · {beds} beds broken"
+	defaultUrchinSniperTemplate  = "{player} urchin score: {score}"
+	defaultUrchinTagsTemplate    = "{player}: {tags}"
 )
 
 // urchinConfig is the module's dashboard configuration. Account is the linked

--- a/app/sesame/modules/urchin_test.go
+++ b/app/sesame/modules/urchin_test.go
@@ -105,7 +105,7 @@ func TestUrchinDailyDefaultTemplate(t *testing.T) {
 	require.Len(t, col.out, 1)
 	assert.Equal(t, outgress.TypeChat, col.out[0].Type)
 	assert.Equal(t, "2", col.out[0].BroadcasterID)
-	assert.Equal(t, "🛏 Techno today: 5W 2L · 21 finals · 9 beds · 7.00 FKDR", col.out[0].Text)
+	assert.Equal(t, "Techno today: 5W 2L · 21 finals · 9 beds · 7.00 FKDR", col.out[0].Text)
 
 	// No linked account and no arg: falls back to the broadcaster's login.
 	assert.Equal(t, "streamer", gw.lastCall(t).req.Account)
@@ -179,7 +179,7 @@ func TestUrchinTagsFormatting(t *testing.T) {
 	var col collector
 	require.NoError(t, cmd.Run(context.Background(), urchinCtx(""), "", col.emit))
 	require.Len(t, col.out, 1)
-	assert.Equal(t, "🏷️ Sus: cheater (bhop), sniper", col.out[0].Text)
+	assert.Equal(t, "Sus: cheater (bhop), sniper", col.out[0].Text)
 }
 
 func TestUrchinTagsClean(t *testing.T) {
@@ -191,7 +191,7 @@ func TestUrchinTagsClean(t *testing.T) {
 	var col collector
 	require.NoError(t, cmd.Run(context.Background(), urchinCtx(""), "", col.emit))
 	require.Len(t, col.out, 1)
-	assert.Equal(t, "🏷️ Clean: no tags — clean", col.out[0].Text)
+	assert.Equal(t, "Clean: no tags — clean", col.out[0].Text)
 }
 
 func TestUrchinSniperScore(t *testing.T) {
@@ -203,5 +203,5 @@ func TestUrchinSniperScore(t *testing.T) {
 	var col collector
 	require.NoError(t, cmd.Run(context.Background(), urchinCtx(""), "", col.emit))
 	require.Len(t, col.out, 1)
-	assert.Equal(t, "🎯 Aim urchin score: 7.5", col.out[0].Text)
+	assert.Equal(t, "Aim urchin score: 7.5", col.out[0].Text)
 }

--- a/app/sesame/modules/urchin_test.go
+++ b/app/sesame/modules/urchin_test.go
@@ -1,0 +1,207 @@
+package modules
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+
+	"ItsBagelBot/app/sesame/engine"
+	"ItsBagelBot/app/sesame/module"
+	"ItsBagelBot/internal/domain/event/lane"
+	"ItsBagelBot/internal/domain/outgress"
+	gatewayrpc "ItsBagelBot/internal/domain/rpc/gateway"
+	"ItsBagelBot/pkg/bus"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// fakeGateway records calls and answers each provider.endpoint with a canned
+// reply value (marshaled into the caller's typed out). err short-circuits.
+type fakeGateway struct {
+	mu      sync.Mutex
+	calls   []fakeGatewayCall
+	replies map[string]any
+	err     error
+	done    chan struct{} // closed on first call, for async handlers
+}
+
+type fakeGatewayCall struct {
+	provider, endpoint string
+	req                gatewayrpc.Request
+}
+
+func (f *fakeGateway) Call(_ context.Context, provider, endpoint string, req gatewayrpc.Request, out any) error {
+	f.mu.Lock()
+	f.calls = append(f.calls, fakeGatewayCall{provider, endpoint, req})
+	if f.done != nil {
+		close(f.done)
+		f.done = nil
+	}
+	f.mu.Unlock()
+
+	if f.err != nil {
+		return f.err
+	}
+	reply, ok := f.replies[provider+"."+endpoint]
+	if !ok {
+		return bus.RPCReplyError{Message: "no responder"}
+	}
+	b, err := json.Marshal(reply)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(b, out)
+}
+
+func (f *fakeGateway) lastCall(t *testing.T) fakeGatewayCall {
+	t.Helper()
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	require.NotEmpty(t, f.calls)
+	return f.calls[len(f.calls)-1]
+}
+
+// urchinCtx builds a chat Context for broadcaster "2" (login streamer) with the
+// given module config.
+func urchinCtx(config string) *module.Context {
+	c := &module.Context{
+		Env: lane.Envelope{
+			Type:                 "channel.chat.message",
+			BroadcasterUserID:    "2",
+			BroadcasterUserLogin: "streamer",
+			ChatterUserID:        "9",
+			ChatterUserLogin:     "viewer",
+		},
+		BroadcasterID: 2,
+		Log:           zap.NewNop(),
+	}
+	if config != "" {
+		c.Config = []byte(config)
+	}
+	return c
+}
+
+func urchinCmd(t *testing.T, gw engine.GatewayCaller, name string) module.Command {
+	t.Helper()
+	m := Urchin(engine.Deps{Gateway: gw, Log: zap.NewNop()})
+	assert.Equal(t, "urchin", m.Name)
+	assert.Equal(t, module.KindOptIn, m.Kind)
+	return findCmd(t, m, name)
+}
+
+func TestUrchinDailyDefaultTemplate(t *testing.T) {
+	gw := &fakeGateway{replies: map[string]any{
+		"urchin.daily": gatewayrpc.UrchinSessionReply{
+			Player: "Techno", Wins: 5, Losses: 2, FinalKills: 21, FinalDeaths: 3, BedsBroken: 9,
+		},
+	}}
+	cmd := urchinCmd(t, gw, "daily")
+
+	var col collector
+	require.NoError(t, cmd.Run(context.Background(), urchinCtx(""), "", col.emit))
+	require.Len(t, col.out, 1)
+	assert.Equal(t, outgress.TypeChat, col.out[0].Type)
+	assert.Equal(t, "2", col.out[0].BroadcasterID)
+	assert.Equal(t, "🛏 Techno today: 5W 2L · 21 finals · 9 beds · 7.00 FKDR", col.out[0].Text)
+
+	// No linked account and no arg: falls back to the broadcaster's login.
+	assert.Equal(t, "streamer", gw.lastCall(t).req.Account)
+}
+
+func TestUrchinAccountResolution(t *testing.T) {
+	gw := &fakeGateway{replies: map[string]any{"urchin.weekly": gatewayrpc.UrchinSessionReply{Player: "X"}}}
+	cmd := urchinCmd(t, gw, "weekly")
+
+	var col collector
+	// Linked account from config wins over the broadcaster login.
+	require.NoError(t, cmd.Run(context.Background(), urchinCtx(`{"account":"LinkedAcc"}`), "", col.emit))
+	assert.Equal(t, "LinkedAcc", gw.lastCall(t).req.Account)
+
+	// An explicit argument wins over the linked account.
+	require.NoError(t, cmd.Run(context.Background(), urchinCtx(`{"account":"LinkedAcc"}`), "@SomePlayer extra words", col.emit))
+	assert.Equal(t, "SomePlayer", gw.lastCall(t).req.Account)
+}
+
+func TestUrchinPerCommandToggleOff(t *testing.T) {
+	gw := &fakeGateway{replies: map[string]any{"urchin.monthly": gatewayrpc.UrchinSessionReply{Player: "X"}}}
+	cmd := urchinCmd(t, gw, "monthly")
+
+	var col collector
+	require.NoError(t, cmd.Run(context.Background(), urchinCtx(`{"monthlyEnabled":"off"}`), "", col.emit))
+	assert.Empty(t, col.out)
+	assert.Empty(t, gw.calls)
+}
+
+func TestUrchinCustomTemplate(t *testing.T) {
+	gw := &fakeGateway{replies: map[string]any{
+		"urchin.stats": gatewayrpc.UrchinStatsReply{Player: "Techno", Stars: 402, Wins: 1000, Losses: 100},
+	}}
+	cmd := urchinCmd(t, gw, "bwstats")
+
+	var col collector
+	cfg := `{"statsMessage":"{player} is {stars} stars with {wlr} WLR"}`
+	require.NoError(t, cmd.Run(context.Background(), urchinCtx(cfg), "", col.emit))
+	require.Len(t, col.out, 1)
+	assert.Equal(t, "Techno is 402 stars with 10.00 WLR", col.out[0].Text)
+}
+
+func TestUrchinReplyErrorChatsBack(t *testing.T) {
+	gw := &fakeGateway{err: bus.RPCReplyError{Message: "player not found"}}
+	cmd := urchinCmd(t, gw, "daily")
+
+	var col collector
+	require.NoError(t, cmd.Run(context.Background(), urchinCtx(""), "ghostplayer", col.emit))
+	require.Len(t, col.out, 1)
+	assert.Equal(t, "ghostplayer: player not found", col.out[0].Text)
+}
+
+func TestUrchinInfraErrorPropagates(t *testing.T) {
+	gw := &fakeGateway{err: context.DeadlineExceeded}
+	cmd := urchinCmd(t, gw, "daily")
+
+	var col collector
+	require.Error(t, cmd.Run(context.Background(), urchinCtx(""), "", col.emit))
+	assert.Empty(t, col.out)
+}
+
+func TestUrchinTagsFormatting(t *testing.T) {
+	gw := &fakeGateway{replies: map[string]any{
+		"urchin.tags": gatewayrpc.UrchinTagsReply{
+			Player: "Sus",
+			Tags:   []gatewayrpc.UrchinTag{{Type: "cheater", Reason: "bhop"}, {Type: "sniper"}},
+		},
+	}}
+	cmd := urchinCmd(t, gw, "tags")
+
+	var col collector
+	require.NoError(t, cmd.Run(context.Background(), urchinCtx(""), "", col.emit))
+	require.Len(t, col.out, 1)
+	assert.Equal(t, "🏷️ Sus: cheater (bhop), sniper", col.out[0].Text)
+}
+
+func TestUrchinTagsClean(t *testing.T) {
+	gw := &fakeGateway{replies: map[string]any{
+		"urchin.tags": gatewayrpc.UrchinTagsReply{Player: "Clean", Tags: nil},
+	}}
+	cmd := urchinCmd(t, gw, "tags")
+
+	var col collector
+	require.NoError(t, cmd.Run(context.Background(), urchinCtx(""), "", col.emit))
+	require.Len(t, col.out, 1)
+	assert.Equal(t, "🏷️ Clean: no tags — clean", col.out[0].Text)
+}
+
+func TestUrchinSniperScore(t *testing.T) {
+	gw := &fakeGateway{replies: map[string]any{
+		"urchin.sniper": gatewayrpc.UrchinSniperReply{Player: "Aim", Score: 7.5, Mode: "warn", TagCount: 1},
+	}}
+	cmd := urchinCmd(t, gw, "sniper")
+
+	var col collector
+	require.NoError(t, cmd.Run(context.Background(), urchinCtx(""), "", col.emit))
+	require.Len(t, col.out, 1)
+	assert.Equal(t, "🎯 Aim urchin score: 7.5", col.out[0].Text)
+}

--- a/console/dashboard/src/routes/(app)/modules/[id]/+page.svelte
+++ b/console/dashboard/src/routes/(app)/modules/[id]/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { deserialize } from '$app/forms';
-  import { Icon, Card, PageHead, Scroller, SaveStatus, toast, getI18n, type ModuleReply } from '@bagel/shared';
+  import { Icon, Card, PageHead, Scroller, SaveStatus, toast, getI18n, type ModuleField, type ModuleReply } from '@bagel/shared';
   import type { SaveState } from '@bagel/shared/components/SaveStatus.svelte';
   import ReplyRow from '$lib/components/modules/ReplyRow.svelte';
   import ReplyEditor from '$lib/components/modules/ReplyEditor.svelte';
@@ -80,6 +80,21 @@
       enabled = before;
       flagError('module');
       toast('err', t('modules.couldNotToggle', { label: def.label }));
+    }
+  }
+
+  // --- Plain settings fields (linked account, ...) ----------------------------
+  async function saveSetting(field: ModuleField, value: string) {
+    const key = field.key;
+    const before = config[key] ?? '';
+    if (value.trim() === before.trim()) return;
+    config = { ...config, [key]: value.trim() };
+    setStatus(`setting:${key}`, 'saving');
+    if (await persist(enabled, config)) ackSaved(`setting:${key}`);
+    else {
+      config = { ...config, [key]: before };
+      flagError(`setting:${key}`);
+      toast('err', t('modules.saveFailed'));
     }
   }
 
@@ -167,6 +182,24 @@
         onclick={toggleModule}
       ></button>
     </div>
+    {#each def.settings ?? [] as field (field.key)}
+      <div class="setting-row">
+        <label class="tr-text" for="mod-setting-{field.key}">
+          <span class="tr-label">{field.label}</span>
+          {#if field.help}<span class="tr-help">{field.help}</span>{/if}
+        </label>
+        <SaveStatus state={modStatus[`setting:${field.key}`] ?? 'idle'} />
+        <input
+          id="mod-setting-{field.key}"
+          class="setting-input"
+          type={field.type === 'number' ? 'number' : 'text'}
+          placeholder={field.placeholder ?? ''}
+          value={config[field.key] ?? ''}
+          onchange={(e) => saveSetting(field, e.currentTarget.value)}
+          onkeydown={(e) => { if (e.key === 'Enter') e.currentTarget.blur(); }}
+        />
+      </div>
+    {/each}
   </Card>
 
   <!-- The deck: reply ledger + docked builder inspector (same as commands). -->
@@ -255,6 +288,35 @@
   .tr-text { display: flex; flex-direction: column; gap: 3px; margin-right: auto; }
   .tr-label { font-family: var(--bb-font-display); font-weight: 700; font-size: 14px; color: var(--bb-white); }
   .tr-help { font-family: var(--bb-font-body); font-size: 12px; color: var(--bb-muted); }
+
+  /* Plain settings fields under the master switch (e.g. linked account). */
+  .setting-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 14px 18px;
+    border-top: 1px solid var(--rule);
+  }
+  .setting-input {
+    width: min(260px, 44vw);
+    padding: 8px 12px;
+    border: 1px solid var(--rule);
+    border-radius: 6px;
+    background: rgba(240, 236, 228, 0.04);
+    color: var(--bb-white);
+    font-family: var(--bb-font-body);
+    font-size: 13px;
+    transition: border-color var(--bb-dur-fast, 140ms) ease;
+  }
+  .setting-input:focus {
+    outline: none;
+    border-color: var(--bb-tan, #c9a87c);
+  }
+  .setting-input::placeholder { color: var(--bb-muted); opacity: 0.7; }
+  @media (max-width: 560px) {
+    .setting-row { flex-wrap: wrap; }
+    .setting-input { width: 100%; }
+  }
 
   /* ── the deck: list + docked inspector (identical to the commands deck) ── */
   .deck {

--- a/console/shared/lib/types.ts
+++ b/console/shared/lib/types.ts
@@ -310,7 +310,7 @@ export const MODULE_CATALOG: readonly ModuleDef[] = [
         event: '!daily',
         enableKey: 'dailyEnabled',
         messageKey: 'dailyMessage',
-        defaultMessage: '🛏 {player} today: {wins}W {losses}L · {finals} finals · {beds} beds · {fkdr} FKDR'
+        defaultMessage: '{player} today: {wins}W {losses}L · {finals} finals · {beds} beds · {fkdr} FKDR'
       },
       {
         key: 'weekly',
@@ -319,7 +319,7 @@ export const MODULE_CATALOG: readonly ModuleDef[] = [
         event: '!weekly',
         enableKey: 'weeklyEnabled',
         messageKey: 'weeklyMessage',
-        defaultMessage: '🛏 {player} this week: {wins}W {losses}L · {finals} finals · {beds} beds · {fkdr} FKDR'
+        defaultMessage: '{player} this week: {wins}W {losses}L · {finals} finals · {beds} beds · {fkdr} FKDR'
       },
       {
         key: 'monthly',
@@ -328,7 +328,7 @@ export const MODULE_CATALOG: readonly ModuleDef[] = [
         event: '!monthly',
         enableKey: 'monthlyEnabled',
         messageKey: 'monthlyMessage',
-        defaultMessage: '🛏 {player} this month: {wins}W {losses}L · {finals} finals · {beds} beds · {fkdr} FKDR'
+        defaultMessage: '{player} this month: {wins}W {losses}L · {finals} finals · {beds} beds · {fkdr} FKDR'
       },
       {
         key: 'stats',
@@ -337,7 +337,7 @@ export const MODULE_CATALOG: readonly ModuleDef[] = [
         event: '!bwstats',
         enableKey: 'statsEnabled',
         messageKey: 'statsMessage',
-        defaultMessage: '🛏 {player}: {stars}✫ · {wins} wins · {finals} finals · {fkdr} FKDR · {beds} beds broken'
+        defaultMessage: '{player}: {stars} stars · {wins} wins · {finals} finals · {fkdr} FKDR · {beds} beds broken'
       },
       {
         key: 'sniper',
@@ -346,7 +346,7 @@ export const MODULE_CATALOG: readonly ModuleDef[] = [
         event: '!sniper',
         enableKey: 'sniperEnabled',
         messageKey: 'sniperMessage',
-        defaultMessage: '🎯 {player} urchin score: {score}'
+        defaultMessage: '{player} urchin score: {score}'
       },
       {
         key: 'tags',
@@ -355,7 +355,7 @@ export const MODULE_CATALOG: readonly ModuleDef[] = [
         event: '!tags',
         enableKey: 'tagsEnabled',
         messageKey: 'tagsMessage',
-        defaultMessage: '🏷️ {player}: {tags}'
+        defaultMessage: '{player}: {tags}'
       }
     ],
     settings: [
@@ -373,7 +373,7 @@ export const MODULE_CATALOG: readonly ModuleDef[] = [
     label: 'MCSR Ranked',
     tagline: 'Ranked elo and per-stream session stats for MCSR runners.',
     description:
-      'Viewer commands backed by the MCSR Ranked API: !elo shows the current rating and season record; !session shows elo and wins/losses since the stream started — the bot snapshots your standing the moment you go live. Commands default to your linked Minecraft account; viewers can also name any player.',
+      'Viewer commands backed by the MCSR Ranked API: !elo shows the current rating and season record; !session shows elo and wins/losses since the stream started, snapshotting your standing the moment you go live. !elo can name any player (e.g. "!elo Feinberg"); !session always tracks your linked account.',
     icon: 'clock',
     defaultEnabled: false,
     replies: [
@@ -384,7 +384,7 @@ export const MODULE_CATALOG: readonly ModuleDef[] = [
         event: '!elo',
         enableKey: 'eloEnabled',
         messageKey: 'eloMessage',
-        defaultMessage: '🏆 {player}: {elo} elo · rank #{rank} · {wins}W {losses}L this season'
+        defaultMessage: '{player}: {elo} elo · rank #{rank} · {wins}W {losses}L this season'
       },
       {
         key: 'session',
@@ -393,7 +393,7 @@ export const MODULE_CATALOG: readonly ModuleDef[] = [
         event: '!session',
         enableKey: 'sessionEnabled',
         messageKey: 'sessionMessage',
-        defaultMessage: '📈 {player} this stream: {elochange} elo ({elo} now) · {wins}W {losses}L in {matches} matches'
+        defaultMessage: '{player} this stream: {elochange} elo ({elo} now) · {wins}W {losses}L in {matches} matches'
       }
     ],
     settings: [

--- a/console/shared/lib/types.ts
+++ b/console/shared/lib/types.ts
@@ -290,6 +290,121 @@ export const MODULE_CATALOG: readonly ModuleDef[] = [
         defaultMessage: '{user} is raiding the channel with {viewers} viewers! Welcome everyone!'
       }
     ]
+  },
+  // External-stats modules: chat commands answered through the gateway service
+  // (external API proxy + cache). Config keys must match the sesame module
+  // structs (app/sesame/modules/urchin.go, mcsr.go).
+  {
+    id: 'urchin',
+    label: 'Bed Wars Stats',
+    tagline: 'Hypixel Bed Wars stats, urchin score and blacklist tags in chat.',
+    description:
+      'Viewer commands backed by urchin.gg: daily, weekly and monthly Bed Wars sessions, lifetime stats, the Urchin sniper score and active blacklist tags. Commands default to your linked Minecraft account; viewers can also name any player, e.g. "!daily Technoblade".',
+    icon: 'pulse',
+    defaultEnabled: false,
+    replies: [
+      {
+        key: 'daily',
+        label: '!daily',
+        tagline: 'Bed Wars session since the daily reset.',
+        event: '!daily',
+        enableKey: 'dailyEnabled',
+        messageKey: 'dailyMessage',
+        defaultMessage: '🛏 {player} today: {wins}W {losses}L · {finals} finals · {beds} beds · {fkdr} FKDR'
+      },
+      {
+        key: 'weekly',
+        label: '!weekly',
+        tagline: 'Bed Wars session since the weekly reset.',
+        event: '!weekly',
+        enableKey: 'weeklyEnabled',
+        messageKey: 'weeklyMessage',
+        defaultMessage: '🛏 {player} this week: {wins}W {losses}L · {finals} finals · {beds} beds · {fkdr} FKDR'
+      },
+      {
+        key: 'monthly',
+        label: '!monthly',
+        tagline: 'Bed Wars session since the monthly reset.',
+        event: '!monthly',
+        enableKey: 'monthlyEnabled',
+        messageKey: 'monthlyMessage',
+        defaultMessage: '🛏 {player} this month: {wins}W {losses}L · {finals} finals · {beds} beds · {fkdr} FKDR'
+      },
+      {
+        key: 'stats',
+        label: '!bwstats',
+        tagline: 'Lifetime Bed Wars stats.',
+        event: '!bwstats',
+        enableKey: 'statsEnabled',
+        messageKey: 'statsMessage',
+        defaultMessage: '🛏 {player}: {stars}✫ · {wins} wins · {finals} finals · {fkdr} FKDR · {beds} beds broken'
+      },
+      {
+        key: 'sniper',
+        label: '!sniper',
+        tagline: 'Urchin (Cubelify overlay) score.',
+        event: '!sniper',
+        enableKey: 'sniperEnabled',
+        messageKey: 'sniperMessage',
+        defaultMessage: '🎯 {player} urchin score: {score}'
+      },
+      {
+        key: 'tags',
+        label: '!tags',
+        tagline: 'Active Urchin blacklist tags.',
+        event: '!tags',
+        enableKey: 'tagsEnabled',
+        messageKey: 'tagsMessage',
+        defaultMessage: '🏷️ {player}: {tags}'
+      }
+    ],
+    settings: [
+      {
+        key: 'account',
+        label: 'Linked Minecraft account',
+        type: 'text',
+        placeholder: 'Your Minecraft username',
+        help: 'Default player for every command. Leave blank to use your Twitch username.'
+      }
+    ]
+  },
+  {
+    id: 'mcsr',
+    label: 'MCSR Ranked',
+    tagline: 'Ranked elo and per-stream session stats for MCSR runners.',
+    description:
+      'Viewer commands backed by the MCSR Ranked API: !elo shows the current rating and season record; !session shows elo and wins/losses since the stream started — the bot snapshots your standing the moment you go live. Commands default to your linked Minecraft account; viewers can also name any player.',
+    icon: 'clock',
+    defaultEnabled: false,
+    replies: [
+      {
+        key: 'elo',
+        label: '!elo',
+        tagline: 'Current elo, rank and season record.',
+        event: '!elo',
+        enableKey: 'eloEnabled',
+        messageKey: 'eloMessage',
+        defaultMessage: '🏆 {player}: {elo} elo · rank #{rank} · {wins}W {losses}L this season'
+      },
+      {
+        key: 'session',
+        label: '!session',
+        tagline: 'Elo and record since the stream started.',
+        event: '!session',
+        enableKey: 'sessionEnabled',
+        messageKey: 'sessionMessage',
+        defaultMessage: '📈 {player} this stream: {elochange} elo ({elo} now) · {wins}W {losses}L in {matches} matches'
+      }
+    ],
+    settings: [
+      {
+        key: 'account',
+        label: 'Linked Minecraft account',
+        type: 'text',
+        placeholder: 'Your Minecraft username',
+        help: 'Default player for every command. Leave blank to use your Twitch username.'
+      }
+    ]
   }
 ];
 

--- a/deploy/flux/clusters/production/images/gateway.yaml
+++ b/deploy/flux/clusters/production/images/gateway.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageRepository
+metadata:
+  name: gateway
+  namespace: flux-system
+spec:
+  image: ghcr.io/adamousmer/itsbagelbot/gateway
+  interval: 5m
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: gateway
+  namespace: flux-system
+spec:
+  digestReflectionPolicy: Always
+  interval: 5m
+  imageRepositoryRef:
+    name: gateway
+  filterTags:
+    pattern: '^main-(?P<ts>[0-9]+)-[a-f0-9]{12}$'
+    extract: $ts
+  policy:
+    numerical:
+      order: asc

--- a/deploy/k8s/NATS-ACCOUNTS.md
+++ b/deploy/k8s/NATS-ACCOUNTS.md
@@ -25,6 +25,7 @@ service's Doppler project.
 | dashboard (console) | `dashboard_bus` | `dashboard_rpc` | DASHBOARD_RPC |
 | admin (console) | `admin_bus` | `admin_rpc` | ADMIN_RPC |
 | twitch-ingress | `twitch_ingress_bus` | `twitch_ingress_rpc` | TWITCH_INGRESS_RPC |
+| gateway | — (RPC-only, no BUS user) | `gateway_rpc` | GATEWAY_RPC |
 
 ## 2. `nats-auth-env` secret keys (broker side)
 
@@ -37,29 +38,31 @@ All values are **bcrypt hashes** except the `*_REMOTE_URL_*` entries.
 `NATS_BCRYPT_TWITCH_INGRESS_BUS`, `NATS_BCRYPT_DASHBOARD_BUS`,
 `NATS_BCRYPT_ADMIN_BUS`
 
-**RPC user hashes (10):**
+**RPC user hashes (11):**
 `NATS_BCRYPT_USERS_RPC`, `NATS_BCRYPT_COMMANDS_RPC`, `NATS_BCRYPT_MODULES_RPC`,
 `NATS_BCRYPT_PROJECTOR_RPC`, `NATS_BCRYPT_OUTGRESS_RPC`,
 `NATS_BCRYPT_WORKER_RPC`, `NATS_BCRYPT_DASHBOARD_RPC`, `NATS_BCRYPT_ADMIN_RPC`,
-`NATS_BCRYPT_TWITCH_INGRESS_RPC`, `NATS_BCRYPT_TRANSACTIONS_RPC`
+`NATS_BCRYPT_TWITCH_INGRESS_RPC`, `NATS_BCRYPT_TRANSACTIONS_RPC`,
+`NATS_BCRYPT_GATEWAY_RPC`
 
 **System account (1):** `NATS_BCRYPT_SYS`
 
-**Leaf link hashes — hub authorization, one per account (11):**
+**Leaf link hashes — hub authorization, one per account (12):**
 `NATS_BCRYPT_LEAF_BUS`, `NATS_BCRYPT_LEAF_USERS`, `NATS_BCRYPT_LEAF_COMMANDS`,
 `NATS_BCRYPT_LEAF_MODULES`, `NATS_BCRYPT_LEAF_PROJECTOR`,
 `NATS_BCRYPT_LEAF_OUTGRESS`, `NATS_BCRYPT_LEAF_WORKER`,
 `NATS_BCRYPT_LEAF_DASHBOARD`, `NATS_BCRYPT_LEAF_ADMIN`,
-`NATS_BCRYPT_LEAF_TWITCH_INGRESS`, `NATS_BCRYPT_LEAF_TRANSACTIONS`
+`NATS_BCRYPT_LEAF_TWITCH_INGRESS`, `NATS_BCRYPT_LEAF_TRANSACTIONS`,
+`NATS_BCRYPT_LEAF_GATEWAY`
 
-**Leaf remote URLs — leaf side, one per account (11):** each embeds the
+**Leaf remote URLs — leaf side, one per account (12):** each embeds the
 *plaintext* leaf password matching the hash above:
 `NATS_LEAF_REMOTE_URL_BUS`, `NATS_LEAF_REMOTE_URL_USERS`,
 `NATS_LEAF_REMOTE_URL_COMMANDS`, `NATS_LEAF_REMOTE_URL_MODULES`,
 `NATS_LEAF_REMOTE_URL_PROJECTOR`, `NATS_LEAF_REMOTE_URL_OUTGRESS`,
 `NATS_LEAF_REMOTE_URL_WORKER`, `NATS_LEAF_REMOTE_URL_DASHBOARD`,
 `NATS_LEAF_REMOTE_URL_ADMIN`, `NATS_LEAF_REMOTE_URL_TWITCH_INGRESS`,
-`NATS_LEAF_REMOTE_URL_TRANSACTIONS`
+`NATS_LEAF_REMOTE_URL_TRANSACTIONS`, `NATS_LEAF_REMOTE_URL_GATEWAY`
 
 Form: `nats-leaf://leaf_<account>:<plaintext>@nats.production.svc.cluster.local:7422`
 e.g. `NATS_LEAF_REMOTE_URL_USERS=nats-leaf://leaf_users:<pw>@nats.production.svc.cluster.local:7422`

--- a/deploy/k8s/gateway.yaml
+++ b/deploy/k8s/gateway.yaml
@@ -1,0 +1,148 @@
+# gateway: the fleet's external-API gateway. Sesame requests third-party data
+# (urchin.gg Coral, MCSR Ranked) over NATS RPC (bagel.rpc.gateway.>); the
+# gateway fetches, normalizes, and caches replies in Valkey. It is the only
+# app that dials those external hosts.
+#
+# gateway-env (Doppler) carries VALKEY_*, URCHIN_API_KEY (provider disabled
+# without it), optional MCSR_API_KEY, NEW_RELIC_*, and the NATS_RPC_USER /
+# NATS_RPC_PASSWORD pair for the GATEWAY_RPC account.
+apiVersion: secrets.doppler.com/v1alpha1
+kind: DopplerSecret
+metadata:
+  name: gateway-env
+  namespace: production
+spec:
+  host: https://api.doppler.com
+  tokenSecret:
+    name: gateway-doppler-token
+  managedSecret:
+    name: gateway-env
+    namespace: production
+    type: Opaque
+  resyncSeconds: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gateway
+  namespace: production
+  annotations:
+    secrets.doppler.com/reload: "true"
+spec:
+  # Stateless and cache-backed: two replicas queue-group the RPC subjects. Not
+  # per-node — the working set is one HTTP client and a Valkey connection.
+  replicas: 2
+  revisionHistoryLimit: 3
+  minReadySeconds: 10
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: gateway
+  template:
+    metadata:
+      labels:
+        app: gateway
+      annotations:
+        linkerd.io/inject: enabled
+        config.linkerd.io/proxy-cpu-request: 5m
+        config.linkerd.io/proxy-cpu-limit: 750m
+        config.linkerd.io/proxy-memory-request: 16Mi
+        config.linkerd.io/proxy-memory-limit: 96Mi
+    spec:
+      tolerations:
+        - key: itsbagelbot.dev/pool
+          operator: Equal
+          value: worker-pool
+          effect: NoSchedule
+        - key: node.kubernetes.io/unreachable
+          operator: Exists
+          effect: NoExecute
+          tolerationSeconds: 60
+        - key: node.kubernetes.io/not-ready
+          operator: Exists
+          effect: NoExecute
+          tolerationSeconds: 60
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: gateway
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        seccompProfile: {type: RuntimeDefault}
+      containers:
+        - name: gateway
+          image: ghcr.io/adamousmer/itsbagelbot/gateway:main # {"$imagepolicy": "flux-system:gateway"}
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: NATS_HOST
+              value: nats
+            # Apps connect only to the node-local leaf cluster; the hub is
+            # reached over the leafnode link. No hub in the server list.
+            - name: NATS_URL
+              value: nats://nats-leaf:4222
+            - name: NATS_RPC_URL
+              value: nats://nats-leaf:4222
+            - name: NATS_LEAF_URL
+              value: nats://nats-leaf:4222
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            # Node-local Valkey reads (NODE_IP:6379); writes ride Sentinel.
+            - name: NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: GOMEMLIMIT
+              value: 96MiB
+          envFrom:
+            - secretRef:
+                name: gateway-env
+          ports:
+            - containerPort: 8080
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 250m
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities: {drop: ["ALL"]}
+          lifecycle:
+            preStop:
+              httpGet:
+                path: /drain
+                port: 8080
+          livenessProbe:
+            httpGet: {path: /healthz, port: 8080}
+            periodSeconds: 30
+          readinessProbe:
+            httpGet: {path: /readyz, port: 8080}
+            periodSeconds: 10
+          startupProbe:
+            httpGet: {path: /healthz, port: 8080}
+            failureThreshold: 18 # 18 × 5s = 90s max startup window
+            periodSeconds: 5
+      terminationGracePeriodSeconds: 45
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: gateway
+  namespace: production
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: gateway

--- a/deploy/k8s/kustomization.yaml
+++ b/deploy/k8s/kustomization.yaml
@@ -6,6 +6,9 @@ resources:
   - commands.yaml
   - console-dashboard.yaml
   # console-admin.yaml now replaces the Go admin tier, sharing the admin.tail451e6d.ts.net host.
+  # gateway is the external-API proxy + cache (urchin.gg, MCSR Ranked) sesame
+  # queries over bagel.rpc.gateway.>.
+  - gateway.yaml
   - modules.yaml
   - notifications.yaml
   - outgress.yaml

--- a/deploy/k8s/nats-auth.conf
+++ b/deploy/k8s/nats-auth.conf
@@ -296,6 +296,16 @@ accounts: {
     ]
   }
 
+  # GATEWAY_RPC answers the external-API endpoints (urchin.gg, MCSR Ranked)
+  # sesame's stats modules request. Fetches + Valkey caching happen inside the
+  # gateway service; it imports nothing.
+  GATEWAY_RPC: {
+    users: [ { user: "gateway_rpc", password: $NATS_BCRYPT_GATEWAY_RPC } ]
+    exports: [
+      { service: "bagel.rpc.gateway.>" }
+    ]
+  }
+
   # WORKER_RPC requests the data services' projections to resolve action state;
   # imports the cache-invalidation sections it caches (status, grant, commands,
   # modules).
@@ -307,6 +317,7 @@ accounts: {
       { service: { account: "COMMANDS_RPC", subject: "bagel.rpc.commands.>" } }
       { service: { account: "MODULES_RPC",  subject: "bagel.rpc.internal.projection.modules.get" } }
       { service: { account: "PROJECTOR_RPC", subject: "bagel.rpc.broadcaster.live.get" } }
+      { service: { account: "GATEWAY_RPC",  subject: "bagel.rpc.gateway.>" } }
       { stream: { account: "USERS_RPC",     subject: "bagel.cache.invalidate.status" } }
       { stream: { account: "USERS_RPC",     subject: "bagel.cache.invalidate.grant" } }
       { stream: { account: "USERS_RPC",     subject: "bagel.cache.invalidate.locale" } }

--- a/deploy/k8s/nats-leaf-server.conf
+++ b/deploy/k8s/nats-leaf-server.conf
@@ -48,6 +48,7 @@ leafnodes {
     { urls: [$NATS_LEAF_REMOTE_URL_NOTIFICATIONS],  account: "NOTIFICATIONS_RPC" }
     { urls: [$NATS_LEAF_REMOTE_URL_TWITCH_INGRESS], account: "TWITCH_INGRESS_RPC" }
     { urls: [$NATS_LEAF_REMOTE_URL_TRANSACTIONS],   account: "TRANSACTIONS_RPC" }
+    { urls: [$NATS_LEAF_REMOTE_URL_GATEWAY],        account: "GATEWAY_RPC" }
   ]
 }
 

--- a/deploy/k8s/nats-secrets.py
+++ b/deploy/k8s/nats-secrets.py
@@ -45,14 +45,17 @@ SERVICES = {
     "admin": "admin",
     "transactions": "transactions",
     "notifications": "notifications",
+    "gateway": "gateway",
 }
 NO_RPC: set[str] = set()
+# gateway is RPC-only (no JetStream/event plane), so it gets no BUS user.
+NO_BUS: set[str] = {"gateway"}
 
 # One leaf link per account: the BUS account plus every *_RPC account.
 LEAF_ACCOUNTS = [
     "bus", "users", "commands", "modules", "projector",
     "outgress", "worker", "dashboard", "admin", "twitch_ingress",
-    "notifications", "transactions",
+    "notifications", "transactions", "gateway",
 ]
 
 
@@ -83,10 +86,11 @@ def main() -> None:
     print("== per-service credentials ==")
     for svc, project in SERVICES.items():
         kv: dict[str, str] = {}
-        bus_pw = gen()
-        kv["NATS_USER"] = f"{svc}_bus"
-        kv["NATS_PASSWORD"] = bus_pw
-        broker[f"NATS_BCRYPT_{svc.upper()}_BUS"] = bcrypt_hash(bus_pw)
+        if svc not in NO_BUS:
+            bus_pw = gen()
+            kv["NATS_USER"] = f"{svc}_bus"
+            kv["NATS_PASSWORD"] = bus_pw
+            broker[f"NATS_BCRYPT_{svc.upper()}_BUS"] = bcrypt_hash(bus_pw)
         if svc not in NO_RPC:
             rpc_pw = gen()
             kv["NATS_RPC_USER"] = f"{svc}_rpc"

--- a/deploy/k8s/nats-server.conf
+++ b/deploy/k8s/nats-server.conf
@@ -44,6 +44,7 @@ leafnodes {
       { user: "leaf_notifications",  password: $NATS_BCRYPT_LEAF_NOTIFICATIONS,  account: "NOTIFICATIONS_RPC" }
       { user: "leaf_twitch_ingress", password: $NATS_BCRYPT_LEAF_TWITCH_INGRESS, account: "TWITCH_INGRESS_RPC" }
       { user: "leaf_transactions",   password: $NATS_BCRYPT_LEAF_TRANSACTIONS,   account: "TRANSACTIONS_RPC" }
+      { user: "leaf_gateway",        password: $NATS_BCRYPT_LEAF_GATEWAY,        account: "GATEWAY_RPC" }
     ]
   }
 }

--- a/deploy/k8s/network-policies.yaml
+++ b/deploy/k8s/network-policies.yaml
@@ -9,7 +9,7 @@ spec:
     matchExpressions:
       - key: app
         operator: In
-        values: [users, commands, modules, transactions, projector, worker, admin, twitch-ingress, outgress, console-dashboard, console-admin]
+        values: [users, commands, modules, transactions, projector, worker, admin, twitch-ingress, outgress, console-dashboard, console-admin, gateway]
   policyTypes:
     - Ingress
     - Egress

--- a/internal/domain/rpc/gateway/gateway.go
+++ b/internal/domain/rpc/gateway/gateway.go
@@ -1,0 +1,133 @@
+// Package gatewayrpc holds the shared wire types for the gateway service RPC
+// surface: the one request shape every provider endpoint accepts, and the typed
+// reply each endpoint answers with.
+//
+// The gateway proxies and caches external API systems (urchin.gg, MCSR Ranked,
+// ...) behind NATS request/reply so no chat-path service ever dials the
+// internet itself. Subjects are "<prefix>.<provider>.<endpoint>" (default
+// prefix "bagel.rpc.gateway"), e.g. "bagel.rpc.gateway.urchin.daily".
+//
+// Every reply embeds the fleet's conventional {"error": ""} envelope, so
+// bus.RequestJSON callers get a Go error (bus.RPCReplyError) instead of a
+// zero-valued success when the provider answered with a failure such as
+// "player not found".
+package gatewayrpc
+
+// Request covers every gateway endpoint; unused fields are zero.
+type Request struct {
+	// Account is the provider-side account the lookup targets (a Minecraft
+	// username or UUID for urchin/mcsr).
+	Account string `json:"account"`
+	// ChannelID scopes session-stateful endpoints (mcsr session snapshots) to
+	// one broadcaster, so two channels tracking the same player never share a
+	// stream session.
+	ChannelID string `json:"channel_id,omitempty"`
+}
+
+// Subject builds the NATS subject for one provider endpoint under prefix.
+func Subject(prefix, provider, endpoint string) string {
+	return prefix + "." + provider + "." + endpoint
+}
+
+// --- urchin (Coral: Hypixel Bed Wars stats + Urchin blacklist) --------------
+
+// UrchinSessionReply is the answer to urchin.daily / urchin.weekly /
+// urchin.monthly: the change in a player's Bed Wars stats since the period's
+// reset.
+type UrchinSessionReply struct {
+	Player      string `json:"player"`
+	SinceUnix   int64  `json:"since_unix"`
+	Wins        int64  `json:"wins"`
+	Losses      int64  `json:"losses"`
+	FinalKills  int64  `json:"final_kills"`
+	FinalDeaths int64  `json:"final_deaths"`
+	BedsBroken  int64  `json:"beds_broken"`
+	GamesPlayed int64  `json:"games_played"`
+	Levels      int64  `json:"levels"`
+	Error       string `json:"error,omitempty"`
+}
+
+// UrchinStatsReply is the answer to urchin.stats: the player's lifetime Bed
+// Wars stats extracted from their Hypixel profile.
+type UrchinStatsReply struct {
+	Player      string `json:"player"`
+	Stars       int64  `json:"stars"`
+	Wins        int64  `json:"wins"`
+	Losses      int64  `json:"losses"`
+	FinalKills  int64  `json:"final_kills"`
+	FinalDeaths int64  `json:"final_deaths"`
+	BedsBroken  int64  `json:"beds_broken"`
+	Error       string `json:"error,omitempty"`
+}
+
+// UrchinSniperReply is the answer to urchin.sniper: the player's Urchin
+// (Cubelify overlay) sniper score.
+type UrchinSniperReply struct {
+	Player string `json:"player"`
+	// Score is the overlay score value; Mode describes how the overlay should
+	// interpret it (as returned by the API).
+	Score    float64 `json:"score"`
+	Mode     string  `json:"mode"`
+	TagCount int     `json:"tag_count"`
+	Error    string  `json:"error,omitempty"`
+}
+
+// UrchinTag is one active blacklist tag on a player.
+type UrchinTag struct {
+	Type   string `json:"type"`
+	Reason string `json:"reason,omitempty"`
+}
+
+// UrchinTagsReply is the answer to urchin.tags: the blacklist tags currently
+// active on a player.
+type UrchinTagsReply struct {
+	Player string      `json:"player"`
+	Tags   []UrchinTag `json:"tags"`
+	Error  string      `json:"error,omitempty"`
+}
+
+// --- mcsr (MCSR Ranked) ------------------------------------------------------
+
+// McsrUserReply is the answer to mcsr.user: the player's current MCSR Ranked
+// standing. Elo and Rank are -1 when the player is unrated this season.
+type McsrUserReply struct {
+	Nickname string `json:"nickname"`
+	UUID     string `json:"uuid"`
+	Elo      int    `json:"elo"`
+	Rank     int    `json:"rank"`
+	Country  string `json:"country,omitempty"`
+	// Season counters (ranked queue).
+	Wins   int `json:"wins"`
+	Loses  int `json:"loses"`
+	Played int `json:"played"`
+	// BestTimeMS is the season's best ranked completion in milliseconds; 0 when
+	// none.
+	BestTimeMS int64  `json:"best_time_ms"`
+	Error      string `json:"error,omitempty"`
+}
+
+// McsrSnapshotReply is the answer to mcsr.session_start: acknowledges the
+// stream-start snapshot the session delta is later computed against.
+type McsrSnapshotReply struct {
+	Nickname string `json:"nickname"`
+	Elo      int    `json:"elo"`
+	Error    string `json:"error,omitempty"`
+}
+
+// McsrSessionReply is the answer to mcsr.session: the change in a player's
+// ranked standing since the stream-start snapshot for this channel.
+//
+// HasSnapshot is false when no snapshot existed for the channel (module was
+// enabled mid-stream, or the gateway lost it); the gateway then takes one, so
+// the next call has a baseline.
+type McsrSessionReply struct {
+	Nickname    string `json:"nickname"`
+	Elo         int    `json:"elo"`
+	EloChange   int    `json:"elo_change"`
+	Wins        int    `json:"wins"`
+	Loses       int    `json:"loses"`
+	Played      int    `json:"played"`
+	SinceUnix   int64  `json:"since_unix"`
+	HasSnapshot bool   `json:"has_snapshot"`
+	Error       string `json:"error,omitempty"`
+}


### PR DESCRIPTION
## Summary
- add the external API gateway with Urchin and MCSR providers
- add opt-in Sesame modules and dashboard configuration
- add NATS, deployment, CI, and shared RPC support
- refine stat templates and session username behavior

## Validation
- `go test ./app/gateway/... ./app/sesame/... ./internal/domain/rpc/gateway/...`
- `bun run check` in `console/dashboard` (0 errors)