### PR TITLE
feat(queue): customizable reply messages with side inspector

### DIFF
--- a/app/sesame/modules/queue.go
+++ b/app/sesame/modules/queue.go
@@ -27,6 +27,21 @@ const queueListLen = 10
 // a shared window on !join would drop other viewers' joins in a burst.
 const queueListCooldown = 5 * time.Second
 
+// queueConfig holds the broadcaster's customized reply templates. Each field is
+// a dashboard-editable message; empty falls back to that reply's localized
+// default (see i18n, keyed by the constant next to each field). Only the
+// conversational replies are customizable — the roster (!list), the status
+// readout, the moderator-action confirmations and the usage/error lines stay
+// fixed system text, so their keys have no field here.
+type queueConfig struct {
+	JoinMessage    string `json:"joinMessage"`    // i18n queue.join.ok       {user} {pos}
+	AlreadyMessage string `json:"alreadyMessage"` // i18n queue.join.already  {user} {pos}
+	LeaveMessage   string `json:"leaveMessage"`   // i18n queue.leave.ok      {user}
+	NextMessage    string `json:"nextMessage"`    // i18n queue.next          {target} {count}
+	OpenedMessage  string `json:"openedMessage"`  // i18n queue.opened
+	ClosedMessage  string `json:"closedMessage"`  // i18n queue.closed
+}
+
 // Queue owns the viewer play queue: a line viewers join to play with the
 // streamer. It is a named, opt-in module (KindOptIn): off by default, enabled
 // on the dashboard. Because a disabled module's triggers fall through to
@@ -42,8 +57,10 @@ const queueListCooldown = 5 * time.Second
 //	!join                   → get in line (also !queue join)
 //	!list                   → show the next 10 (also !queue list, !queuelist)
 //
-// Moderator subcommands typed by a non-mod are silently ignored, matching the
-// engine gate's silence on an insufficient role.
+// The conversational replies (join, next, open/close announcements, ...) are
+// customizable per broadcaster on the dashboard; the roster and system lines
+// are fixed. Moderator subcommands typed by a non-mod are silently ignored,
+// matching the engine gate's silence on an insufficient role.
 func Queue(d engine.Deps) module.Module {
 	log := d.Log
 	if log == nil {
@@ -65,6 +82,8 @@ func queueRun(d engine.Deps, log *zap.Logger) module.RunFunc {
 		if d.Queue == nil {
 			return nil
 		}
+		var cfg queueConfig
+		_ = c.Decode(&cfg)
 		sub, rest := splitFirst(args)
 		isMod := c.Chatter().Allows(module.RoleModerator)
 
@@ -75,17 +94,17 @@ func queueRun(d engine.Deps, log *zap.Logger) module.RunFunc {
 			if !isMod {
 				return nil
 			}
-			return queueSetOpen(ctx, c, d, emit, log, true)
+			return queueSetOpen(ctx, c, d, cfg, emit, log, true)
 		case "close":
 			if !isMod {
 				return nil
 			}
-			return queueSetOpen(ctx, c, d, emit, log, false)
+			return queueSetOpen(ctx, c, d, cfg, emit, log, false)
 		case "next":
 			if !isMod {
 				return nil
 			}
-			return queueNext(ctx, c, d, emit, log)
+			return queueNext(ctx, c, d, cfg, emit, log)
 		case "remove":
 			if !isMod {
 				return nil
@@ -99,16 +118,16 @@ func queueRun(d engine.Deps, log *zap.Logger) module.RunFunc {
 				log.Warn("queue: clear failed", zap.Uint64("broadcaster_id", c.BroadcasterID), zap.Error(err))
 				return err
 			}
-			queueReply(c, emit, "queue.cleared")
+			queueReply(c, emit, "", "queue.cleared")
 			return nil
 		case "join":
-			return queueJoin(ctx, c, d, emit, log)
+			return queueJoin(ctx, c, d, cfg, emit, log)
 		case "leave":
-			return queueLeave(ctx, c, d, emit, log)
+			return queueLeave(ctx, c, d, cfg, emit, log)
 		case "list":
 			return queueList(ctx, c, d, emit, log)
 		default:
-			queueReply(c, emit, "queue.err.usage")
+			queueReply(c, emit, "", "queue.err.usage")
 			return nil
 		}
 	}
@@ -119,7 +138,9 @@ func queueJoinRun(d engine.Deps, log *zap.Logger) module.RunFunc {
 		if d.Queue == nil {
 			return nil
 		}
-		return queueJoin(ctx, c, d, emit, log)
+		var cfg queueConfig
+		_ = c.Decode(&cfg)
+		return queueJoin(ctx, c, d, cfg, emit, log)
 	}
 }
 
@@ -128,7 +149,9 @@ func queueLeaveRun(d engine.Deps, log *zap.Logger) module.RunFunc {
 		if d.Queue == nil {
 			return nil
 		}
-		return queueLeave(ctx, c, d, emit, log)
+		var cfg queueConfig
+		_ = c.Decode(&cfg)
+		return queueLeave(ctx, c, d, cfg, emit, log)
 	}
 }
 
@@ -142,6 +165,7 @@ func queueListRun(d engine.Deps, log *zap.Logger) module.RunFunc {
 }
 
 // queueStatus answers a bare !queue with the open/closed state and line size.
+// The status readout is fixed system text (not customizable).
 func queueStatus(ctx context.Context, c *module.Context, d engine.Deps, emit module.Emit) error {
 	open, err := d.Queue.IsOpen(ctx, c.BroadcasterID)
 	if err != nil {
@@ -155,26 +179,26 @@ func queueStatus(ctx context.Context, c *module.Context, d engine.Deps, emit mod
 	if open {
 		key = "queue.status.open"
 	}
-	queueReply(c, emit, key, "{count}", strconv.FormatInt(total, 10))
+	queueReply(c, emit, "", key, "count", strconv.FormatInt(total, 10))
 	return nil
 }
 
-func queueSetOpen(ctx context.Context, c *module.Context, d engine.Deps, emit module.Emit, log *zap.Logger, open bool) error {
+func queueSetOpen(ctx context.Context, c *module.Context, d engine.Deps, cfg queueConfig, emit module.Emit, log *zap.Logger, open bool) error {
 	if err := d.Queue.SetOpen(ctx, c.BroadcasterID, open); err != nil {
 		log.Warn("queue: set-open failed", zap.Bool("open", open), zap.Uint64("broadcaster_id", c.BroadcasterID), zap.Error(err))
 		return err
 	}
 	if open {
-		queueReply(c, emit, "queue.opened")
+		queueReply(c, emit, cfg.OpenedMessage, "queue.opened")
 	} else {
-		queueReply(c, emit, "queue.closed")
+		queueReply(c, emit, cfg.ClosedMessage, "queue.closed")
 	}
 	return nil
 }
 
 // queueJoin puts the chatter in line when the queue is open. Joining twice
 // keeps the original spot and answers with it.
-func queueJoin(ctx context.Context, c *module.Context, d engine.Deps, emit module.Emit, log *zap.Logger) error {
+func queueJoin(ctx context.Context, c *module.Context, d engine.Deps, cfg queueConfig, emit module.Emit, log *zap.Logger) error {
 	login := strings.ToLower(c.Env.ChatterUserLogin)
 	if login == "" {
 		return nil
@@ -185,7 +209,8 @@ func queueJoin(ctx context.Context, c *module.Context, d engine.Deps, emit modul
 		return err
 	}
 	if !open {
-		queueReply(c, emit, "queue.join.closed")
+		// The "queue is closed" line is a fixed system message.
+		queueReply(c, emit, "", "queue.join.closed")
 		return nil
 	}
 	pos, _, joined, err := d.Queue.Join(ctx, c.BroadcasterID, login)
@@ -193,15 +218,16 @@ func queueJoin(ctx context.Context, c *module.Context, d engine.Deps, emit modul
 		log.Warn("queue: join failed", zap.Uint64("broadcaster_id", c.BroadcasterID), zap.Error(err))
 		return err
 	}
-	key := "queue.join.already"
+	posStr := strconv.FormatInt(pos, 10)
 	if joined {
-		key = "queue.join.ok"
+		queueReply(c, emit, cfg.JoinMessage, "queue.join.ok", "pos", posStr)
+	} else {
+		queueReply(c, emit, cfg.AlreadyMessage, "queue.join.already", "pos", posStr)
 	}
-	queueReply(c, emit, key, "{pos}", strconv.FormatInt(pos, 10))
 	return nil
 }
 
-func queueLeave(ctx context.Context, c *module.Context, d engine.Deps, emit module.Emit, log *zap.Logger) error {
+func queueLeave(ctx context.Context, c *module.Context, d engine.Deps, cfg queueConfig, emit module.Emit, log *zap.Logger) error {
 	login := strings.ToLower(c.Env.ChatterUserLogin)
 	if login == "" {
 		return nil
@@ -212,34 +238,36 @@ func queueLeave(ctx context.Context, c *module.Context, d engine.Deps, emit modu
 		return err
 	}
 	if removed {
-		queueReply(c, emit, "queue.leave.ok")
+		queueReply(c, emit, cfg.LeaveMessage, "queue.leave.ok")
 	} else {
-		queueReply(c, emit, "queue.leave.not_in")
+		// The "you are not in the queue" line is a fixed system message.
+		queueReply(c, emit, "", "queue.leave.not_in")
 	}
 	return nil
 }
 
 // queueNext pulls the front of the line and announces them to chat.
-func queueNext(ctx context.Context, c *module.Context, d engine.Deps, emit module.Emit, log *zap.Logger) error {
+func queueNext(ctx context.Context, c *module.Context, d engine.Deps, cfg queueConfig, emit module.Emit, log *zap.Logger) error {
 	login, remaining, err := d.Queue.Pop(ctx, c.BroadcasterID)
 	if err != nil {
 		log.Warn("queue: next failed", zap.Uint64("broadcaster_id", c.BroadcasterID), zap.Error(err))
 		return err
 	}
 	if login == "" {
-		queueReply(c, emit, "queue.next.empty")
+		queueReply(c, emit, "", "queue.next.empty")
 		return nil
 	}
-	queueReply(c, emit, "queue.next", "{target}", login, "{count}", strconv.FormatInt(remaining, 10))
+	queueReply(c, emit, cfg.NextMessage, "queue.next", "target", login, "count", strconv.FormatInt(remaining, 10))
 	return nil
 }
 
-// queueRemove takes a named viewer out of the line ("!queue remove @user").
+// queueRemove takes a named viewer out of the line ("!queue remove @user"). The
+// confirmation is fixed system text.
 func queueRemove(ctx context.Context, c *module.Context, d engine.Deps, args string, emit module.Emit, log *zap.Logger) error {
 	target, _ := splitFirst(args)
 	target = strings.ToLower(strings.TrimPrefix(target, "@"))
 	if target == "" {
-		queueReply(c, emit, "queue.remove.usage")
+		queueReply(c, emit, "", "queue.remove.usage")
 		return nil
 	}
 	removed, err := d.Queue.Remove(ctx, c.BroadcasterID, target)
@@ -248,15 +276,16 @@ func queueRemove(ctx context.Context, c *module.Context, d engine.Deps, args str
 		return err
 	}
 	if removed {
-		queueReply(c, emit, "queue.remove.ok", "{target}", target)
+		queueReply(c, emit, "", "queue.remove.ok", "target", target)
 	} else {
-		queueReply(c, emit, "queue.remove.not_found", "{target}", target)
+		queueReply(c, emit, "", "queue.remove.not_found", "target", target)
 	}
 	return nil
 }
 
 // queueList shows the next queueListLen players in order, with a "+N more"
-// tail when the line is longer.
+// tail when the line is longer. The roster is fixed system text: it is a
+// structured list, not a free-form template.
 func queueList(ctx context.Context, c *module.Context, d engine.Deps, emit module.Emit, log *zap.Logger) error {
 	entries, total, err := d.Queue.List(ctx, c.BroadcasterID, queueListLen)
 	if err != nil {
@@ -264,7 +293,7 @@ func queueList(ctx context.Context, c *module.Context, d engine.Deps, emit modul
 		return err
 	}
 	if total == 0 {
-		queueReply(c, emit, "queue.list.empty")
+		queueReply(c, emit, "", "queue.list.empty")
 		return nil
 	}
 
@@ -279,19 +308,35 @@ func queueList(ctx context.Context, c *module.Context, d engine.Deps, emit modul
 	}
 
 	if more := total - int64(len(entries)); more > 0 {
-		queueReply(c, emit, "queue.list.more", "{list}", b.String(), "{count}", strconv.FormatInt(more, 10))
+		queueReply(c, emit, "", "queue.list.more", "list", b.String(), "count", strconv.FormatInt(more, 10))
 	} else {
-		queueReply(c, emit, "queue.list", "{list}", b.String())
+		queueReply(c, emit, "", "queue.list", "list", b.String())
 	}
 	return nil
 }
 
-// queueReply emits one localized chat line. pairs are extra {token}, value
-// replacements for the template; {user} (the invoking chatter) is always
-// available.
-func queueReply(c *module.Context, emit module.Emit, key string, pairs ...string) {
-	pairs = append(pairs, "{user}", c.Env.ChatterUserLogin)
-	text := strings.NewReplacer(pairs...).Replace(i18n.T(c.Locale, key))
+// queueReply emits one chat line. override is the broadcaster's customized
+// template for this reply ("" for the fixed system lines, or an uncustomized
+// customizable one); when empty the localized default for key is used. kv are
+// {token},value pairs (token names without braces); {user} (the invoking
+// chatter) and the generic dynamic vars ({random}, {choice:…}) are always
+// available, so a customized template can use them too.
+func queueReply(c *module.Context, emit module.Emit, override, key string, kv ...string) {
+	tmpl := override
+	if tmpl == "" {
+		tmpl = i18n.T(c.Locale, key)
+	}
+	text := module.ExpandString(tmpl, func(k string) (string, bool) {
+		for i := 0; i+1 < len(kv); i += 2 {
+			if kv[i] == k {
+				return kv[i+1], true
+			}
+		}
+		if k == "user" {
+			return c.Env.ChatterUserLogin, true
+		}
+		return module.ParseDynamic(k)
+	})
 	emit(&module.Output{
 		Type:          outgress.TypeChat,
 		BroadcasterID: c.Env.BroadcasterUserID,

--- a/app/sesame/modules/queue_test.go
+++ b/app/sesame/modules/queue_test.go
@@ -335,3 +335,41 @@ func TestQueueJoinAndListViaSubcommand(t *testing.T) {
 	require.Len(t, out, 1)
 	assert.Contains(t, out[0].Text, "1. alice")
 }
+
+// --- customizable reply templates ---
+
+func TestQueueJoinCustomTemplate(t *testing.T) {
+	q := &fakeQueue{open: true}
+	m := Queue(queueDeps(q))
+
+	c := queueCtx("alice", "")
+	c.Config = []byte(`{"joinMessage":"welcome {user}! spot {pos}"}`)
+	out := runQueue(t, m, "join", c, "")
+	require.Len(t, out, 1)
+	assert.Equal(t, "welcome alice! spot 1", out[0].Text)
+}
+
+func TestQueueNextCustomTemplate(t *testing.T) {
+	q := &fakeQueue{open: true, line: []string{"alice", "bob"}}
+	m := Queue(queueDeps(q))
+
+	c := queueCtx("mod", "moderator")
+	c.Config = []byte(`{"nextMessage":"{target} is up, {count} left"}`)
+	out := runQueue(t, m, "queue", c, "next")
+	require.Len(t, out, 1)
+	assert.Equal(t, "alice is up, 1 left", out[0].Text)
+}
+
+// A blank custom template falls back to the localized default; the roster is
+// never customizable, so a stray config key cannot alter it.
+func TestQueueListIgnoresConfig(t *testing.T) {
+	q := &fakeQueue{open: true, line: []string{"a", "b"}}
+	m := Queue(queueDeps(q))
+
+	c := queueCtx("alice", "")
+	c.Config = []byte(`{"joinMessage":"custom"}`)
+	out := runQueue(t, m, "list", c, "")
+	require.Len(t, out, 1)
+	assert.Contains(t, out[0].Text, "1. a")
+	assert.Contains(t, out[0].Text, "2. b")
+}

--- a/console/shared/lib/types.ts
+++ b/console/shared/lib/types.ts
@@ -676,11 +676,77 @@ export const MODULE_CATALOG: readonly ModuleDef[] = [
     icon: 'list',
     category: 'Community',
     defaultEnabled: false,
-    // The queue posts fixed system lines (join confirmations, the roster, next-up
-    // calls), not customizable templates, so there are no editable reply rows or
-    // settings — just the master enable and a read-only list of the commands it
-    // unlocks (see app/sesame/modules/queue.go).
-    replies: [],
+    // The conversational replies are customizable per broadcaster; the roster
+    // (!list), the status readout and the system/error lines stay fixed (see
+    // app/sesame/modules/queue.go). The command list below is read-only. Each
+    // reply rehearses as its command (a viewer types the trigger, the bot
+    // answers) with this reply's own sample values.
+    replies: [
+      {
+        key: 'join',
+        label: 'Join confirmation',
+        tagline: 'When a viewer joins the line.',
+        event: '!join',
+        command: 'join',
+        messageKey: 'joinMessage',
+        defaultMessage: '@{user} you joined the queue at position #{pos}.',
+        tokens: ['user', 'pos'],
+        previewSamples: { user: 'sesame_sam', pos: '3' }
+      },
+      {
+        key: 'already',
+        label: 'Already in queue',
+        tagline: 'When a viewer who is already in line types !join again.',
+        event: '!join',
+        command: 'join',
+        messageKey: 'alreadyMessage',
+        defaultMessage: '@{user} you are already in the queue at position #{pos}.',
+        tokens: ['user', 'pos'],
+        previewSamples: { user: 'sesame_sam', pos: '2' }
+      },
+      {
+        key: 'leave',
+        label: 'Leave confirmation',
+        tagline: 'When a viewer steps out of the line.',
+        event: '!leave',
+        command: 'leave',
+        messageKey: 'leaveMessage',
+        defaultMessage: '@{user} you left the queue.',
+        tokens: ['user'],
+        previewSamples: { user: 'sesame_sam' }
+      },
+      {
+        key: 'next',
+        label: 'Next player up',
+        tagline: 'When you pull up the next player.',
+        event: '!queue next',
+        command: 'queue next',
+        messageKey: 'nextMessage',
+        defaultMessage: '@{target} you are up next! ({count} still waiting)',
+        tokens: ['target', 'count'],
+        previewSamples: { target: 'ferret_king', count: '2' }
+      },
+      {
+        key: 'opened',
+        label: 'Queue opened',
+        tagline: 'Announced when you open the queue.',
+        event: '!queue open',
+        command: 'queue open',
+        messageKey: 'openedMessage',
+        defaultMessage: 'The queue is now open! Type !join to get in line.',
+        previewSamples: {}
+      },
+      {
+        key: 'closed',
+        label: 'Queue closed',
+        tagline: 'Announced when you close the queue.',
+        event: '!queue close',
+        command: 'queue close',
+        messageKey: 'closedMessage',
+        defaultMessage: 'The queue is now closed to new joins.',
+        previewSamples: {}
+      }
+    ],
     commands: [
       { trigger: '!join', summary: 'Get in line to play (also !queue join).' },
       { trigger: '!leave', summary: 'Step out of the line (also !queue leave).' },


### PR DESCRIPTION
## What

Brings the queue module onto the standard module layout: the conversational replies are now editable per broadcaster through the docked side inspector (same surface as alerts/shoutout), while the roster and system lines stay fixed.

### Customizable replies
Six replies are config-driven — the custom template wins, otherwise the **localized** i18n default is used (French defaults preserved):

| Reply | Config key | Tokens |
| --- | --- | --- |
| Join confirmation | `joinMessage` | `{user}` `{pos}` |
| Already in queue | `alreadyMessage` | `{user}` `{pos}` |
| Leave confirmation | `leaveMessage` | `{user}` |
| Next player up | `nextMessage` | `{target}` `{count}` |
| Queue opened | `openedMessage` | — |
| Queue closed | `closedMessage` | — |

Templates expand through `module.ExpandString`, so `{user}`/`{pos}`/`{target}`/`{count}` plus the generic dynamic vars (`{random}`, `{choice:…}`) all work. **Not** customizable: the roster (`!list`), the status readout, the moderator-action confirmations (`remove`/`clear`), and the usage/error lines.

### Dashboard
- The queue catalog entry gains six command-style replies (each rehearses as its trigger — a viewer types `!join` / `!queue next`, the bot answers with sample values) rendered as clickable rows with the side inspector.
- The read-only command list is unchanged and still non-clickable.

## Testing
- Go: `go build`, queue tests green including three new template cases (custom join, custom next, list-ignores-config).
- Dashboard: `svelte-check` 0 errors. Verified in DEMO — 6 reply rows open the inspector with a working "Chat rehearsal" (tokens highlighted, palette chips), the multi-word `!queue next` trigger rehearses correctly, the 9 read-only command rows stay non-clickable, and Save round-trips (`POST /modules/queue?/save` 200, inspector closes).