### PR TITLE
feat(govee): multiple rewards (one light each) in a deck + inspector

### DIFF
--- a/app/sesame/modules/govee.go
+++ b/app/sesame/modules/govee.go
@@ -51,6 +51,31 @@ type goveeConfig struct {
 	ReplyMessage string `json:"replyMessage"`
 }
 
+// goveeConfigs is the module blob shape: a list of reward->light bindings, so a
+// broadcaster can drive several lights, one per channel-points reward. The
+// dashboard enforces one reward per light. The legacy blob was a single binding
+// at the top level; bindingsOf reads either shape.
+type goveeConfigs struct {
+	Bindings []goveeConfig `json:"bindings"`
+}
+
+// bindingsOf returns the module's reward bindings, tolerating the legacy
+// single-binding blob (top-level rewardId/device) as a one-element list so
+// broadcasters configured before the multi-light change keep working.
+func bindingsOf(c *module.Context) []goveeConfig {
+	var wrap goveeConfigs
+	_ = c.Decode(&wrap)
+	if len(wrap.Bindings) > 0 {
+		return wrap.Bindings
+	}
+	var single goveeConfig
+	_ = c.Decode(&single)
+	if goveeConfigured(single) {
+		return []goveeConfig{single}
+	}
+	return nil
+}
+
 // Govee turns a channel-points redemption into a smart-light colour change. It
 // is a named, opt-in module (KindOptIn): off by default, configured on its own
 // dashboard inspector page where the broadcaster stores their Govee API key,
@@ -172,19 +197,24 @@ func renderGoveeReply(tmpl string, ev redemptionEvent, color string) string {
 // unconfigured module, a non-redemption envelope, or a different reward id. The
 // checks are kept as separate single conditions for readability.
 func decodeGoveeRedemption(c *module.Context) (goveeConfig, redemptionEvent, bool) {
-	var cfg goveeConfig
-	_ = c.Decode(&cfg)
-	if !goveeConfigured(cfg) || len(c.Env.Event) == 0 {
-		return cfg, redemptionEvent{}, false
+	bindings := bindingsOf(c)
+	if len(bindings) == 0 || len(c.Env.Event) == 0 {
+		return goveeConfig{}, redemptionEvent{}, false
 	}
 	var ev redemptionEvent
 	if err := json.Unmarshal(c.Env.Event, &ev); err != nil {
-		return cfg, ev, false
+		return goveeConfig{}, ev, false
 	}
-	if ev.Reward.ID != cfg.RewardID || ev.BroadcasterUserID == "" {
-		return cfg, ev, false
+	if ev.BroadcasterUserID == "" {
+		return goveeConfig{}, ev, false
 	}
-	return cfg, ev, true
+	// Drive the binding whose reward was redeemed; unrelated rewards no-op.
+	for _, b := range bindings {
+		if goveeConfigured(b) && b.RewardID == ev.Reward.ID {
+			return b, ev, true
+		}
+	}
+	return goveeConfig{}, ev, false
 }
 
 // goveeConfigured reports whether the module has a complete binding (reward +

--- a/app/sesame/modules/govee_test.go
+++ b/app/sesame/modules/govee_test.go
@@ -193,6 +193,33 @@ func TestGoveeCustomReplyTemplate(t *testing.T) {
 	assert.Equal(t, "CoolViewer painted the room blue", col.out[0].Text, "template tokens fill from the redemption")
 }
 
+func TestGoveeMultiBindingDrivesMatchingLight(t *testing.T) {
+	var col collector
+	gw := okGateway()
+	d := engine.Deps{Live: &fakeLive{live: true}, Gateway: gw}
+	cfg := `{"bindings":[{"rewardId":"rw-1","device":"AA:AA:AA","sku":"H1"},{"rewardId":"rw-2","device":"BB:BB:BB","sku":"H2"}]}`
+	// Redeeming the second reward must drive the second light, not the first.
+	payload := `{"id":"redeem-9","broadcaster_user_id":"2","user_name":"CoolViewer","user_login":"coolviewer","user_input":"red","reward":{"id":"rw-2","title":"x","cost":1}}`
+	require.NoError(t, goveeHandler(t, d)(context.Background(), goveeCtx(payload, cfg), col.emit))
+
+	call := gw.lastCall(t)
+	assert.Equal(t, "BB:BB:BB", call.req.Device, "the redeemed reward's light must be driven")
+	assert.Equal(t, "H2", call.req.SKU)
+	require.Len(t, col.out, 2)
+	assert.Equal(t, outgress.RedemptionFulfilled, col.out[1].Status)
+}
+
+func TestGoveeMultiBindingUnmatchedRewardNoop(t *testing.T) {
+	var col collector
+	gw := okGateway()
+	d := engine.Deps{Live: &fakeLive{live: true}, Gateway: gw}
+	cfg := `{"bindings":[{"rewardId":"rw-1","device":"AA:AA:AA","sku":"H1"}]}`
+	payload := `{"id":"redeem-x","broadcaster_user_id":"2","user_name":"V","user_login":"v","user_input":"red","reward":{"id":"other","title":"x","cost":1}}`
+	require.NoError(t, goveeHandler(t, d)(context.Background(), goveeCtx(payload, cfg), col.emit))
+	assert.Empty(t, gw.calls, "a reward bound to no light must no-op")
+	assert.Empty(t, col.out)
+}
+
 // assertRefund asserts the two-output refund shape: a chat reason then a
 // CANCELED redemption update.
 func assertRefund(t *testing.T, out []module.Output) {

--- a/console/dashboard/src/lib/components/govee/GoveeLightRow.svelte
+++ b/console/dashboard/src/lib/components/govee/GoveeLightRow.svelte
@@ -1,0 +1,136 @@
+<script lang="ts">
+  // One light in the govee deck: the device on the left, its bound reward (or an
+  // empty "not set up" state) on the right. Selecting it loads the reward into
+  // the page's inspector. One reward per light, so a row has at most one reward.
+  import { Icon, type GoveeDevice, type GoveeBinding } from '@bagel/shared';
+
+  let {
+    device,
+    binding,
+    expanded = false,
+    onExpand,
+    onDelete
+  }: {
+    device: GoveeDevice;
+    binding: GoveeBinding | null;
+    expanded?: boolean;
+    onExpand: () => void;
+    onDelete: () => void;
+  } = $props();
+
+  const reward = $derived(binding?.reward ?? null);
+
+  function rowKey(e: KeyboardEvent) {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      onExpand();
+    }
+  }
+</script>
+
+<div class="row-shell {expanded ? 'selected' : ''} {binding ? '' : 'unset'}">
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <div class="trow" role="button" tabindex="0" aria-pressed={expanded} onclick={onExpand} onkeydown={rowKey}>
+    <span class="light">
+      <span class="swatch" style="--sw: {reward?.color || '#6b7079'}"><Icon name="power" size={12} /></span>
+      <span class="light-text">
+        <span class="light-name">{device.name || device.device}</span>
+        <span class="light-sku">{device.sku}</span>
+      </span>
+    </span>
+
+    <span class="status">
+      {#if reward}
+        <span class="reward-title">{reward.title}</span>
+        <span class="reward-cost">{reward.cost.toLocaleString()} pts</span>
+      {:else}
+        <span class="unset-tag">Not set up</span>
+      {/if}
+    </span>
+
+    <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+    <span class="row-act" onclick={(e) => e.stopPropagation()}>
+      {#if binding}
+        <button class="mini" type="button" aria-label="Remove the reward for {device.name || device.device}" onclick={onDelete}>
+          <Icon name="trash" size={15} />
+        </button>
+      {/if}
+      <span class="chev" class:open={expanded} aria-hidden="true"><Icon name="settings" size={13} /></span>
+    </span>
+  </div>
+</div>
+
+<style>
+  .row-shell {
+    border-bottom: 1px solid var(--rule, rgba(240, 236, 228, 0.08));
+    transition: background var(--bb-dur-fast, 140ms) ease;
+  }
+  .row-shell.selected { background: rgba(201, 168, 124, 0.05); }
+  .row-shell.unset .light-name { color: var(--bb-muted); }
+
+  .trow {
+    display: grid;
+    grid-template-columns: minmax(150px, 1.2fr) minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 14px;
+    padding: 12px 14px;
+    cursor: pointer;
+    user-select: none;
+  }
+  .trow:hover { background: rgba(201, 168, 124, 0.045); }
+  .trow:focus-visible { outline: 1px solid var(--bb-tan, #c9a87c); outline-offset: -1px; }
+
+  .light { display: inline-flex; align-items: center; gap: 10px; min-width: 0; }
+  .swatch {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 26px;
+    height: 26px;
+    flex: none;
+    border-radius: 7px;
+    background: color-mix(in srgb, var(--sw) 22%, transparent);
+    border: 1px solid color-mix(in srgb, var(--sw) 55%, transparent);
+    color: color-mix(in srgb, var(--sw) 78%, white);
+  }
+  .swatch :global(svg) { stroke-width: 1.8; }
+  .light-text { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+  .light-name {
+    font-family: var(--bb-font-display);
+    font-weight: 700;
+    font-size: 13.5px;
+    color: var(--bb-white);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .light-sku { font-family: var(--bb-font-mono, monospace); font-size: 11px; color: var(--bb-muted); }
+
+  .status { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+  .reward-title {
+    font-family: var(--bb-font-body);
+    font-size: 13px;
+    color: var(--bb-white);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .reward-cost { font-family: var(--bb-font-mono, monospace); font-size: 11.5px; color: var(--bb-tan-light); }
+  .unset-tag {
+    font-family: var(--bb-font-body);
+    font-size: 12.5px;
+    color: var(--bb-muted);
+    font-style: italic;
+  }
+
+  .row-act { display: inline-flex; align-items: center; gap: 8px; }
+  .chev { display: inline-flex; color: var(--bb-muted); transition: color var(--bb-dur-fast, 140ms) ease; }
+  .row-shell.selected .chev, .chev.open { color: var(--bb-tan); }
+
+  @media (max-width: 620px) {
+    .trow { grid-template-columns: minmax(0, 1fr) auto; grid-template-areas: 'light act' 'status act'; row-gap: 4px; }
+    .light { grid-area: light; }
+    .status { grid-area: status; }
+    .row-act { grid-area: act; }
+  }
+</style>

--- a/console/dashboard/src/lib/components/govee/GoveeRewardEditor.svelte
+++ b/console/dashboard/src/lib/components/govee/GoveeRewardEditor.svelte
@@ -1,0 +1,204 @@
+<script lang="ts">
+  // Inspector body: create/edit the one reward bound to a light. Named form
+  // inputs post straight to ?/saveReward (the page owns the enhance handler);
+  // local state drives the live ChatPreview rehearsal. The page keys this on the
+  // device id so switching lights re-seeds it.
+  import { enhance } from '$app/forms';
+  import type { SubmitFunction } from '@sveltejs/kit';
+  import { Icon, type GoveeDevice, type GoveeBinding } from '@bagel/shared';
+  import ResponseEditor from '$lib/components/commands/ResponseEditor.svelte';
+  import ChatPreview from '$lib/components/commands/ChatPreview.svelte';
+
+  let {
+    device,
+    binding,
+    colors,
+    busy = false,
+    onSubmit,
+    onCancel,
+    onRequestDelete
+  }: {
+    device: GoveeDevice;
+    binding: GoveeBinding | null;
+    colors: string[];
+    busy?: boolean;
+    onSubmit: SubmitFunction;
+    onCancel: () => void;
+    onRequestDelete: () => void;
+  } = $props();
+
+  const DEFAULT_REPLY = '@{user} set the lights to {color}!';
+  const REPLY_TOKENS = [
+    { token: '{user}', label: '{user} → the viewer' },
+    { token: '{color}', label: '{color} → what they typed' }
+  ];
+  const replySamples: Record<string, string> = { user: 'sesame_sam', color: 'blue' };
+
+  // Seeded once per light (the page keys this component on the device id), so
+  // capturing the initial binding is intentional.
+  // svelte-ignore state_referenced_locally
+  const reward = binding?.reward ?? null;
+  // svelte-ignore state_referenced_locally
+  const isNew = !binding?.rewardId;
+
+  // svelte-ignore state_referenced_locally
+  let title = $state(reward?.title || `Colour the ${device.name || 'lights'}`);
+  // svelte-ignore state_referenced_locally
+  let cost = $state(reward?.cost ?? 500);
+  // svelte-ignore state_referenced_locally
+  let color = $state(reward?.color || '#9147ff');
+  // svelte-ignore state_referenced_locally
+  let cooldown = $state(reward?.cooldown ?? 0);
+  // svelte-ignore state_referenced_locally
+  let onRedeem = $state<string>(binding?.onRedeem ?? 'fulfill');
+  // svelte-ignore state_referenced_locally
+  let replyMessage = $state(binding?.replyMessage ?? '');
+  // svelte-ignore state_referenced_locally
+  let allowOff = $state(binding?.allowOff ?? false);
+  // liveOnly is the inverse of the stored allowOffline flag; on by default.
+  // svelte-ignore state_referenced_locally
+  let liveOnly = $state(!binding?.allowOffline);
+</script>
+
+<form method="POST" action="?/saveReward" class="editor" use:enhance={onSubmit}>
+  <input type="hidden" name="device" value={device.device} />
+  <input type="hidden" name="sku" value={device.sku} />
+  <input type="hidden" name="deviceName" value={device.name} />
+
+  <p class="hint">
+    Viewers type a colour when they redeem: a name (<code>{colors.join(', ')}</code>) or a hex like <code>#00ccff</code>.
+  </p>
+
+  <label class="field">
+    <span>Reward title</span>
+    <input class="input" type="text" name="title" maxlength="45" bind:value={title} required />
+  </label>
+
+  <div class="field-row">
+    <label class="field">
+      <span>Cost (points)</span>
+      <input class="input" type="number" name="cost" min="1" max="10000000" bind:value={cost} required />
+    </label>
+    <label class="field color-field">
+      <span>Tile colour</span>
+      <input class="color-in" type="color" name="color" bind:value={color} aria-label="Reward tile colour" />
+    </label>
+  </div>
+
+  <label class="field">
+    <span>Cooldown <small>seconds, 0 = none</small></span>
+    <input class="input" type="number" name="cooldown" min="0" max="604800" bind:value={cooldown} />
+  </label>
+
+  <label class="field">
+    <span>Chat reply <small>optional, {'{user}'} and {'{color}'}</small></span>
+    <ResponseEditor bind:value={replyMessage} name="replyMessage" tokens={REPLY_TOKENS} placeholder={DEFAULT_REPLY} />
+  </label>
+  <ChatPreview response={replyMessage || DEFAULT_REPLY} showViewer={false} tag="on redemption" samplesOnly samples={replySamples} />
+
+  <label class="field">
+    <span>After it runs</span>
+    <select class="input" name="onRedeem" bind:value={onRedeem}>
+      <option value="fulfill">Mark fulfilled</option>
+      <option value="cancel">Refund the points</option>
+      <option value="leave">Leave for a mod</option>
+    </select>
+  </label>
+
+  <div class="setrow {allowOff ? 'on' : ''}">
+    <div class="setrow-text">
+      <span class="setrow-label">Let viewers turn the light off</span>
+      <span class="muted-text">A viewer can type <code>off</code> to turn this light off.</span>
+    </div>
+    <button type="button" class="toggle {allowOff ? 'on' : ''}" aria-label="Let viewers turn the light off" onclick={() => (allowOff = !allowOff)}></button>
+  </div>
+  <input type="hidden" name="allow_off" value={allowOff ? 'on' : ''} />
+
+  <div class="setrow {liveOnly ? '' : 'warn'}">
+    <div class="setrow-text">
+      <span class="setrow-label">Live only</span>
+      <span class="muted-text">
+        {liveOnly
+          ? 'Redemptions only work while your stream is live (recommended).'
+          : 'Off: viewers can change this light even when you are offline.'}
+      </span>
+    </div>
+    <button type="button" class="toggle {liveOnly ? 'on' : ''}" aria-label="Toggle live only" onclick={() => (liveOnly = !liveOnly)}></button>
+  </div>
+  <input type="hidden" name="allow_offline" value={liveOnly ? '' : 'on'} />
+
+  <div class="actions">
+    <button type="button" class="btn ghost" onclick={onCancel} disabled={busy}>Cancel</button>
+    <button type="submit" class="btn primary" disabled={busy || !title.trim()}>
+      <Icon name="check" size={14} />
+      {busy ? 'Saving…' : isNew ? 'Create reward' : 'Save changes'}
+    </button>
+  </div>
+
+  {#if binding}
+    <button type="button" class="btn ghost danger del" onclick={onRequestDelete} disabled={busy}>Delete reward</button>
+  {/if}
+</form>
+
+<style>
+  .editor { padding: 4px 2px 2px; display: grid; gap: 14px; }
+  .hint { margin: 0; font-family: var(--bb-font-body); font-size: 12.5px; line-height: 1.55; color: var(--bb-muted); }
+
+  .field { display: grid; gap: 5px; }
+  .field > span { font-family: var(--bb-font-body); font-size: 12px; font-weight: 600; color: var(--bb-muted); }
+  .field > span small { font-weight: 400; opacity: 0.7; }
+  .input {
+    padding: 8px 12px;
+    border-radius: 6px;
+    border: 1px solid var(--rule);
+    background: rgba(240, 236, 228, 0.04);
+    color: var(--bb-white);
+    font-family: var(--bb-font-body);
+    font-size: 13px;
+    width: 100%;
+    box-sizing: border-box;
+    transition: border-color var(--bb-dur-fast, 140ms) ease;
+  }
+  .input:focus { outline: none; border-color: var(--bb-tan, #c9a87c); }
+
+  .field-row { display: flex; gap: 12px; }
+  .field-row .field { flex: 1; min-width: 0; }
+  .color-field { flex: none; width: 92px; }
+  .color-in {
+    width: 100%;
+    height: 37px;
+    padding: 3px;
+    border: 1px solid var(--rule);
+    border-radius: 6px;
+    background: rgba(240, 236, 228, 0.04);
+    cursor: pointer;
+  }
+
+  .setrow {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 11px 12px;
+    border: 1px solid var(--rule);
+    border-radius: 8px;
+  }
+  .setrow.on { border-color: var(--rule-tan); background: rgba(201, 168, 124, 0.06); }
+  .setrow-text { display: grid; gap: 2px; flex: 1; min-width: 0; }
+  .setrow-label { font-family: var(--bb-font-display); font-weight: 700; font-size: 13px; color: var(--bb-white); }
+  .setrow.warn .setrow-label { color: #d9a441; }
+  .muted-text { margin: 0; font-family: var(--bb-font-body); font-size: 12px; line-height: 1.5; color: var(--bb-muted); }
+  .setrow .toggle { flex: none; }
+
+  .actions { display: flex; gap: 10px; justify-content: flex-end; }
+  .del { justify-self: start; color: #cf8a78; border-color: rgba(176, 90, 70, 0.4); }
+  .del:hover { background: rgba(176, 90, 70, 0.1); color: #dc9c8a; }
+
+  code { font-family: var(--bb-font-mono, monospace); font-size: 0.86em; color: var(--bb-tan-light); }
+
+  @media (max-width: 480px) {
+    .field-row { flex-direction: column; gap: 12px; }
+    .color-field { width: 100%; }
+    .actions { flex-direction: column-reverse; }
+    .actions .btn { width: 100%; justify-content: center; min-height: 44px; }
+  }
+</style>

--- a/console/dashboard/src/lib/server/govee-store.ts
+++ b/console/dashboard/src/lib/server/govee-store.ts
@@ -164,6 +164,30 @@ function callReward(userId: string, verb: string, req: Record<string, unknown>):
   return rpc<RewardReplyWire>(`${SUB.outgressRpc}.channelpoints.${verb}`, { broadcaster_id: userId, ...req }, 8000);
 }
 
+// bindingFromReply builds a light's binding from the saved-reward reply,
+// mirroring the colour + cooldown Twitch echoed back so the editor re-populates.
+function bindingFromReply(
+  device: GoveeDevice,
+  draft: RewardDraft,
+  reply: NonNullable<RewardReplyWire['reward']>,
+  existingId: string
+): GoveeBinding {
+  const rewardId = reply.id ?? existingId;
+  const color = reply.background_color ?? draft.color;
+  const cooldown = reply.global_cooldown_enabled ? reply.global_cooldown_seconds : 0;
+  return {
+    device: device.device,
+    sku: device.sku,
+    deviceName: device.name,
+    onRedeem: draft.onRedeem,
+    rewardId,
+    reward: { rewardId, title: reply.title, cost: reply.cost, color, cooldown },
+    allowOffline: draft.allowOffline,
+    allowOff: draft.allowOff,
+    replyMessage: draft.replyMessage
+  };
+}
+
 // GoveeStore is the per-broadcaster operation set returned by goveeStore.
 export interface GoveeStore {
   read(): Promise<GoveeView>;
@@ -250,8 +274,7 @@ export function goveeStore(userId: string): GoveeStore {
 
   async function saveReward(device: GoveeDevice, draft: RewardDraft): Promise<GoveeResult> {
     const cur = await read();
-    const existing = cur.bindings.find((b) => b.device === device.device);
-    const existingId = existing?.rewardId ?? '';
+    const existingId = cur.bindings.find((b) => b.device === device.device)?.rewardId ?? '';
     const verb = existingId ? 'update' : 'create';
     const req: Record<string, unknown> = { reward: rewardWire(draft, existingId) };
     if (existingId) req.reward_id = existingId;
@@ -260,25 +283,9 @@ export function goveeStore(userId: string): GoveeStore {
     if (reply.missing_scope) return { ok: false, missingScope: true };
     if (reply.error || !reply.reward) return { ok: false, error: reply.error ?? `${verb} failed` };
 
-    const rewardId = reply.reward.id ?? existingId;
-    // Mirror the settings Twitch echoed back (falling back to the draft) so the
-    // editor re-populates the colour + cooldown exactly as stored.
-    const color = reply.reward.background_color ?? draft.color;
-    const cooldown = reply.reward.global_cooldown_enabled ? reply.reward.global_cooldown_seconds : 0;
-    const binding: GoveeBinding = {
-      device: device.device,
-      sku: device.sku,
-      deviceName: device.name,
-      onRedeem: draft.onRedeem,
-      rewardId,
-      reward: { rewardId, title: reply.reward.title, cost: reply.reward.cost, color, cooldown },
-      allowOffline: draft.allowOffline,
-      allowOff: draft.allowOff,
-      replyMessage: draft.replyMessage
-    };
     // One reward per light: replace any existing binding for this device.
-    const bindings = [...cur.bindings.filter((b) => b.device !== device.device), binding];
-    await writeBindings(cur.enabled, bindings);
+    const binding = bindingFromReply(device, draft, reply.reward, existingId);
+    await writeBindings(cur.enabled, [...cur.bindings.filter((b) => b.device !== device.device), binding]);
     if (!existingId) await publishEventSubEnsureOptional(userId);
     return { ok: true };
   }

--- a/console/dashboard/src/lib/server/govee-store.ts
+++ b/console/dashboard/src/lib/server/govee-store.ts
@@ -19,8 +19,13 @@
 // as an argument. A redemption is driven by sesame; this store only sets up.
 import { rpc } from '@bagel/shared/server/nats';
 import { POLICY } from '@bagel/shared/server/cache-keys';
+import type { GoveeOnRedeem, GoveeDevice, GoveeReward, GoveeBinding } from '@bagel/shared';
 import { SUB, fabric, invalidate, publishEventSubEnsureOptional } from './services';
 import { listModules, upsertModule } from './commands-store';
+
+// Re-export the shared govee shapes so existing importers of this store keep
+// working; the definitions live in @bagel/shared for the client components too.
+export type { GoveeOnRedeem, GoveeDevice, GoveeReward, GoveeBinding };
 
 const GOVEE_MODULE = 'govee';
 
@@ -37,59 +42,18 @@ const devicesCacheKey = (userId: string) => `govee-devices:${userId}`;
 // colour formats.
 const REWARD_PROMPT = 'Type a colour: a name like blue, or a hex code like #00ccff';
 
-export type GoveeOnRedeem = 'fulfill' | 'cancel' | 'leave';
-
-// GoveeDevice mirrors gatewayrpc.GoveeDevice (snake/camel already aligned).
-export interface GoveeDevice {
-  device: string;
-  sku: string;
-  name: string;
-  color: boolean;
-}
-
-// GoveeReward is the dashboard mirror of the Twitch reward, kept in the blob so
-// the page renders without a Twitch round trip. color + cooldown are display
-// mirrors of Twitch reward settings so the editor re-populates them.
-export interface GoveeReward {
-  rewardId: string;
-  title: string;
-  cost: number;
-  // color is the Twitch reward tile background ("#rrggbb"); cooldown is the
-  // reward's global cooldown in seconds (0 = disabled).
-  color: string;
-  cooldown: number;
-}
-
-// GoveeBinding is the module blob shape. device/sku/onRedeem/rewardId/allowOffline/
-// allowOff/replyMessage are the fields sesame reads; reward is the dashboard-only
-// display mirror.
-export interface GoveeBinding {
-  device: string;
-  sku: string;
-  deviceName: string;
-  onRedeem: GoveeOnRedeem;
-  rewardId: string;
-  reward: GoveeReward | null;
-  // allowOffline opts out of the live-only gate (default false = live only).
-  // sesame reads this same flag; the dashboard only sets it true behind a warning.
-  allowOffline: boolean;
-  // allowOff opts into the "off" action: a viewer typing "off" turns the light
-  // off. Default false. sesame reads this flag.
-  allowOff: boolean;
-  // replyMessage is the chat reply template ({user}, {color}) sesame posts on a
-  // successful change. Blank uses sesame's built-in default.
-  replyMessage: string;
-}
-
 export interface GoveeView {
   enabled: boolean;
   keyPresent: boolean;
-  binding: GoveeBinding;
+  // bindings is the list of reward->light bindings, one per configured light.
+  // The dashboard enforces one reward per light.
+  bindings: GoveeBinding[];
 }
 
-// RewardDraft is the reward's editable shape, bundled so a save is one argument.
-// title/cost/color/cooldown are Twitch reward settings; onRedeem/replyMessage/
-// allowOff are the binding behaviour sesame reads.
+// RewardDraft is one light's reward + behaviour, bundled so a save is one
+// argument. title/cost/color/cooldown are Twitch reward settings; onRedeem/
+// replyMessage/allowOff/allowOffline are the binding behaviour sesame reads. The
+// light itself (device/sku/name) is passed alongside the draft.
 export interface RewardDraft {
   title: string;
   cost: number;
@@ -100,13 +64,11 @@ export interface RewardDraft {
   cooldown: number;
   replyMessage: string;
   allowOff: boolean;
+  // allowOffline lifts the live-only gate for this reward (default false).
+  allowOffline: boolean;
 }
 
 export type GoveeResult = { ok: true } | { ok: false; missingScope?: boolean; error?: string };
-
-function blankBinding(): GoveeBinding {
-  return { device: '', sku: '', deviceName: '', onRedeem: 'fulfill', rewardId: '', reward: null, allowOffline: false, allowOff: false, replyMessage: '' };
-}
 
 function coerceOnRedeem(v: unknown): GoveeOnRedeem {
   return v === 'cancel' || v === 'leave' ? v : 'fulfill';
@@ -135,6 +97,18 @@ function readBinding(configs: unknown): GoveeBinding {
     allowOff: c.allowOff === true,
     replyMessage: String(c.replyMessage ?? '')
   };
+}
+
+// readBindings coerces the stored blob into the list of reward->light bindings,
+// tolerating the legacy single-binding blob (top-level rewardId/device) as a
+// one-element list so pre-multi-light configs keep rendering.
+function readBindings(configs: unknown): GoveeBinding[] {
+  const c = (configs ?? {}) as { bindings?: unknown };
+  if (Array.isArray(c.bindings)) {
+    return c.bindings.map(readBinding).filter((b) => b.device);
+  }
+  const single = readBinding(configs);
+  return single.device ? [single] : [];
 }
 
 interface RewardWire {
@@ -196,11 +170,11 @@ export interface GoveeStore {
   setKey(key: string): Promise<GoveeResult>;
   clearKey(): Promise<GoveeResult>;
   listDevices(): Promise<{ devices: GoveeDevice[]; error?: string }>;
-  setDevice(device: GoveeDevice): Promise<GoveeResult>;
   setEnabled(enabled: boolean): Promise<GoveeResult>;
-  setAllowOffline(allowOffline: boolean): Promise<GoveeResult>;
-  saveReward(draft: RewardDraft): Promise<GoveeResult>;
-  deleteReward(): Promise<GoveeResult>;
+  // saveReward creates or updates the reward bound to one light.
+  saveReward(device: GoveeDevice, draft: RewardDraft): Promise<GoveeResult>;
+  // deleteReward removes the reward + binding for one light (by device id).
+  deleteReward(deviceId: string): Promise<GoveeResult>;
 }
 
 // goveeStore binds every per-broadcaster operation to one broadcaster id.
@@ -225,20 +199,14 @@ export function goveeStore(userId: string): GoveeStore {
     return {
       enabled: row ? row.is_enabled : false,
       keyPresent: present,
-      binding: row ? readBinding(row.configs) : blankBinding()
+      bindings: row ? readBindings(row.configs) : []
     };
   }
 
-  async function writeBinding(enabled: boolean, binding: GoveeBinding): Promise<void> {
-    await upsertModule(userId, GOVEE_MODULE, enabled, binding as unknown as Record<string, unknown>);
-  }
-
-  // patchBinding merges a partial change into the current binding, preserving the
-  // module enable flag.
-  async function patchBinding(patch: Partial<GoveeBinding>): Promise<GoveeResult> {
-    const cur = await read();
-    await writeBinding(cur.enabled, { ...cur.binding, ...patch });
-    return { ok: true };
+  // writeBindings persists the whole binding list under the module blob's
+  // "bindings" key, preserving the module enable flag.
+  async function writeBindings(enabled: boolean, bindings: GoveeBinding[]): Promise<void> {
+    await upsertModule(userId, GOVEE_MODULE, enabled, { bindings } as unknown as Record<string, unknown>);
   }
 
   async function setKey(key: string): Promise<GoveeResult> {
@@ -280,9 +248,10 @@ export function goveeStore(userId: string): GoveeStore {
     }
   }
 
-  async function saveReward(draft: RewardDraft): Promise<GoveeResult> {
+  async function saveReward(device: GoveeDevice, draft: RewardDraft): Promise<GoveeResult> {
     const cur = await read();
-    const existingId = cur.binding.rewardId;
+    const existing = cur.bindings.find((b) => b.device === device.device);
+    const existingId = existing?.rewardId ?? '';
     const verb = existingId ? 'update' : 'create';
     const req: Record<string, unknown> = { reward: rewardWire(draft, existingId) };
     if (existingId) req.reward_id = existingId;
@@ -296,25 +265,35 @@ export function goveeStore(userId: string): GoveeStore {
     // editor re-populates the colour + cooldown exactly as stored.
     const color = reply.reward.background_color ?? draft.color;
     const cooldown = reply.reward.global_cooldown_enabled ? reply.reward.global_cooldown_seconds : 0;
-    await writeBinding(cur.enabled, {
-      ...cur.binding,
+    const binding: GoveeBinding = {
+      device: device.device,
+      sku: device.sku,
+      deviceName: device.name,
       onRedeem: draft.onRedeem,
-      allowOff: draft.allowOff,
-      replyMessage: draft.replyMessage,
       rewardId,
-      reward: { rewardId, title: reply.reward.title, cost: reply.reward.cost, color, cooldown }
-    });
+      reward: { rewardId, title: reply.reward.title, cost: reply.reward.cost, color, cooldown },
+      allowOffline: draft.allowOffline,
+      allowOff: draft.allowOff,
+      replyMessage: draft.replyMessage
+    };
+    // One reward per light: replace any existing binding for this device.
+    const bindings = [...cur.bindings.filter((b) => b.device !== device.device), binding];
+    await writeBindings(cur.enabled, bindings);
     if (!existingId) await publishEventSubEnsureOptional(userId);
     return { ok: true };
   }
 
-  async function deleteReward(): Promise<GoveeResult> {
+  async function deleteReward(deviceId: string): Promise<GoveeResult> {
     const cur = await read();
-    if (!cur.binding.rewardId) return { ok: true };
-    const reply = await callReward(userId, 'delete', { reward_id: cur.binding.rewardId });
-    if (reply.missing_scope) return { ok: false, missingScope: true };
-    if (reply.error) return { ok: false, error: reply.error };
-    await writeBinding(cur.enabled, { ...cur.binding, rewardId: '', reward: null });
+    const target = cur.bindings.find((b) => b.device === deviceId);
+    if (!target) return { ok: true };
+    if (target.rewardId) {
+      const reply = await callReward(userId, 'delete', { reward_id: target.rewardId });
+      if (reply.missing_scope) return { ok: false, missingScope: true };
+      if (reply.error) return { ok: false, error: reply.error };
+    }
+    const bindings = cur.bindings.filter((b) => b.device !== deviceId);
+    await writeBindings(cur.enabled, bindings);
     return { ok: true };
   }
 
@@ -323,13 +302,11 @@ export function goveeStore(userId: string): GoveeStore {
     setKey,
     clearKey,
     listDevices,
-    setDevice: (device: GoveeDevice) => patchBinding({ device: device.device, sku: device.sku, deviceName: device.name }),
     setEnabled: async (enabled: boolean) => {
       const cur = await read();
-      await writeBinding(enabled, cur.binding);
+      await writeBindings(enabled, cur.bindings);
       return { ok: true };
     },
-    setAllowOffline: (allowOffline: boolean) => patchBinding({ allowOffline }),
     saveReward,
     deleteReward
   };

--- a/console/dashboard/src/routes/(app)/govee/+page.server.ts
+++ b/console/dashboard/src/routes/(app)/govee/+page.server.ts
@@ -30,17 +30,20 @@ function demoView(): GoveeView {
   return {
     enabled: true,
     keyPresent: true,
-    binding: {
-      device: 'AB:CD:EF:12:34:56',
-      sku: 'H6159',
-      deviceName: 'Desk strip',
-      onRedeem: 'fulfill',
-      rewardId: 'demo-reward',
-      reward: { rewardId: 'demo-reward', title: 'Colour my lights', cost: 500, color: '#9147ff', cooldown: 0 },
-      allowOffline: false,
-      allowOff: true,
-      replyMessage: '@{user} set the lights to {color}!'
-    }
+    // One light configured, one left open, so the deck shows both states.
+    bindings: [
+      {
+        device: 'AB:CD:EF:12:34:56',
+        sku: 'H6159',
+        deviceName: 'Desk strip',
+        onRedeem: 'fulfill',
+        rewardId: 'demo-reward',
+        reward: { rewardId: 'demo-reward', title: 'Colour the desk strip', cost: 500, color: '#9147ff', cooldown: 0 },
+        allowOffline: false,
+        allowOff: true,
+        replyMessage: '@{user} set the lights to {color}!'
+      }
+    ]
   };
 }
 
@@ -77,7 +80,7 @@ export const load: PageServerLoad = async ({ locals }) => {
     return {
       enabled: false,
       keyPresent: false,
-      binding: { device: '', sku: '', deviceName: '', onRedeem: 'fulfill' as GoveeOnRedeem, rewardId: '', reward: null, allowOffline: false, allowOff: false, replyMessage: '' },
+      bindings: [] as GoveeView['bindings'],
       devices: { devices: [] as GoveeDevice[], error: undefined },
       colors,
       degraded: true
@@ -101,10 +104,14 @@ function asOnRedeem(v: FormDataEntryValue | null): GoveeOnRedeem {
   return v === 'cancel' || v === 'leave' ? v : 'fulfill';
 }
 
-// parseRewardForm validates the reward editor's fields and returns the draft, or
-// a user-facing error message. Kept out of the action so the action stays a thin
-// parse-then-run.
-function parseRewardForm(f: FormData): { draft: RewardDraft } | { error: string } {
+// parseRewardForm validates the inspector's fields and returns the target light
+// plus the reward draft, or a user-facing error message. Kept out of the action
+// so the action stays a thin parse-then-run.
+function parseRewardForm(f: FormData): { device: GoveeDevice; draft: RewardDraft } | { error: string } {
+  const device = String(f.get('device') ?? '').trim();
+  const sku = String(f.get('sku') ?? '').trim();
+  if (!device || !sku) return { error: 'Pick a light first.' };
+
   const title = String(f.get('title') ?? '').trim();
   if (!title || title.length > 45) return { error: 'Title is required (max 45 characters).' };
 
@@ -124,7 +131,17 @@ function parseRewardForm(f: FormData): { draft: RewardDraft } | { error: string 
   const cooldown = Number.isFinite(rawCooldown) ? Math.min(Math.max(rawCooldown, 0), 604_800) : 0;
 
   return {
-    draft: { title, cost, onRedeem: asOnRedeem(f.get('onRedeem')), color, cooldown, replyMessage, allowOff: f.get('allow_off') === 'on' }
+    device: { device, sku, name: String(f.get('deviceName') ?? '').trim(), color: true },
+    draft: {
+      title,
+      cost,
+      onRedeem: asOnRedeem(f.get('onRedeem')),
+      color,
+      cooldown,
+      replyMessage,
+      allowOff: f.get('allow_off') === 'on',
+      allowOffline: f.get('allow_offline') === 'on'
+    }
   };
 }
 
@@ -163,36 +180,20 @@ export const actions: Actions = {
 
   clearKey: ({ locals }) => run(locals, { action: 'govee:key_clear', detail: '' }, (s) => s.clearKey()),
 
-  pickDevice: async ({ request, locals }) => {
-    const f = await request.formData();
-    const device: GoveeDevice = {
-      device: String(f.get('device') ?? '').trim(),
-      sku: String(f.get('sku') ?? '').trim(),
-      name: String(f.get('deviceName') ?? '').trim(),
-      color: true
-    };
-    if (!device.device || !device.sku) return fail(400, { ok: false, error: 'Pick a device.' });
-    return run(locals, { action: 'govee:device', detail: device.name || device.device }, (s) => s.setDevice(device));
-  },
-
   saveReward: async ({ request, locals }) => {
     const parsed = parseRewardForm(await request.formData());
     if ('error' in parsed) return fail(400, { ok: false, error: parsed.error });
-    return run(locals, { action: 'govee:reward', detail: parsed.draft.title }, (s) => s.saveReward(parsed.draft));
+    return run(locals, { action: 'govee:reward', detail: parsed.draft.title }, (s) => s.saveReward(parsed.device, parsed.draft));
   },
 
-  deleteReward: ({ locals }) => run(locals, { action: 'govee:reward_delete', detail: '' }, (s) => s.deleteReward()),
+  deleteReward: async ({ request, locals }) => {
+    const deviceId = String((await request.formData()).get('device') ?? '').trim();
+    if (!deviceId) return fail(400, { ok: false, error: 'Pick a light first.' });
+    return run(locals, { action: 'govee:reward_delete', detail: deviceId }, (s) => s.deleteReward(deviceId));
+  },
 
   toggle: async ({ request, locals }) => {
     const enabled = (await request.formData()).get('is_enabled') === 'on';
     return run(locals, { action: 'govee:toggle', detail: String(enabled) }, (s) => s.setEnabled(enabled));
-  },
-
-  // liveOnly flips the live-only gate. allow_offline='on' disables it (viewers can
-  // drive the lights while offline); the page guards that direction with a
-  // warning modal before posting here.
-  liveOnly: async ({ request, locals }) => {
-    const allowOffline = (await request.formData()).get('allow_offline') === 'on';
-    return run(locals, { action: 'govee:live_only', detail: allowOffline ? 'off' : 'on' }, (s) => s.setAllowOffline(allowOffline));
   }
 };

--- a/console/dashboard/src/routes/(app)/govee/+page.server.ts
+++ b/console/dashboard/src/routes/(app)/govee/+page.server.ts
@@ -104,14 +104,9 @@ function asOnRedeem(v: FormDataEntryValue | null): GoveeOnRedeem {
   return v === 'cancel' || v === 'leave' ? v : 'fulfill';
 }
 
-// parseRewardForm validates the inspector's fields and returns the target light
-// plus the reward draft, or a user-facing error message. Kept out of the action
-// so the action stays a thin parse-then-run.
-function parseRewardForm(f: FormData): { device: GoveeDevice; draft: RewardDraft } | { error: string } {
-  const device = String(f.get('device') ?? '').trim();
-  const sku = String(f.get('sku') ?? '').trim();
-  if (!device || !sku) return { error: 'Pick a light first.' };
-
+// parseRewardDraft validates the reward + behaviour fields into a draft, or a
+// user-facing error message.
+function parseRewardDraft(f: FormData): { draft: RewardDraft } | { error: string } {
   const title = String(f.get('title') ?? '').trim();
   if (!title || title.length > 45) return { error: 'Title is required (max 45 characters).' };
 
@@ -131,7 +126,6 @@ function parseRewardForm(f: FormData): { device: GoveeDevice; draft: RewardDraft
   const cooldown = Number.isFinite(rawCooldown) ? Math.min(Math.max(rawCooldown, 0), 604_800) : 0;
 
   return {
-    device: { device, sku, name: String(f.get('deviceName') ?? '').trim(), color: true },
     draft: {
       title,
       cost,
@@ -143,6 +137,18 @@ function parseRewardForm(f: FormData): { device: GoveeDevice; draft: RewardDraft
       allowOffline: f.get('allow_offline') === 'on'
     }
   };
+}
+
+// parseRewardForm resolves the target light and its reward draft, or an error.
+// Kept out of the action so the action stays a thin parse-then-run.
+function parseRewardForm(f: FormData): { device: GoveeDevice; draft: RewardDraft } | { error: string } {
+  const device = String(f.get('device') ?? '').trim();
+  const sku = String(f.get('sku') ?? '').trim();
+  if (!device || !sku) return { error: 'Pick a light first.' };
+
+  const parsed = parseRewardDraft(f);
+  if ('error' in parsed) return parsed;
+  return { device: { device, sku, name: String(f.get('deviceName') ?? '').trim(), color: true }, draft: parsed.draft };
 }
 
 // run is the shared action skeleton: gate, resolve the session, short-circuit in

--- a/console/dashboard/src/routes/(app)/govee/+page.svelte
+++ b/console/dashboard/src/routes/(app)/govee/+page.svelte
@@ -1,43 +1,21 @@
 <script lang="ts">
   import { enhance } from '$app/forms';
   import { invalidateAll } from '$app/navigation';
-  import { tick } from 'svelte';
   import type { SubmitFunction } from '@sveltejs/kit';
-  import { Icon, Card, PageHead, ConfirmDialog, toast } from '@bagel/shared';
-  import ResponseEditor from '$lib/components/commands/ResponseEditor.svelte';
-  import ChatPreview from '$lib/components/commands/ChatPreview.svelte';
+  import { Icon, Card, PageHead, Scroller, ConfirmDialog, toast, type GoveeDevice } from '@bagel/shared';
+  import GoveeLightRow from '$lib/components/govee/GoveeLightRow.svelte';
+  import GoveeRewardEditor from '$lib/components/govee/GoveeRewardEditor.svelte';
 
   let { data } = $props();
 
-  // Default chat reply when the template is blank (mirrors sesame's default).
-  const DEFAULT_REPLY = '@{user} set the lights to {color}!';
-  // Reply template palette + rehearsal samples: only {user} and {color} apply.
-  const REPLY_TOKENS = [
-    { token: '{user}', label: '{user} → the viewer' },
-    { token: '{color}', label: '{color} → what they typed' }
-  ];
-  const replySamples: Record<string, string> = { user: 'sesame_sam', color: 'blue' };
-
-  // Local mirrors, reseeded on each SSR load (the /events invalidation stream
-  // re-runs the loader after every confirmed write).
+  // Local mirrors, reseeded on each SSR load (the /events stream re-runs the
+  // loader after every confirmed write).
   // svelte-ignore state_referenced_locally
   let enabled = $state<boolean>(data.enabled ?? false);
   // svelte-ignore state_referenced_locally
   let keyPresent = $state<boolean>(data.keyPresent ?? false);
   // svelte-ignore state_referenced_locally
-  let selectedDevice = $state<string>(data.binding?.device ?? '');
-  // Live-only reflects the inverse of the stored allowOffline flag; on by default.
-  // svelte-ignore state_referenced_locally
-  let liveOnly = $state<boolean>(!(data.binding?.allowOffline));
-  // Reward editor draft mirrors (colour, cooldown, reply template, off action).
-  // svelte-ignore state_referenced_locally
-  let rewardColor = $state<string>(data.binding?.reward?.color || '#9147ff');
-  // svelte-ignore state_referenced_locally
-  let cooldown = $state<number>(data.binding?.reward?.cooldown ?? 0);
-  // svelte-ignore state_referenced_locally
-  let replyMessage = $state<string>(data.binding?.replyMessage ?? '');
-  // svelte-ignore state_referenced_locally
-  let allowOff = $state<boolean>(data.binding?.allowOff ?? false);
+  let bindings = $state([...(data.bindings ?? [])]);
   // svelte-ignore state_referenced_locally
   let seed = data;
   $effect(() => {
@@ -45,14 +23,11 @@
       seed = data;
       enabled = data.enabled ?? false;
       keyPresent = data.keyPresent ?? false;
-      selectedDevice = data.binding?.device ?? '';
-      liveOnly = !(data.binding?.allowOffline);
-      rewardColor = data.binding?.reward?.color || '#9147ff';
-      cooldown = data.binding?.reward?.cooldown ?? 0;
-      replyMessage = data.binding?.replyMessage ?? '';
-      allowOff = data.binding?.allowOff ?? false;
+      bindings = [...(data.bindings ?? [])];
     }
   });
+
+  const bindingFor = (deviceId: string) => bindings.find((b) => b.device === deviceId) ?? null;
 
   let missingScope = $state(false);
 
@@ -62,9 +37,8 @@
     return r.type === 'success' || r.type === 'failure' ? r.data : undefined;
   }
 
-  // formResult is the shared enhance handler: on success it optionally flips an
-  // optimistic mirror, toasts, and reloads; on a missing-scope rejection it shows
-  // the reconnect CTA; otherwise it toasts the error.
+  // formResult is the shared enhance handler for the API-key forms: on success it
+  // optionally flips an optimistic mirror, toasts, and reloads.
   function formResult(okMsg: string, failMsg: string, onOk?: () => void): SubmitFunction {
     return () =>
       async ({ result }) => {
@@ -94,48 +68,76 @@
     };
   };
 
-  // --- Live-only gate (default on; turning it OFF needs a warning) -----------
-  let confirmOff = $state(false);
-  let liveOnlyBusy = $state(false);
-  let pendingAllowOffline = $state(false);
-  let liveOnlyForm = $state<HTMLFormElement | null>(null);
+  // --- Inspector -------------------------------------------------------------
+  let selected = $state<GoveeDevice | null>(null);
+  let busy = $state(false);
 
-  // submitLiveOnly posts the desired allowOffline state. tick() flushes the
-  // bound hidden input before requestSubmit so the form carries the new value.
-  async function submitLiveOnly(allowOffline: boolean) {
-    pendingAllowOffline = allowOffline;
-    await tick();
-    liveOnlyForm?.requestSubmit();
+  function openLight(d: GoveeDevice) {
+    selected = selected?.device === d.device ? null : d;
+  }
+  function closeInspector() {
+    selected = null;
   }
 
-  // Turning live-only OFF (allowOffline true) opens the warning; turning it back
-  // ON is safe and saves immediately.
-  function onToggleLiveOnly() {
-    if (liveOnly) confirmOff = true;
-    else submitLiveOnly(false);
-  }
-
-  const liveOnlySubmit: SubmitFunction = () => {
-    liveOnlyBusy = true;
+  const saveSubmit: SubmitFunction = () => {
+    busy = true;
     return async ({ result }) => {
-      liveOnlyBusy = false;
+      busy = false;
       const payload = payloadOf(result);
       if (result.type === 'success' && payload?.ok !== false) {
-        liveOnly = !pendingAllowOffline;
-        toast('ok', liveOnly ? 'Live only is on.' : 'Live only is off. Offline redemptions allowed.');
+        toast('ok', 'Reward saved.');
+        closeInspector();
         await invalidateAll();
         return;
       }
-      toast('err', 'Could not change the live-only setting.');
+      if (payload?.missingScope) {
+        missingScope = true;
+        closeInspector();
+        return;
+      }
+      toast('err', payload?.error ?? 'Could not save the reward.');
     };
   };
 
-  const boundReward = $derived(data.binding?.reward ?? null);
+  // --- Delete (confirm; Twitch reward deletion is not undoable) ---------------
+  let deleteTarget = $state<GoveeDevice | null>(null);
+  let deleting = $state(false);
+  let deleteForm = $state<HTMLFormElement | null>(null);
+
+  const deleteSubmit: SubmitFunction = () => {
+    deleting = true;
+    return async ({ result }) => {
+      deleting = false;
+      const target = deleteTarget;
+      deleteTarget = null;
+      const payload = payloadOf(result);
+      if (result.type === 'success' && payload?.ok !== false) {
+        if (target && selected?.device === target.device) closeInspector();
+        toast('ok', 'Reward deleted.');
+        await invalidateAll();
+        return;
+      }
+      if (payload?.missingScope) {
+        missingScope = true;
+        return;
+      }
+      toast('err', payload?.error ?? 'Could not delete the reward.');
+    };
+  };
+
+  function onKey(e: KeyboardEvent) {
+    if (e.key !== 'Escape' || !selected) return;
+    const el = e.target as HTMLElement | null;
+    if (el && (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.isContentEditable)) return;
+    closeInspector();
+  }
+
+  const colorDevices = (devices: GoveeDevice[]) => devices.filter((d) => d.color);
 </script>
 
 <section class="screen active">
   <a class="back" href="/modules"><Icon name="x" size={13} /> All modules</a>
-  <PageHead eyebrow="Channel points" description="Let viewers recolour your Govee lights by redeeming channel points. Live only: off-stream redemptions are refunded.">
+  <PageHead eyebrow="Channel points" description="Bind a channel-points reward to each Govee light. Viewers redeem, type a colour (or “off”), and the bot drives that light. One reward per light.">
     Govee <em>Lights</em>
   </PageHead>
 
@@ -150,7 +152,7 @@
     </div>
   {/if}
 
-  <!-- Master switch: same toggle-row surface as the module detail page. -->
+  <!-- Master switch -->
   <Card style="padding:0" class="master-card">
     <div class="toggle-row">
       <div class="tr-text">
@@ -164,188 +166,118 @@
     </div>
   </Card>
 
-  <div class="steps" class:muted={!enabled}>
-    <!-- Step 1: API key -->
-    <Card>
-      <div class="step">
-        <span class="step-index">1</span>
-        <div class="step-body">
-          <h2>Govee API key</h2>
-          <p class="muted-text">
-            Get a key from the Govee mobile app: <strong>Profile → Settings → Apply for API Key</strong>. It is stored
-            encrypted. We never show it back.
-          </p>
-          {#if keyPresent}
-            <div class="row">
-              <span class="ok-pill"><Icon name="check" size={13} /> Key on file</span>
-              <form method="POST" action="?/clearKey" use:enhance={formResult('Key removed.', 'Could not remove the key.', () => (keyPresent = false))}>
-                <button class="btn danger" type="submit">Remove key</button>
-              </form>
-            </div>
-          {:else}
-            <form method="POST" action="?/saveKey" use:enhance={formResult('Key saved.', 'Could not save the key.', () => (keyPresent = true))} class="row">
-              <input class="input" type="password" name="key" placeholder="Paste your Govee API key" autocomplete="off" required />
-              <button class="btn primary" type="submit">Save key</button>
+  <!-- API key -->
+  <Card>
+    <div class="step">
+      <span class="step-index">1</span>
+      <div class="step-body">
+        <h2>Govee API key</h2>
+        <p class="muted-text">
+          Get a key from the Govee mobile app: <strong>Profile → Settings → Apply for API Key</strong>. It is stored
+          encrypted. We never show it back.
+        </p>
+        {#if keyPresent}
+          <div class="row">
+            <span class="ok-pill"><Icon name="check" size={13} /> Key on file</span>
+            <form method="POST" action="?/clearKey" use:enhance={formResult('Key removed.', 'Could not remove the key.', () => (keyPresent = false))}>
+              <button class="btn danger" type="submit">Remove key</button>
             </form>
-          {/if}
-        </div>
+          </div>
+        {:else}
+          <form method="POST" action="?/saveKey" use:enhance={formResult('Key saved.', 'Could not save the key.', () => (keyPresent = true))} class="row">
+            <input class="input" type="password" name="key" placeholder="Paste your Govee API key" autocomplete="off" required />
+            <button class="btn primary" type="submit">Save key</button>
+          </form>
+        {/if}
       </div>
-    </Card>
+    </div>
+  </Card>
 
-    <!-- Step 2: device -->
-    <Card>
-      <div class="step {keyPresent ? '' : 'disabled'}">
-        <span class="step-index">2</span>
-        <div class="step-body">
-          <h2>Pick the light</h2>
-          {#if !keyPresent}
-            <p class="muted-text">Add your API key first to load your devices.</p>
+  {#if keyPresent}
+    <!-- The deck: lights left, docked reward inspector right (same layout as the
+         channel-points + commands decks). -->
+    <div class="deck {selected ? 'inspecting' : ''}" class:muted={!enabled}>
+      <Card style="padding:6px 0 0" class="deck-list">
+        {#await data.devices}
+          <p class="loading"><span class="spinner" aria-hidden="true"></span> Loading your Govee lights…</p>
+        {:then dr}
+          {@const lights = colorDevices(dr.devices ?? [])}
+          {#if dr.error}
+            <p class="err-text"><Icon name="ban" size={13} /> {dr.error}</p>
+          {:else if lights.length === 0}
+            <p class="empty">No colour-capable Govee lights found on this account.</p>
           {:else}
-            {#await data.devices}
-              <p class="loading"><span class="spinner" aria-hidden="true"></span> Loading your Govee devices…</p>
-            {:then dr}
-              {@const colorDevices = (dr.devices ?? []).filter((d) => d.color)}
-              {@const selectedMeta = colorDevices.find((d) => d.device === selectedDevice)}
-              {#if dr.error}
-                <p class="err-text"><Icon name="ban" size={13} /> {dr.error}</p>
-              {:else if colorDevices.length === 0}
-                <p class="muted-text">No colour-capable Govee devices found on this account.</p>
-              {:else}
-                <form method="POST" action="?/pickDevice" use:enhance={formResult('Device saved.', 'Could not save the device.')}>
-                  <ul class="devices">
-                    {#each colorDevices as d (d.device)}
-                      <li>
-                        <label class="device {selectedDevice === d.device ? 'sel' : ''}">
-                          <input type="radio" name="device" value={d.device} checked={selectedDevice === d.device} onchange={() => (selectedDevice = d.device)} />
-                          <span class="device-name">{d.name || d.device}</span>
-                          <span class="device-sku">{d.sku}</span>
-                        </label>
-                      </li>
-                    {/each}
-                  </ul>
-                  <!-- The sku + name that pair with the chosen device id, resolved
-                       from the selection so the server stores a consistent triple. -->
-                  <input type="hidden" name="sku" value={selectedMeta?.sku ?? ''} />
-                  <input type="hidden" name="deviceName" value={selectedMeta?.name ?? ''} />
-                  <button class="btn primary" type="submit" disabled={!selectedDevice}>Save device</button>
-                </form>
-              {/if}
-            {/await}
-          {/if}
-        </div>
-      </div>
-    </Card>
-
-    <!-- Step 3: reward -->
-    <Card>
-      <div class="step {data.binding?.device ? '' : 'disabled'}">
-        <span class="step-index">3</span>
-        <div class="step-body">
-          <h2>The reward</h2>
-          {#if !data.binding?.device}
-            <p class="muted-text">Pick a light first.</p>
-          {:else}
-            <p class="muted-text">
-              Viewers type a colour when they redeem: a name (<code>{data.colors.join(', ')}</code>) or a hex code like
-              <code>#00ccff</code>.
-            </p>
-            <form method="POST" action="?/saveReward" use:enhance={formResult('Reward saved.', 'Could not save the reward.')} class="reward-form">
-              <label class="field">
-                <span>Title</span>
-                <input class="input" type="text" name="title" maxlength="45" value={boundReward?.title ?? 'Colour my lights'} required />
-              </label>
-              <div class="field-row">
-                <label class="field">
-                  <span>Cost (points)</span>
-                  <input class="input" type="number" name="cost" min="1" max="10000000" value={boundReward?.cost ?? 500} required />
-                </label>
-                <label class="field color-field">
-                  <span>Tile colour</span>
-                  <input class="color-in" type="color" name="color" bind:value={rewardColor} aria-label="Reward tile colour" />
-                </label>
-              </div>
-              <label class="field">
-                <span>Cooldown <small>seconds between redemptions, 0 = none</small></span>
-                <input class="input" type="number" name="cooldown" min="0" max="604800" bind:value={cooldown} />
-              </label>
-
-              <label class="field">
-                <span>Chat reply <small>optional, {'{user}'} and {'{color}'}</small></span>
-                <ResponseEditor bind:value={replyMessage} name="replyMessage" tokens={REPLY_TOKENS} placeholder={DEFAULT_REPLY} />
-              </label>
-              <ChatPreview response={replyMessage || DEFAULT_REPLY} showViewer={false} tag="on redemption" samplesOnly samples={replySamples} />
-
-              <label class="field">
-                <span>After it runs</span>
-                <select class="input" name="onRedeem" value={data.binding?.onRedeem ?? 'fulfill'}>
-                  <option value="fulfill">Mark fulfilled</option>
-                  <option value="cancel">Refund the points</option>
-                  <option value="leave">Leave for a mod</option>
-                </select>
-              </label>
-
-              <!-- Opt-in off action. It is a toggle, not a force: with it on, a
-                   viewer typing "off" turns the light off; with it off, "off" is
-                   just an unrecognized colour and refunds. -->
-              <div class="offrow {allowOff ? 'on' : ''}">
-                <div class="offrow-text">
-                  <span class="offrow-label">Let viewers turn the lights off</span>
-                  <span class="muted-text">A viewer can type <code>off</code> to turn the light off instead of setting a colour.</span>
-                </div>
-                <button type="button" class="toggle {allowOff ? 'on' : ''}" aria-label="Let viewers turn the lights off" onclick={() => (allowOff = !allowOff)}></button>
-              </div>
-              <input type="hidden" name="allow_off" value={allowOff ? 'on' : ''} />
-
-              <div class="reward-actions">
-                <button class="btn primary" type="submit">{boundReward ? 'Update reward' : 'Create reward'}</button>
-                {#if boundReward}
-                  <span class="reward-live"><Icon name="check" size={13} /> Live: {boundReward.title} · {boundReward.cost} pts</span>
-                {/if}
-              </div>
-            </form>
-            {#if boundReward}
-              <form method="POST" action="?/deleteReward" use:enhance={formResult('Reward deleted.', 'Could not delete the reward.')}>
-                <button class="btn ghost danger" type="submit">Delete reward</button>
-              </form>
-            {/if}
-
-            <div class="liveonly {liveOnly ? '' : 'warn'}">
-              <div class="liveonly-text">
-                <span class="liveonly-label">Live only</span>
-                <span class="muted-text">
-                  {liveOnly
-                    ? 'Redemptions only work while your stream is live (recommended).'
-                    : 'Off: viewers can change your lights even when you are offline.'}
-                </span>
-              </div>
-              <button type="button" class="toggle {liveOnly ? 'on' : ''}" aria-label="Toggle live only" onclick={onToggleLiveOnly}></button>
+            <div class="list">
+              {#each lights as d (d.device)}
+                <GoveeLightRow
+                  device={d}
+                  binding={bindingFor(d.device)}
+                  expanded={selected?.device === d.device}
+                  onExpand={() => openLight(d)}
+                  onDelete={() => (deleteTarget = d)}
+                />
+              {/each}
             </div>
           {/if}
+        {/await}
+      </Card>
+
+      <!-- svelte-ignore a11y_no_static_element_interactions -->
+      <div
+        class="inspector-backdrop"
+        class:open={!!selected}
+        role="presentation"
+        onclick={closeInspector}
+        onkeydown={(e) => { if (e.key === 'Enter') closeInspector(); }}
+      ></div>
+      <aside class="inspector" class:open={!!selected} aria-label="Reward editor">
+        <div class="inspector-head">
+          <span class="inspector-tag">{selected ? (selected.name || 'Light') : 'Reward editor'}</span>
+          {#if selected}
+            <button class="mini" type="button" aria-label="Close" onclick={closeInspector}><Icon name="x" size={14} /></button>
+          {/if}
         </div>
-      </div>
-    </Card>
-  </div>
+        {#if selected}
+          <Scroller fill padding="16px" data-lenis-prevent>
+            {#key selected.device}
+              <GoveeRewardEditor
+                device={selected}
+                binding={bindingFor(selected.device)}
+                colors={data.colors}
+                {busy}
+                onSubmit={saveSubmit}
+                onCancel={closeInspector}
+                onRequestDelete={() => (deleteTarget = selected)}
+              />
+            {/key}
+          </Scroller>
+        {:else}
+          <div class="inspector-idle">
+            <span class="idle-glyph"><Icon name="power" size={18} /></span>
+            <p>Pick a light to bind a channel-points reward to it.</p>
+          </div>
+        {/if}
+      </aside>
+    </div>
+  {/if}
 </section>
 
-<!-- Hidden form the toggle submits; the value is set before requestSubmit. -->
-<form method="POST" action="?/liveOnly" use:enhance={liveOnlySubmit} bind:this={liveOnlyForm} hidden>
-  <input type="hidden" name="allow_offline" value={pendingAllowOffline ? 'on' : ''} />
-</form>
+<svelte:window onkeydown={onKey} />
 
 <ConfirmDialog
-  open={confirmOff}
-  title="Turn off Live only?"
-  body="With Live only off, anyone who redeems this reward can change your Govee lights even while you are offline or away from your setup. Only turn this off to test. You can turn it back on any time."
-  confirmLabel="Turn it off"
-  cancelLabel="Keep it on"
+  open={deleteTarget !== null}
+  title="Delete this reward?"
+  body="This removes the Twitch reward for {deleteTarget?.name || 'this light'} and unbinds the light. Deleting a Twitch reward cannot be undone."
+  confirmLabel="Delete"
+  cancelLabel="Keep it"
   danger
-  busy={liveOnlyBusy}
-  onCancel={() => (confirmOff = false)}
-  onConfirm={() => {
-    confirmOff = false;
-    submitLiveOnly(true);
-  }}
+  busy={deleting}
+  onCancel={() => (deleteTarget = null)}
+  onConfirm={() => deleteForm?.requestSubmit()}
 />
+<form method="POST" action="?/deleteReward" use:enhance={deleteSubmit} bind:this={deleteForm} hidden>
+  <input type="hidden" name="device" value={deleteTarget?.device ?? ''} />
+</form>
 
 <style>
   .back {
@@ -360,7 +292,6 @@
   }
   .back:hover { color: var(--bb-white); }
 
-  /* Inline notes: degraded backend + reconnect CTA. */
   .note {
     display: flex;
     align-items: center;
@@ -371,21 +302,10 @@
     font-family: var(--bb-font-body);
     font-size: 13px;
   }
-  .note.err {
-    border: 1px solid rgba(176, 90, 70, 0.4);
-    background: rgba(176, 90, 70, 0.08);
-    color: #cf8a78;
-  }
-  .note.reconnect {
-    justify-content: space-between;
-    flex-wrap: wrap;
-    border: 1px solid var(--rule-strong);
-    background: var(--glass-fill);
-    color: var(--bb-white);
-  }
+  .note.err { border: 1px solid rgba(176, 90, 70, 0.4); background: rgba(176, 90, 70, 0.08); color: #cf8a78; }
+  .note.reconnect { justify-content: space-between; flex-wrap: wrap; border: 1px solid var(--rule-strong); background: var(--glass-fill); color: var(--bb-white); }
   .note-text { display: inline-flex; align-items: center; gap: 8px; }
 
-  /* Master switch surface (mirrors the module detail settings card). */
   :global(.master-card) { margin-bottom: 16px; }
   .toggle-row { display: flex; align-items: center; gap: 12px; padding: 16px 18px; }
   .tr-text { display: flex; flex-direction: column; gap: 3px; margin-right: auto; }
@@ -393,16 +313,7 @@
   .tr-help { font-family: var(--bb-font-body); font-size: 12px; color: var(--bb-muted); }
   .master { display: inline-flex; }
 
-  /* Stepped setup: one card per step, dimmed as a group when the module is off. */
-  .steps {
-    display: grid;
-    gap: 14px;
-    transition: opacity var(--bb-dur-fast, 140ms) ease;
-  }
-  .steps.muted { opacity: 0.72; }
-
   .step { display: flex; gap: 14px; align-items: flex-start; }
-  .step.disabled { opacity: 0.55; }
   .step-index {
     flex: none;
     width: 34px;
@@ -418,25 +329,11 @@
     font-size: 14px;
   }
   .step-body { flex: 1; min-width: 0; }
-  .step-body h2 {
-    margin: 0 0 6px;
-    font-family: var(--bb-font-display);
-    font-weight: 700;
-    font-size: 15px;
-    color: var(--bb-white);
-  }
-  .muted-text {
-    color: var(--bb-muted);
-    font-family: var(--bb-font-body);
-    font-size: 13px;
-    line-height: 1.55;
-    margin: 0 0 14px;
-  }
+  .step-body h2 { margin: 0 0 6px; font-family: var(--bb-font-display); font-weight: 700; font-size: 15px; color: var(--bb-white); }
+  .muted-text { color: var(--bb-muted); font-family: var(--bb-font-body); font-size: 13px; line-height: 1.55; margin: 0 0 14px; }
   .muted-text strong { color: var(--bb-tan-light); font-weight: 600; }
 
   .row { display: flex; gap: 10px; align-items: center; flex-wrap: wrap; }
-
-  /* Inputs match the module detail .setting-input token style. */
   .input {
     padding: 8px 12px;
     border-radius: 6px;
@@ -446,143 +343,66 @@
     font-family: var(--bb-font-body);
     font-size: 13px;
     min-width: 13rem;
-    transition: border-color var(--bb-dur-fast, 140ms) ease;
   }
   .input:focus { outline: none; border-color: var(--bb-tan, #c9a87c); }
   .input::placeholder { color: var(--bb-muted); opacity: 0.7; }
 
-  /* danger buttons layer over the global .btn base. */
   .btn.danger { color: #cf8a78; }
-  .btn.ghost.danger { margin-top: 10px; border-color: rgba(176, 90, 70, 0.4); }
-  .btn.ghost.danger:hover { background: rgba(176, 90, 70, 0.1); color: #dc9c8a; }
+  .ok-pill { display: inline-flex; align-items: center; gap: 6px; color: var(--bb-green-glow); font-family: var(--bb-font-body); font-size: 13px; font-weight: 600; }
 
-  .ok-pill {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    color: var(--bb-green-glow);
-    font-family: var(--bb-font-body);
-    font-size: 13px;
-    font-weight: 600;
+  /* Deck (list + docked inspector), mirroring the channel-points page. */
+  .deck { display: grid; grid-template-columns: minmax(0, 1fr); gap: 16px; align-items: start; margin-top: 16px; transition: opacity var(--bb-dur-fast, 140ms) ease; }
+  .deck.muted { opacity: 0.72; }
+  @media (min-width: 1080px) {
+    .deck.inspecting { grid-template-columns: minmax(0, 1fr) 440px; }
+    .deck { grid-template-columns: minmax(0, 1fr) 320px; }
   }
-  .err-text {
-    color: #cf8a78;
-    font-family: var(--bb-font-body);
-    font-size: 13px;
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    margin: 0;
-  }
-  .loading {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    color: var(--bb-muted);
-    font-family: var(--bb-font-body);
-    font-size: 13px;
-    margin: 0;
-  }
+  .list :global(.row-shell:last-child) { border-bottom: none; }
+
+  .loading, .err-text, .empty { display: flex; align-items: center; gap: 10px; padding: 16px 16px; margin: 0; font-family: var(--bb-font-body); font-size: 13px; }
+  .loading { color: var(--bb-muted); }
+  .err-text { color: #cf8a78; gap: 6px; }
+  .empty { color: var(--bb-muted); }
   .spinner {
-    width: 14px;
-    height: 14px;
-    border-radius: 50%;
-    border: 2px solid var(--rule-strong);
-    border-top-color: var(--bb-tan-light);
+    width: 14px; height: 14px; border-radius: 50%;
+    border: 2px solid var(--rule-strong); border-top-color: var(--bb-tan-light);
     animation: spin 0.7s linear infinite;
   }
   @keyframes spin { to { transform: rotate(360deg); } }
 
-  .devices { list-style: none; margin: 0 0 14px; padding: 0; display: grid; gap: 6px; }
-  .device {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    padding: 9px 12px;
+  .inspector {
+    position: sticky;
+    top: 62px;
     border: 1px solid var(--rule);
-    border-radius: 6px;
-    cursor: pointer;
-    transition: border-color var(--bb-dur-fast, 140ms) ease, background var(--bb-dur-fast, 140ms) ease;
-  }
-  .device:hover { border-color: var(--rule-strong); }
-  .device.sel {
-    border-color: var(--rule-tan);
-    background: rgba(201, 168, 124, 0.08);
-  }
-  .device input { accent-color: var(--bb-tan); }
-  .device-name { font-family: var(--bb-font-body); font-weight: 600; font-size: 13px; color: var(--bb-white); }
-  .device-sku { color: var(--bb-muted); font-family: var(--bb-font-mono, monospace); font-size: 11.5px; margin-left: auto; }
-
-  .reward-form { display: grid; gap: 12px; max-width: 30rem; }
-  .field { display: grid; gap: 5px; }
-  .field > span {
-    font-family: var(--bb-font-body);
-    font-size: 12px;
-    font-weight: 600;
-    color: var(--bb-muted);
-  }
-  .field > span small { font-weight: 400; opacity: 0.7; }
-
-  /* Cost + colour side by side, like the channel-points reward editor. */
-  .field-row { display: flex; gap: 12px; }
-  .field-row .field { flex: 1; min-width: 0; }
-  .color-field { flex: none; width: 96px; }
-  .color-in {
-    width: 100%;
-    height: 38px;
-    padding: 3px;
-    border: 1px solid var(--rule);
-    border-radius: 6px;
-    background: rgba(240, 236, 228, 0.04);
-    cursor: pointer;
-  }
-
-  /* Opt-in off-action row (styled like the live-only row). */
-  .offrow {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    padding: 12px;
-    border: 1px solid var(--rule);
+    border-top-color: var(--rule-strong);
     border-radius: 8px;
-  }
-  .offrow.on { border-color: var(--rule-tan); background: rgba(201, 168, 124, 0.06); }
-  .offrow-text { display: grid; gap: 3px; flex: 1; min-width: 0; }
-  .offrow-label { font-family: var(--bb-font-display); font-weight: 700; font-size: 13px; color: var(--bb-white); }
-  .offrow-text .muted-text { margin: 0; }
-  .offrow .toggle { flex: none; }
-
-  @media (max-width: 480px) {
-    .field-row { flex-direction: column; gap: 12px; }
-    .color-field { width: 100%; }
-  }
-
-  .reward-actions { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
-  .reward-live {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    color: var(--bb-green-glow);
-    font-family: var(--bb-font-body);
-    font-size: 12.5px;
-  }
-
-  .liveonly {
+    background: linear-gradient(180deg, rgba(240, 236, 228, 0.03), rgba(240, 236, 228, 0.012));
     display: flex;
-    align-items: center;
-    gap: 12px;
-    margin-top: 16px;
-    padding-top: 14px;
-    border-top: 1px solid var(--rule);
+    flex-direction: column;
+    max-height: calc(100vh - 62px - 108px);
   }
-  .liveonly-text { display: grid; gap: 3px; flex: 1; min-width: 0; }
-  .liveonly-label { font-family: var(--bb-font-display); font-weight: 700; font-size: 13px; color: var(--bb-white); }
-  .liveonly-text .muted-text { margin: 0; }
-  .liveonly.warn .liveonly-label { color: #d9a441; }
+  .inspector-head { display: flex; align-items: center; justify-content: space-between; gap: 10px; padding: 12px 16px; border-bottom: 1px solid var(--rule); }
+  .inspector-tag { font-family: var(--bb-font-display); font-weight: 700; font-size: 12px; letter-spacing: 0.02em; color: var(--bb-tan); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 
-  code {
-    font-family: var(--bb-font-mono, monospace);
-    font-size: 0.86em;
-    color: var(--bb-tan-light);
+  .inspector-idle { padding: 34px 20px; text-align: center; color: var(--bb-muted); font-family: var(--bb-font-body); font-size: 13px; display: flex; flex-direction: column; align-items: center; gap: 12px; }
+  .idle-glyph { display: inline-flex; align-items: center; justify-content: center; width: 40px; height: 40px; border: 1px solid var(--rule-tan); border-radius: 8px; color: var(--bb-tan-light); }
+  .inspector-idle p { margin: 0; max-width: 26ch; line-height: 1.5; }
+
+  .inspector-backdrop { display: none; }
+  @media (max-width: 1079px) {
+    .inspector { display: none; }
+    .inspector.open {
+      display: flex;
+      position: fixed;
+      left: 0; right: 0; bottom: 0;
+      top: auto;
+      z-index: 220;
+      max-height: 88vh;
+      border-radius: 8px 8px 0 0;
+      background: var(--bb-bg-1, #111);
+      animation: sheet-in var(--bb-dur-base, 320ms) var(--bb-ease-out-expo, cubic-bezier(.16,1,.3,1)) both;
+    }
+    .inspector-backdrop.open { display: block; position: fixed; inset: 0; z-index: 219; background: rgba(0, 0, 0, 0.55); }
+    @keyframes sheet-in { from { transform: translateY(100%); } to { transform: translateY(0); } }
   }
 </style>

--- a/console/shared/lib/types.ts
+++ b/console/shared/lib/types.ts
@@ -851,6 +851,43 @@ export const GOVEE_COLOR_NAMES: readonly string[] = [
   'gold'
 ];
 
+// Govee module shapes, shared by the server store and the dashboard components.
+// The module binds channel-points rewards to smart lights: a viewer redeems a
+// reward, types a colour (or "off"), and the bot drives that reward's light.
+// One reward per light. The Twitch reward is owned by outgress; the bindings
+// live in the "govee" module blob and are read by sesame's govee module.
+export type GoveeOnRedeem = 'fulfill' | 'cancel' | 'leave';
+
+// GoveeDevice is one controllable light on the broadcaster's Govee account.
+export interface GoveeDevice {
+  device: string;
+  sku: string;
+  name: string;
+  color: boolean;
+}
+
+// GoveeReward mirrors the Twitch reward settings the dashboard shows for a light.
+export interface GoveeReward {
+  rewardId: string;
+  title: string;
+  cost: number;
+  color: string;
+  cooldown: number;
+}
+
+// GoveeBinding ties one reward to one light plus the behaviour sesame reads.
+export interface GoveeBinding {
+  device: string;
+  sku: string;
+  deviceName: string;
+  onRedeem: GoveeOnRedeem;
+  rewardId: string;
+  reward: GoveeReward | null;
+  allowOffline: boolean;
+  allowOff: boolean;
+  replyMessage: string;
+}
+
 export function moduleDef(id: string): ModuleDef | undefined {
   return MODULE_CATALOG.find((m) => m.id === id);
 }


### PR DESCRIPTION
Extends the Govee module from a single reward→light binding to many, one per light, managed in the channel-points-style 2-column deck (lights list + docked reward inspector). One reward per light is enforced (bindings keyed by device).

## Model
- **sesame** ([govee.go](app/sesame/modules/govee.go)): reads a list of bindings and drives the one whose reward was redeemed. The legacy single-binding blob reads as a one-element list, so existing prod configs keep working with no migration. New tests: multi-binding routing + unmatched-reward no-op; legacy tests unchanged.
- **store**: blob becomes `{ bindings: [...] }`; `saveReward(device, draft)` replaces any existing binding for the device (1-per-light); `deleteReward(deviceId)` removes one light's reward+binding.
- Govee shapes moved to `@bagel/shared` so the server store and client components share one definition.

## UI
- `GoveeLightRow`: deck line per colour-capable light (bound reward or "not set up"); non-colour devices filtered out.
- `GoveeRewardEditor`: inspector — title, cost, tile colour, cooldown, chat reply with live rehearsal, queue policy, off action, live-only. Save/Delete. Mobile bottom sheet.

## Verify
Go build + test + `vet` clean (incl. new multi-binding tests); `svelte-check` 0 errors; browser (DEMO) confirmed deck, create/edit modes, rehearsal, no console errors.

## Blast radius
On merge Flux rebuilds sesame + console-dashboard. Behaviour for existing single-reward users is unchanged (legacy blob still read).