### PR TITLE
sesame: native-shoutout toggle for autoshout module

### DIFF
--- a/app/sesame/modules/shoutout.go
+++ b/app/sesame/modules/shoutout.go
@@ -15,7 +15,18 @@ const defaultShoutoutTemplate = "Massive shoutout to {raider} for the raid with 
 
 type shoutoutConfig struct {
 	Message string `json:"message"`
+	// NativeShoutout is a dashboard toggle stored as "on"/"off"; only an
+	// explicit "on" enables it, so a freshly opted-in module posts just the
+	// custom chat line until the broadcaster turns this on. When on, the raid
+	// also fires Twitch's own Send a Shoutout (the same call /shoutout makes),
+	// which renders the raider's current category in Twitch's native card — no
+	// template token can do that without a live Helix lookup.
+	NativeShoutout string `json:"native_shoutout"`
 }
+
+// nativeShoutoutOn reports whether the native-shoutout toggle is on. Unlike
+// alertOn, this one defaults off: only an explicit "on" counts.
+func nativeShoutoutOn(v string) bool { return v == "on" }
 
 // raidEvent is the subset of the channel.raid EventSub payload we use.
 type raidEvent struct {
@@ -44,9 +55,10 @@ func Shoutout(_ engine.Deps) module.Module {
 			return nil
 		}
 
-		tmpl := defaultShoutoutTemplate
 		var cfg shoutoutConfig
-		if err := c.Decode(&cfg); err == nil && cfg.Message != "" {
+		_ = c.Decode(&cfg)
+		tmpl := defaultShoutoutTemplate
+		if cfg.Message != "" {
 			tmpl = cfg.Message
 		}
 
@@ -73,6 +85,19 @@ func Shoutout(_ engine.Deps) module.Module {
 			BroadcasterID: ev.ToBroadcasterUserID,
 			Text:          msg,
 		})
+
+		// Also fire Twitch's native /shoutout on the raider when the broadcaster
+		// opted in: outgress resolves To (a login) and calls Helix Send a
+		// Shoutout, which Twitch renders with the raider's live category — the
+		// custom chat line above can never show that without a live Helix call
+		// of our own.
+		if nativeShoutoutOn(cfg.NativeShoutout) {
+			emit(&module.Output{
+				Type:          outgress.TypeShoutout,
+				BroadcasterID: ev.ToBroadcasterUserID,
+				To:            strings.TrimPrefix(ev.FromBroadcasterUserLogin, "@"),
+			})
+		}
 		return nil
 	})
 

--- a/app/sesame/modules/shoutout_test.go
+++ b/app/sesame/modules/shoutout_test.go
@@ -57,6 +57,24 @@ func TestShoutoutCustomTemplate(t *testing.T) {
 	assert.Equal(t, "yo CoolStreamer +42", col.out[0].Text)
 }
 
+func TestShoutoutNativeToggleOff(t *testing.T) {
+	var col collector
+	require.NoError(t, raidHandler(t)(context.Background(), raidCtx(`{"native_shoutout":"off"}`), col.emit))
+	require.Len(t, col.out, 1)
+	assert.Equal(t, outgress.TypeChat, col.out[0].Type)
+}
+
+func TestShoutoutNativeToggleOn(t *testing.T) {
+	var col collector
+	require.NoError(t, raidHandler(t)(context.Background(), raidCtx(`{"native_shoutout":"on"}`), col.emit))
+	require.Len(t, col.out, 2)
+	assert.Equal(t, outgress.TypeChat, col.out[0].Type)
+	o := col.out[1]
+	assert.Equal(t, outgress.TypeShoutout, o.Type)
+	assert.Equal(t, "2", o.BroadcasterID)
+	assert.Equal(t, "coolstreamer", o.To)
+}
+
 func TestShoutoutIgnoresEmptyEvent(t *testing.T) {
 	c := &module.Context{Env: lane.Envelope{Type: "channel.raid"}, BroadcasterID: 2, Log: zap.NewNop()}
 	var col collector

--- a/console/shared/lib/types.ts
+++ b/console/shared/lib/types.ts
@@ -403,6 +403,14 @@ export const MODULE_CATALOG: readonly ModuleDef[] = [
         defaultMessage:
           'Massive shoutout to {raider} for the raid with {viewers} viewers! Check them out at twitch.tv/{raider.login}'
       }
+    ],
+    settings: [
+      {
+        key: 'native_shoutout',
+        label: 'Also send Twitch shoutout',
+        type: 'toggle',
+        help: "Fires Twitch's own /shoutout on the raider alongside the chat line, which shows their current category and profile card natively. Off by default."
+      }
     ]
   },
   {


### PR DESCRIPTION
## Summary
- Autoshout (raid-triggered shoutout) module gets a `native_shoutout` toggle (off by default).
- When on, a raid emits a second output that fires Twitch's own Send a Shoutout on the raider, alongside the existing custom chat line — reuses the outgress path `/shoutout` already drives, so Twitch renders the raider's live category in its native card with no new Helix call.
- Dashboard: added the toggle to the Auto Shoutout module settings strip.

## Test plan
- [x] `go test ./app/sesame/modules/... -run TestShoutout` — all pass, including new toggle-on/toggle-off cases
- [x] `go build ./...` / `go vet ./app/sesame/...` clean
- [ ] svelte-check (not run — no node_modules installed in this worktree; new settings entry structurally matches existing `ModuleField` schema and other `settings` entries)