### PR TITLE
fix(dashboard): redesign govee module page, fix nav + slow load

### DIFF
--- a/console/dashboard/src/lib/server/govee-store.ts
+++ b/console/dashboard/src/lib/server/govee-store.ts
@@ -18,15 +18,24 @@
 // which returns them as methods closing over the id, so no operation repeats it
 // as an argument. A redemption is driven by sesame; this store only sets up.
 import { rpc } from '@bagel/shared/server/nats';
-import { SUB, publishEventSubEnsureOptional } from './services';
+import { POLICY } from '@bagel/shared/server/cache-keys';
+import { SUB, fabric, invalidate, publishEventSubEnsureOptional } from './services';
 import { listModules, upsertModule } from './commands-store';
 
 const GOVEE_MODULE = 'govee';
 
+// Cache key for the one slow govee read: the third-party device list. Flushed
+// when the broadcaster's key changes (a new key can front a different Govee
+// account) and rides the coarse per-user flush via userPrefixes() as a bus-gap
+// safety net. The key-presence flag is deliberately NOT cached: it is a cheap
+// indexed DB read and its write path is off the invalidation bus, so caching it
+// per replica could strand a "no key" view on another pod right after a save.
+const devicesCacheKey = (userId: string) => `govee-devices:${userId}`;
+
 // The reward always requires input (the colour), always rides Twitch's request
 // queue (so sesame can fulfil/refund it), and is prompted with the accepted
 // colour formats.
-const REWARD_PROMPT = 'Type a colour — a name like blue, or a hex code like #00ccff';
+const REWARD_PROMPT = 'Type a colour: a name like blue, or a hex code like #00ccff';
 
 export type GoveeOnRedeem = 'fulfill' | 'cancel' | 'leave';
 
@@ -164,6 +173,8 @@ export interface GoveeStore {
 
 // goveeStore binds every per-broadcaster operation to one broadcaster id.
 export function goveeStore(userId: string): GoveeStore {
+  // keyPresent is a direct (uncached) status read: cheap, always authoritative,
+  // and safe to run on every load. A blip degrades to false, exactly as before.
   async function keyPresent(): Promise<boolean> {
     try {
       const r = await rpc<{ present?: boolean }>(`${SUB.goveeKey}.status`, { user_id: userId }, 3000);
@@ -174,11 +185,14 @@ export function goveeStore(userId: string): GoveeStore {
   }
 
   async function read(): Promise<GoveeView> {
-    const rows = await listModules(userId);
+    // The module blob (listModules) and the key-presence flag are independent
+    // reads; run them together so the page's server load is one round trip deep,
+    // not two.
+    const [rows, present] = await Promise.all([listModules(userId), keyPresent()]);
     const row = rows.find((r) => r.name === GOVEE_MODULE);
     return {
       enabled: row ? row.is_enabled : false,
-      keyPresent: await keyPresent(),
+      keyPresent: present,
       binding: row ? readBinding(row.configs) : blankBinding()
     };
   }
@@ -197,22 +211,41 @@ export function goveeStore(userId: string): GoveeStore {
 
   async function setKey(key: string): Promise<GoveeResult> {
     const r = await rpc<{ error?: string }>(`${SUB.goveeKey}.set`, { user_id: userId, key }, 3000);
-    return r.error ? { ok: false, error: r.error } : { ok: true };
+    if (r.error) return { ok: false, error: r.error };
+    // A new key can front a different Govee account: drop the cached device list
+    // so the next read reflects the new account immediately.
+    invalidate(devicesCacheKey(userId));
+    return { ok: true };
   }
 
   async function clearKey(): Promise<GoveeResult> {
     const r = await rpc<{ error?: string }>(`${SUB.goveeKey}.clear`, { user_id: userId }, 3000);
-    return r.error ? { ok: false, error: r.error } : { ok: true };
+    if (r.error) return { ok: false, error: r.error };
+    invalidate(devicesCacheKey(userId));
+    return { ok: true };
   }
 
+  // listDevices is SWR-cached (POLICY.govee). Only a successful device list is
+  // cached; on any error the loader throws so the fabric caches nothing and, if
+  // a recent list exists, serves it stale instead of flashing an error. A cold
+  // error surfaces as { devices: [], error }, same shape as before.
   async function listDevices(): Promise<{ devices: GoveeDevice[]; error?: string }> {
-    const r = await rpc<{ devices?: GoveeDevice[]; error?: string }>(
-      `${SUB.gateway}.govee.devices`,
-      { channel_id: userId },
-      8000
-    );
-    if (r.error) return { devices: [], error: r.error };
-    return { devices: Array.isArray(r.devices) ? r.devices : [] };
+    try {
+      const devices = await fabric.readKey(devicesCacheKey(userId), POLICY.govee, async () => {
+        const r = await rpc<{ devices?: GoveeDevice[]; error?: string }>(
+          `${SUB.gateway}.govee.devices`,
+          { channel_id: userId },
+          // Just over the gateway's devices handler budget (8s) so this RPC
+          // never abandons a fetch the gateway is still completing.
+          9000
+        );
+        if (r.error) throw new Error(r.error);
+        return Array.isArray(r.devices) ? r.devices : [];
+      });
+      return { devices };
+    } catch (e) {
+      return { devices: [], error: e instanceof Error ? e.message : 'device lookup failed' };
+    }
   }
 
   async function saveReward(draft: RewardDraft): Promise<GoveeResult> {

--- a/console/dashboard/src/lib/server/services.ts
+++ b/console/dashboard/src/lib/server/services.ts
@@ -33,7 +33,7 @@ export const SUB = {
 };
 
 function userPrefixes(id: string): string[] {
-  return [`grant:${id}`, `account:${id}`, `tier:${id}`, `billing-state:${id}`, `commands:${id}`, `modules:${id}`, `delegations:${id}`, `locale:${id}`];
+  return [`grant:${id}`, `account:${id}`, `tier:${id}`, `billing-state:${id}`, `commands:${id}`, `modules:${id}`, `delegations:${id}`, `locale:${id}`, `govee-devices:${id}`];
 }
 
 // Scope -> cache key routing for the invalidation bus, declared as data. The

--- a/console/dashboard/src/routes/(app)/+layout.svelte
+++ b/console/dashboard/src/routes/(app)/+layout.svelte
@@ -59,7 +59,7 @@
   const section = $derived(
     path.startsWith('/commands')
       ? 'commands'
-      : path.startsWith('/modules')
+      : path.startsWith('/modules') || path.startsWith('/govee')
         ? 'modules'
         : path.startsWith('/channelpoints')
           ? 'channelpoints'

--- a/console/dashboard/src/routes/(app)/govee/+page.server.ts
+++ b/console/dashboard/src/routes/(app)/govee/+page.server.ts
@@ -56,22 +56,27 @@ export const load: PageServerLoad = async ({ locals }) => {
   const colors = [...GOVEE_COLOR_NAMES];
 
   if (env.DEMO === '1') {
-    return { ...demoView(), devices: demoDevices(), colors };
+    return { ...demoView(), devices: { devices: demoDevices(), error: undefined }, colors };
   }
 
   try {
     const store = goveeStore(uid);
     const view = await store.read();
-    // Only list devices once a key is on file; a lookup failure degrades to an
-    // empty list plus a flag, never a broken page.
-    const { devices, error: deviceError } = view.keyPresent ? await store.listDevices() : { devices: [], error: undefined };
-    return { ...view, devices, deviceError, colors };
+    // The device list is the one slow read (a Govee cloud round trip). Stream it
+    // as an unresolved promise so SSR emits the shell + the key/reward steps
+    // instantly and the picker fills in when it lands. Only fetch once a key is
+    // on file; a lookup failure degrades to an empty list plus a flag on the
+    // resolved value, never a broken page.
+    const devices = view.keyPresent
+      ? store.listDevices()
+      : Promise.resolve({ devices: [] as GoveeDevice[], error: undefined });
+    return { ...view, devices, colors };
   } catch {
     return {
       enabled: false,
       keyPresent: false,
       binding: { device: '', sku: '', deviceName: '', onRedeem: 'fulfill' as GoveeOnRedeem, rewardId: '', reward: null, allowOffline: false },
-      devices: [] as GoveeDevice[],
+      devices: { devices: [] as GoveeDevice[], error: undefined },
       colors,
       degraded: true
     };

--- a/console/dashboard/src/routes/(app)/govee/+page.svelte
+++ b/console/dashboard/src/routes/(app)/govee/+page.svelte
@@ -12,6 +12,8 @@
   // svelte-ignore state_referenced_locally
   let enabled = $state<boolean>(data.enabled ?? false);
   // svelte-ignore state_referenced_locally
+  let keyPresent = $state<boolean>(data.keyPresent ?? false);
+  // svelte-ignore state_referenced_locally
   let selectedDevice = $state<string>(data.binding?.device ?? '');
   // Live-only reflects the inverse of the stored allowOffline flag; on by default.
   // svelte-ignore state_referenced_locally
@@ -22,6 +24,7 @@
     if (data !== seed) {
       seed = data;
       enabled = data.enabled ?? false;
+      keyPresent = data.keyPresent ?? false;
       selectedDevice = data.binding?.device ?? '';
       liveOnly = !(data.binding?.allowOffline);
     }
@@ -35,14 +38,15 @@
     return r.type === 'success' || r.type === 'failure' ? r.data : undefined;
   }
 
-  // formResult is the shared enhance handler: on success it toasts + reloads;
-  // on a missing-scope rejection it shows the reconnect CTA; otherwise it toasts
-  // the error.
-  function formResult(okMsg: string, failMsg: string): SubmitFunction {
+  // formResult is the shared enhance handler: on success it optionally flips an
+  // optimistic mirror, toasts, and reloads; on a missing-scope rejection it shows
+  // the reconnect CTA; otherwise it toasts the error.
+  function formResult(okMsg: string, failMsg: string, onOk?: () => void): SubmitFunction {
     return () =>
       async ({ result }) => {
         const payload = payloadOf(result);
         if (result.type === 'success' && payload?.ok !== false) {
+          onOk?.();
           toast('ok', okMsg);
           await invalidateAll();
           return;
@@ -94,7 +98,7 @@
       const payload = payloadOf(result);
       if (result.type === 'success' && payload?.ok !== false) {
         liveOnly = !pendingAllowOffline;
-        toast('ok', liveOnly ? 'Live only is on.' : 'Live only is off — offline redemptions allowed.');
+        toast('ok', liveOnly ? 'Live only is on.' : 'Live only is off. Offline redemptions allowed.');
         await invalidateAll();
         return;
       }
@@ -102,156 +106,171 @@
     };
   };
 
-  const colorDevices = $derived((data.devices ?? []).filter((d) => d.color));
-  const selectedMeta = $derived(colorDevices.find((d) => d.device === selectedDevice));
   const boundReward = $derived(data.binding?.reward ?? null);
 </script>
 
 <section class="screen active">
+  <a class="back" href="/modules"><Icon name="x" size={13} /> All modules</a>
   <PageHead eyebrow="Channel points" description="Let viewers recolour your Govee lights by redeeming channel points. Live only: off-stream redemptions are refunded.">
     Govee <em>Lights</em>
   </PageHead>
 
   {#if data.degraded}
-    <div class="degraded" role="alert"><Icon name="ban" size={13} /> Couldn't reach the backend. Try again in a moment.</div>
+    <div class="note err" role="alert"><Icon name="ban" size={13} /> Couldn't reach the backend. Try again in a moment.</div>
   {/if}
 
   {#if missingScope}
-    <div class="reconnect" role="alert">
-      <span class="reconnect-text"><Icon name="lock" size={13} /> Reconnect to grant channel-points access.</span>
+    <div class="note reconnect" role="alert">
+      <span class="note-text"><Icon name="lock" size={13} /> Reconnect to grant channel-points access.</span>
       <a class="btn primary" href="/login?next=/govee" data-sveltekit-reload>Reconnect</a>
     </div>
   {/if}
 
-  <div class="toolbar">
-    <form method="POST" action="?/toggle" use:enhance={masterSubmit} class="master">
-      <input type="hidden" name="is_enabled" value={enabled ? '' : 'on'} />
-      <button class="toggle {enabled ? 'on' : ''}" type="submit" aria-label="Toggle Govee lights"></button>
-    </form>
-    <span class="toolbar-label">{enabled ? 'Redemptions drive your lights' : 'Turned off — redemptions are ignored'}</span>
-  </div>
-
-  <!-- Step 1: API key -->
-  <Card>
-    <div class="step">
-      <span class="step-num">1</span>
-      <div class="step-body">
-        <h2>Govee API key</h2>
-        <p class="muted">
-          Get a key from the Govee mobile app: <strong>Profile → Settings → Apply for API Key</strong>. It is stored
-          encrypted — we never show it back.
-        </p>
-        {#if data.keyPresent}
-          <div class="row">
-            <span class="ok-pill"><Icon name="check" size={13} /> Key on file</span>
-            <form method="POST" action="?/clearKey" use:enhance={formResult('Key removed.', 'Could not remove the key.')}>
-              <button class="btn danger" type="submit">Remove key</button>
-            </form>
-          </div>
-        {:else}
-          <form method="POST" action="?/saveKey" use:enhance={formResult('Key saved.', 'Could not save the key.')} class="row">
-            <input class="input" type="password" name="key" placeholder="Paste your Govee API key" autocomplete="off" required />
-            <button class="btn primary" type="submit">Save key</button>
-          </form>
-        {/if}
+  <!-- Master switch: same toggle-row surface as the module detail page. -->
+  <Card style="padding:0" class="master-card">
+    <div class="toggle-row">
+      <div class="tr-text">
+        <span class="tr-label">Enable Govee lights</span>
+        <span class="tr-help">{enabled ? 'Redemptions drive your lights' : 'Turned off, redemptions are ignored'}</span>
       </div>
+      <form method="POST" action="?/toggle" use:enhance={masterSubmit} class="master">
+        <input type="hidden" name="is_enabled" value={enabled ? '' : 'on'} />
+        <button class="toggle {enabled ? 'on' : ''}" type="submit" aria-label="Toggle Govee lights"></button>
+      </form>
     </div>
   </Card>
 
-  <!-- Step 2: device -->
-  <Card>
-    <div class="step {data.keyPresent ? '' : 'disabled'}">
-      <span class="step-num">2</span>
-      <div class="step-body">
-        <h2>Pick the light</h2>
-        {#if !data.keyPresent}
-          <p class="muted">Add your API key first to load your devices.</p>
-        {:else if data.deviceError}
-          <p class="err-text"><Icon name="ban" size={13} /> {data.deviceError}</p>
-        {:else if colorDevices.length === 0}
-          <p class="muted">No colour-capable Govee devices found on this account.</p>
-        {:else}
-          <form method="POST" action="?/pickDevice" use:enhance={formResult('Device saved.', 'Could not save the device.')}>
-            <ul class="devices">
-              {#each colorDevices as d (d.device)}
-                <li>
-                  <label class="device {selectedDevice === d.device ? 'sel' : ''}">
-                    <input type="radio" name="device" value={d.device} checked={selectedDevice === d.device} onchange={() => (selectedDevice = d.device)} />
-                    <span class="device-name">{d.name || d.device}</span>
-                    <span class="device-sku">{d.sku}</span>
-                  </label>
-                </li>
-              {/each}
-            </ul>
-            <!-- The sku + name that pair with the chosen device id, resolved from
-                 the selection so the server stores a consistent triple. -->
-            <input type="hidden" name="sku" value={selectedMeta?.sku ?? ''} />
-            <input type="hidden" name="deviceName" value={selectedMeta?.name ?? ''} />
-            <button class="btn primary" type="submit" disabled={!selectedDevice}>Save device</button>
-          </form>
-        {/if}
-      </div>
-    </div>
-  </Card>
-
-  <!-- Step 3: reward -->
-  <Card>
-    <div class="step {data.binding?.device ? '' : 'disabled'}">
-      <span class="step-num">3</span>
-      <div class="step-body">
-        <h2>The reward</h2>
-        {#if !data.binding?.device}
-          <p class="muted">Pick a light first.</p>
-        {:else}
-          <p class="muted">
-            Viewers type a colour when they redeem: a name (<code>{data.colors.join(', ')}</code>) or a hex code like
-            <code>#00ccff</code>.
+  <div class="steps" class:muted={!enabled}>
+    <!-- Step 1: API key -->
+    <Card>
+      <div class="step">
+        <span class="step-index">1</span>
+        <div class="step-body">
+          <h2>Govee API key</h2>
+          <p class="muted-text">
+            Get a key from the Govee mobile app: <strong>Profile → Settings → Apply for API Key</strong>. It is stored
+            encrypted. We never show it back.
           </p>
-          <form method="POST" action="?/saveReward" use:enhance={formResult('Reward saved.', 'Could not save the reward.')} class="reward-form">
-            <label class="field">
-              <span>Title</span>
-              <input class="input" type="text" name="title" maxlength="45" value={boundReward?.title ?? 'Colour my lights'} required />
-            </label>
-            <label class="field">
-              <span>Cost (points)</span>
-              <input class="input" type="number" name="cost" min="1" max="10000000" value={boundReward?.cost ?? 500} required />
-            </label>
-            <label class="field">
-              <span>After it runs</span>
-              <select class="input" name="onRedeem" value={data.binding?.onRedeem ?? 'fulfill'}>
-                <option value="fulfill">Mark fulfilled</option>
-                <option value="cancel">Refund the points</option>
-                <option value="leave">Leave for a mod</option>
-              </select>
-            </label>
-            <div class="reward-actions">
-              <button class="btn primary" type="submit">{boundReward ? 'Update reward' : 'Create reward'}</button>
-              {#if boundReward}
-                <span class="reward-live"><Icon name="check" size={13} /> Live: {boundReward.title} · {boundReward.cost} pts</span>
-              {/if}
+          {#if keyPresent}
+            <div class="row">
+              <span class="ok-pill"><Icon name="check" size={13} /> Key on file</span>
+              <form method="POST" action="?/clearKey" use:enhance={formResult('Key removed.', 'Could not remove the key.', () => (keyPresent = false))}>
+                <button class="btn danger" type="submit">Remove key</button>
+              </form>
             </div>
-          </form>
-          {#if boundReward}
-            <form method="POST" action="?/deleteReward" use:enhance={formResult('Reward deleted.', 'Could not delete the reward.')}>
-              <button class="btn danger ghost" type="submit">Delete reward</button>
+          {:else}
+            <form method="POST" action="?/saveKey" use:enhance={formResult('Key saved.', 'Could not save the key.', () => (keyPresent = true))} class="row">
+              <input class="input" type="password" name="key" placeholder="Paste your Govee API key" autocomplete="off" required />
+              <button class="btn primary" type="submit">Save key</button>
             </form>
           {/if}
-
-          <div class="liveonly {liveOnly ? '' : 'warn'}">
-            <div class="liveonly-text">
-              <span class="liveonly-label">Live only</span>
-              <span class="muted">
-                {liveOnly
-                  ? 'Redemptions only work while your stream is live (recommended).'
-                  : 'Off: viewers can change your lights even when you are offline.'}
-              </span>
-            </div>
-            <button type="button" class="toggle {liveOnly ? 'on' : ''}" aria-label="Toggle live only" onclick={onToggleLiveOnly}></button>
-          </div>
-        {/if}
+        </div>
       </div>
-    </div>
-  </Card>
+    </Card>
+
+    <!-- Step 2: device -->
+    <Card>
+      <div class="step {keyPresent ? '' : 'disabled'}">
+        <span class="step-index">2</span>
+        <div class="step-body">
+          <h2>Pick the light</h2>
+          {#if !keyPresent}
+            <p class="muted-text">Add your API key first to load your devices.</p>
+          {:else}
+            {#await data.devices}
+              <p class="loading"><span class="spinner" aria-hidden="true"></span> Loading your Govee devices…</p>
+            {:then dr}
+              {@const colorDevices = (dr.devices ?? []).filter((d) => d.color)}
+              {@const selectedMeta = colorDevices.find((d) => d.device === selectedDevice)}
+              {#if dr.error}
+                <p class="err-text"><Icon name="ban" size={13} /> {dr.error}</p>
+              {:else if colorDevices.length === 0}
+                <p class="muted-text">No colour-capable Govee devices found on this account.</p>
+              {:else}
+                <form method="POST" action="?/pickDevice" use:enhance={formResult('Device saved.', 'Could not save the device.')}>
+                  <ul class="devices">
+                    {#each colorDevices as d (d.device)}
+                      <li>
+                        <label class="device {selectedDevice === d.device ? 'sel' : ''}">
+                          <input type="radio" name="device" value={d.device} checked={selectedDevice === d.device} onchange={() => (selectedDevice = d.device)} />
+                          <span class="device-name">{d.name || d.device}</span>
+                          <span class="device-sku">{d.sku}</span>
+                        </label>
+                      </li>
+                    {/each}
+                  </ul>
+                  <!-- The sku + name that pair with the chosen device id, resolved
+                       from the selection so the server stores a consistent triple. -->
+                  <input type="hidden" name="sku" value={selectedMeta?.sku ?? ''} />
+                  <input type="hidden" name="deviceName" value={selectedMeta?.name ?? ''} />
+                  <button class="btn primary" type="submit" disabled={!selectedDevice}>Save device</button>
+                </form>
+              {/if}
+            {/await}
+          {/if}
+        </div>
+      </div>
+    </Card>
+
+    <!-- Step 3: reward -->
+    <Card>
+      <div class="step {data.binding?.device ? '' : 'disabled'}">
+        <span class="step-index">3</span>
+        <div class="step-body">
+          <h2>The reward</h2>
+          {#if !data.binding?.device}
+            <p class="muted-text">Pick a light first.</p>
+          {:else}
+            <p class="muted-text">
+              Viewers type a colour when they redeem: a name (<code>{data.colors.join(', ')}</code>) or a hex code like
+              <code>#00ccff</code>.
+            </p>
+            <form method="POST" action="?/saveReward" use:enhance={formResult('Reward saved.', 'Could not save the reward.')} class="reward-form">
+              <label class="field">
+                <span>Title</span>
+                <input class="input" type="text" name="title" maxlength="45" value={boundReward?.title ?? 'Colour my lights'} required />
+              </label>
+              <label class="field">
+                <span>Cost (points)</span>
+                <input class="input" type="number" name="cost" min="1" max="10000000" value={boundReward?.cost ?? 500} required />
+              </label>
+              <label class="field">
+                <span>After it runs</span>
+                <select class="input" name="onRedeem" value={data.binding?.onRedeem ?? 'fulfill'}>
+                  <option value="fulfill">Mark fulfilled</option>
+                  <option value="cancel">Refund the points</option>
+                  <option value="leave">Leave for a mod</option>
+                </select>
+              </label>
+              <div class="reward-actions">
+                <button class="btn primary" type="submit">{boundReward ? 'Update reward' : 'Create reward'}</button>
+                {#if boundReward}
+                  <span class="reward-live"><Icon name="check" size={13} /> Live: {boundReward.title} · {boundReward.cost} pts</span>
+                {/if}
+              </div>
+            </form>
+            {#if boundReward}
+              <form method="POST" action="?/deleteReward" use:enhance={formResult('Reward deleted.', 'Could not delete the reward.')}>
+                <button class="btn ghost danger" type="submit">Delete reward</button>
+              </form>
+            {/if}
+
+            <div class="liveonly {liveOnly ? '' : 'warn'}">
+              <div class="liveonly-text">
+                <span class="liveonly-label">Live only</span>
+                <span class="muted-text">
+                  {liveOnly
+                    ? 'Redemptions only work while your stream is live (recommended).'
+                    : 'Off: viewers can change your lights even when you are offline.'}
+                </span>
+              </div>
+              <button type="button" class="toggle {liveOnly ? 'on' : ''}" aria-label="Toggle live only" onclick={onToggleLiveOnly}></button>
+            </div>
+          {/if}
+        </div>
+      </div>
+    </Card>
+  </div>
 </section>
 
 <!-- Hidden form the toggle submits; the value is set before requestSubmit. -->
@@ -262,7 +281,7 @@
 <ConfirmDialog
   open={confirmOff}
   title="Turn off Live only?"
-  body="With Live only off, anyone who redeems this reward can change your Govee lights even while you are offline or away from your setup. Only turn this off to test — you can turn it back on any time."
+  body="With Live only off, anyone who redeems this reward can change your Govee lights even while you are offline or away from your setup. Only turn this off to test. You can turn it back on any time."
   confirmLabel="Turn it off"
   cancelLabel="Keep it on"
   danger
@@ -275,225 +294,205 @@
 />
 
 <style>
-  .toolbar {
+  .back {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-family: var(--bb-font-body);
+    font-size: 12.5px;
+    color: var(--bb-muted);
+    text-decoration: none;
+    margin-bottom: 10px;
+  }
+  .back:hover { color: var(--bb-white); }
+
+  /* Inline notes: degraded backend + reconnect CTA. */
+  .note {
     display: flex;
     align-items: center;
-    gap: 0.6rem;
-    margin: 0.5rem 0 1rem;
+    gap: 8px;
+    padding: 10px 14px;
+    border-radius: 8px;
+    margin-bottom: 14px;
+    font-family: var(--bb-font-body);
+    font-size: 13px;
   }
-  .toolbar-label {
-    font-size: 0.85rem;
-    color: var(--text-muted, #8a8f98);
+  .note.err {
+    border: 1px solid rgba(176, 90, 70, 0.4);
+    background: rgba(176, 90, 70, 0.08);
+    color: #cf8a78;
   }
-  .master {
-    display: inline-flex;
+  .note.reconnect {
+    justify-content: space-between;
+    flex-wrap: wrap;
+    border: 1px solid var(--rule-strong);
+    background: var(--glass-fill);
+    color: var(--bb-white);
   }
-  .toggle {
-    width: 42px;
-    height: 24px;
-    border-radius: 999px;
-    border: none;
-    background: var(--border, #3a3d44);
-    position: relative;
-    cursor: pointer;
-    transition: background 0.15s ease;
-  }
-  .toggle::after {
-    content: '';
-    position: absolute;
-    top: 3px;
-    left: 3px;
-    width: 18px;
-    height: 18px;
-    border-radius: 50%;
-    background: #fff;
-    transition: transform 0.15s ease;
-  }
-  .toggle.on {
-    background: var(--accent, #1f69ff);
-  }
-  .toggle.on::after {
-    transform: translateX(18px);
-  }
+  .note-text { display: inline-flex; align-items: center; gap: 8px; }
 
-  .step {
-    display: flex;
-    gap: 1rem;
-    align-items: flex-start;
+  /* Master switch surface (mirrors the module detail settings card). */
+  :global(.master-card) { margin-bottom: 16px; }
+  .toggle-row { display: flex; align-items: center; gap: 12px; padding: 16px 18px; }
+  .tr-text { display: flex; flex-direction: column; gap: 3px; margin-right: auto; }
+  .tr-label { font-family: var(--bb-font-display); font-weight: 700; font-size: 14px; color: var(--bb-white); }
+  .tr-help { font-family: var(--bb-font-body); font-size: 12px; color: var(--bb-muted); }
+  .master { display: inline-flex; }
+
+  /* Stepped setup: one card per step, dimmed as a group when the module is off. */
+  .steps {
+    display: grid;
+    gap: 14px;
+    transition: opacity var(--bb-dur-fast, 140ms) ease;
   }
-  .step.disabled {
-    opacity: 0.55;
-  }
-  .step-num {
+  .steps.muted { opacity: 0.72; }
+
+  .step { display: flex; gap: 14px; align-items: flex-start; }
+  .step.disabled { opacity: 0.55; }
+  .step-index {
     flex: none;
-    width: 28px;
-    height: 28px;
-    border-radius: 50%;
+    width: 34px;
+    height: 34px;
+    border-radius: 8px;
     display: grid;
     place-items: center;
-    background: var(--accent, #1f69ff);
-    color: #fff;
-    font-weight: 700;
-    font-size: 0.85rem;
+    background: rgba(201, 168, 124, 0.12);
+    border: 1px solid var(--glass-border);
+    color: var(--bb-tan-light);
+    font-family: var(--bb-font-mono, "DM Mono", monospace);
+    font-weight: 600;
+    font-size: 14px;
   }
-  .step-body {
-    flex: 1;
-    min-width: 0;
-  }
+  .step-body { flex: 1; min-width: 0; }
   .step-body h2 {
-    margin: 0 0 0.35rem;
-    font-size: 1.05rem;
+    margin: 0 0 6px;
+    font-family: var(--bb-font-display);
+    font-weight: 700;
+    font-size: 15px;
+    color: var(--bb-white);
   }
-  .muted {
-    color: var(--text-muted, #8a8f98);
-    font-size: 0.88rem;
-    margin: 0 0 0.75rem;
+  .muted-text {
+    color: var(--bb-muted);
+    font-family: var(--bb-font-body);
+    font-size: 13px;
+    line-height: 1.55;
+    margin: 0 0 14px;
   }
-  .row {
-    display: flex;
-    gap: 0.6rem;
-    align-items: center;
-    flex-wrap: wrap;
-  }
+  .muted-text strong { color: var(--bb-tan-light); font-weight: 600; }
+
+  .row { display: flex; gap: 10px; align-items: center; flex-wrap: wrap; }
+
+  /* Inputs match the module detail .setting-input token style. */
   .input {
-    padding: 0.5rem 0.7rem;
-    border-radius: 8px;
-    border: 1px solid var(--border, #3a3d44);
-    background: var(--surface, #16181d);
-    color: inherit;
-    font: inherit;
-    min-width: 12rem;
+    padding: 8px 12px;
+    border-radius: 6px;
+    border: 1px solid var(--rule);
+    background: rgba(240, 236, 228, 0.04);
+    color: var(--bb-white);
+    font-family: var(--bb-font-body);
+    font-size: 13px;
+    min-width: 13rem;
+    transition: border-color var(--bb-dur-fast, 140ms) ease;
   }
-  .btn {
-    padding: 0.5rem 0.9rem;
-    border-radius: 8px;
-    border: 1px solid var(--border, #3a3d44);
-    background: var(--surface, #16181d);
-    color: inherit;
-    cursor: pointer;
-    font: inherit;
-  }
-  .btn.primary {
-    background: var(--accent, #1f69ff);
-    border-color: transparent;
-    color: #fff;
-  }
-  .btn.danger {
-    color: #ff6b6b;
-  }
-  .btn.ghost {
-    background: transparent;
-    margin-top: 0.5rem;
-  }
-  .btn:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
+  .input:focus { outline: none; border-color: var(--bb-tan, #c9a87c); }
+  .input::placeholder { color: var(--bb-muted); opacity: 0.7; }
+
+  /* danger buttons layer over the global .btn base. */
+  .btn.danger { color: #cf8a78; }
+  .btn.ghost.danger { margin-top: 10px; border-color: rgba(176, 90, 70, 0.4); }
+  .btn.ghost.danger:hover { background: rgba(176, 90, 70, 0.1); color: #dc9c8a; }
+
   .ok-pill {
     display: inline-flex;
     align-items: center;
-    gap: 0.3rem;
-    color: #48c78e;
-    font-size: 0.88rem;
+    gap: 6px;
+    color: var(--bb-green-glow);
+    font-family: var(--bb-font-body);
+    font-size: 13px;
     font-weight: 600;
   }
   .err-text {
-    color: #ff6b6b;
-    font-size: 0.88rem;
+    color: #cf8a78;
+    font-family: var(--bb-font-body);
+    font-size: 13px;
     display: flex;
     align-items: center;
-    gap: 0.3rem;
+    gap: 6px;
+    margin: 0;
   }
-  .devices {
-    list-style: none;
-    margin: 0 0 0.9rem;
-    padding: 0;
-    display: grid;
-    gap: 0.4rem;
+  .loading {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    color: var(--bb-muted);
+    font-family: var(--bb-font-body);
+    font-size: 13px;
+    margin: 0;
   }
+  .spinner {
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    border: 2px solid var(--rule-strong);
+    border-top-color: var(--bb-tan-light);
+    animation: spin 0.7s linear infinite;
+  }
+  @keyframes spin { to { transform: rotate(360deg); } }
+
+  .devices { list-style: none; margin: 0 0 14px; padding: 0; display: grid; gap: 6px; }
   .device {
     display: flex;
     align-items: center;
-    gap: 0.6rem;
-    padding: 0.55rem 0.7rem;
-    border: 1px solid var(--border, #3a3d44);
-    border-radius: 8px;
+    gap: 10px;
+    padding: 9px 12px;
+    border: 1px solid var(--rule);
+    border-radius: 6px;
     cursor: pointer;
+    transition: border-color var(--bb-dur-fast, 140ms) ease, background var(--bb-dur-fast, 140ms) ease;
   }
+  .device:hover { border-color: var(--rule-strong); }
   .device.sel {
-    border-color: var(--accent, #1f69ff);
-    background: color-mix(in srgb, var(--accent, #1f69ff) 12%, transparent);
+    border-color: var(--rule-tan);
+    background: rgba(201, 168, 124, 0.08);
   }
-  .device-name {
+  .device input { accent-color: var(--bb-tan); }
+  .device-name { font-family: var(--bb-font-body); font-weight: 600; font-size: 13px; color: var(--bb-white); }
+  .device-sku { color: var(--bb-muted); font-family: var(--bb-font-mono, monospace); font-size: 11.5px; margin-left: auto; }
+
+  .reward-form { display: grid; gap: 12px; max-width: 22rem; }
+  .field { display: grid; gap: 5px; }
+  .field > span {
+    font-family: var(--bb-font-body);
+    font-size: 12px;
     font-weight: 600;
+    color: var(--bb-muted);
   }
-  .device-sku {
-    color: var(--text-muted, #8a8f98);
-    font-size: 0.8rem;
-    margin-left: auto;
-  }
-  .reward-form {
-    display: grid;
-    gap: 0.7rem;
-    max-width: 22rem;
-  }
-  .field {
-    display: grid;
-    gap: 0.25rem;
-    font-size: 0.85rem;
-  }
-  .reward-actions {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    flex-wrap: wrap;
-  }
+  .reward-actions { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
   .reward-live {
     display: inline-flex;
     align-items: center;
-    gap: 0.3rem;
-    color: #48c78e;
-    font-size: 0.82rem;
+    gap: 6px;
+    color: var(--bb-green-glow);
+    font-family: var(--bb-font-body);
+    font-size: 12.5px;
   }
+
   .liveonly {
     display: flex;
     align-items: center;
-    gap: 0.75rem;
-    margin-top: 1rem;
-    padding-top: 0.9rem;
-    border-top: 1px solid var(--border, #3a3d44);
+    gap: 12px;
+    margin-top: 16px;
+    padding-top: 14px;
+    border-top: 1px solid var(--rule);
   }
-  .liveonly-text {
-    display: grid;
-    gap: 0.15rem;
-    flex: 1;
-    min-width: 0;
-  }
-  .liveonly-label {
-    font-weight: 600;
-    font-size: 0.9rem;
-  }
-  .liveonly.warn .liveonly-label {
-    color: #ffb454;
-  }
-  .liveonly .toggle {
-    flex: none;
-  }
+  .liveonly-text { display: grid; gap: 3px; flex: 1; min-width: 0; }
+  .liveonly-label { font-family: var(--bb-font-display); font-weight: 700; font-size: 13px; color: var(--bb-white); }
+  .liveonly-text .muted-text { margin: 0; }
+  .liveonly.warn .liveonly-label { color: #d9a441; }
+
   code {
-    font-size: 0.82em;
-  }
-  .degraded,
-  .reconnect {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.6rem 0.8rem;
-    border-radius: 8px;
-    margin-bottom: 0.8rem;
-    font-size: 0.88rem;
-  }
-  .reconnect {
-    justify-content: space-between;
-    flex-wrap: wrap;
+    font-family: var(--bb-font-mono, monospace);
+    font-size: 0.86em;
+    color: var(--bb-tan-light);
   }
 </style>

--- a/console/shared/lib/server/cache-keys.ts
+++ b/console/shared/lib/server/cache-keys.ts
@@ -34,7 +34,14 @@ export const POLICY = {
   adminPage: { freshMs: 3_000, swrMs: 30_000 },
   entity: { freshMs: 120_000, swrMs: 600_000, staleIfErrorMs: 600_000 },
   security: { freshMs: 60_000, swrMs: 120_000, staleIfErrorMs: 300_000 },
-  projected: { freshMs: 600_000, swrMs: 1_800_000 }
+  projected: { freshMs: 600_000, swrMs: 1_800_000 },
+  // govee: the third-party device list + key-presence flag. Both are read on
+  // every govee page load (and every /events invalidation), but the underlying
+  // Govee cloud call is slow and rate-limited, so a short fresh window plus a
+  // long SWR/stale-if-error tail renders the picker instantly and refreshes in
+  // the background. Not bus-scoped: freshness comes from the clock plus an
+  // explicit flush on key set/clear (see govee-store).
+  govee: { freshMs: 60_000, swrMs: 600_000, staleIfErrorMs: 600_000 }
 } as const satisfies Record<string, CachePolicy>;
 
 export type PolicyName = keyof typeof POLICY;


### PR DESCRIPTION
## Problems fixed
- **Off-brand styling.** The Govee page used undefined blue fallback vars (`--accent`→`#1f69ff`) and stacked bare `<Card>`s with no gap, so it matched neither the module pages nor each other. Rebuilt in the console ledger design system (tokens, tan/green accents, mono step index chips, spaced step cards, `.back` link, master toggle-row).
- **Nav jumped to Overview.** `/govee` matched no prefix in the app layout so the crumb + sidebar fell back to `overview`. It now maps to the **Modules** section.
- **Slow load.** SSR blocked on the Govee cloud device fetch on every load and every `/events` invalidation. The device list is now **streamed** (`{#await}` with a spinner) and backed by a dashboard-side SWR cache (`POLICY.govee`) flushed on key set/clear; the module-blob and key-presence reads run in parallel.
- **Token save felt broken.** Key-on-file now reflects **optimistically** on save (and the presence read is no longer cached per-replica, so a save can't strand a stale "no key" view on another pod).

## Verify
`svelte-check` clean; rendered end-to-end in DEMO mode (design, Modules nav active, streamed picker, optimistic save, master toggle dims steps).

Pairs with the gateway PR (feat/gateway-govee-swr), which shortens the gateway devices handler this PR's 9s RPC budget is aligned to.