### PR TITLE
feat(govee): reward colour, custom reply + rehearsal, opt-in off action, cooldown

### DIFF
--- a/app/gateway/internal/providers/govee/govee.go
+++ b/app/gateway/internal/providers/govee/govee.go
@@ -247,7 +247,7 @@ func (p *Provider) control(ctx context.Context, req gatewayrpc.Request) any {
 	}
 
 	target := goveeTarget{http: p.http, headers: authHeader(key), sku: strings.TrimSpace(req.SKU), device: strings.TrimSpace(req.Device)}
-	for _, step := range controlSteps(req.ColorRGB) {
+	for _, step := range controlSteps(req) {
 		if err := target.set(ctx, step.capType, step.instance, step.value); err != nil {
 			p.log.Warn("govee control step failed", zap.String("broadcaster", broadcaster), zap.String("capability", step.capType), zap.Error(err))
 			return gatewayrpc.GoveeControlReply{Error: friendlyControlError(err)}
@@ -266,7 +266,8 @@ func validateControlInput(req gatewayrpc.Request) string {
 	if strings.TrimSpace(req.Device) == "" || strings.TrimSpace(req.SKU) == "" {
 		return "missing device"
 	}
-	if req.ColorRGB < 0 || req.ColorRGB > 0xFFFFFF {
+	// A power-off carries no colour; only validate the colour on a colour set.
+	if !req.PowerOff && (req.ColorRGB < 0 || req.ColorRGB > 0xFFFFFF) {
 		return "colour out of range"
 	}
 	return ""
@@ -300,12 +301,16 @@ type controlStep struct {
 	value    any
 }
 
-// controlSteps is the ordered capability sequence one redemption runs: power on,
-// then set the colour.
-func controlSteps(rgb int) []controlStep {
+// controlSteps is the ordered capability sequence one redemption runs. A colour
+// set powers the device on then sets the colour; a power-off is the single
+// off step (Govee's power capability with value 0).
+func controlSteps(req gatewayrpc.Request) []controlStep {
+	if req.PowerOff {
+		return []controlStep{{powerCapabilityType, powerInstance, 0}}
+	}
 	return []controlStep{
 		{powerCapabilityType, powerInstance, 1},
-		{colorCapabilityType, colorInstance, rgb},
+		{colorCapabilityType, colorInstance, req.ColorRGB},
 	}
 }
 

--- a/app/sesame/modules/govee.go
+++ b/app/sesame/modules/govee.go
@@ -41,6 +41,14 @@ type goveeConfig struct {
 	// so the safe posture is the zero value; the dashboard only sets it true
 	// behind a warning, since it lets viewers control the lights any time.
 	AllowOffline bool `json:"allowOffline"`
+	// AllowOff opts into the "off" action: a viewer typing "off" turns the light
+	// off instead of it being an unrecognized colour. Default false keeps the
+	// reward colour-only. It is a toggle, not a force — the light still only
+	// changes on a redemption.
+	AllowOff bool `json:"allowOff"`
+	// ReplyMessage is the broadcaster's chat reply template for a successful
+	// change, with {user} and {color} tokens. Blank uses the built-in default.
+	ReplyMessage string `json:"replyMessage"`
 }
 
 // Govee turns a channel-points redemption into a smart-light colour change. It
@@ -77,27 +85,71 @@ func goveeRedemption(d engine.Deps) module.EventHandler {
 			goveeRefund(emit, ev, "the lights only change while live, your points were refunded")
 			return nil
 		}
-		rgb, ok := parseColor(ev.UserInput)
+
+		input := strings.TrimSpace(ev.UserInput)
+
+		// Opt-in off action: a viewer typing "off" turns the light off. Only when
+		// the broadcaster enabled it; otherwise "off" falls through to parseColor
+		// and refunds as an unrecognized colour.
+		if cfg.AllowOff && isOffInput(input) {
+			if err := goveeControl(ctx, d, ev, cfg, gatewayrpc.Request{PowerOff: true}); err != nil {
+				goveeRefund(emit, ev, goveeFailureMessage(err))
+				return nil
+			}
+			goveeChat(emit, ev, renderGoveeReply(cfg.ReplyMessage, ev, "off"))
+			emitRedemptionStatus(emit, ev, goveeSuccessStatus(cfg.OnRedeem))
+			return nil
+		}
+
+		rgb, ok := parseColor(input)
 		if !ok {
 			goveeRefund(emit, ev, "didn't recognize that colour, your points were refunded (try a name like blue, or a hex like #00ccff)")
 			return nil
 		}
-
-		var reply gatewayrpc.GoveeControlReply
-		if err := d.Gateway.Call(ctx, "govee", "control", gatewayrpc.Request{
-			ChannelID: ev.BroadcasterUserID,
-			Device:    cfg.Device,
-			SKU:       cfg.SKU,
-			ColorRGB:  rgb,
-		}, &reply); err != nil {
+		if err := goveeControl(ctx, d, ev, cfg, gatewayrpc.Request{ColorRGB: rgb}); err != nil {
 			goveeRefund(emit, ev, goveeFailureMessage(err))
 			return nil
 		}
 
-		goveeChat(emit, ev, "set the lights to "+strings.TrimSpace(ev.UserInput)+"!")
+		goveeChat(emit, ev, renderGoveeReply(cfg.ReplyMessage, ev, input))
 		emitRedemptionStatus(emit, ev, goveeSuccessStatus(cfg.OnRedeem))
 		return nil
 	}
+}
+
+// goveeControl issues one gateway control call for this redemption, filling the
+// broadcaster + device fields around the caller's colour/off intent.
+func goveeControl(ctx context.Context, d engine.Deps, ev redemptionEvent, cfg goveeConfig, req gatewayrpc.Request) error {
+	req.ChannelID = ev.BroadcasterUserID
+	req.Device = cfg.Device
+	req.SKU = cfg.SKU
+	var reply gatewayrpc.GoveeControlReply
+	return d.Gateway.Call(ctx, "govee", "control", req, &reply)
+}
+
+// isOffInput reports whether the viewer's input asks to turn the light off. The
+// accepted phrasings are kept small and unambiguous, like the colour names.
+func isOffInput(input string) bool {
+	switch strings.ToLower(strings.TrimSpace(input)) {
+	case "off", "turn off", "lights off", "light off":
+		return true
+	default:
+		return false
+	}
+}
+
+// defaultGoveeReply is the built-in success reply used when the broadcaster
+// leaves the template blank. It addresses the redeemer and names the colour.
+const defaultGoveeReply = "@{user} set the lights to {color}!"
+
+// renderGoveeReply fills the reply template's {user} and {color} tokens for one
+// redemption, falling back to defaultGoveeReply when the template is blank.
+func renderGoveeReply(tmpl string, ev redemptionEvent, color string) string {
+	if strings.TrimSpace(tmpl) == "" {
+		tmpl = defaultGoveeReply
+	}
+	user := strings.TrimPrefix(displayName(ev.UserName, ev.UserLogin), "@")
+	return strings.NewReplacer("{user}", user, "{color}", color).Replace(tmpl)
 }
 
 // decodeGoveeRedemption decodes the module config and the redemption event, and
@@ -163,19 +215,23 @@ func goveeFailureMessage(err error) string {
 }
 
 // goveeRefund tells the viewer why and cancels the redemption (refunding the
-// points) in one place, so every rejection path stays consistent.
+// points) in one place, so every rejection path stays consistent. Its reasons
+// are fixed notices (not the broadcaster's template), so it addresses the
+// redeemer itself.
 func goveeRefund(emit module.Emit, ev redemptionEvent, reason string) {
-	goveeChat(emit, ev, reason)
+	user := strings.TrimPrefix(displayName(ev.UserName, ev.UserLogin), "@")
+	goveeChat(emit, ev, "@"+user+" "+reason)
 	emitRedemptionStatus(emit, ev, outgress.RedemptionCanceled)
 }
 
-// goveeChat posts a reply addressed to the redeemer.
+// goveeChat posts a raw chat line for this redemption. Success replies come from
+// renderGoveeReply (which places {user} itself); refund notices are addressed by
+// goveeRefund. So this stays a plain emitter.
 func goveeChat(emit module.Emit, ev redemptionEvent, text string) {
-	user := strings.TrimPrefix(displayName(ev.UserName, ev.UserLogin), "@")
 	emit(&module.Output{
 		Type:          outgress.TypeChat,
 		BroadcasterID: ev.BroadcasterUserID,
-		Text:          "@" + user + " " + text,
+		Text:          text,
 	})
 }
 

--- a/app/sesame/modules/govee_test.go
+++ b/app/sesame/modules/govee_test.go
@@ -155,6 +155,44 @@ func TestGoveeSuccessLeavePolicyEmitsNoUpdate(t *testing.T) {
 	assert.Equal(t, outgress.TypeChat, col.out[0].Type)
 }
 
+func TestGoveeOffActionPowersOffWhenAllowed(t *testing.T) {
+	var col collector
+	gw := okGateway()
+	d := engine.Deps{Live: &fakeLive{live: true}, Gateway: gw}
+	cfg := `{"rewardId":"rw-1","device":"AB:CD:EF","sku":"H6159","allowOff":true}`
+	payload := `{"id":"redeem-2","broadcaster_user_id":"2","user_name":"CoolViewer","user_login":"coolviewer","user_input":"off","reward":{"id":"rw-1","title":"x","cost":1}}`
+	require.NoError(t, goveeHandler(t, d)(context.Background(), goveeCtx(payload, cfg), col.emit))
+
+	call := gw.lastCall(t)
+	assert.Equal(t, "control", call.endpoint)
+	assert.True(t, call.req.PowerOff, "off input must power the light off")
+	assert.Equal(t, 0, call.req.ColorRGB, "an off action carries no colour")
+	require.Len(t, col.out, 2)
+	assert.Equal(t, outgress.RedemptionFulfilled, col.out[1].Status)
+}
+
+func TestGoveeOffInputRefundsWhenNotAllowed(t *testing.T) {
+	var col collector
+	gw := okGateway()
+	d := engine.Deps{Live: &fakeLive{live: true}, Gateway: gw}
+	// Default config: the off action is not enabled, so "off" is just an
+	// unrecognized colour and refunds before the gateway.
+	payload := `{"id":"redeem-3","broadcaster_user_id":"2","user_name":"CoolViewer","user_login":"coolviewer","user_input":"off","reward":{"id":"rw-1","title":"x","cost":1}}`
+	require.NoError(t, goveeHandler(t, d)(context.Background(), goveeCtx(payload, goveeCfg), col.emit))
+	assert.Empty(t, gw.calls, "off must not reach the gateway when the action is disabled")
+	assertRefund(t, col.out)
+}
+
+func TestGoveeCustomReplyTemplate(t *testing.T) {
+	var col collector
+	gw := okGateway()
+	d := engine.Deps{Live: &fakeLive{live: true}, Gateway: gw}
+	cfg := `{"rewardId":"rw-1","device":"AB:CD:EF","sku":"H6159","replyMessage":"{user} painted the room {color}"}`
+	require.NoError(t, goveeHandler(t, d)(context.Background(), goveeCtx(goveeRedeemJSON, cfg), col.emit))
+	require.Len(t, col.out, 2)
+	assert.Equal(t, "CoolViewer painted the room blue", col.out[0].Text, "template tokens fill from the redemption")
+}
+
 // assertRefund asserts the two-output refund shape: a chat reason then a
 // CANCELED redemption update.
 func assertRefund(t *testing.T, out []module.Output) {

--- a/console/dashboard/src/lib/server/govee-store.ts
+++ b/console/dashboard/src/lib/server/govee-store.ts
@@ -48,15 +48,21 @@ export interface GoveeDevice {
 }
 
 // GoveeReward is the dashboard mirror of the Twitch reward, kept in the blob so
-// the page renders without a Twitch round trip.
+// the page renders without a Twitch round trip. color + cooldown are display
+// mirrors of Twitch reward settings so the editor re-populates them.
 export interface GoveeReward {
   rewardId: string;
   title: string;
   cost: number;
+  // color is the Twitch reward tile background ("#rrggbb"); cooldown is the
+  // reward's global cooldown in seconds (0 = disabled).
+  color: string;
+  cooldown: number;
 }
 
-// GoveeBinding is the module blob shape. device/sku/onRedeem/rewardId/allowOffline
-// are the fields sesame reads; reward is the dashboard-only display mirror.
+// GoveeBinding is the module blob shape. device/sku/onRedeem/rewardId/allowOffline/
+// allowOff/replyMessage are the fields sesame reads; reward is the dashboard-only
+// display mirror.
 export interface GoveeBinding {
   device: string;
   sku: string;
@@ -67,6 +73,12 @@ export interface GoveeBinding {
   // allowOffline opts out of the live-only gate (default false = live only).
   // sesame reads this same flag; the dashboard only sets it true behind a warning.
   allowOffline: boolean;
+  // allowOff opts into the "off" action: a viewer typing "off" turns the light
+  // off. Default false. sesame reads this flag.
+  allowOff: boolean;
+  // replyMessage is the chat reply template ({user}, {color}) sesame posts on a
+  // successful change. Blank uses sesame's built-in default.
+  replyMessage: string;
 }
 
 export interface GoveeView {
@@ -76,16 +88,24 @@ export interface GoveeView {
 }
 
 // RewardDraft is the reward's editable shape, bundled so a save is one argument.
+// title/cost/color/cooldown are Twitch reward settings; onRedeem/replyMessage/
+// allowOff are the binding behaviour sesame reads.
 export interface RewardDraft {
   title: string;
   cost: number;
   onRedeem: GoveeOnRedeem;
+  // color is the reward tile background ("#rrggbb"); '' leaves Twitch's default.
+  color: string;
+  // cooldown is the global cooldown in seconds; 0 disables it.
+  cooldown: number;
+  replyMessage: string;
+  allowOff: boolean;
 }
 
 export type GoveeResult = { ok: true } | { ok: false; missingScope?: boolean; error?: string };
 
 function blankBinding(): GoveeBinding {
-  return { device: '', sku: '', deviceName: '', onRedeem: 'fulfill', rewardId: '', reward: null, allowOffline: false };
+  return { device: '', sku: '', deviceName: '', onRedeem: 'fulfill', rewardId: '', reward: null, allowOffline: false, allowOff: false, replyMessage: '' };
 }
 
 function coerceOnRedeem(v: unknown): GoveeOnRedeem {
@@ -95,7 +115,7 @@ function coerceOnRedeem(v: unknown): GoveeOnRedeem {
 // readBinding coerces a stored "govee" module blob into a normalized binding.
 function readBinding(configs: unknown): GoveeBinding {
   const c = (configs ?? {}) as Partial<GoveeBinding>;
-  const reward = c.reward && typeof c.reward === 'object' ? (c.reward as GoveeReward) : null;
+  const reward = c.reward && typeof c.reward === 'object' ? (c.reward as Partial<GoveeReward>) : null;
   return {
     device: String(c.device ?? ''),
     sku: String(c.sku ?? ''),
@@ -103,9 +123,17 @@ function readBinding(configs: unknown): GoveeBinding {
     onRedeem: coerceOnRedeem(c.onRedeem),
     rewardId: String(c.rewardId ?? ''),
     reward: reward
-      ? { rewardId: String(reward.rewardId ?? ''), title: String(reward.title ?? ''), cost: Number(reward.cost ?? 0) }
+      ? {
+          rewardId: String(reward.rewardId ?? ''),
+          title: String(reward.title ?? ''),
+          cost: Number(reward.cost ?? 0),
+          color: String(reward.color ?? ''),
+          cooldown: Number(reward.cooldown ?? 0)
+        }
       : null,
-    allowOffline: c.allowOffline === true
+    allowOffline: c.allowOffline === true,
+    allowOff: c.allowOff === true,
+    replyMessage: String(c.replyMessage ?? '')
   };
 }
 
@@ -114,6 +142,7 @@ interface RewardWire {
   title: string;
   cost: number;
   prompt?: string;
+  background_color?: string;
   is_enabled: boolean;
   is_paused: boolean;
   is_user_input_required: boolean;
@@ -136,11 +165,14 @@ interface RewardReplyWire {
 // requires input (the colour) and rides the request queue so sesame can resolve
 // it.
 function rewardWire(draft: RewardDraft, id: string): RewardWire {
+  const cooldown = Number.isFinite(draft.cooldown) && draft.cooldown > 0 ? Math.trunc(draft.cooldown) : 0;
   return {
     id: id || undefined,
     title: draft.title,
     cost: draft.cost,
     prompt: REWARD_PROMPT,
+    // Empty leaves Twitch's default tile colour rather than sending "".
+    background_color: draft.color || undefined,
     is_enabled: true,
     is_paused: false,
     is_user_input_required: true,
@@ -149,8 +181,8 @@ function rewardWire(draft: RewardDraft, id: string): RewardWire {
     max_per_stream: 1,
     max_per_user_per_stream_enabled: false,
     max_per_user_per_stream: 1,
-    global_cooldown_enabled: false,
-    global_cooldown_seconds: 5
+    global_cooldown_enabled: cooldown > 0,
+    global_cooldown_seconds: cooldown
   };
 }
 
@@ -260,11 +292,17 @@ export function goveeStore(userId: string): GoveeStore {
     if (reply.error || !reply.reward) return { ok: false, error: reply.error ?? `${verb} failed` };
 
     const rewardId = reply.reward.id ?? existingId;
+    // Mirror the settings Twitch echoed back (falling back to the draft) so the
+    // editor re-populates the colour + cooldown exactly as stored.
+    const color = reply.reward.background_color ?? draft.color;
+    const cooldown = reply.reward.global_cooldown_enabled ? reply.reward.global_cooldown_seconds : 0;
     await writeBinding(cur.enabled, {
       ...cur.binding,
       onRedeem: draft.onRedeem,
+      allowOff: draft.allowOff,
+      replyMessage: draft.replyMessage,
       rewardId,
-      reward: { rewardId, title: reply.reward.title, cost: reply.reward.cost }
+      reward: { rewardId, title: reply.reward.title, cost: reply.reward.cost, color, cooldown }
     });
     if (!existingId) await publishEventSubEnsureOptional(userId);
     return { ok: true };

--- a/console/dashboard/src/routes/(app)/govee/+page.server.ts
+++ b/console/dashboard/src/routes/(app)/govee/+page.server.ts
@@ -36,8 +36,10 @@ function demoView(): GoveeView {
       deviceName: 'Desk strip',
       onRedeem: 'fulfill',
       rewardId: 'demo-reward',
-      reward: { rewardId: 'demo-reward', title: 'Colour my lights', cost: 500 },
-      allowOffline: false
+      reward: { rewardId: 'demo-reward', title: 'Colour my lights', cost: 500, color: '#9147ff', cooldown: 0 },
+      allowOffline: false,
+      allowOff: true,
+      replyMessage: '@{user} set the lights to {color}!'
     }
   };
 }
@@ -75,7 +77,7 @@ export const load: PageServerLoad = async ({ locals }) => {
     return {
       enabled: false,
       keyPresent: false,
-      binding: { device: '', sku: '', deviceName: '', onRedeem: 'fulfill' as GoveeOnRedeem, rewardId: '', reward: null, allowOffline: false },
+      binding: { device: '', sku: '', deviceName: '', onRedeem: 'fulfill' as GoveeOnRedeem, rewardId: '', reward: null, allowOffline: false, allowOff: false, replyMessage: '' },
       devices: { devices: [] as GoveeDevice[], error: undefined },
       colors,
       degraded: true
@@ -153,7 +155,21 @@ export const actions: Actions = {
     if (!title || title.length > 45) return fail(400, { ok: false, error: 'Title is required (max 45 characters).' });
     if (!Number.isFinite(cost)) return fail(400, { ok: false, error: 'Enter a valid point cost.' });
     if (cost < 1 || cost > 10_000_000) return fail(400, { ok: false, error: 'Enter a valid point cost.' });
-    const draft: RewardDraft = { title, cost, onRedeem: asOnRedeem(f.get('onRedeem')) };
+
+    // Reward tile colour: a "#rrggbb" hex, or blank for Twitch's default.
+    const color = String(f.get('color') ?? '').trim();
+    if (color && !/^#[0-9a-fA-F]{6}$/.test(color)) return fail(400, { ok: false, error: 'Pick a valid colour.' });
+
+    // Global cooldown in seconds; 0 disables. Twitch caps a reward cooldown at
+    // 604800s (one week).
+    const rawCooldown = Math.trunc(Number(f.get('cooldown') ?? 0));
+    const cooldown = Number.isFinite(rawCooldown) ? Math.min(Math.max(rawCooldown, 0), 604_800) : 0;
+
+    const replyMessage = String(f.get('replyMessage') ?? '').trim();
+    if (replyMessage.length > 200) return fail(400, { ok: false, error: 'Reply is too long (max 200 characters).' });
+    const allowOff = f.get('allow_off') === 'on';
+
+    const draft: RewardDraft = { title, cost, onRedeem: asOnRedeem(f.get('onRedeem')), color, cooldown, replyMessage, allowOff };
     return run(locals, { action: 'govee:reward', detail: title }, (s) => s.saveReward(draft));
   },
 

--- a/console/dashboard/src/routes/(app)/govee/+page.svelte
+++ b/console/dashboard/src/routes/(app)/govee/+page.svelte
@@ -4,8 +4,19 @@
   import { tick } from 'svelte';
   import type { SubmitFunction } from '@sveltejs/kit';
   import { Icon, Card, PageHead, ConfirmDialog, toast } from '@bagel/shared';
+  import ResponseEditor from '$lib/components/commands/ResponseEditor.svelte';
+  import ChatPreview from '$lib/components/commands/ChatPreview.svelte';
 
   let { data } = $props();
+
+  // Default chat reply when the template is blank (mirrors sesame's default).
+  const DEFAULT_REPLY = '@{user} set the lights to {color}!';
+  // Reply template palette + rehearsal samples: only {user} and {color} apply.
+  const REPLY_TOKENS = [
+    { token: '{user}', label: '{user} → the viewer' },
+    { token: '{color}', label: '{color} → what they typed' }
+  ];
+  const replySamples: Record<string, string> = { user: 'sesame_sam', color: 'blue' };
 
   // Local mirrors, reseeded on each SSR load (the /events invalidation stream
   // re-runs the loader after every confirmed write).
@@ -18,6 +29,15 @@
   // Live-only reflects the inverse of the stored allowOffline flag; on by default.
   // svelte-ignore state_referenced_locally
   let liveOnly = $state<boolean>(!(data.binding?.allowOffline));
+  // Reward editor draft mirrors (colour, cooldown, reply template, off action).
+  // svelte-ignore state_referenced_locally
+  let rewardColor = $state<string>(data.binding?.reward?.color || '#9147ff');
+  // svelte-ignore state_referenced_locally
+  let cooldown = $state<number>(data.binding?.reward?.cooldown ?? 0);
+  // svelte-ignore state_referenced_locally
+  let replyMessage = $state<string>(data.binding?.replyMessage ?? '');
+  // svelte-ignore state_referenced_locally
+  let allowOff = $state<boolean>(data.binding?.allowOff ?? false);
   // svelte-ignore state_referenced_locally
   let seed = data;
   $effect(() => {
@@ -27,6 +47,10 @@
       keyPresent = data.keyPresent ?? false;
       selectedDevice = data.binding?.device ?? '';
       liveOnly = !(data.binding?.allowOffline);
+      rewardColor = data.binding?.reward?.color || '#9147ff';
+      cooldown = data.binding?.reward?.cooldown ?? 0;
+      replyMessage = data.binding?.replyMessage ?? '';
+      allowOff = data.binding?.allowOff ?? false;
     }
   });
 
@@ -230,10 +254,27 @@
                 <span>Title</span>
                 <input class="input" type="text" name="title" maxlength="45" value={boundReward?.title ?? 'Colour my lights'} required />
               </label>
+              <div class="field-row">
+                <label class="field">
+                  <span>Cost (points)</span>
+                  <input class="input" type="number" name="cost" min="1" max="10000000" value={boundReward?.cost ?? 500} required />
+                </label>
+                <label class="field color-field">
+                  <span>Tile colour</span>
+                  <input class="color-in" type="color" name="color" bind:value={rewardColor} aria-label="Reward tile colour" />
+                </label>
+              </div>
               <label class="field">
-                <span>Cost (points)</span>
-                <input class="input" type="number" name="cost" min="1" max="10000000" value={boundReward?.cost ?? 500} required />
+                <span>Cooldown <small>seconds between redemptions, 0 = none</small></span>
+                <input class="input" type="number" name="cooldown" min="0" max="604800" bind:value={cooldown} />
               </label>
+
+              <label class="field">
+                <span>Chat reply <small>optional, {'{user}'} and {'{color}'}</small></span>
+                <ResponseEditor bind:value={replyMessage} name="replyMessage" tokens={REPLY_TOKENS} placeholder={DEFAULT_REPLY} />
+              </label>
+              <ChatPreview response={replyMessage || DEFAULT_REPLY} showViewer={false} tag="on redemption" samplesOnly samples={replySamples} />
+
               <label class="field">
                 <span>After it runs</span>
                 <select class="input" name="onRedeem" value={data.binding?.onRedeem ?? 'fulfill'}>
@@ -242,6 +283,19 @@
                   <option value="leave">Leave for a mod</option>
                 </select>
               </label>
+
+              <!-- Opt-in off action. It is a toggle, not a force: with it on, a
+                   viewer typing "off" turns the light off; with it off, "off" is
+                   just an unrecognized colour and refunds. -->
+              <div class="offrow {allowOff ? 'on' : ''}">
+                <div class="offrow-text">
+                  <span class="offrow-label">Let viewers turn the lights off</span>
+                  <span class="muted-text">A viewer can type <code>off</code> to turn the light off instead of setting a colour.</span>
+                </div>
+                <button type="button" class="toggle {allowOff ? 'on' : ''}" aria-label="Let viewers turn the lights off" onclick={() => (allowOff = !allowOff)}></button>
+              </div>
+              <input type="hidden" name="allow_off" value={allowOff ? 'on' : ''} />
+
               <div class="reward-actions">
                 <button class="btn primary" type="submit">{boundReward ? 'Update reward' : 'Create reward'}</button>
                 {#if boundReward}
@@ -459,7 +513,7 @@
   .device-name { font-family: var(--bb-font-body); font-weight: 600; font-size: 13px; color: var(--bb-white); }
   .device-sku { color: var(--bb-muted); font-family: var(--bb-font-mono, monospace); font-size: 11.5px; margin-left: auto; }
 
-  .reward-form { display: grid; gap: 12px; max-width: 22rem; }
+  .reward-form { display: grid; gap: 12px; max-width: 30rem; }
   .field { display: grid; gap: 5px; }
   .field > span {
     font-family: var(--bb-font-body);
@@ -467,6 +521,42 @@
     font-weight: 600;
     color: var(--bb-muted);
   }
+  .field > span small { font-weight: 400; opacity: 0.7; }
+
+  /* Cost + colour side by side, like the channel-points reward editor. */
+  .field-row { display: flex; gap: 12px; }
+  .field-row .field { flex: 1; min-width: 0; }
+  .color-field { flex: none; width: 96px; }
+  .color-in {
+    width: 100%;
+    height: 38px;
+    padding: 3px;
+    border: 1px solid var(--rule);
+    border-radius: 6px;
+    background: rgba(240, 236, 228, 0.04);
+    cursor: pointer;
+  }
+
+  /* Opt-in off-action row (styled like the live-only row). */
+  .offrow {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 12px;
+    border: 1px solid var(--rule);
+    border-radius: 8px;
+  }
+  .offrow.on { border-color: var(--rule-tan); background: rgba(201, 168, 124, 0.06); }
+  .offrow-text { display: grid; gap: 3px; flex: 1; min-width: 0; }
+  .offrow-label { font-family: var(--bb-font-display); font-weight: 700; font-size: 13px; color: var(--bb-white); }
+  .offrow-text .muted-text { margin: 0; }
+  .offrow .toggle { flex: none; }
+
+  @media (max-width: 480px) {
+    .field-row { flex-direction: column; gap: 12px; }
+    .color-field { width: 100%; }
+  }
+
   .reward-actions { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
   .reward-live {
     display: inline-flex;

--- a/internal/domain/rpc/gateway/gateway.go
+++ b/internal/domain/rpc/gateway/gateway.go
@@ -42,6 +42,10 @@ type Request struct {
 	// Range 0..0xFFFFFF; the caller rejects an unparseable colour before the
 	// call, so 0 (sent as omitted) only reaches control as a deliberate black.
 	ColorRGB int `json:"color_rgb,omitempty"`
+	// PowerOff, when true, makes govee.control turn the device OFF instead of
+	// powering it on and setting a colour; ColorRGB is ignored. This backs the
+	// opt-in "a viewer types off to turn the lights off" reward behaviour.
+	PowerOff bool `json:"power_off,omitempty"`
 }
 
 // Subject builds the NATS subject for one provider endpoint under prefix.


### PR DESCRIPTION
Extends the Govee lights reward with the same editing surface as the Channel Points section, plus an opt-in "off" action and a cooldown.

## Dashboard
- **Tile colour picker** → the Twitch reward background, via the same outgress reward fields the Channel Points tab uses.
- **Custom chat reply** template (`{user}`/`{color}`) with a **live rehearsal** — reuses `ResponseEditor` + `ChatPreview` from the commands editor.
- **Cooldown** field (seconds, 0 = none) → the reward's Twitch global cooldown.
- **"Let viewers turn the lights off"** toggle (opt-in).
- Store maps colour + cooldown onto the reward contract and persists the reply template + off flag on the module binding; editor re-populates from Twitch's echo.

## Runtime (sesame + gateway)
- sesame ([govee.go](app/sesame/modules/govee.go)): a viewer typing `off` (when enabled) powers the light off instead of it being an unrecognized colour; posts the broadcaster's reply template (built-in default when blank). It is a toggle, not a force — the light only changes on a redemption.
- gateway: new `PowerOff` path on `govee.control` (single power-off step, colour validation skipped); `gatewayrpc.Request.PowerOff`.

## Off switch
The module master toggle stays the one-switch global off.

## Verify
- Go build + `vet` clean; new sesame tests (off powers off + fulfills, off-when-disabled refunds without hitting the gateway, reply-template rendering); existing govee tests unaffected.
- `svelte-check` 0 errors; browser (DEMO) confirmed colour/cooldown/reply/rehearsal/off-toggle live, no console errors.

## Blast radius
On merge Flux rebuilds gateway, sesame, and console-dashboard. The reply is one template shared by colour + off redemptions (`{color}` renders as `off`).