### PR TITLE
feat(transactions): query processed-transaction proof from the webhook audit

### DIFF
--- a/app/transactions/repository/transactions.go
+++ b/app/transactions/repository/transactions.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"time"
 
 	"ItsBagelBot/app/transactions/ent"
 	"ItsBagelBot/app/transactions/ent/tebexwebhookevents"
@@ -107,6 +108,53 @@ func (r *Transactions) SaveWebhookEvent(ctx context.Context, event WebhookEvent)
 
 		return update.Exec(ctx)
 	})
+}
+
+// TransactionProof is the audit evidence that a verified Tebex webhook applied a
+// transaction: the webhook that carried it, its type, the entitled user, and
+// when it was recorded. It is read straight from the webhook audit log; there is
+// no separate transaction store (Tebex stays the payment system of record).
+type TransactionProof struct {
+	TransactionID string
+	UserID        uint64
+	WebhookID     string
+	EventType     string
+	ProcessedAt   time.Time
+}
+
+// ProcessedProof returns the audit evidence that a given Tebex transaction was
+// processed: the earliest webhook event with status "processed" carrying that
+// transaction id. ok is false when the audit holds no processed row for it. This
+// is the proof-of-processing lookup over the existing audit; it adds no storage.
+func (r *Transactions) ProcessedProof(ctx context.Context, transactionID string) (TransactionProof, bool, error) {
+
+	if transactionID == "" {
+		return TransactionProof{}, false, errors.New("transaction id required")
+	}
+
+	row, err := db.WithQuery(ctx, func(ctx context.Context) (*ent.TebexWebhookEvents, error) {
+		return r.client.TebexWebhookEvents.Query().
+			Where(
+				tebexwebhookevents.TransactionIDEQ(transactionID),
+				tebexwebhookevents.StatusEQ(tebexwebhookevents.StatusProcessed),
+			).
+			Order(ent.Asc(tebexwebhookevents.FieldCreatedAt)).
+			First(ctx)
+	})
+	if ent.IsNotFound(err) {
+		return TransactionProof{}, false, nil
+	}
+	if err != nil {
+		return TransactionProof{}, false, err
+	}
+
+	return TransactionProof{
+		TransactionID: row.TransactionID,
+		UserID:        row.UserID,
+		WebhookID:     row.ID,
+		EventType:     row.EventType,
+		ProcessedAt:   row.CreatedAt,
+	}, true, nil
 }
 
 func webhookStatus(status WebhookStatus) (tebexwebhookevents.Status, error) {

--- a/app/transactions/repository/transactions_test.go
+++ b/app/transactions/repository/transactions_test.go
@@ -49,3 +49,46 @@ func TestSaveWebhookEventUpsertsState(t *testing.T) {
 	assert.Equal(t, "tbx-1234", row.TransactionID)
 	assert.Equal(t, uint64(1001), row.UserID)
 }
+
+func TestProcessedProof(t *testing.T) {
+
+	client := enttest.Open(t, "sqlite3", "file:proof?mode=memory&cache=shared&_fk=1")
+	t.Cleanup(func() { _ = client.Close() })
+
+	repo := repository.NewTransactions(client)
+	ctx := context.Background()
+
+	// A processed payment leaves proof.
+	require.NoError(t, repo.SaveWebhookEvent(ctx, repository.WebhookEvent{
+		ID: "evt-ok", Type: "payment.completed", Status: repository.WebhookProcessed,
+		TransactionID: "tbx-ok", UserID: 4242,
+	}))
+	// A non-processed event for a different transaction is not proof.
+	require.NoError(t, repo.SaveWebhookEvent(ctx, repository.WebhookEvent{
+		ID: "evt-ignored", Type: "payment.declined", Status: repository.WebhookIgnored,
+		TransactionID: "tbx-ignored", UserID: 4242,
+	}))
+
+	proof, ok, err := repo.ProcessedProof(ctx, "tbx-ok")
+	require.NoError(t, err)
+	require.True(t, ok, "a processed transaction must have proof")
+	assert.Equal(t, "tbx-ok", proof.TransactionID)
+	assert.Equal(t, uint64(4242), proof.UserID)
+	assert.Equal(t, "evt-ok", proof.WebhookID)
+	assert.Equal(t, "payment.completed", proof.EventType)
+	assert.False(t, proof.ProcessedAt.IsZero())
+
+	// An ignored-only transaction is not proof of processing.
+	_, ok, err = repo.ProcessedProof(ctx, "tbx-ignored")
+	require.NoError(t, err)
+	assert.False(t, ok, "a non-processed transaction must not read as proof")
+
+	// Unknown transaction: no proof, no error.
+	_, ok, err = repo.ProcessedProof(ctx, "tbx-missing")
+	require.NoError(t, err)
+	assert.False(t, ok)
+
+	// Empty id is rejected.
+	_, _, err = repo.ProcessedProof(ctx, "")
+	assert.Error(t, err)
+}


### PR DESCRIPTION
Per the decision to keep the **webhook audit** as the proof-of-processing (no separate transaction table — Tebex stays the payment system of record):

- **Audit intact**: confirmed the #190 webhook refactor drops no audit rows — every outcome still writes its row (`processed`/`failed`/`ignored`/`validation`), asserted by the 15 webhook tests.
- **New query**: `Transactions.ProcessedProof(ctx, transactionID)` returns the earliest `status=processed` audit row carrying that transaction id — webhook id, user, event type, recorded time — as proof, or `ok=false` when none. Indexed on `transaction_id`. `TestProcessedProof` covers hit / non-processed / missing / empty-id.

This is the repository-level query primitive. It is **not yet wired to an external surface** — tell me where you want to reach it (internal admin RPC, admin dashboard view, or a support lookup) and I'll add that consumer.