### PR TITLE
refactor(govee): resolve CodeScene code-health regressions

### DIFF
--- a/app/gateway/internal/providers/govee/govee.go
+++ b/app/gateway/internal/providers/govee/govee.go
@@ -267,10 +267,15 @@ func validateControlInput(req gatewayrpc.Request) string {
 		return "missing device"
 	}
 	// A power-off carries no colour; only validate the colour on a colour set.
-	if !req.PowerOff && (req.ColorRGB < 0 || req.ColorRGB > 0xFFFFFF) {
+	if !req.PowerOff && !validColorRGB(req.ColorRGB) {
 		return "colour out of range"
 	}
 	return ""
+}
+
+// validColorRGB reports whether rgb is a packed 24-bit colour (0..0xFFFFFF).
+func validColorRGB(rgb int) bool {
+	return rgb >= 0 && rgb <= 0xFFFFFF
 }
 
 // controlKey resolves the broadcaster's key, returning ("", msg) with a

--- a/app/sesame/modules/govee.go
+++ b/app/sesame/modules/govee.go
@@ -81,50 +81,65 @@ func goveeRedemption(d engine.Deps) module.EventHandler {
 		if !ok {
 			return nil
 		}
+		r := goveeRun{d: d, emit: emit, ev: ev, cfg: cfg}
 		if !goveeLivePermits(ctx, d, cfg, c.BroadcasterID) {
-			goveeRefund(emit, ev, "the lights only change while live, your points were refunded")
+			r.refund("the lights only change while live, your points were refunded")
 			return nil
 		}
-
-		input := strings.TrimSpace(ev.UserInput)
-
-		// Opt-in off action: a viewer typing "off" turns the light off. Only when
-		// the broadcaster enabled it; otherwise "off" falls through to parseColor
-		// and refunds as an unrecognized colour.
-		if cfg.AllowOff && isOffInput(input) {
-			if err := goveeControl(ctx, d, ev, cfg, gatewayrpc.Request{PowerOff: true}); err != nil {
-				goveeRefund(emit, ev, goveeFailureMessage(err))
-				return nil
-			}
-			goveeChat(emit, ev, renderGoveeReply(cfg.ReplyMessage, ev, "off"))
-			emitRedemptionStatus(emit, ev, goveeSuccessStatus(cfg.OnRedeem))
-			return nil
-		}
-
-		rgb, ok := parseColor(input)
-		if !ok {
-			goveeRefund(emit, ev, "didn't recognize that colour, your points were refunded (try a name like blue, or a hex like #00ccff)")
-			return nil
-		}
-		if err := goveeControl(ctx, d, ev, cfg, gatewayrpc.Request{ColorRGB: rgb}); err != nil {
-			goveeRefund(emit, ev, goveeFailureMessage(err))
-			return nil
-		}
-
-		goveeChat(emit, ev, renderGoveeReply(cfg.ReplyMessage, ev, input))
-		emitRedemptionStatus(emit, ev, goveeSuccessStatus(cfg.OnRedeem))
+		r.apply(ctx)
 		return nil
 	}
 }
 
-// goveeControl issues one gateway control call for this redemption, filling the
+// goveeRun is one redemption in flight: the deps plus the decoded event and
+// binding. The action helpers hang off it so they pass state through the
+// receiver instead of a long argument list.
+type goveeRun struct {
+	d    engine.Deps
+	emit module.Emit
+	ev   redemptionEvent
+	cfg  goveeConfig
+}
+
+// apply resolves the viewer's input to an off action or a colour, drives the
+// light, and resolves the redemption — refunding on an unrecognized colour or a
+// gateway failure.
+func (r goveeRun) apply(ctx context.Context) {
+	req, label, ok := goveeIntent(r.cfg, strings.TrimSpace(r.ev.UserInput))
+	if !ok {
+		r.refund("didn't recognize that colour, your points were refunded (try a name like blue, or a hex like #00ccff)")
+		return
+	}
+	if err := r.control(ctx, req); err != nil {
+		r.refund(goveeFailureMessage(err))
+		return
+	}
+	r.chat(renderGoveeReply(r.cfg.ReplyMessage, r.ev, label))
+	emitRedemptionStatus(r.emit, r.ev, goveeSuccessStatus(r.cfg.OnRedeem))
+}
+
+// control issues one gateway control call for this redemption, filling the
 // broadcaster + device fields around the caller's colour/off intent.
-func goveeControl(ctx context.Context, d engine.Deps, ev redemptionEvent, cfg goveeConfig, req gatewayrpc.Request) error {
-	req.ChannelID = ev.BroadcasterUserID
-	req.Device = cfg.Device
-	req.SKU = cfg.SKU
+func (r goveeRun) control(ctx context.Context, req gatewayrpc.Request) error {
+	req.ChannelID = r.ev.BroadcasterUserID
+	req.Device = r.cfg.Device
+	req.SKU = r.cfg.SKU
 	var reply gatewayrpc.GoveeControlReply
-	return d.Gateway.Call(ctx, "govee", "control", req, &reply)
+	return r.d.Gateway.Call(ctx, "govee", "control", req, &reply)
+}
+
+// goveeIntent maps the viewer's input to a control request and its colour label:
+// an off action when the broadcaster enabled it, otherwise a parsed colour. ok
+// is false for an unrecognized colour, which the caller refunds.
+func goveeIntent(cfg goveeConfig, input string) (gatewayrpc.Request, string, bool) {
+	if cfg.AllowOff && isOffInput(input) {
+		return gatewayrpc.Request{PowerOff: true}, "off", true
+	}
+	rgb, ok := parseColor(input)
+	if !ok {
+		return gatewayrpc.Request{}, "", false
+	}
+	return gatewayrpc.Request{ColorRGB: rgb}, input, true
 }
 
 // isOffInput reports whether the viewer's input asks to turn the light off. The
@@ -214,23 +229,22 @@ func goveeFailureMessage(err error) string {
 	return "couldn't reach your lights, your points were refunded"
 }
 
-// goveeRefund tells the viewer why and cancels the redemption (refunding the
-// points) in one place, so every rejection path stays consistent. Its reasons
-// are fixed notices (not the broadcaster's template), so it addresses the
-// redeemer itself.
-func goveeRefund(emit module.Emit, ev redemptionEvent, reason string) {
-	user := strings.TrimPrefix(displayName(ev.UserName, ev.UserLogin), "@")
-	goveeChat(emit, ev, "@"+user+" "+reason)
-	emitRedemptionStatus(emit, ev, outgress.RedemptionCanceled)
+// refund tells the viewer why and cancels the redemption (refunding the points)
+// in one place, so every rejection path stays consistent. Its reasons are fixed
+// notices (not the broadcaster's template), so it addresses the redeemer itself.
+func (r goveeRun) refund(reason string) {
+	user := strings.TrimPrefix(displayName(r.ev.UserName, r.ev.UserLogin), "@")
+	r.chat("@" + user + " " + reason)
+	emitRedemptionStatus(r.emit, r.ev, outgress.RedemptionCanceled)
 }
 
-// goveeChat posts a raw chat line for this redemption. Success replies come from
+// chat posts a raw chat line for this redemption. Success replies come from
 // renderGoveeReply (which places {user} itself); refund notices are addressed by
-// goveeRefund. So this stays a plain emitter.
-func goveeChat(emit module.Emit, ev redemptionEvent, text string) {
-	emit(&module.Output{
+// refund. So this stays a plain emitter.
+func (r goveeRun) chat(text string) {
+	r.emit(&module.Output{
 		Type:          outgress.TypeChat,
-		BroadcasterID: ev.BroadcasterUserID,
+		BroadcasterID: r.ev.BroadcasterUserID,
 		Text:          text,
 	})
 }

--- a/console/dashboard/src/routes/(app)/govee/+page.server.ts
+++ b/console/dashboard/src/routes/(app)/govee/+page.server.ts
@@ -109,7 +109,8 @@ function parseRewardForm(f: FormData): { draft: RewardDraft } | { error: string 
   if (!title || title.length > 45) return { error: 'Title is required (max 45 characters).' };
 
   const cost = Math.trunc(Number(f.get('cost')));
-  if (!Number.isFinite(cost) || cost < 1 || cost > 10_000_000) return { error: 'Enter a valid point cost.' };
+  if (!Number.isFinite(cost)) return { error: 'Enter a valid point cost.' };
+  if (cost < 1 || cost > 10_000_000) return { error: 'Enter a valid point cost.' };
 
   // Reward tile colour: a "#rrggbb" hex, or blank for Twitch's default.
   const color = String(f.get('color') ?? '').trim();

--- a/console/dashboard/src/routes/(app)/govee/+page.server.ts
+++ b/console/dashboard/src/routes/(app)/govee/+page.server.ts
@@ -101,6 +101,32 @@ function asOnRedeem(v: FormDataEntryValue | null): GoveeOnRedeem {
   return v === 'cancel' || v === 'leave' ? v : 'fulfill';
 }
 
+// parseRewardForm validates the reward editor's fields and returns the draft, or
+// a user-facing error message. Kept out of the action so the action stays a thin
+// parse-then-run.
+function parseRewardForm(f: FormData): { draft: RewardDraft } | { error: string } {
+  const title = String(f.get('title') ?? '').trim();
+  if (!title || title.length > 45) return { error: 'Title is required (max 45 characters).' };
+
+  const cost = Math.trunc(Number(f.get('cost')));
+  if (!Number.isFinite(cost) || cost < 1 || cost > 10_000_000) return { error: 'Enter a valid point cost.' };
+
+  // Reward tile colour: a "#rrggbb" hex, or blank for Twitch's default.
+  const color = String(f.get('color') ?? '').trim();
+  if (color && !/^#[0-9a-fA-F]{6}$/.test(color)) return { error: 'Pick a valid colour.' };
+
+  const replyMessage = String(f.get('replyMessage') ?? '').trim();
+  if (replyMessage.length > 200) return { error: 'Reply is too long (max 200 characters).' };
+
+  // Global cooldown in seconds; 0 disables. Twitch caps it at 604800s (one week).
+  const rawCooldown = Math.trunc(Number(f.get('cooldown') ?? 0));
+  const cooldown = Number.isFinite(rawCooldown) ? Math.min(Math.max(rawCooldown, 0), 604_800) : 0;
+
+  return {
+    draft: { title, cost, onRedeem: asOnRedeem(f.get('onRedeem')), color, cooldown, replyMessage, allowOff: f.get('allow_off') === 'on' }
+  };
+}
+
 // run is the shared action skeleton: gate, resolve the session, short-circuit in
 // demo, then run the store operation with uniform error handling + audit. Each
 // action only parses its own form and calls run, so there is one copy of the
@@ -149,28 +175,9 @@ export const actions: Actions = {
   },
 
   saveReward: async ({ request, locals }) => {
-    const f = await request.formData();
-    const title = String(f.get('title') ?? '').trim();
-    const cost = Math.trunc(Number(f.get('cost')));
-    if (!title || title.length > 45) return fail(400, { ok: false, error: 'Title is required (max 45 characters).' });
-    if (!Number.isFinite(cost)) return fail(400, { ok: false, error: 'Enter a valid point cost.' });
-    if (cost < 1 || cost > 10_000_000) return fail(400, { ok: false, error: 'Enter a valid point cost.' });
-
-    // Reward tile colour: a "#rrggbb" hex, or blank for Twitch's default.
-    const color = String(f.get('color') ?? '').trim();
-    if (color && !/^#[0-9a-fA-F]{6}$/.test(color)) return fail(400, { ok: false, error: 'Pick a valid colour.' });
-
-    // Global cooldown in seconds; 0 disables. Twitch caps a reward cooldown at
-    // 604800s (one week).
-    const rawCooldown = Math.trunc(Number(f.get('cooldown') ?? 0));
-    const cooldown = Number.isFinite(rawCooldown) ? Math.min(Math.max(rawCooldown, 0), 604_800) : 0;
-
-    const replyMessage = String(f.get('replyMessage') ?? '').trim();
-    if (replyMessage.length > 200) return fail(400, { ok: false, error: 'Reply is too long (max 200 characters).' });
-    const allowOff = f.get('allow_off') === 'on';
-
-    const draft: RewardDraft = { title, cost, onRedeem: asOnRedeem(f.get('onRedeem')), color, cooldown, replyMessage, allowOff };
-    return run(locals, { action: 'govee:reward', detail: title }, (s) => s.saveReward(draft));
+    const parsed = parseRewardForm(await request.formData());
+    if ('error' in parsed) return fail(400, { ok: false, error: parsed.error });
+    return run(locals, { action: 'govee:reward', detail: parsed.draft.title }, (s) => s.saveReward(parsed.draft));
   },
 
   deleteReward: ({ locals }) => run(locals, { action: 'govee:reward_delete', detail: '' }, (s) => s.deleteReward()),


### PR DESCRIPTION
Fixes the three advisory Code Health rules the govee reward-customization change (#285) tripped. No behaviour change — all existing govee tests pass unchanged.

| File | Rule | Fix |
|-|-|-|
| `app/sesame/modules/govee.go` | Complex Method (`goveeRedemption`) + Excess Function Arguments (`goveeControl`) | Thread per-redemption state through a `goveeRun` receiver; split input→intent into `goveeIntent`. Handler is now a thin dispatch; helpers lose their long arg lists. |
| `app/gateway/internal/providers/govee/govee.go` | Complex Conditional (`validateControlInput`) | Extract the colour-range test into `validColorRGB`. |
| `console/dashboard/src/routes/(app)/govee/+page.server.ts` | Complex Method (`saveReward`) | Move parsing + validation into `parseRewardForm`; action is a thin parse-then-run. |

## Verify
Go build + test + `vet` clean; `svelte-check` 0 errors.