### PR TITLE
chore(flux): drop image-scan polling to 1h backstop

### DIFF
--- a/deploy/flux/clusters/production/image-update-automation.yaml
+++ b/deploy/flux/clusters/production/image-update-automation.yaml
@@ -4,6 +4,16 @@
 # No build loop: deploy/k8s/* changes do NOT match the publish-images.yml path filter
 # (which only matches app/<svc>/*, pkg/*, .containerignore, go.mod, go.sum, and the
 # workflow file itself), so Flux commits here never trigger a new CI image build.
+#
+# interval is a BACKSTOP, not the hot path. The image pipeline is event-driven:
+# GHCR publish -> GitHub `package` webhook -> github-image-receiver reconciles the
+# ImageRepository -> image-reflector re-evaluates the ImagePolicy (it watches its
+# ImageRepository) -> image-automation-controller reconciles THIS automation (it
+# watches ImagePolicy) -> pin commit. So a new image is pinned within seconds of
+# publish without waiting out any interval. 1h only bounds recovery if a webhook
+# is missed (delivery failure / controller restart); do NOT drop it back to
+# minutes to "speed up deploys" — the webhook chain already does that. Same
+# rationale applies to the ImageRepository/ImagePolicy intervals in ./images.
 ---
 apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageUpdateAutomation
@@ -11,7 +21,7 @@ metadata:
   name: bagelbot-apps
   namespace: flux-system
 spec:
-  interval: 5m
+  interval: 1h
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/deploy/flux/clusters/production/images/commands.yaml
+++ b/deploy/flux/clusters/production/images/commands.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: flux-system
 spec:
   image: ghcr.io/adamousmer/itsbagelbot/commands
-  interval: 5m
+  interval: 1h
 ---
 apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
@@ -15,7 +15,7 @@ metadata:
   namespace: flux-system
 spec:
   digestReflectionPolicy: Always
-  interval: 5m
+  interval: 1h
   imageRepositoryRef:
     name: commands
   filterTags:

--- a/deploy/flux/clusters/production/images/console-admin.yaml
+++ b/deploy/flux/clusters/production/images/console-admin.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: flux-system
 spec:
   image: ghcr.io/adamousmer/itsbagelbot/console-admin
-  interval: 5m
+  interval: 1h
 ---
 apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
@@ -15,7 +15,7 @@ metadata:
   namespace: flux-system
 spec:
   digestReflectionPolicy: Always
-  interval: 5m
+  interval: 1h
   imageRepositoryRef:
     name: console-admin
   filterTags:

--- a/deploy/flux/clusters/production/images/console-dashboard.yaml
+++ b/deploy/flux/clusters/production/images/console-dashboard.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: flux-system
 spec:
   image: ghcr.io/adamousmer/itsbagelbot/console-dashboard
-  interval: 5m
+  interval: 1h
 ---
 apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
@@ -15,7 +15,7 @@ metadata:
   namespace: flux-system
 spec:
   digestReflectionPolicy: Always
-  interval: 5m
+  interval: 1h
   imageRepositoryRef:
     name: console-dashboard
   filterTags:

--- a/deploy/flux/clusters/production/images/gateway.yaml
+++ b/deploy/flux/clusters/production/images/gateway.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: flux-system
 spec:
   image: ghcr.io/adamousmer/itsbagelbot/gateway
-  interval: 5m
+  interval: 1h
 ---
 apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
@@ -15,7 +15,7 @@ metadata:
   namespace: flux-system
 spec:
   digestReflectionPolicy: Always
-  interval: 5m
+  interval: 1h
   imageRepositoryRef:
     name: gateway
   filterTags:

--- a/deploy/flux/clusters/production/images/modules.yaml
+++ b/deploy/flux/clusters/production/images/modules.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: flux-system
 spec:
   image: ghcr.io/adamousmer/itsbagelbot/modules
-  interval: 5m
+  interval: 1h
 ---
 apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
@@ -15,7 +15,7 @@ metadata:
   namespace: flux-system
 spec:
   digestReflectionPolicy: Always
-  interval: 5m
+  interval: 1h
   imageRepositoryRef:
     name: modules
   filterTags:

--- a/deploy/flux/clusters/production/images/notifications.yaml
+++ b/deploy/flux/clusters/production/images/notifications.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: flux-system
 spec:
   image: ghcr.io/adamousmer/itsbagelbot/notifications
-  interval: 5m
+  interval: 1h
 ---
 apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
@@ -15,7 +15,7 @@ metadata:
   namespace: flux-system
 spec:
   digestReflectionPolicy: Always
-  interval: 5m
+  interval: 1h
   imageRepositoryRef:
     name: notifications
   filterTags:

--- a/deploy/flux/clusters/production/images/outgress.yaml
+++ b/deploy/flux/clusters/production/images/outgress.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: flux-system
 spec:
   image: ghcr.io/adamousmer/itsbagelbot/outgress
-  interval: 5m
+  interval: 1h
 ---
 apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
@@ -15,7 +15,7 @@ metadata:
   namespace: flux-system
 spec:
   digestReflectionPolicy: Always
-  interval: 5m
+  interval: 1h
   imageRepositoryRef:
     name: outgress
   filterTags:

--- a/deploy/flux/clusters/production/images/projector.yaml
+++ b/deploy/flux/clusters/production/images/projector.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: flux-system
 spec:
   image: ghcr.io/adamousmer/itsbagelbot/projector
-  interval: 5m
+  interval: 1h
 ---
 apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
@@ -15,7 +15,7 @@ metadata:
   namespace: flux-system
 spec:
   digestReflectionPolicy: Always
-  interval: 5m
+  interval: 1h
   imageRepositoryRef:
     name: projector
   filterTags:

--- a/deploy/flux/clusters/production/images/sesame.yaml
+++ b/deploy/flux/clusters/production/images/sesame.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: flux-system
 spec:
   image: ghcr.io/adamousmer/itsbagelbot/sesame
-  interval: 5m
+  interval: 1h
 ---
 apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
@@ -15,7 +15,7 @@ metadata:
   namespace: flux-system
 spec:
   digestReflectionPolicy: Always
-  interval: 5m
+  interval: 1h
   imageRepositoryRef:
     name: sesame
   filterTags:

--- a/deploy/flux/clusters/production/images/transactions.yaml
+++ b/deploy/flux/clusters/production/images/transactions.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: flux-system
 spec:
   image: ghcr.io/adamousmer/itsbagelbot/transactions
-  interval: 5m
+  interval: 1h
 ---
 apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
@@ -15,7 +15,7 @@ metadata:
   namespace: flux-system
 spec:
   digestReflectionPolicy: Always
-  interval: 5m
+  interval: 1h
   imageRepositoryRef:
     name: transactions
   filterTags:

--- a/deploy/flux/clusters/production/images/twitch-ingress.yaml
+++ b/deploy/flux/clusters/production/images/twitch-ingress.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: flux-system
 spec:
   image: ghcr.io/adamousmer/itsbagelbot/twitch-ingress
-  interval: 5m
+  interval: 1h
 ---
 apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
@@ -15,7 +15,7 @@ metadata:
   namespace: flux-system
 spec:
   digestReflectionPolicy: Always
-  interval: 5m
+  interval: 1h
   imageRepositoryRef:
     name: twitch-ingress
   filterTags:

--- a/deploy/flux/clusters/production/images/users.yaml
+++ b/deploy/flux/clusters/production/images/users.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: flux-system
 spec:
   image: ghcr.io/adamousmer/itsbagelbot/users
-  interval: 5m
+  interval: 1h
 ---
 apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
@@ -15,7 +15,7 @@ metadata:
   namespace: flux-system
 spec:
   digestReflectionPolicy: Always
-  interval: 5m
+  interval: 1h
   imageRepositoryRef:
     name: users
   filterTags:


### PR DESCRIPTION
## Why

The image pipeline is already event-driven end to end:

```
GHCR publish → GitHub `package` webhook → github-image-receiver
  → ImageRepository reconcile
  → ImagePolicy re-eval (watches its ImageRepository)
  → ImageUpdateAutomation reconcile (image-automation v1.1.4 watches ImagePolicy)
  → pin commit → push → github-receiver → Kustomization apply → rollout
```

A new image is pinned within seconds of publish without waiting out any interval. The `interval: 5m` on ImageRepository, ImagePolicy and ImageUpdateAutomation was redundant polling layered on top of that chain.

## Change

Set those intervals to `1h` (all 12 services + the automation). Webhook chain is the fast path; the interval is now purely a recovery backstop for a missed webhook. Cuts idle GHCR scans + git reconciles 12×, no latency cost on the happy path.

Also documented the rationale in `image-update-automation.yaml` so it isn't "fixed" back to minutes.

## Tradeoff

Missed webhook (delivery failure / controller restart) → recovery up to 1h instead of 5m. Acceptable.

## Note

Not adding the automation to a Receiver deliberately: triggering it off the `package` event races the ImagePolicy update (fires before the policy has the new digest), so it would miss and then wait the backstop. The ImagePolicy watch is the correct trigger and already exists.