### PR TITLE
fix(console): enforce session gates on every request, cap token lifetimes

### DIFF
--- a/console/admin/src/hooks.server.ts
+++ b/console/admin/src/hooks.server.ts
@@ -1,6 +1,8 @@
 import type { Handle, HandleServerError, ServerInit } from '@sveltejs/kit';
+import { redirect } from '@sveltejs/kit';
 import newrelic from 'newrelic';
 import { COOKIE, open } from '$lib/server/session';
+import { requireAdmin, isDemo } from '$lib/server/access';
 import { warm } from '@bagel/shared/server/nats';
 import { registerServerConfig } from '@bagel/shared/server/config';
 import { rumTransform } from '@bagel/shared/server/rum';
@@ -45,10 +47,38 @@ export const init: ServerInit = async () => {
   startInvalidationListener();
 };
 
-// Session + the security headers SvelteKit's CSP config does not own.
+// Login/OAuth flow and probes stay reachable without a staff session; every
+// other route is gated below.
+const PUBLIC_PREFIXES = ['/auth', '/login', '/healthz', '/readyz'];
+
+function isPublic(pathname: string): boolean {
+  return PUBLIC_PREFIXES.some((p) => pathname === p || pathname.startsWith(p + '/'));
+}
+
+// Session + staff gate + the security headers SvelteKit's CSP config does not
+// own.
 export const handle: Handle = async ({ event, resolve }) => {
   const cookie = event.cookies.get(COOKIE);
   event.locals.session = cookie ? open(cookie) : null;
+  // Expired/invalid cookie: drop it eagerly so the browser stops replaying it.
+  if (cookie && !event.locals.session) {
+    event.cookies.delete(COOKIE, { path: '/', secure: event.url.protocol === 'https:' });
+  }
+
+  // Staff gate for every non-public request — form actions and +server.ts
+  // endpoints included, which layout loads never cover. The per-route
+  // requireAdmin checks stay as defense in depth; this hook makes "session
+  // exists but is no longer active staff" die at the door (adminCheck is
+  // fabric-cached and push-invalidated on the staff scope, so a roster change
+  // revokes access on every replica within one request). requireAdmin fails
+  // closed on an auth-service outage, matching the per-route posture.
+  if (!isDemo() && !isPublic(event.url.pathname)) {
+    if (event.locals.session && !(await requireAdmin(event.locals.session))) {
+      event.cookies.delete(COOKIE, { path: '/', secure: event.url.protocol === 'https:' });
+      event.locals.session = null;
+      throw redirect(303, '/login?e=denied');
+    }
+  }
 
   // New Relic: name the web transaction by SvelteKit route (not the raw URL, so
   // per-id paths group), and tag it with request/session context for faceting.

--- a/console/admin/src/lib/server/access.ts
+++ b/console/admin/src/lib/server/access.ts
@@ -3,7 +3,10 @@
 // (served by the users service over NATS, auth.check). The tailnet is the
 // network boundary; this is the identity boundary on top of it. DEMO=1
 // synthesizes an allowed superadmin so the panel renders without auth wired up.
-import { env } from '$env/dynamic/private';
+// DEMO is read from process.env, NOT $env/dynamic/private: this module is in
+// the boot import graph (hooks.server.ts -> access), and even importing the
+// dynamic-env proxy there deadlocks server.init (exit 13). process.env carries
+// the same runtime value.
 import type { Session } from './session';
 import { adminCheck, type AdminRole } from './services';
 
@@ -19,11 +22,12 @@ export const demoSession: Session = {
   login: 'itsmavey',
   display_name: 'Mavey',
   role: 'streamer',
+  iat: Math.floor(Date.now() / 1000),
   expires_at: Math.floor(Date.now() / 1000) + 3600
 };
 
 export function isDemo(): boolean {
-  return env.DEMO === '1';
+  return process.env.DEMO === '1';
 }
 
 const RANK: Record<AdminRole, number> = { moderator: 1, admin: 2, owner: 3 };

--- a/console/admin/src/lib/server/session.ts
+++ b/console/admin/src/lib/server/session.ts
@@ -7,19 +7,24 @@
 // in the boot import graph (hooks.server.ts -> session), and even importing the
 // dynamic-env proxy there deadlocks server.init (exit 13). process.env carries
 // the same runtime value; the key getter runs per seal/open (request time).
-import { createSessionCodec, decodeKey } from '@bagel/shared/server/session';
+import { createSessionCodec, decodeKey, SESSION_TTL_SECONDS } from '@bagel/shared/server/session';
+
+export { SESSION_TTL_SECONDS };
 
 export interface Session {
   user_id: string;
   login: string;
   display_name: string;
   role: 'streamer' | 'mod';
+  iat: number;
   expires_at: number;
 }
 
 const codec = createSessionCodec<Session>(() => decodeKey(process.env.SESSION_KEY));
 
 export const seal = (s: Session): string => codec.seal(s);
-export const open = (value: string): Session | null => codec.open(value);
+// Total lifetime is capped from iat, so a re-sealed payload with a pushed-out
+// expires_at can never outlive the normal login TTL.
+export const open = (value: string): Session | null => codec.open(value, SESSION_TTL_SECONDS);
 
 export const COOKIE = 'bagel_session';

--- a/console/admin/src/routes/auth/callback/+server.ts
+++ b/console/admin/src/routes/auth/callback/+server.ts
@@ -3,10 +3,8 @@ import { redirect } from '@sveltejs/kit';
 import { decodeIdToken, OAuth2RequestError } from 'arctic';
 import { twitch } from '$lib/server/oauth';
 import { adminCheck } from '$lib/server/services';
-import { COOKIE, seal } from '$lib/server/session';
+import { COOKIE, seal, SESSION_TTL_SECONDS } from '$lib/server/session';
 import { env } from '$env/dynamic/private';
-
-const SESSION_TTL = 7 * 24 * 3600;
 
 // Twitch redirects the operator's browser here (on the tailnet). The token
 // exchange below is a server-side outbound call to id.twitch.tv, so the private
@@ -49,12 +47,14 @@ export const GET: RequestHandler = async ({ url, cookies }) => {
     const check = await adminCheck(userId, login, displayName);
     if (!check.admin) throw redirect(302, '/login?e=denied');
 
+    const now = Math.floor(Date.now() / 1000);
     const value = seal({
       user_id: userId,
       login,
       display_name: displayName,
       role: 'streamer',
-      expires_at: Math.floor(Date.now() / 1000) + SESSION_TTL
+      iat: now,
+      expires_at: now + SESSION_TTL_SECONDS
     });
 
     cookies.set(COOKIE, value, {
@@ -62,7 +62,7 @@ export const GET: RequestHandler = async ({ url, cookies }) => {
       httpOnly: true,
       secure: url.protocol === 'https:',
       sameSite: 'lax',
-      maxAge: SESSION_TTL
+      maxAge: SESSION_TTL_SECONDS
     });
   } catch (e) {
     if (e instanceof OAuth2RequestError) throw redirect(302, '/login?e=oauth');

--- a/console/dashboard/src/hooks.server.ts
+++ b/console/dashboard/src/hooks.server.ts
@@ -1,6 +1,7 @@
 import type { Handle, HandleServerError, ServerInit } from '@sveltejs/kit';
 import newrelic from 'newrelic';
 import { COOKIE, open } from '$lib/server/session';
+import { guardSession } from '$lib/server/guard';
 import { warm } from '@bagel/shared/server/nats';
 import { warm as warmValkey } from '@bagel/shared/server/valkey-store';
 import { registerServerConfig } from '@bagel/shared/server/config';
@@ -82,10 +83,15 @@ function pickLimiter(pathname: string, method: string): ValkeyRateLimiter {
   return readLimiter;
 }
 
-// Session + the security headers SvelteKit's CSP config does not own.
+// Session + account gates + the security headers SvelteKit's CSP config does
+// not own.
 export const handle: Handle = async ({ event, resolve }) => {
   const cookie = event.cookies.get(COOKIE);
   event.locals.session = cookie ? open(cookie) : null;
+  // Expired/invalid cookie: drop it eagerly so the browser stops replaying it.
+  if (cookie && !event.locals.session) {
+    event.cookies.delete(COOKIE, { path: '/', secure: event.url.protocol === 'https:' });
+  }
 
   if (!RATE_EXEMPT.has(event.url.pathname)) {
     const key = event.locals.session?.user_id
@@ -103,6 +109,14 @@ export const handle: Handle = async ({ event, resolve }) => {
         }
       });
     }
+  }
+
+  // Account gates (ban / deleted account / delegation revoke / delegate scope)
+  // for every authenticated request — actions and API endpoints included, which
+  // layout loads never cover. Throws kit-native redirects; runs after the rate
+  // limiter so the gate RPCs sit behind the same request budget.
+  if (event.locals.session) {
+    event.locals.session = await guardSession(event, event.locals.session);
   }
 
   let queryLang = event.url.searchParams.get('lang');

--- a/console/dashboard/src/lib/server/guard.ts
+++ b/console/dashboard/src/lib/server/guard.ts
@@ -1,0 +1,89 @@
+// Request-level account gates, run from hooks.server.ts on EVERY request.
+//
+// These gates used to live in the (app) layout load, but SvelteKit never runs
+// layout loads for form actions or +server.ts endpoints — so a banned or
+// revoked session kept its write access until the cookie expired. Enforcing in
+// the handle hook closes that: pages, actions, data requests and API endpoints
+// all pass through here. Thrown redirect()s are kit-native and are encoded
+// correctly for documents, __data.json and action JSON requests alike.
+//
+// All checks ride the same cache fabric the layout used (push-invalidated on
+// the NATS bus), so per-request cost stays ~0 and an admin ban / delegation
+// revoke propagates to every replica within one request.
+// DEMO is read from process.env, NOT $env/dynamic/private: this module is in
+// the boot import graph (hooks.server.ts -> guard), and even importing the
+// dynamic-env proxy there deadlocks server.init (exit 13). process.env carries
+// the same runtime value.
+import { redirect, type RequestEvent } from '@sveltejs/kit';
+import { COOKIE, type Session } from '$lib/server/session';
+import { accountState, delegationAccess, isBanned } from '$lib/server/services';
+import { RpcError } from '@bagel/shared/server/nats';
+
+// Paths that must stay reachable with a denied session: the login + OAuth flow
+// (a banned user must still be able to reach the callback's own gate), logout,
+// health probes, the locale switch and the pre-login delegation-accept landing.
+const PUBLIC_PREFIXES = ['/auth', '/login', '/healthz', '/readyz', '/lang', '/delegate/accept'];
+
+function isPublic(pathname: string): boolean {
+  return PUBLIC_PREFIXES.some((p) => pathname === p || pathname.startsWith(p + '/'));
+}
+
+function wipe(event: RequestEvent): void {
+  event.cookies.delete(COOKIE, { path: '/', secure: event.url.protocol === 'https:' });
+}
+
+// guardSession validates an already-opened session against authoritative
+// account state. Returns the session to keep in locals, or throws a redirect
+// (wiping the cookie when the session itself is dead). Anonymous requests
+// never reach this — the (app) layout owns the login redirect for pages and
+// endpoints already 401 on a missing session.
+export async function guardSession(event: RequestEvent, s: Session): Promise<Session> {
+  if (process.env.DEMO === '1' || isPublic(event.url.pathname)) return s;
+
+  // Platform ban — own account. Same outage posture as before: isBanned serves
+  // last-known state through a users-service outage and fails open only with
+  // no cached state at all.
+  if (await isBanned(s.user_id)) {
+    wipe(event);
+    throw redirect(303, '/login?e=banned');
+  }
+
+  // Ghost-session gate: only an authoritative "no such user" (RpcError) wipes
+  // the cookie; a transport blip keeps the session and pages degrade instead.
+  try {
+    await accountState(s.user_id);
+  } catch (err) {
+    if (err instanceof RpcError) {
+      wipe(event);
+      throw redirect(303, '/login?e=signedout');
+    }
+  }
+
+  if (s.delegate_of && event.url.pathname !== '/delegate/exit') {
+    // A delegate board dies out from under the session when the owner is
+    // banned or revokes the share. Bounce through /delegate/exit, which
+    // re-seals the visitor's own normal session; delegationAccess is
+    // push-invalidated on the delegation scope, so a revoke lands within one
+    // request. Fail open on transport blips, matching the gates above.
+    let boardGone = await isBanned(s.delegate_of);
+    if (!boardGone) {
+      try {
+        const grants = await delegationAccess(s.user_id);
+        boardGone = !grants.some((g) => g.owner_user_id === s.delegate_of);
+      } catch {
+        /* transport blip: keep the session */
+      }
+    }
+    if (boardGone) throw redirect(303, '/delegate/exit');
+
+    // Section scope for everything under (app) — pages AND their actions
+    // (the per-page gates remain as defense in depth).
+    if (event.route.id?.startsWith('/(app)')) {
+      const allowed = (s.sections ?? []).map((sec) => `/${sec}`);
+      const ok = allowed.some((p) => event.url.pathname === p || event.url.pathname.startsWith(p + '/'));
+      if (!ok) throw redirect(303, allowed[0] ?? '/delegate/exit');
+    }
+  }
+
+  return s;
+}

--- a/console/dashboard/src/lib/server/session.ts
+++ b/console/dashboard/src/lib/server/session.ts
@@ -5,13 +5,21 @@
 // in the boot import graph (hooks.server.ts -> session), and even importing the
 // dynamic-env proxy there deadlocks server.init (exit 13). process.env carries
 // the same runtime value; the key getter runs per seal/open (request time).
-import { createSessionCodec, decodeKey } from '@bagel/shared/server/session';
+import {
+  createSessionCodec,
+  decodeKey,
+  IMPERSONATION_TTL_SECONDS,
+  SESSION_TTL_SECONDS
+} from '@bagel/shared/server/session';
+
+export { IMPERSONATION_TTL_SECONDS, SESSION_TTL_SECONDS };
 
 export interface Session {
   user_id: string;
   login: string;
   display_name: string;
   role: 'streamer' | 'mod';
+  iat: number;
   expires_at: number;
   // Set only when an admin is viewing this dashboard "as" the user. Carries the
   // acting admin so every write during the session is audited back to them.
@@ -28,7 +36,18 @@ export interface Session {
 const codec = createSessionCodec<Session>(() => decodeKey(process.env.SESSION_KEY));
 
 export const seal = (s: Session): string => codec.seal(s);
-export const open = (value: string): Session | null => codec.open(value);
+
+// open applies the lifetime cap for the session's kind, measured from iat.
+// An impersonation ("view as") session is hard-capped at 1h no matter what
+// expires_at a mint or re-seal path wrote; everything else caps at the normal
+// login TTL.
+export const open = (value: string): Session | null => {
+  const s = codec.open(value);
+  if (!s) return null;
+  const cap = s.impersonator_id ? IMPERSONATION_TTL_SECONDS : SESSION_TTL_SECONDS;
+  if (Date.now() / 1000 - s.iat > cap) return null;
+  return s;
+};
 
 export const COOKIE = 'bagel_session';
 export const ACCOUNT_DELETED_COOKIE = 'bagel_account_deleted';

--- a/console/dashboard/src/routes/(app)/+layout.server.ts
+++ b/console/dashboard/src/routes/(app)/+layout.server.ts
@@ -1,9 +1,8 @@
-import { redirect, type Cookies } from '@sveltejs/kit';
+import { redirect } from '@sveltejs/kit';
 import { env } from '$env/dynamic/private';
 import type { LayoutServerLoad } from './$types';
-import { COOKIE, type Session } from '$lib/server/session';
-import { accountState, isBanned, notificationsForUser, delegationAccess, type NotificationWire } from '$lib/server/services';
-import { RpcError } from '@bagel/shared/server/nats';
+import type { Session } from '$lib/server/session';
+import { accountState, notificationsForUser, delegationAccess, type NotificationWire } from '$lib/server/services';
 import { demoNotifications } from '$lib/server/demo-notifications';
 
 const BELL_PEEK = 5;
@@ -15,42 +14,9 @@ const demo: Session = {
   login: 'itsmavey',
   display_name: 'Mavey',
   role: 'streamer',
+  iat: Math.floor(Date.now() / 1000),
   expires_at: Math.floor(Date.now() / 1000) + 3600
 };
-
-// enforceAccountGates bounces a session whose account was banned or deleted
-// after sign-in. Both checks fail open on a transport blip so an RPC outage
-// never locks the whole app out; only an authoritative "no such user"
-// (RpcError) wipes the cookie.
-async function enforceAccountGates(s: Session, url: URL, cookies: Cookies): Promise<void> {
-  // Defense in depth: bounce a session whose user was banned after sign-in.
-  if (await isBanned(s.user_id)) throw redirect(302, '/login?e=banned');
-
-  // Ghost-session gate: a session cookie stays cryptographically valid until
-  // it expires, so a browser that still holds one for a DELETED account (or
-  // one deleted from another device) could keep acting on the app — and its
-  // stale deletion cookies could bounce it through /goodbye on any action.
-  // accountState is fabric-cached, so this costs ~0 on the hot path.
-  try {
-    await accountState(s.user_id);
-  } catch (err) {
-    if (err instanceof RpcError) {
-      cookies.delete(COOKIE, { path: '/', secure: url.protocol === 'https:' });
-      throw redirect(302, '/login?e=signedout');
-    }
-    // Transient transport problem: keep the session, pages degrade instead.
-  }
-}
-
-// enforceDelegateScope keeps a delegate inside the sections they were granted.
-// Home, account (overview actions) and the share-management page are
-// owner-only; an out-of-scope path bounces to the first allowed section.
-function enforceDelegateScope(s: Session, url: URL): void {
-  if (!s.delegate_of) return;
-  const allowed = (s.sections ?? []).map((sec) => `/${sec}`);
-  const onAllowed = allowed.some((p) => url.pathname === p || url.pathname.startsWith(p + '/'));
-  if (!onAllowed) throw redirect(302, allowed[0] ?? '/login?e=link');
-}
 
 // loadBellPeek fetches the owner's notification bell, best-effort: an RPC blip
 // must never block the shell, so a failed fetch just shows an empty peek.
@@ -95,7 +61,11 @@ async function loadAuthorizedDashboards(s: Session): Promise<{ href: string; nam
   }
 }
 
-export const load: LayoutServerLoad = async ({ locals, url, cookies }) => {
+// Account gates (ban / deleted account / delegation revoke / delegate scope)
+// run in hooks.server.ts for every request — including form actions and API
+// endpoints, which this load never covers. This load only owns the
+// login-redirect UX and the shell data.
+export const load: LayoutServerLoad = async ({ locals, url }) => {
   let s = locals.session;
   if (!s && env.DEMO === '1') s = demo;
   // Keep the requested path through the login flow (e.g. the pricing page
@@ -105,9 +75,6 @@ export const load: LayoutServerLoad = async ({ locals, url, cookies }) => {
     const next = url.pathname + url.search;
     throw redirect(302, next === '/' ? '/login' : `/login?next=${encodeURIComponent(next)}`);
   }
-
-  if (env.DEMO !== '1') await enforceAccountGates(s, url, cookies);
-  enforceDelegateScope(s, url);
 
   const [{ unreadCount, notifications }, authorizedDashboards, acc] = await Promise.all([
     loadBellPeek(s),

--- a/console/dashboard/src/routes/auth/callback/+server.ts
+++ b/console/dashboard/src/routes/auth/callback/+server.ts
@@ -5,12 +5,11 @@ import { decodeIdToken, OAuth2RequestError } from 'arctic';
 import { twitch, safeNextPath, fetchAccountEmail } from '$lib/server/oauth';
 import { rpc } from '@bagel/shared/server/nats';
 import { saveGrant, isBanned, delegationConsume, userLocale, setLocale } from '$lib/server/services';
-import { COOKIE, seal } from '$lib/server/session';
+import { COOKIE, seal, SESSION_TTL_SECONDS } from '$lib/server/session';
 import { isLocale, LOCALE_COOKIE } from '@bagel/shared/i18n';
 import { env } from '$env/dynamic/private';
 
 const DASHBOARD = env.NATS_DASHBOARD_SUBJECT_PREFIX ?? 'bagel.rpc.dashboard';
-const SESSION_TTL = 7 * 24 * 3600;
 
 type IdTokenClaims = {
   sub: string;
@@ -58,17 +57,19 @@ function setSessionCookie(cookies: Cookies, url: URL, session: Parameters<typeof
     httpOnly: true,
     secure: url.protocol === 'https:',
     sameSite: 'lax',
-    maxAge: SESSION_TTL
+    maxAge: SESSION_TTL_SECONDS
   });
 }
 
 function streamerSession(id: Identity) {
+  const now = Math.floor(Date.now() / 1000);
   return {
     user_id: id.userId,
     login: id.login,
     display_name: id.displayName,
     role: 'streamer' as const,
-    expires_at: Math.floor(Date.now() / 1000) + SESSION_TTL
+    iat: now,
+    expires_at: now + SESSION_TTL_SECONDS
   };
 }
 

--- a/console/dashboard/src/routes/auth/impersonate/+server.ts
+++ b/console/dashboard/src/routes/auth/impersonate/+server.ts
@@ -1,26 +1,43 @@
-// Redeem an admin "view as" link: verify the signed token, then seal a short
-// (1h) dashboard session for the target user that also carries the acting
-// admin (impersonator_*). hooks.server.ts opens it like any session; the write
+// Redeem an admin "view as" link: verify the signed token, burn its jti (a
+// link is single-use), then seal a short (1h) dashboard session for the target
+// user that also carries the acting admin (impersonator_*). hooks.server.ts
+// opens it like any session — with a hard 1h cap from iat — and the write
 // actions audit back to the admin while these fields are present.
 import type { RequestHandler } from './$types';
 import { redirect } from '@sveltejs/kit';
+import newrelic from 'newrelic';
 import { verifyViewAs } from '@bagel/shared/server/impersonation';
-import { COOKIE, seal } from '$lib/server/session';
+import { claimOnce } from '@bagel/shared/server/rate-limit';
+import { COOKIE, seal, IMPERSONATION_TTL_SECONDS } from '$lib/server/session';
 import { LOCALE_COOKIE } from '@bagel/shared/i18n';
 
-const SESSION_TTL = 3600; // 1h — shorter than a normal login.
+// jti claims only need to outlive the token's own 5-minute validity window
+// (plus clock skew); after that verifyViewAs rejects the token anyway.
+const JTI_TTL_SECONDS = 6 * 60;
 
-export const GET: RequestHandler = ({ url, cookies }) => {
+export const GET: RequestHandler = async ({ url, cookies }) => {
   const token = url.searchParams.get('t') ?? '';
   const p = verifyViewAs(token);
   if (!p) throw redirect(302, '/login?e=imp');
 
+  // Single-use gate. Fail closed when Valkey is configured but unreachable:
+  // impersonation is an admin surface, and a retry in a minute beats leaving a
+  // replayable admin-grade link in browser history. 'unconfigured' (dev, no
+  // Valkey) passes so local flows still work.
+  const claim = await claimOnce(`viewas:jti:${p.jti}`, JTI_TTL_SECONDS);
+  if (claim === 'replayed' || claim === 'unavailable') {
+    newrelic.addCustomAttributes({ 'viewas.claim': claim, 'viewas.by': p.by_id });
+    throw redirect(302, '/login?e=imp');
+  }
+
+  const now = Math.floor(Date.now() / 1000);
   const value = seal({
     user_id: p.sub,
     login: p.login,
     display_name: p.display_name,
     role: 'streamer',
-    expires_at: Math.floor(Date.now() / 1000) + SESSION_TTL,
+    iat: now,
+    expires_at: now + IMPERSONATION_TTL_SECONDS,
     impersonator_id: p.by_id,
     impersonator_login: p.by_login
   });
@@ -30,7 +47,7 @@ export const GET: RequestHandler = ({ url, cookies }) => {
     httpOnly: true,
     secure: url.protocol === 'https:',
     sameSite: 'lax',
-    maxAge: SESSION_TTL
+    maxAge: IMPERSONATION_TTL_SECONDS
   });
 
   // Impersonation is an admin surface: keep its chrome in English regardless

--- a/console/dashboard/src/routes/delegate/enter/+server.ts
+++ b/console/dashboard/src/routes/delegate/enter/+server.ts
@@ -3,14 +3,18 @@ import { redirect } from '@sveltejs/kit';
 import { delegationAccess } from '$lib/server/services';
 import { COOKIE, seal } from '$lib/server/session';
 
-const SESSION_TTL = 7 * 24 * 3600;
-
 // Open a dashboard that was shared with the signed-in user. Requires a NORMAL
-// (non-delegate) session, verifies the grant still exists, then swaps the cookie
-// for a section-limited delegate session over the owner's board.
+// (non-delegate, non-impersonated) session, verifies the grant still exists,
+// then swaps the cookie for a section-limited delegate session over the
+// owner's board. An admin "view as" session is refused: swapping it here would
+// launder the 1h impersonation into a session without the impersonator_*
+// fields, losing both the short cap and the audit trail.
+//
+// The re-seal keeps the original iat/expires_at: switching boards must never
+// extend a session's lifetime — only a fresh OAuth login does that.
 export const GET: RequestHandler = async ({ url, locals, cookies }) => {
   const s = locals.session;
-  if (!s || s.delegate_of) throw redirect(302, '/login');
+  if (!s || s.delegate_of || s.impersonator_id) throw redirect(302, '/login');
 
   const owner = url.searchParams.get('owner');
   if (!owner) throw redirect(302, '/settings?e=access');
@@ -30,7 +34,8 @@ export const GET: RequestHandler = async ({ url, locals, cookies }) => {
     login: s.login,
     display_name: s.display_name,
     role: 'streamer',
-    expires_at: Math.floor(Date.now() / 1000) + SESSION_TTL,
+    iat: s.iat,
+    expires_at: s.expires_at,
     delegate_of: owner,
     delegate_login: grant.owner_login,
     sections: grant.sections
@@ -40,7 +45,7 @@ export const GET: RequestHandler = async ({ url, locals, cookies }) => {
     httpOnly: true,
     secure: url.protocol === 'https:',
     sameSite: 'lax',
-    maxAge: SESSION_TTL
+    maxAge: Math.max(1, s.expires_at - Math.floor(Date.now() / 1000))
   });
 
   throw redirect(302, grant.sections[0] ? `/${grant.sections[0]}` : '/');

--- a/console/dashboard/src/routes/delegate/exit/+server.ts
+++ b/console/dashboard/src/routes/delegate/exit/+server.ts
@@ -2,11 +2,12 @@ import type { RequestHandler } from './$types';
 import { redirect } from '@sveltejs/kit';
 import { COOKIE, seal } from '$lib/server/session';
 
-const SESSION_TTL = 7 * 24 * 3600;
-
 // Leave a delegated session and return to the user's OWN dashboard. Re-seals a
 // normal session for themselves (dropping the delegate fields) rather than
 // logging out entirely. A non-delegate just goes home.
+//
+// The re-seal keeps the original iat/expires_at: leaving a board must never
+// extend a session's lifetime — only a fresh OAuth login does that.
 export const GET: RequestHandler = ({ url, locals, cookies }) => {
   const s = locals.session;
   if (s?.delegate_of) {
@@ -15,14 +16,15 @@ export const GET: RequestHandler = ({ url, locals, cookies }) => {
       login: s.login,
       display_name: s.display_name,
       role: 'streamer',
-      expires_at: Math.floor(Date.now() / 1000) + SESSION_TTL
+      iat: s.iat,
+      expires_at: s.expires_at
     });
     cookies.set(COOKIE, value, {
       path: '/',
       httpOnly: true,
       secure: url.protocol === 'https:',
       sameSite: 'lax',
-      maxAge: SESSION_TTL
+      maxAge: Math.max(1, s.expires_at - Math.floor(Date.now() / 1000))
     });
   }
   throw redirect(302, '/');

--- a/console/shared/lib/server/rate-limit.ts
+++ b/console/shared/lib/server/rate-limit.ts
@@ -260,6 +260,32 @@ export async function rateLimiterReady(): Promise<boolean> {
 }
 
 /**
+ * Claim a single-use id (SET NX EX on the Sentinel master), sharing the
+ * rate limiter's write client + breaker: it is the same fleet-wide Valkey
+ * write path and a second connection buys nothing. Used to make signed
+ * one-shot tokens (e.g. admin "view as" links) non-replayable.
+ *
+ *   'claimed'      — first redemption; proceed.
+ *   'replayed'     — the id was redeemed before; reject.
+ *   'unconfigured' — no Valkey configured (dev/tests); caller decides.
+ *   'unavailable'  — backend configured but unreachable; caller decides.
+ */
+export type ClaimResult = 'claimed' | 'replayed' | 'unconfigured' | 'unavailable';
+
+export async function claimOnce(key: string, ttlSec: number): Promise<ClaimResult> {
+  const client = getWriteClient();
+  if (!client) return 'unconfigured';
+  try {
+    const r = await writeBreaker.run(() =>
+      withTimeout(client.set(key, '1', 'EX', ttlSec, 'NX'), OP_TIMEOUT_MS, 'valkey claim-once')
+    );
+    return r === 'OK' ? 'claimed' : 'replayed';
+  } catch {
+    return 'unavailable';
+  }
+}
+
+/**
  * Drop the cached write client and its disabled latch so a test can re-run
  * client resolution against fresh config. Test-only; never call in app code.
  */

--- a/console/shared/lib/server/session.test.ts
+++ b/console/shared/lib/server/session.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from 'bun:test';
+import { randomBytes, createCipheriv } from 'node:crypto';
+import { createSessionCodec, decodeKey, type SessionBase } from './session';
+
+interface TestSession extends SessionBase {
+  user_id: string;
+}
+
+const key = randomBytes(32);
+const codec = createSessionCodec<TestSession>(() => key);
+const now = () => Math.floor(Date.now() / 1000);
+
+function make(overrides: Partial<TestSession> = {}): TestSession {
+  return { user_id: '42', iat: now(), expires_at: now() + 3600, ...overrides };
+}
+
+// Seal an arbitrary JSON payload with the codec's exact wire format, so tests
+// can produce cryptographically valid cookies with invalid claims.
+function sealRaw(payload: unknown): string {
+  const iv = randomBytes(12);
+  const c = createCipheriv('aes-256-gcm', key, iv);
+  c.setAAD(Buffer.from('session'));
+  const ct = Buffer.concat([c.update(JSON.stringify(payload), 'utf8'), c.final()]);
+  return Buffer.concat([iv, ct, c.getAuthTag()]).toString('base64url');
+}
+
+describe('session codec', () => {
+  test('round-trips a valid session', () => {
+    const s = make();
+    expect(codec.open(codec.seal(s))).toEqual(s);
+  });
+
+  test('rejects tampered ciphertext and the wrong key', () => {
+    const sealed = codec.seal(make());
+    expect(codec.open(sealed.slice(0, -2))).toBeNull();
+    const other = createSessionCodec<TestSession>(() => randomBytes(32));
+    expect(other.open(sealed)).toBeNull();
+  });
+
+  test('rejects an expired session', () => {
+    expect(codec.open(codec.seal(make({ iat: now() - 7200, expires_at: now() - 3600 })))).toBeNull();
+  });
+
+  test('rejects a session without iat (pre-iat cookies)', () => {
+    const sealed = sealRaw({ user_id: '42', expires_at: now() + 3600 });
+    expect(codec.open(sealed)).toBeNull();
+  });
+
+  test('rejects a future-dated iat beyond clock skew', () => {
+    expect(codec.open(codec.seal(make({ iat: now() + 300 })))).toBeNull();
+  });
+
+  test('rejects expires_at at or before iat', () => {
+    const t = now();
+    expect(codec.open(codec.seal(make({ iat: t, expires_at: t })))).toBeNull();
+  });
+
+  test('enforces maxAgeSec from iat regardless of expires_at', () => {
+    const s = make({ iat: now() - 7200, expires_at: now() + 3600 });
+    const sealed = codec.seal(s);
+    expect(codec.open(sealed)).toEqual(s); // no cap: still valid
+    expect(codec.open(sealed, 3600)).toBeNull(); // capped at 1h: too old
+    expect(codec.open(sealed, 8000)).toEqual(s); // cap not yet reached
+  });
+
+  test('decodeKey validates presence and length', () => {
+    expect(() => decodeKey(undefined)).toThrow('SESSION_KEY not set');
+    expect(() => decodeKey(Buffer.alloc(16).toString('base64'))).toThrow('32 bytes');
+    expect(decodeKey(key.toString('base64'))).toEqual(key);
+  });
+});

--- a/console/shared/lib/server/session.ts
+++ b/console/shared/lib/server/session.ts
@@ -8,14 +8,37 @@ import { createCipheriv, createDecipheriv, randomBytes } from 'node:crypto';
 
 const AAD = Buffer.from('session');
 
-/** Minimum contract: every session carries a unix-seconds expiry. */
+/**
+ * Minimum contract: every session carries unix-seconds issue + expiry stamps.
+ * `iat` pins the true issue time so a session's total lifetime can be capped
+ * server-side even if a buggy flow re-seals the payload with a fresh
+ * `expires_at`; `open()` rejects payloads without a sane `iat`, which also
+ * retires any pre-iat cookies still in the wild (one forced re-login).
+ */
 export interface SessionBase {
+  iat: number;
   expires_at: number;
 }
 
 export interface SessionCodec<T extends SessionBase> {
   seal(s: T): string;
-  open(value: string): T | null;
+  /** `maxAgeSec` caps the total lifetime measured from `iat` (kind-specific). */
+  open(value: string, maxAgeSec?: number): T | null;
+}
+
+/**
+ * Canonical session lifetimes. Every mint site seals `iat: now` and
+ * `expires_at: now + TTL`; the verifier side passes the matching TTL as
+ * `open()`'s `maxAgeSec` so a re-sealed cookie can never outlive its class.
+ */
+export const SESSION_TTL_SECONDS = 7 * 24 * 3600;
+export const IMPERSONATION_TTL_SECONDS = 3600; // admin "view as" — deliberately short
+
+/** Tolerated clock drift between replicas when validating `iat`. */
+const MAX_CLOCK_SKEW_SECONDS = 30;
+
+function isUnixSeconds(v: unknown): v is number {
+  return typeof v === 'number' && Number.isSafeInteger(v) && v > 0;
 }
 
 /** Decode and validate a base64 SESSION_KEY into a 32-byte buffer. */
@@ -40,7 +63,7 @@ export function createSessionCodec<T extends SessionBase>(getKey: () => Buffer):
       const ct = Buffer.concat([c.update(JSON.stringify(s), 'utf8'), c.final()]);
       return Buffer.concat([iv, ct, c.getAuthTag()]).toString('base64url');
     },
-    open(value: string): T | null {
+    open(value: string, maxAgeSec?: number): T | null {
       try {
         const raw = Buffer.from(value, 'base64url');
         if (raw.length < 12 + 16) return null;
@@ -52,7 +75,12 @@ export function createSessionCodec<T extends SessionBase>(getKey: () => Buffer):
         d.setAuthTag(tag);
         const pt = Buffer.concat([d.update(ct), d.final()]).toString('utf8');
         const s = JSON.parse(pt) as T;
-        if (Date.now() / 1000 > s.expires_at) return null;
+        const now = Date.now() / 1000;
+        if (!isUnixSeconds(s.iat) || !isUnixSeconds(s.expires_at)) return null;
+        if (s.iat > now + MAX_CLOCK_SKEW_SECONDS) return null;
+        if (s.expires_at <= s.iat) return null;
+        if (now > s.expires_at) return null;
+        if (maxAgeSec !== undefined && now - s.iat > maxAgeSec) return null;
         return s;
       } catch {
         return null;


### PR DESCRIPTION
## Problem

Session validation lived only in the `(app)` layout load, which SvelteKit never runs for form actions or `+server.ts` endpoints. Consequences:

- A **banned** user's cookie kept full write access (settings, modules, commands, SSE, billing) until expiry — up to 7 days.
- A **revoked delegate** kept the owner's board for up to 7 days (grant checked only at `/delegate/enter`).
- An admin **"view as" session (1h) could be laundered into a fresh 7-day session** with the audit fields stripped, via `/delegate/enter` → `/delegate/exit` re-seals.
- View-as links were **replayable** for their whole 5-minute validity window (`jti` was never stored).

## Fix

- Sessions now carry `iat`; the shared codec rejects payloads without a sane issue time and caps total lifetime per kind (impersonation 1h hard, login 7d). Re-seals can never extend a session.
- Ban / deleted-account / delegation-revoke / delegate-scope gates moved into the dashboard `handle` hook — pages, actions, data requests and API endpoints all covered. Checks ride the existing cache fabric (NATS push invalidation), so a ban or revoke lands within one request at ~0 per-request cost.
- Admin app gains the same hook-level staff gate; per-route `requireAdmin` checks stay as defense in depth.
- View-as tokens are single-use: `jti` burned via SET NX EX on the Valkey write path, failing closed when the backend is unreachable.
- `/delegate/enter` refuses impersonated sessions; enter/exit preserve original `iat`/`expires_at`.
- Guard/access modules read `DEMO` from `process.env` (boot import graph must not touch the dynamic-env proxy — exit 13).

## Verification

- 41 shared tests pass (8 new codec tests: iat validation, lifetime caps, tamper rejection).
- `svelte-check`: 0 errors on both apps.
- Both production builds boot under `node serve-node.js` and wipe invalid cookies (`Set-Cookie: bagel_session=; Max-Age=0`).

## Deploy note

Existing cookies lack `iat`, so **every session is invalidated once** on deploy (one forced re-login).

🤖 Generated with [Claude Code](https://claude.com/claude-code)