### PR TITLE
feat(commands): multi-line responses, one message per line

### DIFF
--- a/app/commands/ent/migrate/schema.go
+++ b/app/commands/ent/migrate/schema.go
@@ -14,7 +14,7 @@ var (
 		{Name: "user_id", Type: field.TypeUint64},
 		{Name: "name", Type: field.TypeString},
 		{Name: "aliases", Type: field.TypeJSON, Nullable: true},
-		{Name: "response", Type: field.TypeString},
+		{Name: "response", Type: field.TypeString, Size: 2504},
 		{Name: "is_active", Type: field.TypeBool, Default: true},
 		{Name: "stream_online_only", Type: field.TypeBool, Default: false},
 		{Name: "perm", Type: field.TypeString, Default: "everyone"},

--- a/app/commands/ent/runtime/runtime.go
+++ b/app/commands/ent/runtime/runtime.go
@@ -23,7 +23,21 @@ func init() {
 	// commandsDescResponse is the schema descriptor for response field.
 	commandsDescResponse := commandsFields[3].Descriptor()
 	// commands.ResponseValidator is a validator for the "response" field. It is called by the builders before save.
-	commands.ResponseValidator = commandsDescResponse.Validators[0].(func(string) error)
+	commands.ResponseValidator = func() func(string) error {
+		validators := commandsDescResponse.Validators
+		fns := [...]func(string) error{
+			validators[0].(func(string) error),
+			validators[1].(func(string) error),
+		}
+		return func(response string) error {
+			for _, fn := range fns {
+				if err := fn(response); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+	}()
 	// commandsDescIsActive is the schema descriptor for is_active field.
 	commandsDescIsActive := commandsFields[4].Descriptor()
 	// commands.DefaultIsActive holds the default value on creation for the is_active field.

--- a/app/commands/ent/schema/commands.go
+++ b/app/commands/ent/schema/commands.go
@@ -30,7 +30,11 @@ func (Commands) Fields() []ent.Field {
 		// collision.
 		field.Strings("aliases").Optional(),
 
-		field.String("response").NotEmpty(),
+		// Newline-delimited: the bot sends one chat message per line, up to 5
+		// lines of 500 characters each (see validate.CommandResponse). Sized to
+		// hold the worst case (5*500 + 4 separators) so the column outgrows the
+		// dialect's default varchar.
+		field.String("response").NotEmpty().MaxLen(2504),
 
 		field.Bool("is_active").Default(true),
 

--- a/app/commands/repository/commands.go
+++ b/app/commands/repository/commands.go
@@ -36,6 +36,26 @@ func normalizeName(name string) string {
 	return strings.ToLower(strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(name), "!")))
 }
 
+// normalizeResponse canonicalizes a newline-delimited response before
+// validation: CRLF/CR fold to LF, trailing whitespace per line is dropped
+// (invisible in chat, burns budget), and blank lines vanish — the bot sends
+// one message per line and an empty message is unsendable. Validation then
+// only has to reject, never repair.
+func normalizeResponse(response string) string {
+	response = strings.ReplaceAll(response, "\r\n", "\n")
+	response = strings.ReplaceAll(response, "\r", "\n")
+	lines := strings.Split(response, "\n")
+	out := lines[:0]
+	for _, line := range lines {
+		line = strings.TrimRight(line, " \t")
+		if line == "" {
+			continue
+		}
+		out = append(out, line)
+	}
+	return strings.Join(out, "\n")
+}
+
 func normalizeAliases(aliases []string) []string {
 	if len(aliases) == 0 {
 		return aliases
@@ -184,6 +204,7 @@ type CommandSpec struct {
 func (s *CommandSpec) normalize() {
 	s.Name = normalizeName(s.Name)
 	s.Aliases = normalizeAliases(s.Aliases)
+	s.Response = normalizeResponse(s.Response)
 }
 
 func (s *CommandSpec) validate() error {

--- a/app/commands/repository/commands_test.go
+++ b/app/commands/repository/commands_test.go
@@ -59,6 +59,33 @@ func TestUpsertCoalescesEdits(t *testing.T) {
 	require.Len(t, pub.On(data.SubjectCommandChanged), 1)
 }
 
+// TestUpsertNormalizesMultiLineResponse proves the response canonicalization:
+// CRLF folds to LF, trailing whitespace and blank lines vanish, and what lands
+// in the row is the newline-delimited form the worker splits on.
+func TestUpsertNormalizesMultiLineResponse(t *testing.T) {
+	client, _, repo := setup(t)
+	ctx := context.Background()
+
+	require.NoError(t, repo.Upsert(1001, spec("!multi", "line one  \r\n\r\nline two\r\nline three", false, 0)))
+
+	repo.Close(ctx) // deterministic flush
+
+	rows := client.Commands.Query().AllX(ctx)
+	require.Len(t, rows, 1)
+	assert.Equal(t, "line one\nline two\nline three", rows[0].Response)
+}
+
+// TestUpsertRejectsTooManyLines proves the six-line response is refused at the
+// trust boundary (five is the ceiling).
+func TestUpsertRejectsTooManyLines(t *testing.T) {
+	_, _, repo := setup(t)
+
+	err := repo.Upsert(1001, spec("!multi", "1\n2\n3\n4\n5\n6", false, 0))
+	require.Error(t, err)
+
+	repo.Close(context.Background())
+}
+
 func TestDeleteIsImmediateAndAnnounced(t *testing.T) {
 	client, pub, repo := setup(t)
 	ctx := context.Background()

--- a/app/sesame/engine/dispatch.go
+++ b/app/sesame/engine/dispatch.go
@@ -8,6 +8,7 @@ import (
 
 	"ItsBagelBot/app/sesame/module"
 	"ItsBagelBot/internal/domain/outgress"
+	"ItsBagelBot/internal/domain/validate"
 	"ItsBagelBot/internal/projection"
 
 	"go.uber.org/zap"
@@ -84,12 +85,12 @@ func (p *Pipeline) runCustom(ctx context.Context, c *module.Context, name, args 
 		zap.Uint64("broadcaster_id", c.BroadcasterID),
 	)
 
-	// Route the expanded response through the post-processing middleware. A
-	// response left with no payload (an "/announce" with no text, a "/shoutout"
-	// with no target) is dropped and not counted.
-	out := renderResponse(c, cc.Response, args)
-	emitted := p.emitCommand(out, emit)
-	PutOutput(out)
+	// Route the expanded response through the post-processing middleware, one
+	// output per line — a multi-line response sends one chat message per line,
+	// each with its own slash-verb translation. A line left with no payload (an
+	// "/announce" with no text, a "/shoutout" with no target) is dropped; the
+	// run counts once if anything was emitted.
+	emitted := p.emitResponse(c, cc.Response, args, emit)
 	if !emitted {
 		return nil
 	}
@@ -105,9 +106,14 @@ func (p *Pipeline) runCustom(ctx context.Context, c *module.Context, name, args 
 	return nil
 }
 
-// renderResponse expands a custom command's response template into a pooled
-// Output. The caller owns the returned Output and must PutOutput it after use.
-func renderResponse(c *module.Context, response, args string) *module.Output {
+// emitResponse expands a custom command's response template once, then emits
+// one chat output per non-empty line through the post-processing middleware
+// (each line gets its own slash-verb translation, so "/announce hi\nplain"
+// mixes an announcement and a chat line). The line count is capped at
+// validate.MaxResponseLines — the write path enforces it, this is the emit-side
+// backstop so an expanded token can never fan out further. Reports whether at
+// least one line was actually emitted.
+func (p *Pipeline) emitResponse(c *module.Context, response, args string, emit module.Emit) bool {
 	sender := c.Env.ChatterUserLogin
 	touser := sender
 	if args != "" {
@@ -123,12 +129,29 @@ func renderResponse(c *module.Context, response, args string) *module.Output {
 		touser:  touser,
 		channel: c.Env.BroadcasterUserLogin,
 	})
-	out := GetOutput()
-	out.Type = outgress.TypeChat
-	out.BroadcasterID = c.Env.BroadcasterUserID
-	out.Text = string(buf)
+	expanded := string(buf)
 	PutBuf(buf)
-	return out
+
+	emitted := false
+	lines := 0
+	for line := range strings.SplitSeq(expanded, "\n") {
+		if line == "" {
+			continue
+		}
+		lines++
+		if lines > validate.MaxResponseLines {
+			break
+		}
+		out := GetOutput()
+		out.Type = outgress.TypeChat
+		out.BroadcasterID = c.Env.BroadcasterUserID
+		out.Text = line
+		if p.emitCommand(out, emit) {
+			emitted = true
+		}
+		PutOutput(out)
+	}
+	return emitted
 }
 
 // emitCommand is the command-output post-processing middleware. Every output a

--- a/app/sesame/engine/dispatch_test.go
+++ b/app/sesame/engine/dispatch_test.go
@@ -81,6 +81,42 @@ func TestCustomPlainChatStillEmits(t *testing.T) {
 	assert.Equal(t, outgress.TypeChat, got[0].Type)
 }
 
+// TestCustomMultiLineEmitsOnePerLine proves a newline-delimited response fans
+// out into one chat message per line, in order, with tokens expanded on every
+// line and each line getting its own slash-verb translation.
+func TestCustomMultiLineEmitsOnePerLine(t *testing.T) {
+	p := customPipeline("first {user}\nsecond line\n/announce third", "everyone")
+	got := collectDispatch(p, chatCtx("!so", ""))
+	require.Len(t, got, 3)
+	assert.Equal(t, outgress.TypeChat, got[0].Type)
+	assert.Equal(t, "first alice", got[0].Text)
+	assert.Equal(t, outgress.TypeChat, got[1].Type)
+	assert.Equal(t, "second line", got[1].Text)
+	assert.Equal(t, outgress.TypeAnnounce, got[2].Type)
+	assert.Equal(t, "third", got[2].Text)
+}
+
+// TestCustomMultiLineCappedAtMax proves the emit-side backstop: a response
+// with more lines than the ceiling (e.g. a stale row predating validation)
+// stops at validate.MaxResponseLines messages.
+func TestCustomMultiLineCappedAtMax(t *testing.T) {
+	p := customPipeline("1\n2\n3\n4\n5\n6\n7", "everyone")
+	got := collectDispatch(p, chatCtx("!so", ""))
+	require.Len(t, got, 5)
+	assert.Equal(t, "5", got[4].Text)
+}
+
+// TestCustomMultiLineSkipsEmptyLines proves blank lines never become empty
+// chat messages, and an all-verb line with no payload is dropped without
+// suppressing its siblings.
+func TestCustomMultiLineSkipsEmptyLines(t *testing.T) {
+	p := customPipeline("one\n\n/announce\ntwo", "everyone")
+	got := collectDispatch(p, chatCtx("!so", ""))
+	require.Len(t, got, 2)
+	assert.Equal(t, "one", got[0].Text)
+	assert.Equal(t, "two", got[1].Text)
+}
+
 // --- baked command dispatch + gate ---
 
 // cmdEmit builds a module owning one everyone-perm command that emits reply.

--- a/console/dashboard/src/lib/components/commands/ChatPreview.svelte
+++ b/console/dashboard/src/lib/components/commands/ChatPreview.svelte
@@ -9,7 +9,10 @@
   // line (see app/worker/module/slash.go). The rehearsal mirrors that parse so
   // authors can see they're driving a Twitch command — an announcement callout,
   // a shoutout card, or an italic /me action — with a badge naming the verb.
-  import { normName, getI18n } from '@bagel/shared';
+  // A multi-line response (newline-delimited, up to 5 lines) is acted out as
+  // the bot sending one chat message per line, in order — the same fan-out the
+  // worker performs — so authors see exactly how many messages they're minting.
+  import { normName, responseLines, RESPONSE_MAX_LINES, getI18n } from '@bagel/shared';
 
   const { t } = getI18n();
 
@@ -88,8 +91,7 @@
     return null;
   }
 
-  const parsed = $derived.by<Parsed>(() => {
-    const text = response;
+  function parseLine(text: string): Parsed {
     for (const [verb, color] of ANNOUNCE) {
       const rest = cutVerb(text, verb);
       if (rest !== null) return { mode: 'announce', body: rest, verb, color };
@@ -107,34 +109,46 @@
     const me = cutVerb(text, '/me');
     if (me !== null) return { mode: 'me', body: me, verb: '/me' };
     return { mode: 'chat', body: text };
-  });
+  }
 
   // Human label for the "uses Twitch command" badge.
-  const verbLabel = $derived.by(() => {
-    if (parsed.mode === 'announce') {
-      return parsed.color === 'primary' ? '/announce' : `/announce (${parsed.color})`;
+  function verbLabelOf(p: Parsed): string {
+    if (p.mode === 'announce') {
+      return p.color === 'primary' ? '/announce' : `/announce (${p.color})`;
     }
-    return parsed.verb ?? '';
-  });
+    return p.verb ?? '';
+  }
 
   // Substituted segments over the *stripped* body: known tokens become
   // highlighted sample values, unknown {tokens} stay marked so typos are visible.
   type Seg = { text: string; kind: 'plain' | 'sample' | 'unknown' };
-  const segments = $derived.by<Seg[]>(() => {
-    const body = parsed.body;
+  function segmentsOf(body: string, samples: Record<string, string>): Seg[] {
     const out: Seg[] = [];
     const re = /\{([a-z_]+)\}/gi;
     let last = 0;
     for (const m of body.matchAll(re)) {
       if (m.index > last) out.push({ text: body.slice(last, m.index), kind: 'plain' });
       const key = m[1].toLowerCase();
-      if (key in SAMPLES) out.push({ text: SAMPLES[key], kind: 'sample' });
+      if (key in samples) out.push({ text: samples[key], kind: 'sample' });
       else out.push({ text: m[0], kind: 'unknown' });
       last = m.index + m[0].length;
     }
     if (last < body.length) out.push({ text: body.slice(last), kind: 'plain' });
     return out;
-  });
+  }
+
+  // One rehearsed bot message per response line, mirroring the worker's
+  // fan-out: every line is parsed for its own slash-verb and substituted
+  // independently, capped at the same ceiling the service enforces.
+  type LineView = Parsed & { segments: Seg[] };
+  const views = $derived.by<LineView[]>(() =>
+    responseLines(response)
+      .slice(0, RESPONSE_MAX_LINES)
+      .map((line) => {
+        const p = parseLine(line);
+        return { ...p, segments: segmentsOf(p.body, SAMPLES) };
+      })
+  );
 
   // Typing beat: edits flip to the dots, settle back to the reply. Debounced so
   // the bot doesn't stutter on every keystroke.
@@ -163,67 +177,89 @@
       <span class="msg">{trigger}</span>
     </div>
   {/if}
-  <div class="line bot" class:special={parsed.mode !== 'chat'} class:me={parsed.mode === 'me'}>
-    <span class="who bot-name">
-      <img src="/logo.png" alt="" class="bot-avatar" />
-      ItsBagelBot
-    </span>
-    {#if typing}
+  {#if typing}
+    <div class="line bot">
+      <span class="who bot-name">
+        <img src="/logo.png" alt="" class="bot-avatar" />
+        ItsBagelBot
+      </span>
       <span class="msg typing" aria-label={t('chatPreview.ariaTyping')}>
         <span class="tdot"></span><span class="tdot"></span><span class="tdot"></span>
       </span>
-    {:else if parsed.mode === 'announce'}
-      <div class="announce" style="--acc: {ACCENT[parsed.color ?? 'primary']}">
-        <span class="announce-head">
-          <span class="via" title={t('chatPreview.runsVerb', { verb: parsed.verb ?? '' })}>Twitch {verbLabel}</span>
-          {t('chatPreview.announcement')}
+    </div>
+  {:else if views.length === 0}
+    <div class="line bot">
+      <span class="who bot-name">
+        <img src="/logo.png" alt="" class="bot-avatar" />
+        ItsBagelBot
+      </span>
+      <span class="msg empty">{t('chatPreview.nothingToSay')}</span>
+    </div>
+  {:else}
+    <!-- One bot message per response line, staggered like the worker's send order. -->
+    {#each views as v, li (li)}
+      <div
+        class="line bot"
+        class:special={v.mode !== 'chat'}
+        class:me={v.mode === 'me'}
+        style="--reply-delay: {li * 140}ms"
+      >
+        <span class="who bot-name">
+          <img src="/logo.png" alt="" class="bot-avatar" />
+          ItsBagelBot
         </span>
-        {#if segments.length}
+        {#if v.mode === 'announce'}
+          <div class="announce" style="--acc: {ACCENT[v.color ?? 'primary']}">
+            <span class="announce-head">
+              <span class="via" title={t('chatPreview.runsVerb', { verb: v.verb ?? '' })}>Twitch {verbLabelOf(v)}</span>
+              {t('chatPreview.announcement')}
+            </span>
+            {#if v.segments.length}
+              <span class="msg reply">
+                {#each v.segments as seg, i (i)}
+                  {#if seg.kind === 'sample'}<mark>{seg.text}</mark>
+                  {:else if seg.kind === 'unknown'}<mark class="unknown" title={t('chatPreview.unknownVar')}>{seg.text}</mark>
+                  {:else}{seg.text}{/if}
+                {/each}
+              </span>
+            {:else}
+              <span class="msg empty">{t('chatPreview.addMessageAfter', { verb: v.verb ?? '' })}</span>
+            {/if}
+          </div>
+        {:else if v.mode === 'shoutout'}
+          <div class="shoutout">
+            <span class="via" title={t('chatPreview.runsVerb', { verb: '/shoutout' })}>Twitch /shoutout</span>
+            {#if v.target}
+              <span class="msg reply">{t('chatPreview.shoutsOut')} <strong>@{v.target}</strong></span>
+            {:else}
+              <span class="msg empty">{t('chatPreview.nameChannel')}</span>
+            {/if}
+          </div>
+        {:else if v.mode === 'me'}
+          <span class="via inline" title={t('chatPreview.runsVerb', { verb: '/me' })}>Twitch /me</span>
+          {#if v.segments.length}
+            <span class="msg reply action">
+              {#each v.segments as seg, i (i)}
+                {#if seg.kind === 'sample'}<mark>{seg.text}</mark>
+                {:else if seg.kind === 'unknown'}<mark class="unknown" title={t('chatPreview.unknownVar')}>{seg.text}</mark>
+                {:else}{seg.text}{/if}
+              {/each}
+            </span>
+          {:else}
+            <span class="msg empty">{t('chatPreview.addActionAfterMe')}</span>
+          {/if}
+        {:else}
           <span class="msg reply">
-            {#each segments as seg, i (i)}
+            {#each v.segments as seg, i (i)}
               {#if seg.kind === 'sample'}<mark>{seg.text}</mark>
               {:else if seg.kind === 'unknown'}<mark class="unknown" title={t('chatPreview.unknownVar')}>{seg.text}</mark>
               {:else}{seg.text}{/if}
             {/each}
           </span>
-        {:else}
-          <span class="msg empty">{t('chatPreview.addMessageAfter', { verb: parsed.verb ?? '' })}</span>
         {/if}
       </div>
-    {:else if parsed.mode === 'shoutout'}
-      <div class="shoutout">
-        <span class="via" title={t('chatPreview.runsVerb', { verb: '/shoutout' })}>Twitch /shoutout</span>
-        {#if parsed.target}
-          <span class="msg reply">{t('chatPreview.shoutsOut')} <strong>@{parsed.target}</strong></span>
-        {:else}
-          <span class="msg empty">{t('chatPreview.nameChannel')}</span>
-        {/if}
-      </div>
-    {:else if parsed.mode === 'me'}
-      <span class="via inline" title={t('chatPreview.runsVerb', { verb: '/me' })}>Twitch /me</span>
-      {#if segments.length}
-        <span class="msg reply action">
-          {#each segments as seg, i (i)}
-            {#if seg.kind === 'sample'}<mark>{seg.text}</mark>
-            {:else if seg.kind === 'unknown'}<mark class="unknown" title={t('chatPreview.unknownVar')}>{seg.text}</mark>
-            {:else}{seg.text}{/if}
-          {/each}
-        </span>
-      {:else}
-        <span class="msg empty">{t('chatPreview.addActionAfterMe')}</span>
-      {/if}
-    {:else if parsed.body.trim()}
-      <span class="msg reply">
-        {#each segments as seg, i (i)}
-          {#if seg.kind === 'sample'}<mark>{seg.text}</mark>
-          {:else if seg.kind === 'unknown'}<mark class="unknown" title={t('chatPreview.unknownVar')}>{seg.text}</mark>
-          {:else}{seg.text}{/if}
-        {/each}
-      </span>
-    {:else}
-      <span class="msg empty">{t('chatPreview.nothingToSay')}</span>
-    {/if}
-  </div>
+    {/each}
+  {/if}
 </div>
 
 <style>
@@ -282,7 +318,7 @@
   }
   .line.viewer .msg { font-family: var(--bb-font-mono); color: var(--bb-tan-light); font-size: 12.5px; }
 
-  .reply { animation: reply-in 240ms var(--bb-ease-out-back, ease-out) both; }
+  .reply { animation: reply-in 240ms var(--bb-ease-out-back, ease-out) both; animation-delay: var(--reply-delay, 0ms); }
   @keyframes reply-in {
     from { opacity: 0; transform: translateY(4px); }
     to { opacity: 1; transform: translateY(0); }
@@ -328,6 +364,7 @@
     border-radius: 8px 8px;
     background: color-mix(in srgb, var(--acc) 10%, rgba(0, 0, 0, 0.25));
     animation: reply-in 240ms var(--bb-ease-out-back, ease-out) both;
+    animation-delay: var(--reply-delay, 0ms);
   }
   .announce-head {
     display: inline-flex;
@@ -353,6 +390,7 @@
     border: 1px dashed rgba(82, 183, 136, 0.4);
     background: rgba(82, 183, 136, 0.06);
     animation: reply-in 240ms var(--bb-ease-out-back, ease-out) both;
+    animation-delay: var(--reply-delay, 0ms);
   }
   .shoutout .reply strong { color: var(--bb-green-glow); }
 

--- a/console/dashboard/src/lib/components/commands/CommandEditor.svelte
+++ b/console/dashboard/src/lib/components/commands/CommandEditor.svelte
@@ -13,6 +13,7 @@
     validateCommand,
     normName,
     COOLDOWN_MAX,
+    RESPONSE_MAX_LINES,
     getI18n,
     type CommandErrors
   } from '@bagel/shared';
@@ -102,7 +103,7 @@
 
   <label class="field">
     <span>{t('commandEditor.response')}</span>
-    <ResponseEditor bind:value={draft.response} />
+    <ResponseEditor bind:value={draft.response} maxLines={RESPONSE_MAX_LINES} />
     <FieldError message={errors.response} />
   </label>
 

--- a/console/dashboard/src/lib/components/commands/ResponseEditor.svelte
+++ b/console/dashboard/src/lib/components/commands/ResponseEditor.svelte
@@ -2,7 +2,12 @@
   // Response textarea with a variable palette (insert-at-cursor), live counter,
   // and a preview line that highlights {tokens} so authors can see what the bot
   // will substitute.
-  import { RESPONSE_MAX, getI18n } from '@bagel/shared';
+  //
+  // maxLines > 1 turns the response newline-delimited: each line is sent as its
+  // own chat message (commands allow up to 5). The default stays single-line
+  // for callers whose reply is one message (module replies) — Enter is
+  // swallowed and pasted newlines collapse to spaces.
+  import { RESPONSE_MAX, responseLines, getI18n } from '@bagel/shared';
 
   const i18n = getI18n();
 
@@ -21,12 +26,14 @@
     value = $bindable(''),
     name = 'response',
     tokens = DEFAULT_TOKENS,
-    placeholder
+    placeholder,
+    maxLines = 1
   }: {
     value: string;
     name?: string;
     tokens?: PaletteToken[];
     placeholder?: string;
+    maxLines?: number;
   } = $props();
 
   const chipTitle = (tk: PaletteToken) => (tk.hint ? i18n.t(tk.hint) : (tk.label ?? tk.token));
@@ -45,6 +52,24 @@
     });
   }
 
+  // The lines that will actually be sent (blank lines don't count) and the
+  // longest one, for the per-message character budget.
+  const lines = $derived(responseLines(value));
+  const longest = $derived(lines.reduce((m, l) => Math.max(m, l.length), 0));
+  const overChars = $derived(longest > RESPONSE_MAX);
+  const overLines = $derived(lines.length > maxLines);
+
+  // Enter must not mint a sixth message (or any second one in single-line
+  // mode). Blocked at keydown so the counter never flashes an error state the
+  // form would reject anyway; pasted newlines are handled in oninput below.
+  function onKeydown(e: KeyboardEvent) {
+    if (e.key === 'Enter' && (maxLines === 1 || lines.length >= maxLines)) e.preventDefault();
+  }
+
+  // Single-line callers keep their one-message contract even against paste.
+  function onInput() {
+    if (maxLines === 1 && /[\r\n]/.test(value)) value = value.replace(/[\r\n]+/g, ' ');
+  }
 </script>
 
 <div class="resp-wrap">
@@ -52,13 +77,23 @@
     class="resp-area"
     {name}
     rows="4"
-    maxlength={RESPONSE_MAX}
     placeholder={placeholder ?? i18n.t('commandEditor.responsePlaceholder')}
     bind:value
     bind:this={area}
+    onkeydown={onKeydown}
+    oninput={onInput}
   ></textarea>
-  <span class="resp-count">{value.length}/{RESPONSE_MAX}</span>
+  <span class="resp-count" class:over={overChars || overLines}>
+    {#if maxLines > 1}
+      {i18n.t('commandEditor.linesCount', { n: String(lines.length), max: String(maxLines) })} · {longest}/{RESPONSE_MAX}
+    {:else}
+      {value.length}/{RESPONSE_MAX}
+    {/if}
+  </span>
 </div>
+{#if maxLines > 1}
+  <small class="lines-hint">{i18n.t('commandEditor.linesHint', { max: String(maxLines) })}</small>
+{/if}
 
 <div class="palette" role="toolbar" aria-label={i18n.t('commandEditor.insertVariable')}>
   {#each tokens as tk (tk.token)}
@@ -102,6 +137,15 @@
     font-size: 10.5px;
     color: var(--bb-muted);
     pointer-events: none;
+    opacity: 0.7;
+  }
+  .resp-count.over { color: #cf8a78; opacity: 1; }
+
+  .lines-hint {
+    display: block;
+    margin-top: 6px;
+    font-size: 11px;
+    color: var(--bb-muted);
     opacity: 0.7;
   }
 

--- a/console/dashboard/src/routes/(app)/commands/+page.server.ts
+++ b/console/dashboard/src/routes/(app)/commands/+page.server.ts
@@ -95,7 +95,10 @@ function parseCommand(f: FormData) {
     aliases.push(a);
   }
 
-  const response = String(f.get('response') ?? '');
+  // Form submission encodes textarea newlines as CRLF; fold to LF so the wire
+  // payload matches the commands service's stored form (it normalizes anyway,
+  // this keeps the optimistic UI's echo identical to what comes back).
+  const response = String(f.get('response') ?? '').replace(/\r\n|\r/g, '\n');
   const permRaw = String(f.get('perm') ?? 'everyone');
   const perm: Perm = (PERMS as readonly string[]).includes(permRaw) ? (permRaw as Perm) : 'everyone';
 

--- a/console/shared/lib/commands-validate.ts
+++ b/console/shared/lib/commands-validate.ts
@@ -26,8 +26,16 @@ export function normName(s: string): string {
 export function responseLines(response: string): string[] {
   return response
     .split(/\r\n|\r|\n/)
-    .map((l) => l.replace(/[ \t]+$/, ''))
+    .map(trimLineEnd)
     .filter((l) => l !== '');
+}
+
+// Linear-time right-trim of spaces/tabs (mirrors Go's TrimRight(" \t")); a
+// trailing-whitespace regex backtracks polynomially on adversarial input.
+function trimLineEnd(line: string): string {
+  let end = line.length;
+  while (end > 0 && (line[end - 1] === ' ' || line[end - 1] === '\t')) end--;
+  return line.slice(0, end);
 }
 
 export interface CommandFields {

--- a/console/shared/lib/commands-validate.ts
+++ b/console/shared/lib/commands-validate.ts
@@ -6,12 +6,28 @@
 // leading "!" and is lower-case; chat keeps the "!" to invoke.
 
 export const COMMAND_NAME_MAX = 64;
+/** Per line — each line is sent as its own chat message (Twitch limit). */
 export const RESPONSE_MAX = 500;
+/** A response is newline-delimited: the bot sends one message per line. */
+export const RESPONSE_MAX_LINES = 5;
 export const COOLDOWN_MAX = 86400;
 
 /** The bare command trigger: drop a leading "!" and lower-case. */
 export function normName(s: string): string {
   return s.trim().replace(/^!+/, '').trim().toLowerCase();
+}
+
+/**
+ * The response's meaningful lines, mirroring the commands service's
+ * normalization: CRLF folds to LF, trailing whitespace per line and blank
+ * lines are dropped. Shared by the validator, the editor's counters and the
+ * chat rehearsal so all three agree on what actually gets sent.
+ */
+export function responseLines(response: string): string[] {
+  return response
+    .split(/\r\n|\r|\n/)
+    .map((l) => l.replace(/[ \t]+$/, ''))
+    .filter((l) => l !== '');
 }
 
 export interface CommandFields {
@@ -62,9 +78,12 @@ export function validateCommand(f: CommandFields): CommandErrors {
     seen.add(a);
   }
 
-  if (!f.response.trim()) errors.response = 'Response is required.';
-  else if (f.response.length > RESPONSE_MAX) {
-    errors.response = `Response must be at most ${RESPONSE_MAX} characters.`;
+  const lines = responseLines(f.response);
+  if (lines.length === 0) errors.response = 'Response is required.';
+  else if (lines.length > RESPONSE_MAX_LINES) {
+    errors.response = `Response can be at most ${RESPONSE_MAX_LINES} lines — each line is sent as its own chat message.`;
+  } else if (lines.some((l) => l.length > RESPONSE_MAX)) {
+    errors.response = `Each line must be at most ${RESPONSE_MAX} characters.`;
   }
 
   if (!Number.isFinite(f.cooldown) || f.cooldown < 0 || f.cooldown > COOLDOWN_MAX) {

--- a/console/shared/lib/i18n/en.ts
+++ b/console/shared/lib/i18n/en.ts
@@ -367,6 +367,8 @@ export const en = {
     removeAlias: 'Remove {name}',
     response: 'Response',
     responsePlaceholder: 'What the bot replies… insert variables below.',
+    linesCount: '{n}/{max} lines',
+    linesHint: 'Up to {max} lines — each line is sent as its own chat message.',
     insertVariable: 'Insert variable',
     tokUser: 'who ran the command',
     tokTarget: 'first argument, e.g. a mentioned user',

--- a/console/shared/lib/i18n/fr.ts
+++ b/console/shared/lib/i18n/fr.ts
@@ -366,6 +366,8 @@ export const fr = {
     removeAlias: 'Supprimer {name}',
     response: 'Réponse',
     responsePlaceholder: 'Ce que le bot répond… insérez des variables ci-dessous.',
+    linesCount: '{n}/{max} lignes',
+    linesHint: 'Jusqu\'à {max} lignes — chaque ligne est envoyée comme un message de chat distinct.',
     insertVariable: 'Insérer une variable',
     tokUser: 'qui a lancé la commande',
     tokTarget: 'premier argument, ex. un utilisateur mentionné',

--- a/internal/domain/validate/validate.go
+++ b/internal/domain/validate/validate.go
@@ -18,12 +18,17 @@ const (
 	maxEmailLength         = 254 // RFC 5321
 	maxCommandNameLength   = 64
 	maxCommandAliases      = 25
-	maxResponseLength      = 500   // Twitch chat message limit
+	maxResponseLineLength  = 500   // Twitch chat message limit, per line
 	maxCooldownSeconds     = 86400 // one day; guards against absurd values
 	maxModuleNameLength    = 64
 	maxConfigsBytes        = 16 << 10
 	maxTokenBytes          = 8 << 10
 )
+
+// MaxResponseLines caps how many chat messages one command response may fan
+// out into: the response is newline-delimited and the bot sends one message
+// per line. Exported so the worker can enforce the same ceiling at emit time.
+const MaxResponseLines = 5
 
 var (
 	ErrUserIDZero      = errors.New("user id must not be zero")
@@ -31,7 +36,7 @@ var (
 	ErrEmailInvalid    = errors.New("email address is not valid")
 	ErrCommandName     = errors.New("command name must be 1-64 printable ASCII characters without spaces")
 	ErrCommandAliases  = errors.New("aliases must each be a valid command name, unique, and at most 25 in total")
-	ErrResponseInvalid = errors.New("command response must be 1-500 characters without control characters")
+	ErrResponseInvalid = errors.New("command response must be 1-5 lines, each 1-500 characters without control characters")
 	ErrPermInvalid     = errors.New("perm must be one of everyone, sub, vip, mod, lead_mod, broadcaster")
 	ErrCooldownInvalid = errors.New("cooldown must be between 0 and 86400 seconds")
 	ErrModuleName      = errors.New("module name must be 1-64 characters of [a-z0-9_-]")
@@ -122,15 +127,30 @@ func CommandAliases(aliases []string) error {
 	return nil
 }
 
+// CommandResponse checks a newline-delimited command response: at most
+// MaxResponseLines lines, each line 1-500 characters with no control
+// characters. The bot sends one chat message per line, so each line is held
+// to the single-message limit. Callers normalize first (CRLF folded to LF,
+// blank lines dropped), so a blank line here is a hard error, not noise.
 func CommandResponse(response string) error {
 
-	if len(response) == 0 || len(response) > maxResponseLength {
+	if len(response) == 0 {
 		return ErrResponseInvalid
 	}
 
-	for _, r := range response {
-		if r < ' ' { // control characters, including CR/LF
+	lines := strings.Split(response, "\n")
+	if len(lines) > MaxResponseLines {
+		return ErrResponseInvalid
+	}
+
+	for _, line := range lines {
+		if len(line) == 0 || len(line) > maxResponseLineLength {
 			return ErrResponseInvalid
+		}
+		for _, r := range line {
+			if r < ' ' { // control characters, including CR
+				return ErrResponseInvalid
+			}
 		}
 	}
 

--- a/internal/domain/validate/validate_test.go
+++ b/internal/domain/validate/validate_test.go
@@ -46,10 +46,17 @@ func TestCommandName(t *testing.T) {
 
 func TestCommandResponse(t *testing.T) {
 	assert.NoError(t, validate.CommandResponse("Welcome to the stream! 🎉"))
+	assert.NoError(t, validate.CommandResponse("line one\nline two"), "newlines separate chat messages")
+	assert.NoError(t, validate.CommandResponse(strings.Repeat("one\n", 4)+"five"), "five lines is the ceiling")
+	assert.NoError(t, validate.CommandResponse(strings.Repeat("a", 500)+"\n"+strings.Repeat("b", 500)), "each line gets the full single-message budget")
 
 	assert.Error(t, validate.CommandResponse(""))
-	assert.Error(t, validate.CommandResponse("line\nbreak"), "control characters must be refused")
-	assert.Error(t, validate.CommandResponse(strings.Repeat("a", 501)))
+	assert.Error(t, validate.CommandResponse("tab\tcharacter"), "control characters must be refused")
+	assert.Error(t, validate.CommandResponse("carriage\rreturn"), "CR must be normalized away before validation")
+	assert.Error(t, validate.CommandResponse(strings.Repeat("a", 501)), "a single line beyond the message limit")
+	assert.Error(t, validate.CommandResponse("ok\n"+strings.Repeat("a", 501)), "any line beyond the message limit")
+	assert.Error(t, validate.CommandResponse(strings.Repeat("line\n", 5)+"six"), "more than five lines")
+	assert.Error(t, validate.CommandResponse("blank\n\nline"), "blank lines must be normalized away before validation")
 }
 
 func TestModuleName(t *testing.T) {


### PR DESCRIPTION
## What

Custom command responses can now span up to **5 lines**, and the bot sends **one chat message per line**. The dashboard's chat rehearsal acts out the exact fan-out.

## How

The response stays a single newline-delimited string, so nothing on the wire changes (RPC DTOs, change events, valkey projection all untouched).

- **commands**: `validate.CommandResponse` is line-aware (max 5 lines, 500 chars each — full Twitch budget per line); the repository normalizes CRLF/trailing whitespace/blank lines before validation; the `response` column widens to `MaxLen(2504)` via ent auto-migrate (also fixes the latent default-varchar(255) vs 500-char-validation mismatch).
- **sesame**: `runCustom` expands tokens once, splits on newlines, and emits one output per line — each line gets its own slash-verb translation (`/announce` + plain lines mix), with an emit-side cap at `validate.MaxResponseLines` as a backstop for stale rows. A run counts once if any line lands.
- **dashboard**: shared `responseLines()` mirrors the Go normalization so client, server action, and service agree; `ResponseEditor` gains a `maxLines` prop (commands pass 5 — line counter + Enter guard; module replies keep their single-line contract, pasted newlines collapse); `ChatPreview` rehearses one bot message per line in send order with per-line verb badges and token substitution. EN + FR strings included.

## Rollout note

Deploy the commands service before users save multi-line responses: old pods reject `\n` (previous validator), and the column widening lands via auto-migrate at pod start.

## Testing

- Full Go suite with `-race` green; new unit tests for line-aware validation, response normalization, multi-line dispatch (fan-out order, 5-line cap, empty-action lines skipped).
- `bun test shared` + svelte-check on both consoles: 0 errors.
- Browser-verified in DEMO mode: multi-line save round trip, 6-line rejection with inline error, per-line rehearsal incl. `/announcegreen`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #98
