### PR TITLE
feat(gateway): SWR reply cache, shared HTTP transport, tighter govee timeouts

### DIFF
--- a/app/gateway/internal/core/bytes.go
+++ b/app/gateway/internal/core/bytes.go
@@ -2,29 +2,42 @@ package core
 
 import (
 	"context"
+	"strconv"
 	"sync"
 	"time"
 
 	"github.com/bytedance/sonic"
 )
 
-// Byte-flow caching: the pass-through endpoints (urchin, hypixel) shape their
-// reply once on fetch and cache the READY-TO-SEND wire bytes. A cache hit then
-// answers with zero JSON work — no envelope unmarshal, no reply re-marshal —
-// the stored payload is sliced out of the entry and handed straight to the
-// NATS responder. This mirrors sesame's hot-path discipline (pooled buffers,
-// sonic, no allocation above the transport floor).
+// Byte-flow caching with stale-while-revalidate: the pass-through endpoints
+// (urchin, hypixel, govee) shape their reply once on fetch and cache the
+// READY-TO-SEND wire bytes. A hit answers with zero JSON work — no envelope
+// unmarshal, no reply re-marshal — the stored payload is sliced out of the
+// entry and handed straight to the NATS responder. This mirrors sesame's
+// hot-path discipline (pooled buffers, sonic, no allocation above the transport
+// floor).
 //
-// Entry format: {"gw1":<reply bytes>} — a fixed prefix marker plus the raw
-// reply. The marker is the format guard: an entry without it (legacy format,
-// foreign writer, shape drift after a version bump) reads as poison and is
-// refetched, never served as a zero-value reply. Bumping the format is
-// renaming the marker. The whole entry stays valid JSON so operators can read
-// it in valkey-cli.
+// SWR: an entry is stored with a fresh window (the build's TTL) and physically
+// retained for twice that. A read inside the fresh window returns the payload
+// as-is; a read in the stale tail returns the payload immediately AND kicks a
+// single background refresh, so the slow upstream (a Govee cloud round trip) is
+// almost never on a caller's critical path — only the very first, cold fetch is.
+//
+// Entry format: {"gw2":<freshUntilUnixMs>,"p":<reply bytes>} — a fixed prefix
+// marker, the fresh-until stamp, then the raw reply. The marker is the format
+// guard: an entry without it (legacy {"gw1":…}, foreign writer, shape drift
+// after a version bump) reads as poison and is refetched, never served as a
+// zero-value reply. Bumping the format is renaming the marker. The whole entry
+// stays valid JSON so operators can read it in valkey-cli.
 var (
-	entryPrefix = []byte(`{"gw1":`)
+	entryPrefix = []byte(`{"gw2":`)
+	entryMid    = []byte(`,"p":`)
 	entrySuffix = byte('}')
 )
+
+// swrRefreshTimeout bounds a background revalidation's own context (the request
+// that triggered it has already been answered from the stale value).
+const swrRefreshTimeout = 15 * time.Second
 
 // entryBufPool recycles the scratch buffers entries are assembled in before
 // the store write copies them onto the wire.
@@ -35,33 +48,60 @@ var entryBufPool = sync.Pool{
 	},
 }
 
-// unwrapEntry extracts the reply payload from one stored entry, or reports a
-// format mismatch. The returned slice aliases b.
-func unwrapEntry(b []byte) ([]byte, bool) {
-	if len(b) < len(entryPrefix)+1 || b[len(b)-1] != entrySuffix {
-		return nil, false
+// unwrapEntry extracts (freshUntilUnixMs, payload) from one stored entry, or
+// reports a format mismatch. The returned payload slice aliases b. It scans the
+// fresh-until digits inline — no JSON unmarshal — so the hit path stays
+// allocation-free.
+func unwrapEntry(b []byte) (int64, []byte, bool) {
+	if len(b) < len(entryPrefix)+len(entryMid)+1 || b[len(b)-1] != entrySuffix {
+		return 0, nil, false
 	}
 	for i := range entryPrefix {
 		if b[i] != entryPrefix[i] {
-			return nil, false
+			return 0, nil, false
 		}
 	}
-	return b[len(entryPrefix) : len(b)-1], true
+	i := len(entryPrefix)
+	start := i
+	var fresh int64
+	for i < len(b) && b[i] >= '0' && b[i] <= '9' {
+		fresh = fresh*10 + int64(b[i]-'0')
+		i++
+	}
+	if i == start || i+len(entryMid) > len(b) {
+		return 0, nil, false
+	}
+	for j := range entryMid {
+		if b[i+j] != entryMid[j] {
+			return 0, nil, false
+		}
+	}
+	payload := b[i+len(entryMid) : len(b)-1]
+	if len(payload) == 0 {
+		return 0, nil, false
+	}
+	return fresh, payload, true
 }
 
 // CachedBytes returns the ready-to-send reply bytes under key, or runs build to
-// produce them. build returns the reply bytes and the TTL to store them for;
-// a TTL of zero (or less) answers without caching — that is how a rate-limit
-// denial stays friendly but is retried on the very next request. Negative
-// replies (player not found) are ordinary replies with a short TTL: the
+// produce them. build returns the reply bytes and the fresh-window TTL to store
+// them for; a TTL of zero (or less) answers without caching — that is how a
+// rate-limit denial stays friendly but is retried on the very next request.
+// Negative replies (player not found) are ordinary replies with a short TTL: the
 // provider shapes them, so a hit on a negative costs the same zero JSON work
 // as a hit on a success.
 //
-// Concurrent misses for one key collapse through singleflight. A Store error
-// degrades to a direct build rather than failing the lookup.
+// A fresh hit returns as-is; a stale hit returns the stored bytes and revalidates
+// in the background. Concurrent misses for one key collapse through singleflight.
+// A Store error degrades to a direct build rather than failing the lookup.
 func CachedBytes(ctx context.Context, c *Cache, key string, build func(context.Context) ([]byte, time.Duration, error)) ([]byte, error) {
 	if b, ok, err := c.store.Get(ctx, key); err == nil && ok {
-		if payload, valid := unwrapEntry(b); valid {
+		if fresh, payload, valid := unwrapEntry(b); valid {
+			if time.Now().UnixMilli() < fresh {
+				return payload, nil
+			}
+			// Stale but still retained: serve it now, revalidate behind the scenes.
+			c.refreshBytes(key, build)
 			return payload, nil
 		}
 		// Poison entry (legacy or foreign format): drop it and refetch.
@@ -71,7 +111,7 @@ func CachedBytes(ctx context.Context, c *Cache, key string, build func(context.C
 	res, err, _ := c.sf.Do(key, func() (any, error) {
 		// A previous flight may have filled the key while we queued.
 		if b, ok, gerr := c.store.Get(ctx, key); gerr == nil && ok {
-			if payload, valid := unwrapEntry(b); valid {
+			if _, payload, valid := unwrapEntry(b); valid {
 				return payload, nil
 			}
 		}
@@ -80,22 +120,59 @@ func CachedBytes(ctx context.Context, c *Cache, key string, build func(context.C
 		if berr != nil {
 			return nil, berr
 		}
-		if ttl > 0 {
-			bufp := entryBufPool.Get().(*[]byte)
-			buf := (*bufp)[:0]
-			buf = append(buf, entryPrefix...)
-			buf = append(buf, payload...)
-			buf = append(buf, entrySuffix)
-			_ = c.store.Set(ctx, key, buf, ttl)
-			*bufp = buf[:0]
-			entryBufPool.Put(bufp)
-		}
+		storeEntry(ctx, c, key, payload, ttl)
 		return payload, nil
 	})
 	if err != nil {
 		return nil, err
 	}
 	return res.([]byte), nil
+}
+
+// storeEntry writes payload with a fresh window of ttl and a physical retention
+// of 2*ttl, so the entry outlives its fresh window into a stale tail where it is
+// served while a background refresh runs. ttl<=0 is not cached (a friendly
+// rate-limit denial must retry on the next request, never pin).
+func storeEntry(ctx context.Context, c *Cache, key string, payload []byte, ttl time.Duration) {
+	if ttl <= 0 {
+		return
+	}
+	freshMs := time.Now().Add(ttl).UnixMilli()
+	bufp := entryBufPool.Get().(*[]byte)
+	buf := (*bufp)[:0]
+	buf = append(buf, entryPrefix...)
+	buf = strconv.AppendInt(buf, freshMs, 10)
+	buf = append(buf, entryMid...)
+	buf = append(buf, payload...)
+	buf = append(buf, entrySuffix)
+	_ = c.store.Set(ctx, key, buf, 2*ttl)
+	*bufp = buf[:0]
+	entryBufPool.Put(bufp)
+}
+
+// refreshBytes revalidates one stale key in the background, deduped via
+// c.refreshing so only one refresh runs per key. It uses a detached context (the
+// triggering request was already answered from the stale value) and
+// single-flights with any concurrent blocking miss. A failed refresh is
+// swallowed and leaves the stale entry to expire on its physical TTL, so an
+// upstream blip degrades to slightly-old data rather than an error.
+func (c *Cache) refreshBytes(key string, build func(context.Context) ([]byte, time.Duration, error)) {
+	if _, busy := c.refreshing.LoadOrStore(key, struct{}{}); busy {
+		return
+	}
+	go func() {
+		defer c.refreshing.Delete(key)
+		ctx, cancel := context.WithTimeout(context.Background(), swrRefreshTimeout)
+		defer cancel()
+		_, _, _ = c.sf.Do(key, func() (any, error) {
+			payload, ttl, err := build(ctx)
+			if err != nil {
+				return nil, err
+			}
+			storeEntry(ctx, c, key, payload, ttl)
+			return payload, nil
+		})
+	}()
 }
 
 // MarshalReply renders one reply value for the wire (and for CachedBytes

--- a/app/gateway/internal/core/bytes_test.go
+++ b/app/gateway/internal/core/bytes_test.go
@@ -99,14 +99,49 @@ func TestCachedBytesSharedAcrossInstances(t *testing.T) {
 }
 
 func TestUnwrapEntry(t *testing.T) {
-	payload, ok := unwrapEntry([]byte(`{"gw1":{"a":1}}`))
+	fresh, payload, ok := unwrapEntry([]byte(`{"gw2":123,"p":{"a":1}}`))
 	require.True(t, ok)
+	assert.Equal(t, int64(123), fresh)
 	assert.Equal(t, `{"a":1}`, string(payload))
 
-	for _, bad := range []string{"", "{}", `{"gw1":`, `{"player":"x"}`, `{"gw2":{"a":1}}`} {
-		_, ok := unwrapEntry([]byte(bad))
+	// Rejected: empty, non-entry JSON, truncations, a missing/empty fresh stamp,
+	// an empty payload, and the legacy {"gw1":…} marker (format bump = poison).
+	for _, bad := range []string{
+		"", "{}", `{"gw2":`, `{"gw2":123}`, `{"gw2":,"p":{}}`, `{"gw2":123,"p":}`,
+		`{"player":"x"}`, `{"gw1":{"a":1}}`,
+	} {
+		_, _, ok := unwrapEntry([]byte(bad))
 		assert.False(t, ok, "must reject %q", bad)
 	}
+}
+
+// A stale entry is served immediately and revalidated in the background, so the
+// slow upstream stays off the caller's path after the first cold fill.
+func TestCachedBytesStaleServedThenRevalidated(t *testing.T) {
+	c := NewCache(newMemStore())
+	var builds atomic.Int32
+	ctx := context.Background()
+
+	// Cold fill, fresh for 20ms.
+	b, err := CachedBytes(ctx, c, "k", buildStatic(`{"n":1}`, 20*time.Millisecond, &builds))
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"n":1}`, string(b))
+	require.Equal(t, int32(1), builds.Load())
+
+	// Let the fresh window lapse. memStore keeps the bytes; SWR is driven by the
+	// embedded fresh-until stamp, not physical expiry.
+	time.Sleep(40 * time.Millisecond)
+
+	// Stale hit: returns the OLD bytes at once and kicks one background rebuild.
+	b, err = CachedBytes(ctx, c, "k", buildStatic(`{"n":2}`, time.Minute, &builds))
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"n":1}`, string(b), "stale hit must serve the old bytes")
+
+	// The revalidation lands the new value; once fresh, later reads serve it.
+	require.Eventually(t, func() bool {
+		got, gerr := CachedBytes(ctx, c, "k", buildStatic(`{"n":2}`, time.Minute, &builds))
+		return gerr == nil && string(got) == `{"n":2}`
+	}, time.Second, 10*time.Millisecond)
 }
 
 // The reply-bytes hit path is the gateway's hot path: after the store read it

--- a/app/gateway/internal/core/cache.go
+++ b/app/gateway/internal/core/cache.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/bytedance/sonic"
@@ -66,6 +67,9 @@ func (s *ValkeyStore) Del(ctx context.Context, key string) error {
 type Cache struct {
 	store Store
 	sf    singleflight.Group
+	// refreshing dedups background SWR revalidations: one per key at a time
+	// (see refreshBytes). Keys are cleared as each refresh finishes.
+	refreshing sync.Map
 }
 
 func NewCache(store Store) *Cache { return &Cache{store: store} }

--- a/app/gateway/internal/core/http.go
+++ b/app/gateway/internal/core/http.go
@@ -33,8 +33,27 @@ func (e *UpstreamError) Error() string {
 	return fmt.Sprintf("upstream status %d", e.Status)
 }
 
+// sharedTransport is the one outbound transport every provider's HTTPClient
+// runs on. Pooling connections (and their TLS sessions) here — instead of each
+// client falling back to http.DefaultTransport with its stingy
+// 2-idle-conns-per-host default — lets repeated calls to an upstream (a burst of
+// Govee control redemptions, a chat spike of stats lookups) reuse a warm
+// connection instead of paying a fresh TLS handshake each time. Per-call
+// timeouts still live on the individual clients.
+var sharedTransport = newSharedTransport()
+
+func newSharedTransport() *http.Transport {
+	t := http.DefaultTransport.(*http.Transport).Clone()
+	t.MaxIdleConns = 200
+	t.MaxIdleConnsPerHost = 32
+	t.IdleConnTimeout = 90 * time.Second
+	t.ForceAttemptHTTP2 = true
+	return t
+}
+
 // HTTPClient is the outbound fetcher a provider dials its API with: one base
-// URL, a fixed header set (API keys), and a bounded per-request timeout.
+// URL, a fixed header set (API keys), and a bounded per-request timeout. All
+// clients share sharedTransport, so connection reuse spans providers.
 type HTTPClient struct {
 	base    string
 	headers map[string]string
@@ -47,7 +66,7 @@ func NewHTTPClient(base string, headers map[string]string, timeout time.Duration
 	if timeout <= 0 {
 		timeout = 10 * time.Second
 	}
-	return &HTTPClient{base: base, headers: headers, hc: &http.Client{Timeout: timeout}}
+	return &HTTPClient{base: base, headers: headers, hc: &http.Client{Timeout: timeout, Transport: sharedTransport}}
 }
 
 // Request is one outbound call: the HTTP method, a path appended to the base

--- a/app/gateway/internal/providers/govee/govee.go
+++ b/app/gateway/internal/providers/govee/govee.go
@@ -34,8 +34,17 @@ const (
 	devicesTTL  = 60 * time.Second
 	negativeTTL = 10 * time.Second
 
-	httpTimeout    = 10 * time.Second
-	handlerTimeout = 12 * time.Second
+	// httpTimeout bounds one Govee call. Trimmed from 10s: Govee answers a
+	// healthy request in ~1-2s, and the byte-flow cache now serves the device
+	// list stale-while-revalidate, so a caller almost never waits on the wire.
+	httpTimeout = 6 * time.Second
+	// devicesTimeout bounds the whole devices handler (key resolve + one HTTP
+	// call). Kept under the dashboard's 9s RPC budget so the caller always
+	// outlasts the handler instead of abandoning a fetch it is still running.
+	devicesTimeout = 8 * time.Second
+	// controlTimeout is looser: a redemption fires two sequential Govee calls
+	// (power, then colour) plus the key resolve.
+	controlTimeout = 12 * time.Second
 
 	// Govee's per-key budget window and a conservative per-broadcaster ceiling.
 	// Govee documents ~10 requests/minute for device control; control spends two
@@ -104,8 +113,8 @@ func (p *Provider) Name() string { return "govee" }
 
 func (p *Provider) Endpoints() []provider.Endpoint {
 	return []provider.Endpoint{
-		{Name: "devices", Timeout: handlerTimeout, Handle: p.devices},
-		{Name: "control", Timeout: handlerTimeout, Handle: p.control},
+		{Name: "devices", Timeout: devicesTimeout, Handle: p.devices},
+		{Name: "control", Timeout: controlTimeout, Handle: p.control},
 	}
 }
 


### PR DESCRIPTION
Cuts the ~8s Govee device transaction by moving the slow upstream off the caller's critical path, using the shared gateway machinery (not a govee-only path).

## Changes
- **Stale-while-revalidate byte-flow cache.** Was hard-TTL: every 60s the next caller ate the full Govee fetch synchronously. Entries now carry a fresh-until stamp (format `gw1`→`gw2`) and are physically retained 2× TTL, so a stale hit returns the cached bytes instantly and kicks **one deduped background refresh** on a detached context. Benefits every provider (hypixel/mcsr/urchin too). Hot hit path stays **0 alloc**.
- **Shared tuned `http.Transport`.** Every provider client fell back to `http.DefaultTransport` (2 idle conns/host). Now one pooled transport (MaxIdleConnsPerHost 32, HTTP/2, 90s idle) so TLS connections to upstreams are reused.
- **Tighter/aligned timeouts.** Govee HTTP 10s→6s; devices handler split from control (devices 8s, control 12s). Dashboard devices RPC bumped 8s→9s so it never abandons an in-flight gateway fetch.

## Blast radius
Shared-cache change affects all providers. On deploy, existing `gw1` entries read as poison and refetch once (singleflight-collapsed). Decrypted keys are **not** cached (custody model unchanged).

## Verify
`go build`, all gateway package tests, `go vet`, `-race` clean; `BenchmarkCachedBytesHit` still `0 B/op, 0 allocs/op`.