### PR TITLE
feat(triggers): dashboard config + resolve CodeScene complexity

### DIFF
--- a/app/sesame/modules/triggers.go
+++ b/app/sesame/modules/triggers.go
@@ -17,102 +17,174 @@ import (
 // slowing every line. Extra rules past the cap are ignored.
 const maxTriggers = 50
 
-// triggersConfig is the broadcaster's trigger-word rule set, read from the
-// module's Configs blob (the pipeline wires it into the Context).
+// triggersConfig is the broadcaster's trigger-word config, read from the module's
+// Configs blob (the pipeline wires it into the Context). Rules is the raw
+// dashboard textarea: one "phrase => response" rule per line (see rules).
 type triggersConfig struct {
-	Triggers []triggerWord `json:"triggers"`
+	Rules string `json:"rules"`
 }
 
-// triggerWord is one phrase→response rule.
-//
-//   - Phrase is the text to look for in a chat message.
-//   - Response is the chat line the bot posts on a match. It supports the same
-//     {user}/{random}/{choice:…} tokens custom commands do.
-//   - Match selects how Phrase is compared: "word" (default, whole-word match so
-//     "hi" does not fire on "this"), "contains" (anywhere as a substring),
-//     "exact" (the whole message equals the phrase), or "prefix" (the message
-//     starts with the phrase). Unknown values fall back to "word".
-//   - CaseSensitive keeps the comparison case-exact; by default it is folded.
+// triggerWord is one parsed phrase→response rule. Match is the comparison mode
+// (word/contains/exact/prefix); Phrase and Response are already trimmed.
 type triggerWord struct {
-	Phrase        string `json:"phrase"`
-	Response      string `json:"response"`
-	Match         string `json:"match"`
-	CaseSensitive bool   `json:"case_sensitive"`
+	Phrase   string
+	Response string
+	Match    string
+}
+
+// triggerLine is one chat message under evaluation: its trimmed text plus the
+// chatter display name that fills {user} in a response. Bundling the two keeps
+// the matchers method-shaped instead of threading raw strings everywhere.
+type triggerLine struct {
+	text string
+	user string
 }
 
 // Triggers is the trigger-words module: it watches ordinary chat and, when a
-// message contains one of the broadcaster's configured phrases, posts the paired
+// message matches one of the broadcaster's configured phrases, posts the paired
 // response — no "!" command needed. It is a named, opt-in module (KindOptIn): off
 // by default, enabled and configured per channel from the dashboard.
 //
 // The handler runs on the non-command chat path, so it fires on plain messages.
 // Reaching it depends on ingress passing non-"!" chat through (the
 // chat_passthrough lane gate); premium/special-user chat always flows.
-//
-// Command lines (a leading "!") and folded duplicate cohorts are skipped, and
-// the first matching rule wins so one message yields at most one reply.
 func Triggers(_ engine.Deps) module.Module {
 	m := module.NewModule("triggers", module.KindOptIn)
-
-	m.On("channel.chat.message", func(_ context.Context, c *module.Context, emit module.Emit) error {
-		// Cohorts are folded duplicate spam, and a "!"-prefixed line is a command
-		// the dispatcher owns; neither is a trigger-word candidate.
-		text := strings.TrimSpace(c.Env.Text)
-		if text == "" || len(c.Env.Senders) > 0 || strings.HasPrefix(text, "!") {
-			return nil
-		}
-
-		var cfg triggersConfig
-		if err := c.Decode(&cfg); err != nil {
-			return err
-		}
-		if len(cfg.Triggers) == 0 {
-			return nil
-		}
-
-		for i, tw := range cfg.Triggers {
-			if i >= maxTriggers {
-				break
-			}
-			if tw.Phrase == "" || tw.Response == "" {
-				continue
-			}
-			if !matchTrigger(text, tw.Phrase, tw.Match, tw.CaseSensitive) {
-				continue
-			}
-
-			user := strings.TrimPrefix(c.Env.ChatterName(), "@")
-			msg := module.ExpandString(tw.Response, func(key string) (string, bool) {
-				if key == "user" {
-					return user, true
-				}
-				return module.ParseDynamic(key)
-			})
-			if msg == "" {
-				return nil
-			}
-			emit(&module.Output{
-				Type:          outgress.TypeChat,
-				BroadcasterID: c.Env.BroadcasterUserID,
-				Text:          msg,
-			})
-			return nil
-		}
-		return nil
-	})
-
+	m.On("channel.chat.message", triggersOnChat)
 	return m.Build()
 }
 
-// matchTrigger reports whether text satisfies the phrase under the given match
-// mode. Comparisons fold case unless caseSensitive is set. An unknown mode is
-// treated as "word".
-func matchTrigger(text, phrase, mode string, caseSensitive bool) bool {
-	if !caseSensitive {
-		text = strings.ToLower(text)
-		phrase = strings.ToLower(phrase)
+// triggersOnChat is the chat handler: it screens the line, parses the rules, and
+// emits the first matching rule's response (at most one reply per message).
+func triggersOnChat(_ context.Context, c *module.Context, emit module.Emit) error {
+	text, ok := triggerCandidate(c)
+	if !ok {
+		return nil
 	}
-	switch strings.ToLower(mode) {
+	var cfg triggersConfig
+	if err := c.Decode(&cfg); err != nil {
+		return err
+	}
+	line := triggerLine{text: text, user: strings.TrimPrefix(c.Env.ChatterName(), "@")}
+	reply, ok := line.firstReply(cfg.rules())
+	if !ok {
+		return nil
+	}
+	emit(&module.Output{
+		Type:          outgress.TypeChat,
+		BroadcasterID: c.Env.BroadcasterUserID,
+		Text:          reply,
+	})
+	return nil
+}
+
+// triggerCandidate returns the trimmed chat text and whether the line is eligible
+// for trigger matching: non-empty, not a folded duplicate cohort (Senders
+// present), and not a "!" command (the dispatcher owns those).
+func triggerCandidate(c *module.Context) (string, bool) {
+	text := strings.TrimSpace(c.Env.Text)
+	switch {
+	case text == "":
+		return "", false
+	case len(c.Env.Senders) > 0:
+		return "", false
+	case strings.HasPrefix(text, "!"):
+		return "", false
+	default:
+		return text, true
+	}
+}
+
+// rules turns the dashboard textarea into trigger rules, one per line:
+//
+//	hello => hi {user}!
+//	contains: lol => lmao
+//
+// A line is "[mode:] phrase => response". The optional mode is word (default),
+// contains, exact, or prefix. Blank lines, "#" comments, lines without "=>", and
+// lines with an empty phrase or response are skipped. At most maxTriggers rules
+// are returned.
+func (cfg triggersConfig) rules() []triggerWord {
+	if cfg.Rules == "" {
+		return nil
+	}
+	var out []triggerWord
+	for _, ln := range strings.Split(cfg.Rules, "\n") {
+		tw, ok := parseRuleLine(ln)
+		if !ok {
+			continue
+		}
+		out = append(out, tw)
+		if len(out) >= maxTriggers {
+			break
+		}
+	}
+	return out
+}
+
+// parseRuleLine parses one textarea line into a rule, reporting ok=false for a
+// blank line, a comment, a line with no "=>", or an empty phrase/response.
+func parseRuleLine(ln string) (triggerWord, bool) {
+	ln = strings.TrimSpace(ln)
+	if ln == "" || strings.HasPrefix(ln, "#") {
+		return triggerWord{}, false
+	}
+	left, response, ok := strings.Cut(ln, "=>")
+	if !ok {
+		return triggerWord{}, false
+	}
+	mode, phrase := splitMode(strings.TrimSpace(left))
+	response = strings.TrimSpace(response)
+	if phrase == "" || response == "" {
+		return triggerWord{}, false
+	}
+	return triggerWord{Phrase: phrase, Response: response, Match: mode}, true
+}
+
+// splitMode peels an optional "mode:" prefix (word/contains/exact/prefix) off a
+// phrase. An unknown or absent prefix yields the default "word" mode with the
+// phrase left unchanged.
+func splitMode(phrase string) (mode, rest string) {
+	pre, after, ok := strings.Cut(phrase, ":")
+	if !ok {
+		return "word", phrase
+	}
+	switch strings.ToLower(strings.TrimSpace(pre)) {
+	case "word", "contains", "exact", "prefix":
+		return strings.ToLower(strings.TrimSpace(pre)), strings.TrimSpace(after)
+	default:
+		return "word", phrase
+	}
+}
+
+// firstReply returns the expanded response of the first rule that matches the
+// line, or ok=false when none do. {user} resolves to the chatter name; {random}
+// and {choice:…} resolve through the shared dynamic vars.
+func (l triggerLine) firstReply(rules []triggerWord) (string, bool) {
+	for _, tw := range rules {
+		if !tw.matches(l) {
+			continue
+		}
+		msg := module.ExpandString(tw.Response, func(key string) (string, bool) {
+			if key == "user" {
+				return l.user, true
+			}
+			return module.ParseDynamic(key)
+		})
+		if msg == "" {
+			return "", false
+		}
+		return msg, true
+	}
+	return "", false
+}
+
+// matches reports whether tw fires on the line under its mode. The comparison is
+// case-insensitive. An unknown mode is treated as "word".
+func (tw triggerWord) matches(l triggerLine) bool {
+	text := strings.ToLower(l.text)
+	phrase := strings.ToLower(tw.Phrase)
+	switch tw.Match {
 	case "contains":
 		return strings.Contains(text, phrase)
 	case "exact":
@@ -146,9 +218,8 @@ func containsWord(hay, needle string) bool {
 	return false
 }
 
-// wordEdge reports whether position idx in s is a word boundary: the start or end
-// of s, or a spot where the adjacent rune is not alphanumeric. idx is the byte
-// index just before the rune that follows the boundary (0 and len(s) are edges).
+// wordEdge reports whether byte position idx in s is a word boundary: the start
+// or end of s, or a spot where the rune on either side is not alphanumeric.
 func wordEdge(s string, idx int) bool {
 	if idx <= 0 || idx >= len(s) {
 		return true

--- a/app/sesame/modules/triggers_test.go
+++ b/app/sesame/modules/triggers_test.go
@@ -2,6 +2,9 @@ package modules
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
 	"testing"
 
 	"ItsBagelBot/app/sesame/engine"
@@ -24,7 +27,9 @@ func triggersHandler(t *testing.T) module.EventHandler {
 	return h
 }
 
-func triggersCtx(text, config string) *module.Context {
+// triggersCtx builds a chat Context whose Config blob carries the given rules
+// textarea (empty rules leaves the blob unset).
+func triggersCtx(text, rules string) *module.Context {
 	c := &module.Context{
 		Env: lane.Envelope{
 			Type:              "channel.chat.message",
@@ -35,17 +40,22 @@ func triggersCtx(text, config string) *module.Context {
 		BroadcasterID: 2,
 		Log:           zap.NewNop(),
 	}
-	if config != "" {
-		c.Config = []byte(config)
+	if rules != "" {
+		c.Config = rulesBlob(rules)
 	}
 	return c
 }
 
-const helloCfg = `{"triggers":[{"phrase":"hello","response":"hi {user}!"}]}`
+// rulesBlob marshals a rules string into the {"rules":"…"} Configs blob, matching
+// what the dashboard persists. Marshaling a single string field never errors.
+func rulesBlob(rules string) []byte {
+	b, _ := json.Marshal(triggersConfig{Rules: rules})
+	return b
+}
 
 func TestTriggersWordMatch(t *testing.T) {
 	var col collector
-	require.NoError(t, triggersHandler(t)(context.Background(), triggersCtx("oh hello there", helloCfg), col.emit))
+	require.NoError(t, triggersHandler(t)(context.Background(), triggersCtx("oh hello there", "hello => hi {user}!"), col.emit))
 	require.Len(t, col.out, 1)
 	o := col.out[0]
 	assert.Equal(t, outgress.TypeChat, o.Type)
@@ -56,55 +66,52 @@ func TestTriggersWordMatch(t *testing.T) {
 func TestTriggersWordMatchIsWholeWord(t *testing.T) {
 	var col collector
 	// "hello" must not fire on "hellovision" under the default word mode.
-	require.NoError(t, triggersHandler(t)(context.Background(), triggersCtx("watch hellovision", helloCfg), col.emit))
+	require.NoError(t, triggersHandler(t)(context.Background(), triggersCtx("watch hellovision", "hello => hi"), col.emit))
 	assert.Empty(t, col.out)
 }
 
-func TestTriggersCaseInsensitiveByDefault(t *testing.T) {
+func TestTriggersCaseInsensitive(t *testing.T) {
 	var col collector
-	require.NoError(t, triggersHandler(t)(context.Background(), triggersCtx("HELLO everyone", helloCfg), col.emit))
+	require.NoError(t, triggersHandler(t)(context.Background(), triggersCtx("HELLO everyone", "hello => hi {user}!"), col.emit))
 	require.Len(t, col.out, 1)
 	assert.Equal(t, "hi Bob!", col.out[0].Text)
 }
 
 func TestTriggersContainsMode(t *testing.T) {
 	var col collector
-	cfg := `{"triggers":[{"phrase":"lol","response":"lmao","match":"contains"}]}`
-	require.NoError(t, triggersHandler(t)(context.Background(), triggersCtx("hahalolhaha", cfg), col.emit))
+	require.NoError(t, triggersHandler(t)(context.Background(), triggersCtx("hahalolhaha", "contains: lol => lmao"), col.emit))
 	require.Len(t, col.out, 1)
 	assert.Equal(t, "lmao", col.out[0].Text)
 }
 
 func TestTriggersExactMode(t *testing.T) {
-	cfg := `{"triggers":[{"phrase":"gg","response":"good game","match":"exact"}]}`
+	rules := "exact: gg => good game"
 
 	var hit collector
-	require.NoError(t, triggersHandler(t)(context.Background(), triggersCtx("gg", cfg), hit.emit))
+	require.NoError(t, triggersHandler(t)(context.Background(), triggersCtx("gg", rules), hit.emit))
 	require.Len(t, hit.out, 1)
+	assert.Equal(t, "good game", hit.out[0].Text)
 
 	var miss collector
-	require.NoError(t, triggersHandler(t)(context.Background(), triggersCtx("gg wp", cfg), miss.emit))
+	require.NoError(t, triggersHandler(t)(context.Background(), triggersCtx("gg wp", rules), miss.emit))
 	assert.Empty(t, miss.out)
 }
 
 func TestTriggersPrefixMode(t *testing.T) {
-	cfg := `{"triggers":[{"phrase":"!hype","response":"HYPE"}, {"phrase":"gm","response":"morning","match":"prefix"}]}`
-	// leading "!" lines are skipped entirely, so only the prefix rule can fire.
 	var col collector
-	require.NoError(t, triggersHandler(t)(context.Background(), triggersCtx("gm chat", cfg), col.emit))
+	require.NoError(t, triggersHandler(t)(context.Background(), triggersCtx("gm chat", "prefix: gm => morning"), col.emit))
 	require.Len(t, col.out, 1)
 	assert.Equal(t, "morning", col.out[0].Text)
 }
 
 func TestTriggersSkipsCommands(t *testing.T) {
 	var col collector
-	cfg := `{"triggers":[{"phrase":"hello","response":"hi","match":"contains"}]}`
-	require.NoError(t, triggersHandler(t)(context.Background(), triggersCtx("!hello", cfg), col.emit))
+	require.NoError(t, triggersHandler(t)(context.Background(), triggersCtx("!hello", "contains: hello => hi"), col.emit))
 	assert.Empty(t, col.out)
 }
 
 func TestTriggersSkipsCohorts(t *testing.T) {
-	c := triggersCtx("hello", helloCfg)
+	c := triggersCtx("hello", "hello => hi")
 	c.Env.Senders = []lane.Sender{{ChatterUserID: "9"}}
 	var col collector
 	require.NoError(t, triggersHandler(t)(context.Background(), c, col.emit))
@@ -112,9 +119,8 @@ func TestTriggersSkipsCohorts(t *testing.T) {
 }
 
 func TestTriggersFirstMatchWins(t *testing.T) {
-	cfg := `{"triggers":[{"phrase":"hi","response":"one"},{"phrase":"there","response":"two"}]}`
 	var col collector
-	require.NoError(t, triggersHandler(t)(context.Background(), triggersCtx("hi there", cfg), col.emit))
+	require.NoError(t, triggersHandler(t)(context.Background(), triggersCtx("hi there", "hi => one\nthere => two"), col.emit))
 	require.Len(t, col.out, 1)
 	assert.Equal(t, "one", col.out[0].Text)
 }
@@ -125,10 +131,36 @@ func TestTriggersNoConfigNoOp(t *testing.T) {
 	assert.Empty(t, col.out)
 }
 
-func TestTriggersEmptyPhraseOrResponseSkipped(t *testing.T) {
-	var col collector
-	cfg := `{"triggers":[{"phrase":"","response":"x"},{"phrase":"y","response":""},{"phrase":"z","response":"zed"}]}`
-	require.NoError(t, triggersHandler(t)(context.Background(), triggersCtx("z", cfg), col.emit))
-	require.Len(t, col.out, 1)
-	assert.Equal(t, "zed", col.out[0].Text)
+// TestParseRules exercises the textarea parser directly: comments, blanks, mode
+// prefixes, and malformed lines are all handled.
+func TestParseRules(t *testing.T) {
+	raw := "# a comment\n\nhello => hi {user}!\n  contains: lol =>  lmao \nnoseparator here\nempty => \n => noPhrase"
+	rules := triggersConfig{Rules: raw}.rules()
+	require.Len(t, rules, 2)
+
+	assert.Equal(t, "hello", rules[0].Phrase)
+	assert.Equal(t, "hi {user}!", rules[0].Response)
+	assert.Equal(t, "word", rules[0].Match)
+
+	assert.Equal(t, "lol", rules[1].Phrase)
+	assert.Equal(t, "lmao", rules[1].Response)
+	assert.Equal(t, "contains", rules[1].Match)
+}
+
+// TestParseRulesUnknownMode keeps a colon that is not a real mode as part of the
+// phrase rather than dropping it.
+func TestParseRulesUnknownMode(t *testing.T) {
+	rules := triggersConfig{Rules: "time:30 => later"}.rules()
+	require.Len(t, rules, 1)
+	assert.Equal(t, "time:30", rules[0].Phrase)
+	assert.Equal(t, "word", rules[0].Match)
+}
+
+// TestParseRulesCap stops at maxTriggers.
+func TestParseRulesCap(t *testing.T) {
+	var b strings.Builder
+	for i := 0; i < maxTriggers+10; i++ {
+		fmt.Fprintf(&b, "w%d => r%d\n", i, i)
+	}
+	assert.Len(t, triggersConfig{Rules: b.String()}.rules(), maxTriggers)
 }

--- a/console/dashboard/src/routes/(app)/modules/[id]/+page.svelte
+++ b/console/dashboard/src/routes/(app)/modules/[id]/+page.svelte
@@ -197,7 +197,7 @@
       ></button>
     </div>
     {#each def.settings ?? [] as field (field.key)}
-      <div class="setting-row">
+      <div class="setting-row {field.type === 'textarea' ? 'stacked' : ''}">
         <label class="tr-text" for="mod-setting-{field.key}">
           <span class="tr-label">{field.label}</span>
           {#if field.help}<span class="tr-help">{field.help}</span>{/if}
@@ -222,6 +222,14 @@
               <option value={opt.value}>{opt.label}</option>
             {/each}
           </select>
+        {:else if field.type === 'textarea'}
+          <textarea
+            id="mod-setting-{field.key}"
+            class="setting-input setting-textarea"
+            placeholder={field.placeholder ?? ''}
+            value={config[field.key] ?? ''}
+            onchange={(e) => saveSetting(field, e.currentTarget.value)}
+          ></textarea>
         {:else}
           <input
             id="mod-setting-{field.key}"
@@ -366,6 +374,19 @@
     border-color: var(--bb-tan, #c9a87c);
   }
   .setting-input::placeholder { color: var(--bb-muted); opacity: 0.7; }
+
+  /* A textarea setting (e.g. trigger rules) stacks full-width under its label. */
+  .setting-row.stacked { flex-direction: column; align-items: stretch; }
+  .setting-row.stacked .tr-text { margin-right: 0; }
+  .setting-textarea {
+    width: 100%;
+    min-height: 132px;
+    padding: 10px 12px;
+    line-height: 1.55;
+    resize: vertical;
+    white-space: pre;
+    overflow-wrap: normal;
+  }
   @media (max-width: 560px) {
     .setting-row { flex-wrap: wrap; }
     .setting-input { width: 100%; }

--- a/console/shared/lib/types.ts
+++ b/console/shared/lib/types.ts
@@ -772,6 +772,29 @@ export const MODULE_CATALOG: readonly ModuleDef[] = [
     // the tile opens a bespoke inspector instead.
     href: '/govee',
     replies: []
+  },
+  {
+    id: 'triggers',
+    label: 'Trigger Words',
+    tagline: 'Auto-reply when a word shows up in chat — no "!" needed.',
+    description:
+      'Give the bot a list of words or phrases and the line to post when it sees one in ordinary chat — no command prefix required. Write one rule per line as "phrase => response". Prefix the phrase with contains:, exact: or prefix: to change how it matches (the default matches the whole word, so "hi" will not fire inside "this"). Responses support {user}, {random} and {choice:a,b,c}. The first matching rule wins, so one message gets at most one reply.',
+    icon: 'caps',
+    category: 'Community',
+    defaultEnabled: false,
+    // Trigger rules are a free-form list, which the fixed reply/settings schema
+    // cannot express as rows; the whole list rides in one textarea the sesame
+    // module parses line by line (see app/sesame/modules/triggers.go).
+    replies: [],
+    settings: [
+      {
+        key: 'rules',
+        label: 'Trigger rules',
+        type: 'textarea',
+        placeholder: 'hello => hi {user}!\ncontains: lol => lmao\nexact: gg => good game',
+        help: 'One rule per line: phrase => response. Prefix the phrase with contains:, exact: or prefix: to change matching (default is whole-word). Tokens: {user}, {random}, {choice:a,b,c}. Lines starting with # are ignored.'
+      }
+    ]
   }
 ];
 


### PR DESCRIPTION
Follow-up to #284. Makes the trigger-words module configurable from the dashboard and clears the CodeScene findings.

## Dashboard ("I don't see it")
The modules list is `MODULE_CATALOG.map(...)`, and `triggers` was never added to the catalog — so no tile rendered. This adds:
- A `triggers` `MODULE_CATALOG` entry (icon `caps`, Community, off by default) with a `rules` textarea.
- A `textarea` render branch on the module page (previously fell through to a single-line `<input>`; also improves automod's block/allow-terms fields).

## Config format
sesame now parses the textarea, one rule per line, instead of a raw JSON array:
```
hello => hi {user}!
contains: lol => lmao
exact: gg => good game
```
- Optional mode prefix `contains:` / `exact:` / `prefix:` (default whole-word).
- Tokens `{user}`, `{random}`, `{choice:a,b,c}`; `#` comment lines; first match wins; capped at 50 rules.

## CodeScene (#284 findings)
`Triggers` was cyclomatic 13 with a 3-way `||` conditional. Split into `triggersOnChat`, `triggerCandidate` (switch), `parseRules`/`parseRuleLine`, `splitMode`, `firstTriggerReply`. No function exceeds the thresholds now.

## Tests / checks
`go test ./app/sesame/modules` (incl. new `parseRules` cases) + `go vet` clean; dashboard `svelte-check` 0 errors and `vite build` clean.