### PR TITLE
feat(timers): stream-only repeating chat messages

### DIFF
--- a/app/sesame/engine/deps.go
+++ b/app/sesame/engine/deps.go
@@ -46,6 +46,10 @@ type Deps struct {
 	Commands CommandManager
 	Gateway  GatewayCaller
 	Log      *zap.Logger
+	// Timers arms/disarms a broadcaster's repeating chat-message timers for the
+	// length of one stream; ValkeyTimerStore is the default. nil disables it (the
+	// live module's stream.online/offline hooks skip the calls).
+	Timers TimersStore
 	// Automod is the inline chat guard. nil disables it; when set it inspects
 	// each chat line and the engine acts on or shadow-logs the verdict.
 	Automod *automod.Gate
@@ -96,6 +100,16 @@ type CooldownStore interface {
 type DedupStore interface {
 	Claim(ctx context.Context, key string) (bool, error)
 	Release(ctx context.Context, key string) error
+}
+
+// TimersStore arms and disarms a broadcaster's repeating chat-message timers
+// for the length of one stream. Both calls are fire-and-forget from the
+// caller's perspective (no error to act on): a failure is logged by the store
+// itself and, at worst, delays a timer starting or stopping until the next
+// stream event or expiry.
+type TimersStore interface {
+	ArmAll(ctx context.Context, broadcasterID uint64)
+	DisarmAll(ctx context.Context, broadcasterID uint64)
 }
 
 // NoopCooldown never gates: every call is allowed. Used in tests and when no

--- a/app/sesame/engine/timers_valkey.go
+++ b/app/sesame/engine/timers_valkey.go
@@ -1,0 +1,293 @@
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+	"strings"
+	"time"
+
+	"ItsBagelBot/app/sesame/module"
+	"ItsBagelBot/internal/domain/outgress"
+	"ItsBagelBot/internal/moderation"
+	"ItsBagelBot/internal/projection"
+	"ItsBagelBot/pkg/bus"
+
+	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/valkey-io/valkey-go"
+	"go.uber.org/zap"
+)
+
+// timersModuleName is the ModuleView key the dashboard's Timers tab writes:
+// its enable toggle is the master switch, and its Configs blob carries the
+// list of repeating messages this store reads.
+const timersModuleName = "timers"
+
+// timerKeyPrefix is the Valkey schedule key for one timer: EX'd to its own
+// interval. Its expiry, not a running goroutine, is the clock — the same
+// idiom ValkeyLiveStore uses for its key-expiry re-check (live_valkey.go).
+const timerKeyPrefix = "timer:"
+
+// timerClaimPrefix guards one expiry so only one replica of the fleet fires
+// it; nested under timerKeyPrefix the way live:recheck: nests under live:, so
+// onExpired can tell its own claim keys apart from a schedule key.
+const timerClaimPrefix = "timer:claim:"
+
+const timerClaimTTL = 5 * time.Second
+
+// minTimerInterval floors a configured interval. The dashboard already clamps
+// to 60s; this only guards a hand-crafted RPC call from arming a tight
+// expire/fire/re-arm loop.
+const minTimerInterval = 30 * time.Second
+
+// timerDef is one broadcaster-authored repeating chat message.
+type timerDef struct {
+	ID       string `json:"id"`
+	Message  string `json:"message"`
+	Interval int    `json:"intervalSeconds"`
+	Enabled  bool   `json:"enabled"`
+}
+
+// timersConfig is the "timers" module's Configs blob.
+type timersConfig struct {
+	Timers []timerDef `json:"timers"`
+}
+
+// ValkeyTimerStore arms a broadcaster's repeating messages for the length of
+// one stream and fires them off Valkey key expiry: stream.online SETs one key
+// per enabled timer (EX = its interval), stream.offline deletes them, and each
+// expiry re-checks live state + config, posts the message, and re-arms.
+//
+// A missed expiry notification (the watcher's pub/sub connection drops and
+// reconnects) silently stalls that one timer until the next stream.online —
+// there is no reconciliation sweep. Given the stream-only requirement and the
+// modest stakes (a scheduled chat line, not a payment), a rare stall until the
+// next stream is an accepted trade for not running a second polling mechanism
+// alongside this one.
+type ValkeyTimerStore struct {
+	client valkey.Client
+	pub    message.Publisher
+	proj   projection.Reader
+	live   IsLiveChecker
+
+	outgressPremium  string
+	outgressStandard string
+
+	keyspaceDB int
+	log        *zap.Logger
+}
+
+// TimersConfig wires a ValkeyTimerStore.
+type TimersConfig struct {
+	OutgressPremiumSubject  string
+	OutgressStandardSubject string
+	// KeyspaceDB is the Valkey db the expiry watcher listens on (default 0).
+	KeyspaceDB int
+	// Log is the store's logger; a nil Log defaults to a no-op.
+	Log *zap.Logger
+}
+
+// NewValkeyTimerStore builds a timer store. proj resolves a broadcaster's
+// "timers" ModuleView and tier (for the outgress lane); live gates every fire
+// and re-arm to the broadcaster's current live state.
+func NewValkeyTimerStore(client valkey.Client, pub message.Publisher, proj projection.Reader, live IsLiveChecker, cfg TimersConfig) *ValkeyTimerStore {
+	log := cfg.Log
+	if log == nil {
+		log = zap.NewNop()
+	}
+	return &ValkeyTimerStore{
+		client:           client,
+		pub:              pub,
+		proj:             proj,
+		live:             live,
+		outgressPremium:  cfg.OutgressPremiumSubject,
+		outgressStandard: cfg.OutgressStandardSubject,
+		keyspaceDB:       cfg.KeyspaceDB,
+		log:              log,
+	}
+}
+
+func timerKey(broadcasterID uint64, timerID string) string {
+	return timerKeyPrefix + strconv.FormatUint(broadcasterID, 10) + ":" + timerID
+}
+
+// ArmAll SETs one Valkey key per enabled timer of an enabled "timers" module,
+// each EX'd to its own interval — the broadcaster's stream just went online,
+// so every timer starts its countdown fresh.
+func (s *ValkeyTimerStore) ArmAll(ctx context.Context, broadcasterID uint64) {
+	cfg, ok := s.config(ctx, broadcasterID)
+	if !ok {
+		return
+	}
+	for _, td := range cfg.Timers {
+		s.arm(ctx, broadcasterID, td)
+	}
+}
+
+// arm SETs one timer's schedule key. NX leaves an already-counting-down key
+// alone: ArmAll must not reset the clock on a redelivered stream.online, and
+// onExpired's re-arm must not clobber a fresh key a concurrent ArmAll just set
+// (the narrow race of a stream ending and restarting within the same instant).
+func (s *ValkeyTimerStore) arm(ctx context.Context, broadcasterID uint64, td timerDef) {
+	if !td.Enabled || td.ID == "" {
+		return
+	}
+	interval := time.Duration(td.Interval) * time.Second
+	if interval < minTimerInterval {
+		interval = minTimerInterval
+	}
+	err := s.client.Do(ctx, s.client.B().Set().Key(timerKey(broadcasterID, td.ID)).Value("1").Nx().ExSeconds(int64(interval.Seconds())).Build()).Error()
+	if err != nil && !valkey.IsValkeyNil(err) {
+		s.log.Warn("timers: failed to arm", zap.Uint64("broadcaster_id", broadcasterID), zap.String("timer_id", td.ID), zap.Error(err))
+	}
+}
+
+// DisarmAll deletes every configured timer's key so a stream that just ended
+// stops immediately rather than waiting out its longest-running timer's
+// interval. Best-effort: a config read failure leaves the keys to expire and
+// self-stop on their own (onExpired's live check fails the same way).
+func (s *ValkeyTimerStore) DisarmAll(ctx context.Context, broadcasterID uint64) {
+	cfg, ok := s.config(ctx, broadcasterID)
+	if !ok {
+		return
+	}
+	for _, td := range cfg.Timers {
+		if td.ID == "" {
+			continue
+		}
+		if err := s.client.Do(ctx, s.client.B().Del().Key(timerKey(broadcasterID, td.ID)).Build()).Error(); err != nil {
+			s.log.Warn("timers: failed to disarm", zap.Uint64("broadcaster_id", broadcasterID), zap.String("timer_id", td.ID), zap.Error(err))
+		}
+	}
+}
+
+// config resolves the broadcaster's "timers" ModuleView, reporting false when
+// the module is missing, disabled, unconfigured, or the read failed.
+func (s *ValkeyTimerStore) config(ctx context.Context, broadcasterID uint64) (timersConfig, bool) {
+	views, err := s.proj.Modules(ctx, broadcasterID)
+	if err != nil {
+		s.log.Warn("timers: failed to read module views", zap.Uint64("broadcaster_id", broadcasterID), zap.Error(err))
+		return timersConfig{}, false
+	}
+	for _, v := range views {
+		if v.Name != timersModuleName {
+			continue
+		}
+		if !v.IsEnabled || len(v.Configs) == 0 {
+			return timersConfig{}, false
+		}
+		var cfg timersConfig
+		if err := json.Unmarshal(v.Configs, &cfg); err != nil {
+			s.log.Warn("timers: bad config", zap.Uint64("broadcaster_id", broadcasterID), zap.Error(err))
+			return timersConfig{}, false
+		}
+		return cfg, true
+	}
+	return timersConfig{}, false
+}
+
+// StartExpiryWatcher subscribes to Valkey key-expiry notifications and fires
+// (or drops) each timer whose key expires. It runs until ctx is cancelled and
+// reconnects on a dropped subscription, mirroring ValkeyLiveStore's watcher.
+// Requires notify-keyspace-events to include expired-key events (Ex), already
+// on for the live-recheck watcher this shares the deployment with.
+func (s *ValkeyTimerStore) StartExpiryWatcher(ctx context.Context) {
+	channel := "__keyevent@" + strconv.Itoa(s.keyspaceDB) + "__:expired"
+	s.log.Info("timers: expiry watcher starting", zap.String("channel", channel))
+
+	for ctx.Err() == nil {
+		err := s.client.Receive(ctx, s.client.B().Subscribe().Channel(channel).Build(), func(msg valkey.PubSubMessage) {
+			s.onExpired(ctx, msg.Message)
+		})
+		if ctx.Err() != nil {
+			return
+		}
+		s.log.Warn("timers: expiry watcher dropped, reconnecting", zap.Error(err))
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(time.Second):
+		}
+	}
+}
+
+// onExpired handles one expired key. It ignores anything that is not a
+// schedule key, claims the expiry so only one replica acts on it, then
+// re-validates live state + config before firing and re-arming: a timer
+// paused, deleted, or whose stream ended between arming and this expiry is
+// dropped instead of fired.
+func (s *ValkeyTimerStore) onExpired(ctx context.Context, key string) {
+	if !strings.HasPrefix(key, timerKeyPrefix) || strings.HasPrefix(key, timerClaimPrefix) {
+		return
+	}
+	rest := strings.TrimPrefix(key, timerKeyPrefix)
+	parts := strings.SplitN(rest, ":", 2)
+	if len(parts) != 2 {
+		return
+	}
+	broadcasterID, err := strconv.ParseUint(parts[0], 10, 64)
+	if err != nil || broadcasterID == 0 {
+		return
+	}
+	timerID := parts[1]
+
+	// One replica per expiry fires the timer.
+	claimKey := timerClaimPrefix + parts[0] + ":" + timerID
+	got, err := s.client.Do(ctx, s.client.B().Set().Key(claimKey).Value("1").Nx().ExSeconds(int64(timerClaimTTL.Seconds())).Build()).ToString()
+	if err != nil || got != "OK" {
+		return
+	}
+
+	live, err := s.live.IsLive(ctx, broadcasterID)
+	if err != nil || !live {
+		return // stream ended: stay stopped until the next stream.online arms fresh
+	}
+
+	cfg, ok := s.config(ctx, broadcasterID)
+	if !ok {
+		return // module disabled or unreadable since arming: drop, don't re-arm
+	}
+	td, ok := findTimer(cfg.Timers, timerID)
+	if !ok || !td.Enabled {
+		return // this timer was disabled or deleted since arming: drop, don't re-arm
+	}
+
+	s.fire(ctx, broadcasterID, td)
+	s.arm(ctx, broadcasterID, td)
+}
+
+func findTimer(timers []timerDef, id string) (timerDef, bool) {
+	for _, td := range timers {
+		if td.ID == id {
+			return td, true
+		}
+	}
+	return timerDef{}, false
+}
+
+// fire posts one timer's message the same way the pipeline posts any module
+// Output: the send-time floor guard first (the config was already floor-
+// checked at save time; this only covers drift), then whichever premium/
+// standard lane the broadcaster's own tier resolves to.
+func (s *ValkeyTimerStore) fire(ctx context.Context, broadcasterID uint64, td timerDef) {
+	if term, hit := moderation.CheckFloor(td.Message); hit {
+		s.log.Warn("timers: suppressed message carrying floor content",
+			zap.Uint64("broadcaster_id", broadcasterID), zap.String("timer_id", td.ID), zap.String("term", term))
+		return
+	}
+
+	idStr := strconv.FormatUint(broadcasterID, 10)
+	subject := s.outgressStandard
+	if u, err := s.proj.User(ctx, broadcasterID); err == nil && u.Premium() {
+		subject = s.outgressPremium
+	}
+
+	body, err := buildOutgress(&module.Output{Type: outgress.TypeChat, BroadcasterID: idStr, Text: td.Message})
+	if err != nil {
+		s.log.Warn("timers: failed to build outgress message", zap.Uint64("broadcaster_id", broadcasterID), zap.String("timer_id", td.ID), zap.Error(err))
+		return
+	}
+	if err := bus.PublishRaw(ctx, s.pub, subject, body); err != nil {
+		s.log.Warn("timers: failed to publish", zap.Uint64("broadcaster_id", broadcasterID), zap.String("timer_id", td.ID), zap.Error(err))
+	}
+}

--- a/app/sesame/main.go
+++ b/app/sesame/main.go
@@ -72,6 +72,8 @@ func main() {
 	live := newLive(ctx, in, cfg, log)
 	defer live.Close()
 
+	timers := newTimers(ctx, in, proj, live, cfg, log)
+
 	// Deps is the bundle every module fn captures; main builds it once. modules.All
 	// returns the built modules (core commands + bagel, live tracker, opt-in
 	// shoutout), which the engine registry indexes. Adding a feature is a new file
@@ -94,6 +96,7 @@ func main() {
 		Automod:    guard,
 		Reputation: engine.NewValkeyReputation(valkeyClient, 6*time.Hour, log),
 		Campaign:   engine.NewValkeyCampaign(valkeyClient, log),
+		Timers:     timers,
 
 		PublicBaseURL: cfg.PublicBaseURL,
 	}
@@ -266,6 +269,21 @@ func newLive(ctx context.Context, in infra, cfg *config.Config, log *zap.Logger)
 	live.StartInvalidationListener()
 	go live.StartExpiryWatcher(ctx)
 	return live
+}
+
+// newTimers builds the Valkey-backed timer store — one schedule key per
+// enabled repeating message, armed on stream.online and fired off key expiry
+// (see live_valkey.go's key-expiry idiom, which this shares the deployment's
+// notify-keyspace-events config with) — and starts its expiry watcher.
+func newTimers(ctx context.Context, in infra, proj *projection.Client, live *engine.ValkeyLiveStore, cfg *config.Config, log *zap.Logger) *engine.ValkeyTimerStore {
+	timers := engine.NewValkeyTimerStore(in.vc, in.pub, proj, live, engine.TimersConfig{
+		OutgressPremiumSubject:  cfg.OutgressPremiumSubject,
+		OutgressStandardSubject: cfg.OutgressStandardSubject,
+		KeyspaceDB:              0,
+		Log:                     log,
+	})
+	go timers.StartExpiryWatcher(ctx)
+	return timers
 }
 
 // newConsumer builds the one autoscaling consumer that drains the premium and

--- a/app/sesame/modules/live.go
+++ b/app/sesame/modules/live.go
@@ -47,6 +47,10 @@ func Live(d engine.Deps) module.Module {
 			if err := d.Greet.ResetGreets(wctx, id); err != nil {
 				log.Warn("live: failed to reset greets", zap.Uint64("broadcaster_id", id), zap.Error(err))
 			}
+			// New session: every repeating timer starts its countdown fresh.
+			if d.Timers != nil {
+				d.Timers.ArmAll(wctx, id)
+			}
 		}()
 		
 		emit(&module.Output{
@@ -66,6 +70,11 @@ func Live(d engine.Deps) module.Module {
 			defer cancel()
 			if err := d.Live.ClearLive(wctx, id); err != nil {
 				log.Warn("live: failed to clear live", zap.Uint64("broadcaster_id", id), zap.Error(err))
+			}
+			// Stream ended: stop every repeating timer immediately rather than
+			// waiting out its longest-running interval.
+			if d.Timers != nil {
+				d.Timers.DisarmAll(wctx, id)
 			}
 		}()
 		log.Debug("stream offline", zap.Uint64("broadcaster_id", id))

--- a/console/dashboard/src/lib/components/timers/TimerEditor.svelte
+++ b/console/dashboard/src/lib/components/timers/TimerEditor.svelte
@@ -1,0 +1,112 @@
+<script lang="ts">
+  // Inline timer editor (create + edit share it), rendered in the page's
+  // docked inspector — the same surface as the reward/command editors. The
+  // whole draft travels as one JSON field; the server validates and
+  // normalizes it.
+  import { enhance } from '$app/forms';
+  import type { SubmitFunction } from '@sveltejs/kit';
+  import { Icon, getI18n, type TimerDef } from '@bagel/shared';
+  import CheckButton from '$lib/components/CheckButton.svelte';
+
+  let {
+    draft = $bindable<TimerDef>(),
+    isNew,
+    busy = false,
+    onCancel,
+    onSubmit
+  }: {
+    draft: TimerDef;
+    isNew: boolean;
+    busy?: boolean;
+    onCancel: () => void;
+    onSubmit: SubmitFunction;
+  } = $props();
+
+  const { t } = getI18n();
+
+  // The wire value is whole seconds; the field reads/writes whole minutes so
+  // "every 10" reads naturally instead of "every 600".
+  let minutes = $state(Math.max(1, Math.round(draft.intervalSeconds / 60)));
+  $effect(() => {
+    draft.intervalSeconds = minutes * 60;
+  });
+
+  const payload = $derived(JSON.stringify(draft));
+</script>
+
+<form method="POST" action={isNew ? '?/create' : '?/update'} class="editor" novalidate use:enhance={onSubmit}>
+  <input type="hidden" name="timer" value={payload} />
+
+  <label class="field">
+    <span>{t('timers.fieldMessage')}</span>
+    <textarea
+      class="search msg-area"
+      placeholder={t('timers.fieldMessagePh')}
+      maxlength="500"
+      required
+      rows="3"
+      bind:value={draft.message}
+    ></textarea>
+  </label>
+
+  <label class="field">
+    <span>{t('timers.fieldInterval')}</span>
+    <div class="interval-row">
+      <input class="search num" type="number" min="1" max="1440" bind:value={minutes} />
+      <span class="unit">{t('timers.unitMinutes')}</span>
+    </div>
+    <small>{t('timers.fieldIntervalHint')}</small>
+  </label>
+
+  <div class="check">
+    <CheckButton bind:checked={draft.enabled} label={t('timers.active')} />
+  </div>
+
+  <div class="actions">
+    <button type="button" class="btn ghost" onclick={onCancel} disabled={busy}>{t('common.cancel')}</button>
+    <button type="submit" class="btn primary" disabled={busy || !draft.message.trim()}>
+      <Icon name="check" size={14} />
+      {busy ? t('timers.saving') : isNew ? t('timers.create') : t('timers.saveChanges')}
+    </button>
+  </div>
+</form>
+
+<style>
+  .editor { padding: 4px 2px 2px; }
+
+  .field { display: flex; flex-direction: column; gap: 6px; margin-bottom: 14px; }
+  .field > span {
+    font-family: var(--bb-font-body);
+    font-size: 12.5px;
+    color: var(--bb-muted);
+    letter-spacing: 0.01em;
+  }
+  .field small { color: var(--bb-muted); opacity: 0.7; font-size: 11px; }
+  .field :global(.search) { width: 100%; box-sizing: border-box; }
+
+  .msg-area {
+    font-family: var(--bb-font-body);
+    font-size: 13.5px;
+    resize: vertical;
+    min-height: 64px;
+    padding: 9px 11px;
+    border: 1px solid var(--bb-border);
+    border-radius: 8px;
+    background: rgba(0, 0, 0, 0.35);
+    color: var(--bb-white);
+  }
+
+  .interval-row { display: flex; align-items: center; gap: 10px; }
+  .interval-row .num { width: 100px; flex: none; }
+  .unit { font-family: var(--bb-font-body); font-size: 13px; color: var(--bb-muted); }
+
+  .check { margin: 4px 0 14px; }
+  .check :global(.cb) { align-items: center; }
+
+  .actions { display: flex; gap: 10px; justify-content: flex-end; margin-top: 6px; }
+
+  @media (max-width: 480px) {
+    .actions { flex-direction: column-reverse; }
+    .actions .btn { width: 100%; justify-content: center; min-height: 44px; }
+  }
+</style>

--- a/console/dashboard/src/lib/components/timers/TimerRow.svelte
+++ b/console/dashboard/src/lib/components/timers/TimerRow.svelte
@@ -2,7 +2,8 @@
   // One ledger line in the timers deck. Selecting a row loads it into the
   // page's inspector pane; the row itself owns only the quick actions
   // (pause/resume toggle, delete) — the page passes the enhance handlers so
-  // all optimistic-UI state lives in one place. Mirrors RewardRow.
+  // all optimistic-UI state lives in one place. Mirrors CommandRow/RewardRow:
+  // idx | message | interval (mono meta) | actions.
   import { enhance } from '$app/forms';
   import type { SubmitFunction } from '@sveltejs/kit';
   import { Icon, getI18n, type TimerDef } from '@bagel/shared';
@@ -32,9 +33,10 @@
   // treats an update as authoritative, so nothing else changes.
   const togglePayload = $derived(JSON.stringify({ ...r, enabled: !r.enabled }));
 
-  // formatInterval renders whole hours/minutes cleanly and falls back to raw
-  // seconds only for the (dashboard-disallowed but defensively handled) case
-  // of a value that isn't a whole minute.
+  // formatInterval renders whole hours/minutes cleanly, mirroring the bare
+  // tabular values the sibling rows show (a command's cooldown, a reward's
+  // cost). Falls back to raw seconds only for a non-whole-minute value the
+  // dashboard normally disallows.
   function formatInterval(seconds: number): string {
     if (seconds > 0 && seconds % 3600 === 0) return `${seconds / 3600}h`;
     if (seconds > 0 && seconds % 60 === 0) return `${seconds / 60}m`;
@@ -55,14 +57,13 @@
     {#if idx}<span class="idx" aria-hidden="true">{idx}</span>{/if}
 
     <span class="msg">
-      <span class="msg-text">
-        <span class="swatch"><Icon name="clock" size={11} /></span>
-        {r.message}
-        {#if !r.enabled}<span class="hidden-tag">{t('timers.hiddenTag')}</span>{/if}
-      </span>
-      <span class="tags">
-        <span class="tag">{t('timers.chipInterval', { n: formatInterval(r.intervalSeconds) })}</span>
-      </span>
+      <span class="swatch"><Icon name="clock" size={11} /></span>
+      <span class="msg-text">{r.message}</span>
+      {#if !r.enabled}<span class="hidden-tag">{t('timers.hiddenTag')}</span>{/if}
+    </span>
+
+    <span class="meta" title={t('timers.fieldInterval')}>
+      <span class="interval">{formatInterval(r.intervalSeconds)}</span>
     </span>
 
     <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
@@ -80,7 +81,7 @@
 
 <style>
   /* Ledger line: hairline baselines, index number, selection keyed by a faint
-     tan tint — matches RewardRow/CommandRow. */
+     tan tint — matches CommandRow/RewardRow. */
   .row-shell {
     border-bottom: 1px solid var(--rule, rgba(240, 236, 228, 0.08));
     transition: background var(--bb-dur-fast, 140ms) ease;
@@ -90,7 +91,7 @@
 
   .trow {
     display: grid;
-    grid-template-columns: 28px minmax(0, 1fr) auto;
+    grid-template-columns: 28px minmax(0, 1fr) auto auto;
     align-items: center;
     gap: 14px;
     padding: 12px 14px;
@@ -103,18 +104,18 @@
   .idx { font-family: var(--bb-font-mono); font-size: 10px; color: var(--bb-muted); opacity: 0.55; }
   .row-shell.selected .idx { color: var(--bb-tan); opacity: 1; }
 
-  .msg { display: flex; flex-direction: column; gap: 4px; min-width: 0; }
+  /* Primary content: the message, worn like the reward-name slot (leading
+     chip + text + optional state tag). */
+  .msg { display: inline-flex; align-items: center; gap: 8px; min-width: 0; }
   .msg-text {
-    display: inline-flex;
-    align-items: center;
-    gap: 8px;
     font-family: var(--bb-font-body);
+    font-weight: 600;
     font-size: 13.5px;
     color: var(--bb-white);
-    min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    min-width: 0;
   }
 
   .swatch {
@@ -132,6 +133,7 @@
   .swatch :global(svg) { stroke-width: 1.8; }
 
   .hidden-tag {
+    flex: none;
     font-family: var(--bb-font-display);
     font-weight: 700;
     font-size: 9.5px;
@@ -141,18 +143,17 @@
     border: 1px solid var(--rule, rgba(240, 236, 228, 0.1));
     border-radius: var(--bb-radius-pill, 100px);
     padding: 1px 8px;
-    flex: none;
   }
 
-  .tags { display: flex; flex-wrap: wrap; gap: 4px; }
-  .tag {
+  /* Right meta column: the repeat interval, a bare tabular value like a
+     command's cooldown or a reward's cost. */
+  .meta { display: inline-flex; align-items: center; justify-content: flex-end; }
+  .interval {
     font-family: var(--bb-font-mono);
-    font-size: 10px;
-    color: var(--bb-muted);
-    border: 1px solid var(--rule, rgba(240, 236, 228, 0.1));
-    border-radius: 8px;
-    padding: 1px 6px;
+    font-size: 13.5px;
+    color: var(--bb-tan-light);
     white-space: nowrap;
+    font-variant-numeric: tabular-nums;
   }
 
   .row-act { display: inline-flex; align-items: center; gap: 6px; }
@@ -162,12 +163,12 @@
       grid-template-columns: minmax(0, 1fr) auto;
       grid-template-areas:
         'msg act'
-        'msg act';
+        'meta act';
       row-gap: 4px;
     }
     .idx { display: none; }
     .msg { grid-area: msg; }
-    .msg-text { white-space: normal; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; }
+    .meta { grid-area: meta; justify-content: flex-start; padding-left: 28px; }
     .row-act { grid-area: act; flex-direction: column; gap: 4px; }
     .row-act form { display: flex; align-items: center; justify-content: center; min-width: 44px; min-height: 44px; }
     .mini { min-width: 44px; min-height: 44px; }

--- a/console/dashboard/src/lib/components/timers/TimerRow.svelte
+++ b/console/dashboard/src/lib/components/timers/TimerRow.svelte
@@ -1,0 +1,175 @@
+<script lang="ts">
+  // One ledger line in the timers deck. Selecting a row loads it into the
+  // page's inspector pane; the row itself owns only the quick actions
+  // (pause/resume toggle, delete) — the page passes the enhance handlers so
+  // all optimistic-UI state lives in one place. Mirrors RewardRow.
+  import { enhance } from '$app/forms';
+  import type { SubmitFunction } from '@sveltejs/kit';
+  import { Icon, getI18n, type TimerDef } from '@bagel/shared';
+
+  const { t } = getI18n();
+
+  let {
+    timer,
+    index = undefined as number | undefined,
+    expanded = false,
+    onExpand,
+    onDelete,
+    toggleSubmit
+  }: {
+    timer: TimerDef;
+    index?: number;
+    expanded?: boolean;
+    onExpand: () => void;
+    onDelete: () => void;
+    toggleSubmit: SubmitFunction;
+  } = $props();
+
+  const r = $derived(timer);
+  const idx = $derived(index !== undefined ? String(index).padStart(2, '0') : '');
+
+  // The quick toggle posts the full timer with enabled flipped; the server
+  // treats an update as authoritative, so nothing else changes.
+  const togglePayload = $derived(JSON.stringify({ ...r, enabled: !r.enabled }));
+
+  // formatInterval renders whole hours/minutes cleanly and falls back to raw
+  // seconds only for the (dashboard-disallowed but defensively handled) case
+  // of a value that isn't a whole minute.
+  function formatInterval(seconds: number): string {
+    if (seconds > 0 && seconds % 3600 === 0) return `${seconds / 3600}h`;
+    if (seconds > 0 && seconds % 60 === 0) return `${seconds / 60}m`;
+    return `${seconds}s`;
+  }
+
+  function rowKey(e: KeyboardEvent) {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      onExpand();
+    }
+  }
+</script>
+
+<div class="row-shell reveal {expanded ? 'selected' : ''} {r.enabled ? '' : 'off'}" style="--i: {(index ?? 1) - 1}">
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <div class="trow" role="button" tabindex="0" aria-pressed={expanded} onclick={onExpand} onkeydown={rowKey}>
+    {#if idx}<span class="idx" aria-hidden="true">{idx}</span>{/if}
+
+    <span class="msg">
+      <span class="msg-text">
+        <span class="swatch"><Icon name="clock" size={11} /></span>
+        {r.message}
+        {#if !r.enabled}<span class="hidden-tag">{t('timers.hiddenTag')}</span>{/if}
+      </span>
+      <span class="tags">
+        <span class="tag">{t('timers.chipInterval', { n: formatInterval(r.intervalSeconds) })}</span>
+      </span>
+    </span>
+
+    <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+    <span class="row-act" onclick={(e) => e.stopPropagation()}>
+      <form method="POST" action="?/update" use:enhance={toggleSubmit}>
+        <input type="hidden" name="timer" value={togglePayload} />
+        <button class="toggle {r.enabled ? 'on' : ''}" type="submit" aria-label={t('timers.toggleAria')}></button>
+      </form>
+      <button class="mini" type="button" aria-label={t('timers.deleteAria')} onclick={onDelete}>
+        <Icon name="trash" size={15} />
+      </button>
+    </span>
+  </div>
+</div>
+
+<style>
+  /* Ledger line: hairline baselines, index number, selection keyed by a faint
+     tan tint — matches RewardRow/CommandRow. */
+  .row-shell {
+    border-bottom: 1px solid var(--rule, rgba(240, 236, 228, 0.08));
+    transition: background var(--bb-dur-fast, 140ms) ease;
+  }
+  .row-shell.selected { background: rgba(201, 168, 124, 0.05); }
+  .row-shell.off .trow > :not(.row-act) { opacity: 0.5; }
+
+  .trow {
+    display: grid;
+    grid-template-columns: 28px minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 14px;
+    padding: 12px 14px;
+    cursor: pointer;
+    user-select: none;
+  }
+  .trow:hover { background: rgba(201, 168, 124, 0.045); }
+  .trow:focus-visible { outline: 1px solid var(--bb-tan, #c9a87c); outline-offset: -1px; }
+
+  .idx { font-family: var(--bb-font-mono); font-size: 10px; color: var(--bb-muted); opacity: 0.55; }
+  .row-shell.selected .idx { color: var(--bb-tan); opacity: 1; }
+
+  .msg { display: flex; flex-direction: column; gap: 4px; min-width: 0; }
+  .msg-text {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-family: var(--bb-font-body);
+    font-size: 13.5px;
+    color: var(--bb-white);
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .swatch {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 20px;
+    height: 20px;
+    flex: none;
+    border-radius: 6px;
+    background: color-mix(in srgb, var(--bb-tan, #c9a87c) 24%, transparent);
+    border: 1px solid color-mix(in srgb, var(--bb-tan, #c9a87c) 55%, transparent);
+    color: color-mix(in srgb, var(--bb-tan, #c9a87c) 75%, white);
+  }
+  .swatch :global(svg) { stroke-width: 1.8; }
+
+  .hidden-tag {
+    font-family: var(--bb-font-display);
+    font-weight: 700;
+    font-size: 9.5px;
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+    color: var(--bb-muted);
+    border: 1px solid var(--rule, rgba(240, 236, 228, 0.1));
+    border-radius: var(--bb-radius-pill, 100px);
+    padding: 1px 8px;
+    flex: none;
+  }
+
+  .tags { display: flex; flex-wrap: wrap; gap: 4px; }
+  .tag {
+    font-family: var(--bb-font-mono);
+    font-size: 10px;
+    color: var(--bb-muted);
+    border: 1px solid var(--rule, rgba(240, 236, 228, 0.1));
+    border-radius: 8px;
+    padding: 1px 6px;
+    white-space: nowrap;
+  }
+
+  .row-act { display: inline-flex; align-items: center; gap: 6px; }
+
+  @media (max-width: 760px) {
+    .trow {
+      grid-template-columns: minmax(0, 1fr) auto;
+      grid-template-areas:
+        'msg act'
+        'msg act';
+      row-gap: 4px;
+    }
+    .idx { display: none; }
+    .msg { grid-area: msg; }
+    .msg-text { white-space: normal; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; }
+    .row-act { grid-area: act; flex-direction: column; gap: 4px; }
+    .row-act form { display: flex; align-items: center; justify-content: center; min-width: 44px; min-height: 44px; }
+    .mini { min-width: 44px; min-height: 44px; }
+  }
+</style>

--- a/console/dashboard/src/lib/server/timers-store.ts
+++ b/console/dashboard/src/lib/server/timers-store.ts
@@ -1,0 +1,67 @@
+// Timers store: a broadcaster's repeating chat messages, stream-only.
+//
+// Unlike channel points there is no external Twitch entity to CRUD — the
+// "timers" module blob (the same modules service every other feature uses) is
+// the sole source of truth. sesame arms every enabled timer on stream.online,
+// disarms them on stream.offline, and fires each off its own Valkey key expiry
+// (app/sesame/engine/timers_valkey.go), re-reading this same blob every cycle.
+import { randomUUID } from 'node:crypto';
+import type { TimerDef } from '@bagel/shared';
+import { listModules, upsertModule } from './commands-store';
+
+const TIMERS_MODULE = 'timers';
+
+export interface TimersView {
+  enabled: boolean;
+  timers: TimerDef[];
+}
+
+export type TimerResult = { ok: true; timer?: TimerDef } | { ok: false; error?: string };
+
+// readTimers loads the current blob (enable flag + timer records).
+export async function readTimers(userId: string): Promise<TimersView> {
+  const rows = await listModules(userId);
+  const row = rows.find((r) => r.name === TIMERS_MODULE);
+  const enabled = row ? row.is_enabled : false;
+  const configs = (row?.configs ?? {}) as { timers?: TimerDef[] };
+  return { enabled, timers: Array.isArray(configs.timers) ? configs.timers : [] };
+}
+
+async function writeTimers(userId: string, enabled: boolean, timers: TimerDef[]): Promise<void> {
+  await upsertModule(userId, TIMERS_MODULE, enabled, timers.length ? { timers } : {});
+}
+
+export async function createTimer(userId: string, draft: TimerDef): Promise<TimerResult> {
+  const created: TimerDef = { ...draft, id: draft.id || randomUUID() };
+  const cur = await readTimers(userId);
+  // Adding the first timer turns the module on; later adds preserve whatever
+  // enable state the broadcaster set.
+  const enabled = cur.timers.length === 0 ? true : cur.enabled;
+  await writeTimers(userId, enabled, [...cur.timers, created]);
+  return { ok: true, timer: created };
+}
+
+export async function updateTimer(userId: string, draft: TimerDef): Promise<TimerResult> {
+  if (!draft.id) return { ok: false, error: 'missing timer id' };
+  const cur = await readTimers(userId);
+  const timers = cur.timers.map((t) => (t.id === draft.id ? draft : t));
+  await writeTimers(userId, cur.enabled, timers);
+  return { ok: true, timer: draft };
+}
+
+export async function deleteTimer(userId: string, timerId: string): Promise<TimerResult> {
+  const cur = await readTimers(userId);
+  await writeTimers(
+    userId,
+    cur.enabled,
+    cur.timers.filter((t) => t.id !== timerId)
+  );
+  return { ok: true };
+}
+
+// setTimersEnabled flips the whole module on/off (whether sesame arms any
+// timer at all) without touching the timers themselves.
+export async function setTimersEnabled(userId: string, enabled: boolean): Promise<void> {
+  const cur = await readTimers(userId);
+  await writeTimers(userId, enabled, cur.timers);
+}

--- a/console/dashboard/src/routes/(app)/+layout.svelte
+++ b/console/dashboard/src/routes/(app)/+layout.svelte
@@ -63,11 +63,13 @@
         ? 'modules'
         : path.startsWith('/channelpoints')
           ? 'channelpoints'
-          : path.startsWith('/billing')
-            ? 'billing'
-            : path.startsWith('/settings') || path.startsWith('/access')
-              ? 'settings'
-              : 'overview'
+          : path.startsWith('/timers')
+            ? 'timers'
+            : path.startsWith('/billing')
+              ? 'billing'
+              : path.startsWith('/settings') || path.startsWith('/access')
+                ? 'settings'
+                : 'overview'
   );
   const crumb = $derived(t(`nav.${section}`));
 
@@ -77,6 +79,7 @@
   const canCommands = $derived(!isDelegate || sections.includes('commands'));
   const canModules = $derived(!isDelegate || sections.includes('modules'));
   const canChannelPoints = $derived(!isDelegate || sections.includes('channelpoints'));
+  const canTimers = $derived(!isDelegate || sections.includes('timers'));
   // Billing is owner-only except for a delegate explicitly granted it (view-only).
   const canBilling = $derived(!isDelegate || sections.includes('billing'));
 
@@ -95,6 +98,7 @@
     ...(canChannelPoints
       ? [{ href: '/channelpoints', icon: 'gem', label: t('nav.channelpoints'), active: section === 'channelpoints' }]
       : []),
+    ...(canTimers ? [{ href: '/timers', icon: 'clock', label: t('nav.timers'), active: section === 'timers' }] : []),
     ...(canBilling
       ? [{ href: '/billing', icon: 'card', label: t('nav.billing'), active: section === 'billing' }]
       : []),

--- a/console/dashboard/src/routes/(app)/settings/+page.server.ts
+++ b/console/dashboard/src/routes/(app)/settings/+page.server.ts
@@ -21,7 +21,7 @@ import { env } from '$env/dynamic/private';
 
 // Dashboard sections an owner can delegate. Billing is view-only for a delegate
 // (the money actions stay owner-only — see billing/+page.server.ts).
-const SECTIONS = ['commands', 'modules', 'channelpoints', 'billing'] as const;
+const SECTIONS = ['commands', 'modules', 'channelpoints', 'timers', 'billing'] as const;
 
 function tokenLabel(token: string): string {
   return token.length <= 8 ? 'token=redacted' : `token=${token.slice(0, 8)}...`;

--- a/console/dashboard/src/routes/(app)/settings/+page.svelte
+++ b/console/dashboard/src/routes/(app)/settings/+page.svelte
@@ -26,13 +26,17 @@
   const origin = $derived(page.url.origin);
 
   // Sections an owner can grant (from the server so it stays in one place).
-  const grantable = $derived((data.grantableSections ?? ['commands', 'modules', 'channelpoints', 'billing']) as string[]);
+  const grantable = $derived(
+    (data.grantableSections ?? ['commands', 'modules', 'channelpoints', 'timers', 'billing']) as string[]
+  );
   function sectionLabel(sec: string): string {
     switch (sec) {
       case 'modules':
         return t('settings.modules');
       case 'channelpoints':
         return t('nav.channelpoints');
+      case 'timers':
+        return t('nav.timers');
       case 'billing':
         return t('settings.billing');
       default:

--- a/console/dashboard/src/routes/(app)/timers/+page.server.ts
+++ b/console/dashboard/src/routes/(app)/timers/+page.server.ts
@@ -1,0 +1,162 @@
+import type { Actions, PageServerLoad } from './$types';
+import type { TimerDef } from '@bagel/shared';
+import { blankTimer } from '@bagel/shared';
+import {
+  readTimers,
+  createTimer,
+  updateTimer,
+  deleteTimer,
+  setTimersEnabled,
+  type TimerResult
+} from '$lib/server/timers-store';
+import { auditDashboardImpersonation } from '$lib/server/services';
+import type { Session } from '$lib/server/session';
+import { env } from '$env/dynamic/private';
+import { fail, redirect } from '@sveltejs/kit';
+
+function effectiveId(session: Session | null | undefined): string {
+  return session?.delegate_of ?? session?.user_id ?? 'demo';
+}
+
+// A delegate needs the 'timers' section; a normal login always may.
+function gate(session: Session | null | undefined): void {
+  if (session?.delegate_of && !(session.sections ?? []).includes('timers')) {
+    throw redirect(302, '/');
+  }
+}
+
+// Demo timers so the tab renders without a live backend.
+function demoTimers(): TimerDef[] {
+  return [
+    { ...blankTimer(), id: 'demo-1', message: 'Follow on socials: twitch.tv/yourchannel', intervalSeconds: 900 },
+    { ...blankTimer(), id: 'demo-2', message: '!discord for the community server', intervalSeconds: 1800 }
+  ];
+}
+
+export const load: PageServerLoad = async ({ locals }) => {
+  gate(locals.session);
+  const uid = effectiveId(locals.session);
+  if (env.DEMO === '1') return { enabled: true, timers: demoTimers() };
+  try {
+    const view = await readTimers(uid);
+    return { enabled: view.enabled, timers: view.timers };
+  } catch {
+    return { enabled: false, timers: [] as TimerDef[], degraded: true };
+  }
+};
+
+// clampInt coerces a form value into a bounded integer.
+function clampInt(raw: unknown, min: number, max: number, dflt: number): number {
+  const n = Math.trunc(Number(raw));
+  if (!Number.isFinite(n)) return dflt;
+  return Math.min(max, Math.max(min, n));
+}
+
+// parseTimer validates and normalizes the posted timer JSON into a full
+// TimerDef. Returns null on anything malformed. The interval is clamped to
+// 60s-24h here; sesame floors it again defensively at arm time.
+function parseTimer(raw: string): TimerDef | null {
+  let obj: Partial<TimerDef>;
+  try {
+    obj = JSON.parse(raw) as Partial<TimerDef>;
+  } catch {
+    return null;
+  }
+  const message = String(obj.message ?? '').trim();
+  if (!message || message.length > 500) return null;
+
+  return {
+    id: String(obj.id ?? ''),
+    message,
+    intervalSeconds: clampInt(obj.intervalSeconds, 60, 86_400, 600),
+    enabled: obj.enabled !== false
+  };
+}
+
+export const actions: Actions = {
+  create: async ({ request, locals }) => {
+    gate(locals.session);
+    const uid = effectiveId(locals.session);
+    if (env.DEMO !== '1' && !locals.session) return fail(401, { ok: false, error: 'Not signed in.' });
+
+    const f = await request.formData();
+    const draft = parseTimer(String(f.get('timer') ?? ''));
+    if (!draft) return fail(400, { ok: false, error: 'Invalid timer.' });
+    if (env.DEMO === '1') return { ok: true };
+
+    let res: TimerResult;
+    try {
+      res = await createTimer(uid, draft);
+    } catch (e) {
+      console.error('[timers] create failed:', e instanceof Error ? (e.stack ?? e.message) : e);
+      return fail(400, { ok: false, error: 'create failed' });
+    }
+    if (!res.ok) return fail(400, { ok: false, error: res.error ?? 'failed' });
+    auditDashboardImpersonation(locals.session, 'timers:create', draft.message);
+    return { ok: true };
+  },
+
+  update: async ({ request, locals }) => {
+    gate(locals.session);
+    const uid = effectiveId(locals.session);
+    if (env.DEMO !== '1' && !locals.session) return fail(401, { ok: false, error: 'Not signed in.' });
+
+    const f = await request.formData();
+    const draft = parseTimer(String(f.get('timer') ?? ''));
+    if (!draft || !draft.id) return fail(400, { ok: false, error: 'Invalid timer.' });
+    if (env.DEMO === '1') return { ok: true };
+
+    let res: TimerResult;
+    try {
+      res = await updateTimer(uid, draft);
+    } catch (e) {
+      console.error('[timers] update failed:', e instanceof Error ? (e.stack ?? e.message) : e);
+      return fail(400, { ok: false, error: 'update failed' });
+    }
+    if (!res.ok) return fail(400, { ok: false, error: res.error ?? 'failed' });
+    auditDashboardImpersonation(locals.session, 'timers:update', draft.message);
+    return { ok: true };
+  },
+
+  delete: async ({ request, locals }) => {
+    gate(locals.session);
+    const uid = effectiveId(locals.session);
+    if (env.DEMO !== '1' && !locals.session) return fail(401, { ok: false, error: 'Not signed in.' });
+
+    const f = await request.formData();
+    const id = String(f.get('id') ?? '');
+    if (!id) return fail(400, { ok: false, error: 'Missing timer id.' });
+    if (env.DEMO === '1') return { ok: true };
+
+    let res: TimerResult;
+    try {
+      res = await deleteTimer(uid, id);
+    } catch (e) {
+      console.error('[timers] delete failed:', e instanceof Error ? (e.stack ?? e.message) : e);
+      return fail(400, { ok: false, error: 'delete failed' });
+    }
+    if (!res.ok) return fail(400, { ok: false, error: res.error ?? 'failed' });
+    auditDashboardImpersonation(locals.session, 'timers:delete', id);
+    return { ok: true };
+  },
+
+  // Master on/off for whether sesame arms any timer at all.
+  toggle: async ({ request, locals }) => {
+    gate(locals.session);
+    const uid = effectiveId(locals.session);
+    if (env.DEMO !== '1' && !locals.session) return fail(401, { ok: false, error: 'Not signed in.' });
+
+    const f = await request.formData();
+    const enabled = f.get('is_enabled') === 'on';
+    if (env.DEMO === '1') return { ok: true, enabled };
+
+    try {
+      await setTimersEnabled(uid, enabled);
+    } catch (e) {
+      console.error('[timers] toggle failed:', e instanceof Error ? (e.stack ?? e.message) : e);
+      return fail(400, { ok: false });
+    }
+    auditDashboardImpersonation(locals.session, 'timers:toggle', String(enabled));
+    return { ok: true, enabled };
+  }
+};

--- a/console/dashboard/src/routes/(app)/timers/+page.svelte
+++ b/console/dashboard/src/routes/(app)/timers/+page.svelte
@@ -259,9 +259,9 @@
     font-size: 13px;
   }
 
-  /* Master switch, worn like a toolbar control. */
-  .toolbar { display: flex; align-items: center; gap: 14px; margin-bottom: 16px; }
-  .grow { flex: 1; }
+  /* Master switch, worn like a toolbar control. The .toolbar/.grow layout is
+     the shared app.css rule (matches commands/channelpoints); only the master
+     block is page-local. */
   .master { display: inline-flex; align-items: center; gap: 12px; }
   .master-text { display: flex; flex-direction: column; gap: 1px; min-width: 0; }
   .master-label {

--- a/console/dashboard/src/routes/(app)/timers/+page.svelte
+++ b/console/dashboard/src/routes/(app)/timers/+page.svelte
@@ -1,0 +1,386 @@
+<script lang="ts">
+  import { enhance } from '$app/forms';
+  import { invalidateAll } from '$app/navigation';
+  import type { SubmitFunction } from '@sveltejs/kit';
+  import { Icon, Card, PageHead, Scroller, ConfirmDialog, toast, getI18n, blankTimer, type TimerDef } from '@bagel/shared';
+  import TimerRow from '$lib/components/timers/TimerRow.svelte';
+  import TimerEditor from '$lib/components/timers/TimerEditor.svelte';
+
+  let { data } = $props();
+  const { t } = getI18n();
+
+  // Local source of truth, reseeded when a fresh SSR load lands (the /events
+  // invalidation stream re-runs the loader after every confirmed write).
+  // svelte-ignore state_referenced_locally
+  let timers = $state<TimerDef[]>(data.timers ?? []);
+  // svelte-ignore state_referenced_locally
+  let enabled = $state<boolean>(data.enabled ?? false);
+  // svelte-ignore state_referenced_locally
+  let seed = data;
+  $effect(() => {
+    if (data !== seed) {
+      seed = data;
+      timers = data.timers ?? [];
+      enabled = data.enabled ?? false;
+    }
+  });
+
+  const rows = $derived(timers.toSorted((a, b) => a.intervalSeconds - b.intervalSeconds));
+
+  // --- Inspector -------------------------------------------------------------
+  const NEW = '__new__';
+  let expanded = $state<string | null>(null);
+  let editorDraft = $state<TimerDef | null>(null);
+  let busy = $state(false);
+
+  function openNew() {
+    editorDraft = blankTimer();
+    expanded = NEW;
+  }
+  function openEdit(tmr: TimerDef) {
+    if (expanded === tmr.id) {
+      closeEditor();
+      return;
+    }
+    editorDraft = { ...tmr };
+    expanded = tmr.id;
+  }
+  function closeEditor() {
+    expanded = null;
+    editorDraft = null;
+  }
+
+  type ActionResult = { ok?: boolean; error?: string };
+
+  function payloadOf(result: unknown): ActionResult | undefined {
+    const r = result as { type: string; data?: ActionResult };
+    return r.type === 'success' || r.type === 'failure' ? r.data : undefined;
+  }
+
+  function failed(payload: ActionResult | undefined, fallbackKey: string) {
+    toast('err', payload?.error ?? t(fallbackKey));
+  }
+
+  // --- Save (create or update from the inspector) -----------------------------
+  const saveSubmit: SubmitFunction = () => {
+    const d = editorDraft;
+    if (!d) return;
+    const creating = expanded === NEW;
+    busy = true;
+    return async ({ result }) => {
+      busy = false;
+      const payload = payloadOf(result);
+      if (result.type === 'success' && payload?.ok) {
+        toast('ok', t(creating ? 'timers.toastCreated' : 'timers.toastSaved'));
+        closeEditor();
+        await invalidateAll();
+        return;
+      }
+      failed(payload, 'timers.toastSaveFailed');
+    };
+  };
+
+  // --- Row quick toggle (pause/resume, optimistic) ----------------------------
+  const toggleSubmit =
+    (tmr: TimerDef): SubmitFunction =>
+    () => {
+      const was = tmr.enabled;
+      timers = timers.map((x) => (x.id === tmr.id ? { ...x, enabled: !was } : x));
+      return async ({ result }) => {
+        const payload = payloadOf(result);
+        if (result.type === 'success' && payload?.ok) return;
+        timers = timers.map((x) => (x.id === tmr.id ? { ...x, enabled: was } : x));
+        failed(payload, 'timers.toastToggleFailed');
+      };
+    };
+
+  // --- Master toggle (whether any timer arms at all, optimistic) --------------
+  const masterSubmit: SubmitFunction = () => {
+    const was = enabled;
+    enabled = !was;
+    return async ({ result }) => {
+      if (result.type !== 'success') {
+        enabled = was;
+        toast('err', t('timers.toastToggleFailed'));
+      }
+    };
+  };
+
+  // --- Delete (confirm dialog) -------------------------------------------------
+  let deleteTarget = $state<TimerDef | null>(null);
+  let deleting = $state(false);
+  let deleteForm = $state<HTMLFormElement | null>(null);
+
+  const deleteSubmit: SubmitFunction = () => {
+    deleting = true;
+    return async ({ result }) => {
+      deleting = false;
+      const target = deleteTarget;
+      deleteTarget = null;
+      const payload = payloadOf(result);
+      if (result.type === 'success' && payload?.ok) {
+        if (target) {
+          timers = timers.filter((x) => x.id !== target.id);
+          if (expanded === target.id) closeEditor();
+          toast('ok', t('timers.toastDeleted'));
+        }
+        await invalidateAll();
+        return;
+      }
+      failed(payload, 'timers.toastDeleteFailed');
+    };
+  };
+
+  function onKey(e: KeyboardEvent) {
+    if (e.key === 'Escape' && editorDraft) closeEditor();
+  }
+</script>
+
+<section class="screen active">
+  <PageHead eyebrow={t('timers.eyebrow')} description={t('timers.description')}>
+    {t('timers.titlePre')}<em>{t('timers.titleEm')}</em>
+  </PageHead>
+
+  {#if data.degraded}
+    <div class="degraded" role="alert"><Icon name="ban" size={13} /> {t('timers.degraded')}</div>
+  {/if}
+
+  <div class="toolbar">
+    <form method="POST" action="?/toggle" use:enhance={masterSubmit} class="master">
+      <input type="hidden" name="is_enabled" value={enabled ? '' : 'on'} />
+      <button class="toggle {enabled ? 'on' : ''}" type="submit" aria-label={t('timers.botOn')}></button>
+      <span class="master-text">
+        <span class="master-label">{t('timers.botOn')}</span>
+        <span class="master-hint">{t('timers.botOnHint')}</span>
+      </span>
+    </form>
+    <div class="grow"></div>
+    <button class="btn primary" onclick={openNew} disabled={expanded === NEW}>
+      <Icon name="plus" size={14} /> {t('timers.newTimer')}
+    </button>
+  </div>
+
+  <!-- The deck: ledger list left, docked inspector right — same layout as
+       channelpoints/commands, so every management screen reads as one system. -->
+  <div class="deck {editorDraft ? 'inspecting' : ''}">
+    <Card style="padding:6px 0 0" class="deck-list">
+      <div class="list">
+        {#each rows as tmr, i (tmr.id)}
+          <TimerRow
+            timer={tmr}
+            index={i + 1}
+            expanded={expanded === tmr.id}
+            onExpand={() => openEdit(tmr)}
+            onDelete={() => (deleteTarget = tmr)}
+            toggleSubmit={toggleSubmit(tmr)}
+          />
+        {/each}
+        {#if rows.length === 0}
+          <div class="empty">
+            <p class="empty-title">{t('timers.emptyTitle')}</p>
+            <p class="empty-sub">{t('timers.emptySub')}</p>
+            <button class="btn primary" onclick={openNew}><Icon name="plus" size={14} /> {t('timers.newTimer')}</button>
+          </div>
+        {/if}
+      </div>
+    </Card>
+
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
+    <div
+      class="inspector-backdrop"
+      class:open={!!editorDraft}
+      role="presentation"
+      onclick={closeEditor}
+      onkeydown={(e) => {
+        if (e.key === 'Enter') closeEditor();
+      }}
+    ></div>
+    <aside class="inspector" class:open={!!editorDraft} aria-label={t('timers.inspector')}>
+      <div class="inspector-head">
+        <span class="inspector-tag">
+          {#if editorDraft}
+            {expanded === NEW ? t('timers.newTimer') : t('timers.editing')}
+          {:else}
+            {t('timers.inspector')}
+          {/if}
+        </span>
+        {#if editorDraft}
+          <button class="mini" type="button" aria-label={t('common.cancel')} onclick={closeEditor}>
+            <Icon name="x" size={14} />
+          </button>
+        {/if}
+      </div>
+      {#if editorDraft}
+        <Scroller fill padding="16px" data-lenis-prevent>
+          {#key expanded}
+            <TimerEditor bind:draft={editorDraft} isNew={expanded === NEW} {busy} onCancel={closeEditor} onSubmit={saveSubmit} />
+          {/key}
+        </Scroller>
+      {:else}
+        <div class="inspector-idle">
+          <span class="idle-glyph"><Icon name="clock" size={18} /></span>
+          <p>{t('timers.inspectorIdle')}</p>
+          <button class="btn ghost" onclick={openNew}><Icon name="plus" size={13} /> {t('timers.newTimer')}</button>
+        </div>
+      {/if}
+    </aside>
+  </div>
+</section>
+
+<svelte:window onkeydown={onKey} />
+
+<ConfirmDialog
+  open={deleteTarget !== null}
+  title={t('timers.deleteTitle')}
+  body={t('timers.deleteBody')}
+  confirmLabel={t('timers.del')}
+  cancelLabel={t('common.cancel')}
+  danger
+  busy={deleting}
+  onCancel={() => (deleteTarget = null)}
+  onConfirm={() => deleteForm?.requestSubmit()}
+/>
+<form method="POST" action="?/delete" use:enhance={deleteSubmit} bind:this={deleteForm} hidden>
+  <input type="hidden" name="id" value={deleteTarget?.id ?? ''} />
+</form>
+
+<style>
+  .degraded {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 14px;
+    padding: 10px 14px;
+    border: 1px solid rgba(176, 90, 70, 0.4);
+    border-radius: 8px;
+    background: rgba(176, 90, 70, 0.08);
+    color: #cf8a78;
+    font-family: var(--bb-font-body);
+    font-size: 13px;
+  }
+
+  /* Master switch, worn like a toolbar control. */
+  .toolbar { display: flex; align-items: center; gap: 14px; margin-bottom: 16px; }
+  .grow { flex: 1; }
+  .master { display: inline-flex; align-items: center; gap: 12px; }
+  .master-text { display: flex; flex-direction: column; gap: 1px; min-width: 0; }
+  .master-label {
+    font-family: var(--bb-font-display);
+    font-weight: 700;
+    font-size: 13px;
+    color: var(--bb-white);
+  }
+  .master-hint { font-family: var(--bb-font-body); font-size: 11.5px; color: var(--bb-muted); }
+
+  /* ── the deck: list + docked inspector (mirrors channelpoints/commands) ── */
+  .deck {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    gap: 16px;
+    align-items: start;
+  }
+  @media (min-width: 1080px) {
+    .deck.inspecting { grid-template-columns: minmax(0, 1fr) 420px; }
+    .deck { grid-template-columns: minmax(0, 1fr) 300px; }
+  }
+
+  .list :global(.row-shell:last-child) { border-bottom: none; }
+
+  .inspector {
+    position: sticky;
+    top: 62px;
+    border: 1px solid var(--rule);
+    border-top-color: var(--rule-strong);
+    border-radius: 8px;
+    background: linear-gradient(180deg, rgba(240, 236, 228, 0.03), rgba(240, 236, 228, 0.012));
+    display: flex;
+    flex-direction: column;
+    max-height: calc(100vh - 62px - 108px);
+  }
+  .inspector-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--rule);
+  }
+  .inspector-tag {
+    font-family: var(--bb-font-display);
+    font-weight: 700;
+    font-size: 12px;
+    letter-spacing: 0.02em;
+    color: var(--bb-tan);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .inspector-idle {
+    padding: 34px 20px;
+    text-align: center;
+    color: var(--bb-muted);
+    font-family: var(--bb-font-body);
+    font-size: 13px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
+  }
+  .idle-glyph {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+    border: 1px solid var(--rule-tan);
+    border-radius: 8px;
+    color: var(--bb-tan-light);
+  }
+  .inspector-idle p { margin: 0; max-width: 26ch; line-height: 1.5; }
+
+  .inspector-backdrop { display: none; }
+
+  /* Mobile / narrow: the inspector docks as a bottom sheet over the list. */
+  @media (max-width: 1079px) {
+    .inspector { display: none; }
+    .inspector.open {
+      display: flex;
+      position: fixed;
+      left: 0; right: 0; bottom: 0;
+      top: auto;
+      z-index: 220;
+      max-height: 88vh;
+      border-radius: 8px 8px 0 0;
+      background: var(--bb-bg-1, #111);
+      animation: sheet-in var(--bb-dur-base, 320ms) var(--bb-ease-out-expo, cubic-bezier(.16,1,.3,1)) both;
+    }
+    .inspector-backdrop.open {
+      display: block;
+      position: fixed; inset: 0; z-index: 219;
+      background: rgba(0, 0, 0, 0.55);
+    }
+    @keyframes sheet-in { from { transform: translateY(100%); } to { transform: translateY(0); } }
+  }
+
+  .empty {
+    padding: 34px 18px;
+    text-align: center;
+    color: var(--bb-muted);
+    font-family: var(--bb-font-body);
+    font-size: 13px;
+  }
+  .empty-title {
+    font-family: var(--bb-font-display);
+    font-weight: 700;
+    font-size: 17px;
+    color: var(--bb-white);
+    margin: 0 0 6px;
+  }
+  .empty-sub { margin: 0 auto 16px; max-width: 44ch; }
+
+  @media (max-width: 760px) {
+    .toolbar { gap: 10px; }
+    .master-hint { display: none; }
+  }
+</style>

--- a/console/shared/lib/i18n/en.ts
+++ b/console/shared/lib/i18n/en.ts
@@ -38,6 +38,7 @@ export const en = {
     commands: 'Commands',
     modules: 'Modules',
     channelpoints: 'Channel Points',
+    timers: 'Timers',
     billing: 'Billing',
     settings: 'Settings'
   },
@@ -372,6 +373,46 @@ export const en = {
     toastSaveFailed: 'Could not save the reward.',
     toastDeleteFailed: 'Could not delete the reward.',
     toastToggleFailed: 'Could not update the reward.'
+  },
+
+  timers: {
+    eyebrow: 'Manage',
+    titlePre: 'Chat ',
+    titleEm: 'timers',
+    description: 'Messages the bot repeats on a schedule while you’re live — announcements, socials, reminders.',
+    degraded: 'Timers are temporarily unavailable. Try again shortly.',
+    botOn: 'Timers active',
+    botOnHint: 'Master switch: timers only run while this is on, and only while you’re live.',
+    newTimer: 'New timer',
+    inspector: 'Timer inspector',
+    inspectorIdle: 'Select a timer to edit it here, or create a new one.',
+    editing: 'Editing timer',
+    emptyTitle: 'No timers yet',
+    emptySub: 'Create one — it starts repeating the moment your stream goes live.',
+    chipInterval: 'every {n}',
+    hiddenTag: 'paused',
+    toggleAria: 'Pause or resume this timer',
+    deleteAria: 'Delete this timer',
+    // editor
+    fieldMessage: 'Message',
+    fieldMessagePh: 'e.g. Follow on socials: {link}',
+    fieldInterval: 'Repeat every',
+    fieldIntervalHint: 'Minimum 1 minute, maximum 24 hours.',
+    unitMinutes: 'minutes',
+    active: 'Active',
+    // actions + toasts
+    create: 'Create timer',
+    saveChanges: 'Save changes',
+    saving: 'Saving…',
+    deleteTitle: 'Delete this timer?',
+    deleteBody: 'This timer stops repeating immediately. This cannot be undone.',
+    del: 'Delete',
+    toastCreated: 'Timer created.',
+    toastSaved: 'Timer saved.',
+    toastDeleted: 'Timer deleted.',
+    toastSaveFailed: 'Could not save the timer.',
+    toastDeleteFailed: 'Could not delete the timer.',
+    toastToggleFailed: 'Could not update the timer.'
   },
 
   modules: {

--- a/console/shared/lib/i18n/fr.ts
+++ b/console/shared/lib/i18n/fr.ts
@@ -37,6 +37,7 @@ export const fr = {
     commands: 'Commandes',
     modules: 'Modules',
     channelpoints: 'Points de chaîne',
+    timers: 'Minuteries',
     billing: 'Facturation',
     settings: 'Paramètres'
   },
@@ -371,6 +372,46 @@ export const fr = {
     toastSaveFailed: 'Impossible d’enregistrer la récompense.',
     toastDeleteFailed: 'Impossible de supprimer la récompense.',
     toastToggleFailed: 'Impossible de mettre à jour la récompense.'
+  },
+
+  timers: {
+    eyebrow: 'Gérer',
+    titlePre: 'Minuteries de ',
+    titleEm: 'chat',
+    description: 'Messages que le bot répète selon un intervalle pendant que vous êtes en live — annonces, réseaux sociaux, rappels.',
+    degraded: 'Les minuteries sont momentanément indisponibles. Réessayez bientôt.',
+    botOn: 'Minuteries actives',
+    botOnHint: 'Interrupteur général : les minuteries ne tournent que lorsqu’il est activé, et uniquement en live.',
+    newTimer: 'Nouvelle minuterie',
+    inspector: 'Inspecteur',
+    inspectorIdle: 'Sélectionnez une minuterie pour la modifier ici, ou créez-en une nouvelle.',
+    editing: 'Modification de la minuterie',
+    emptyTitle: 'Aucune minuterie',
+    emptySub: 'Créez-en une — elle commence à se répéter dès que votre live démarre.',
+    chipInterval: 'toutes les {n}',
+    hiddenTag: 'en pause',
+    toggleAria: 'Mettre en pause ou reprendre cette minuterie',
+    deleteAria: 'Supprimer cette minuterie',
+    // editor
+    fieldMessage: 'Message',
+    fieldMessagePh: 'ex. Suivez-moi sur les réseaux : {link}',
+    fieldInterval: 'Répéter toutes les',
+    fieldIntervalHint: 'Minimum 1 minute, maximum 24 heures.',
+    unitMinutes: 'minutes',
+    active: 'Active',
+    // actions + toasts
+    create: 'Créer la minuterie',
+    saveChanges: 'Enregistrer',
+    saving: 'Enregistrement…',
+    deleteTitle: 'Supprimer cette minuterie ?',
+    deleteBody: 'Cette minuterie cesse de se répéter immédiatement. Action irréversible.',
+    del: 'Supprimer',
+    toastCreated: 'Minuterie créée.',
+    toastSaved: 'Minuterie enregistrée.',
+    toastDeleted: 'Minuterie supprimée.',
+    toastSaveFailed: 'Impossible d’enregistrer la minuterie.',
+    toastDeleteFailed: 'Impossible de supprimer la minuterie.',
+    toastToggleFailed: 'Impossible de mettre à jour la minuterie.'
   },
 
   modules: {

--- a/console/shared/lib/types.ts
+++ b/console/shared/lib/types.ts
@@ -710,3 +710,19 @@ export function blankReward(): ChannelPointReward {
     onRedeem: 'fulfill'
   };
 }
+
+// One repeating chat message: stream-only (armed on stream.online, stopped on
+// stream.offline; see sesame's ValkeyTimerStore). No Twitch-side entity, so
+// unlike ChannelPointReward there is nothing to CRUD but this blob's own id.
+export interface TimerDef {
+  // id is a dashboard-generated id; empty only on an unsaved draft.
+  id: string;
+  message: string;
+  intervalSeconds: number;
+  enabled: boolean;
+}
+
+// blankTimer is the default draft for the "new timer" form.
+export function blankTimer(): TimerDef {
+  return { id: '', message: '', intervalSeconds: 600, enabled: true };
+}


### PR DESCRIPTION
## What

Broadcasters can configure chat messages the bot repeats on a fixed interval **while the channel is live**. Timers arm on `stream.online`, disarm on `stream.offline`.

## How

- **sesame engine** (`app/sesame/engine/timers_valkey.go`): `ValkeyTimerStore` mirrors `ValkeyLiveStore`'s key-expiry idiom. One Valkey key per enabled timer, `EX`'d to its interval; the key's expiry (not a running goroutine) is the clock. On expiry: re-check live + config → post the message → re-arm. One replica per expiry via an NX claim, same as the live re-check.
- **No DB schema change**: timers reuse the existing generic `modules` table via the `"timers"` module name (the path channelpoints already established). The config blob is `{ timers: [{ id, message, intervalSeconds, enabled }] }`.
- **Lifecycle hooks**: `app/sesame/modules/live.go` calls `ArmAll`/`DisarmAll` on the stream events it already handles → naturally stream-only, clock resets each stream.
- **Dashboard**: own Timers tab (list + docked editor, mirroring channelpoints), store, nav + delegate-section wiring, EN/FR i18n.

## Known tradeoff

No reconciliation sweep. A missed Valkey key-expiry notification (rare pub/sub reconnect window) stalls one timer until the next `stream.online`. Accepted vs. running a second polling mechanism, given the modest stakes (a scheduled chat line) and the stream-only scope — same tradeoff the existing live re-check watcher already makes.

## Verification

- `go build ./...` + `go vet ./app/sesame/...` clean
- dashboard `svelte-check`: 0 errors
- Drove the tab live in preview: create / edit / toggle / delete / nav all round-trip clean