### PR TITLE
test(batch): fix flaky TestFailedFlushRetriesWithoutClobbering

### DIFF
--- a/pkg/batch/batcher_test.go
+++ b/pkg/batch/batcher_test.go
@@ -14,21 +14,29 @@ import (
 )
 
 type recorder struct {
-	mu      sync.Mutex
-	flushes [][]int
-	fail    bool
+	mu       sync.Mutex
+	flushes  [][]int
+	attempts int
+	fail     bool
 }
 
 func (r *recorder) flush(_ context.Context, items []int) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	r.attempts++
 	if r.fail {
 		return errors.New("flush failed")
 	}
 
 	r.flushes = append(r.flushes, append([]int(nil), items...))
 	return nil
+}
+
+func (r *recorder) attemptCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.attempts
 }
 
 func (r *recorder) all() []int {
@@ -110,7 +118,15 @@ func TestFailedFlushRetriesWithoutClobbering(t *testing.T) {
 
 	b.Add("key", 1) // flushes immediately and fails
 
+	// Wait for the first flush to have actually RUN and failed, returning the
+	// item to pending. Gating on pending alone is racy: "key" is present from
+	// Add before the flush ever takes it, so the wait could fall through before
+	// the failing flush runs — then fail=false would take effect and the flush
+	// of "1" would succeed, leaving [1, 2] instead of [2].
 	assert.Eventually(t, func() bool {
+		if rec.attemptCount() < 1 {
+			return false
+		}
 		b.mu.Lock()
 		defer b.mu.Unlock()
 		_, pending := b.pending["key"]


### PR DESCRIPTION
## Problem
`TestFailedFlushRetriesWithoutClobbering` in `pkg/batch` fails intermittently (`go test -race ./...`), producing `[1, 2]` instead of the expected `[2]`. It went red on recent merges (e.g. #271, whose diff is TS-only and unrelated) and is reproducible locally roughly 1 in 200 runs under `-race`.

## Root cause
The test uses `assert.Eventually` on `b.pending["key"]` to know the failing flush has returned the item to pending, then sets `fail=false` and writes a newer value. But `"key"` is present in `pending` from the initial `Add` — *before* the background loop takes it to flush. So the wait can fall through before the first flush runs; with `fail` already flipped to `false`, the flush of value `1` succeeds, so both `1` and `2` are recorded.

The batcher is correct — this is purely a test-synchronization bug.

## Fix
Add an `attempts` counter to the test `recorder` (incremented on every flush call) and gate the wait on `attempts >= 1` as well as pending, so it only proceeds once a flush has actually run and failed.

## Verification
- `go test -race -run TestFailedFlushRetriesWithoutClobbering -count=1000 ./pkg/batch/` → ok
- `go test -race ./pkg/batch/` → ok