### PR TITLE
feat(dashboard): move Channel Points and Timers into module slots

### DIFF
--- a/console/dashboard/src/routes/(app)/+layout.svelte
+++ b/console/dashboard/src/routes/(app)/+layout.svelte
@@ -59,17 +59,16 @@
   const section = $derived(
     path.startsWith('/commands')
       ? 'commands'
-      : path.startsWith('/modules') || path.startsWith('/govee')
+      : path.startsWith('/modules') ||
+          path.startsWith('/govee') ||
+          path.startsWith('/channelpoints') ||
+          path.startsWith('/timers')
         ? 'modules'
-        : path.startsWith('/channelpoints')
-          ? 'channelpoints'
-          : path.startsWith('/timers')
-            ? 'timers'
-            : path.startsWith('/billing')
-              ? 'billing'
-              : path.startsWith('/settings') || path.startsWith('/access')
-                ? 'settings'
-                : 'overview'
+        : path.startsWith('/billing')
+          ? 'billing'
+          : path.startsWith('/settings') || path.startsWith('/access')
+            ? 'settings'
+            : 'overview'
   );
   const crumb = $derived(t(`nav.${section}`));
 
@@ -78,9 +77,6 @@
   const sections = $derived((data.sections ?? []) as string[]);
   const canCommands = $derived(!isDelegate || sections.includes('commands'));
   const canModules = $derived(!isDelegate || sections.includes('modules'));
-  const canChannelPoints = $derived(!isDelegate || sections.includes('channelpoints'));
-  // Timers rides under the commands scope; legacy 'timers' grants still count.
-  const canTimers = $derived(!isDelegate || sections.includes('commands') || sections.includes('timers'));
   // Billing is owner-only except for a delegate explicitly granted it (view-only).
   const canBilling = $derived(!isDelegate || sections.includes('billing'));
 
@@ -96,10 +92,6 @@
     ...(canModules
       ? [{ href: '/modules', icon: 'modules', label: t('nav.modules'), active: section === 'modules' }]
       : []),
-    ...(canChannelPoints
-      ? [{ href: '/channelpoints', icon: 'gem', label: t('nav.channelpoints'), active: section === 'channelpoints' }]
-      : []),
-    ...(canTimers ? [{ href: '/timers', icon: 'clock', label: t('nav.timers'), active: section === 'timers' }] : []),
     ...(canBilling
       ? [{ href: '/billing', icon: 'card', label: t('nav.billing'), active: section === 'billing' }]
       : []),

--- a/console/dashboard/src/routes/(app)/modules/+page.server.ts
+++ b/console/dashboard/src/routes/(app)/modules/+page.server.ts
@@ -70,17 +70,16 @@ export const actions: Actions = {
     if (!moduleDef(name)) return fail(400, { ok: false, error: 'Unknown module.' });
     const enabled = f.get('is_enabled') === 'on';
 
-    let config: Record<string, string> | undefined;
-    try {
-      const raw = String(f.get('config') ?? '');
-      config = raw ? (JSON.parse(raw) as Record<string, string>) : undefined;
-    } catch {
-      config = undefined;
-    }
-
     if (env.DEMO === '1') return { ok: true, name, enabled };
 
     try {
+      // The tile only flips enabled: re-read the stored config and write it back
+      // untouched. Never rebuild it from the tile form — the page flattens every
+      // config value to a string for its reply inputs, which would corrupt the
+      // nested blobs some modules own (channel-points rewards, timers) into
+      // "[object Object]" and wipe them on a toggle.
+      const rows = await listModules(uid);
+      const config = rows.find((r) => r.name === name)?.configs;
       await upsertModule(uid, name, enabled, config);
     } catch (e) {
       console.error(`[modules] toggle ${name} failed:`, e instanceof Error ? (e.stack ?? e.message) : e);

--- a/console/dashboard/src/routes/(app)/modules/+page.svelte
+++ b/console/dashboard/src/routes/(app)/modules/+page.svelte
@@ -195,7 +195,6 @@
                   <SaveStatus state={modStatus[m.def.id] ?? 'idle'} />
                   <form method="POST" action="?/toggle" use:enhance={toggleSubmit(m)}>
                     <input type="hidden" name="name" value={m.def.id} />
-                    <input type="hidden" name="config" value={JSON.stringify(m.config)} />
                     <input type="hidden" name="is_enabled" value={m.enabled ? '' : 'on'} />
                     <button
                       class="toggle {m.enabled ? 'on' : ''}"

--- a/console/dashboard/src/routes/(app)/modules/[id]/+page.server.ts
+++ b/console/dashboard/src/routes/(app)/modules/[id]/+page.server.ts
@@ -1,5 +1,5 @@
 import type { Actions, PageServerLoad } from './$types';
-import { moduleDef } from '@bagel/shared';
+import { moduleDef, type ModuleDef } from '@bagel/shared';
 import { listModules, upsertModule } from '$lib/server/commands-store';
 import { auditDashboardImpersonation } from '$lib/server/services';
 import type { Session } from '$lib/server/session';
@@ -31,6 +31,9 @@ export const load: PageServerLoad = async ({ params, locals }) => {
   gateModules(locals.session);
   const def = moduleDef(params.id);
   if (!def) throw error(404, 'Unknown module');
+  // href modules (channel points, timers, govee) own a bespoke page; the generic
+  // reply inspector cannot render them, so send any direct hit there.
+  if (def.href) throw redirect(302, def.href);
 
   const uid = effectiveId(locals.session);
   if (env.DEMO === '1') return { def, enabled: def.defaultEnabled, config: {} as Record<string, string> };
@@ -49,6 +52,25 @@ export const load: PageServerLoad = async ({ params, locals }) => {
   }
 };
 
+// buildConfig reads the posted draft into the module's stored config: a
+// customized message per reply (blank falls back to the sesame default), an
+// explicit "off" for a per-reply toggle the user turned off (empty/absent = on,
+// matching sesame's alertOn semantics), and each non-blank plain setting. Only
+// non-default values are stored, so the blob stays minimal.
+function buildConfig(def: ModuleDef, f: FormData): Record<string, string> {
+  const get = (key: string) => String(f.get(`cfg.${key}`) ?? '').trim();
+  const config: Record<string, string> = {};
+  for (const reply of def.replies) {
+    const msg = get(reply.messageKey);
+    if (msg) config[reply.messageKey] = msg;
+    if (reply.enableKey && get(reply.enableKey) === 'off') config[reply.enableKey] = 'off';
+  }
+  for (const field of (def.settings ?? []).filter((s) => get(s.key))) {
+    config[field.key] = get(field.key);
+  }
+  return config;
+}
+
 export const actions: Actions = {
   // One save persists the whole module config (enable + every reply message and
   // per-reply toggle). The client always posts the full draft, so upsertModule's
@@ -64,23 +86,7 @@ export const actions: Actions = {
 
     const f = await request.formData();
     const enabled = f.get('is_enabled') === 'on';
-
-    const config: Record<string, string> = {};
-    for (const reply of def.replies) {
-      // Store a customized message; drop blanks so the module falls back to the
-      // sesame default.
-      const msg = String(f.get(`cfg.${reply.messageKey}`) ?? '').trim();
-      if (msg) config[reply.messageKey] = msg;
-      // Per-reply toggle: only persist an explicit "off" (empty/absent = on,
-      // matching sesame's alertOn semantics), so a default-on reply stores nothing.
-      if (reply.enableKey && String(f.get(`cfg.${reply.enableKey}`) ?? '') === 'off') {
-        config[reply.enableKey] = 'off';
-      }
-    }
-    for (const field of def.settings ?? []) {
-      const v = String(f.get(`cfg.${field.key}`) ?? '').trim();
-      if (v) config[field.key] = v;
-    }
+    const config = buildConfig(def, f);
 
     if (env.DEMO === '1') return { ok: true, enabled };
 

--- a/console/shared/lib/types.ts
+++ b/console/shared/lib/types.ts
@@ -795,6 +795,35 @@ export const MODULE_CATALOG: readonly ModuleDef[] = [
         help: 'One rule per line: phrase => response. Prefix the phrase with contains:, exact: or prefix: to change matching (default is whole-word). Tokens: {user}, {random}, {choice:a,b,c}. Lines starting with # are ignored.'
       }
     ]
+  },
+  // Channel Points and Timers are full modules (their own enable flag + config
+  // blob in the modules service, read by sesame), but their setup cannot be
+  // expressed as reply rows: channel points needs the reward CRUD surface and
+  // timers the schedule editor. Each tile therefore opens its bespoke page via
+  // href instead of the generic /modules/[id] inspector.
+  {
+    id: 'channelpoints',
+    label: 'Channel Points',
+    tagline: 'Turn channel-point redemptions into bot actions.',
+    description:
+      'Create the custom rewards viewers redeem with channel points (made under the bot on Twitch, styled natively) and bind each one to a bot action, like posting a chat line. Choose whether each redemption is fulfilled, refunded, or left for a mod. Manage the rewards on this page.',
+    icon: 'gem',
+    category: 'Stream Engagement',
+    defaultEnabled: false,
+    href: '/channelpoints',
+    replies: []
+  },
+  {
+    id: 'timers',
+    label: 'Timers',
+    tagline: 'Post repeating chat messages on a schedule while you are live.',
+    description:
+      'Set messages the bot repeats on a schedule while you are live: announcements, socials, reminders. Each timer keeps its own interval and only fires during the stream. Add, edit and arm them on this page.',
+    icon: 'clock',
+    category: 'Stream Engagement',
+    defaultEnabled: false,
+    href: '/timers',
+    replies: []
   }
 ];
 


### PR DESCRIPTION
## What

Move **Channel Points** and **Timers** out of standalone dashboard sections and into module tiles under a new **Stream Engagement** category on the modules page. Each tile reopens its existing bespoke page via the module `href` (the same mechanism Govee uses), so the setup UI is unchanged.

## Changes

- **Catalog**: add `channelpoints` and `timers` entries to `MODULE_CATALOG` (category `Stream Engagement`, `href` → `/channelpoints` / `/timers`).
- **Nav**: remove the standalone Channel Points / Timers nav items and their gates; fold both routes into the Modules breadcrumb + active-section logic.
- **Routing**: a direct hit on `/modules/<href-module>` now 302s to the bespoke page (covers channelpoints, timers, govee); the generic reply inspector can't render them.
- **Bug fix (data loss)**: the modules-page quick toggle rebuilt config from the page's *flattened* string map. For channelpoints/timers (whose whole blob is a single nested `rewards`/`timers` array) that flattened to `"[object Object]"` and **wiped every reward/timer on a toggle**. The toggle now re-reads the stored config and only flips `is_enabled`.
- **Cleanup**: extract `buildConfig` from the module `save` action to drop its cyclomatic complexity.

## Verification

- `svelte-check`: 0 errors.
- CodeScene `delta`: **no new issues**; `[id]/+page.server.ts` improved 9.48 → **10.00** (Complex Method + Bumpy Road on `save` fixed).
- Live dev (DEMO): Stream Engagement category renders both tiles → `/channelpoints`, `/timers`; `/modules/{channelpoints,timers,govee}` redirect to their pages; standalone nav items gone.