### PR TITLE
Strict rolling-window rate buckets (Hypixel 300/5min, premium 25% reserve)

### DIFF
--- a/app/gateway/internal/core/buckets.go
+++ b/app/gateway/internal/core/buckets.go
@@ -17,17 +17,39 @@ type Buckets struct {
 	standard ratelimit.Spec
 }
 
+// strictBucket derives a token bucket that can never exceed limit requests in
+// ANY window of windowSeconds. A bucket with burst B and refill r admits up to
+// B + r*window requests per window in the worst case (full burst, then a full
+// window of refill), so sizing burst = refill-per-window = limit/2 keeps every
+// rolling window at or under the upstream's allowance — a bucket naively sized
+// capacity=limit, refill=limit/window would admit up to 2x the allowance.
+// Burst is floored because ratelimit.NewSpec requires an integer capacity and
+// panicking at boot over an odd configured limit would crashloop the pod.
+func strictBucket(limit, windowSeconds float64) (burst, refillPerSecond float64) {
+	burst = math.Max(1, math.Floor(limit/2))
+	refillPerSecond = (limit - burst) / windowSeconds
+	if refillPerSecond <= 0 {
+		// Degenerate budget (limit ~1): NewSpec requires a positive refill;
+		// strictness yields to a valid spec on a config that tiny.
+		refillPerSecond = burst / windowSeconds
+	}
+	return burst, refillPerSecond
+}
+
 // NewBuckets derives the (general, standard) token-bucket pair for one
-// upstream allowing capacity requests per windowSeconds. Capacities are
-// floored because ratelimit.NewSpec requires integers and panicking at boot
-// over an odd configured limit would crashloop the pod.
+// upstream allowing capacity requests per windowSeconds — strictly: the
+// general bucket bounds TOTAL spend to the allowance in every rolling window,
+// and the standard bucket bounds standard-lane spend to 75% of it, so premium
+// always keeps a 25% reserve.
 func NewBuckets(key string, capacity, windowSeconds float64) Buckets {
 	gen := math.Max(1, math.Floor(capacity))
 	std := math.Max(1, math.Floor(gen*0.75))
+	genBurst, genRefill := strictBucket(gen, windowSeconds)
+	stdBurst, stdRefill := strictBucket(std, windowSeconds)
 	return Buckets{
 		key:      key,
-		general:  ratelimit.NewSpec(gen, gen/windowSeconds),
-		standard: ratelimit.NewSpec(std, std/windowSeconds),
+		general:  ratelimit.NewSpec(genBurst, genRefill),
+		standard: ratelimit.NewSpec(stdBurst, stdRefill),
 	}
 }
 

--- a/app/gateway/internal/core/buckets_test.go
+++ b/app/gateway/internal/core/buckets_test.go
@@ -1,0 +1,63 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// The upstream allowance is a ROLLING window: a token bucket with burst B and
+// refill r admits up to B + r*window per window, so the strict derivation must
+// keep that sum at or under the limit — never the naive capacity=limit sizing
+// that admits double.
+func TestStrictBucketNeverExceedsWindow(t *testing.T) {
+	for _, tc := range []struct {
+		limit, window float64
+	}{
+		{300, 300},  // hypixel: 300 requests / 5 min
+		{600, 300},  // urchin: 600 requests / 5 min
+		{500, 600},  // mcsr: 500 requests / 10 min
+		{225, 300},  // hypixel standard lane (75%)
+		{301, 300},  // odd limit
+		{100.3, 60}, // fractional config value
+	} {
+		burst, refill := strictBucket(tc.limit, tc.window)
+		worstWindow := burst + refill*tc.window
+		assert.LessOrEqualf(t, worstWindow, tc.limit,
+			"limit %v/%vs: worst-case window %v must not exceed the allowance", tc.limit, tc.window, worstWindow)
+		assert.GreaterOrEqual(t, burst, 1.0)
+		assert.Greater(t, refill, 0.0)
+		assert.Equal(t, burst, float64(int64(burst)), "burst must be integral for NewSpec")
+	}
+}
+
+// Hypixel's 300/5min budget: half burst, half refill; the standard lane keeps
+// 75% of the total so premium always has a 25% reserve.
+func TestStrictBucketHypixelNumbers(t *testing.T) {
+	burst, refill := strictBucket(300, 300)
+	assert.Equal(t, 150.0, burst)
+	assert.InDelta(t, 0.5, refill, 1e-9) // 150 more over the 5-minute window
+
+	stdBurst, stdRefill := strictBucket(225, 300) // floor(300*0.75)
+	assert.Equal(t, 112.0, stdBurst)
+	// Standard lane worst window: 112 + 113 = 225 = 75% of the allowance.
+	assert.InDelta(t, 225.0, stdBurst+stdRefill*300, 1e-9)
+}
+
+// A degenerate tiny budget still builds a valid spec (positive refill) rather
+// than panicking NewSpec; strictness yields on configs that small.
+func TestStrictBucketDegenerateBudget(t *testing.T) {
+	burst, refill := strictBucket(1, 300)
+	assert.Equal(t, 1.0, burst)
+	assert.Greater(t, refill, 0.0)
+}
+
+// Odd configured limits (including the 0.75 derivation) must build, not panic.
+func TestNewBucketsDoesNotPanic(t *testing.T) {
+	assert.NotPanics(t, func() {
+		NewBuckets("k", 300, 300)
+		NewBuckets("k", 550.5, 300)
+		NewBuckets("k", 1, 300)
+		NewBuckets("k", 0, 300) // clamped to 1 by the caller-facing floor
+	})
+}

--- a/console/dashboard/src/lib/components/commands/ChatPreview.svelte
+++ b/console/dashboard/src/lib/components/commands/ChatPreview.svelte
@@ -23,7 +23,8 @@
     args = '',
     showViewer = true,
     tag = undefined as string | undefined,
-    samples = undefined as Record<string, string> | undefined
+    samples = undefined as Record<string, string> | undefined,
+    samplesOnly = false
   }: {
     name?: string;
     response?: string;
@@ -31,6 +32,12 @@
     showViewer?: boolean;
     tag?: string;
     samples?: Record<string, string>;
+    // samplesOnly drops the default command samples entirely: gateway module
+    // replies substitute ONLY their own tokens ({player}, {wins}, ...) — the
+    // bot never expands {user}/{uptime} there, so previewing those as values
+    // would rehearse a reply the bot cannot produce. Unknown tokens stay
+    // marked, exactly like a typo in a custom command.
+    samplesOnly?: boolean;
   } = $props();
 
   const DEFAULT_SAMPLES: Record<string, string> = {
@@ -45,7 +52,11 @@
     viewers: '42'
   };
   // Caller overrides win (e.g. a raid alert where {user} is the raiding channel).
-  const SAMPLES = $derived<Record<string, string>>({ ...DEFAULT_SAMPLES, ...(samples ?? {}) });
+  const SAMPLES = $derived<Record<string, string>>(
+    samplesOnly ? (samples ?? {}) : { ...DEFAULT_SAMPLES, ...(samples ?? {}) }
+  );
+  // The sample viewer typing the trigger; module replies carry no {user} sample.
+  const viewerName = $derived(SAMPLES.user ?? DEFAULT_SAMPLES.user);
 
   const trigger = $derived('!' + (normName(name) || 'command') + (args ? ' ' + args : ''));
 
@@ -159,7 +170,7 @@
   <span class="chat-tag">{tag ?? t('chatPreview.rehearsal')}</span>
   {#if showViewer}
     <div class="line viewer">
-      <span class="who viewer-name">{SAMPLES.user}</span>
+      <span class="who viewer-name">{viewerName}</span>
       <span class="msg">{trigger}</span>
     </div>
   {/if}

--- a/console/dashboard/src/lib/components/modules/ReplyEditor.svelte
+++ b/console/dashboard/src/lib/components/modules/ReplyEditor.svelte
@@ -1,9 +1,19 @@
 <script lang="ts">
   // Builder inspector for one module reply — the same surface as editing a custom
   // command's response: the shared ResponseEditor (message + token chips) and the
-  // ChatPreview rehearsal (ItsBagelBot name + logo), framed by the firing event
-  // instead of a viewer typing a command. Save/Cancel are handled by the page so
-  // the whole-module config persists in one place.
+  // ChatPreview rehearsal (ItsBagelBot name + logo).
+  //
+  // Two reply shapes:
+  //  - event replies (shoutout, alerts): framed by the firing event (`tag`),
+  //    bot line only, default samples.
+  //  - command replies (gateway modules: reply.command set): rehearsed exactly
+  //    like a custom command — "Chat rehearsal" border, a sample viewer typing
+  //    the trigger, the bot answering with THIS reply's own sample values
+  //    substituted (samplesOnly, so foreign tokens stay marked as unknown) —
+  //    and the token palette swaps to the reply's supported variables.
+  //
+  // Save/Cancel are handled by the page so the whole-module config persists in
+  // one place.
   import { Icon, getI18n, type ModuleReply } from '@bagel/shared';
   import ResponseEditor from '$lib/components/commands/ResponseEditor.svelte';
   import ChatPreview from '$lib/components/commands/ChatPreview.svelte';
@@ -27,16 +37,40 @@
   // Blank posts the module default, so preview the default (matches the
   // placeholder) instead of an empty "nothing to say yet".
   const effectiveMessage = $derived(message.trim() ? message : reply.defaultMessage);
+
+  const isCommand = $derived(!!reply.command);
+  // The reply's own insert palette; undefined keeps ResponseEditor's default
+  // command tokens (event replies define no token list yet). The chip tooltip
+  // shows the sample value the preview substitutes.
+  const palette = $derived(
+    reply.tokens?.map((tk) => {
+      const token = `{${tk}}`;
+      const sample = reply.previewSamples?.[tk];
+      return { token, label: sample ? `${token} → ${sample}` : token };
+    })
+  );
 </script>
 
 <div class="editor">
   <label class="field">
     <span>{t('modules.replyMessage', { label: reply.label })}</span>
-    <ResponseEditor bind:value={message} placeholder={reply.defaultMessage} />
+    <ResponseEditor bind:value={message} placeholder={reply.defaultMessage} tokens={palette} />
     <small>{t('modules.replyBlankHint')}</small>
   </label>
 
-  <ChatPreview name="" showViewer={false} tag={reply.event} response={effectiveMessage} />
+  {#if isCommand}
+    <!-- Same rehearsal as the commands page: viewer types the trigger, the bot
+         answers with the reply's sample values substituted. -->
+    <ChatPreview
+      name={reply.command}
+      args={reply.previewArgs ?? ''}
+      samples={reply.previewSamples}
+      samplesOnly
+      response={effectiveMessage}
+    />
+  {:else}
+    <ChatPreview name="" showViewer={false} tag={reply.event} response={effectiveMessage} />
+  {/if}
 
   <div class="actions">
     <button type="button" class="btn ghost" onclick={onCancel} disabled={busy}>{t('common.cancel')}</button>

--- a/console/shared/lib/types.ts
+++ b/console/shared/lib/types.ts
@@ -198,6 +198,23 @@ export interface ModuleReply {
   // empty/absent means on, matching sesame's alertOn semantics.
   enableKey?: string;
   defaultMessage: string; // sesame default template (placeholder + preview fallback)
+
+  // --- command-style replies (gateway modules: urchin, mcsr) ---------------
+  // command is the chat trigger without '!' (e.g. 'daily'). When set, the
+  // inspector rehearses the reply exactly like a custom command: the border
+  // reads "Chat rehearsal", a viewer line types the trigger, and the bot
+  // answers with previewSamples substituted into the template.
+  command?: string;
+  // previewArgs is what the sample viewer types after the trigger.
+  previewArgs?: string;
+  // previewSamples maps this reply's tokens to sample values. When command is
+  // set the preview substitutes ONLY these (samplesOnly): sesame expands only
+  // the module's own tokens here, so the generic {user}/{uptime} samples would
+  // preview values the bot will never produce.
+  previewSamples?: Record<string, string>;
+  // tokens is the editor's insert palette (without braces), replacing the
+  // default command tokens with the ones this reply actually supports.
+  tokens?: string[];
 }
 
 export interface ModuleDef {
@@ -222,6 +239,31 @@ export interface ModuleState {
   enabled: boolean;
   config: Record<string, string>;
 }
+
+// Shared token palette + preview samples for the Bed Wars session commands
+// (!daily / !weekly / !monthly) — same template surface, one source of truth.
+const BW_SESSION_TOKENS = [
+  'player',
+  'wins',
+  'losses',
+  'finals',
+  'finaldeaths',
+  'beds',
+  'games',
+  'levels',
+  'fkdr'
+];
+const BW_SESSION_SAMPLES: Record<string, string> = {
+  player: 'Technoblade',
+  wins: '5',
+  losses: '2',
+  finals: '21',
+  finaldeaths: '3',
+  beds: '9',
+  games: '8',
+  levels: '1',
+  fkdr: '7.00'
+};
 
 export const MODULE_CATALOG: readonly ModuleDef[] = [
   {
@@ -308,54 +350,102 @@ export const MODULE_CATALOG: readonly ModuleDef[] = [
         label: '!daily',
         tagline: 'Bed Wars session since the daily reset.',
         event: '!daily',
+        command: 'daily',
         enableKey: 'dailyEnabled',
         messageKey: 'dailyMessage',
-        defaultMessage: '{player} today: {wins}W {losses}L · {finals} finals · {beds} beds · {fkdr} FKDR'
+        defaultMessage: '{player} today: {wins}W {losses}L · {finals} finals · {beds} beds · {fkdr} FKDR',
+        tokens: BW_SESSION_TOKENS,
+        previewSamples: BW_SESSION_SAMPLES
       },
       {
         key: 'weekly',
         label: '!weekly',
         tagline: 'Bed Wars session since the weekly reset.',
         event: '!weekly',
+        command: 'weekly',
         enableKey: 'weeklyEnabled',
         messageKey: 'weeklyMessage',
-        defaultMessage: '{player} this week: {wins}W {losses}L · {finals} finals · {beds} beds · {fkdr} FKDR'
+        defaultMessage: '{player} this week: {wins}W {losses}L · {finals} finals · {beds} beds · {fkdr} FKDR',
+        tokens: BW_SESSION_TOKENS,
+        previewSamples: BW_SESSION_SAMPLES
       },
       {
         key: 'monthly',
         label: '!monthly',
         tagline: 'Bed Wars session since the monthly reset.',
         event: '!monthly',
+        command: 'monthly',
         enableKey: 'monthlyEnabled',
         messageKey: 'monthlyMessage',
-        defaultMessage: '{player} this month: {wins}W {losses}L · {finals} finals · {beds} beds · {fkdr} FKDR'
+        defaultMessage: '{player} this month: {wins}W {losses}L · {finals} finals · {beds} beds · {fkdr} FKDR',
+        tokens: BW_SESSION_TOKENS,
+        previewSamples: BW_SESSION_SAMPLES
       },
       {
         key: 'stats',
         label: '!bwstats',
         tagline: 'Lifetime Bed Wars stats.',
         event: '!bwstats',
+        command: 'bwstats',
         enableKey: 'statsEnabled',
         messageKey: 'statsMessage',
-        defaultMessage: '{player}: {stars} stars · {wins} wins · {finals} finals · {fkdr} FKDR · {beds} beds broken'
+        defaultMessage: '{player}: {stars} stars · {wins} wins · {finals} finals · {fkdr} FKDR · {beds} beds broken',
+        tokens: ['player', 'stars', 'wins', 'losses', 'finals', 'finaldeaths', 'beds', 'fkdr', 'wlr'],
+        previewSamples: {
+          player: 'Technoblade',
+          stars: '402',
+          wins: '1000',
+          losses: '100',
+          finals: '5000',
+          finaldeaths: '500',
+          beds: '2000',
+          fkdr: '10.00',
+          wlr: '10.00'
+        }
       },
       {
         key: 'sniper',
         label: '!sniper',
         tagline: 'Urchin (Cubelify overlay) score.',
         event: '!sniper',
+        command: 'sniper',
         enableKey: 'sniperEnabled',
         messageKey: 'sniperMessage',
-        defaultMessage: '{player} urchin score: {score}'
+        defaultMessage: '{player} urchin score: {score}',
+        tokens: ['player', 'score', 'mode', 'tagcount'],
+        previewSamples: { player: 'Technoblade', score: '7.5', mode: 'warn', tagcount: '1' }
       },
       {
         key: 'tags',
-        label: '!tags',
+        label: '!tag',
         tagline: 'Active Urchin blacklist tags.',
-        event: '!tags',
+        event: '!tag',
+        command: 'tag',
         enableKey: 'tagsEnabled',
         messageKey: 'tagsMessage',
-        defaultMessage: '{player}: {tags}'
+        defaultMessage: '{player}: {tags}',
+        tokens: ['player', 'tags', 'tagcount'],
+        previewSamples: {
+          player: 'Technoblade',
+          tags: 'Blatant Cheater (added Jul 3, 2024)',
+          tagcount: '1'
+        }
+      },
+      {
+        key: 'tagdescription',
+        label: '!tagdescription',
+        tagline: 'Blacklist tags with their reasons.',
+        event: '!tagdescription',
+        command: 'tagdescription',
+        enableKey: 'tagDescriptionEnabled',
+        messageKey: 'tagDescriptionMessage',
+        defaultMessage: '{player}: {tags}',
+        tokens: ['player', 'tags', 'tagcount'],
+        previewSamples: {
+          player: 'Technoblade',
+          tags: 'Blatant Cheater (bhop - added Jul 3, 2024)',
+          tagcount: '1'
+        }
       }
     ],
     settings: [
@@ -382,18 +472,39 @@ export const MODULE_CATALOG: readonly ModuleDef[] = [
         label: '!elo',
         tagline: 'Current elo, rank and season record.',
         event: '!elo',
+        command: 'elo',
         enableKey: 'eloEnabled',
         messageKey: 'eloMessage',
-        defaultMessage: '{player}: {elo} elo · rank #{rank} · {wins}W {losses}L this season'
+        defaultMessage: '{player}: {elo} elo · rank #{rank} · {wins}W {losses}L this season',
+        tokens: ['player', 'elo', 'rank', 'wins', 'losses', 'matches', 'country'],
+        previewSamples: {
+          player: 'Feinberg',
+          elo: '1650',
+          rank: '12',
+          wins: '40',
+          losses: '20',
+          matches: '61',
+          country: 'us'
+        }
       },
       {
         key: 'session',
         label: '!session',
         tagline: 'Elo and record since the stream started.',
         event: '!session',
+        command: 'session',
         enableKey: 'sessionEnabled',
         messageKey: 'sessionMessage',
-        defaultMessage: '{player} this stream: {elochange} elo ({elo} now) · {wins}W {losses}L in {matches} matches'
+        defaultMessage: '{player} this stream: {elochange} elo ({elo} now) · {wins}W {losses}L in {matches} matches',
+        tokens: ['player', 'elo', 'elochange', 'wins', 'losses', 'matches'],
+        previewSamples: {
+          player: 'Feinberg',
+          elo: '1660',
+          elochange: '+24',
+          wins: '3',
+          losses: '1',
+          matches: '4'
+        }
       }
     ],
     settings: [


### PR DESCRIPTION
## Why

A token bucket sized `capacity = limit`, `refill = limit/window` admits up to **2x the allowance** in a worst-case rolling window: full 300-token burst, then a full window of refill — 600 requests against Hypixel's 300/5min budget. Same flaw on the urchin (600/5min) and mcsr (500/10min) budgets.

## What

`core.NewBuckets` now derives strict specs: **burst = refill-per-window = limit/2**, so `burst + refill×window ≤ limit` holds for every rolling window.

- **Hypixel** (300/5min): general = 150 burst + 0.5/s; standard lane = 75% → 112 burst + ~0.38/s (worst window 225) — **premium keeps its 25% reserve**, enforced by the existing atomic two-bucket script.
- **Urchin** (600/5min): 300 burst + 1/s.
- **MCSR** (500/10min): 250 burst + ~0.42/s.
- Degenerate tiny budgets fall back to a valid positive refill instead of panicking `ratelimit.NewSpec`.

## Tests

Property test: worst-case rolling window ≤ allowance for all fleet budgets + odd/fractional limits; exact Hypixel numbers; degenerate budget; no-panic constructor. Full gateway suite green.