### PR TITLE
fix(console): restore admin impersonation redemption

### DIFF
--- a/console/dashboard/src/routes/auth/impersonate/+server.ts
+++ b/console/dashboard/src/routes/auth/impersonate/+server.ts
@@ -20,13 +20,20 @@ export const GET: RequestHandler = async ({ url, cookies }) => {
   const p = verifyViewAs(token);
   if (!p) throw redirect(302, '/login?e=imp');
 
-  // Single-use gate. Fail closed when Valkey is configured but unreachable:
-  // impersonation is an admin surface, and a retry in a minute beats leaving a
-  // replayable admin-grade link in browser history. 'unconfigured' (dev, no
-  // Valkey) passes so local flows still work.
+  // Single-use gate. Only a proven replay is rejected. The jti burn is
+  // defense-in-depth behind the token's own controls (5-min TTL + single-actor
+  // Ed25519 signature), so it degrades OPEN when the Valkey write path is down:
+  // Valkey is never a hard dependency elsewhere (readyz doesn't gate it, reads
+  // fall back to RPC), and failing closed here turned a write-path blip into a
+  // total outage of an admin-only, audited surface. The residual risk is a
+  // link replayable for <=5 min only while the write path is unreachable.
+  // 'unconfigured' (dev, no Valkey) also passes so local flows work. We still
+  // tag 'unavailable' so a persistent write-path outage stays visible.
   const claim = await claimOnce(`viewas:jti:${p.jti}`, JTI_TTL_SECONDS);
   if (claim === 'replayed' || claim === 'unavailable') {
     newrelic.addCustomAttributes({ 'viewas.claim': claim, 'viewas.by': p.by_id });
+  }
+  if (claim === 'replayed') {
     throw redirect(302, '/login?e=imp');
   }
 

--- a/console/dashboard/src/routes/login/+page.svelte
+++ b/console/dashboard/src/routes/login/+page.svelte
@@ -12,7 +12,8 @@
     signedout: t('login.noticeSignedout'),
     banned: t('login.noticeBanned'),
     link: t('login.noticeLink'),
-    retry: t('login.noticeRetry')
+    retry: t('login.noticeRetry'),
+    imp: t('login.noticeImpersonation')
   };
   const notice = $derived(NOTICES[page.url.searchParams.get('e') ?? ''] ?? null);
 

--- a/console/shared/lib/i18n/en.ts
+++ b/console/shared/lib/i18n/en.ts
@@ -77,6 +77,7 @@ export const en = {
     noticeBanned: 'This account can no longer use the console.',
     noticeLink: 'That share link is no longer valid. Ask the broadcaster for a new one.',
     noticeRetry: 'Sign-in did not finish on our side. Nothing was saved. Please try again.',
+    noticeImpersonation: 'That view-as link is invalid or has already been used. Mint a new one from the admin console.',
     consent: 'I agree to the <a href="https://itsbagelbot.com/terms" target="_blank">Terms</a> and <a href="https://itsbagelbot.com/privacy" target="_blank">Privacy Policy</a>',
     back: 'Back to itsbagelbot.com'
   },

--- a/console/shared/lib/i18n/fr.ts
+++ b/console/shared/lib/i18n/fr.ts
@@ -76,6 +76,7 @@ export const fr = {
     noticeBanned: 'Ce compte ne peut plus utiliser la console.',
     noticeLink: 'Ce lien de partage n\'est plus valide. Demandez un nouveau lien au diffuseur.',
     noticeRetry: 'La connexion n\'a pas abouti. Rien n\'a été sauvegardé. Veuillez réessayer.',
+    noticeImpersonation: 'Ce lien d\'aperçu n\'est plus valide ou a déjà été utilisé. Générez-en un nouveau depuis la console d\'administration.',
     back: 'Retour à itsbagelbot.com',
     consent: 'J\'accepte les <a href="https://itsbagelbot.com/terms" target="_blank">Conditions</a> et la <a href="https://itsbagelbot.com/privacy" target="_blank">Politique de confidentialité</a>'
   },

--- a/console/shared/lib/server/rate-limit.ts
+++ b/console/shared/lib/server/rate-limit.ts
@@ -201,7 +201,11 @@ function getWriteClient(): RateLimitClient | null {
     const [host, portStr] = cfg.sentinelAddr.split(':');
     client = new Redis({
       sentinels: [{ host: host || '127.0.0.1', port: portStr ? Number(portStr) : 26379 }],
-      name: cfg.sentinelMaster ?? 'myprimary',
+      // `||` not `??`: an empty VALKEY_MASTER_SET (unset in Doppler comes
+      // through as "") must fall back to the sentinel's monitored name, not be
+      // used verbatim — a blank master name never resolves, so every write
+      // (rate-limit AND single-use claimOnce) would silently time out.
+      name: cfg.sentinelMaster || 'myprimary',
       password: cfg.password || undefined,
       // Fail fast, never queue: an unreachable master must degrade to the
       // per-pod fallback immediately, not grow an unbounded command queue.


### PR DESCRIPTION
## Problem
Admin "view as" (impersonation) links always redirected to the dashboard `/login` page. Regression from the session-hardening in `57fd601`.

## Root cause
Two compounding issues, both proven live against the cluster:

1. **Blank Sentinel master name.** `VALKEY_MASTER_SET` is an empty string (`""`) in the `dashboard-env` Doppler secret. `getWriteClient` defaulted it with `cfg.sentinelMaster ?? 'myprimary'`, but `??` does not catch `""`, so the ioredis Sentinel client was handed a blank master name and never resolved the elected master (`sentinel get-master-addr-by-name ""` returns nil; `myprimary` returns `100.95.95.9:6379`). Every write on that client timed out.
   - Fleet-wide rate limiting silently degraded to per-pod buckets (unnoticed).
   - The single-use `claimOnce` jti gate returned `'unavailable'` on every redemption.

2. **Fail-closed redemption.** `/auth/impersonate` treated `'unavailable'` as a hard reject, so the write-path outage became a total impersonation outage. The bounce went to `/login?e=imp`, which had **no** matching notice, so it rendered as a blank login page (looked like a normal logged-out redirect).

## Changes
- `rate-limit.ts`: `cfg.sentinelMaster ?? 'myprimary'` → `|| 'myprimary'` so empty/unset both fall back to the Sentinel-monitored master name.
- `auth/impersonate/+server.ts`: degrade **open** on `'unavailable'` (only a proven `'replayed'` is rejected). The jti burn stays as defense-in-depth behind the token's 5-min TTL + single-actor Ed25519 signature; Valkey is never a hard dependency elsewhere (`/readyz` does not gate it, reads fall back to RPC). Still tagged in New Relic so a persistent write-path outage is visible.
- Login page + EN/FR catalogs: add the missing `imp` notice so an invalid or already-used view-as link explains itself.

## Notes
- Optional cleanup: set `VALKEY_MASTER_SET=myprimary` in Doppler for clarity; the code fix makes it unnecessary.
- The Go `gateway` service was checked and is **not** affected: `pkg/valkey` hardcodes `MasterSet: "myprimary"` and never reads `VALKEY_MASTER_SET`.

## Verification
- `sentinel get-master-addr-by-name myprimary` resolves the master; the empty name returns nil (confirms the fix path).
- No tests covered the affected paths; catalog EN/FR parity verified.