### PR TITLE
fix(dashboard): fold control chars in command response on save

### DIFF
--- a/console/dashboard/src/routes/(app)/commands/+page.server.ts
+++ b/console/dashboard/src/routes/(app)/commands/+page.server.ts
@@ -112,10 +112,11 @@ function parseCommand(f: FormData) {
     aliases.push(a);
   }
 
-  // Form submission encodes textarea newlines as CRLF; fold to LF so the wire
-  // payload matches the commands service's stored form (it normalizes anyway,
-  // this keeps the optimistic UI's echo identical to what comes back).
-  const response = String(f.get('response') ?? '').replace(/\r\n|\r/g, '\n');
+  // Twitch chat is single-line: a textarea lets users press Enter, but the
+  // shared validator rejects any control character (CR/LF/tab). Fold control
+  // characters to spaces and trim so a pasted multi-line note saves cleanly
+  // instead of failing validation.
+  const response = String(f.get('response') ?? '').replace(/[\u0000-\u001F]+/g, ' ').trim();
   const permRaw = String(f.get('perm') ?? 'everyone');
   const perm: Perm = (PERMS as readonly string[]).includes(permRaw) ? (permRaw as Perm) : 'everyone';
 


### PR DESCRIPTION
## Problem
Saving a command with a multi-line response failed in prod: `command response must be 1-500 characters without control characters`.

The response textarea lets users press Enter, but the Go validator (`internal/domain/validate/validate.go:132`) rejects any char `< 0x20` (CR/LF/tab). The prior fold on main only converted CRLF/CR to LF, which is still a control char, so the RPC still rejected it.

## Fix
Fold **all** control chars to spaces and trim in `parseCommand`, before validation and the upsert RPC. Twitch chat is single-line, so a pasted/typed multi-line response now saves cleanly.

- `console/dashboard/src/routes/(app)/commands/+page.server.ts`

## Verify
`npm run check` — 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)