### PR TITLE
fix(console): stop injecting New Relic Browser RUM on every SSR render

### DIFF
--- a/console/shared/lib/server/rum.ts
+++ b/console/shared/lib/server/rum.ts
@@ -1,32 +1,23 @@
-// New Relic Browser (RUM) injection for streamed SSR, shared by both consoles.
+// New Relic Browser (RUM) injection — DISABLED, shared by both consoles.
 //
-// The agent loader must be inline in <head> and must carry the per-response CSP
-// nonce SvelteKit emitted (script-src stays nonce-based, no 'unsafe-inline').
-// Streaming constraint: the transform must never hold state ACROSS chunks — the
-// previous implementation captured the nonce from "whichever chunk carries it",
-// which serialized page flushes behind nonce capture. In SvelteKit's HTML shell
-// the chunk containing </head> always also carries the nonce attributes, so we
-// operate on that single chunk in one pass and pass every other chunk through
-// untouched.
+// This used to inject the New Relic Browser agent (a ~69KB inline <script> from
+// newrelic.getBrowserTimingHeader) into the <head> of every SSR HTML page. It was
+// removed because:
+//   * getBrowserTimingHeader sat on the streamed response's first-chunk critical
+//     path and added ~2s to EVERY full-page render, so every page in both
+//     consoles (not just any one route) was slow;
+//   * it shipped a third-party browser agent that stored a client-side session id
+//     and reported user data to New Relic with no consent gate — a privacy/ePrivacy
+//     concern for EU (fr) visitors.
+// Server-side APM is unaffected; only the browser-side agent is gone.
 //
-// Returns '' -> no-op when the agent is not connected (dev), when no nonce is
-// present (CSP would block the inline script anyway), or after injection.
-import newrelic from 'newrelic';
+// rumTransform is kept as a no-op passthrough so the hooks.server.ts wiring in
+// both apps stays unchanged. To re-enable RUM: restore the getBrowserTimingHeader
+// injection (cache the static loader once per process and splice only the
+// per-request CSP nonce in, so it never re-blocks the render) AND add a consent
+// gate before the agent ever reaches the browser.
 
-/** Per-request transformPageChunk. Construct one per handled request. */
+/** Per-request transformPageChunk. No-op: RUM injection is disabled. */
 export function rumTransform(): (opts: { html: string }) => string {
-  let injected = false;
-  return ({ html }) => {
-    if (injected || !html.includes('</head>')) return html;
-    injected = true;
-    const nonce = html.match(/nonce="([^"]+)"/)?.[1];
-    if (!nonce) return html;
-    let snippet = '';
-    try {
-      snippet = newrelic.getBrowserTimingHeader({ nonce });
-    } catch {
-      /* agent not ready (e.g. dev); skip injection */
-    }
-    return snippet ? html.replace('</head>', `${snippet}</head>`) : html;
-  };
+  return ({ html }) => html;
 }


### PR DESCRIPTION
## What
Disable the New Relic Browser (RUM) injection in both consoles by making the shared `rumTransform` a no-op passthrough.

## Why
- `newrelic.getBrowserTimingHeader()` blocked the streamed SSR response's first chunk by **~2s on every full HTML page** in both dashboard and admin. Measured in prod: `/login` TTFB ~1.5-2.4s vs ~35ms for redirects/`/readyz`; pod CPU stayed idle (3-7m) → I/O-wait on the injection, not render cost. Uniform across all pods/nodes.
- The injected ~69KB agent stored a client-side session id and reported user data to New Relic with **no consent gate** — a privacy/ePrivacy concern for EU (fr) users.

## Scope
- Single shared file: `console/shared/lib/server/rum.ts` (function → passthrough). Both hooks keep the same signature.
- Server-side APM untouched. The type decl + re-enable notes (cache the static loader, splice only the per-request nonce, add a consent gate) are left in place.

## Verify
Post-deploy: `/login` TTFB should drop from ~3s to ~35ms.