### PR TITLE
fix(clip,live): post clip reply + invalidate live cache on stream events

### DIFF
--- a/app/outgress/internal/worker/worker.go
+++ b/app/outgress/internal/worker/worker.go
@@ -1310,6 +1310,12 @@ func sleepCtx(ctx context.Context, d time.Duration) bool {
 // the normal chat path (rate buckets, sender-id injection). Its error is only
 // for the caller to log; the clip already exists, so the caller must not
 // redeliver on a reply failure.
+//
+// processChat runs the send with payload.Endpoint/Method/As already resolved: on
+// the normal chat path the dispatcher fills them from typeRoutes before calling
+// it. This synthetic reply bypasses the dispatcher, so it must set the same chat
+// route itself — otherwise the request goes out with an empty endpoint/method
+// and Twitch's edge rejects it (403).
 func (w *Worker) sendClipReply(ctx context.Context, broadcasterID string, meta clipMeta, clipURL string) error {
 	body, err := sonic.Marshal(struct {
 		BroadcasterID string `json:"broadcaster_id"`
@@ -1318,9 +1324,13 @@ func (w *Worker) sendClipReply(ctx context.Context, broadcasterID string, meta c
 	if err != nil {
 		return err
 	}
+	route := typeRoutes[outgress.TypeChat]
 	return w.processChat(ctx, outgress.Message{
 		Type:          outgress.TypeChat,
 		BroadcasterID: broadcasterID,
+		Endpoint:      route.endpoint,
+		Method:        route.method,
+		As:            route.as,
 		Payload:       body,
 	})
 }

--- a/app/projector/projector.go
+++ b/app/projector/projector.go
@@ -9,6 +9,7 @@ import (
 	"ItsBagelBot/internal/domain/event/data"
 	"ItsBagelBot/internal/domain/event/twitch"
 	"ItsBagelBot/internal/domain/invalidate"
+	livekey "ItsBagelBot/internal/domain/live"
 	"ItsBagelBot/internal/domain/validate"
 	"ItsBagelBot/internal/projection"
 
@@ -243,6 +244,15 @@ func (p *Projector) HandleStreamEvent(msg *message.Message) error {
 		return err
 	}
 
+	// Fan the live change to every live-cache holder (sesame's per-replica bool
+	// cache) so a go-live/go-offline is reflected immediately instead of only on
+	// the cache's short TTL. Without this the projection is fresh but sesame keeps
+	// serving its cached (often stale-offline) answer until the entry lapses. Both
+	// directions invalidate: online and offline. Best effort — the projection is
+	// already written, so a missed ping only delays visibility until the TTL and
+	// the cold-key RPC that reads this same state.
+	p.broadcastLiveInvalidate(st.BroadcasterID)
+
 	if !st.Live {
 		return nil
 	}
@@ -250,4 +260,18 @@ func (p *Projector) HandleStreamEvent(msg *message.Message) error {
 	p.log.Info("refreshing settings cache for stream online", zap.Uint64("user_id", st.BroadcasterID))
 	p.hydrator.RefreshAsync(st.BroadcasterID)
 	return nil
+}
+
+// broadcastLiveInvalidate fans a live-state change over the console cache bus on
+// the "live" scope sesame's invalidation listener subscribes to, so every sesame
+// replica drops its cached live bool and re-reads the freshly projected state.
+// Best effort: Valkey is already written, so a missed ping only delays visibility
+// until the cache TTL lapses.
+func (p *Projector) broadcastLiveInvalidate(userID uint64) {
+	if p.nc == nil || p.cacheInvalidatePrefix == "" {
+		return
+	}
+	if err := invalidate.Publish(p.nc, p.cacheInvalidatePrefix, livekey.InvalidateScope, strconv.FormatUint(userID, 10)); err != nil {
+		p.log.Warn("failed to broadcast live invalidation", zap.Uint64("user_id", userID), zap.Error(err))
+	}
 }


### PR DESCRIPTION
## Clip reply never posted (403)
`sendClipReply` called `processChat` with a bare `TypeChat` message, so `Endpoint`/`Method`/`As` were never filled — the dispatcher fills them from `typeRoutes` only on the normal chat path. The reply went out with an empty endpoint → Twitch edge 403. Now sets the chat route on the synthetic reply, same as the dispatcher.

## Live cache stale on go-live
The projector wrote the settings hash on stream.online/offline but never broadcast on the `live` invalidation scope, so sesame kept serving its cached (often stale-offline) live bool until the short TTL lapsed. Now broadcasts the live invalidation both directions so sesame drops it immediately.

Build + tests pass (outgress worker suite, projector).

🤖 Generated with [Claude Code](https://claude.com/claude-code)