### PR TITLE
fix(ingress): anchor load counter to first real timestamp

### DIFF
--- a/app/ingress/lib/ingress/load_counter.ex
+++ b/app/ingress/lib/ingress/load_counter.ex
@@ -3,17 +3,22 @@ defmodule Ingress.LoadCounter do
   A constant-time aggregate load counter for a rolling window of seconds.
   Instead of recording individual event timestamps, this tracks load in
   per-second buckets. The hot path for same-second increments is O(1).
+
+  Timestamps are raw `System.monotonic_time(:millisecond)` values, which on
+  the BEAM are negative. The counter carries no epoch of its own: it adopts
+  the first timestamp it is given, so it works for any monotonic clock
+  regardless of sign or origin.
   """
 
   defstruct window_seconds: 60,
-            current_second: 0,
+            current_second: nil,
             current_count: 0,
             completed_buckets: [],
             completed_total: 0
 
   @type t :: %__MODULE__{
           window_seconds: pos_integer(),
-          current_second: integer(),
+          current_second: integer() | nil,
           current_count: non_neg_integer(),
           completed_buckets: [{integer(), non_neg_integer()}],
           completed_total: non_neg_integer()
@@ -26,7 +31,7 @@ defmodule Ingress.LoadCounter do
   def new(window_seconds \\ 60) do
     %__MODULE__{
       window_seconds: window_seconds,
-      current_second: 0,
+      current_second: nil,
       current_count: 0,
       completed_buckets: [],
       completed_total: 0
@@ -39,7 +44,7 @@ defmodule Ingress.LoadCounter do
   """
   @spec increment(t(), integer()) :: t()
   def increment(counter, monotonic_ms) do
-    sec = div(monotonic_ms, 1000)
+    sec = Integer.floor_div(monotonic_ms, 1000)
 
     if sec == counter.current_second do
       %{counter | current_count: counter.current_count + 1}
@@ -56,9 +61,19 @@ defmodule Ingress.LoadCounter do
   """
   @spec value(t(), integer()) :: {non_neg_integer(), t()}
   def value(counter, monotonic_ms) do
-    sec = div(monotonic_ms, 1000)
+    sec = Integer.floor_div(monotonic_ms, 1000)
     counter = roll_to(counter, sec)
     {counter.completed_total + counter.current_count, counter}
+  end
+
+  # First timestamp ever seen: adopt it as the epoch. The struct default
+  # cannot pre-fill one — BEAM monotonic time is negative, so any fixed
+  # default (e.g. 0) sits permanently "in the future", every real timestamp
+  # reads as a clock regression, and the window never expires. This clause
+  # must stay above the regression guard: integers compare below `nil` in
+  # Erlang term order, so `target_sec <= nil` is always true.
+  defp roll_to(%{current_second: nil} = counter, target_sec) do
+    %{counter | current_second: target_sec}
   end
 
   defp roll_to(counter, target_sec) when target_sec <= counter.current_second do

--- a/app/ingress/test/load_counter_test.exs
+++ b/app/ingress/test/load_counter_test.exs
@@ -1,0 +1,106 @@
+defmodule Ingress.LoadCounterTest do
+  use ExUnit.Case, async: true
+
+  alias Ingress.LoadCounter
+
+  # BEAM monotonic time is a large negative number. Every test that models
+  # production behaviour must use timestamps in that range: the original bug
+  # (a frozen, ever-growing load reading on the admin dashboard) only
+  # reproduced with negative timestamps and passed with positive ones.
+  @beam_mono_ms -576_460_751_000_000
+
+  describe "with real (negative) monotonic timestamps" do
+    test "window expires after traffic stops" do
+      base = @beam_mono_ms
+      counter = LoadCounter.new()
+
+      counter =
+        Enum.reduce(1..900, counter, fn i, acc ->
+          LoadCounter.increment(acc, base + i * 100)
+        end)
+
+      # 900 events over 90s: only the last 60s may remain in the window.
+      {during, counter} = LoadCounter.value(counter, base + 90_000)
+      assert during <= 600
+      assert during > 0
+
+      # Hours later with no traffic the reading must be zero, not frozen.
+      {idle, _} = LoadCounter.value(counter, base + 90_000 + 3 * 3600 * 1000)
+      assert idle == 0
+    end
+
+    test "live System.monotonic_time values count and expire" do
+      now = System.monotonic_time(:millisecond)
+      counter = LoadCounter.new()
+
+      counter = Enum.reduce(1..5, counter, fn _, acc -> LoadCounter.increment(acc, now) end)
+
+      {value, counter} = LoadCounter.value(counter, now)
+      assert value == 5
+
+      {expired, _} = LoadCounter.value(counter, now + 61_000)
+      assert expired == 0
+    end
+  end
+
+  describe "windowing" do
+    test "counts only events inside the window" do
+      counter = LoadCounter.new(60)
+      counter = LoadCounter.increment(counter, 0)
+      counter = LoadCounter.increment(counter, 30_000)
+      counter = LoadCounter.increment(counter, 59_000)
+
+      # At t=61s the t=0 event has left the 60s window.
+      {value, _} = LoadCounter.value(counter, 61_000)
+      assert value == 2
+    end
+
+    test "same-second increments accumulate in one bucket" do
+      counter = LoadCounter.new()
+      counter = Enum.reduce(1..10, counter, fn _, acc -> LoadCounter.increment(acc, 5_500) end)
+
+      assert counter.current_count == 10
+      assert counter.completed_buckets == []
+
+      {value, _} = LoadCounter.value(counter, 5_900)
+      assert value == 10
+    end
+
+    test "long idle gap clears all buckets at once" do
+      counter = LoadCounter.new(60)
+      counter = Enum.reduce(0..59, counter, fn s, acc -> LoadCounter.increment(acc, s * 1000) end)
+
+      {full, counter} = LoadCounter.value(counter, 59_999)
+      assert full == 60
+
+      {after_gap, counter} = LoadCounter.value(counter, 59_999 + 600_000)
+      assert after_gap == 0
+      assert counter.completed_buckets == []
+      assert counter.completed_total == 0
+    end
+  end
+
+  describe "clock regression" do
+    test "an older timestamp neither crashes nor inflates the total" do
+      counter = LoadCounter.new()
+      counter = LoadCounter.increment(counter, 10_000)
+      counter = LoadCounter.increment(counter, 9_000)
+
+      {value, _} = LoadCounter.value(counter, 10_500)
+      assert value == 2
+    end
+
+    test "value with an older timestamp keeps the window anchored" do
+      counter = LoadCounter.new()
+      counter = LoadCounter.increment(counter, 10_000)
+
+      {value, _} = LoadCounter.value(counter, 8_000)
+      assert value == 1
+    end
+  end
+
+  test "fresh counter reads zero" do
+    {value, _} = LoadCounter.value(LoadCounter.new(), System.monotonic_time(:millisecond))
+    assert value == 0
+  end
+end


### PR DESCRIPTION
## Problem

Admin dashboard showed a constant ~15 ev/s on shard 0 hours after streams ended. Live snapshot confirmed `load: 870` frozen across samples 74s apart (window is 60s).

Root cause: `LoadCounter` initialized `current_second: 0`, but BEAM monotonic time is negative. Every real timestamp read as a clock regression, buckets never rolled or expired, and `load` reported a lifetime notification count instead of a 60s window. Dashboard divides by 60, hence the frozen "rate". The shard autoscaler consumes the same value, so under real load it would scale up and never back down.

Websocket layer itself verified healthy in prod (fresh keepalives, watchdog fine, no stuck handshakes).

## Fix

- Adopt the first observed timestamp as the epoch (`nil` sentinel), so the counter works with any monotonic clock regardless of sign or origin
- `Integer.floor_div` for uniform bucket boundaries on negative milliseconds
- New regression tests use real negative BEAM monotonic values; positive-only timestamps masked the bug

## Verification

- `mix test`: 59 tests, 0 failures
- Prod-scenario repro: 900 events over 90s reads 593 in-window right after traffic, 0 after 3h idle (was frozen 900 for both)

🤖 Generated with [Claude Code](https://claude.com/claude-code)