### PR TITLE
feat(clip): !clipN duration + Get Clips URL reply

### DIFF
--- a/app/outgress/internal/worker/worker.go
+++ b/app/outgress/internal/worker/worker.go
@@ -22,12 +22,12 @@ import (
 
 	"ItsBagelBot/app/outgress/internal/channels"
 	"ItsBagelBot/app/outgress/internal/conduit"
-	"ItsBagelBot/pkg/ratelimit"
 	"ItsBagelBot/app/outgress/internal/twitch"
 	eventtwitch "ItsBagelBot/internal/domain/event/twitch"
 	"ItsBagelBot/internal/domain/outgress"
 	"ItsBagelBot/internal/domain/rpc/manage"
 	"ItsBagelBot/pkg/cache"
+	"ItsBagelBot/pkg/ratelimit"
 
 	"github.com/ThreeDotsLabs/watermill/message"
 	"github.com/bytedance/sonic"
@@ -1140,12 +1140,14 @@ func drainResponse(res *http.Response) {
 }
 
 // clipMeta is the metadata sesame threads on a TypeClip message: the title the
-// viewer typed and their login. The Create Clip call needs neither
-// (broadcaster_id rides the query, no body); they compose the chat reply posted
-// with the clip URL.
+// viewer typed, their login, and the requested clip length. Title and Duration
+// are passed through to Twitch's Create Clip call (both in the query string);
+// Title and Clipper also compose the chat reply posted with the clip URL.
+// Duration 0 means unset, so Twitch applies its default (30s).
 type clipMeta struct {
-	Title   string `json:"title"`
-	Clipper string `json:"clipper"`
+	Title    string  `json:"title"`
+	Clipper  string  `json:"clipper"`
+	Duration float64 `json:"duration"`
 }
 
 // clipCreateReply is the subset of the Helix Create Clip response we read.
@@ -1155,6 +1157,24 @@ type clipCreateReply struct {
 		EditURL string `json:"edit_url"`
 	} `json:"data"`
 }
+
+// clipGetReply is the subset of the Helix Get Clips response we read: the public
+// URL of the finished clip. Get Clips is also how Twitch says to confirm a clip
+// was actually created (an empty data array means it is not ready yet).
+type clipGetReply struct {
+	Data []struct {
+		URL string `json:"url"`
+	} `json:"data"`
+}
+
+// Creating a clip is asynchronous: the id comes back immediately but Get Clips
+// only returns the clip once Twitch finishes processing it. These bound the
+// confirmation poll — a few quick tries, then fall back to the constructed URL
+// rather than block the lane worker for Twitch's full 60s window.
+const (
+	clipConfirmAttempts = 4
+	clipConfirmDelay    = time.Second
+)
 
 // processClip creates a clip on the broadcaster's channel and posts the public
 // clip URL back to chat. The Create Clip response (and thus the URL) is visible
@@ -1175,8 +1195,18 @@ func (w *Worker) processClip(ctx context.Context, payload outgress.Message) erro
 		return err // no clip created yet: safe to redeliver
 	}
 
-	// broadcaster_id rides the query string; the Create Clip call takes no body.
-	endpoint := "/helix/clips?broadcaster_id=" + url.QueryEscape(payload.BroadcasterID)
+	// broadcaster_id, and the optional title and duration, all ride the query
+	// string; the Create Clip call takes no body. Duration 0 is omitted so Twitch
+	// applies its default length.
+	q := url.Values{}
+	q.Set("broadcaster_id", payload.BroadcasterID)
+	if title := strings.TrimSpace(meta.Title); title != "" {
+		q.Set("title", title)
+	}
+	if meta.Duration > 0 {
+		q.Set("duration", strconv.FormatFloat(meta.Duration, 'f', -1, 64))
+	}
+	endpoint := "/helix/clips?" + q.Encode()
 	res, err := w.twitch.ExecuteAs(ctx, twitch.ParseIdentity(outgress.AsBroadcaster),
 		payload.BroadcasterID, http.MethodPost, endpoint, nil)
 	if err != nil {
@@ -1215,12 +1245,63 @@ func (w *Worker) processClip(ctx context.Context, payload outgress.Message) erro
 		return nil
 	}
 
-	clipURL := "https://clips.twitch.tv/" + reply.Data[0].ID
+	// Confirm the clip and read its canonical public URL via Get Clips (Twitch's
+	// prescribed success check). Falls back to the constructed short URL if the
+	// clip is still processing after the poll — that link resolves once Twitch
+	// publishes the clip, so the reply is never left without a URL.
+	clipID := reply.Data[0].ID
+	clipURL := w.resolveClipURL(ctx, payload.BroadcasterID, clipID)
 	if err := w.sendClipReply(ctx, payload.BroadcasterID, meta, clipURL); err != nil {
 		w.log.Warn("clip created but reply chat failed",
 			zap.String("broadcaster_id", payload.BroadcasterID), zap.Error(err))
 	}
 	return nil
+}
+
+// resolveClipURL confirms a freshly created clip and returns its public URL. It
+// polls Get Clips by id a few times (creation is asynchronous, so the clip is
+// briefly absent) and returns the URL Twitch reports. If the clip has not
+// surfaced by the end of the poll it returns the constructed short URL
+// (https://clips.twitch.tv/<id>), which redirects to the clip once it is
+// published, so the caller always has a usable link. Never returns an error: the
+// clip already exists, and a missing confirmation must not fail the reply.
+func (w *Worker) resolveClipURL(ctx context.Context, broadcasterID, clipID string) string {
+	endpoint := "/helix/clips?id=" + url.QueryEscape(clipID)
+	for attempt := 0; attempt < clipConfirmAttempts; attempt++ {
+		if attempt > 0 && !sleepCtx(ctx, clipConfirmDelay) {
+			break // context cancelled: stop polling, use the fallback
+		}
+		res, err := w.twitch.ExecuteAs(ctx, twitch.ParseIdentity(outgress.AsBroadcaster),
+			broadcasterID, http.MethodGet, endpoint, nil)
+		if err != nil {
+			w.log.Warn("clip confirm request failed",
+				zap.String("broadcaster_id", broadcasterID), zap.Error(err))
+			continue
+		}
+		var got clipGetReply
+		if res.StatusCode == http.StatusOK {
+			_ = json.NewDecoder(io.LimitReader(res.Body, 4096)).Decode(&got)
+		}
+		drainResponse(res)
+		if len(got.Data) > 0 && got.Data[0].URL != "" {
+			return got.Data[0].URL
+		}
+	}
+	return "https://clips.twitch.tv/" + clipID
+}
+
+// sleepCtx waits for d or until ctx is cancelled, whichever comes first. It
+// reports true when the full delay elapsed and false when ctx cancelled, so a
+// polling loop can stop early on shutdown.
+func sleepCtx(ctx context.Context, d time.Duration) bool {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-t.C:
+		return true
+	}
 }
 
 // sendClipReply posts the chat line announcing a freshly created clip through

--- a/app/sesame/engine/dispatch.go
+++ b/app/sesame/engine/dispatch.go
@@ -32,9 +32,9 @@ func (p *Pipeline) dispatchCommand(ctx context.Context, c *module.Context, views
 	if !ok {
 		return nil
 	}
-	if bc, _, isBaked := p.registry.ResolveCommand(name); isBaked {
+	if bc, num, isBaked := p.registry.ResolveCommand(name); isBaked {
 		if p.enabled(bc.Owner, views, c) {
-			return p.runBaked(ctx, c, bc.Cmd, args, emit)
+			return p.runBaked(ctx, c, bc.Cmd, num, args, emit)
 		}
 		// The owner module is off: fall through to the broadcaster's custom
 		// commands so an opt-in module's trigger (e.g. !daily) never reserves the
@@ -45,12 +45,15 @@ func (p *Pipeline) dispatchCommand(ctx context.Context, c *module.Context, views
 
 // runBaked gates and runs a command a module owns. Every output the command
 // emits is routed through the post-processing middleware (see emitCommand), so a
-// baked command can write "/announce ..." the same way a custom one does.
-func (p *Pipeline) runBaked(ctx context.Context, c *module.Context, cmd module.Command, args string, emit module.Emit) error {
+// baked command can write "/announce ..." the same way a custom one does. num is
+// the inline numeric suffix the trigger absorbed ("" when none / not a
+// NumericSuffix command); it is exposed on the Context for the command to read.
+func (p *Pipeline) runBaked(ctx context.Context, c *module.Context, cmd module.Command, num, args string, emit module.Emit) error {
 	pass, err := p.gate(ctx, c, gateRule{cmd.Name, cmd.AllowedUserID, cmd.Perm, cmd.LiveOnly, cmd.Cooldown})
 	if err != nil || !pass {
 		return err
 	}
+	c.Num = num
 	// Resolve the broadcaster's UI locale so baked commands can localize replies.
 	// Only for commands that actually run (past the gate); the read is cache
 	// fronted, and any miss leaves Locale empty (default language).

--- a/app/sesame/engine/pipeline.go
+++ b/app/sesame/engine/pipeline.go
@@ -371,14 +371,16 @@ func buildOutgress(o *module.Output) ([]byte, error) {
 			Payload:       []byte("{}"),
 		}
 	case outgress.TypeClip:
-		// The Create Clip call itself needs no body (broadcaster_id rides the
-		// query string, added by outgress). This payload is metadata outgress
-		// reads to compose the reply it posts with the clip URL: the title the
-		// viewer typed and their login.
+		// The Create Clip call takes no body: broadcaster_id, title and duration
+		// all ride the query string, which outgress builds. This payload carries
+		// what outgress needs — the title and duration to pass to Twitch, plus the
+		// clipper login used only to compose the reply posted with the clip URL.
+		// Duration 0 (plain !clip) is omitted so Twitch applies its default.
 		payload, err := sonic.Marshal(struct {
-			Title   string `json:"title,omitempty"`
-			Clipper string `json:"clipper,omitempty"`
-		}{o.Text, o.To})
+			Title    string  `json:"title,omitempty"`
+			Clipper  string  `json:"clipper,omitempty"`
+			Duration float64 `json:"duration,omitempty"`
+		}{o.Text, o.To, o.Duration})
 		if err != nil {
 			return nil, err
 		}

--- a/app/sesame/module/context.go
+++ b/app/sesame/module/context.go
@@ -28,6 +28,12 @@ type Context struct {
 	// engine sets it before calling a named module. Empty for core modules.
 	Config json.RawMessage
 
+	// Num is the inline numeric suffix a NumericSuffix command absorbed from its
+	// trigger ("30" for "!clip30"), or empty when none was typed or the command
+	// does not opt into NumericSuffix. Set by the engine before running a baked
+	// command; a command reads it to interpret the number (e.g. clip duration).
+	Num string
+
 	role    Role
 	roleSet bool
 }
@@ -61,6 +67,7 @@ func (c *Context) Reset() {
 	c.BroadcasterID = 0
 	c.Locale = ""
 	c.Config = nil
+	c.Num = ""
 	c.role = RoleEveryone
 	c.roleSet = false
 }

--- a/app/sesame/module/module.go
+++ b/app/sesame/module/module.go
@@ -61,12 +61,16 @@ func (k Kind) String() string {
 //   - Color is the announce color (primary/blue/green/orange/purple); empty
 //     unless Type is an announce.
 //   - To is the shoutout target (login or id); empty unless Type is a shoutout.
+//   - Duration is the requested clip length in seconds (Twitch allows 5–60);
+//     zero means unset, so Twitch applies its default (30). Only Type clip
+//     reads it.
 type Output struct {
 	Type          string
 	BroadcasterID string
 	Text          string
 	Color         string
 	To            string
+	Duration      float64
 }
 
 // Emit publishes one Output. The callee must not retain o past the call: the

--- a/app/sesame/modules/clip.go
+++ b/app/sesame/modules/clip.go
@@ -2,6 +2,7 @@ package modules
 
 import (
 	"context"
+	"strconv"
 	"strings"
 	"time"
 
@@ -10,6 +11,14 @@ import (
 	"ItsBagelBot/internal/domain/outgress"
 
 	"go.uber.org/zap"
+)
+
+// Twitch's Create Clip API accepts a duration from 5 to 60 seconds inclusive; a
+// request outside that range is rejected, so the inline number is clamped into
+// it here rather than sent raw.
+const (
+	clipMinDuration = 5
+	clipMaxDuration = 60
 )
 
 // clipCooldown is the shared per-channel window on !clip so a single viewer (or
@@ -33,10 +42,10 @@ const clipModuleName = "clip"
 // command gate skips it when the broadcaster is not streaming.
 //
 // !clip <title> and !clip<N> <title> both work: N is an inline number the
-// trigger absorbs (NumericSuffix). Twitch's Create Clip API cannot set a clip
-// title or a custom duration (clips are a fixed recent window, titled later on
-// Twitch's edit page), so <title> and N are cosmetic on Twitch's side; the title
-// is echoed back in the chat reply outgress posts with the clip URL.
+// trigger absorbs (NumericSuffix) and sets the clip length in seconds. Twitch's
+// Create Clip API takes a duration from 5 to 60 (default 30); N is clamped into
+// that range and passed through outgress, and <title> becomes the clip's title.
+// Both are echoed back in the chat reply outgress posts with the clip URL.
 func Clip(d engine.Deps) module.Module {
 	log := d.Log
 	if log == nil {
@@ -49,10 +58,10 @@ func Clip(d engine.Deps) module.Module {
 }
 
 // clipRun creates a clip for the broadcaster when the built-in is enabled. It
-// emits one TypeClip outgress action carrying the title and the clipper's login;
-// outgress creates the clip and posts the resulting public URL (with the title)
-// back to chat, since the Create Clip response — and thus the URL — is only
-// visible to outgress, never here.
+// emits one TypeClip outgress action carrying the title, the requested duration,
+// and the clipper's login; outgress creates the clip and posts the resulting
+// public URL (with the title) back to chat, since the Create Clip response — and
+// thus the URL — is only visible to outgress, never here.
 func clipRun(d engine.Deps, log *zap.Logger) module.RunFunc {
 	return func(ctx context.Context, c *module.Context, args string, emit module.Emit) error {
 		if !clipEnabled(ctx, d, c.BroadcasterID, log) {
@@ -61,11 +70,32 @@ func clipRun(d engine.Deps, log *zap.Logger) module.RunFunc {
 		emit(&module.Output{
 			Type:          outgress.TypeClip,
 			BroadcasterID: c.Env.BroadcasterUserID,
-			Text:          strings.TrimSpace(args), // clip title, echoed in the reply
-			To:            c.Env.ChatterUserLogin,   // the clipper, named in the reply
+			Text:          strings.TrimSpace(args), // clip title, sent to Twitch and echoed
+			To:            c.Env.ChatterUserLogin,  // the clipper, named in the reply
+			Duration:      clipDuration(c.Num),     // inline !clipN, clamped to Twitch's 5–60
 		})
 		return nil
 	}
+}
+
+// clipDuration turns the inline numeric suffix ("30" for !clip30) into a Twitch
+// Create Clip duration in seconds. An empty suffix (plain !clip) returns 0,
+// which outgress omits so Twitch applies its default (30). Any typed value is
+// clamped to Twitch's accepted 5–60 range so an out-of-range number (!clip3,
+// !clip90) still creates a clip at the nearest legal length instead of being
+// rejected. A number too large to parse (overflow) is treated as the maximum.
+func clipDuration(num string) float64 {
+	if num == "" {
+		return 0
+	}
+	n, err := strconv.Atoi(num)
+	if err != nil || n > clipMaxDuration {
+		return clipMaxDuration
+	}
+	if n < clipMinDuration {
+		return clipMinDuration
+	}
+	return float64(n)
 }
 
 // clipEnabled reports whether the broadcaster has the built-in clip command on.

--- a/app/sesame/modules/clip_test.go
+++ b/app/sesame/modules/clip_test.go
@@ -73,8 +73,37 @@ func TestClipEmitsWhenEnabled(t *testing.T) {
 	o := col.out[0]
 	assert.Equal(t, outgress.TypeClip, o.Type)
 	assert.Equal(t, "5", o.BroadcasterID)
-	assert.Equal(t, "Sick play", o.Text)   // title echoed
-	assert.Equal(t, "viewer", o.To)         // clipper for the reply
+	assert.Equal(t, "Sick play", o.Text) // title echoed + sent to Twitch
+	assert.Equal(t, "viewer", o.To)      // clipper for the reply
+	assert.Zero(t, o.Duration, "plain !clip leaves duration unset (Twitch default)")
+}
+
+func TestClipDurationFromNumericSuffix(t *testing.T) {
+	cmd := clipCommand(t, engine.Deps{Proj: clipReader{}, Log: zap.NewNop()})
+	c := clipCtx()
+	c.Num = "45" // !clip45
+	var col collector
+	require.NoError(t, cmd.Run(context.Background(), c, "", col.emit))
+	require.Len(t, col.out, 1)
+	assert.Equal(t, 45.0, col.out[0].Duration)
+}
+
+func TestClipDuration(t *testing.T) {
+	cases := map[string]float64{
+		"":                         0,  // plain !clip: unset, Twitch default
+		"30":                       30, // in range
+		"5":                        5,  // min
+		"60":                       60, // max
+		"3":                        5,  // below min clamps up
+		"90":                       60, // above max clamps down
+		"0":                        5,  // zero clamps to min
+		"999999999999999999999999": 60, // overflow clamps to max
+	}
+	for in, want := range cases {
+		if got := clipDuration(in); got != want {
+			t.Errorf("clipDuration(%q) = %v, want %v", in, got, want)
+		}
+	}
 }
 
 func TestClipSuppressedWhenDisabled(t *testing.T) {

--- a/console/dashboard/src/lib/server/oauth.ts
+++ b/console/dashboard/src/lib/server/oauth.ts
@@ -13,8 +13,9 @@ export function scopes(): string[] {
   // Broadcaster grant. Mirrors the v1 broadcaster scope set (settings.py:
   // moderator:read:followers + user:read:chat + user:write:chat) plus channel:bot
   // so the bot may act in the channel. Adds channel:read:subscriptions and bits:read
-  // for EventSub access.
-  const bot = 'channel:bot moderator:read:followers user:read:chat user:write:chat channel:read:subscriptions bits:read user:read:moderated_channels'
+  // for EventSub access, and clips:edit so !clip can create clips on the channel
+  // (Create Clip runs on the broadcaster's own token, not the bot's).
+  const bot = 'channel:bot moderator:read:followers user:read:chat user:write:chat channel:read:subscriptions bits:read user:read:moderated_channels clips:edit'
     .split(/\s+/)
     .filter(Boolean);
   return ['openid', 'user:read:email', ...bot];


### PR DESCRIPTION
## What
- `!clip<N>` (e.g. `!clip13`) now sets clip length. The numeric suffix threads through `Context.Num` → `Output.Duration`, clamped to Twitch's 5–60s (bare `!clip` = default 30s).
- Create Clip query now carries `broadcaster_id` + `title` + `duration`.
- Reply URL comes from **Get Clips** (Twitch's prescribed success check): outgress polls Get Clips by id for the canonical `url`, falls back to `clips.twitch.tv/<id>` if still processing.
- Added `clips:edit` to the dashboard **broadcaster** grant (Create Clip runs on the broadcaster's own token, not the bot's).

## Duration mapping
`!clip5`..`!clip60` exact, `!clip13`→13s, below 5 clamps up, above 60 clamps down, bare `!clip`→30s. Integer seconds only.

## Operational caveats
- **Re-auth required:** broadcaster tokens issued before this lack `clips:edit` → Create Clip 401s until they re-login through the dashboard.
- If `DASHBOARD_LOGIN_SCOPES` (Doppler) is set, it overrides the whole scope list, so `clips:edit` must be added there too.

## Tests
`go build ./...` clean; sesame + outgress suites pass. Added `clipDuration` table test + `Num`→`Duration` emit test.