### PR TITLE
Legal: creator code terms + privacy/ToS polish

### DIFF
--- a/web/src/components/layout/Footer.astro
+++ b/web/src/components/layout/Footer.astro
@@ -55,6 +55,7 @@ const t = useTranslations(lang);
         <div class="legal">
             <a href={localizePath('/privacy', lang)}>{t('footer.privacy')}</a>
             <a href={localizePath('/terms', lang)}>{t('footer.terms')}</a>
+            <a href={localizePath('/creator-terms', lang)}>{t('footer.creatorTerms')}</a>
         </div>
     </div>
 </footer>

--- a/web/src/components/layout/LanguageSwitcher.astro
+++ b/web/src/components/layout/LanguageSwitcher.astro
@@ -6,7 +6,7 @@
  */
 import { getLangFromUrl, type Lang } from '../../i18n/ui';
 
-const LOCALIZED = new Set(['/', '/pricing', '/contact', '/privacy', '/terms']);
+const LOCALIZED = new Set(['/', '/pricing', '/contact', '/privacy', '/terms', '/creator-terms']);
 const current = getLangFromUrl(Astro.url);
 
 function localePath(url: URL, target: Lang): string {

--- a/web/src/i18n/ui.ts
+++ b/web/src/i18n/ui.ts
@@ -34,6 +34,7 @@ const en = {
   'footer.note': 'No data sold · No trackers · No surprises',
   'footer.privacy': 'Privacy Policy',
   'footer.terms': 'Terms of Service',
+  'footer.creatorTerms': 'Creator Codes',
 
   // ── Home ────────────────────────────────────────────────────────
   'home.metaTitle': 'ItsBagelBot. Your Stream, Your Rules',
@@ -280,6 +281,7 @@ const fr: Partial<Record<UIKey, string>> = {
   'footer.note': 'Aucune donnée vendue · Aucun traceur · Aucune surprise',
   'footer.privacy': 'Politique de confidentialité',
   'footer.terms': "Conditions d'utilisation",
+  'footer.creatorTerms': 'Codes de créateur',
 
   'home.metaTitle': 'ItsBagelBot. Votre stream, vos règles',
   'home.metaDesc': 'Le compagnon Twitch tout-en-un, conçu pour l\'indépendance. Une modération qui tourne toute seule, des commandes sur mesure et des outils qui gardent le chat vivant.',

--- a/web/src/pages/creator-terms.astro
+++ b/web/src/pages/creator-terms.astro
@@ -1,0 +1,133 @@
+---
+import Layout from '../layouts/Layout.astro';
+import PageHero from '../components/ui/PageHero.astro';
+import LegalShell from '../components/legal/LegalShell.astro';
+
+const sections = [
+    { id: 'agreement', heading: 'Agreement', plain: 'These terms add to the main Terms of Service and apply to anyone who holds or uses a creator code.' },
+    { id: 'program', heading: 'The Creator Code Program', plain: 'Approved creators get a code. Purchases made with it support the creator, and some codes include a discount.' },
+    { id: 'eligibility', heading: 'Eligibility & Applications', plain: 'You apply, we review. Approval is at our discretion and you must stay in good standing.' },
+    { id: 'codes', heading: 'Your Code', plain: "Your code is personal and non-transferable. We can change or deactivate codes when we need to." },
+    { id: 'revenue-share', heading: 'Revenue Share & Payouts', plain: 'Your share is set when you are approved. Tebex tracks it and pays it out under their rules.' },
+    { id: 'discounts', heading: 'Buyer Discounts', plain: 'Some codes give buyers a discount at checkout. Codes have no cash value and cannot be combined.' },
+    { id: 'conduct', heading: 'Creator Conduct', plain: "Promote honestly, disclose that you earn from your code, and don't game the system." },
+    { id: 'adjustments', heading: 'Refunds, Chargebacks & Adjustments', plain: 'If a purchase is refunded or charged back, the matching share is reversed.' },
+    { id: 'termination', heading: 'Termination', plain: 'Either of us can end participation at any time. Fraud forfeits earnings.' },
+    { id: 'relationship', heading: 'Relationship', plain: "You're an independent creator, not our employee, agent, or partner." },
+    { id: 'changes', heading: 'Changes', plain: 'These terms can change; keeping your code active means you accept the new ones.' },
+    { id: 'contact', heading: 'Contact', plain: 'Questions go to support@itsbagelbot.com.' },
+];
+---
+
+<Layout title="Creator Code Terms — ItsBagelBot" description="Terms governing the ItsBagelBot creator code program: eligibility, revenue share, payouts, and creator conduct.">
+    <PageHero eyebrow="Legal" title="Creator Code Terms" description="The full text, with a plain-words note on every section." />
+
+    <LegalShell updated="July 2026" sections={sections}>
+        <Fragment slot="agreement">
+            <p>
+                These Creator Code Terms supplement the ItsBagelBot <a href="/terms">Terms of Service</a> and apply to anyone who applies for, holds, or uses a
+                creator code. By participating in the program, you agree to these terms in addition to the Terms of Service, and, where payments are involved, to
+                <a href="https://checkout.tebex.io/terms" target="_blank" rel="noopener noreferrer">Tebex's Terms and Conditions</a>. If these terms conflict with
+                the Terms of Service on a creator code matter, these terms prevail. They are governed by the same law and contact channels as the Terms of Service.
+            </p>
+        </Fragment>
+
+        <Fragment slot="program">
+            <p>
+                The creator code program lets approved creators share a personal code with their community. When a supporter uses the code at checkout, the purchase
+                is attributed to the creator, who receives a revenue share. Some codes also apply a discount to the supporter's purchase; others do not. The entire
+                program runs on Tebex, our payment and monetization platform and merchant of record: Tebex issues and tracks codes, records attributed purchases, and
+                handles creator payouts.
+            </p>
+        </Fragment>
+
+        <Fragment slot="eligibility">
+            <p>To receive a creator code, you must apply and be approved. Approval, and the terms attached to any individual code, are at our sole discretion. To participate you must:</p>
+            <ul>
+                <li>Have an ItsBagelBot account in good standing and comply with the Terms of Service and Twitch's Terms of Service</li>
+                <li>Be of the age of majority in your jurisdiction, since payouts require the capacity to enter a contract</li>
+                <li>Meet any account or verification requirements Tebex imposes for receiving payouts</li>
+            </ul>
+            <p>We may decline any application without giving a reason.</p>
+        </Fragment>
+
+        <Fragment slot="codes">
+            <p>
+                Your creator code is personal to you and non-transferable: you may not sell it, lend it, or let anyone else operate it. Whether a code carries a buyer
+                discount, and at what rate, is set per code and may differ between creators. We and Tebex may modify, suspend, or deactivate any code at any time,
+                including to correct errors, respond to abuse, or change the program. We will make reasonable efforts to notify you of changes that affect your code.
+            </p>
+        </Fragment>
+
+        <Fragment slot="revenue-share">
+            <p>
+                Your revenue share rate is communicated to you when your application is approved and may be updated with notice. Attribution, tracking, and payouts are
+                handled by Tebex as merchant of record, under Tebex's payout schedules, minimum thresholds, and terms. ItsBagelBot does not hold or transfer creator
+                funds directly.
+            </p>
+            <p>
+                You are solely responsible for any taxes, duties, or reporting obligations arising from amounts you earn through the program. Nothing in these terms
+                constitutes tax advice.
+            </p>
+        </Fragment>
+
+        <Fragment slot="discounts">
+            <p>
+                Where a code includes a buyer discount, the discount is applied at Tebex checkout and shown before payment. Codes have no cash value, cannot be
+                exchanged for money, cannot be combined with other codes or promotions unless we say otherwise, and only apply to purchases where the code is entered
+                at checkout. We may change or end a discount prospectively at any time; completed purchases are not affected.
+            </p>
+        </Fragment>
+
+        <Fragment slot="conduct">
+            <p>As a participating creator, you must not:</p>
+            <ul>
+                <li>Use your own code, or arrange purchases through intermediaries, to earn a share on your own spending</li>
+                <li>Make false or misleading claims about ItsBagelBot, the discount, or your relationship with us</li>
+                <li>Promote your code through spam, unsolicited messages, or paid ads on our name or trademarks</li>
+                <li>Encourage purchases you know are likely to be refunded or charged back</li>
+            </ul>
+            <p>
+                You must clearly disclose, where your code is promoted, that you earn from purchases made with it, as required by applicable advertising and consumer
+                protection rules.
+            </p>
+        </Fragment>
+
+        <Fragment slot="adjustments">
+            <p>
+                If a purchase attributed to your code is refunded, reversed, or charged back, the corresponding revenue share is reversed as well, and may be deducted
+                from pending or future payouts in accordance with Tebex's processes. We may also withhold or reverse amounts that we or Tebex reasonably determine
+                result from fraud, self-purchasing, or other breaches of these terms.
+            </p>
+        </Fragment>
+
+        <Fragment slot="termination">
+            <p>
+                You may leave the program at any time by asking us to deactivate your code. We may suspend or remove you from the program at any time, with or without
+                cause; where practical, we will tell you why. Legitimately earned amounts that are already payable are paid out per Tebex's terms. Amounts arising from
+                fraud or breach of these terms are forfeited. Termination of your ItsBagelBot account ends your participation automatically.
+            </p>
+        </Fragment>
+
+        <Fragment slot="relationship">
+            <p>
+                Participation in the program does not create an employment, agency, partnership, or joint venture relationship between you and ItsBagelBot. You have no
+                authority to make commitments on our behalf, and you may not present yourself as our employee or official representative.
+            </p>
+        </Fragment>
+
+        <Fragment slot="changes">
+            <p>
+                We may update these terms. Significant changes will be communicated via Discord and dashboard notifications. Continuing to hold or use a creator code
+                after changes take effect constitutes acceptance.
+            </p>
+        </Fragment>
+
+        <Fragment slot="contact">
+            <p>
+                Questions about the creator code program? Email
+                <a href="mailto:support@itsbagelbot.com">support@itsbagelbot.com</a>.
+            </p>
+        </Fragment>
+    </LegalShell>
+</Layout>

--- a/web/src/pages/fr/creator-terms.astro
+++ b/web/src/pages/fr/creator-terms.astro
@@ -1,0 +1,112 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import PageHero from '../../components/ui/PageHero.astro';
+import LegalShell from '../../components/legal/LegalShell.astro';
+
+const sections = [
+    { id: 'agreement', heading: 'Acceptation', plain: 'Ces conditions s’ajoutent aux Conditions d’utilisation et s’appliquent à quiconque détient ou utilise un code de créateur.' },
+    { id: 'program', heading: 'Le programme de codes de créateur', plain: 'Les créateurs approuvés reçoivent un code. Les achats faits avec ce code soutiennent le créateur, et certains codes offrent un rabais.' },
+    { id: 'eligibility', heading: 'Admissibilité et candidatures', plain: 'Vous soumettez une candidature, nous l’évaluons. L’approbation est à notre discrétion et votre compte doit rester en règle.' },
+    { id: 'codes', heading: 'Votre code', plain: 'Votre code est personnel et incessible. Nous pouvons le modifier ou le désactiver au besoin.' },
+    { id: 'revenue-share', heading: 'Partage des revenus et versements', plain: 'Votre part est fixée à l’approbation. Tebex en assure le suivi et le versement selon ses règles.' },
+    { id: 'discounts', heading: 'Rabais pour les acheteurs', plain: 'Certains codes donnent un rabais au paiement. Les codes n’ont aucune valeur en argent et ne sont pas cumulables.' },
+    { id: 'conduct', heading: 'Conduite du créateur', plain: 'Faites une promotion honnête, divulguez que votre code vous rapporte et ne trichez pas.' },
+    { id: 'adjustments', heading: 'Remboursements, rétrofacturations et ajustements', plain: 'Si un achat est remboursé ou rétrofacturé, la part correspondante est annulée.' },
+    { id: 'termination', heading: 'Résiliation', plain: 'Chacun peut mettre fin à la participation en tout temps. La fraude entraîne la perte des gains.' },
+    { id: 'relationship', heading: 'Relation', plain: 'Vous êtes un créateur indépendant, ni employé, ni mandataire, ni associé.' },
+    { id: 'changes', heading: 'Modifications', plain: 'Ces conditions peuvent changer; conserver un code actif signifie que vous acceptez les nouvelles conditions.' },
+    { id: 'contact', heading: 'Nous joindre', plain: 'Écrivez à support@itsbagelbot.com si vous avez des questions.' },
+];
+---
+
+<Layout title="Conditions des codes de créateur — ItsBagelBot" description="Conditions régissant le programme de codes de créateur d’ItsBagelBot : admissibilité, partage des revenus, versements et conduite des créateurs.">
+    <PageHero eyebrow="Juridique" title="Conditions des codes de créateur" description="Le texte intégral, accompagné d’une explication en clair pour chaque section." />
+
+    <LegalShell updated="juillet 2026" sections={sections}>
+        <Fragment slot="agreement">
+            <p>
+                Les présentes Conditions des codes de créateur complètent les <a href="/fr/terms">Conditions d’utilisation</a> d’ItsBagelBot et s’appliquent à quiconque soumet une candidature pour un code de créateur, en détient un ou en utilise un. En participant au programme, vous acceptez les présentes conditions en plus des Conditions d’utilisation et, lorsque des paiements sont en cause, des <a href="https://checkout.tebex.io/terms" target="_blank" rel="noopener noreferrer">conditions générales de Tebex</a>. En cas de conflit avec les Conditions d’utilisation sur une question relative aux codes de créateur, les présentes conditions ont préséance. Elles sont régies par le même droit applicable et les mêmes voies de communication que les Conditions d’utilisation.
+            </p>
+        </Fragment>
+
+        <Fragment slot="program">
+            <p>
+                Le programme de codes de créateur permet aux créateurs approuvés de partager un code personnel avec leur communauté. Lorsqu’une personne utilise ce code au moment du paiement, l’achat est attribué au créateur, qui reçoit une part des revenus. Certains codes appliquent également un rabais à l’achat; d’autres non. L’ensemble du programme fonctionne sur Tebex, notre plateforme de paiement et de monétisation et marchand officiel : Tebex émet les codes, en assure le suivi, enregistre les achats attribués et gère les versements aux créateurs.
+            </p>
+        </Fragment>
+
+        <Fragment slot="eligibility">
+            <p>Pour recevoir un code de créateur, vous devez soumettre une candidature et être approuvé. L’approbation, ainsi que les modalités rattachées à chaque code, relèvent de notre entière discrétion. Pour participer, vous devez :</p>
+            <ul>
+                <li>détenir un compte ItsBagelBot en règle et respecter les Conditions d’utilisation ainsi que les Conditions d’utilisation de Twitch;</li>
+                <li>avoir atteint l’âge de la majorité dans votre juridiction, puisque les versements exigent la capacité de contracter;</li>
+                <li>satisfaire aux exigences de compte ou de vérification imposées par Tebex pour recevoir des versements.</li>
+            </ul>
+            <p>Nous pouvons refuser toute candidature sans motif.</p>
+        </Fragment>
+
+        <Fragment slot="codes">
+            <p>
+                Votre code de créateur est personnel et incessible : vous ne pouvez ni le vendre, ni le prêter, ni laisser quelqu’un d’autre l’exploiter. Le fait qu’un code comporte ou non un rabais pour l’acheteur, et à quel taux, est établi code par code et peut varier d’un créateur à l’autre. Nous et Tebex pouvons modifier, suspendre ou désactiver tout code en tout temps, notamment pour corriger des erreurs, répondre à un abus ou faire évoluer le programme. Nous ferons des efforts raisonnables pour vous aviser des changements qui touchent votre code.
+            </p>
+        </Fragment>
+
+        <Fragment slot="revenue-share">
+            <p>
+                Votre taux de partage des revenus vous est communiqué à l’approbation de votre candidature et peut être mis à jour moyennant un préavis. L’attribution, le suivi et les versements sont gérés par Tebex à titre de marchand officiel, selon les calendriers de versement, seuils minimaux et conditions de Tebex. ItsBagelBot ne détient ni ne transfère directement les fonds des créateurs.
+            </p>
+            <p>
+                Vous êtes seul responsable des impôts, taxes et obligations de déclaration découlant des montants gagnés dans le cadre du programme. Rien dans les présentes conditions ne constitue un conseil fiscal.
+            </p>
+        </Fragment>
+
+        <Fragment slot="discounts">
+            <p>
+                Lorsqu’un code comporte un rabais pour l’acheteur, celui-ci est appliqué au paiement Tebex et affiché avant la conclusion de l’achat. Les codes n’ont aucune valeur en argent, ne peuvent être échangés contre de l’argent, ne peuvent être combinés à d’autres codes ou promotions sauf indication contraire de notre part, et ne s’appliquent qu’aux achats où le code est saisi au moment du paiement. Nous pouvons modifier un rabais ou y mettre fin pour l’avenir en tout temps; les achats déjà conclus ne sont pas touchés.
+            </p>
+        </Fragment>
+
+        <Fragment slot="conduct">
+            <p>À titre de créateur participant, vous ne devez pas :</p>
+            <ul>
+                <li>utiliser votre propre code, ou faire passer des achats par des intermédiaires, afin de toucher une part sur vos propres dépenses;</li>
+                <li>faire des déclarations fausses ou trompeuses au sujet d’ItsBagelBot, du rabais ou de votre relation avec nous;</li>
+                <li>promouvoir votre code par des pourriels, des messages non sollicités ou des publicités payantes portant sur notre nom ou nos marques;</li>
+                <li>encourager des achats dont vous savez qu’ils seront vraisemblablement remboursés ou rétrofacturés.</li>
+            </ul>
+            <p>
+                Vous devez divulguer clairement, partout où votre code est promu, que les achats effectués avec celui-ci vous rapportent, conformément aux règles applicables en matière de publicité et de protection du consommateur.
+            </p>
+        </Fragment>
+
+        <Fragment slot="adjustments">
+            <p>
+                Si un achat attribué à votre code est remboursé, annulé ou rétrofacturé, la part de revenus correspondante est annulée elle aussi et peut être déduite des versements en attente ou à venir, conformément aux processus de Tebex. Nous pouvons également retenir ou annuler des montants qui, selon notre évaluation raisonnable ou celle de Tebex, découlent d’une fraude, d’achats effectués pour soi-même ou d’un autre manquement aux présentes conditions.
+            </p>
+        </Fragment>
+
+        <Fragment slot="termination">
+            <p>
+                Vous pouvez quitter le programme en tout temps en nous demandant de désactiver votre code. Nous pouvons suspendre votre participation ou y mettre fin en tout temps, avec ou sans motif; dans la mesure du possible, nous vous en expliquerons la raison. Les montants légitimement gagnés et déjà exigibles sont versés selon les conditions de Tebex. Les montants découlant d’une fraude ou d’un manquement aux présentes conditions sont perdus. La fermeture de votre compte ItsBagelBot met automatiquement fin à votre participation.
+            </p>
+        </Fragment>
+
+        <Fragment slot="relationship">
+            <p>
+                La participation au programme ne crée aucune relation d’emploi, de mandat, de société de personnes ou de coentreprise entre vous et ItsBagelBot. Vous n’avez aucun pouvoir de nous engager et vous ne pouvez pas vous présenter comme notre employé ou représentant officiel.
+            </p>
+        </Fragment>
+
+        <Fragment slot="changes">
+            <p>
+                Nous pouvons mettre les présentes conditions à jour. Toute modification importante sera annoncée sur Discord et dans le tableau de bord. Le fait de conserver ou d’utiliser un code de créateur après l’entrée en vigueur des modifications constitue votre acceptation.
+            </p>
+        </Fragment>
+
+        <Fragment slot="contact">
+            <p>
+                Des questions sur le programme de codes de créateur? Écrivez à <a href="mailto:support@itsbagelbot.com">support@itsbagelbot.com</a>.
+            </p>
+        </Fragment>
+    </LegalShell>
+</Layout>

--- a/web/src/pages/fr/privacy.astro
+++ b/web/src/pages/fr/privacy.astro
@@ -5,13 +5,13 @@ import LegalShell from '../../components/legal/LegalShell.astro';
 
 const sections = [
     { id: 'overview', heading: 'Aperçu', plain: 'Ce que nous recueillons, pourquoi nous le faisons et les choix qui vous sont offerts.' },
-    { id: 'data-collected', heading: 'Renseignements recueillis', plain: 'Votre identifiant Twitch, le clavardage traité sur le moment et des statistiques d’utilisation agrégées.' },
+    { id: 'data-collected', heading: 'Renseignements recueillis', plain: 'Votre identifiant Twitch, le clavardage traité sur le moment, des statistiques d’utilisation agrégées et un courriel de contact facultatif.' },
     { id: 'data-not-collected', heading: 'Renseignements non recueillis', plain: 'Aucun profil de navigation personnel, aucune donnée publicitaire et aucun suivi par adresse IP de notre part.' },
     { id: 'cookies', heading: 'Cloudflare, témoins et analytique', plain: 'Cloudflare protège et achemine le service. L’analytique est sans témoin; des témoins de sécurité peuvent être utilisés au besoin.' },
     { id: 'data-use', heading: 'Utilisation et fondements juridiques', plain: 'Nous utilisons les renseignements pour fournir et sécuriser le service. Nous ne les vendons ni ne les louons.' },
-    { id: 'payment-processing', heading: 'Autres fournisseurs tiers', plain: 'Tebex traite le paiement de façon sécurisée et agit comme marchand officiel.' },
+    { id: 'payment-processing', heading: 'Autres fournisseurs tiers', plain: 'Tebex traite le paiement de façon sécurisée et agit comme marchand officiel. Resend livre nos courriels transactionnels.' },
     { id: 'storage', heading: 'Stockage et transferts', plain: 'Le clavardage est traité en direct, sans être conservé. Les réglages sont chiffrés au Canada; Cloudflare traite le trafic mondialement.' },
-    { id: 'rights', heading: 'Vos droits (RGPD, LPRPDE, Loi 25)', plain: 'Vous pouvez demander l’accès, la rectification, la portabilité ou la suppression de vos renseignements.' },
+    { id: 'rights', heading: 'Vos droits (RGPD, LPRPDE, Loi 25)', plain: 'Vous pouvez demander l’accès, la rectification, la portabilité ou la suppression de vos renseignements, ou porter plainte auprès d’un organisme de protection de la vie privée.' },
     { id: 'changes', heading: 'Modifications', plain: 'Nous vous aviserons si cette politique change de façon importante.' },
     { id: 'contact', heading: 'Nous joindre et responsable de la protection des renseignements personnels', plain: 'Écrivez à support@itsbagelbot.com pour toute question relative à la vie privée.' },
 ];
@@ -33,6 +33,7 @@ const sections = [
                 <li>les renseignements de votre compte Twitch (nom d’utilisateur et identifiant de chaîne) transmis lors de la connexion OAuth;</li>
                 <li>les messages de clavardage traités en temps réel aux fins de modération, sans conservation permanente;</li>
                 <li>des données d’utilisation agrégées et anonymisées, sans renseignements personnels;</li>
+                <li>une adresse courriel de contact facultative, si vous choisissez de la fournir, utilisée pour les reçus d’achat, les avis de cadeau et les messages liés à votre compte. Elle est chiffrée au repos et n’est jamais utilisée à des fins de marketing sans votre consentement;</li>
                 <li>les données techniques de requête et de sécurité traitées par Cloudflare, comme l’adresse IP, les données d’acheminement, les renseignements sur le navigateur ou l’appareil, l’URL demandée et les événements de sécurité.</li>
             </ul>
         </Fragment>
@@ -69,6 +70,9 @@ const sections = [
             <p>
                 Pour offrir les abonnements Premium, nous intégrons Tebex, qui agit comme marchand officiel pour toutes les transactions. Lorsque vous commencez un paiement, nous créons un panier sécurisé et vous redirigeons vers Tebex pour conclure l’achat. Nous ne traitons, ne recueillons et ne conservons aucun renseignement de paiement, comme un numéro de carte de crédit. Nous recevons uniquement l’identifiant de transaction et l’état de la commande afin d’activer votre abonnement. Tebex traite vos renseignements de paiement conformément à sa propre politique de confidentialité.
             </p>
+            <p>
+                Nous faisons appel à Resend, Inc. pour livrer nos courriels transactionnels, comme les reçus d’achat et les avis de cadeau. Lorsque nous vous envoyons un courriel, Resend traite votre adresse courriel et le contenu du message uniquement aux fins de livraison, conformément à sa propre politique de confidentialité. Nous ne communiquons votre adresse courriel à aucun autre tiers.
+            </p>
         </Fragment>
 
         <Fragment slot="storage">
@@ -79,7 +83,10 @@ const sections = [
 
         <Fragment slot="rights">
             <p>
-                En vertu du RGPD, de la Loi 25 et de la LPRPDE, vous pouvez demander l’accès à vos renseignements personnels, leur rectification, leur portabilité ou leur suppression. Vous pouvez demander une copie ou la suppression de vos données en tout temps en écrivant à <a href="mailto:support@itsbagelbot.com">support@itsbagelbot.com</a>. La suppression de votre compte efface immédiatement toutes les données qui y sont associées.
+                En vertu du RGPD, de la Loi 25 et de la LPRPDE, vous pouvez demander l’accès à vos renseignements personnels, leur rectification, leur portabilité ou leur suppression. Vous pouvez demander une copie ou la suppression de vos données en tout temps en écrivant à <a href="mailto:support@itsbagelbot.com">support@itsbagelbot.com</a>. La suppression de votre compte efface immédiatement toutes les données qui y sont associées, à l’exception des registres minimaux que la loi nous oblige à conserver, comme les journaux d’audit des transactions.
+            </p>
+            <p>
+                Si vous estimez que nous n’avons pas traité vos renseignements personnels correctement, vous avez également le droit de porter plainte auprès d’une autorité de contrôle : la Commission d’accès à l’information au Québec, le Commissariat à la protection de la vie privée du Canada, ou votre autorité locale de protection des données dans l’UE ou l’EEE.
             </p>
         </Fragment>
 

--- a/web/src/pages/fr/privacy.astro
+++ b/web/src/pages/fr/privacy.astro
@@ -7,10 +7,11 @@ const sections = [
     { id: 'overview', heading: 'Aperçu', plain: 'Ce que nous recueillons, pourquoi nous le faisons et les choix qui vous sont offerts.' },
     { id: 'data-collected', heading: 'Renseignements recueillis', plain: 'Votre identifiant Twitch, le clavardage traité sur le moment, des statistiques d’utilisation agrégées et un courriel de contact facultatif.' },
     { id: 'data-not-collected', heading: 'Renseignements non recueillis', plain: 'Aucun profil de navigation personnel, aucune donnée publicitaire et aucun suivi par adresse IP de notre part.' },
-    { id: 'cookies', heading: 'Cloudflare, témoins et analytique', plain: 'Cloudflare protège et achemine le service. L’analytique est sans témoin; des témoins de sécurité peuvent être utilisés au besoin.' },
+    { id: 'cookies', heading: 'Cloudflare, témoins et analytique', plain: 'Cloudflare héberge, protège et achemine le service. L’analytique est sans témoin; des témoins de sécurité peuvent être utilisés au besoin.' },
     { id: 'data-use', heading: 'Utilisation et fondements juridiques', plain: 'Nous utilisons les renseignements pour fournir et sécuriser le service. Nous ne les vendons ni ne les louons.' },
-    { id: 'payment-processing', heading: 'Autres fournisseurs tiers', plain: 'Tebex traite le paiement de façon sécurisée et agit comme marchand officiel. Resend livre nos courriels automatisés; Zoho gère notre correspondance directe.' },
-    { id: 'storage', heading: 'Stockage et transferts', plain: 'Le clavardage est traité en direct, sans être conservé. Les réglages sont chiffrés au Canada; Cloudflare traite le trafic mondialement.' },
+    { id: 'payment-processing', heading: 'Services tiers', plain: 'Tebex traite les paiements, Resend nos courriels automatisés, Zoho notre correspondance, et le soutien passe aussi par Discord.' },
+    { id: 'storage', heading: 'Stockage, conservation et transferts', plain: 'Le clavardage est traité en direct, sans être conservé. Les réglages restent chiffrés au Canada tant que votre compte existe.' },
+    { id: 'children', heading: 'Vie privée des enfants', plain: 'Le service ne s’adresse pas aux enfants de moins de 13 ans et nous ne recueillons pas sciemment leurs renseignements.' },
     { id: 'rights', heading: 'Vos droits (RGPD, LPRPDE, Loi 25, CCPA)', plain: 'Vous pouvez demander l’accès, la rectification, la portabilité ou la suppression de vos renseignements. Les résidents de la Californie bénéficient aussi des droits prévus par la CCPA. Vous pouvez également porter plainte auprès d’un organisme de protection de la vie privée.' },
     { id: 'changes', heading: 'Modifications', plain: 'Nous vous aviserons si cette politique change de façon importante.' },
     { id: 'contact', heading: 'Nous joindre et responsable de la protection des renseignements personnels', plain: 'Écrivez à support@itsbagelbot.com pour toute question relative à la vie privée.' },
@@ -50,7 +51,7 @@ const sections = [
 
         <Fragment slot="cookies">
             <p>
-                Nous faisons appel à Cloudflare, Inc. pour acheminer et protéger nos sites Web et nos services. Cloudflare agit comme mandataire inverse, réseau de diffusion de contenu, fournisseur DNS, service de protection contre les attaques DDoS et les robots, et fournisseur de tunnel sécurisé. Puisque les requêtes passent par Cloudflare avant d’atteindre notre infrastructure, Cloudflare traite nécessairement certaines données techniques, notamment votre adresse IP, les données d’acheminement, les renseignements sur le système et le navigateur, les URL demandées et les signaux de sécurité. Ce traitement sert à livrer le contenu, prévenir les abus, enquêter sur les incidents de sécurité et assurer la fiabilité du service.
+                Nous faisons appel à Cloudflare, Inc. pour héberger, acheminer et protéger nos sites Web et nos services. Notre site Web et notre documentation sont hébergés sur Cloudflare Pages, et Cloudflare fournit également la diffusion de contenu, le DNS et la protection contre les attaques et le trafic abusif. Puisque les requêtes passent par le réseau de Cloudflare, celui-ci traite nécessairement certaines données techniques, notamment votre adresse IP, les données d’acheminement, les renseignements sur le système et le navigateur, les URL demandées et les signaux de sécurité. Ce traitement sert à livrer le contenu, prévenir les abus, enquêter sur les incidents de sécurité et assurer la fiabilité du service.
             </p>
             <p>
                 Nous utilisons également Cloudflare Web Analytics pour mesurer, sous forme agrégée, le trafic et la performance des pages. Sa balise de navigateur <strong>n’utilise ni témoins ni stockage du navigateur</strong> et ne sert pas à suivre des personnes d’un site à l’autre. La balise reçoit une adresse IP dans le cadre normal de la requête réseau, mais Cloudflare indique qu’elle la supprime au centre de données le plus proche plutôt que de la conserver dans les journaux de Web Analytics.
@@ -64,6 +65,9 @@ const sections = [
             <p>
                 Nous utilisons vos renseignements uniquement pour fournir le service ItsBagelBot : modérer le clavardage, exécuter les commandes et faire fonctionner les fonctions de participation. Le traitement repose sur l’exécution de notre contrat avec vous (les Conditions d’utilisation) et sur notre intérêt légitime à sécuriser et à améliorer le service. Nous ne vendons ni ne louons vos renseignements personnels. Nous les communiquons seulement aux fournisseurs décrits dans cette politique lorsque cela est nécessaire à la prestation du service, ou lorsque la loi l’exige.
             </p>
+            <p>
+                La modération du clavardage est automatisée et suit les règles configurées par chaque diffuseur. Les actions automatisées se limitent au clavardage lui-même, comme la suppression d’un message ou la mise en sourdine temporaire d’un utilisateur, et n’ont aucun effet juridique ni aucune autre incidence importante sur vous.
+            </p>
         </Fragment>
 
         <Fragment slot="payment-processing">
@@ -76,11 +80,20 @@ const sections = [
             <p>
                 Nous utilisons les services de courriel de Zoho Corporation pour notre correspondance non automatisée, comme les réponses de notre équipe de soutien. Lorsque vous nous écrivez, ou que nous vous écrivons directement, Zoho traite votre adresse courriel et le contenu de l’échange afin de livrer et d’héberger cette correspondance, conformément à sa propre politique de confidentialité. À l’exception des fournisseurs décrits dans la présente politique, nous ne communiquons votre adresse courriel à personne.
             </p>
+            <p>
+                Nous offrons également du soutien sur notre serveur Discord. Si vous nous y contactez, Discord Inc. traite les renseignements de votre compte Discord et vos messages conformément à la <a href="https://discord.com/privacy" target="_blank" rel="noopener noreferrer">politique de confidentialité de Discord</a>, sur laquelle nous n’exerçons aucun contrôle. Évitez de publier des renseignements sensibles dans les canaux publics.
+            </p>
         </Fragment>
 
         <Fragment slot="storage">
             <p>
-                Les messages de clavardage sont traités en temps réel et ne sont pas conservés de façon permanente. Les données de configuration sont chiffrées au repos et les données en transit le sont au moyen de TLS. Les données de notre application sont hébergées au Canada, qui bénéficie d’une décision d’adéquation de la Commission européenne au titre du RGPD. Comme Cloudflare exploite un réseau mondial, les données techniques de requête, de sécurité et de témoins peuvent être traitées à l’extérieur du Canada, notamment aux États-Unis et dans d’autres pays où Cloudflare exerce ses activités. Cloudflare encadre ces transferts au moyen des mesures décrites dans sa politique de confidentialité et son addenda sur le traitement des données.
+                Les messages de clavardage sont traités en temps réel et ne sont pas conservés de façon permanente. Les données de configuration sont chiffrées au repos et les données en transit le sont au moyen de TLS. Les données de compte et de configuration ne sont conservées que tant que votre compte existe et sont supprimées lorsque vous le supprimez. Les données de notre application sont hébergées au Canada, qui bénéficie d’une décision d’adéquation de la Commission européenne au titre du RGPD. Comme Cloudflare exploite un réseau mondial, les données techniques de requête, de sécurité et de témoins peuvent être traitées à l’extérieur du Canada, notamment aux États-Unis et dans d’autres pays où Cloudflare exerce ses activités. Cloudflare encadre ces transferts au moyen des mesures décrites dans sa politique de confidentialité et son addenda sur le traitement des données.
+            </p>
+        </Fragment>
+
+        <Fragment slot="children">
+            <p>
+                ItsBagelBot ne s’adresse pas aux enfants de moins de 13 ans (ou de 16 ans dans l’UE ou l’EEE) et nous ne recueillons pas sciemment leurs renseignements personnels. Si vous croyez qu’un enfant nous a transmis des renseignements personnels, écrivez à <a href="mailto:support@itsbagelbot.com">support@itsbagelbot.com</a> et nous les supprimerons.
             </p>
         </Fragment>
 

--- a/web/src/pages/fr/privacy.astro
+++ b/web/src/pages/fr/privacy.astro
@@ -9,9 +9,9 @@ const sections = [
     { id: 'data-not-collected', heading: 'Renseignements non recueillis', plain: 'Aucun profil de navigation personnel, aucune donnée publicitaire et aucun suivi par adresse IP de notre part.' },
     { id: 'cookies', heading: 'Cloudflare, témoins et analytique', plain: 'Cloudflare protège et achemine le service. L’analytique est sans témoin; des témoins de sécurité peuvent être utilisés au besoin.' },
     { id: 'data-use', heading: 'Utilisation et fondements juridiques', plain: 'Nous utilisons les renseignements pour fournir et sécuriser le service. Nous ne les vendons ni ne les louons.' },
-    { id: 'payment-processing', heading: 'Autres fournisseurs tiers', plain: 'Tebex traite le paiement de façon sécurisée et agit comme marchand officiel. Resend livre nos courriels transactionnels.' },
+    { id: 'payment-processing', heading: 'Autres fournisseurs tiers', plain: 'Tebex traite le paiement de façon sécurisée et agit comme marchand officiel. Resend livre nos courriels automatisés; Zoho gère notre correspondance directe.' },
     { id: 'storage', heading: 'Stockage et transferts', plain: 'Le clavardage est traité en direct, sans être conservé. Les réglages sont chiffrés au Canada; Cloudflare traite le trafic mondialement.' },
-    { id: 'rights', heading: 'Vos droits (RGPD, LPRPDE, Loi 25)', plain: 'Vous pouvez demander l’accès, la rectification, la portabilité ou la suppression de vos renseignements, ou porter plainte auprès d’un organisme de protection de la vie privée.' },
+    { id: 'rights', heading: 'Vos droits (RGPD, LPRPDE, Loi 25, CCPA)', plain: 'Vous pouvez demander l’accès, la rectification, la portabilité ou la suppression de vos renseignements. Les résidents de la Californie bénéficient aussi des droits prévus par la CCPA. Vous pouvez également porter plainte auprès d’un organisme de protection de la vie privée.' },
     { id: 'changes', heading: 'Modifications', plain: 'Nous vous aviserons si cette politique change de façon importante.' },
     { id: 'contact', heading: 'Nous joindre et responsable de la protection des renseignements personnels', plain: 'Écrivez à support@itsbagelbot.com pour toute question relative à la vie privée.' },
 ];
@@ -23,7 +23,7 @@ const sections = [
     <LegalShell updated="juillet 2026" sections={sections}>
         <Fragment slot="overview">
             <p>
-                ItsBagelBot s’engage à protéger votre vie privée conformément au Règlement général sur la protection des données (RGPD) en Europe, à la Loi sur la protection des renseignements personnels et les documents électroniques (LPRPDE) au Canada et à la Loi 25 au Québec. Cette politique explique les renseignements que nous recueillons, l’usage que nous en faisons et les droits dont vous disposez.
+                ItsBagelBot s’engage à protéger votre vie privée conformément au Règlement général sur la protection des données (RGPD) en Europe, à la Loi sur la protection des renseignements personnels et les documents électroniques (LPRPDE) au Canada, à la Loi 25 au Québec et à la California Consumer Privacy Act (CCPA) en Californie. Cette politique explique les renseignements que nous recueillons, l’usage que nous en faisons et les droits dont vous disposez.
             </p>
         </Fragment>
 
@@ -71,7 +71,10 @@ const sections = [
                 Pour offrir les abonnements Premium, nous intégrons Tebex, qui agit comme marchand officiel pour toutes les transactions. Lorsque vous commencez un paiement, nous créons un panier sécurisé et vous redirigeons vers Tebex pour conclure l’achat. Nous ne traitons, ne recueillons et ne conservons aucun renseignement de paiement, comme un numéro de carte de crédit. Nous recevons uniquement l’identifiant de transaction et l’état de la commande afin d’activer votre abonnement. Tebex traite vos renseignements de paiement conformément à sa propre politique de confidentialité.
             </p>
             <p>
-                Nous faisons appel à Resend, Inc. pour livrer nos courriels transactionnels, comme les reçus d’achat et les avis de cadeau. Lorsque nous vous envoyons un courriel, Resend traite votre adresse courriel et le contenu du message uniquement aux fins de livraison, conformément à sa propre politique de confidentialité. Nous ne communiquons votre adresse courriel à aucun autre tiers.
+                Nous faisons appel à Resend, Inc. pour livrer nos courriels transactionnels automatisés, comme les reçus d’achat et les avis de cadeau. Lorsque nous vous envoyons un tel courriel, Resend traite votre adresse courriel et le contenu du message uniquement aux fins de livraison, conformément à sa propre politique de confidentialité.
+            </p>
+            <p>
+                Nous utilisons les services de courriel de Zoho Corporation pour notre correspondance non automatisée, comme les réponses de notre équipe de soutien. Lorsque vous nous écrivez, ou que nous vous écrivons directement, Zoho traite votre adresse courriel et le contenu de l’échange afin de livrer et d’héberger cette correspondance, conformément à sa propre politique de confidentialité. À l’exception des fournisseurs décrits dans la présente politique, nous ne communiquons votre adresse courriel à personne.
             </p>
         </Fragment>
 
@@ -86,7 +89,10 @@ const sections = [
                 En vertu du RGPD, de la Loi 25 et de la LPRPDE, vous pouvez demander l’accès à vos renseignements personnels, leur rectification, leur portabilité ou leur suppression. Vous pouvez demander une copie ou la suppression de vos données en tout temps en écrivant à <a href="mailto:support@itsbagelbot.com">support@itsbagelbot.com</a>. La suppression de votre compte efface immédiatement toutes les données qui y sont associées, à l’exception des registres minimaux que la loi nous oblige à conserver, comme les journaux d’audit des transactions.
             </p>
             <p>
-                Si vous estimez que nous n’avons pas traité vos renseignements personnels correctement, vous avez également le droit de porter plainte auprès d’une autorité de contrôle : la Commission d’accès à l’information au Québec, le Commissariat à la protection de la vie privée du Canada, ou votre autorité locale de protection des données dans l’UE ou l’EEE.
+                <strong>Résidents de la Californie :</strong> en vertu de la California Consumer Privacy Act (CCPA, telle que modifiée par la CPRA), vous avez le droit de connaître les renseignements personnels que nous recueillons, d’y accéder, de les faire rectifier, de les faire supprimer et de ne subir aucune discrimination pour avoir exercé ces droits. Nous ne vendons pas vos renseignements personnels et ne les communiquons pas à des fins de publicité comportementale intersites; il n’y a donc aucun retrait à demander. Vous pouvez exercer ces droits, vous-même ou par l’entremise d’un agent autorisé, en écrivant à <a href="mailto:support@itsbagelbot.com">support@itsbagelbot.com</a>; nous vérifierons votre demande et y répondrons dans les délais prévus par la CCPA.
+            </p>
+            <p>
+                Si vous estimez que nous n’avons pas traité vos renseignements personnels correctement, vous avez également le droit de porter plainte auprès d’une autorité de contrôle : la Commission d’accès à l’information au Québec, le Commissariat à la protection de la vie privée du Canada, votre autorité locale de protection des données dans l’UE ou l’EEE, ou la California Privacy Protection Agency.
             </p>
         </Fragment>
 

--- a/web/src/pages/fr/terms.astro
+++ b/web/src/pages/fr/terms.astro
@@ -40,7 +40,8 @@ const sections = [
                 <li>enfreindre les Conditions d’utilisation de Twitch;</li>
                 <li>harceler autrui ou lui causer du tort;</li>
                 <li>diffuser des pourriels ou utiliser le service de façon abusive;</li>
-                <li>tenter de faire de l’ingénierie inverse sur le logiciel ou de le redistribuer.</li>
+                <li>tenter de perturber ou de surcharger le service, ou d’y accéder sans autorisation;</li>
+                <li>redistribuer le logiciel ou l’utiliser en dehors des conditions de sa licence à code source disponible.</li>
             </ul>
         </Fragment>
 
@@ -51,7 +52,8 @@ const sections = [
         <Fragment slot="payments">
             <p>ItsBagelBot utilise Tebex comme plateforme officielle de paiement et de monétisation. Lorsque vous achetez un abonnement Premium ou tout autre produit, Tebex agit comme marchand officiel. En concluant un achat, vous acceptez également les <a href="https://checkout.tebex.io/terms" target="_blank" rel="noopener noreferrer">conditions générales de Tebex</a>.</p>
             <p><strong>Politique de remboursement et rétrofacturations :</strong> Tous les paiements sont définitifs et non remboursables, sauf lorsque la loi applicable l’exige expressément. En cas de problème avec une transaction, vous devez d’abord communiquer avec notre équipe de soutien. L’ouverture d’un litige de paiement ou d’une rétrofacturation sans nous avoir contactés entraînera la résiliation immédiate et permanente de votre compte ItsBagelBot.</p>
-            <p>Le forfait gratuit est sans frais et sans limitations. L’abonnement Premium (7 $ CA plus taxes par mois) peut être annulé en tout temps avant le prochain cycle de facturation. La tarification Entreprise est établie sur mesure et précisée dans des ententes distinctes.</p>
+            <p>Le forfait gratuit est sans frais. L’abonnement Premium (7 $ CA plus taxes applicables par mois) peut être annulé en tout temps avant le prochain cycle de facturation. La tarification Entreprise est établie sur mesure et précisée dans des ententes distinctes.</p>
+            <p>Certains achats peuvent être effectués avec un code de créateur, qui peut donner droit à un rabais et soutient le créateur qui l’a partagé. Les codes de créateur sont régis par les <a href="/fr/creator-terms">Conditions des codes de créateur</a>, qui complètent les présentes Conditions d’utilisation.</p>
         </Fragment>
 
         <Fragment slot="liability">

--- a/web/src/pages/privacy.astro
+++ b/web/src/pages/privacy.astro
@@ -7,10 +7,11 @@ const sections = [
     { id: 'overview', heading: 'Overview', plain: 'What we collect, why, and what you can do about it.' },
     { id: 'data-collected', heading: 'Data We Collect', plain: 'Your Twitch handle, chat processed in the moment, aggregated usage stats, and an optional contact email.' },
     { id: 'data-not-collected', heading: "Data We Don't Collect", plain: 'No personal browsing profiles, ad data, or IP-based tracking by us.' },
-    { id: 'cookies', heading: 'Cloudflare, Cookies & Analytics', plain: 'Cloudflare protects and delivers the service. Analytics are cookie-free; security cookies may be used when needed.' },
+    { id: 'cookies', heading: 'Cloudflare, Cookies & Analytics', plain: 'Cloudflare hosts, protects, and delivers the service. Analytics are cookie-free; security cookies may be used when needed.' },
     { id: 'data-use', heading: 'How We Use Your Data & Legal Basis', plain: 'We use data to provide and secure the service. We never sell or rent it.' },
-    { id: 'payment-processing', heading: 'Other Third-Party Processors', plain: 'Tebex handles checkout and payments as the merchant of record. Resend delivers our automated emails; Zoho handles our direct correspondence.' },
-    { id: 'storage', heading: 'Data Storage & Transfers', plain: 'Chat is processed live, not kept. Settings stay encrypted in Canada; Cloudflare processes traffic globally.' },
+    { id: 'payment-processing', heading: 'Third-Party Services', plain: 'Tebex handles payments, Resend our automated emails, Zoho our correspondence, and support also runs on Discord.' },
+    { id: 'storage', heading: 'Data Storage, Retention & Transfers', plain: 'Chat is processed live, not kept. Settings stay encrypted in Canada for as long as your account exists.' },
+    { id: 'children', heading: "Children's Privacy", plain: 'The service is not for children under 13, and we do not knowingly collect their data.' },
     { id: 'rights', heading: 'Your Rights (GDPR, PIPEDA, Law 25, CCPA)', plain: 'Ask for your data, portability, or its deletion any time. California residents get CCPA rights too. You can also complain to a privacy regulator.' },
     { id: 'changes', heading: 'Changes', plain: "If this policy changes meaningfully, you'll hear about it." },
     { id: 'contact', heading: 'Contact & Data Protection Officer', plain: 'Privacy questions go to support@itsbagelbot.com.' },
@@ -51,7 +52,7 @@ const sections = [
 
         <Fragment slot="cookies">
             <p>
-                We use Cloudflare, Inc. to deliver and protect our websites and services. Cloudflare operates as our reverse proxy, content delivery network, DNS provider, DDoS and bot protection provider, and secure Tunnel provider. Because requests pass through Cloudflare before reaching our infrastructure, Cloudflare necessarily processes technical data such as your IP address, traffic-routing data, system and browser information, requested URLs, and security signals. We use this processing to deliver content, prevent abuse, investigate security incidents, and keep the service reliable.
+                We use Cloudflare, Inc. to host, deliver, and protect our websites and services. Our website and documentation are hosted on Cloudflare Pages, and Cloudflare also provides content delivery, DNS, and protection against attacks and abusive traffic. Because requests pass through Cloudflare's network, Cloudflare necessarily processes technical data such as your IP address, traffic-routing data, system and browser information, requested URLs, and security signals. We use this processing to deliver content, prevent abuse, investigate security incidents, and keep the service reliable.
             </p>
             <p>
                 We also use Cloudflare Web Analytics to measure traffic and page performance in aggregate. Its browser beacon does <strong>not use cookies or browser storage</strong> and is not used to follow individuals across websites. The beacon receives an IP address as part of the network request, but Cloudflare states that it discards that address at the nearest data centre rather than storing it in Web Analytics logs.
@@ -66,6 +67,9 @@ const sections = [
                 Solely to provide the ItsBagelBot service: moderate chat, execute commands, and run engagement
                 features. Our legal basis for processing this data is the fulfillment of our contract with you (Terms of Service) and our legitimate interest in securing and improving our service. We do not sell or rent your personal data. We disclose it only to service providers described in this policy, when needed to provide the service, or when required by law.
             </p>
+            <p>
+                Chat moderation is automated and follows the rules each broadcaster configures. Automated actions are limited to chat itself, such as removing a message or timing out a user, and have no legal or similarly significant effect on you.
+            </p>
         </Fragment>
 
         <Fragment slot="payment-processing">
@@ -78,12 +82,21 @@ const sections = [
             <p>
                 We use Zoho Corporation's email services for non-automated correspondence, such as replies from our support team. When you email us, or we write to you directly, Zoho processes your email address and the content of the exchange to deliver and host that correspondence, subject to Zoho's own Privacy Policy. Aside from the processors described in this policy, we do not share your email address with anyone.
             </p>
+            <p>
+                We also offer support through our Discord server. If you contact us there, Discord Inc. processes your Discord account information and messages under <a href="https://discord.com/privacy" target="_blank" rel="noopener noreferrer">Discord's own Privacy Policy</a>, which we do not control. Avoid posting sensitive information in public channels.
+            </p>
         </Fragment>
 
         <Fragment slot="storage">
             <p>
                 Chat messages are processed in real-time and not permanently stored. Configuration data is
-                encrypted at rest. Data in transit is encrypted using TLS. Our application data is hosted in Canada, which benefits from an adequacy decision by the European Commission under the GDPR. Because Cloudflare operates a global network, technical request, security, and cookie data may be processed outside Canada, including in the United States and other countries where Cloudflare operates. Cloudflare handles those transfers under the safeguards described in its Privacy Policy and Data Processing Addendum.
+                encrypted at rest, and data in transit is encrypted using TLS. Account and configuration data is retained only for as long as your account exists and is deleted when you delete your account. Our application data is hosted in Canada, which benefits from an adequacy decision by the European Commission under the GDPR. Because Cloudflare operates a global network, technical request, security, and cookie data may be processed outside Canada, including in the United States and other countries where Cloudflare operates. Cloudflare handles those transfers under the safeguards described in its Privacy Policy and Data Processing Addendum.
+            </p>
+        </Fragment>
+
+        <Fragment slot="children">
+            <p>
+                ItsBagelBot is not directed at children under 13 (or 16 in the EU/EEA), and we do not knowingly collect personal data from them. If you believe a child has provided us with personal data, contact <a href="mailto:support@itsbagelbot.com">support@itsbagelbot.com</a> and we will delete it.
             </p>
         </Fragment>
 

--- a/web/src/pages/privacy.astro
+++ b/web/src/pages/privacy.astro
@@ -9,9 +9,9 @@ const sections = [
     { id: 'data-not-collected', heading: "Data We Don't Collect", plain: 'No personal browsing profiles, ad data, or IP-based tracking by us.' },
     { id: 'cookies', heading: 'Cloudflare, Cookies & Analytics', plain: 'Cloudflare protects and delivers the service. Analytics are cookie-free; security cookies may be used when needed.' },
     { id: 'data-use', heading: 'How We Use Your Data & Legal Basis', plain: 'We use data to provide and secure the service. We never sell or rent it.' },
-    { id: 'payment-processing', heading: 'Other Third-Party Processors', plain: 'Tebex handles checkout and payments as the merchant of record. Resend delivers our transactional emails.' },
+    { id: 'payment-processing', heading: 'Other Third-Party Processors', plain: 'Tebex handles checkout and payments as the merchant of record. Resend delivers our automated emails; Zoho handles our direct correspondence.' },
     { id: 'storage', heading: 'Data Storage & Transfers', plain: 'Chat is processed live, not kept. Settings stay encrypted in Canada; Cloudflare processes traffic globally.' },
-    { id: 'rights', heading: 'Your Rights (GDPR, PIPEDA, Law 25)', plain: 'Ask for your data, portability, or its deletion any time. You can also complain to a privacy regulator.' },
+    { id: 'rights', heading: 'Your Rights (GDPR, PIPEDA, Law 25, CCPA)', plain: 'Ask for your data, portability, or its deletion any time. California residents get CCPA rights too. You can also complain to a privacy regulator.' },
     { id: 'changes', heading: 'Changes', plain: "If this policy changes meaningfully, you'll hear about it." },
     { id: 'contact', heading: 'Contact & Data Protection Officer', plain: 'Privacy questions go to support@itsbagelbot.com.' },
 ];
@@ -23,7 +23,7 @@ const sections = [
     <LegalShell updated="July 2026" sections={sections}>
         <Fragment slot="overview">
             <p>
-                ItsBagelBot is committed to protecting your privacy in accordance with GDPR (Europe), PIPEDA (Canada), and Law 25 (Quebec). This policy explains what data we collect,
+                ItsBagelBot is committed to protecting your privacy in accordance with GDPR (Europe), PIPEDA (Canada), Law 25 (Quebec), and the CCPA (California). This policy explains what data we collect,
                 how we use it, and your rights.
             </p>
         </Fragment>
@@ -73,7 +73,10 @@ const sections = [
                 To offer premium subscriptions, we integrate with Tebex. Tebex acts as the merchant of record for all transactions. When you initiate a checkout, we create a secure basket and redirect you to Tebex to complete the purchase. We do not process, collect, or store any payment details (like credit card numbers). We only receive the transaction ID and order status to fulfill your subscription. Tebex processes your payment data subject to their own Privacy Policy.
             </p>
             <p>
-                We use Resend, Inc. to deliver transactional emails, such as purchase receipts and gift notifications. When we send you an email, Resend processes your email address and the message content for delivery purposes only, subject to Resend's own Privacy Policy. We do not share your email address with any other third party.
+                We use Resend, Inc. to deliver automated transactional emails, such as purchase receipts and gift notifications. When we send you such an email, Resend processes your email address and the message content for delivery purposes only, subject to Resend's own Privacy Policy.
+            </p>
+            <p>
+                We use Zoho Corporation's email services for non-automated correspondence, such as replies from our support team. When you email us, or we write to you directly, Zoho processes your email address and the content of the exchange to deliver and host that correspondence, subject to Zoho's own Privacy Policy. Aside from the processors described in this policy, we do not share your email address with anyone.
             </p>
         </Fragment>
 
@@ -92,7 +95,10 @@ const sections = [
                 removes all associated data immediately, except for minimal records we are legally required to keep, such as transaction audit logs.
             </p>
             <p>
-                If you believe we have not handled your personal data properly, you also have the right to lodge a complaint with a supervisory authority: the Commission d'accès à l'information in Quebec, the Office of the Privacy Commissioner of Canada, or your local data protection authority in the EU/EEA.
+                <strong>California residents:</strong> under the California Consumer Privacy Act (CCPA, as amended by the CPRA), you have the right to know what personal information we collect, to access it, to correct it, to delete it, and to not be discriminated against for exercising these rights. We do not sell your personal information and do not share it for cross-context behavioural advertising, so there is nothing to opt out of. You can exercise these rights, yourself or through an authorized agent, by contacting <a href="mailto:support@itsbagelbot.com">support@itsbagelbot.com</a>; we will verify your request and respond within the timelines the CCPA requires.
+            </p>
+            <p>
+                If you believe we have not handled your personal data properly, you also have the right to lodge a complaint with a supervisory authority: the Commission d'accès à l'information in Quebec, the Office of the Privacy Commissioner of Canada, your local data protection authority in the EU/EEA, or the California Privacy Protection Agency.
             </p>
         </Fragment>
 

--- a/web/src/pages/privacy.astro
+++ b/web/src/pages/privacy.astro
@@ -5,13 +5,13 @@ import LegalShell from '../components/legal/LegalShell.astro';
 
 const sections = [
     { id: 'overview', heading: 'Overview', plain: 'What we collect, why, and what you can do about it.' },
-    { id: 'data-collected', heading: 'Data We Collect', plain: 'Your Twitch handle, chat processed in the moment, and aggregated usage stats.' },
+    { id: 'data-collected', heading: 'Data We Collect', plain: 'Your Twitch handle, chat processed in the moment, aggregated usage stats, and an optional contact email.' },
     { id: 'data-not-collected', heading: "Data We Don't Collect", plain: 'No personal browsing profiles, ad data, or IP-based tracking by us.' },
     { id: 'cookies', heading: 'Cloudflare, Cookies & Analytics', plain: 'Cloudflare protects and delivers the service. Analytics are cookie-free; security cookies may be used when needed.' },
     { id: 'data-use', heading: 'How We Use Your Data & Legal Basis', plain: 'We use data to provide and secure the service. We never sell or rent it.' },
-    { id: 'payment-processing', heading: 'Other Third-Party Processors', plain: 'We use Tebex to securely handle checkout and payments. They act as the merchant of record.' },
+    { id: 'payment-processing', heading: 'Other Third-Party Processors', plain: 'Tebex handles checkout and payments as the merchant of record. Resend delivers our transactional emails.' },
     { id: 'storage', heading: 'Data Storage & Transfers', plain: 'Chat is processed live, not kept. Settings stay encrypted in Canada; Cloudflare processes traffic globally.' },
-    { id: 'rights', heading: 'Your Rights (GDPR, PIPEDA, Law 25)', plain: 'Ask for your data, portability, or its deletion any time.' },
+    { id: 'rights', heading: 'Your Rights (GDPR, PIPEDA, Law 25)', plain: 'Ask for your data, portability, or its deletion any time. You can also complain to a privacy regulator.' },
     { id: 'changes', heading: 'Changes', plain: "If this policy changes meaningfully, you'll hear about it." },
     { id: 'contact', heading: 'Contact & Data Protection Officer', plain: 'Privacy questions go to support@itsbagelbot.com.' },
 ];
@@ -34,6 +34,7 @@ const sections = [
                 <li>Twitch account information (username, channel ID) provided during OAuth connection</li>
                 <li>Chat messages processed in real-time for moderation (not stored permanently)</li>
                 <li>Usage analytics (aggregated, anonymized, no PII)</li>
+                <li>An optional contact email address, if you choose to provide one, used for purchase receipts, gift notifications, and account-related messages. It is encrypted at rest and never used for marketing without your consent</li>
                 <li>Technical request and security data processed by Cloudflare, such as IP address, routing data, browser or device information, requested URL, and security events</li>
             </ul>
         </Fragment>
@@ -71,6 +72,9 @@ const sections = [
             <p>
                 To offer premium subscriptions, we integrate with Tebex. Tebex acts as the merchant of record for all transactions. When you initiate a checkout, we create a secure basket and redirect you to Tebex to complete the purchase. We do not process, collect, or store any payment details (like credit card numbers). We only receive the transaction ID and order status to fulfill your subscription. Tebex processes your payment data subject to their own Privacy Policy.
             </p>
+            <p>
+                We use Resend, Inc. to deliver transactional emails, such as purchase receipts and gift notifications. When we send you an email, Resend processes your email address and the message content for delivery purposes only, subject to Resend's own Privacy Policy. We do not share your email address with any other third party.
+            </p>
         </Fragment>
 
         <Fragment slot="storage">
@@ -82,10 +86,13 @@ const sections = [
 
         <Fragment slot="rights">
             <p>
-                Under GDPR, Law 25, and PIPEDA, you have the right to access, rectify, port, or erase your personal data. 
+                Under GDPR, Law 25, and PIPEDA, you have the right to access, rectify, port, or erase your personal data.
                 You can request data export or deletion at any time by contacting
                 <a href="mailto:support@itsbagelbot.com">support@itsbagelbot.com</a>. Deleting your account
-                removes all associated data immediately.
+                removes all associated data immediately, except for minimal records we are legally required to keep, such as transaction audit logs.
+            </p>
+            <p>
+                If you believe we have not handled your personal data properly, you also have the right to lodge a complaint with a supervisory authority: the Commission d'accès à l'information in Quebec, the Office of the Privacy Commissioner of Canada, or your local data protection authority in the EU/EEA.
             </p>
         </Fragment>
 

--- a/web/src/pages/terms.astro
+++ b/web/src/pages/terms.astro
@@ -46,7 +46,8 @@ const sections = [
                 <li>Violate Twitch's Terms of Service</li>
                 <li>Harass or harm others</li>
                 <li>Spam or abuse the service</li>
-                <li>Attempt to reverse-engineer or redistribute the software</li>
+                <li>Attempt to disrupt, overload, or gain unauthorized access to the service</li>
+                <li>Redistribute the software or use it outside the terms of its source-available license</li>
             </ul>
         </Fragment>
 
@@ -66,8 +67,12 @@ const sections = [
                 <strong>Refund Policy & Chargebacks:</strong> All payments are final and non-refundable unless explicitly required by applicable law. If you experience an issue with a transaction, you must contact our support team first. Opening a payment dispute or chargeback without contacting us will result in the immediate and permanent termination of your ItsBagelBot account.
             </p>
             <p>
-                Free tier has no cost and no limitations. Premium ($7 CAD +tx/month) can be canceled anytime prior to the next billing cycle. Enterprise
+                The free tier costs nothing. Premium ($7 CAD plus applicable taxes per month) can be canceled anytime prior to the next billing cycle. Enterprise
                 pricing is custom and outlined in separate agreements.
+            </p>
+            <p>
+                Some purchases can be made with a creator code, which may apply a discount and supports the creator who shared it. Creator codes are governed by the
+                <a href="/creator-terms">Creator Code Terms</a>, which supplement these Terms of Service.
             </p>
         </Fragment>
 


### PR DESCRIPTION
## Summary
- New Creator Code Terms page (EN + FR), linked from footer, ToS, language switcher
- ToS: reworded acceptable-use bullets, free tier wording, links creator terms
- Privacy: discloses Resend (automated email), Zoho (correspondence), Discord (support), Cloudflare Pages hosting
- Privacy: adds CCPA/CPRA rights, children's privacy section, data retention statement, complaint-authority list

## Test plan
- [x] `bun run build` succeeds, 14 pages generated
- [x] Verified new pages, links, and disclosures present in built HTML output (EN + FR)