### PR TITLE
fix(nats): import outgress channelpoints RPC into dashboard account

### DIFF
--- a/deploy/k8s/nats-auth.conf
+++ b/deploy/k8s/nats-auth.conf
@@ -341,6 +341,7 @@ accounts: {
       { service: { account: "PROJECTOR_RPC", subject: "bagel.rpc.projector.dashboard.>" } }
       { service: { account: "PROJECTOR_RPC", subject: "bagel.rpc.broadcaster.status.get" } }
       { service: { account: "OUTGRESS_RPC",  subject: "bagel.rpc.outgress.channel.get" } }
+      { service: { account: "OUTGRESS_RPC",  subject: "bagel.rpc.outgress.channelpoints.>" } }
       { service: { account: "NOTIFICATIONS_RPC", subject: "bagel.rpc.notifications.>" } }
       { service: { account: "TRANSACTIONS_RPC",  subject: "bagel.rpc.transactions.>" } }
       { stream: { account: "USERS_RPC",     subject: "bagel.cache.invalidate.grant" } }


### PR DESCRIPTION
## Problem
Creating channel-point rewards from the dashboard failed. Dashboard logs (all pods):
```
[channelpoints] create failed: NatsError: 503
```
`503` = NATS no-responders. The RPC `bagel.rpc.outgress.channelpoints.create` reached no subscriber.

## Root cause
Not a scope or affiliate issue. The outgress service subscribes the channelpoints verbs correctly (running image is at current HEAD, "outgress ready" logged), and OUTGRESS_RPC exports `bagel.rpc.outgress.>`. The gap is the **cross-account import**: NATS imports are per-subject, and `DASHBOARD_RPC` imported only `bagel.rpc.outgress.channel.get` from OUTGRESS_RPC. The `channelpoints.*` subjects were never mapped into the dashboard account, so the request never crossed the account boundary and NATS answered 503.

## Fix
Add the `bagel.rpc.outgress.channelpoints.>` import to `DASHBOARD_RPC` (least-privilege: covers list/create/update/delete). Flux-managed config, so a push hot-reloads the ACL via config-reloader SIGHUP: no NATS restart, no re-consent.