### PR TITLE
fix(timers): expiry events reach master, stalled timers self-recover, jittered fire

### DIFF
--- a/app/sesame/engine/timers_valkey.go
+++ b/app/sesame/engine/timers_valkey.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"context"
 	"encoding/json"
+	"math/rand/v2"
 	"strconv"
 	"strings"
 	"time"
@@ -41,6 +42,15 @@ const timerClaimTTL = 5 * time.Second
 // to 60s; this only guards a hand-crafted RPC call from arming a tight
 // expire/fire/re-arm loop.
 const minTimerInterval = 30 * time.Second
+
+// timerFirstFireJitter caps the random phase offset added to a timer's FIRST
+// interval at arm time. It desynchronizes timers armed in the same instant
+// (every timer at stream.online, or a freshly added same-interval one) so they
+// don't all expire together and post as one wall of chat. Only the first fire
+// is offset; re-arms use the exact interval, so the configured cadence holds.
+// The offset is floored at the smaller of this cap and the interval itself, so
+// a 30s timer never gets a 60s first wait.
+const timerFirstFireJitter = 30 * time.Second
 
 // rearmTimeout bounds one mid-stream rearm (IsLive read + ArmAll) triggered off
 // a modules cache-invalidation, so a stalled Valkey/projector never pins the
@@ -136,15 +146,18 @@ func timerKey(broadcasterID uint64, timerID string) string {
 }
 
 // ArmAll SETs one Valkey key per enabled timer of an enabled "timers" module,
-// each EX'd to its own interval — the broadcaster's stream just went online,
-// so every timer starts its countdown fresh.
+// each EX'd to its interval plus a small random phase offset (armJittered) so
+// timers armed together here don't all fire in the same instant. NX means a
+// timer already counting down is left alone, so this only starts the ones not
+// yet armed — the freshly added timer on a mid-stream rearm, or every timer on
+// a fresh stream.online.
 func (s *ValkeyTimerStore) ArmAll(ctx context.Context, broadcasterID uint64) {
 	cfg, ok := s.config(ctx, broadcasterID)
 	if !ok {
 		return
 	}
 	for _, td := range cfg.Timers {
-		s.arm(ctx, broadcasterID, td)
+		s.armJittered(ctx, broadcasterID, td)
 	}
 }
 
@@ -171,19 +184,47 @@ func (s *ValkeyTimerStore) RearmIfLive(ctx context.Context, broadcasterID uint64
 	s.ArmAll(ctx, broadcasterID)
 }
 
-// arm SETs one timer's schedule key. NX leaves an already-counting-down key
-// alone: ArmAll must not reset the clock on a redelivered stream.online, and
-// onExpired's re-arm must not clobber a fresh key a concurrent ArmAll just set
-// (the narrow race of a stream ending and restarting within the same instant).
+// clampInterval turns a configured interval (seconds) into a Duration floored
+// at minTimerInterval, the single place the floor is applied.
+func clampInterval(seconds int) time.Duration {
+	d := time.Duration(seconds) * time.Second
+	if d < minTimerInterval {
+		d = minTimerInterval
+	}
+	return d
+}
+
+// arm re-arms a timer at exactly its interval — the onExpired path, which must
+// preserve the cadence set by the first (jittered) fire.
 func (s *ValkeyTimerStore) arm(ctx context.Context, broadcasterID uint64, td timerDef) {
+	s.armAfter(ctx, broadcasterID, td, clampInterval(td.Interval))
+}
+
+// armJittered arms a timer's first schedule key at its interval plus a random
+// phase offset (see timerFirstFireJitter), so timers armed in the same instant
+// don't all expire together. It is the ArmAll (stream.online + mid-stream
+// rearm) path; onExpired re-arms via arm() at the exact interval, so the offset
+// shifts only when the timer first fires this session, not its cadence after.
+func (s *ValkeyTimerStore) armJittered(ctx context.Context, broadcasterID uint64, td timerDef) {
+	interval := clampInterval(td.Interval)
+	spread := interval
+	if spread > timerFirstFireJitter {
+		spread = timerFirstFireJitter
+	}
+	offset := time.Duration(rand.Int64N(int64(spread.Seconds())+1)) * time.Second
+	s.armAfter(ctx, broadcasterID, td, interval+offset)
+}
+
+// armAfter SETs one timer's schedule key EX'd to ex. NX leaves an
+// already-counting-down key alone: ArmAll must not reset the clock on a
+// redelivered stream.online (or a mid-stream rearm), and onExpired's re-arm
+// must not clobber a fresh key a concurrent ArmAll just set (the narrow race of
+// a stream ending and restarting within the same instant).
+func (s *ValkeyTimerStore) armAfter(ctx context.Context, broadcasterID uint64, td timerDef, ex time.Duration) {
 	if !td.Enabled || td.ID == "" {
 		return
 	}
-	interval := time.Duration(td.Interval) * time.Second
-	if interval < minTimerInterval {
-		interval = minTimerInterval
-	}
-	err := s.client.Do(ctx, s.client.B().Set().Key(timerKey(broadcasterID, td.ID)).Value("1").Nx().ExSeconds(int64(interval.Seconds())).Build()).Error()
+	err := s.client.Do(ctx, s.client.B().Set().Key(timerKey(broadcasterID, td.ID)).Value("1").Nx().ExSeconds(int64(ex.Seconds())).Build()).Error()
 	if err != nil && !valkey.IsValkeyNil(err) {
 		s.log.Warn("timers: failed to arm", zap.Uint64("broadcaster_id", broadcasterID), zap.String("timer_id", td.ID), zap.Error(err))
 	}

--- a/app/sesame/engine/timers_valkey.go
+++ b/app/sesame/engine/timers_valkey.go
@@ -10,6 +10,7 @@ import (
 
 	"ItsBagelBot/app/sesame/module"
 	"ItsBagelBot/internal/domain/invalidate"
+	livekey "ItsBagelBot/internal/domain/live"
 	"ItsBagelBot/internal/domain/outgress"
 	"ItsBagelBot/internal/moderation"
 	"ItsBagelBot/internal/projection"
@@ -56,6 +57,20 @@ const timerFirstFireJitter = 30 * time.Second
 // a modules cache-invalidation, so a stalled Valkey/projector never pins the
 // goroutine the rearm watcher spawns per message.
 const rearmTimeout = 5 * time.Second
+
+// reconcileInterval is how often the reconciler re-arms live broadcasters'
+// timers, recovering any that silently stalled (a missed expiry notification).
+// A stalled timer comes back within one interval, no stream restart needed.
+const reconcileInterval = time.Minute
+
+// reconcileClaimKey serializes the sweep to one replica per tick. It sorts
+// under timerClaimPrefix so onExpired ignores its own expiry, and its short TTL
+// only has to cover the skew between replicas' independent tickers — a rare
+// double-sweep is harmless (NX arming dedups it), so this is efficiency, not
+// correctness.
+const reconcileClaimKey = timerClaimPrefix + "reconcile"
+
+const reconcileClaimTTL = 30 * time.Second
 
 // timerDef is one broadcaster-authored repeating chat message.
 type timerDef struct {
@@ -182,6 +197,71 @@ func (s *ValkeyTimerStore) RearmIfLive(ctx context.Context, broadcasterID uint64
 		return
 	}
 	s.ArmAll(ctx, broadcasterID)
+}
+
+// StartReconciler periodically re-arms every live broadcaster's timers, so a
+// timer that silently stalled comes back mid-stream without a stream restart.
+// A stall happens when an expiry notification is lost — Valkey pub/sub is
+// fire-and-forget with no replay, so a Sentinel failover, a watcher reconnect,
+// or an onExpired that hit a transient error and returned without re-arming can
+// leave a timer's key expired and never re-set. The expiry watcher alone never
+// recovers that until the next stream.online; this sweep does.
+//
+// ArmAll's NX SET keeps it cheap and safe: a still-armed timer is untouched,
+// only a missing (stalled) one is re-armed. One replica sweeps per tick (a
+// fleet-wide NX claim), so the scan isn't multiplied across the pool. Runs
+// until ctx is cancelled.
+func (s *ValkeyTimerStore) StartReconciler(ctx context.Context) {
+	ticker := time.NewTicker(reconcileInterval)
+	defer ticker.Stop()
+	s.log.Info("timers: reconciler starting", zap.Duration("interval", reconcileInterval))
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.reconcile(ctx)
+		}
+	}
+}
+
+// reconcile claims the sweep for this tick, then re-arms every live
+// broadcaster's timers. RearmIfLive re-checks live state and NX-arms, so an
+// already-armed timer is left counting down and only a stalled one restarts.
+func (s *ValkeyTimerStore) reconcile(ctx context.Context) {
+	got, err := s.client.Do(ctx, s.client.B().Set().Key(reconcileClaimKey).Value("1").Nx().ExSeconds(int64(reconcileClaimTTL.Seconds())).Build()).ToString()
+	if err != nil || got != "OK" {
+		return // another replica owns this tick, or the claim write failed
+	}
+	for _, id := range s.liveBroadcasters(ctx) {
+		s.RearmIfLive(ctx, id)
+	}
+}
+
+// liveBroadcasters SCANs the live-key set and returns the broadcaster ids
+// currently live, skipping the recheck guard keys that share the live: prefix.
+func (s *ValkeyTimerStore) liveBroadcasters(ctx context.Context) []uint64 {
+	var ids []uint64
+	cursor := uint64(0)
+	for {
+		entry, err := s.client.Do(ctx, s.client.B().Scan().Cursor(cursor).Match(livekey.KeyPrefix+"*").Count(200).Build()).AsScanEntry()
+		if err != nil {
+			s.log.Warn("timers: reconcile scan failed", zap.Error(err))
+			return ids
+		}
+		for _, k := range entry.Elements {
+			if strings.HasPrefix(k, recheckKeyPrefix) {
+				continue
+			}
+			if id, err := strconv.ParseUint(strings.TrimPrefix(k, livekey.KeyPrefix), 10, 64); err == nil && id != 0 {
+				ids = append(ids, id)
+			}
+		}
+		cursor = entry.Cursor
+		if cursor == 0 {
+			return ids
+		}
+	}
 }
 
 // clampInterval turns a configured interval (seconds) into a Duration floored

--- a/app/sesame/main.go
+++ b/app/sesame/main.go
@@ -295,6 +295,7 @@ func newTimers(ctx context.Context, in infra, proj *projection.Client, live *eng
 	})
 	go timers.StartExpiryWatcher(ctx)
 	go timers.StartRearmWatcher(ctx)
+	go timers.StartReconciler(ctx)
 	return timers
 }
 

--- a/pkg/valkey/client.go
+++ b/pkg/valkey/client.go
@@ -22,6 +22,19 @@ const localReadPort = "6379"
 //
 // Exported for testing.
 func BuildClientOption(address, password string) valkey_go.ClientOption {
+	return buildOption(address, password, true)
+}
+
+// buildOption builds a Valkey client option. replicaReads enables the
+// SendToReplicas read-offload for a Sentinel deployment.
+//
+// It MUST stay off for the pub/sub client: keyspace notifications (the expired
+// events the timer + live-recheck watchers subscribe to) are published only by
+// the master, so SendToReplicas — which routes the pub/sub SUBSCRIBE to a
+// replica — pins the subscription to a node that never emits them, silently
+// dropping every expiry. Reads still offload via the node-local client (Do),
+// so the pub/sub client losing replica-reads costs nothing.
+func buildOption(address, password string, replicaReads bool) valkey_go.ClientOption {
 	opts := valkey_go.ClientOption{
 		InitAddress:  []string{address},
 		Password:     password,
@@ -33,10 +46,12 @@ func BuildClientOption(address, password string) valkey_go.ClientOption {
 			MasterSet: "myprimary",
 			Password:  password,
 		}
-		// Without a node-local read client, fall back to sending read-only
-		// commands to a Sentinel replica. Writes still go to the master.
-		opts.SendToReplicas = func(cmd valkey_go.Completed) bool {
-			return cmd.IsReadOnly()
+		if replicaReads {
+			// Without a node-local read client, fall back to sending read-only
+			// commands to a Sentinel replica. Writes still go to the master.
+			opts.SendToReplicas = func(cmd valkey_go.Completed) bool {
+				return cmd.IsReadOnly()
+			}
 		}
 	}
 	return opts
@@ -50,10 +65,13 @@ func BuildClientOption(address, password string) valkey_go.ClientOption {
 // primary node, a replica everywhere else) it is always the lowest-latency
 // instance for pods on that node. So:
 //
-//   - writes, topology and pub/sub  -> the embedded Sentinel client, which
-//     always tracks the current master and fails over automatically;
-//   - read-only commands            -> a direct connection to NODE_IP:6379,
-//     the local instance, with no cross-node hop.
+//   - writes and topology  -> the embedded Sentinel client, which always tracks
+//     the current master and fails over automatically;
+//   - pub/sub (Receive)     -> a dedicated master-pinned Sentinel client with no
+//     replica-read offload, so expiry notifications (master-only) are actually
+//     received;
+//   - read-only commands    -> a direct connection to NODE_IP:6379, the local
+//     instance, with no cross-node hop.
 //
 // valkey-go's Sentinel client cannot prefer a local replica on its own:
 // ReadNodeSelector is cluster-mode only, and the Sentinel path picks a replica
@@ -61,6 +79,7 @@ func BuildClientOption(address, password string) valkey_go.ClientOption {
 type Client struct {
 	valkey_go.Client                  // master/write path plus everything not overridden
 	local            valkey_go.Client // node-local read path; nil when unavailable
+	pubsub           valkey_go.Client // master-pinned pub/sub path; nil for standalone
 }
 
 // Do sends read-only commands to the local instance and everything else to the
@@ -81,10 +100,25 @@ func (c *Client) DoMulti(ctx context.Context, multi ...valkey_go.Completed) []va
 	return c.Client.DoMulti(ctx, multi...)
 }
 
-// Close releases both the master/write client and the local read client.
+// Receive routes pub/sub to the master-pinned client. Keyspace notifications
+// (the expired events the timer + live-recheck watchers subscribe to) are
+// emitted only by the master; the default client's SendToReplicas read-offload
+// would otherwise pin the subscription to a replica that never delivers them.
+func (c *Client) Receive(ctx context.Context, subscribe valkey_go.Completed, fn func(msg valkey_go.PubSubMessage)) error {
+	if c.pubsub != nil {
+		return c.pubsub.Receive(ctx, subscribe, fn)
+	}
+	return c.Client.Receive(ctx, subscribe, fn)
+}
+
+// Close releases the master/write client, the local read client and the
+// master-pinned pub/sub client.
 func (c *Client) Close() {
 	if c.local != nil {
 		c.local.Close()
+	}
+	if c.pubsub != nil {
+		c.pubsub.Close()
 	}
 	c.Client.Close()
 }
@@ -111,11 +145,26 @@ func NewClient(address, password string) (valkey_go.Client, error) {
 		return nil, err
 	}
 
-	// The node-local read path only applies to a Sentinel deployment where
-	// every node hosts a Valkey instance on NODE_IP:6379.
-	nodeIP := os.Getenv("NODE_IP")
-	if nodeIP == "" || !strings.HasSuffix(address, ":26379") {
+	// Standalone (dev / single instance): that one node is the master, so its
+	// own Do/Receive already land on the right place. No wrapper needed.
+	if !strings.HasSuffix(address, ":26379") {
 		return master, nil
+	}
+
+	// Sentinel: pub/sub must be pinned to the master (no SendToReplicas) or the
+	// expiry watchers subscribe to a replica that never emits expired events.
+	pubsub, err := valkey_go.NewClient(buildOption(address, password, false))
+	if err != nil {
+		master.Close()
+		return nil, err
+	}
+	wrapped := &Client{Client: master, pubsub: pubsub}
+
+	// Node-local read path: a Sentinel deployment where every node hosts a
+	// Valkey instance on NODE_IP:6379.
+	nodeIP := os.Getenv("NODE_IP")
+	if nodeIP == "" {
+		return wrapped, nil
 	}
 
 	local, err := valkey_go.NewClient(valkey_go.ClientOption{
@@ -128,9 +177,10 @@ func NewClient(address, password string) (valkey_go.Client, error) {
 		// rather than fail the service. Reads go to a Sentinel replica;
 		// correctness is unaffected, only locality is lost.
 		log.Printf("valkey: node-local read client unavailable (%v); reading via Sentinel", err)
-		return master, nil
+		return wrapped, nil
 	}
 
 	log.Printf("valkey: reading from node-local instance %s:%s", nodeIP, localReadPort)
-	return &Client{Client: master, local: local}, nil
+	wrapped.local = local
+	return wrapped, nil
 }


### PR DESCRIPTION
Timers never fired in production. Root cause + two safety improvements.

## 1. fix(valkey): pin pub/sub to the master (the actual bug)

The Sentinel client sets `SendToReplicas` for read-offload, which also routes the pub/sub `SUBSCRIBE` to a **replica**. Keyspace `expired` notifications are emitted **only by the master**, so the timer expiry watcher (and the live-recheck watcher) subscribed to a node that never delivered them — every expiry silently dropped. Verified in prod: the master's `pubsub channels` had no `__keyevent@0__:expired` subscriber; the valkey-go subscriptions sat on the replicas.

Fix: dedicated master-pinned pub/sub client (Sentinel option **without** `SendToReplicas`), and `Client.Receive` routes to it. Reads still offload to the node-local client, so no read-locality is lost. Also fixes the live-recheck watcher, broken the same way.

## 2. feat(sesame): reconcile stalled timers

Valkey expiry notifications are fire-and-forget with no replay, so a lost one (Sentinel failover, watcher reconnect, transient `onExpired` error) would strand a timer until the next `stream.online`. `StartReconciler` runs once a minute; one replica (fleet-wide NX claim) SCANs the live set and `RearmIfLive` each broadcaster. NX arming leaves still-armed timers alone and re-arms only stalled ones — **a dead timer recovers within a minute, no stream restart.**

## 3. feat(sesame): jitter first fire

`ArmAll` armed every enabled timer in the same instant, so same-interval timers expired in lockstep and posted as one wall. First fire now gets a random 0..min(interval,30s) phase offset; re-arm stays exact, so cadence is preserved.

## Verification
- Confirmed master emits `__keyevent@0__:expired` (replicas don't).
- Confirmed the mid-stream rearm-on-save path works end to end (toggling barney's timer armed the key).
- `go build ./...`, `go vet`, `pkg/valkey` + `app/sesame/engine` tests green.