### PR TITLE
feat(dashboard): fold timers into commands delegate scope

### DIFF
--- a/console/dashboard/src/lib/server/guard.ts
+++ b/console/dashboard/src/lib/server/guard.ts
@@ -80,6 +80,8 @@ export async function guardSession(event: RequestEvent, s: Session): Promise<Ses
     // (the per-page gates remain as defense in depth).
     if (event.route.id?.startsWith('/(app)')) {
       const allowed = (s.sections ?? []).map((sec) => `/${sec}`);
+      // Timers has no standalone scope: the commands grant covers /timers too.
+      if (s.sections?.includes('commands')) allowed.push('/timers');
       const ok = allowed.some((p) => event.url.pathname === p || event.url.pathname.startsWith(p + '/'));
       if (!ok) throw redirect(303, allowed[0] ?? '/delegate/exit');
     }

--- a/console/dashboard/src/routes/(app)/+layout.svelte
+++ b/console/dashboard/src/routes/(app)/+layout.svelte
@@ -79,7 +79,8 @@
   const canCommands = $derived(!isDelegate || sections.includes('commands'));
   const canModules = $derived(!isDelegate || sections.includes('modules'));
   const canChannelPoints = $derived(!isDelegate || sections.includes('channelpoints'));
-  const canTimers = $derived(!isDelegate || sections.includes('timers'));
+  // Timers rides under the commands scope; legacy 'timers' grants still count.
+  const canTimers = $derived(!isDelegate || sections.includes('commands') || sections.includes('timers'));
   // Billing is owner-only except for a delegate explicitly granted it (view-only).
   const canBilling = $derived(!isDelegate || sections.includes('billing'));
 

--- a/console/dashboard/src/routes/(app)/settings/+page.server.ts
+++ b/console/dashboard/src/routes/(app)/settings/+page.server.ts
@@ -20,8 +20,9 @@ import { demoNotifications } from '$lib/server/demo-notifications';
 import { env } from '$env/dynamic/private';
 
 // Dashboard sections an owner can delegate. Billing is view-only for a delegate
-// (the money actions stay owner-only — see billing/+page.server.ts).
-const SECTIONS = ['commands', 'modules', 'channelpoints', 'timers', 'billing'] as const;
+// (the money actions stay owner-only — see billing/+page.server.ts). Timers has
+// no standalone scope: it rides under 'commands' (see guard.ts + timers gate).
+const SECTIONS = ['commands', 'modules', 'channelpoints', 'billing'] as const;
 
 function tokenLabel(token: string): string {
   return token.length <= 8 ? 'token=redacted' : `token=${token.slice(0, 8)}...`;

--- a/console/dashboard/src/routes/(app)/settings/+page.svelte
+++ b/console/dashboard/src/routes/(app)/settings/+page.svelte
@@ -27,7 +27,7 @@
 
   // Sections an owner can grant (from the server so it stays in one place).
   const grantable = $derived(
-    (data.grantableSections ?? ['commands', 'modules', 'channelpoints', 'timers', 'billing']) as string[]
+    (data.grantableSections ?? ['commands', 'modules', 'channelpoints', 'billing']) as string[]
   );
   function sectionLabel(sec: string): string {
     switch (sec) {

--- a/console/dashboard/src/routes/(app)/timers/+page.server.ts
+++ b/console/dashboard/src/routes/(app)/timers/+page.server.ts
@@ -18,9 +18,11 @@ function effectiveId(session: Session | null | undefined): string {
   return session?.delegate_of ?? session?.user_id ?? 'demo';
 }
 
-// A delegate needs the 'timers' section; a normal login always may.
+// Timers rides under the 'commands' scope (no standalone timers grant). Legacy
+// links minted with a bare 'timers' section still pass. A normal login always may.
 function gate(session: Session | null | undefined): void {
-  if (session?.delegate_of && !(session.sections ?? []).includes('timers')) {
+  const secs = session?.sections ?? [];
+  if (session?.delegate_of && !secs.includes('commands') && !secs.includes('timers')) {
     throw redirect(302, '/');
   }
 }


### PR DESCRIPTION
## What

Timers no longer has its own delegate permission scope. Granting a delegate the **commands** scope now also covers the **timers** page. **Channel Points** remains an independent scope.

## Changes

- **settings** (`+page.server.ts`): drop `timers` from the grantable `SECTIONS` list.
- **guard** (`guard.ts`): a delegate with `commands` is allowed the `/timers` path.
- **timers page gate** (`timers/+page.server.ts`) + **nav** (`+layout.svelte`): accept `commands`.
- **settings UI** (`+page.svelte`): timers removed from the share-link picker; `sectionLabel` keeps the timers case so legacy chips still render.

## Backward compat

Links minted with a bare `timers` section still work: guard maps it `/timers` 1:1, and both the page gate and nav still honor a literal `timers` section. No backend change (delegation RPC has no section allowlist, only requires >= 1 section).

## Verified

DEMO dashboard `/settings`: share-link picker shows Commands / Modules / Channel Points / Billing only, no Timers checkbox. Channel Points still independent.