### PR TITLE
feat(clip): customizable !clip reply template with {clip} token

### DIFF
--- a/app/outgress/internal/worker/clip_reply_test.go
+++ b/app/outgress/internal/worker/clip_reply_test.go
@@ -1,0 +1,62 @@
+package worker
+
+import "testing"
+
+const testClipURL = "https://clips.twitch.tv/AbCdEf"
+
+func TestClipReplyTextDefault(t *testing.T) {
+	cases := []struct {
+		name string
+		meta clipMeta
+		want string
+	}{
+		{
+			name: "clipper and title",
+			meta: clipMeta{Clipper: "viewer", Title: "sick play"},
+			want: "viewer clipped: sick play → " + testClipURL,
+		},
+		{
+			name: "clipper only",
+			meta: clipMeta{Clipper: "viewer"},
+			want: "viewer made a clip → " + testClipURL,
+		},
+		{
+			name: "title only",
+			meta: clipMeta{Title: "sick play"},
+			want: "Clip: sick play → " + testClipURL,
+		},
+		{
+			name: "neither",
+			meta: clipMeta{},
+			want: "New clip → " + testClipURL,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := clipReplyText(tc.meta, testClipURL); got != tc.want {
+				t.Errorf("clipReplyText = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestClipReplyTextCustomTemplate(t *testing.T) {
+	meta := clipMeta{
+		Clipper: "viewer",
+		Title:   "sick play",
+		Reply:   "{user} made {clip} titled {target}",
+	}
+	want := "viewer made " + testClipURL + " titled sick play"
+	if got := clipReplyText(meta, testClipURL); got != want {
+		t.Errorf("clipReplyText custom = %q, want %q", got, want)
+	}
+}
+
+func TestClipExpand(t *testing.T) {
+	// {clipper} and {title} aliases, plus an unknown token left untouched.
+	got := clipExpand("{clipper}: {title} {clip} {mystery}", "viewer", "sick play", testClipURL)
+	want := "viewer: sick play " + testClipURL + " {mystery}"
+	if got != want {
+		t.Errorf("clipExpand = %q, want %q", got, want)
+	}
+}

--- a/app/outgress/internal/worker/worker.go
+++ b/app/outgress/internal/worker/worker.go
@@ -1140,14 +1140,16 @@ func drainResponse(res *http.Response) {
 }
 
 // clipMeta is the metadata sesame threads on a TypeClip message: the title the
-// viewer typed, their login, and the requested clip length. Title and Duration
-// are passed through to Twitch's Create Clip call (both in the query string);
-// Title and Clipper also compose the chat reply posted with the clip URL.
-// Duration 0 means unset, so Twitch applies its default (30s).
+// viewer typed, their login, the requested clip length, and the broadcaster's
+// custom reply template. Title and Duration are passed through to Twitch's
+// Create Clip call (both in the query string); Title, Clipper and Reply compose
+// the chat reply posted with the clip URL. Duration 0 means unset, so Twitch
+// applies its default (30s); an empty Reply falls back to the default format.
 type clipMeta struct {
 	Title    string  `json:"title"`
 	Clipper  string  `json:"clipper"`
 	Duration float64 `json:"duration"`
+	Reply    string  `json:"reply"`
 }
 
 // clipCreateReply is the subset of the Helix Create Clip response we read.
@@ -1323,19 +1325,40 @@ func (w *Worker) sendClipReply(ctx context.Context, broadcasterID string, meta c
 	})
 }
 
-// clipReplyText composes the chat line for a new clip: it names the clipper,
-// echoes the title they typed (when any), and links the public clip URL.
+// clipReplyText composes the chat line for a new clip. When the broadcaster set
+// a custom reply template it is expanded (see clipExpand); otherwise a default
+// line is used that names the clipper, echoes the title they typed (when any),
+// and links the public clip URL.
 func clipReplyText(meta clipMeta, clipURL string) string {
 	who := meta.Clipper
 	title := strings.TrimSpace(meta.Title)
+	if tmpl := strings.TrimSpace(meta.Reply); tmpl != "" {
+		return clipExpand(tmpl, who, title, clipURL)
+	}
 	switch {
 	case who != "" && title != "":
-		return "🎬 " + who + " clipped: " + title + " → " + clipURL
+		return who + " clipped: " + title + " → " + clipURL
 	case who != "":
-		return "🎬 " + who + " made a clip → " + clipURL
+		return who + " made a clip → " + clipURL
 	case title != "":
-		return "🎬 Clip: " + title + " → " + clipURL
+		return "Clip: " + title + " → " + clipURL
 	default:
-		return "🎬 New clip → " + clipURL
+		return "New clip → " + clipURL
 	}
+}
+
+// clipExpand substitutes the clip reply tokens into a broadcaster's custom
+// template: {clip} → the public clip URL, {user}/{clipper} → the clipper's
+// login, {target}/{title} → the title the viewer typed. Unknown tokens are left
+// untouched (mirroring the dashboard rehearsal, which marks them). The {user}
+// and {target} aliases match the standard command tokens so the same palette
+// applies; {clipper}/{title} read more naturally for a clip.
+func clipExpand(tmpl, clipper, title, clipURL string) string {
+	return strings.NewReplacer(
+		"{clip}", clipURL,
+		"{user}", clipper,
+		"{clipper}", clipper,
+		"{target}", title,
+		"{title}", title,
+	).Replace(tmpl)
 }

--- a/app/sesame/engine/pipeline.go
+++ b/app/sesame/engine/pipeline.go
@@ -373,14 +373,16 @@ func buildOutgress(o *module.Output) ([]byte, error) {
 	case outgress.TypeClip:
 		// The Create Clip call takes no body: broadcaster_id, title and duration
 		// all ride the query string, which outgress builds. This payload carries
-		// what outgress needs — the title and duration to pass to Twitch, plus the
-		// clipper login used only to compose the reply posted with the clip URL.
-		// Duration 0 (plain !clip) is omitted so Twitch applies its default.
+		// what outgress needs — the title and duration to pass to Twitch, the
+		// clipper login, and the broadcaster's custom reply template — to compose
+		// the reply posted with the clip URL (outgress expands its {clip} token).
+		// Duration 0 (plain !clip) and an empty reply are omitted.
 		payload, err := sonic.Marshal(struct {
 			Title    string  `json:"title,omitempty"`
 			Clipper  string  `json:"clipper,omitempty"`
 			Duration float64 `json:"duration,omitempty"`
-		}{o.Text, o.To, o.Duration})
+			Reply    string  `json:"reply,omitempty"`
+		}{o.Text, o.To, o.Duration, o.Template})
 		if err != nil {
 			return nil, err
 		}

--- a/app/sesame/module/module.go
+++ b/app/sesame/module/module.go
@@ -64,6 +64,10 @@ func (k Kind) String() string {
 //   - Duration is the requested clip length in seconds (Twitch allows 5–60);
 //     zero means unset, so Twitch applies its default (30). Only Type clip
 //     reads it.
+//   - Template is a custom reply template a command can carry for downstream
+//     expansion (e.g. the clip reply's {clip} token, expanded by outgress once
+//     the clip URL exists). Empty means use the default reply. Only Type clip
+//     reads it.
 type Output struct {
 	Type          string
 	BroadcasterID string
@@ -71,6 +75,7 @@ type Output struct {
 	Color         string
 	To            string
 	Duration      float64
+	Template      string
 }
 
 // Emit publishes one Output. The callee must not retain o past the call: the

--- a/app/sesame/modules/clip.go
+++ b/app/sesame/modules/clip.go
@@ -2,6 +2,7 @@ package modules
 
 import (
 	"context"
+	"encoding/json"
 	"strconv"
 	"strings"
 	"time"
@@ -59,12 +60,14 @@ func Clip(d engine.Deps) module.Module {
 
 // clipRun creates a clip for the broadcaster when the built-in is enabled. It
 // emits one TypeClip outgress action carrying the title, the requested duration,
-// and the clipper's login; outgress creates the clip and posts the resulting
-// public URL (with the title) back to chat, since the Create Clip response — and
+// the clipper's login, and the broadcaster's custom reply template (if any);
+// outgress creates the clip and posts the resulting public URL back to chat
+// (expanding the template's {clip} token), since the Create Clip response — and
 // thus the URL — is only visible to outgress, never here.
 func clipRun(d engine.Deps, log *zap.Logger) module.RunFunc {
 	return func(ctx context.Context, c *module.Context, args string, emit module.Emit) error {
-		if !clipEnabled(ctx, d, c.BroadcasterID, log) {
+		enabled, reply := clipSettings(ctx, d, c.BroadcasterID, log)
+		if !enabled {
 			return nil
 		}
 		emit(&module.Output{
@@ -73,6 +76,7 @@ func clipRun(d engine.Deps, log *zap.Logger) module.RunFunc {
 			Text:          strings.TrimSpace(args), // clip title, sent to Twitch and echoed
 			To:            c.Env.ChatterUserLogin,  // the clipper, named in the reply
 			Duration:      clipDuration(c.Num),     // inline !clipN, clamped to Twitch's 5–60
+			Template:      reply,                   // custom reply template; empty = default
 		})
 		return nil
 	}
@@ -98,25 +102,39 @@ func clipDuration(num string) float64 {
 	return float64(n)
 }
 
-// clipEnabled reports whether the broadcaster has the built-in clip command on.
-// The toggle lives in the modules service under clipModuleName; a missing row
-// means default-on (the built-in ships enabled). Read lazily here, not on the
-// hot chat path. On a projection error it fails open (allows the clip): a
-// transient read blip should not silently swallow a viewer's clip.
-func clipEnabled(ctx context.Context, d engine.Deps, broadcasterID uint64, log *zap.Logger) bool {
+// clipConfig is the built-in clip command's per-broadcaster config, stored in
+// the modules-service "clip" row's config blob alongside the on/off toggle.
+// Reply is the custom chat-reply template the broadcaster set on the dashboard;
+// empty means outgress falls back to the default reply format. The template's
+// {clip} token is expanded to the clip URL by outgress (only it knows the URL).
+type clipConfig struct {
+	Reply string `json:"reply"`
+}
+
+// clipSettings reads the built-in clip command's per-broadcaster state from the
+// modules service: whether it is enabled and the custom reply template (if any).
+// The state lives under clipModuleName; a missing row means default-on with no
+// custom template (the built-in ships enabled). Read lazily here, not on the hot
+// chat path. On a projection error it fails open (enabled, no template): a
+// transient read blip must not silently swallow a viewer's clip.
+func clipSettings(ctx context.Context, d engine.Deps, broadcasterID uint64, log *zap.Logger) (enabled bool, reply string) {
 	if d.Proj == nil {
-		return true
+		return true, ""
 	}
 	views, err := d.Proj.Modules(ctx, broadcasterID)
 	if err != nil {
 		log.Warn("clip: module state read failed, allowing",
 			zap.Uint64("broadcaster_id", broadcasterID), zap.Error(err))
-		return true
+		return true, ""
 	}
 	for _, v := range views {
 		if v.Name == clipModuleName {
-			return v.IsEnabled
+			var cfg clipConfig
+			if len(v.Configs) > 0 {
+				_ = json.Unmarshal(v.Configs, &cfg)
+			}
+			return v.IsEnabled, strings.TrimSpace(cfg.Reply)
 		}
 	}
-	return true
+	return true, ""
 }

--- a/app/sesame/modules/clip_test.go
+++ b/app/sesame/modules/clip_test.go
@@ -78,6 +78,25 @@ func TestClipEmitsWhenEnabled(t *testing.T) {
 	assert.Zero(t, o.Duration, "plain !clip leaves duration unset (Twitch default)")
 }
 
+func TestClipReplyTemplateFromConfig(t *testing.T) {
+	reader := clipReader{modules: []projection.ModuleView{
+		{Name: "clip", IsEnabled: true, Configs: []byte(`{"reply":"{user} clipped {clip}"}`)},
+	}}
+	cmd := clipCommand(t, engine.Deps{Proj: reader, Log: zap.NewNop()})
+	var col collector
+	require.NoError(t, cmd.Run(context.Background(), clipCtx(), "x", col.emit))
+	require.Len(t, col.out, 1)
+	assert.Equal(t, "{user} clipped {clip}", col.out[0].Template)
+}
+
+func TestClipNoTemplateWhenConfigEmpty(t *testing.T) {
+	cmd := clipCommand(t, engine.Deps{Proj: clipReader{}, Log: zap.NewNop()})
+	var col collector
+	require.NoError(t, cmd.Run(context.Background(), clipCtx(), "x", col.emit))
+	require.Len(t, col.out, 1)
+	assert.Empty(t, col.out[0].Template)
+}
+
 func TestClipDurationFromNumericSuffix(t *testing.T) {
 	cmd := clipCommand(t, engine.Deps{Proj: clipReader{}, Log: zap.NewNop()})
 	c := clipCtx()

--- a/console/dashboard/src/lib/components/commands/BuiltinInspector.svelte
+++ b/console/dashboard/src/lib/components/commands/BuiltinInspector.svelte
@@ -11,6 +11,7 @@
   import { enhance } from '$app/forms';
   import type { SubmitFunction } from '@sveltejs/kit';
   import {
+    Icon,
     getI18n,
     PERM_LABELS,
     type CommandView,
@@ -18,19 +19,54 @@
     type Perm
   } from '@bagel/shared';
   import ChatPreview from './ChatPreview.svelte';
+  import ResponseEditor from './ResponseEditor.svelte';
 
   let {
     command,
     def,
-    toggleSubmit
+    toggleSubmit,
+    replySubmit,
+    busy = false
   }: {
     command: CommandView;
     def: BuiltinCommandDef;
     toggleSubmit: SubmitFunction;
+    // replySubmit persists an editable built-in's reply template (only used when
+    // def.editable). Omitted for read-only built-ins.
+    replySubmit?: SubmitFunction;
+    busy?: boolean;
   } = $props();
 
   const { t } = getI18n();
   const c = $derived(command);
+
+  // --- Editable reply (e.g. clip) ------------------------------------------
+  // Seed the editor from the saved template (command.response), and re-seed when
+  // switching to a different built-in row so the draft never leaks across rows.
+  // seededFor starts null so the first effect run seeds it; it re-seeds only on
+  // an actual row change, so editing (which leaves the name unchanged) never
+  // fights the seed.
+  let message = $state('');
+  let seededFor = $state<string | null>(null);
+  $effect(() => {
+    if (command.name !== seededFor) {
+      seededFor = command.name;
+      message = command.response;
+    }
+  });
+
+  // The insert palette: the built-in's own tokens, each chip tooltip showing the
+  // sample value the rehearsal substitutes (mirrors the module ReplyEditor).
+  const palette = $derived(
+    (def.tokens ?? []).map((tk) => {
+      const token = `{${tk}}`;
+      const sample = def.previewSamples?.[tk];
+      return { token, label: sample ? `${token} → ${sample}` : token };
+    })
+  );
+  // Blank posts the default template, so preview the default instead of "nothing
+  // to say yet".
+  const effectiveMessage = $derived(message.trim() ? message : def.preview);
 </script>
 
 <div class="editor builtin">
@@ -60,10 +96,37 @@
     </ul>
   </div>
 
-  <div class="field">
-    <span>{t('builtinInspector.preview')}</span>
-    <ChatPreview name={def.id} args={def.previewArgs ?? ''} response={def.preview} samples={def.previewSamples} />
-  </div>
+  {#if def.editable && replySubmit}
+    <!-- Editable reply: same surface as a custom command — message editor with a
+         token palette, then the chat rehearsal. Saved to the modules-service
+         config (via ?/saveBuiltinReply), not the commands service. -->
+    <form class="reply-form" method="POST" action="?/saveBuiltinReply" use:enhance={replySubmit}>
+      <input type="hidden" name="name" value={c.name} />
+      <input type="hidden" name="is_active" value={c.is_active ? 'on' : ''} />
+      <div class="field">
+        <span>{t('builtinInspector.replyMessage')}</span>
+        <ResponseEditor name="reply" bind:value={message} tokens={palette} placeholder={def.preview} />
+        <small class="hint">{t('builtinInspector.replyHint')}</small>
+      </div>
+      <ChatPreview
+        name={def.id}
+        args={def.previewArgs ?? ''}
+        response={effectiveMessage}
+        samples={def.previewSamples}
+      />
+      <div class="reply-actions">
+        <button class="btn primary" type="submit" disabled={busy}>
+          <Icon name="check" size={14} />
+          {t('builtinInspector.saveReply')}
+        </button>
+      </div>
+    </form>
+  {:else}
+    <div class="field">
+      <span>{t('builtinInspector.preview')}</span>
+      <ChatPreview name={def.id} args={def.previewArgs ?? ''} response={def.preview} samples={def.previewSamples} />
+    </div>
+  {/if}
 
   <div class="field-row">
     <div class="field">
@@ -133,6 +196,13 @@
     font-size: 12.5px;
     color: var(--bb-muted);
     letter-spacing: 0.01em;
+  }
+
+  .reply-form { margin-bottom: 14px; }
+  .field .hint { color: var(--bb-muted); opacity: 0.7; font-size: 11px; }
+  .reply-actions { display: flex; justify-content: flex-end; margin-top: 12px; }
+  @media (max-width: 480px) {
+    .reply-actions .btn { width: 100%; justify-content: center; min-height: 44px; }
   }
 
   .field-row {

--- a/console/dashboard/src/routes/(app)/commands/+page.server.ts
+++ b/console/dashboard/src/routes/(app)/commands/+page.server.ts
@@ -1,7 +1,7 @@
 import type { Actions, PageServerLoad } from './$types';
 import type { CommandView, Perm } from '@bagel/shared';
-import { PERMS, normName, validateCommand, firstError, BUILTIN_COMMANDS, BUILTIN_NAMES, builtinDef } from '@bagel/shared';
-import { listCommands, upsertCommand, deleteCommand, listModules, upsertModule } from '$lib/server/commands-store';
+import { PERMS, RESPONSE_MAX, normName, validateCommand, firstError, BUILTIN_COMMANDS, BUILTIN_NAMES, builtinDef } from '@bagel/shared';
+import { listCommands, upsertCommand, deleteCommand, listModules, upsertModule, type ModuleView } from '$lib/server/commands-store';
 import { auditDashboardImpersonation } from '$lib/server/services';
 import type { Session } from '$lib/server/session';
 import { env } from '$env/dynamic/private';
@@ -33,17 +33,34 @@ const sample: CommandView[] = [
   { name: 'followage', response: "{user} you've followed for {followage}", perm: 'sub', cooldown: 15, uses: '177', is_active: true }
 ];
 
+// configString reads one string field out of a module's opaque config blob,
+// tolerating any non-object/absent shape. Used to pull a built-in's saved reply
+// template out of the modules-service config.
+function configString(configs: unknown, key: string): string {
+  if (configs && typeof configs === 'object') {
+    const v = (configs as Record<string, unknown>)[key];
+    if (typeof v === 'string') return v;
+  }
+  return '';
+}
+
 // builtinViews turns the built-in catalog into command rows, reading each
-// built-in's on/off state from the modules service (key = the built-in id). A
-// missing module row means the catalog default. These render read-only on the
-// commands page with a toggle + preview.
-function builtinViews(modules: { name: string; is_enabled: boolean }[]): CommandView[] {
+// built-in's on/off state (and, for editable built-ins, its saved reply
+// template) from the modules service (key = the built-in id). A missing module
+// row means the catalog default. Non-editable built-ins render read-only with a
+// toggle + preview; editable ones (e.g. clip) expose a reply template whose
+// current value seeds the inspector's editor.
+function builtinViews(modules: ModuleView[]): CommandView[] {
   const byName = new Map(modules.map((m) => [m.name, m]));
   return BUILTIN_COMMANDS.map((def) => {
     const row = byName.get(def.id);
+    const savedReply = def.editable && def.replyKey ? configString(row?.configs, def.replyKey) : '';
     return {
       name: def.id,
-      response: def.summary,
+      // Editable built-ins carry the saved template (or the default) so the
+      // inspector's editor and rehearsal start from the real value; others show
+      // the static summary.
+      response: def.editable ? savedReply || def.preview : def.summary,
       is_active: row ? row.is_enabled : def.defaultActive,
       perm: def.defaultPerm,
       cooldown: def.defaultCooldown,
@@ -55,7 +72,7 @@ function builtinViews(modules: { name: string; is_enabled: boolean }[]): Command
 
 // mergeCommands lists built-ins first, then the user's custom commands with any
 // name colliding with a built-in dropped (built-ins reserve their trigger).
-function mergeCommands(custom: CommandView[], modules: { name: string; is_enabled: boolean }[]): CommandView[] {
+function mergeCommands(custom: CommandView[], modules: ModuleView[]): CommandView[] {
   const builtins = builtinViews(modules);
   const customs = custom.filter((c) => !BUILTIN_NAMES.has(c.name));
   return [...builtins, ...customs];
@@ -293,6 +310,56 @@ export const actions: Actions = {
     }
 
     auditDashboardImpersonation(locals.session, 'command:builtin_toggle', `${name}=${isActive}`);
+    return { ok: true, action: 'updated', name, commands: [view], silent: true };
+  },
+
+  // Save an editable built-in's custom reply template. Like the toggle, the
+  // value lives in the modules service (under the built-in id, config key
+  // def.replyKey), so this writes there — not the commands service. An empty
+  // reply clears the override (upsertModule omits empty config), so the bot
+  // falls back to the default template. The current on/off state rides along so
+  // the write preserves it.
+  saveBuiltinReply: async ({ request, locals }) => {
+    gateCommands(locals.session);
+    const uid = effectiveId(locals.session);
+    if (env.DEMO !== '1' && !locals.session) {
+      return fail(401, { ok: false, error: 'Not signed in.' });
+    }
+
+    const f = await request.formData();
+    const name = normName(String(f.get('name') ?? ''));
+    const def = builtinDef(name);
+    if (!def || !def.editable || !def.replyKey) {
+      return fail(400, { ok: false, error: 'This command has no editable reply.' });
+    }
+    const reply = String(f.get('reply') ?? '').trim();
+    if (reply.length > RESPONSE_MAX) {
+      return fail(400, { ok: false, error: `Reply is too long (max ${RESPONSE_MAX}).` });
+    }
+    const isActive = f.get('is_active') === 'on';
+
+    const view: CommandView = {
+      name: def.id,
+      response: reply || def.preview,
+      is_active: isActive,
+      perm: def.defaultPerm,
+      cooldown: def.defaultCooldown,
+      stream_online_only: def.liveOnly,
+      builtin: true
+    };
+
+    if (env.DEMO === '1') {
+      return { ok: true, action: 'updated', name, commands: [view], silent: true };
+    }
+
+    try {
+      await upsertModule(uid, def.id, isActive, reply ? { [def.replyKey]: reply } : undefined);
+    } catch (e) {
+      logRpcFailure('saveBuiltinReply', e);
+      return fail(400, { ok: false });
+    }
+
+    auditDashboardImpersonation(locals.session, 'command:builtin_reply', name);
     return { ok: true, action: 'updated', name, commands: [view], silent: true };
   }
 };

--- a/console/dashboard/src/routes/(app)/commands/+page.svelte
+++ b/console/dashboard/src/routes/(app)/commands/+page.svelte
@@ -325,6 +325,34 @@
       };
     };
 
+  // --- Built-in reply save (optimistic response swap) ------------------------
+  // Editable built-ins (e.g. clip) persist their reply template to the modules
+  // service. Optimistically swap the row's response to the typed value, then let
+  // the server's rebuilt row reconcile (it normalizes a blank reply back to the
+  // default template).
+  const replySubmit =
+    (c: CommandView): SubmitFunction =>
+    ({ formData }) => {
+      const next = String(formData.get('reply') ?? '');
+      const before = { ...c };
+      items = items.map((x) => (x.name === c.name ? { ...x, response: next } : x));
+      setStatus(c.name, 'saving');
+      return async ({ result }) => {
+        const payload =
+          result.type === 'success' || result.type === 'failure'
+            ? (result.data as ActionResult | undefined)
+            : undefined;
+        if (result.type === 'success' && payload?.ok) {
+          applyResult(payload); // silent from the server
+          ackSaved(c.name);
+        } else {
+          items = items.map((x) => (x.name === c.name ? before : x));
+          flagError(c.name);
+          toast('err', payload?.error ?? t('commands.toastSaveFailed'));
+        }
+      };
+    };
+
   // --- Delete (optimistic removal + undo toast) --------------------------------
   function postAction(action: string, body: FormData): Promise<ActionResult | null> {
     return fetch(`?/${action}`, { method: 'POST', body })
@@ -517,7 +545,13 @@
           {#if editorDraft.builtin && selectedCmd}
             {@const def = builtinDef(selectedCmd.name)}
             {#if def}
-              <BuiltinInspector command={selectedCmd} {def} toggleSubmit={toggleSubmit(selectedCmd)} />
+              <BuiltinInspector
+                command={selectedCmd}
+                {def}
+                toggleSubmit={toggleSubmit(selectedCmd)}
+                replySubmit={replySubmit(selectedCmd)}
+                {busy}
+              />
             {/if}
           {:else}
             <!-- Keyed on the selected command so switching rows mounts a FRESH

--- a/console/shared/lib/i18n/en.ts
+++ b/console/shared/lib/i18n/en.ts
@@ -419,6 +419,9 @@ export const en = {
     usage: 'Usage',
     preview: 'Preview',
     access: 'Access',
-    cooldown: 'Cooldown'
+    cooldown: 'Cooldown',
+    replyMessage: 'Reply message',
+    replyHint: 'Leave blank for the default. {clip} = the clip link, {user} = the clipper, {target} = the title.',
+    saveReply: 'Save reply'
   }
 } satisfies MessageTree;

--- a/console/shared/lib/i18n/fr.ts
+++ b/console/shared/lib/i18n/fr.ts
@@ -418,6 +418,9 @@ export const fr = {
     usage: 'Utilisation',
     preview: 'Aperçu',
     access: 'Accès',
-    cooldown: 'Délai'
+    cooldown: 'Délai',
+    replyMessage: 'Message de réponse',
+    replyHint: 'Laissez vide pour le message par défaut. {clip} = le lien du clip, {user} = le créateur, {target} = le titre.',
+    saveReply: 'Enregistrer'
   }
 } satisfies MessageTree;

--- a/console/shared/lib/types.ts
+++ b/console/shared/lib/types.ts
@@ -68,6 +68,19 @@ export interface BuiltinCommandDef {
   defaultCooldown: number; // seconds
   // liveOnly commands run only while the broadcaster is streaming.
   liveOnly: boolean;
+  // editable: the reply template can be customized on the dashboard. When true
+  // the inspector shows a ResponseEditor (with the `tokens` palette) and a
+  // rehearsal, and saves the template into the modules-service config under
+  // `replyKey`. The bot expands the tokens when it posts the reply (e.g. {clip}
+  // → the clip URL, resolved by outgress once the clip exists). Non-editable
+  // built-ins stay a read-only preview. `preview` doubles as the default
+  // template when no custom reply is set.
+  editable?: boolean;
+  // replyKey is the Configs key the custom reply template is stored under (only
+  // meaningful when editable).
+  replyKey?: string;
+  // tokens is the reply editor's insert palette (token names without braces).
+  tokens?: string[];
 }
 
 export const BUILTIN_COMMANDS: readonly BuiltinCommandDef[] = [
@@ -78,16 +91,22 @@ export const BUILTIN_COMMANDS: readonly BuiltinCommandDef[] = [
     description:
       'Viewers create a clip of the recent stream and the bot replies in chat with the clip link. Add an optional title after the command. Only works while you are live.',
     usage: ['!clip', '!clip <title>'],
-    // Real reply format: "🎬 <clipper> clipped: <title> → <url>" (see
+    // Real reply format: "<clipper> clipped: <title> → <url>" (see
     // app/outgress/internal/worker clipReplyText). {user} = the clipper, {target}
     // = the title argument (standard command token).
-    preview: '🎬 {user} clipped: {target} → {clip}',
+    preview: '{user} clipped: {target} → {clip}',
     previewArgs: 'That is amazing',
     previewSamples: { target: 'That is amazing', clip: 'clips.twitch.tv/AbCdEf' },
     defaultActive: true,
     defaultPerm: 'everyone',
     defaultCooldown: 15,
-    liveOnly: true
+    liveOnly: true,
+    // The reply is customizable: {clip} is the clip link, {user} the clipper,
+    // {target} the title the viewer typed. Stored under the "reply" config key,
+    // read by sesame and expanded by outgress (see app/sesame/modules/clip.go).
+    editable: true,
+    replyKey: 'reply',
+    tokens: ['clip', 'user', 'target']
   }
 ];
 


### PR DESCRIPTION
## What
Makes the built-in `!clip` reply **customizable per broadcaster**, with a `{clip}` token expanded to the clip URL.

### Backend
- Reply template stored in the modules-service `clip` row config (key `reply`) — reuses the existing `upsertModule` config plumbing.
- sesame [`clip.go`](app/sesame/modules/clip.go): `clipSettings` reads enabled + `reply` from config, threads the template into `Output.Template`.
- `Output.Template` → pipeline clip payload `reply` → outgress.
- outgress [`clipReplyText`](app/outgress/internal/worker/worker.go): expands the template via `clipExpand` — `{clip}`→URL, `{user}`/`{clipper}`→clipper, `{target}`/`{title}`→title. Empty template → default line. Unknown tokens left intact.
- Default reply line drops the leading emoji.

### Dashboard
- The clip built-in inspector is no longer read-only: `ResponseEditor` with a `{clip}/{user}/{target}` palette + live rehearsal.
- New `saveBuiltinReply` action persists the template via `upsertModule` config; `builtinViews` seeds the editor from the saved value; optimistic `replySubmit` handler.
- en + fr i18n.

## Tests
- `go build ./...` clean; sesame + outgress suites pass (added `clipExpand`, custom-template, and config→template tests).
- `bun run check` (dashboard): 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)