### PR TITLE
Fleet-wide dashboard rate limiting + DB write-behind hardening

### DIFF
--- a/app/commands/ent/commands_create.go
+++ b/app/commands/ent/commands_create.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"time"
 
+	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
 )
@@ -18,6 +19,7 @@ type CommandsCreate struct {
 	config
 	mutation *CommandsMutation
 	hooks    []Hook
+	conflict []sql.ConflictOption
 }
 
 // SetUserID sets the "user_id" field.
@@ -305,6 +307,7 @@ func (_c *CommandsCreate) createSpec() (*Commands, *sqlgraph.CreateSpec) {
 		_node = &Commands{config: _c.config}
 		_spec = sqlgraph.NewCreateSpec(commands.Table, sqlgraph.NewFieldSpec(commands.FieldID, field.TypeInt))
 	)
+	_spec.OnConflict = _c.conflict
 	if value, ok := _c.mutation.UserID(); ok {
 		_spec.SetField(commands.FieldUserID, field.TypeUint64, value)
 		_node.UserID = value
@@ -356,11 +359,477 @@ func (_c *CommandsCreate) createSpec() (*Commands, *sqlgraph.CreateSpec) {
 	return _node, _spec
 }
 
+// OnConflict allows configuring the `ON CONFLICT` / `ON DUPLICATE KEY` clause
+// of the `INSERT` statement. For example:
+//
+//	client.Commands.Create().
+//		SetUserID(v).
+//		OnConflict(
+//			// Update the row with the new values
+//			// the was proposed for insertion.
+//			sql.ResolveWithNewValues(),
+//		).
+//		// Override some of the fields with custom
+//		// update values.
+//		Update(func(u *ent.CommandsUpsert) {
+//			SetUserID(v+v).
+//		}).
+//		Exec(ctx)
+func (_c *CommandsCreate) OnConflict(opts ...sql.ConflictOption) *CommandsUpsertOne {
+	_c.conflict = opts
+	return &CommandsUpsertOne{
+		create: _c,
+	}
+}
+
+// OnConflictColumns calls `OnConflict` and configures the columns
+// as conflict target. Using this option is equivalent to using:
+//
+//	client.Commands.Create().
+//		OnConflict(sql.ConflictColumns(columns...)).
+//		Exec(ctx)
+func (_c *CommandsCreate) OnConflictColumns(columns ...string) *CommandsUpsertOne {
+	_c.conflict = append(_c.conflict, sql.ConflictColumns(columns...))
+	return &CommandsUpsertOne{
+		create: _c,
+	}
+}
+
+type (
+	// CommandsUpsertOne is the builder for "upsert"-ing
+	//  one Commands node.
+	CommandsUpsertOne struct {
+		create *CommandsCreate
+	}
+
+	// CommandsUpsert is the "OnConflict" setter.
+	CommandsUpsert struct {
+		*sql.UpdateSet
+	}
+)
+
+// SetName sets the "name" field.
+func (u *CommandsUpsert) SetName(v string) *CommandsUpsert {
+	u.Set(commands.FieldName, v)
+	return u
+}
+
+// UpdateName sets the "name" field to the value that was provided on create.
+func (u *CommandsUpsert) UpdateName() *CommandsUpsert {
+	u.SetExcluded(commands.FieldName)
+	return u
+}
+
+// SetAliases sets the "aliases" field.
+func (u *CommandsUpsert) SetAliases(v []string) *CommandsUpsert {
+	u.Set(commands.FieldAliases, v)
+	return u
+}
+
+// UpdateAliases sets the "aliases" field to the value that was provided on create.
+func (u *CommandsUpsert) UpdateAliases() *CommandsUpsert {
+	u.SetExcluded(commands.FieldAliases)
+	return u
+}
+
+// ClearAliases clears the value of the "aliases" field.
+func (u *CommandsUpsert) ClearAliases() *CommandsUpsert {
+	u.SetNull(commands.FieldAliases)
+	return u
+}
+
+// SetResponse sets the "response" field.
+func (u *CommandsUpsert) SetResponse(v string) *CommandsUpsert {
+	u.Set(commands.FieldResponse, v)
+	return u
+}
+
+// UpdateResponse sets the "response" field to the value that was provided on create.
+func (u *CommandsUpsert) UpdateResponse() *CommandsUpsert {
+	u.SetExcluded(commands.FieldResponse)
+	return u
+}
+
+// SetIsActive sets the "is_active" field.
+func (u *CommandsUpsert) SetIsActive(v bool) *CommandsUpsert {
+	u.Set(commands.FieldIsActive, v)
+	return u
+}
+
+// UpdateIsActive sets the "is_active" field to the value that was provided on create.
+func (u *CommandsUpsert) UpdateIsActive() *CommandsUpsert {
+	u.SetExcluded(commands.FieldIsActive)
+	return u
+}
+
+// SetStreamOnlineOnly sets the "stream_online_only" field.
+func (u *CommandsUpsert) SetStreamOnlineOnly(v bool) *CommandsUpsert {
+	u.Set(commands.FieldStreamOnlineOnly, v)
+	return u
+}
+
+// UpdateStreamOnlineOnly sets the "stream_online_only" field to the value that was provided on create.
+func (u *CommandsUpsert) UpdateStreamOnlineOnly() *CommandsUpsert {
+	u.SetExcluded(commands.FieldStreamOnlineOnly)
+	return u
+}
+
+// SetPerm sets the "perm" field.
+func (u *CommandsUpsert) SetPerm(v string) *CommandsUpsert {
+	u.Set(commands.FieldPerm, v)
+	return u
+}
+
+// UpdatePerm sets the "perm" field to the value that was provided on create.
+func (u *CommandsUpsert) UpdatePerm() *CommandsUpsert {
+	u.SetExcluded(commands.FieldPerm)
+	return u
+}
+
+// SetCooldown sets the "cooldown" field.
+func (u *CommandsUpsert) SetCooldown(v uint) *CommandsUpsert {
+	u.Set(commands.FieldCooldown, v)
+	return u
+}
+
+// UpdateCooldown sets the "cooldown" field to the value that was provided on create.
+func (u *CommandsUpsert) UpdateCooldown() *CommandsUpsert {
+	u.SetExcluded(commands.FieldCooldown)
+	return u
+}
+
+// AddCooldown adds v to the "cooldown" field.
+func (u *CommandsUpsert) AddCooldown(v uint) *CommandsUpsert {
+	u.Add(commands.FieldCooldown, v)
+	return u
+}
+
+// SetAllowedUserID sets the "allowed_user_id" field.
+func (u *CommandsUpsert) SetAllowedUserID(v uint64) *CommandsUpsert {
+	u.Set(commands.FieldAllowedUserID, v)
+	return u
+}
+
+// UpdateAllowedUserID sets the "allowed_user_id" field to the value that was provided on create.
+func (u *CommandsUpsert) UpdateAllowedUserID() *CommandsUpsert {
+	u.SetExcluded(commands.FieldAllowedUserID)
+	return u
+}
+
+// AddAllowedUserID adds v to the "allowed_user_id" field.
+func (u *CommandsUpsert) AddAllowedUserID(v uint64) *CommandsUpsert {
+	u.Add(commands.FieldAllowedUserID, v)
+	return u
+}
+
+// SetUses sets the "uses" field.
+func (u *CommandsUpsert) SetUses(v uint64) *CommandsUpsert {
+	u.Set(commands.FieldUses, v)
+	return u
+}
+
+// UpdateUses sets the "uses" field to the value that was provided on create.
+func (u *CommandsUpsert) UpdateUses() *CommandsUpsert {
+	u.SetExcluded(commands.FieldUses)
+	return u
+}
+
+// AddUses adds v to the "uses" field.
+func (u *CommandsUpsert) AddUses(v uint64) *CommandsUpsert {
+	u.Add(commands.FieldUses, v)
+	return u
+}
+
+// SetCreatedAt sets the "created_at" field.
+func (u *CommandsUpsert) SetCreatedAt(v time.Time) *CommandsUpsert {
+	u.Set(commands.FieldCreatedAt, v)
+	return u
+}
+
+// UpdateCreatedAt sets the "created_at" field to the value that was provided on create.
+func (u *CommandsUpsert) UpdateCreatedAt() *CommandsUpsert {
+	u.SetExcluded(commands.FieldCreatedAt)
+	return u
+}
+
+// SetUpdatedAt sets the "updated_at" field.
+func (u *CommandsUpsert) SetUpdatedAt(v time.Time) *CommandsUpsert {
+	u.Set(commands.FieldUpdatedAt, v)
+	return u
+}
+
+// UpdateUpdatedAt sets the "updated_at" field to the value that was provided on create.
+func (u *CommandsUpsert) UpdateUpdatedAt() *CommandsUpsert {
+	u.SetExcluded(commands.FieldUpdatedAt)
+	return u
+}
+
+// UpdateNewValues updates the mutable fields using the new values that were set on create.
+// Using this option is equivalent to using:
+//
+//	client.Commands.Create().
+//		OnConflict(
+//			sql.ResolveWithNewValues(),
+//		).
+//		Exec(ctx)
+func (u *CommandsUpsertOne) UpdateNewValues() *CommandsUpsertOne {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWithNewValues())
+	u.create.conflict = append(u.create.conflict, sql.ResolveWith(func(s *sql.UpdateSet) {
+		if _, exists := u.create.mutation.UserID(); exists {
+			s.SetIgnore(commands.FieldUserID)
+		}
+	}))
+	return u
+}
+
+// Ignore sets each column to itself in case of conflict.
+// Using this option is equivalent to using:
+//
+//	client.Commands.Create().
+//	    OnConflict(sql.ResolveWithIgnore()).
+//	    Exec(ctx)
+func (u *CommandsUpsertOne) Ignore() *CommandsUpsertOne {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWithIgnore())
+	return u
+}
+
+// DoNothing configures the conflict_action to `DO NOTHING`.
+// Supported only by SQLite and PostgreSQL.
+func (u *CommandsUpsertOne) DoNothing() *CommandsUpsertOne {
+	u.create.conflict = append(u.create.conflict, sql.DoNothing())
+	return u
+}
+
+// Update allows overriding fields `UPDATE` values. See the CommandsCreate.OnConflict
+// documentation for more info.
+func (u *CommandsUpsertOne) Update(set func(*CommandsUpsert)) *CommandsUpsertOne {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWith(func(update *sql.UpdateSet) {
+		set(&CommandsUpsert{UpdateSet: update})
+	}))
+	return u
+}
+
+// SetName sets the "name" field.
+func (u *CommandsUpsertOne) SetName(v string) *CommandsUpsertOne {
+	return u.Update(func(s *CommandsUpsert) {
+		s.SetName(v)
+	})
+}
+
+// UpdateName sets the "name" field to the value that was provided on create.
+func (u *CommandsUpsertOne) UpdateName() *CommandsUpsertOne {
+	return u.Update(func(s *CommandsUpsert) {
+		s.UpdateName()
+	})
+}
+
+// SetAliases sets the "aliases" field.
+func (u *CommandsUpsertOne) SetAliases(v []string) *CommandsUpsertOne {
+	return u.Update(func(s *CommandsUpsert) {
+		s.SetAliases(v)
+	})
+}
+
+// UpdateAliases sets the "aliases" field to the value that was provided on create.
+func (u *CommandsUpsertOne) UpdateAliases() *CommandsUpsertOne {
+	return u.Update(func(s *CommandsUpsert) {
+		s.UpdateAliases()
+	})
+}
+
+// ClearAliases clears the value of the "aliases" field.
+func (u *CommandsUpsertOne) ClearAliases() *CommandsUpsertOne {
+	return u.Update(func(s *CommandsUpsert) {
+		s.ClearAliases()
+	})
+}
+
+// SetResponse sets the "response" field.
+func (u *CommandsUpsertOne) SetResponse(v string) *CommandsUpsertOne {
+	return u.Update(func(s *CommandsUpsert) {
+		s.SetResponse(v)
+	})
+}
+
+// UpdateResponse sets the "response" field to the value that was provided on create.
+func (u *CommandsUpsertOne) UpdateResponse() *CommandsUpsertOne {
+	return u.Update(func(s *CommandsUpsert) {
+		s.UpdateResponse()
+	})
+}
+
+// SetIsActive sets the "is_active" field.
+func (u *CommandsUpsertOne) SetIsActive(v bool) *CommandsUpsertOne {
+	return u.Update(func(s *CommandsUpsert) {
+		s.SetIsActive(v)
+	})
+}
+
+// UpdateIsActive sets the "is_active" field to the value that was provided on create.
+func (u *CommandsUpsertOne) UpdateIsActive() *CommandsUpsertOne {
+	return u.Update(func(s *CommandsUpsert) {
+		s.UpdateIsActive()
+	})
+}
+
+// SetStreamOnlineOnly sets the "stream_online_only" field.
+func (u *CommandsUpsertOne) SetStreamOnlineOnly(v bool) *CommandsUpsertOne {
+	return u.Update(func(s *CommandsUpsert) {
+		s.SetStreamOnlineOnly(v)
+	})
+}
+
+// UpdateStreamOnlineOnly sets the "stream_online_only" field to the value that was provided on create.
+func (u *CommandsUpsertOne) UpdateStreamOnlineOnly() *CommandsUpsertOne {
+	return u.Update(func(s *CommandsUpsert) {
+		s.UpdateStreamOnlineOnly()
+	})
+}
+
+// SetPerm sets the "perm" field.
+func (u *CommandsUpsertOne) SetPerm(v string) *CommandsUpsertOne {
+	return u.Update(func(s *CommandsUpsert) {
+		s.SetPerm(v)
+	})
+}
+
+// UpdatePerm sets the "perm" field to the value that was provided on create.
+func (u *CommandsUpsertOne) UpdatePerm() *CommandsUpsertOne {
+	return u.Update(func(s *CommandsUpsert) {
+		s.UpdatePerm()
+	})
+}
+
+// SetCooldown sets the "cooldown" field.
+func (u *CommandsUpsertOne) SetCooldown(v uint) *CommandsUpsertOne {
+	return u.Update(func(s *CommandsUpsert) {
+		s.SetCooldown(v)
+	})
+}
+
+// AddCooldown adds v to the "cooldown" field.
+func (u *CommandsUpsertOne) AddCooldown(v uint) *CommandsUpsertOne {
+	return u.Update(func(s *CommandsUpsert) {
+		s.AddCooldown(v)
+	})
+}
+
+// UpdateCooldown sets the "cooldown" field to the value that was provided on create.
+func (u *CommandsUpsertOne) UpdateCooldown() *CommandsUpsertOne {
+	return u.Update(func(s *CommandsUpsert) {
+		s.UpdateCooldown()
+	})
+}
+
+// SetAllowedUserID sets the "allowed_user_id" field.
+func (u *CommandsUpsertOne) SetAllowedUserID(v uint64) *CommandsUpsertOne {
+	return u.Update(func(s *CommandsUpsert) {
+		s.SetAllowedUserID(v)
+	})
+}
+
+// AddAllowedUserID adds v to the "allowed_user_id" field.
+func (u *CommandsUpsertOne) AddAllowedUserID(v uint64) *CommandsUpsertOne {
+	return u.Update(func(s *CommandsUpsert) {
+		s.AddAllowedUserID(v)
+	})
+}
+
+// UpdateAllowedUserID sets the "allowed_user_id" field to the value that was provided on create.
+func (u *CommandsUpsertOne) UpdateAllowedUserID() *CommandsUpsertOne {
+	return u.Update(func(s *CommandsUpsert) {
+		s.UpdateAllowedUserID()
+	})
+}
+
+// SetUses sets the "uses" field.
+func (u *CommandsUpsertOne) SetUses(v uint64) *CommandsUpsertOne {
+	return u.Update(func(s *CommandsUpsert) {
+		s.SetUses(v)
+	})
+}
+
+// AddUses adds v to the "uses" field.
+func (u *CommandsUpsertOne) AddUses(v uint64) *CommandsUpsertOne {
+	return u.Update(func(s *CommandsUpsert) {
+		s.AddUses(v)
+	})
+}
+
+// UpdateUses sets the "uses" field to the value that was provided on create.
+func (u *CommandsUpsertOne) UpdateUses() *CommandsUpsertOne {
+	return u.Update(func(s *CommandsUpsert) {
+		s.UpdateUses()
+	})
+}
+
+// SetCreatedAt sets the "created_at" field.
+func (u *CommandsUpsertOne) SetCreatedAt(v time.Time) *CommandsUpsertOne {
+	return u.Update(func(s *CommandsUpsert) {
+		s.SetCreatedAt(v)
+	})
+}
+
+// UpdateCreatedAt sets the "created_at" field to the value that was provided on create.
+func (u *CommandsUpsertOne) UpdateCreatedAt() *CommandsUpsertOne {
+	return u.Update(func(s *CommandsUpsert) {
+		s.UpdateCreatedAt()
+	})
+}
+
+// SetUpdatedAt sets the "updated_at" field.
+func (u *CommandsUpsertOne) SetUpdatedAt(v time.Time) *CommandsUpsertOne {
+	return u.Update(func(s *CommandsUpsert) {
+		s.SetUpdatedAt(v)
+	})
+}
+
+// UpdateUpdatedAt sets the "updated_at" field to the value that was provided on create.
+func (u *CommandsUpsertOne) UpdateUpdatedAt() *CommandsUpsertOne {
+	return u.Update(func(s *CommandsUpsert) {
+		s.UpdateUpdatedAt()
+	})
+}
+
+// Exec executes the query.
+func (u *CommandsUpsertOne) Exec(ctx context.Context) error {
+	if len(u.create.conflict) == 0 {
+		return errors.New("ent: missing options for CommandsCreate.OnConflict")
+	}
+	return u.create.Exec(ctx)
+}
+
+// ExecX is like Exec, but panics if an error occurs.
+func (u *CommandsUpsertOne) ExecX(ctx context.Context) {
+	if err := u.create.Exec(ctx); err != nil {
+		panic(err)
+	}
+}
+
+// Exec executes the UPSERT query and returns the inserted/updated ID.
+func (u *CommandsUpsertOne) ID(ctx context.Context) (id int, err error) {
+	node, err := u.create.Save(ctx)
+	if err != nil {
+		return id, err
+	}
+	return node.ID, nil
+}
+
+// IDX is like ID, but panics if an error occurs.
+func (u *CommandsUpsertOne) IDX(ctx context.Context) int {
+	id, err := u.ID(ctx)
+	if err != nil {
+		panic(err)
+	}
+	return id
+}
+
 // CommandsCreateBulk is the builder for creating many Commands entities in bulk.
 type CommandsCreateBulk struct {
 	config
 	err      error
 	builders []*CommandsCreate
+	conflict []sql.ConflictOption
 }
 
 // Save creates the Commands entities in the database.
@@ -390,6 +859,7 @@ func (_c *CommandsCreateBulk) Save(ctx context.Context) ([]*Commands, error) {
 					_, err = mutators[i+1].Mutate(root, _c.builders[i+1].mutation)
 				} else {
 					spec := &sqlgraph.BatchCreateSpec{Nodes: specs}
+					spec.OnConflict = _c.conflict
 					// Invoke the actual operation on the latest mutation in the chain.
 					if err = sqlgraph.BatchCreate(ctx, _c.driver, spec); err != nil {
 						if sqlgraph.IsConstraintError(err) {
@@ -440,6 +910,299 @@ func (_c *CommandsCreateBulk) Exec(ctx context.Context) error {
 // ExecX is like Exec, but panics if an error occurs.
 func (_c *CommandsCreateBulk) ExecX(ctx context.Context) {
 	if err := _c.Exec(ctx); err != nil {
+		panic(err)
+	}
+}
+
+// OnConflict allows configuring the `ON CONFLICT` / `ON DUPLICATE KEY` clause
+// of the `INSERT` statement. For example:
+//
+//	client.Commands.CreateBulk(builders...).
+//		OnConflict(
+//			// Update the row with the new values
+//			// the was proposed for insertion.
+//			sql.ResolveWithNewValues(),
+//		).
+//		// Override some of the fields with custom
+//		// update values.
+//		Update(func(u *ent.CommandsUpsert) {
+//			SetUserID(v+v).
+//		}).
+//		Exec(ctx)
+func (_c *CommandsCreateBulk) OnConflict(opts ...sql.ConflictOption) *CommandsUpsertBulk {
+	_c.conflict = opts
+	return &CommandsUpsertBulk{
+		create: _c,
+	}
+}
+
+// OnConflictColumns calls `OnConflict` and configures the columns
+// as conflict target. Using this option is equivalent to using:
+//
+//	client.Commands.Create().
+//		OnConflict(sql.ConflictColumns(columns...)).
+//		Exec(ctx)
+func (_c *CommandsCreateBulk) OnConflictColumns(columns ...string) *CommandsUpsertBulk {
+	_c.conflict = append(_c.conflict, sql.ConflictColumns(columns...))
+	return &CommandsUpsertBulk{
+		create: _c,
+	}
+}
+
+// CommandsUpsertBulk is the builder for "upsert"-ing
+// a bulk of Commands nodes.
+type CommandsUpsertBulk struct {
+	create *CommandsCreateBulk
+}
+
+// UpdateNewValues updates the mutable fields using the new values that
+// were set on create. Using this option is equivalent to using:
+//
+//	client.Commands.Create().
+//		OnConflict(
+//			sql.ResolveWithNewValues(),
+//		).
+//		Exec(ctx)
+func (u *CommandsUpsertBulk) UpdateNewValues() *CommandsUpsertBulk {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWithNewValues())
+	u.create.conflict = append(u.create.conflict, sql.ResolveWith(func(s *sql.UpdateSet) {
+		for _, b := range u.create.builders {
+			if _, exists := b.mutation.UserID(); exists {
+				s.SetIgnore(commands.FieldUserID)
+			}
+		}
+	}))
+	return u
+}
+
+// Ignore sets each column to itself in case of conflict.
+// Using this option is equivalent to using:
+//
+//	client.Commands.Create().
+//		OnConflict(sql.ResolveWithIgnore()).
+//		Exec(ctx)
+func (u *CommandsUpsertBulk) Ignore() *CommandsUpsertBulk {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWithIgnore())
+	return u
+}
+
+// DoNothing configures the conflict_action to `DO NOTHING`.
+// Supported only by SQLite and PostgreSQL.
+func (u *CommandsUpsertBulk) DoNothing() *CommandsUpsertBulk {
+	u.create.conflict = append(u.create.conflict, sql.DoNothing())
+	return u
+}
+
+// Update allows overriding fields `UPDATE` values. See the CommandsCreateBulk.OnConflict
+// documentation for more info.
+func (u *CommandsUpsertBulk) Update(set func(*CommandsUpsert)) *CommandsUpsertBulk {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWith(func(update *sql.UpdateSet) {
+		set(&CommandsUpsert{UpdateSet: update})
+	}))
+	return u
+}
+
+// SetName sets the "name" field.
+func (u *CommandsUpsertBulk) SetName(v string) *CommandsUpsertBulk {
+	return u.Update(func(s *CommandsUpsert) {
+		s.SetName(v)
+	})
+}
+
+// UpdateName sets the "name" field to the value that was provided on create.
+func (u *CommandsUpsertBulk) UpdateName() *CommandsUpsertBulk {
+	return u.Update(func(s *CommandsUpsert) {
+		s.UpdateName()
+	})
+}
+
+// SetAliases sets the "aliases" field.
+func (u *CommandsUpsertBulk) SetAliases(v []string) *CommandsUpsertBulk {
+	return u.Update(func(s *CommandsUpsert) {
+		s.SetAliases(v)
+	})
+}
+
+// UpdateAliases sets the "aliases" field to the value that was provided on create.
+func (u *CommandsUpsertBulk) UpdateAliases() *CommandsUpsertBulk {
+	return u.Update(func(s *CommandsUpsert) {
+		s.UpdateAliases()
+	})
+}
+
+// ClearAliases clears the value of the "aliases" field.
+func (u *CommandsUpsertBulk) ClearAliases() *CommandsUpsertBulk {
+	return u.Update(func(s *CommandsUpsert) {
+		s.ClearAliases()
+	})
+}
+
+// SetResponse sets the "response" field.
+func (u *CommandsUpsertBulk) SetResponse(v string) *CommandsUpsertBulk {
+	return u.Update(func(s *CommandsUpsert) {
+		s.SetResponse(v)
+	})
+}
+
+// UpdateResponse sets the "response" field to the value that was provided on create.
+func (u *CommandsUpsertBulk) UpdateResponse() *CommandsUpsertBulk {
+	return u.Update(func(s *CommandsUpsert) {
+		s.UpdateResponse()
+	})
+}
+
+// SetIsActive sets the "is_active" field.
+func (u *CommandsUpsertBulk) SetIsActive(v bool) *CommandsUpsertBulk {
+	return u.Update(func(s *CommandsUpsert) {
+		s.SetIsActive(v)
+	})
+}
+
+// UpdateIsActive sets the "is_active" field to the value that was provided on create.
+func (u *CommandsUpsertBulk) UpdateIsActive() *CommandsUpsertBulk {
+	return u.Update(func(s *CommandsUpsert) {
+		s.UpdateIsActive()
+	})
+}
+
+// SetStreamOnlineOnly sets the "stream_online_only" field.
+func (u *CommandsUpsertBulk) SetStreamOnlineOnly(v bool) *CommandsUpsertBulk {
+	return u.Update(func(s *CommandsUpsert) {
+		s.SetStreamOnlineOnly(v)
+	})
+}
+
+// UpdateStreamOnlineOnly sets the "stream_online_only" field to the value that was provided on create.
+func (u *CommandsUpsertBulk) UpdateStreamOnlineOnly() *CommandsUpsertBulk {
+	return u.Update(func(s *CommandsUpsert) {
+		s.UpdateStreamOnlineOnly()
+	})
+}
+
+// SetPerm sets the "perm" field.
+func (u *CommandsUpsertBulk) SetPerm(v string) *CommandsUpsertBulk {
+	return u.Update(func(s *CommandsUpsert) {
+		s.SetPerm(v)
+	})
+}
+
+// UpdatePerm sets the "perm" field to the value that was provided on create.
+func (u *CommandsUpsertBulk) UpdatePerm() *CommandsUpsertBulk {
+	return u.Update(func(s *CommandsUpsert) {
+		s.UpdatePerm()
+	})
+}
+
+// SetCooldown sets the "cooldown" field.
+func (u *CommandsUpsertBulk) SetCooldown(v uint) *CommandsUpsertBulk {
+	return u.Update(func(s *CommandsUpsert) {
+		s.SetCooldown(v)
+	})
+}
+
+// AddCooldown adds v to the "cooldown" field.
+func (u *CommandsUpsertBulk) AddCooldown(v uint) *CommandsUpsertBulk {
+	return u.Update(func(s *CommandsUpsert) {
+		s.AddCooldown(v)
+	})
+}
+
+// UpdateCooldown sets the "cooldown" field to the value that was provided on create.
+func (u *CommandsUpsertBulk) UpdateCooldown() *CommandsUpsertBulk {
+	return u.Update(func(s *CommandsUpsert) {
+		s.UpdateCooldown()
+	})
+}
+
+// SetAllowedUserID sets the "allowed_user_id" field.
+func (u *CommandsUpsertBulk) SetAllowedUserID(v uint64) *CommandsUpsertBulk {
+	return u.Update(func(s *CommandsUpsert) {
+		s.SetAllowedUserID(v)
+	})
+}
+
+// AddAllowedUserID adds v to the "allowed_user_id" field.
+func (u *CommandsUpsertBulk) AddAllowedUserID(v uint64) *CommandsUpsertBulk {
+	return u.Update(func(s *CommandsUpsert) {
+		s.AddAllowedUserID(v)
+	})
+}
+
+// UpdateAllowedUserID sets the "allowed_user_id" field to the value that was provided on create.
+func (u *CommandsUpsertBulk) UpdateAllowedUserID() *CommandsUpsertBulk {
+	return u.Update(func(s *CommandsUpsert) {
+		s.UpdateAllowedUserID()
+	})
+}
+
+// SetUses sets the "uses" field.
+func (u *CommandsUpsertBulk) SetUses(v uint64) *CommandsUpsertBulk {
+	return u.Update(func(s *CommandsUpsert) {
+		s.SetUses(v)
+	})
+}
+
+// AddUses adds v to the "uses" field.
+func (u *CommandsUpsertBulk) AddUses(v uint64) *CommandsUpsertBulk {
+	return u.Update(func(s *CommandsUpsert) {
+		s.AddUses(v)
+	})
+}
+
+// UpdateUses sets the "uses" field to the value that was provided on create.
+func (u *CommandsUpsertBulk) UpdateUses() *CommandsUpsertBulk {
+	return u.Update(func(s *CommandsUpsert) {
+		s.UpdateUses()
+	})
+}
+
+// SetCreatedAt sets the "created_at" field.
+func (u *CommandsUpsertBulk) SetCreatedAt(v time.Time) *CommandsUpsertBulk {
+	return u.Update(func(s *CommandsUpsert) {
+		s.SetCreatedAt(v)
+	})
+}
+
+// UpdateCreatedAt sets the "created_at" field to the value that was provided on create.
+func (u *CommandsUpsertBulk) UpdateCreatedAt() *CommandsUpsertBulk {
+	return u.Update(func(s *CommandsUpsert) {
+		s.UpdateCreatedAt()
+	})
+}
+
+// SetUpdatedAt sets the "updated_at" field.
+func (u *CommandsUpsertBulk) SetUpdatedAt(v time.Time) *CommandsUpsertBulk {
+	return u.Update(func(s *CommandsUpsert) {
+		s.SetUpdatedAt(v)
+	})
+}
+
+// UpdateUpdatedAt sets the "updated_at" field to the value that was provided on create.
+func (u *CommandsUpsertBulk) UpdateUpdatedAt() *CommandsUpsertBulk {
+	return u.Update(func(s *CommandsUpsert) {
+		s.UpdateUpdatedAt()
+	})
+}
+
+// Exec executes the query.
+func (u *CommandsUpsertBulk) Exec(ctx context.Context) error {
+	if u.create.err != nil {
+		return u.create.err
+	}
+	for i, b := range u.create.builders {
+		if len(b.conflict) != 0 {
+			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the CommandsCreateBulk instead", i)
+		}
+	}
+	if len(u.create.conflict) == 0 {
+		return errors.New("ent: missing options for CommandsCreateBulk.OnConflict")
+	}
+	return u.create.Exec(ctx)
+}
+
+// ExecX is like Exec, but panics if an error occurs.
+func (u *CommandsUpsertBulk) ExecX(ctx context.Context) {
+	if err := u.create.Exec(ctx); err != nil {
 		panic(err)
 	}
 }

--- a/app/commands/repository/commands.go
+++ b/app/commands/repository/commands.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"ItsBagelBot/app/commands/ent"
@@ -17,6 +18,8 @@ import (
 	"ItsBagelBot/pkg/bus"
 	"ItsBagelBot/pkg/cache"
 	"ItsBagelBot/pkg/db"
+
+	entsql "entgo.io/ent/dialect/sql"
 
 	"github.com/ThreeDotsLabs/watermill/message"
 
@@ -95,6 +98,11 @@ type Commands struct {
 	usesPend   map[commandKey]uint64
 	usesTicker *time.Ticker
 	usesDone   chan struct{}
+
+	// Single-flight guard for the overflow-triggered flush: a viral chat can
+	// trip the key cap on every RecordUse, and each trip must not spawn
+	// another concurrent flush goroutine.
+	usesFlushing atomic.Bool
 }
 
 func NewCommands(client *ent.Client, pub message.Publisher, app *newrelic.Application, log *zap.Logger) *Commands {
@@ -375,8 +383,11 @@ func (r *Commands) RecordUse(userID uint64, name string, count uint64) {
 	r.usesPend[commandKey{userID: userID, name: name}] += count
 	overflow := len(r.usesPend) >= usesFlushMaxKeys
 	r.usesMu.Unlock()
-	if overflow {
-		go r.flushUses(context.Background())
+	if overflow && r.usesFlushing.CompareAndSwap(false, true) {
+		go func() {
+			defer r.usesFlushing.Store(false)
+			r.flushUses(context.Background())
+		}()
 	}
 }
 
@@ -531,34 +542,27 @@ func (r *Commands) flush(ctx context.Context, items []data.CommandChangedDTO) er
 
 	ctx = newrelic.NewContext(ctx, txn)
 
+	// Fast path: the whole window lands as one INSERT ... ON DUPLICATE KEY
+	// UPDATE. If that statement fails, fall back to per-item writes so one
+	// unpersistable row cannot wedge the entire batch in the retry loop
+	// forever (the old whole-batch rollback + requeue did exactly that).
+	landed := items
 	if err := db.WithExec(ctx, func(ctx context.Context) error {
-		tx, err := r.client.Tx(ctx)
-		if err != nil {
-			return err
-		}
-
-		for _, item := range items {
-			if err := upsertCommand(ctx, tx, item); err != nil {
-				_ = tx.Rollback()
-				txn.NoticeError(err)
-				return err
-			}
-		}
-
-		if err := tx.Commit(); err != nil {
-			txn.NoticeError(err)
-			return err
-		}
-		return nil
+		return bulkUpsertCommands(ctx, r.client, items)
 	}); err != nil {
-		return err
+		txn.NoticeError(err)
+		landed = r.upsertEach(ctx, txn, items)
+	}
+
+	if len(landed) == 0 {
+		return nil
 	}
 
 	// Publish DB truth rather than the queued edit: the row keeps counters the
 	// edit never carried (uses), and event-carried state transfer must not
 	// regress them in the projection.
-	keys := make([]commandKey, 0, len(items))
-	for _, item := range items {
+	keys := make([]commandKey, 0, len(landed))
+	for _, item := range landed {
 		keys = append(keys, commandKey{userID: item.UserID, name: item.Name})
 	}
 	states, serr := r.rowStates(ctx, keys)
@@ -566,7 +570,7 @@ func (r *Commands) flush(ctx context.Context, items []data.CommandChangedDTO) er
 		r.log.Warn("failed to reload rows after flush; publishing queued state", zap.Error(serr))
 	}
 
-	for _, item := range items {
+	for _, item := range landed {
 
 		r.Invalidate(item.UserID)
 
@@ -586,9 +590,82 @@ func (r *Commands) flush(ctx context.Context, items []data.CommandChangedDTO) er
 	return nil
 }
 
-func upsertCommand(ctx context.Context, tx *ent.Tx, item data.CommandChangedDTO) error {
+// bulkUpsertCommands lands one flush window as a single
+// INSERT ... ON DUPLICATE KEY UPDATE keyed on the (user_id, name) unique
+// index. Only the edit-owned columns are updated on conflict: `uses` belongs
+// to the counter flush and created_at to the original insert, and neither
+// must be regressed by an edit.
+func bulkUpsertCommands(ctx context.Context, client *ent.Client, items []data.CommandChangedDTO) error {
 
-	updated, err := tx.Commands.Update().
+	builders := make([]*ent.CommandsCreate, 0, len(items))
+	for _, item := range items {
+		builders = append(builders, client.Commands.Create().
+			SetUserID(item.UserID).
+			SetName(item.Name).
+			SetAliases(item.Aliases).
+			SetResponse(item.Response).
+			SetIsActive(item.IsActive).
+			SetStreamOnlineOnly(item.StreamOnlineOnly).
+			SetPerm(item.Perm).
+			SetCooldown(item.Cooldown).
+			SetAllowedUserID(item.AllowedUserID))
+	}
+
+	// MySQL ignores the conflict target (ON DUPLICATE KEY UPDATE is index-less);
+	// SQLite (tests) requires it.
+	return client.Commands.CreateBulk(builders...).
+		OnConflict(entsql.ConflictColumns(commands.FieldUserID, commands.FieldName)).
+		Update(func(u *ent.CommandsUpsert) {
+			u.UpdateAliases()
+			u.UpdateResponse()
+			u.UpdateIsActive()
+			u.UpdateStreamOnlineOnly()
+			u.UpdatePerm()
+			u.UpdateCooldown()
+			u.UpdateAllowedUserID()
+			u.UpdateUpdatedAt()
+		}).
+		Exec(ctx)
+}
+
+// upsertEach persists a failed window one item at a time and returns the
+// items that landed. Rows the database will never accept (validation or
+// constraint errors) are dropped with an error log; transiently failing rows
+// are requeued into the batcher so the next window retries them without
+// holding the rest of the batch hostage.
+func (r *Commands) upsertEach(ctx context.Context, txn *newrelic.Transaction, items []data.CommandChangedDTO) []data.CommandChangedDTO {
+
+	landed := make([]data.CommandChangedDTO, 0, len(items))
+	for _, item := range items {
+		err := db.WithExec(ctx, func(ctx context.Context) error {
+			return upsertCommand(ctx, r.client.Commands, item)
+		})
+		if err == nil {
+			landed = append(landed, item)
+			continue
+		}
+		txn.NoticeError(err)
+		if ent.IsValidationError(err) || ent.IsConstraintError(err) {
+			r.log.Error("dropping unpersistable command edit",
+				zap.Uint64("user_id", item.UserID),
+				zap.String("command", item.Name),
+				zap.Error(err),
+			)
+			continue
+		}
+		r.log.Warn("requeueing command edit after transient flush failure",
+			zap.Uint64("user_id", item.UserID),
+			zap.String("command", item.Name),
+			zap.Error(err),
+		)
+		r.batcher.Requeue(commandKey{userID: item.UserID, name: item.Name}, item)
+	}
+	return landed
+}
+
+func upsertCommand(ctx context.Context, c *ent.CommandsClient, item data.CommandChangedDTO) error {
+
+	updated, err := c.Update().
 		Where(
 			commands.UserIDEQ(item.UserID),
 			commands.NameEQ(item.Name),
@@ -609,7 +686,7 @@ func upsertCommand(ctx context.Context, tx *ent.Tx, item data.CommandChangedDTO)
 		return nil
 	}
 
-	if err := tx.Commands.Create().
+	if err := c.Create().
 		SetUserID(item.UserID).
 		SetName(item.Name).
 		SetAliases(item.Aliases).
@@ -621,7 +698,7 @@ func upsertCommand(ctx context.Context, tx *ent.Tx, item data.CommandChangedDTO)
 		SetAllowedUserID(item.AllowedUserID).
 		Exec(ctx); err != nil {
 		if ent.IsConstraintError(err) {
-			_, err = tx.Commands.Update().
+			_, err = c.Update().
 				Where(
 					commands.UserIDEQ(item.UserID),
 					commands.NameEQ(item.Name),

--- a/app/commands/repository/flush_internal_test.go
+++ b/app/commands/repository/flush_internal_test.go
@@ -1,0 +1,67 @@
+package repository
+
+import (
+	"context"
+	"testing"
+
+	"ItsBagelBot/app/commands/ent/enttest"
+	"ItsBagelBot/internal/domain/event/data"
+	"ItsBagelBot/pkg/bus/bustest"
+
+	_ "github.com/mattn/go-sqlite3" // Required for the in-memory DB
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.uber.org/zap"
+)
+
+// A row the database will never accept (empty response violates the schema
+// validator) must be dropped by the per-item fallback while the rest of the
+// window lands — the poison item must not wedge the whole batch.
+func TestUpsertEachIsolatesPoisonItem(t *testing.T) {
+	client := enttest.Open(t, "sqlite3", "file:commandsflush?mode=memory&cache=shared&_fk=1")
+	t.Cleanup(func() { _ = client.Close() })
+
+	r := NewCommands(client, bustest.NewPublisher(), nil, zap.NewNop())
+
+	ctx := context.Background()
+	good := data.CommandChangedDTO{UserID: 1001, Name: "ok", Response: "fine", IsActive: true, Perm: "everyone"}
+	poison := data.CommandChangedDTO{UserID: 1001, Name: "bad", Response: "", IsActive: true, Perm: "everyone"}
+
+	landed := r.upsertEach(ctx, nil, []data.CommandChangedDTO{good, poison})
+
+	require.Len(t, landed, 1)
+	assert.Equal(t, "ok", landed[0].Name)
+
+	rows := client.Commands.Query().AllX(ctx)
+	require.Len(t, rows, 1)
+	assert.Equal(t, "ok", rows[0].Name)
+
+	// A permanent failure must not be requeued: the next flush window would
+	// hit the same validation error forever. Close drains anything pending,
+	// so the row count must not change.
+	r.Close(ctx)
+	assert.Len(t, client.Commands.Query().AllX(ctx), 1)
+}
+
+// The bulk fast path must not touch the uses counter when an edit updates an
+// existing row: the counter belongs to the counter flush alone.
+func TestBulkUpsertPreservesUses(t *testing.T) {
+	client := enttest.Open(t, "sqlite3", "file:commandsuses?mode=memory&cache=shared&_fk=1")
+	t.Cleanup(func() { _ = client.Close() })
+
+	ctx := context.Background()
+	client.Commands.Create().
+		SetUserID(1001).
+		SetName("hello").
+		SetResponse("old wording").
+		SetUses(42).
+		SaveX(ctx)
+
+	edit := data.CommandChangedDTO{UserID: 1001, Name: "hello", Response: "new wording", IsActive: true, Perm: "everyone"}
+	require.NoError(t, bulkUpsertCommands(ctx, client, []data.CommandChangedDTO{edit}))
+
+	row := client.Commands.Query().OnlyX(ctx)
+	assert.Equal(t, "new wording", row.Response)
+	assert.Equal(t, uint64(42), row.Uses)
+}

--- a/app/modules/ent/modules_create.go
+++ b/app/modules/ent/modules_create.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"time"
 
+	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
 )
@@ -18,6 +19,7 @@ type ModulesCreate struct {
 	config
 	mutation *ModulesMutation
 	hooks    []Hook
+	conflict []sql.ConflictOption
 }
 
 // SetUserID sets the "user_id" field.
@@ -156,6 +158,7 @@ func (_c *ModulesCreate) createSpec() (*Modules, *sqlgraph.CreateSpec) {
 		_node = &Modules{config: _c.config}
 		_spec = sqlgraph.NewCreateSpec(modules.Table, sqlgraph.NewFieldSpec(modules.FieldID, field.TypeInt))
 	)
+	_spec.OnConflict = _c.conflict
 	if value, ok := _c.mutation.UserID(); ok {
 		_spec.SetField(modules.FieldUserID, field.TypeUint64, value)
 		_node.UserID = value
@@ -179,11 +182,256 @@ func (_c *ModulesCreate) createSpec() (*Modules, *sqlgraph.CreateSpec) {
 	return _node, _spec
 }
 
+// OnConflict allows configuring the `ON CONFLICT` / `ON DUPLICATE KEY` clause
+// of the `INSERT` statement. For example:
+//
+//	client.Modules.Create().
+//		SetUserID(v).
+//		OnConflict(
+//			// Update the row with the new values
+//			// the was proposed for insertion.
+//			sql.ResolveWithNewValues(),
+//		).
+//		// Override some of the fields with custom
+//		// update values.
+//		Update(func(u *ent.ModulesUpsert) {
+//			SetUserID(v+v).
+//		}).
+//		Exec(ctx)
+func (_c *ModulesCreate) OnConflict(opts ...sql.ConflictOption) *ModulesUpsertOne {
+	_c.conflict = opts
+	return &ModulesUpsertOne{
+		create: _c,
+	}
+}
+
+// OnConflictColumns calls `OnConflict` and configures the columns
+// as conflict target. Using this option is equivalent to using:
+//
+//	client.Modules.Create().
+//		OnConflict(sql.ConflictColumns(columns...)).
+//		Exec(ctx)
+func (_c *ModulesCreate) OnConflictColumns(columns ...string) *ModulesUpsertOne {
+	_c.conflict = append(_c.conflict, sql.ConflictColumns(columns...))
+	return &ModulesUpsertOne{
+		create: _c,
+	}
+}
+
+type (
+	// ModulesUpsertOne is the builder for "upsert"-ing
+	//  one Modules node.
+	ModulesUpsertOne struct {
+		create *ModulesCreate
+	}
+
+	// ModulesUpsert is the "OnConflict" setter.
+	ModulesUpsert struct {
+		*sql.UpdateSet
+	}
+)
+
+// SetName sets the "name" field.
+func (u *ModulesUpsert) SetName(v string) *ModulesUpsert {
+	u.Set(modules.FieldName, v)
+	return u
+}
+
+// UpdateName sets the "name" field to the value that was provided on create.
+func (u *ModulesUpsert) UpdateName() *ModulesUpsert {
+	u.SetExcluded(modules.FieldName)
+	return u
+}
+
+// SetIsEnabled sets the "is_enabled" field.
+func (u *ModulesUpsert) SetIsEnabled(v bool) *ModulesUpsert {
+	u.Set(modules.FieldIsEnabled, v)
+	return u
+}
+
+// UpdateIsEnabled sets the "is_enabled" field to the value that was provided on create.
+func (u *ModulesUpsert) UpdateIsEnabled() *ModulesUpsert {
+	u.SetExcluded(modules.FieldIsEnabled)
+	return u
+}
+
+// SetConfigs sets the "configs" field.
+func (u *ModulesUpsert) SetConfigs(v []uint8) *ModulesUpsert {
+	u.Set(modules.FieldConfigs, v)
+	return u
+}
+
+// UpdateConfigs sets the "configs" field to the value that was provided on create.
+func (u *ModulesUpsert) UpdateConfigs() *ModulesUpsert {
+	u.SetExcluded(modules.FieldConfigs)
+	return u
+}
+
+// ClearConfigs clears the value of the "configs" field.
+func (u *ModulesUpsert) ClearConfigs() *ModulesUpsert {
+	u.SetNull(modules.FieldConfigs)
+	return u
+}
+
+// SetUpdatedAt sets the "updated_at" field.
+func (u *ModulesUpsert) SetUpdatedAt(v time.Time) *ModulesUpsert {
+	u.Set(modules.FieldUpdatedAt, v)
+	return u
+}
+
+// UpdateUpdatedAt sets the "updated_at" field to the value that was provided on create.
+func (u *ModulesUpsert) UpdateUpdatedAt() *ModulesUpsert {
+	u.SetExcluded(modules.FieldUpdatedAt)
+	return u
+}
+
+// UpdateNewValues updates the mutable fields using the new values that were set on create.
+// Using this option is equivalent to using:
+//
+//	client.Modules.Create().
+//		OnConflict(
+//			sql.ResolveWithNewValues(),
+//		).
+//		Exec(ctx)
+func (u *ModulesUpsertOne) UpdateNewValues() *ModulesUpsertOne {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWithNewValues())
+	u.create.conflict = append(u.create.conflict, sql.ResolveWith(func(s *sql.UpdateSet) {
+		if _, exists := u.create.mutation.UserID(); exists {
+			s.SetIgnore(modules.FieldUserID)
+		}
+	}))
+	return u
+}
+
+// Ignore sets each column to itself in case of conflict.
+// Using this option is equivalent to using:
+//
+//	client.Modules.Create().
+//	    OnConflict(sql.ResolveWithIgnore()).
+//	    Exec(ctx)
+func (u *ModulesUpsertOne) Ignore() *ModulesUpsertOne {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWithIgnore())
+	return u
+}
+
+// DoNothing configures the conflict_action to `DO NOTHING`.
+// Supported only by SQLite and PostgreSQL.
+func (u *ModulesUpsertOne) DoNothing() *ModulesUpsertOne {
+	u.create.conflict = append(u.create.conflict, sql.DoNothing())
+	return u
+}
+
+// Update allows overriding fields `UPDATE` values. See the ModulesCreate.OnConflict
+// documentation for more info.
+func (u *ModulesUpsertOne) Update(set func(*ModulesUpsert)) *ModulesUpsertOne {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWith(func(update *sql.UpdateSet) {
+		set(&ModulesUpsert{UpdateSet: update})
+	}))
+	return u
+}
+
+// SetName sets the "name" field.
+func (u *ModulesUpsertOne) SetName(v string) *ModulesUpsertOne {
+	return u.Update(func(s *ModulesUpsert) {
+		s.SetName(v)
+	})
+}
+
+// UpdateName sets the "name" field to the value that was provided on create.
+func (u *ModulesUpsertOne) UpdateName() *ModulesUpsertOne {
+	return u.Update(func(s *ModulesUpsert) {
+		s.UpdateName()
+	})
+}
+
+// SetIsEnabled sets the "is_enabled" field.
+func (u *ModulesUpsertOne) SetIsEnabled(v bool) *ModulesUpsertOne {
+	return u.Update(func(s *ModulesUpsert) {
+		s.SetIsEnabled(v)
+	})
+}
+
+// UpdateIsEnabled sets the "is_enabled" field to the value that was provided on create.
+func (u *ModulesUpsertOne) UpdateIsEnabled() *ModulesUpsertOne {
+	return u.Update(func(s *ModulesUpsert) {
+		s.UpdateIsEnabled()
+	})
+}
+
+// SetConfigs sets the "configs" field.
+func (u *ModulesUpsertOne) SetConfigs(v []uint8) *ModulesUpsertOne {
+	return u.Update(func(s *ModulesUpsert) {
+		s.SetConfigs(v)
+	})
+}
+
+// UpdateConfigs sets the "configs" field to the value that was provided on create.
+func (u *ModulesUpsertOne) UpdateConfigs() *ModulesUpsertOne {
+	return u.Update(func(s *ModulesUpsert) {
+		s.UpdateConfigs()
+	})
+}
+
+// ClearConfigs clears the value of the "configs" field.
+func (u *ModulesUpsertOne) ClearConfigs() *ModulesUpsertOne {
+	return u.Update(func(s *ModulesUpsert) {
+		s.ClearConfigs()
+	})
+}
+
+// SetUpdatedAt sets the "updated_at" field.
+func (u *ModulesUpsertOne) SetUpdatedAt(v time.Time) *ModulesUpsertOne {
+	return u.Update(func(s *ModulesUpsert) {
+		s.SetUpdatedAt(v)
+	})
+}
+
+// UpdateUpdatedAt sets the "updated_at" field to the value that was provided on create.
+func (u *ModulesUpsertOne) UpdateUpdatedAt() *ModulesUpsertOne {
+	return u.Update(func(s *ModulesUpsert) {
+		s.UpdateUpdatedAt()
+	})
+}
+
+// Exec executes the query.
+func (u *ModulesUpsertOne) Exec(ctx context.Context) error {
+	if len(u.create.conflict) == 0 {
+		return errors.New("ent: missing options for ModulesCreate.OnConflict")
+	}
+	return u.create.Exec(ctx)
+}
+
+// ExecX is like Exec, but panics if an error occurs.
+func (u *ModulesUpsertOne) ExecX(ctx context.Context) {
+	if err := u.create.Exec(ctx); err != nil {
+		panic(err)
+	}
+}
+
+// Exec executes the UPSERT query and returns the inserted/updated ID.
+func (u *ModulesUpsertOne) ID(ctx context.Context) (id int, err error) {
+	node, err := u.create.Save(ctx)
+	if err != nil {
+		return id, err
+	}
+	return node.ID, nil
+}
+
+// IDX is like ID, but panics if an error occurs.
+func (u *ModulesUpsertOne) IDX(ctx context.Context) int {
+	id, err := u.ID(ctx)
+	if err != nil {
+		panic(err)
+	}
+	return id
+}
+
 // ModulesCreateBulk is the builder for creating many Modules entities in bulk.
 type ModulesCreateBulk struct {
 	config
 	err      error
 	builders []*ModulesCreate
+	conflict []sql.ConflictOption
 }
 
 // Save creates the Modules entities in the database.
@@ -213,6 +461,7 @@ func (_c *ModulesCreateBulk) Save(ctx context.Context) ([]*Modules, error) {
 					_, err = mutators[i+1].Mutate(root, _c.builders[i+1].mutation)
 				} else {
 					spec := &sqlgraph.BatchCreateSpec{Nodes: specs}
+					spec.OnConflict = _c.conflict
 					// Invoke the actual operation on the latest mutation in the chain.
 					if err = sqlgraph.BatchCreate(ctx, _c.driver, spec); err != nil {
 						if sqlgraph.IsConstraintError(err) {
@@ -263,6 +512,180 @@ func (_c *ModulesCreateBulk) Exec(ctx context.Context) error {
 // ExecX is like Exec, but panics if an error occurs.
 func (_c *ModulesCreateBulk) ExecX(ctx context.Context) {
 	if err := _c.Exec(ctx); err != nil {
+		panic(err)
+	}
+}
+
+// OnConflict allows configuring the `ON CONFLICT` / `ON DUPLICATE KEY` clause
+// of the `INSERT` statement. For example:
+//
+//	client.Modules.CreateBulk(builders...).
+//		OnConflict(
+//			// Update the row with the new values
+//			// the was proposed for insertion.
+//			sql.ResolveWithNewValues(),
+//		).
+//		// Override some of the fields with custom
+//		// update values.
+//		Update(func(u *ent.ModulesUpsert) {
+//			SetUserID(v+v).
+//		}).
+//		Exec(ctx)
+func (_c *ModulesCreateBulk) OnConflict(opts ...sql.ConflictOption) *ModulesUpsertBulk {
+	_c.conflict = opts
+	return &ModulesUpsertBulk{
+		create: _c,
+	}
+}
+
+// OnConflictColumns calls `OnConflict` and configures the columns
+// as conflict target. Using this option is equivalent to using:
+//
+//	client.Modules.Create().
+//		OnConflict(sql.ConflictColumns(columns...)).
+//		Exec(ctx)
+func (_c *ModulesCreateBulk) OnConflictColumns(columns ...string) *ModulesUpsertBulk {
+	_c.conflict = append(_c.conflict, sql.ConflictColumns(columns...))
+	return &ModulesUpsertBulk{
+		create: _c,
+	}
+}
+
+// ModulesUpsertBulk is the builder for "upsert"-ing
+// a bulk of Modules nodes.
+type ModulesUpsertBulk struct {
+	create *ModulesCreateBulk
+}
+
+// UpdateNewValues updates the mutable fields using the new values that
+// were set on create. Using this option is equivalent to using:
+//
+//	client.Modules.Create().
+//		OnConflict(
+//			sql.ResolveWithNewValues(),
+//		).
+//		Exec(ctx)
+func (u *ModulesUpsertBulk) UpdateNewValues() *ModulesUpsertBulk {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWithNewValues())
+	u.create.conflict = append(u.create.conflict, sql.ResolveWith(func(s *sql.UpdateSet) {
+		for _, b := range u.create.builders {
+			if _, exists := b.mutation.UserID(); exists {
+				s.SetIgnore(modules.FieldUserID)
+			}
+		}
+	}))
+	return u
+}
+
+// Ignore sets each column to itself in case of conflict.
+// Using this option is equivalent to using:
+//
+//	client.Modules.Create().
+//		OnConflict(sql.ResolveWithIgnore()).
+//		Exec(ctx)
+func (u *ModulesUpsertBulk) Ignore() *ModulesUpsertBulk {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWithIgnore())
+	return u
+}
+
+// DoNothing configures the conflict_action to `DO NOTHING`.
+// Supported only by SQLite and PostgreSQL.
+func (u *ModulesUpsertBulk) DoNothing() *ModulesUpsertBulk {
+	u.create.conflict = append(u.create.conflict, sql.DoNothing())
+	return u
+}
+
+// Update allows overriding fields `UPDATE` values. See the ModulesCreateBulk.OnConflict
+// documentation for more info.
+func (u *ModulesUpsertBulk) Update(set func(*ModulesUpsert)) *ModulesUpsertBulk {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWith(func(update *sql.UpdateSet) {
+		set(&ModulesUpsert{UpdateSet: update})
+	}))
+	return u
+}
+
+// SetName sets the "name" field.
+func (u *ModulesUpsertBulk) SetName(v string) *ModulesUpsertBulk {
+	return u.Update(func(s *ModulesUpsert) {
+		s.SetName(v)
+	})
+}
+
+// UpdateName sets the "name" field to the value that was provided on create.
+func (u *ModulesUpsertBulk) UpdateName() *ModulesUpsertBulk {
+	return u.Update(func(s *ModulesUpsert) {
+		s.UpdateName()
+	})
+}
+
+// SetIsEnabled sets the "is_enabled" field.
+func (u *ModulesUpsertBulk) SetIsEnabled(v bool) *ModulesUpsertBulk {
+	return u.Update(func(s *ModulesUpsert) {
+		s.SetIsEnabled(v)
+	})
+}
+
+// UpdateIsEnabled sets the "is_enabled" field to the value that was provided on create.
+func (u *ModulesUpsertBulk) UpdateIsEnabled() *ModulesUpsertBulk {
+	return u.Update(func(s *ModulesUpsert) {
+		s.UpdateIsEnabled()
+	})
+}
+
+// SetConfigs sets the "configs" field.
+func (u *ModulesUpsertBulk) SetConfigs(v []uint8) *ModulesUpsertBulk {
+	return u.Update(func(s *ModulesUpsert) {
+		s.SetConfigs(v)
+	})
+}
+
+// UpdateConfigs sets the "configs" field to the value that was provided on create.
+func (u *ModulesUpsertBulk) UpdateConfigs() *ModulesUpsertBulk {
+	return u.Update(func(s *ModulesUpsert) {
+		s.UpdateConfigs()
+	})
+}
+
+// ClearConfigs clears the value of the "configs" field.
+func (u *ModulesUpsertBulk) ClearConfigs() *ModulesUpsertBulk {
+	return u.Update(func(s *ModulesUpsert) {
+		s.ClearConfigs()
+	})
+}
+
+// SetUpdatedAt sets the "updated_at" field.
+func (u *ModulesUpsertBulk) SetUpdatedAt(v time.Time) *ModulesUpsertBulk {
+	return u.Update(func(s *ModulesUpsert) {
+		s.SetUpdatedAt(v)
+	})
+}
+
+// UpdateUpdatedAt sets the "updated_at" field to the value that was provided on create.
+func (u *ModulesUpsertBulk) UpdateUpdatedAt() *ModulesUpsertBulk {
+	return u.Update(func(s *ModulesUpsert) {
+		s.UpdateUpdatedAt()
+	})
+}
+
+// Exec executes the query.
+func (u *ModulesUpsertBulk) Exec(ctx context.Context) error {
+	if u.create.err != nil {
+		return u.create.err
+	}
+	for i, b := range u.create.builders {
+		if len(b.conflict) != 0 {
+			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the ModulesCreateBulk instead", i)
+		}
+	}
+	if len(u.create.conflict) == 0 {
+		return errors.New("ent: missing options for ModulesCreateBulk.OnConflict")
+	}
+	return u.create.Exec(ctx)
+}
+
+// ExecX is like Exec, but panics if an error occurs.
+func (u *ModulesUpsertBulk) ExecX(ctx context.Context) {
+	if err := u.create.Exec(ctx); err != nil {
 		panic(err)
 	}
 }

--- a/app/modules/repository/modules.go
+++ b/app/modules/repository/modules.go
@@ -15,6 +15,8 @@ import (
 	"ItsBagelBot/pkg/cache"
 	"ItsBagelBot/pkg/db"
 
+	entsql "entgo.io/ent/dialect/sql"
+
 	"github.com/ThreeDotsLabs/watermill/message"
 
 	"github.com/newrelic/go-agent/v3/newrelic"
@@ -190,9 +192,9 @@ func (r *Modules) Close(ctx context.Context) {
 	r.views.Close()
 }
 
-// flush lands one window of coalesced changes in a single transaction, then
-// invalidates the local cache and announces every change on the bus. It runs
-// detached from any request, so it reports as its own background transaction.
+// flush lands one window of coalesced changes, then invalidates the local
+// cache and announces every landed change on the bus. It runs detached from
+// any request, so it reports as its own background transaction.
 func (r *Modules) flush(ctx context.Context, items []data.ModuleChangedDTO) error {
 
 	txn := r.app.StartTransaction("flush modules")
@@ -200,30 +202,19 @@ func (r *Modules) flush(ctx context.Context, items []data.ModuleChangedDTO) erro
 
 	ctx = newrelic.NewContext(ctx, txn)
 
+	// Fast path: the whole window lands as one INSERT ... ON DUPLICATE KEY
+	// UPDATE. If that statement fails, fall back to per-item writes so one
+	// unpersistable row cannot wedge the entire batch in the retry loop
+	// forever (the old whole-batch rollback + requeue did exactly that).
+	landed := items
 	if err := db.WithExec(ctx, func(ctx context.Context) error {
-		tx, err := r.client.Tx(ctx)
-		if err != nil {
-			return err
-		}
-
-		for _, item := range items {
-			if err := upsertModule(ctx, tx, item); err != nil {
-				_ = tx.Rollback()
-				txn.NoticeError(err)
-				return err
-			}
-		}
-
-		if err := tx.Commit(); err != nil {
-			txn.NoticeError(err)
-			return err
-		}
-		return nil
+		return bulkUpsertModules(ctx, r.client, items)
 	}); err != nil {
-		return err
+		txn.NoticeError(err)
+		landed = r.upsertEach(ctx, txn, items)
 	}
 
-	for _, item := range items {
+	for _, item := range landed {
 
 		r.Invalidate(item.UserID)
 
@@ -241,9 +232,69 @@ func (r *Modules) flush(ctx context.Context, items []data.ModuleChangedDTO) erro
 	return nil
 }
 
-func upsertModule(ctx context.Context, tx *ent.Tx, item data.ModuleChangedDTO) error {
+// bulkUpsertModules lands one flush window as a single
+// INSERT ... ON DUPLICATE KEY UPDATE keyed on the (user_id, name) unique index.
+func bulkUpsertModules(ctx context.Context, client *ent.Client, items []data.ModuleChangedDTO) error {
 
-	updated, err := tx.Modules.Update().
+	builders := make([]*ent.ModulesCreate, 0, len(items))
+	for _, item := range items {
+		builders = append(builders, client.Modules.Create().
+			SetUserID(item.UserID).
+			SetName(item.Name).
+			SetIsEnabled(item.IsEnabled).
+			SetConfigs(item.Configs))
+	}
+
+	// MySQL ignores the conflict target (ON DUPLICATE KEY UPDATE is index-less);
+	// SQLite (tests) requires it.
+	return client.Modules.CreateBulk(builders...).
+		OnConflict(entsql.ConflictColumns(modules.FieldUserID, modules.FieldName)).
+		Update(func(u *ent.ModulesUpsert) {
+			u.UpdateIsEnabled()
+			u.UpdateConfigs()
+			u.UpdateUpdatedAt()
+		}).
+		Exec(ctx)
+}
+
+// upsertEach persists a failed window one item at a time and returns the
+// items that landed. Rows the database will never accept (validation or
+// constraint errors) are dropped with an error log; transiently failing rows
+// are requeued into the batcher so the next window retries them without
+// holding the rest of the batch hostage.
+func (r *Modules) upsertEach(ctx context.Context, txn *newrelic.Transaction, items []data.ModuleChangedDTO) []data.ModuleChangedDTO {
+
+	landed := make([]data.ModuleChangedDTO, 0, len(items))
+	for _, item := range items {
+		err := db.WithExec(ctx, func(ctx context.Context) error {
+			return upsertModule(ctx, r.client.Modules, item)
+		})
+		if err == nil {
+			landed = append(landed, item)
+			continue
+		}
+		txn.NoticeError(err)
+		if ent.IsValidationError(err) || ent.IsConstraintError(err) {
+			r.log.Error("dropping unpersistable module change",
+				zap.Uint64("user_id", item.UserID),
+				zap.String("module", item.Name),
+				zap.Error(err),
+			)
+			continue
+		}
+		r.log.Warn("requeueing module change after transient flush failure",
+			zap.Uint64("user_id", item.UserID),
+			zap.String("module", item.Name),
+			zap.Error(err),
+		)
+		r.batcher.Requeue(moduleKey{userID: item.UserID, name: item.Name}, item)
+	}
+	return landed
+}
+
+func upsertModule(ctx context.Context, c *ent.ModulesClient, item data.ModuleChangedDTO) error {
+
+	updated, err := c.Update().
 		Where(
 			modules.UserIDEQ(item.UserID),
 			modules.NameEQ(item.Name),
@@ -259,14 +310,14 @@ func upsertModule(ctx context.Context, tx *ent.Tx, item data.ModuleChangedDTO) e
 		return nil
 	}
 
-	if err := tx.Modules.Create().
+	if err := c.Create().
 		SetUserID(item.UserID).
 		SetName(item.Name).
 		SetIsEnabled(item.IsEnabled).
 		SetConfigs(item.Configs).
 		Exec(ctx); err != nil {
 		if ent.IsConstraintError(err) {
-			_, err = tx.Modules.Update().
+			_, err = c.Update().
 				Where(
 					modules.UserIDEQ(item.UserID),
 					modules.NameEQ(item.Name),

--- a/console/dashboard/src/hooks.server.ts
+++ b/console/dashboard/src/hooks.server.ts
@@ -5,6 +5,7 @@ import { warm } from '@bagel/shared/server/nats';
 import { warm as warmValkey } from '@bagel/shared/server/valkey-store';
 import { registerServerConfig } from '@bagel/shared/server/config';
 import { rumTransform } from '@bagel/shared/server/rum';
+import { RateLimiter, clientIp } from '@bagel/shared/server/rate-limit';
 import { detectLocale, LOCALE_COOKIE } from '@bagel/shared/i18n';
 import { startInvalidationListener } from '$lib/server/services';
 import { assertConfigSane } from '$lib/server/config-sanity';
@@ -42,10 +43,53 @@ export const init: ServerInit = async () => {
   startInvalidationListener();
 };
 
+// Per-pod rate limits (see rate-limit.ts for why these are not Valkey-backed).
+// Three tiers, tightest wins by route/method:
+//   * auth   — /auth/* + /delegate/*: OAuth redirects/callbacks and session
+//     escalation. Brute-force target, humans hit it a handful of times.
+//   * write  — any non-GET/HEAD elsewhere: form actions and API mutations.
+//     Clicking around settings is bursty, so allow a real burst but a modest
+//     sustained rate (the Go batchers coalesce anyway).
+//   * read   — everything else: page loads, __data.json, SSE connects.
+// Keyed by session user id when logged in (stable across CGNAT/mobile IP
+// churn), else by client IP.
+const authLimiter = new RateLimiter({ capacity: 10, refillPerSec: 10 / 60 });
+const writeLimiter = new RateLimiter({ capacity: 30, refillPerSec: 0.5 });
+const readLimiter = new RateLimiter({ capacity: 60, refillPerSec: 2 });
+
+// Kubelet probes are frequent, unauthenticated and share the node IP; limiting
+// them would let the limiter fail readiness. Static /_app assets never reach
+// this handle (served by sirv in serve-node.js).
+const RATE_EXEMPT = new Set(['/healthz', '/readyz']);
+
+function pickLimiter(pathname: string, method: string): RateLimiter {
+  if (pathname.startsWith('/auth/') || pathname.startsWith('/delegate/')) return authLimiter;
+  if (method !== 'GET' && method !== 'HEAD') return writeLimiter;
+  return readLimiter;
+}
+
 // Session + the security headers SvelteKit's CSP config does not own.
 export const handle: Handle = async ({ event, resolve }) => {
   const cookie = event.cookies.get(COOKIE);
   event.locals.session = cookie ? open(cookie) : null;
+
+  if (!RATE_EXEMPT.has(event.url.pathname)) {
+    const key = event.locals.session?.user_id
+      ? `u:${event.locals.session.user_id}`
+      : `ip:${clientIp(event.request.headers, event.getClientAddress)}`;
+    const decision = pickLimiter(event.url.pathname, event.request.method).check(key);
+    if (!decision.allowed) {
+      newrelic.addCustomAttributes({ 'ratelimit.limited': true, 'route.id': event.route.id ?? 'unmatched' });
+      return new Response('Too many requests', {
+        status: 429,
+        headers: {
+          'Retry-After': String(decision.retryAfterSec),
+          'Cache-Control': 'no-store',
+          'Content-Type': 'text/plain; charset=utf-8'
+        }
+      });
+    }
+  }
 
   let queryLang = event.url.searchParams.get('lang');
   if (queryLang === 'fr' || queryLang === 'en') {

--- a/console/dashboard/src/hooks.server.ts
+++ b/console/dashboard/src/hooks.server.ts
@@ -5,7 +5,7 @@ import { warm } from '@bagel/shared/server/nats';
 import { warm as warmValkey } from '@bagel/shared/server/valkey-store';
 import { registerServerConfig } from '@bagel/shared/server/config';
 import { rumTransform } from '@bagel/shared/server/rum';
-import { RateLimiter, clientIp } from '@bagel/shared/server/rate-limit';
+import { ValkeyRateLimiter, warmRateLimiter, clientIp } from '@bagel/shared/server/rate-limit';
 import { detectLocale, LOCALE_COOKIE } from '@bagel/shared/i18n';
 import { startInvalidationListener } from '$lib/server/services';
 import { assertConfigSane } from '$lib/server/config-sanity';
@@ -29,21 +29,35 @@ export const init: ServerInit = async () => {
   // Register the caching-layer config (Valkey read tier + invalidation bus) so
   // shared infra resolves it without touching $env itself.
   registerServerConfig({
-    valkey: env.VALKEY_ADDR ? { addr: env.VALKEY_ADDR, password: env.VALKEY_PASSWORD } : undefined,
+    valkey: env.VALKEY_ADDR
+      ? {
+          addr: env.VALKEY_ADDR,
+          password: env.VALKEY_PASSWORD,
+          // Optional Sentinel endpoint for write-path clients (rate limiter):
+          // tracks the elected master across failovers instead of pinning a
+          // node-local instance that may be a read-only replica.
+          sentinelAddr: env.VALKEY_SENTINEL_ADDR,
+          sentinelMaster: env.VALKEY_MASTER_SET
+        }
+      : undefined,
     cacheInvalidationPrefix: env.NATS_CACHE_INVALIDATION_PREFIX ?? 'bagel.cache.invalidate'
   });
 
-  // Pre-dial NATS and pre-connect the Valkey read pool so the first request hits
-  // warm connections instead of paying the cold dial/connect on the hot path.
+  // Pre-dial NATS and pre-connect the Valkey read pool and rate-limit write
+  // client so the first request hits warm connections instead of paying the
+  // cold dial/connect on the hot path.
   warm();
   warmValkey();
+  warmRateLimiter();
 
   // Subscribe to the cache-invalidation bus so writes in Go services push-drop
   // the right keys without waiting on TTL expiry.
   startInvalidationListener();
 };
 
-// Per-pod rate limits (see rate-limit.ts for why these are not Valkey-backed).
+// Fleet-wide rate limits: the buckets live in Valkey (Sentinel master), so
+// every pod enforces the same global budget; on any Valkey failure each tier
+// degrades to a per-pod bucket with the same tuning (see rate-limit.ts).
 // Three tiers, tightest wins by route/method:
 //   * auth   — /auth/* + /delegate/*: OAuth redirects/callbacks and session
 //     escalation. Brute-force target, humans hit it a handful of times.
@@ -53,16 +67,16 @@ export const init: ServerInit = async () => {
 //   * read   — everything else: page loads, __data.json, SSE connects.
 // Keyed by session user id when logged in (stable across CGNAT/mobile IP
 // churn), else by client IP.
-const authLimiter = new RateLimiter({ capacity: 10, refillPerSec: 10 / 60 });
-const writeLimiter = new RateLimiter({ capacity: 30, refillPerSec: 0.5 });
-const readLimiter = new RateLimiter({ capacity: 60, refillPerSec: 2 });
+const authLimiter = new ValkeyRateLimiter({ name: 'auth', capacity: 10, refillPerSec: 10 / 60 });
+const writeLimiter = new ValkeyRateLimiter({ name: 'write', capacity: 30, refillPerSec: 0.5 });
+const readLimiter = new ValkeyRateLimiter({ name: 'read', capacity: 60, refillPerSec: 2 });
 
 // Kubelet probes are frequent, unauthenticated and share the node IP; limiting
 // them would let the limiter fail readiness. Static /_app assets never reach
 // this handle (served by sirv in serve-node.js).
 const RATE_EXEMPT = new Set(['/healthz', '/readyz']);
 
-function pickLimiter(pathname: string, method: string): RateLimiter {
+function pickLimiter(pathname: string, method: string): ValkeyRateLimiter {
   if (pathname.startsWith('/auth/') || pathname.startsWith('/delegate/')) return authLimiter;
   if (method !== 'GET' && method !== 'HEAD') return writeLimiter;
   return readLimiter;
@@ -77,7 +91,7 @@ export const handle: Handle = async ({ event, resolve }) => {
     const key = event.locals.session?.user_id
       ? `u:${event.locals.session.user_id}`
       : `ip:${clientIp(event.request.headers, event.getClientAddress)}`;
-    const decision = pickLimiter(event.url.pathname, event.request.method).check(key);
+    const decision = await pickLimiter(event.url.pathname, event.request.method).check(key);
     if (!decision.allowed) {
       newrelic.addCustomAttributes({ 'ratelimit.limited': true, 'route.id': event.route.id ?? 'unmatched' });
       return new Response('Too many requests', {

--- a/console/dashboard/src/routes/readyz/+server.ts
+++ b/console/dashboard/src/routes/readyz/+server.ts
@@ -1,6 +1,7 @@
 import type { RequestHandler } from './$types';
 import { ready } from '@bagel/shared/server/nats';
 import { ready as warmValkey } from '@bagel/shared/server/valkey-store';
+import { rateLimiterReady } from '@bagel/shared/server/rate-limit';
 
 export const GET: RequestHandler = async () => {
   // Gate readiness on NATS (the hard dependency) and best-effort-warm the Valkey
@@ -9,7 +10,9 @@ export const GET: RequestHandler = async () => {
   // not pull every replica out of rotation. Re-warming each probe means a
   // rotated-in pod's pool is hot within one interval, so the first real request
   // rarely pays a cold connect.
-  const [natsReady] = await Promise.all([ready(), warmValkey()]);
+  // The rate-limiter write client warms on the same terms (its outage only
+  // loosens limits to per-pod buckets, never gates readiness).
+  const [natsReady] = await Promise.all([ready(), warmValkey(), rateLimiterReady()]);
   if (!natsReady) {
     return new Response('not ready', { status: 503, headers: { 'cache-control': 'no-store' } });
   }

--- a/console/shared/lib/server/config.ts
+++ b/console/shared/lib/server/config.ts
@@ -20,6 +20,15 @@ export interface ValkeyConfig {
   /** host:port of the node-local read instance, e.g. "127.0.0.1:6379". */
   addr: string;
   password?: string;
+  /**
+   * host:port of a Sentinel endpoint, e.g. "valkey.valkey.svc:26379". When set,
+   * write-path clients (rate limiter) connect through Sentinel so they always
+   * track the elected master across failovers; when absent, writes go to
+   * `addr` directly (single-instance/dev setups).
+   */
+  sentinelAddr?: string;
+  /** Sentinel master set name. Defaults to "myprimary" (the fleet's set). */
+  sentinelMaster?: string;
 }
 
 export interface ServerConfig {

--- a/console/shared/lib/server/rate-limit.test.ts
+++ b/console/shared/lib/server/rate-limit.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from 'bun:test';
+import { RateLimiter, clientIp } from './rate-limit';
+
+/** Limiter on a manual clock so refill is deterministic. */
+function make(opts: { capacity: number; refillPerSec: number; maxKeys?: number }) {
+  let t = 0;
+  const limiter = new RateLimiter({ ...opts, now: () => t });
+  return { limiter, advance: (ms: number) => (t += ms) };
+}
+
+describe('RateLimiter', () => {
+  test('allows the full burst then rejects', () => {
+    const { limiter } = make({ capacity: 3, refillPerSec: 1 });
+    expect(limiter.check('k').allowed).toBe(true);
+    expect(limiter.check('k').allowed).toBe(true);
+    expect(limiter.check('k').allowed).toBe(true);
+    const denied = limiter.check('k');
+    expect(denied.allowed).toBe(false);
+    expect(denied.retryAfterSec).toBeGreaterThanOrEqual(1);
+    limiter.dispose();
+  });
+
+  test('refills over time up to capacity', () => {
+    const { limiter, advance } = make({ capacity: 2, refillPerSec: 1 });
+    limiter.check('k');
+    limiter.check('k');
+    expect(limiter.check('k').allowed).toBe(false);
+
+    advance(1000); // one token back
+    expect(limiter.check('k').allowed).toBe(true);
+    expect(limiter.check('k').allowed).toBe(false);
+
+    advance(60_000); // caps at capacity, not 60 tokens
+    expect(limiter.check('k').allowed).toBe(true);
+    expect(limiter.check('k').allowed).toBe(true);
+    expect(limiter.check('k').allowed).toBe(false);
+    limiter.dispose();
+  });
+
+  test('keys are independent', () => {
+    const { limiter } = make({ capacity: 1, refillPerSec: 1 });
+    expect(limiter.check('a').allowed).toBe(true);
+    expect(limiter.check('a').allowed).toBe(false);
+    expect(limiter.check('b').allowed).toBe(true);
+    limiter.dispose();
+  });
+
+  test('retryAfterSec reflects the refill rate', () => {
+    // 1 token per 10s: an empty bucket says wait 10s.
+    const { limiter } = make({ capacity: 1, refillPerSec: 0.1 });
+    limiter.check('k');
+    expect(limiter.check('k').retryAfterSec).toBe(10);
+    limiter.dispose();
+  });
+
+  test('evicts oldest keys at the ceiling, keeps serving', () => {
+    const { limiter } = make({ capacity: 1, refillPerSec: 0, maxKeys: 3 });
+    limiter.check('a');
+    limiter.check('b');
+    limiter.check('c');
+    limiter.check('d'); // over ceiling: 'a' evicted
+    expect(limiter.size).toBe(3);
+    // 'a' was forgotten, so it gets a fresh burst; 'd' is still tracked/empty.
+    expect(limiter.check('a').allowed).toBe(true);
+    expect(limiter.check('d').allowed).toBe(false);
+    limiter.dispose();
+  });
+});
+
+describe('clientIp', () => {
+  const fallback = () => '10.0.0.1';
+
+  test('prefers Cf-Connecting-Ip', () => {
+    const h = new Headers({ 'cf-connecting-ip': '1.2.3.4', 'x-forwarded-for': '5.6.7.8' });
+    expect(clientIp(h, fallback)).toBe('1.2.3.4');
+  });
+
+  test('falls back to first X-Forwarded-For hop', () => {
+    const h = new Headers({ 'x-forwarded-for': ' 5.6.7.8 , 9.9.9.9' });
+    expect(clientIp(h, fallback)).toBe('5.6.7.8');
+  });
+
+  test('uses the socket address when no proxy headers exist', () => {
+    expect(clientIp(new Headers(), fallback)).toBe('10.0.0.1');
+  });
+
+  test('never throws when the fallback does', () => {
+    expect(
+      clientIp(new Headers(), () => {
+        throw new Error('socket gone');
+      })
+    ).toBe('unknown');
+  });
+});

--- a/console/shared/lib/server/rate-limit.test.ts
+++ b/console/shared/lib/server/rate-limit.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, test } from 'bun:test';
-import { RateLimiter, clientIp } from './rate-limit';
+import {
+  RateLimiter,
+  ValkeyRateLimiter,
+  clientIp,
+  rateLimiterReady,
+  resetRateLimiterBackendForTests
+} from './rate-limit';
+import { registerServerConfig } from './config';
 
 /** Limiter on a manual clock so refill is deterministic. */
 function make(opts: { capacity: number; refillPerSec: number; maxKeys?: number }) {
@@ -64,6 +71,72 @@ describe('RateLimiter', () => {
     expect(limiter.check('a').allowed).toBe(true);
     expect(limiter.check('d').allowed).toBe(false);
     limiter.dispose();
+  });
+});
+
+describe('ValkeyRateLimiter', () => {
+  test('degrades to the per-pod bucket when Valkey is unconfigured', async () => {
+    resetRateLimiterBackendForTests();
+    const limiter = new ValkeyRateLimiter({ name: 'test', capacity: 2, refillPerSec: 1 });
+    expect((await limiter.check('k')).allowed).toBe(true);
+    expect((await limiter.check('k')).allowed).toBe(true);
+    const denied = await limiter.check('k');
+    expect(denied.allowed).toBe(false);
+    expect(denied.retryAfterSec).toBeGreaterThanOrEqual(1);
+    limiter.dispose();
+  });
+
+  test('degrades to the per-pod bucket when Valkey is unreachable', async () => {
+    resetRateLimiterBackendForTests();
+    registerServerConfig({
+      // Nothing listens here; every op fails fast and the breaker trips.
+      valkey: { addr: '127.0.0.1:1' },
+      cacheInvalidationPrefix: 'test'
+    });
+    const limiter = new ValkeyRateLimiter({ name: 'down', capacity: 1, refillPerSec: 0.001 });
+    expect((await limiter.check('k')).allowed).toBe(true);
+    expect((await limiter.check('k')).allowed).toBe(false);
+    limiter.dispose();
+    resetRateLimiterBackendForTests();
+  });
+
+  // Real-backend integration: opt-in via RATE_LIMIT_TEST_VALKEY (host:port of
+  // a disposable Valkey), so the default suite stays dependency-free.
+  const integrationAddr = process.env.RATE_LIMIT_TEST_VALKEY;
+  test.if(!!integrationAddr)('enforces one shared budget across limiter instances', async () => {
+    resetRateLimiterBackendForTests();
+    registerServerConfig({ valkey: { addr: integrationAddr! }, cacheInvalidationPrefix: 'test' });
+
+    // Wait for the write client to finish its dial (commands never queue, so
+    // pre-ready checks would exercise the fallback instead of the backend).
+    const deadline = Date.now() + 2000;
+    while (!(await rateLimiterReady())) {
+      if (Date.now() > deadline) throw new Error('valkey backend never became ready');
+      await new Promise((r) => setTimeout(r, 50));
+    }
+
+    // Two instances of the same tier = two pods sharing one bucket.
+    const key = `it-${Date.now()}`;
+    const podA = new ValkeyRateLimiter({ name: 'itest', capacity: 3, refillPerSec: 1 });
+    const podB = new ValkeyRateLimiter({ name: 'itest', capacity: 3, refillPerSec: 1 });
+
+    expect((await podA.check(key)).allowed).toBe(true);
+    expect((await podB.check(key)).allowed).toBe(true);
+    expect((await podA.check(key)).allowed).toBe(true);
+
+    // Burst of 3 spent globally: the fourth request is denied on EITHER pod.
+    const denied = await podB.check(key);
+    expect(denied.allowed).toBe(false);
+    expect(denied.retryAfterSec).toBeGreaterThanOrEqual(1);
+
+    // Refill restores the shared bucket for both pods.
+    await new Promise((r) => setTimeout(r, 1100));
+    expect((await podB.check(key)).allowed).toBe(true);
+    expect((await podA.check(key)).allowed).toBe(false);
+
+    podA.dispose();
+    podB.dispose();
+    resetRateLimiterBackendForTests();
   });
 });
 

--- a/console/shared/lib/server/rate-limit.ts
+++ b/console/shared/lib/server/rate-limit.ts
@@ -1,15 +1,25 @@
-// In-memory, per-pod token bucket rate limiter for the console SSR backends.
+// Token bucket rate limiting for the console SSR backends.
 //
-// Deliberately NOT Valkey-backed: the write master lives in NA, so a
-// per-request Valkey write from the EU node would spend the p99 budget on a
-// transatlantic round-trip just to count requests. Per-node PreferClose routing
-// already gives rough client→pod affinity, so a per-pod limit multiplied by the
-// replica count is an acceptable global ceiling — this is an abuse brake, not
-// an exact quota.
+// Two backends share the same bucket semantics (up to `capacity` tokens, a
+// continuous refill of `refillPerSec`, one token per request):
 //
-// Classic token bucket: each key holds up to `capacity` tokens (the burst) and
-// refills continuously at `refillPerSec`. A request spends one token; an empty
-// bucket rejects with the seconds until one token is available again.
+//   * RateLimiter        — in-memory, per-pod. Zero dependencies, used directly
+//                          in tests and as the fallback tier.
+//   * ValkeyRateLimiter  — fleet-wide. The bucket lives in Valkey and is
+//                          updated by one atomic Lua script, so every pod
+//                          enforces the same global budget. Connects through
+//                          Sentinel (when configured) so writes always reach
+//                          the elected master across failovers.
+//
+// Fail-safe posture: the Valkey path runs under a circuit breaker and a
+// per-op timeout, exactly like the valkey-store read tier. Any failure — no
+// config, connection down, slow op, open circuit — degrades to the embedded
+// per-pod limiter. Rate limiting must never take a page down; the worst
+// failure mode is a looser (per-pod) limit for a few seconds.
+
+import Redis from 'iovalkey';
+import { getServerConfig, hasServerConfig } from './config';
+import { CircuitBreaker, withTimeout } from './resilience';
 
 export interface RateLimiterOptions {
   /** Burst size: requests allowed instantly from a cold/full bucket. */
@@ -121,6 +131,198 @@ export class RateLimiter {
       this.buckets.delete(key);
       if (--excess <= 0) return;
     }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Valkey-backed fleet-wide limiter.
+
+// The whole bucket update is one atomic script, so concurrent requests across
+// pods never interleave between the read and the write. Time comes from the
+// server (TIME) rather than the pods, so bucket refill is immune to pod clock
+// skew. Returns {allowed, retryAfterSec}.
+const TOKEN_BUCKET_LUA = `
+local capacity = tonumber(ARGV[1])
+local refill = tonumber(ARGV[2])
+local t = redis.call('TIME')
+local now = t[1] * 1000 + math.floor(t[2] / 1000)
+local state = redis.call('HMGET', KEYS[1], 't', 'ts')
+local tokens = tonumber(state[1])
+local ts = tonumber(state[2])
+if tokens == nil or ts == nil then
+  tokens = capacity
+  ts = now
+end
+tokens = math.min(capacity, tokens + math.max(0, now - ts) / 1000 * refill)
+local allowed = 0
+local retry = 0
+if tokens >= 1 then
+  tokens = tokens - 1
+  allowed = 1
+else
+  retry = math.ceil((1 - tokens) / refill)
+  if retry < 1 then retry = 1 end
+end
+redis.call('HSET', KEYS[1], 't', tostring(tokens), 'ts', now)
+redis.call('PEXPIRE', KEYS[1], math.ceil(capacity / refill * 1000) + 60000)
+return {allowed, retry}
+`;
+
+interface RateLimitClient extends Redis {
+  rateLimit(key: string, capacity: number, refillPerSec: number): Promise<[number, number]>;
+}
+
+const OP_TIMEOUT_MS = 150;
+
+// One connection + one breaker for every limiter tier: it is a single
+// dependency, and a second tier probing a dead master buys nothing but
+// another timeout.
+let writeClient: RateLimitClient | null = null;
+let writeDisabled = false;
+let writeBreaker = newWriteBreaker();
+
+function newWriteBreaker(): CircuitBreaker {
+  return new CircuitBreaker({ name: 'valkey-ratelimit', failureThreshold: 3, resetMs: 5_000 });
+}
+
+function getWriteClient(): RateLimitClient | null {
+  if (writeDisabled) return null;
+  if (writeClient) return writeClient;
+  // Config is registered by the init hook; tolerate its absence (unit tests,
+  // misordered boot) by degrading to the per-pod fallback instead of throwing.
+  const cfg = hasServerConfig() ? getServerConfig().valkey : undefined;
+  if (!cfg) {
+    writeDisabled = true;
+    return null;
+  }
+
+  let client: Redis;
+  if (cfg.sentinelAddr) {
+    const [host, portStr] = cfg.sentinelAddr.split(':');
+    client = new Redis({
+      sentinels: [{ host: host || '127.0.0.1', port: portStr ? Number(portStr) : 26379 }],
+      name: cfg.sentinelMaster ?? 'myprimary',
+      password: cfg.password || undefined,
+      // Fail fast, never queue: an unreachable master must degrade to the
+      // per-pod fallback immediately, not grow an unbounded command queue.
+      enableOfflineQueue: false,
+      maxRetriesPerRequest: 1,
+      connectTimeout: 1000,
+      retryStrategy: (times) => Math.min(times * 200, 2000),
+      sentinelRetryStrategy: (times: number) => Math.min(times * 200, 2000)
+    });
+  } else {
+    const [host, portStr] = cfg.addr.split(':');
+    client = new Redis({
+      host: host || '127.0.0.1',
+      port: portStr ? Number(portStr) : 6379,
+      password: cfg.password || undefined,
+      enableOfflineQueue: false,
+      maxRetriesPerRequest: 1,
+      connectTimeout: 1000,
+      retryStrategy: (times) => Math.min(times * 200, 2000)
+    });
+  }
+
+  // Swallow connection errors; ops fail fast and the limiter falls back local.
+  client.on('error', () => {});
+  // defineCommand handles EVALSHA with automatic EVAL fallback on script-cache
+  // misses (fresh master after a failover, restarted instance).
+  client.defineCommand('rateLimit', { numberOfKeys: 1, lua: TOKEN_BUCKET_LUA });
+  writeClient = client as RateLimitClient;
+  return writeClient;
+}
+
+/**
+ * Pre-connect the write client at boot so the first request does not pay the
+ * dial. Best-effort, no-op when Valkey is unconfigured. Call from the init hook.
+ */
+export function warmRateLimiter(): void {
+  getWriteClient();
+}
+
+/**
+ * Probe the write path (PING under the breaker + timeout), connecting it as a
+ * side effect. Returns true when the backend is reachable OR unconfigured —
+ * the fleet-wide tier is optional (per-pod fallback), never a readiness
+ * blocker. Wire into /readyz next to the valkey-store probe so a rotated-in
+ * pod's write client is hot within one probe interval.
+ */
+export async function rateLimiterReady(): Promise<boolean> {
+  const client = getWriteClient();
+  if (!client) return true;
+  try {
+    await writeBreaker.run(() => withTimeout(client.ping(), OP_TIMEOUT_MS, 'valkey rate-limit'));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Drop the cached write client and its disabled latch so a test can re-run
+ * client resolution against fresh config. Test-only; never call in app code.
+ */
+export function resetRateLimiterBackendForTests(): void {
+  writeClient?.disconnect();
+  writeClient = null;
+  writeDisabled = false;
+  writeBreaker = newWriteBreaker();
+}
+
+export interface ValkeyRateLimiterOptions {
+  /** Key namespace for this tier, e.g. "auth" → keys "rl:auth:<key>". */
+  name: string;
+  capacity: number;
+  refillPerSec: number;
+  /** Fallback tuning override; defaults to the same capacity/refill. */
+  fallback?: RateLimiterOptions;
+}
+
+/**
+ * Fleet-wide token bucket in Valkey with a per-pod in-memory fallback. check()
+ * never throws and never exceeds ~OP_TIMEOUT_MS added latency.
+ */
+export class ValkeyRateLimiter {
+  private readonly prefix: string;
+  private readonly capacity: number;
+  private readonly refillPerSec: number;
+  private readonly fallback: RateLimiter;
+
+  constructor(opts: ValkeyRateLimiterOptions) {
+    this.prefix = `rl:${opts.name}:`;
+    this.capacity = opts.capacity;
+    this.refillPerSec = opts.refillPerSec;
+    this.fallback = new RateLimiter(
+      opts.fallback ?? { capacity: opts.capacity, refillPerSec: opts.refillPerSec }
+    );
+  }
+
+  async check(key: string): Promise<RateDecision> {
+    const client = getWriteClient();
+    if (client) {
+      try {
+        const [allowed, retry] = await writeBreaker.run(() =>
+          withTimeout(
+            client.rateLimit(this.prefix + key, this.capacity, this.refillPerSec),
+            OP_TIMEOUT_MS,
+            'valkey rate-limit'
+          )
+        );
+        return allowed === 1
+          ? { allowed: true, retryAfterSec: 0 }
+          : { allowed: false, retryAfterSec: retry };
+      } catch {
+        // Open circuit, timeout, READONLY replica, connection down — fall
+        // through to the per-pod bucket below.
+      }
+    }
+    return this.fallback.check(key);
+  }
+
+  /** Release the fallback sweeper (tests / teardown). */
+  dispose(): void {
+    this.fallback.dispose();
   }
 }
 

--- a/console/shared/lib/server/rate-limit.ts
+++ b/console/shared/lib/server/rate-limit.ts
@@ -1,0 +1,148 @@
+// In-memory, per-pod token bucket rate limiter for the console SSR backends.
+//
+// Deliberately NOT Valkey-backed: the write master lives in NA, so a
+// per-request Valkey write from the EU node would spend the p99 budget on a
+// transatlantic round-trip just to count requests. Per-node PreferClose routing
+// already gives rough client→pod affinity, so a per-pod limit multiplied by the
+// replica count is an acceptable global ceiling — this is an abuse brake, not
+// an exact quota.
+//
+// Classic token bucket: each key holds up to `capacity` tokens (the burst) and
+// refills continuously at `refillPerSec`. A request spends one token; an empty
+// bucket rejects with the seconds until one token is available again.
+
+export interface RateLimiterOptions {
+  /** Burst size: requests allowed instantly from a cold/full bucket. */
+  capacity: number;
+  /** Sustained rate: tokens restored per second. */
+  refillPerSec: number;
+  /**
+   * Memory ceiling on tracked keys. When exceeded, idle (fully refilled)
+   * buckets are swept, then the oldest survivors are evicted. Default 50_000.
+   */
+  maxKeys?: number;
+  /** Clock override for tests. Milliseconds, defaults to Date.now. */
+  now?: () => number;
+}
+
+export interface RateDecision {
+  allowed: boolean;
+  /** Whole seconds the client should wait before retrying; 0 when allowed. */
+  retryAfterSec: number;
+}
+
+interface Bucket {
+  tokens: number;
+  /** Last refill timestamp (ms). */
+  at: number;
+}
+
+const SWEEP_INTERVAL_MS = 60_000;
+const DEFAULT_MAX_KEYS = 50_000;
+
+export class RateLimiter {
+  private readonly buckets = new Map<string, Bucket>();
+  private readonly capacity: number;
+  private readonly refillPerSec: number;
+  private readonly maxKeys: number;
+  private readonly now: () => number;
+  private readonly sweeper: ReturnType<typeof setInterval>;
+
+  constructor(opts: RateLimiterOptions) {
+    this.capacity = opts.capacity;
+    this.refillPerSec = opts.refillPerSec;
+    this.maxKeys = opts.maxKeys ?? DEFAULT_MAX_KEYS;
+    this.now = opts.now ?? Date.now;
+
+    // Drop idle buckets so long-gone clients do not accumulate forever. unref:
+    // the sweeper must never hold the process open on shutdown.
+    this.sweeper = setInterval(() => this.sweep(), SWEEP_INTERVAL_MS);
+    this.sweeper.unref?.();
+  }
+
+  /** Spend one token for `key`. Never throws. */
+  check(key: string): RateDecision {
+    const now = this.now();
+    let bucket = this.buckets.get(key);
+
+    if (!bucket) {
+      if (this.buckets.size >= this.maxKeys) this.evict();
+      bucket = { tokens: this.capacity, at: now };
+      this.buckets.set(key, bucket);
+    } else {
+      const elapsedSec = (now - bucket.at) / 1000;
+      if (elapsedSec > 0) {
+        bucket.tokens = Math.min(this.capacity, bucket.tokens + elapsedSec * this.refillPerSec);
+        bucket.at = now;
+      }
+    }
+
+    if (bucket.tokens >= 1) {
+      bucket.tokens -= 1;
+      return { allowed: true, retryAfterSec: 0 };
+    }
+
+    return {
+      allowed: false,
+      retryAfterSec: Math.max(1, Math.ceil((1 - bucket.tokens) / this.refillPerSec))
+    };
+  }
+
+  /** Tracked key count; exposed for tests and metrics. */
+  get size(): number {
+    return this.buckets.size;
+  }
+
+  /** Stop the background sweeper (tests / graceful teardown). */
+  dispose(): void {
+    clearInterval(this.sweeper);
+    this.buckets.clear();
+  }
+
+  /** Remove buckets that have fully refilled — an idle key costs nothing to recreate. */
+  private sweep(): void {
+    const now = this.now();
+    for (const [key, bucket] of this.buckets) {
+      const tokens = bucket.tokens + ((now - bucket.at) / 1000) * this.refillPerSec;
+      if (tokens >= this.capacity) this.buckets.delete(key);
+    }
+  }
+
+  /**
+   * Over the key ceiling: sweep idle buckets first; if that is not enough,
+   * evict the oldest entries (Map preserves insertion order) so hot keys —
+   * the ones being limited — survive.
+   */
+  private evict(): void {
+    this.sweep();
+    let excess = this.buckets.size - this.maxKeys + 1;
+    if (excess <= 0) return;
+    for (const key of this.buckets.keys()) {
+      this.buckets.delete(key);
+      if (--excess <= 0) return;
+    }
+  }
+}
+
+/**
+ * Resolve the client IP for rate-limit keying behind the cloudflared → traefik
+ * chain. Cf-Connecting-Ip is set by Cloudflare itself and cannot be spoofed
+ * through the tunnel, so it wins; X-Forwarded-For's first hop covers direct
+ * tailnet/edge access; `fallback` is the socket address (getClientAddress).
+ */
+export function clientIp(headers: Headers, fallback: () => string): string {
+  const cf = headers.get('cf-connecting-ip');
+  if (cf) return cf.trim();
+  const xff = headers.get('x-forwarded-for');
+  if (xff) {
+    const first = xff.split(',')[0]?.trim();
+    if (first) return first;
+  }
+  try {
+    return fallback();
+  } catch {
+    // adapter-node can throw when the socket is already gone; one shared
+    // bucket for unattributable requests is better than throwing into SSR.
+    return 'unknown';
+  }
+}

--- a/console/shared/package.json
+++ b/console/shared/package.json
@@ -16,6 +16,7 @@
     "./server/service": "./lib/server/service.ts",
     "./server/rum": "./lib/server/rum.ts",
     "./server/resilience": "./lib/server/resilience.ts",
+    "./server/rate-limit": "./lib/server/rate-limit.ts",
     "./server/cache": "./lib/server/cache.ts",
     "./server/cache-keys": "./lib/server/cache-keys.ts",
     "./server/cache-fabric": "./lib/server/cache-fabric.ts",

--- a/pkg/batch/batcher.go
+++ b/pkg/batch/batcher.go
@@ -70,6 +70,19 @@ func (b *Batcher[K, V]) Add(key K, value V) {
 	}
 }
 
+// Requeue restores a value whose flush failed transiently, unless a newer
+// write for the same key arrived while the flush ran — the newer value wins,
+// exactly like the batcher's own whole-batch retry. Flush callbacks use this
+// to retry individual items instead of failing the entire batch.
+func (b *Batcher[K, V]) Requeue(key K, value V) {
+
+	b.mu.Lock()
+	if _, exists := b.pending[key]; !exists {
+		b.pending[key] = value
+	}
+	b.mu.Unlock()
+}
+
 // Close flushes whatever is pending and stops the background loop.
 func (b *Batcher[K, V]) Close(ctx context.Context) {
 

--- a/pkg/batch/batcher_test.go
+++ b/pkg/batch/batcher_test.go
@@ -127,3 +127,22 @@ func TestFailedFlushRetriesWithoutClobbering(t *testing.T) {
 
 	require.Equal(t, []int{2}, rec.all())
 }
+
+// Requeue restores a transiently failed item unless a newer write for the
+// same key arrived while the flush ran.
+func TestRequeueDoesNotClobberNewerWrite(t *testing.T) {
+	rec := &recorder{}
+
+	b := New[string, int](time.Hour, 100, rec.flush, zap.NewNop())
+
+	b.Requeue("gone", 1) // no pending value: restored
+	b.Add("fresh", 2)
+	b.Requeue("fresh", 1) // newer pending value wins
+
+	b.mu.Lock()
+	assert.Equal(t, 1, b.pending["gone"])
+	assert.Equal(t, 2, b.pending["fresh"])
+	b.mu.Unlock()
+
+	b.Close(context.Background())
+}


### PR DESCRIPTION
## Summary

**Dashboard rate limiting (fleet-wide):**
- Token-bucket rate limiter in `@bagel/shared` with two backends: an atomic Lua bucket in Valkey (shared budget across all pods, server-time refill) and an in-memory per-pod fallback.
- Three tiers in the dashboard handle hook: auth routes (10 burst @ 10/min), writes (30 @ 0.5/s), reads (60 @ 2/s); keyed by session user id, else Cf-Connecting-Ip/XFF/socket. 429 + Retry-After when exhausted; healthz/readyz exempt.
- Write path connects through Sentinel (`VALKEY_SENTINEL_ADDR`, master set `myprimary`) so it tracks the elected master across failovers. Any failure (dial, timeout, READONLY replica, open circuit) degrades to the per-pod bucket: limiting never takes a page down and never gates readiness.
- Doppler dashboard/prd already carries `VALKEY_SENTINEL_ADDR` + `VALKEY_PASSWORD`, so this activates fleet-wide on deploy.

**DB write-behind hardening (commands/modules repos):**
- Poison-row isolation: flush no longer rolls back + requeues the whole batch forever. Bulk statement first; on failure, per-item writes where validation/constraint failures drop with an error log and transient failures requeue via `Batcher.Requeue` (newer pending writes win).
- Flush windows land as a single `INSERT ... ON DUPLICATE KEY UPDATE` (up to 256 round-trips -> 1); on-conflict updates only edit-owned columns so `uses`/`created_at` are never regressed. ent regenerated with `--feature sql/upsert` (additive only).
- `RecordUse` overflow flushes are single-flight (no unbounded goroutine spawn under viral chat load).

## Verification

- Shared-budget integration test against real Valkey (two limiter instances, one budget) plus live outage drill: reads kept serving on fallback, write tier stayed enforced, limiter re-attached after the breaker's half-open trial.
- `bun test shared` 33 pass; svelte-check 0 errors; `go build ./...`, `go vet`, and all repo/batch tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)