### PR TITLE
fix(bus,clip): drop consumer BackOff; reply with constructed URL

### DIFF
--- a/app/outgress/internal/worker/worker.go
+++ b/app/outgress/internal/worker/worker.go
@@ -1160,27 +1160,15 @@ type clipCreateReply struct {
 	} `json:"data"`
 }
 
-// clipGetReply is the subset of the Helix Get Clips response we read: the public
-// URL of the finished clip. Get Clips is also how Twitch says to confirm a clip
-// was actually created (an empty data array means it is not ready yet).
-type clipGetReply struct {
-	Data []struct {
-		URL string `json:"url"`
-	} `json:"data"`
-}
-
-// Creating a clip is asynchronous: the id comes back immediately but Get Clips
-// only returns the clip once Twitch finishes processing it. These bound the
-// confirmation poll — a few quick tries, then fall back to the constructed URL
-// rather than block the lane worker for Twitch's full 60s window.
-const (
-	clipConfirmAttempts = 4
-	clipConfirmDelay    = time.Second
-)
-
 // processClip creates a clip on the broadcaster's channel and posts the public
 // clip URL back to chat. The Create Clip response (and thus the URL) is visible
 // only here, so this is the one place that can surface it.
+//
+// The reply posts immediately with the constructed public URL
+// (https://clips.twitch.tv/<id>): the Create Clip id doubles as the clip's
+// public slug, and Get Clips reports exactly that link once processing
+// finishes, so polling it first only delayed the reply by seconds while
+// pinning a lane routine — the link resolves the moment Twitch publishes.
 //
 // Redelivery safety: once the clip is created (2xx) this returns nil no matter
 // what happens to the reply — re-running the message would create a DUPLICATE
@@ -1247,63 +1235,12 @@ func (w *Worker) processClip(ctx context.Context, payload outgress.Message) erro
 		return nil
 	}
 
-	// Confirm the clip and read its canonical public URL via Get Clips (Twitch's
-	// prescribed success check). Falls back to the constructed short URL if the
-	// clip is still processing after the poll — that link resolves once Twitch
-	// publishes the clip, so the reply is never left without a URL.
-	clipID := reply.Data[0].ID
-	clipURL := w.resolveClipURL(ctx, payload.BroadcasterID, clipID)
+	clipURL := "https://clips.twitch.tv/" + reply.Data[0].ID
 	if err := w.sendClipReply(ctx, payload.BroadcasterID, meta, clipURL); err != nil {
 		w.log.Warn("clip created but reply chat failed",
 			zap.String("broadcaster_id", payload.BroadcasterID), zap.Error(err))
 	}
 	return nil
-}
-
-// resolveClipURL confirms a freshly created clip and returns its public URL. It
-// polls Get Clips by id a few times (creation is asynchronous, so the clip is
-// briefly absent) and returns the URL Twitch reports. If the clip has not
-// surfaced by the end of the poll it returns the constructed short URL
-// (https://clips.twitch.tv/<id>), which redirects to the clip once it is
-// published, so the caller always has a usable link. Never returns an error: the
-// clip already exists, and a missing confirmation must not fail the reply.
-func (w *Worker) resolveClipURL(ctx context.Context, broadcasterID, clipID string) string {
-	endpoint := "/helix/clips?id=" + url.QueryEscape(clipID)
-	for attempt := 0; attempt < clipConfirmAttempts; attempt++ {
-		if attempt > 0 && !sleepCtx(ctx, clipConfirmDelay) {
-			break // context cancelled: stop polling, use the fallback
-		}
-		res, err := w.twitch.ExecuteAs(ctx, twitch.ParseIdentity(outgress.AsBroadcaster),
-			broadcasterID, http.MethodGet, endpoint, nil)
-		if err != nil {
-			w.log.Warn("clip confirm request failed",
-				zap.String("broadcaster_id", broadcasterID), zap.Error(err))
-			continue
-		}
-		var got clipGetReply
-		if res.StatusCode == http.StatusOK {
-			_ = json.NewDecoder(io.LimitReader(res.Body, 4096)).Decode(&got)
-		}
-		drainResponse(res)
-		if len(got.Data) > 0 && got.Data[0].URL != "" {
-			return got.Data[0].URL
-		}
-	}
-	return "https://clips.twitch.tv/" + clipID
-}
-
-// sleepCtx waits for d or until ctx is cancelled, whichever comes first. It
-// reports true when the full delay elapsed and false when ctx cancelled, so a
-// polling loop can stop early on shutdown.
-func sleepCtx(ctx context.Context, d time.Duration) bool {
-	t := time.NewTimer(d)
-	defer t.Stop()
-	select {
-	case <-ctx.Done():
-		return false
-	case <-t.C:
-		return true
-	}
 }
 
 // sendClipReply posts the chat line announcing a freshly created clip through

--- a/app/outgress/main.go
+++ b/app/outgress/main.go
@@ -30,9 +30,17 @@ const serviceName = "outgress"
 // A failed command is retried three times at one-second intervals. The
 // work-queue stream also has a five-second MaxAge, so it cannot survive a
 // restart and reappear later as stale chat output.
+//
+// System (EventSub enroll / stream_status) jobs live on their own stream with
+// a five-minute MaxAge, so their retries are slower and more numerous: a
+// transient Twitch or rate-limit failure gets another shot every fifteen
+// seconds for as long as the message survives.
 const (
 	nakDelay        = time.Second
 	maxRedeliveries = 3
+
+	systemNakDelay        = 15 * time.Second
+	systemMaxRedeliveries = 6
 )
 
 func main() {
@@ -218,27 +226,19 @@ func main() {
 	system.SetLiveWriter(worker.NewLiveWriter(valkeyClient, nc, cfg.CacheInvalidatePrefix, cfg.LiveTTL, log.Named("live")))
 
 	// paced redelivery keeps rate-limit nacks from spinning.
-	premiumSub, err := bus.NewLaneSubscriber(cfg.NATSURL, bus.OutgressStream.Name, cfg.PremiumSubject, "outgress-premium", []time.Duration{nakDelay}, maxRedeliveries, log)
+	premiumSub, err := bus.NewLaneSubscriber(cfg.NATSURL, bus.OutgressStream.Name, cfg.PremiumSubject, "outgress-premium", nakDelay, maxRedeliveries, log)
 	if err != nil {
 		log.Fatal("failed to connect premium subscriber", zap.Error(err))
 	}
 	defer func() { _ = premiumSub.Close() }()
 
-	standardSub, err := bus.NewLaneSubscriber(cfg.NATSURL, bus.OutgressStream.Name, cfg.StandardSubject, "outgress-standard", []time.Duration{nakDelay}, maxRedeliveries, log)
+	standardSub, err := bus.NewLaneSubscriber(cfg.NATSURL, bus.OutgressStream.Name, cfg.StandardSubject, "outgress-standard", nakDelay, maxRedeliveries, log)
 	if err != nil {
 		log.Fatal("failed to connect standard subscriber", zap.Error(err))
 	}
 	defer func() { _ = standardSub.Close() }()
 
-	systemBackoff := []time.Duration{
-		15 * time.Second,
-		time.Minute,
-		3 * time.Minute,
-		5 * time.Minute,
-		15 * time.Minute,
-		30 * time.Minute,
-	}
-	systemSub, err := bus.NewLaneSubscriber(cfg.NATSURL, bus.OutgressSystemStream.Name, cfg.SystemSubject, "outgress-system", systemBackoff, uint64(len(systemBackoff)), log)
+	systemSub, err := bus.NewLaneSubscriber(cfg.NATSURL, bus.OutgressSystemStream.Name, cfg.SystemSubject, "outgress-system", systemNakDelay, systemMaxRedeliveries, log)
 	if err != nil {
 		log.Fatal("failed to connect system subscriber", zap.Error(err))
 	}

--- a/pkg/bus/bus.go
+++ b/pkg/bus/bus.go
@@ -62,10 +62,17 @@ func NewSubscriber(url string, group string, log *zap.Logger) (message.Subscribe
 // deleted when the creating pod unsubscribes, which used to erase the shared
 // ACK floor during every rolling update and replay the retained stream.
 //
+// nakDelay paces redelivery after a NACK (rate limits, transient failures),
+// applied per message through Watermill's NakWithDelay. It must NOT become a
+// consumer-level BackOff: the server forces AckWait down to backoff[0], so a
+// short nack delay would also redeliver every message whose handler is merely
+// slower than that delay — while the first replica is still working — and fan
+// one job out across the whole fleet (duplicate chat sends, duplicate clips).
+//
 // maxRedeliveries excludes the first delivery. NATS enforces the total on the
 // consumer and the Watermill delay terminates the final failed delivery, so a
 // failed command cannot come back after its budget is exhausted.
-func NewLaneSubscriber(url, stream, subject, group string, backoff []time.Duration, maxRedeliveries uint64, log *zap.Logger) (message.Subscriber, error) {
+func NewLaneSubscriber(url, stream, subject, group string, nakDelay time.Duration, maxRedeliveries uint64, log *zap.Logger) (message.Subscriber, error) {
 	maxDeliveries := maxRedeliveries + 1
 	consumer := durableName(group, subject)
 
@@ -79,21 +86,16 @@ func NewLaneSubscriber(url, stream, subject, group string, backoff []time.Durati
 		nc.Close()
 		return nil, err
 	}
-	if err := ensureLaneConsumer(js, stream, subject, group, consumer, int(maxDeliveries), backoff); err != nil {
+	if err := ensureLaneConsumer(js, stream, subject, group, consumer, int(maxDeliveries)); err != nil {
 		nc.Close()
 		return nil, err
-	}
-
-	var baseDelay time.Duration
-	if len(backoff) > 0 {
-		baseDelay = backoff[0]
 	}
 
 	sub, err := wmnats.NewSubscriberWithNatsConn(nc, wmnats.SubscriberSubscriptionConfig{
 		QueueGroupPrefix: group,
 		SubscribersCount: 1,
 		AckWaitTimeout:   30 * time.Second,
-		NakDelay:         wmnats.NewMaxRetryDelay(baseDelay, maxDeliveries),
+		NakDelay:         wmnats.NewMaxRetryDelay(nakDelay, maxDeliveries),
 		Unmarshaler:      &wmnats.NATSMarshaler{},
 		JetStream: wmnats.JetStreamConfig{
 			AutoProvision:     false,
@@ -115,8 +117,8 @@ func NewLaneSubscriber(url, stream, subject, group string, backoff []time.Durati
 
 const managedConsumerMetadata = "itsbagelbot.dev/managed"
 
-func ensureLaneConsumer(js nats.JetStreamManager, stream, subject, group, name string, maxDeliveries int, backoff []time.Duration) error {
-	desired := laneConsumerConfig(subject, group, name, maxDeliveries, backoff)
+func ensureLaneConsumer(js nats.JetStreamManager, stream, subject, group, name string, maxDeliveries int) error {
+	desired := laneConsumerConfig(subject, group, name, maxDeliveries)
 	info, err := js.ConsumerInfo(stream, name)
 	if err != nil {
 		if errors.Is(err, nats.ErrConsumerNotFound) {
@@ -126,15 +128,31 @@ func ensureLaneConsumer(js nats.JetStreamManager, stream, subject, group, name s
 		return err
 	}
 
-	// Update mutable parameters.
+	// Update mutable parameters. Some transitions are not updatable in place
+	// (notably clearing a legacy BackOff schedule on older servers), so fall
+	// back to replacing the consumer: the deliver subject and group are
+	// deterministic, so replicas already bound keep receiving from the
+	// recreated consumer, and the lanes are perishable work queues with no
+	// replay to preserve.
 	desired.DeliverSubject = info.Config.DeliverSubject
 	if _, err := js.UpdateConsumer(stream, desired); err != nil {
-		return fmt.Errorf("bus: update consumer %q: %w", name, err)
+		if derr := js.DeleteConsumer(stream, name); derr != nil && !errors.Is(derr, nats.ErrConsumerNotFound) {
+			return fmt.Errorf("bus: update consumer %q: %w (replace failed: %v)", name, err, derr)
+		}
+		if _, aerr := js.AddConsumer(stream, desired); aerr != nil {
+			return fmt.Errorf("bus: recreate consumer %q: %w", name, aerr)
+		}
 	}
 	return nil
 }
 
-func laneConsumerConfig(subject, group, name string, maxDeliveries int, backoff []time.Duration) *nats.ConsumerConfig {
+// laneConsumerConfig deliberately sets no BackOff: the server clamps AckWait to
+// backoff[0], and a short first step turns every handler slower than it into a
+// premature redelivery to another replica while the first is still working —
+// the same job then executes on several pods (duplicate chat sends / clips).
+// NACK pacing lives in the subscriber's per-message NakWithDelay instead, which
+// leaves AckWait as the sole in-flight redelivery clock.
+func laneConsumerConfig(subject, group, name string, maxDeliveries int) *nats.ConsumerConfig {
 	return &nats.ConsumerConfig{
 		Durable:        name,
 		Name:           name,
@@ -143,7 +161,6 @@ func laneConsumerConfig(subject, group, name string, maxDeliveries int, backoff 
 		AckPolicy:      nats.AckExplicitPolicy,
 		AckWait:        30 * time.Second,
 		MaxDeliver:     maxDeliveries,
-		BackOff:        backoff,
 		FilterSubject:  subject,
 		ReplayPolicy:   nats.ReplayInstantPolicy,
 		MaxAckPending:  1000,
@@ -235,7 +252,7 @@ func (s *fleetSubscriber) Subscribe(ctx context.Context, topic string) (<-chan *
 			nc.Close()
 			return nil, err
 		}
-		if err := ensureLaneConsumer(js, stream, topic, s.group, consumer, 1000, nil); err != nil {
+		if err := ensureLaneConsumer(js, stream, topic, s.group, consumer, 1000); err != nil {
 			nc.Close()
 			return nil, err
 		}

--- a/pkg/bus/provision_test.go
+++ b/pkg/bus/provision_test.go
@@ -81,11 +81,20 @@ func TestLaneConsumerHasBoundedDeliveryBudget(t *testing.T) {
 		"outgress-premium",
 		"outgress-premium_twitch_outgress_premium",
 		4,
-		nil,
 	)
 
 	if cfg.MaxDeliver != 4 {
 		t.Fatalf("max deliver = %d, want initial delivery plus 3 redeliveries", cfg.MaxDeliver)
+	}
+	// A consumer BackOff clamps AckWait to backoff[0] on the server, which
+	// redelivers still-in-flight slow handlers to other replicas and duplicates
+	// the job fleet-wide (the !clip reply incident). NACK pacing belongs to the
+	// subscriber's per-message NakWithDelay, never to the consumer.
+	if len(cfg.BackOff) != 0 {
+		t.Fatalf("backoff = %v, want none: it would clamp ack wait to its first step", cfg.BackOff)
+	}
+	if cfg.AckWait != 30*time.Second {
+		t.Fatalf("ack wait = %v, want 30s of in-flight tolerance", cfg.AckWait)
 	}
 	if cfg.AckPolicy != nats.AckExplicitPolicy {
 		t.Fatalf("ack policy = %v, want explicit", cfg.AckPolicy)


### PR DESCRIPTION
## Problem

One `!clip` produced a clip and a chat reply from **every** outgress replica, and the reply took 4-10s to appear.

## Root cause

JetStream clamps a consumer's `AckWait` to `backoff[0]` when `BackOff` is set (verified live: consumer showed `ack_wait: 1s` despite code requesting 30s). The lane consumers carried the 1s nack delay as consumer `BackOff`, so any handler slower than 1s was redelivered to the next queue-group member while the first replica was still working. Fast chat sends never hit it; the multi-second clip handler (create + Get Clips confirm poll) fanned out to all replicas (MaxDeliver 4), each creating its own clip and posting its own reply.

## Fix

- **pkg/bus**: never set consumer-level `BackOff`; `AckWait` is a real 30s again. Nack pacing stays with watermill's per-message `NakWithDelay` (which overrides consumer backoff anyway). `NewLaneSubscriber` takes a single `nakDelay` instead of a schedule. `ensureLaneConsumer` falls back to delete+recreate when `UpdateConsumer` rejects a transition (safe: durable name, deliver subject, and deliver group are deterministic, so bound replicas keep receiving).
- **app/outgress/main.go**: system lane's escalating backoff ladder removed; it was dead (constant `NakWithDelay` always overrode it, and steps past 5m exceeded the stream MaxAge). Plain 15s nack delay, 6 redeliveries.
- **worker.go**: clip reply no longer polls Get Clips first. The Create Clip id is the public slug, so the reply posts immediately with `https://clips.twitch.tv/<id>` (the same link Get Clips reports). `!clip` reply latency drops from ~4-10s to ~1s.
- **provision_test.go**: regression assertions (no BackOff, AckWait 30s).

## Rollout

No manual NATS surgery: each pod's startup reconcile updates the live consumers (prod nats-server 2.11.17 supports the in-place update; recreate fallback covers rejection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)