### PR TITLE
fix(bus): update consumer config test call

### DIFF
--- a/pkg/bus/provision_test.go
+++ b/pkg/bus/provision_test.go
@@ -81,6 +81,7 @@ func TestLaneConsumerHasBoundedDeliveryBudget(t *testing.T) {
 		"outgress-premium",
 		"outgress-premium_twitch_outgress_premium",
 		4,
+		nil,
 	)
 
 	if cfg.MaxDeliver != 4 {


### PR DESCRIPTION
## Summary
- pass the new backoff argument to `laneConsumerConfig` in the bounded-delivery test
- restore compilation of `pkg/bus` and the Go Test Pipeline

## Verification
- `go test ./pkg/bus`
- `go test -race ./...`