### PR TITLE
perf(deploy): cut memory ceilings for flux, NR, nats-leaf

### DIFF
--- a/deploy/flux/clusters/production/flux-system/kustomization.yaml
+++ b/deploy/flux/clusters/production/flux-system/kustomization.yaml
@@ -3,3 +3,40 @@ kind: Kustomization
 resources:
 - gotk-components.yaml
 - gotk-sync.yaml
+patches:
+# Memory-limit trims. Upstream gotk-components ships every controller with
+# limits.memory: 1Gi, and GOMEMLIMIT is wired to limits.memory via
+# resourceFieldRef, so the Go GC happily lets the heap coast toward 1Gi.
+# Lowering the limit lowers GOMEMLIMIT with it and the GC keeps RSS near the
+# real working set instead. Measured before the trim (2026-07-06):
+# image-reflector 580Mi RSS (12 ImageRepositories, ~5.5k tags in its badger
+# cache), kustomize 210Mi. 384Mi leaves the reflector headroom for badger
+# compaction spikes; kustomize builds this small repo well under 256Mi.
+- patch: |-
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: image-reflector-controller
+      namespace: flux-system
+    spec:
+      template:
+        spec:
+          containers:
+            - name: manager
+              resources:
+                limits:
+                  memory: 384Mi
+- patch: |-
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: kustomize-controller
+      namespace: flux-system
+    spec:
+      template:
+        spec:
+          containers:
+            - name: manager
+              resources:
+                limits:
+                  memory: 256Mi

--- a/deploy/flux/clusters/production/newrelic.yaml
+++ b/deploy/flux/clusters/production/newrelic.yaml
@@ -199,8 +199,14 @@ spec:
             mountPath: /secrets/valkey
             readOnly: true
 
-      # controlPlane autodiscovery is the chart default and matches the live
-      # render (etcd/scheduler selectors in kube-system); left at defaults.
+      # Control-plane scraping is OFF: k3s embeds etcd(kine)/scheduler/
+      # controller-manager/apiserver inside the k3s server process, so there
+      # are NO kube-system pods for the chart's etcd/scheduler autodiscovery
+      # selectors to match (verified 2026-07-06: zero matches, the nrk8s-
+      # controlplane pod collected nothing). Removing the DaemonSet frees
+      # ~40Mi on node2 with no data loss.
+      controlPlane:
+        enabled: false
 
     # =======================================================================
     # kube-state-metrics (bundled subchart, image pinned by the chart)

--- a/deploy/k8s/nats-leaf.yaml
+++ b/deploy/k8s/nats-leaf.yaml
@@ -79,6 +79,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            # Leaves are JS-disabled local RPC relays; without a heap target the
+            # Go GC let RSS drift to 130-180Mi per node. 96MiB keeps the GC
+            # honest while staying above the leaf's real working set (client
+            # buffers + leaf mesh routes).
+            - name: GOMEMLIMIT
+              value: 96MiB
           envFrom:
             - secretRef:
                 name: nats-auth-env
@@ -93,8 +99,10 @@ spec:
           resources:
             # Leaves are encrypted local relays, not durable stores; keep burst
             # headroom but avoid reserving hub-sized memory on every node.
-            requests: {cpu: 50m, memory: 192Mi}
-            limits: {cpu: 1500m, memory: 512Mi}
+            # Sized against GOMEMLIMIT=96MiB above: ~110-120Mi steady RSS
+            # (heap target + goroutine stacks + mmap), 256Mi hard cap.
+            requests: {cpu: 50m, memory: 96Mi}
+            limits: {cpu: 1500m, memory: 256Mi}
           securityContext:
             allowPrivilegeEscalation: false
             capabilities: {drop: ["ALL"]}


### PR DESCRIPTION
RSS audit (2026-07-06) found the Go GC coasting toward oversized limits cluster-wide:

- flux: image-reflector 580Mi / kustomize 210Mi RSS against 1Gi limits; GOMEMLIMIT tracks limits.memory, so 384Mi/256Mi caps pull RSS back to the real working set.
- newrelic: disable nrk8s-controlplane; k3s embeds the control plane in-process, the etcd/scheduler autodiscovery selectors match zero pods, the scraper collected nothing.
- nats-leaf: GOMEMLIMIT=96MiB (JS-disabled relays drifted to 130-180Mi RSS); requests 192->96Mi, limits 512->256Mi.

k3s server itself got GOMEMLIMIT=1300MiB / GOGC=75 applied live on node2 (/etc/systemd/system/k3s.service.env, not repo-tracked): 1894Mi -> ~830Mi after restart.