### PR TITLE
fix(dashboard): add {args} to command rehearsal samples

### DIFF
--- a/console/dashboard/src/lib/components/commands/ChatPreview.svelte
+++ b/console/dashboard/src/lib/components/commands/ChatPreview.svelte
@@ -45,6 +45,7 @@
 
   const DEFAULT_SAMPLES: Record<string, string> = {
     user: 'sesame_sam',
+    args: 'aaaa',
     target: 'ferret_king',
     uptime: '3h 24m',
     followage: '8 months',


### PR DESCRIPTION
## Summary
- Command rehearsal (ChatPreview) had no sample for `{args}`, the actual token sesame substitutes with the text after a command trigger (e.g. `!test aaaa` -> `aaaa`). It rendered as an unknown/typo token instead of a live example.
- Added `args: 'aaaa'` to the default sample set.

## Test plan
- [x] Verified in dashboard preview: response `you said: {args}` rehearses as `you said: aaaa` (highlighted, not marked unknown)