### PR TITLE
feat(triggers): rule editor on the alerts reply surface

### DIFF
--- a/console/dashboard/src/lib/components/commands/ChatPreview.svelte
+++ b/console/dashboard/src/lib/components/commands/ChatPreview.svelte
@@ -25,6 +25,7 @@
     response = '',
     args = '',
     showViewer = true,
+    viewerText = undefined as string | undefined,
     tag = undefined as string | undefined,
     samples = undefined as Record<string, string> | undefined,
     samplesOnly = false
@@ -33,6 +34,10 @@
     response?: string;
     args?: string;
     showViewer?: boolean;
+    // viewerText renders the viewer line verbatim (a plain chat message, no "!"
+    // trigger) — used by trigger-word rehearsals where a normal message fires the
+    // reply. When unset the viewer types the "!command" trigger.
+    viewerText?: string;
     tag?: string;
     samples?: Record<string, string>;
     // samplesOnly drops the default command samples entirely: gateway module
@@ -186,7 +191,7 @@
   {#if showViewer}
     <div class="line viewer">
       <span class="who viewer-name">{viewerName}</span>
-      <span class="msg">{trigger}</span>
+      <span class="msg" class:plain={viewerText !== undefined}>{viewerText ?? trigger}</span>
     </div>
   {/if}
   {#if typing}
@@ -329,6 +334,8 @@
     min-width: 0;
   }
   .line.viewer .msg { font-family: var(--bb-font-mono); color: var(--bb-tan-light); font-size: 12.5px; }
+  /* A plain viewer message (trigger-word rehearsal) reads like normal chat. */
+  .line.viewer .msg.plain { font-family: var(--bb-font-body); color: var(--bb-white); font-size: 13px; }
 
   .reply { animation: reply-in 240ms var(--bb-ease-out-back, ease-out) both; animation-delay: var(--reply-delay, 0ms); }
   @keyframes reply-in {

--- a/console/dashboard/src/lib/components/modules/TriggerRuleEditor.svelte
+++ b/console/dashboard/src/lib/components/modules/TriggerRuleEditor.svelte
@@ -1,0 +1,166 @@
+<script lang="ts">
+  // Builder inspector for one trigger-word rule — the module twin of ReplyEditor,
+  // extended with the two fields a trigger owns: the phrase to watch for and how
+  // it matches. The response reuses the exact command builder surface
+  // (ResponseEditor + its variable palette) and the ChatPreview rehearsal, so a
+  // trigger reply is authored just like a command reply, tokens and all. Here the
+  // rehearsal's viewer types a plain message containing the phrase (no "!"), which
+  // is what actually fires the reply.
+  //
+  // Save/Cancel/Delete are handled by the page so the whole rule list persists in
+  // one place.
+  import { Icon, getI18n } from '@bagel/shared';
+  import ResponseEditor from '$lib/components/commands/ResponseEditor.svelte';
+  import ChatPreview from '$lib/components/commands/ChatPreview.svelte';
+
+  export type Match = 'word' | 'contains' | 'exact' | 'prefix';
+
+  let {
+    phrase = $bindable(''),
+    match = $bindable('word' as Match),
+    message = $bindable(''),
+    busy = false,
+    onSave,
+    onCancel,
+    onDelete
+  }: {
+    phrase: string;
+    match: Match;
+    message: string;
+    busy?: boolean;
+    onSave: () => void;
+    onCancel: () => void;
+    onDelete: () => void;
+  } = $props();
+
+  const { t } = getI18n();
+
+  const MODES: { value: Match; label: string; hint: string }[] = [
+    { value: 'word', label: 'Whole word', hint: 'Fires when the phrase appears as its own word (so "hi" will not fire inside "this").' },
+    { value: 'contains', label: 'Contains', hint: 'Fires when the phrase appears anywhere, even inside another word.' },
+    { value: 'exact', label: 'Exact message', hint: 'Fires only when the whole message equals the phrase.' },
+    { value: 'prefix', label: 'Starts with', hint: 'Fires when the message begins with the phrase.' }
+  ];
+
+  // The response palette: the tokens sesame expands (module.ParseDynamic + {user}).
+  const TOKENS = [
+    { token: '{user}', label: '{user} → the chatter' },
+    { token: '{random}', label: '{random} → a number 1-100' },
+    { token: '{choice:a,b,c}', label: '{choice:a,b,c} → a random option' }
+  ];
+
+  const DEFAULT_RESPONSE = 'hi {user}!';
+  const effectiveMessage = $derived(message.trim() ? message : DEFAULT_RESPONSE);
+  const modeHint = $derived(MODES.find((m) => m.value === match)?.hint ?? '');
+
+  // A sample chat line that would fire this rule, shaped per match mode so the
+  // rehearsed viewer message actually triggers the reply.
+  const sampleMessage = $derived.by(() => {
+    const p = phrase.trim() || 'hello';
+    switch (match) {
+      case 'exact':
+        return p;
+      case 'prefix':
+        return `${p} everyone`;
+      default:
+        return `hey ${p} there`;
+    }
+  });
+
+  const canSave = $derived(phrase.trim().length > 0 && message.trim().length > 0);
+</script>
+
+<div class="editor">
+  <label class="field">
+    <span>Trigger phrase</span>
+    <input class="rule-input" type="text" placeholder="hello" bind:value={phrase} />
+  </label>
+
+  <label class="field">
+    <span>Match</span>
+    <select class="rule-input" bind:value={match}>
+      {#each MODES as m (m.value)}<option value={m.value}>{m.label}</option>{/each}
+    </select>
+    <small>{modeHint}</small>
+  </label>
+
+  <div class="field">
+    <span>Response</span>
+    <ResponseEditor bind:value={message} placeholder={DEFAULT_RESPONSE} tokens={TOKENS} />
+  </div>
+
+  <ChatPreview
+    name=""
+    viewerText={sampleMessage}
+    tag={`on "${phrase.trim() || 'hello'}"`}
+    samples={{ user: 'sesame_sam', random: '42' }}
+    response={effectiveMessage}
+  />
+
+  <div class="actions">
+    <button type="button" class="btn danger" onclick={onDelete} disabled={busy}>
+      <Icon name="trash" size={14} /> Delete
+    </button>
+    <span class="spacer"></span>
+    <button type="button" class="btn ghost" onclick={onCancel} disabled={busy}>{t('common.cancel')}</button>
+    <button type="button" class="btn primary" onclick={onSave} disabled={busy || !canSave}>
+      <Icon name="check" size={14} />
+      {busy ? t('modules.loading') : t('modules.saveChanges')}
+    </button>
+  </div>
+</div>
+
+<style>
+  .editor { padding: 4px 2px 2px; }
+  .field { display: flex; flex-direction: column; gap: 8px; margin-bottom: 14px; }
+  .field > span { font-family: var(--bb-font-body); font-size: 12.5px; color: var(--bb-muted); letter-spacing: 0.01em; }
+  .field small { color: var(--bb-muted); opacity: 0.75; font-size: 11px; }
+
+  .rule-input {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 12px 14px;
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid var(--glass-border);
+    border-radius: 8px 8px;
+    color: var(--bb-white);
+    font-family: var(--bb-font-body);
+    font-size: 13.5px;
+    transition: border-color var(--bb-dur-base, 160ms) ease, box-shadow var(--bb-dur-base, 160ms) ease;
+  }
+  .rule-input::placeholder { color: var(--bb-muted); opacity: 0.7; }
+  .rule-input:focus {
+    outline: none;
+    border-color: rgba(82, 183, 136, 0.5);
+    box-shadow: 0 0 0 3px rgba(82, 183, 136, 0.12);
+    background: rgba(255, 255, 255, 0.04);
+  }
+
+  .actions { display: flex; align-items: center; gap: 10px; margin-top: 12px; }
+  .spacer { flex: 1; }
+  .btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 14px;
+    border-radius: 8px 8px;
+    font-family: var(--bb-font-body);
+    font-size: 13px;
+    cursor: pointer;
+    border: 1px solid var(--rule);
+    background: transparent;
+    color: var(--bb-muted);
+    transition: all var(--bb-dur-fast, 140ms) ease;
+  }
+  .btn.ghost:hover { color: var(--bb-white); }
+  .btn.primary { background: rgba(82, 183, 136, 0.16); border-color: rgba(82, 183, 136, 0.5); color: var(--bb-green-glow, #52b788); }
+  .btn.primary:disabled { opacity: 0.5; cursor: default; }
+  .btn.danger { border-color: transparent; color: #cf8a78; }
+  .btn.danger:hover { border-color: rgba(176, 90, 70, 0.5); background: rgba(176, 90, 70, 0.08); }
+
+  @media (max-width: 480px) {
+    .actions { flex-wrap: wrap; }
+    .actions .btn { flex: 1; justify-content: center; min-height: 44px; }
+    .spacer { display: none; }
+  }
+</style>

--- a/console/dashboard/src/routes/(app)/modules/[id]/+page.server.ts
+++ b/console/dashboard/src/routes/(app)/modules/[id]/+page.server.ts
@@ -68,6 +68,10 @@ function buildConfig(def: ModuleDef, f: FormData): Record<string, string> {
   for (const field of (def.settings ?? []).filter((s) => get(s.key))) {
     config[field.key] = get(field.key);
   }
+  // Triggers persists its whole rule list as one "rules" string (one rule per
+  // line); the sesame module parses it (app/sesame/modules/triggers.go).
+  const rules = def.id === 'triggers' ? get('rules') : '';
+  if (rules) config.rules = rules;
   return config;
 }
 

--- a/console/dashboard/src/routes/(app)/modules/[id]/+page.svelte
+++ b/console/dashboard/src/routes/(app)/modules/[id]/+page.svelte
@@ -5,6 +5,7 @@
   import ReplyRow from '$lib/components/modules/ReplyRow.svelte';
   import ReplyEditor from '$lib/components/modules/ReplyEditor.svelte';
   import ModuleCommandRow from '$lib/components/modules/ModuleCommandRow.svelte';
+  import TriggerRuleEditor from '$lib/components/modules/TriggerRuleEditor.svelte';
 
   let { data } = $props();
 
@@ -20,6 +21,18 @@
   let enabled = $state(data.enabled);
   // svelte-ignore state_referenced_locally
   let config = $state<Record<string, string>>({ ...data.config });
+
+  // Trigger words is the one module whose "replies" are a free-form list the
+  // author grows: it renders trigger rules as add/removable ReplyRows and reads
+  // the whole list out of one "rules" config string (see the trigger block
+  // below). Every other module keeps its fixed def.replies.
+  const isTriggers = $derived(def.id === 'triggers');
+  // svelte-ignore state_referenced_locally
+  let rules = $state<Rule[]>(parseRules(data.config.rules ?? ''));
+  // The inspector column exists for any module that has an editable ledger —
+  // fixed replies or the dynamic trigger list.
+  const hasInspector = $derived(isTriggers || hasReplies);
+
   // svelte-ignore state_referenced_locally
   let seedId = data.def.id;
   $effect(() => {
@@ -27,6 +40,8 @@
       seedId = data.def.id;
       enabled = data.enabled;
       config = { ...data.config };
+      rules = parseRules(data.config.rules ?? '');
+      ruleIndex = null;
       expanded = null;
     }
   });
@@ -60,6 +75,8 @@
       if (reply.enableKey) body.set(`cfg.${reply.enableKey}`, cfg[reply.enableKey] === 'off' ? 'off' : 'on');
     }
     for (const field of def.settings ?? []) body.set(`cfg.${field.key}`, cfg[field.key] ?? '');
+    // Triggers persists its whole rule list as one config string.
+    if (def.id === 'triggers') body.set('cfg.rules', cfg.rules ?? '');
     return body;
   }
 
@@ -165,6 +182,157 @@
     }
   }
 
+  // --- Trigger words: dynamic rule list ---------------------------------------
+  // A rule is one "phrase => response" line. The list persists as one config
+  // string (config.rules); a disabled rule is stored as a "#" comment the sesame
+  // parser skips. parse/serialize mirror app/sesame/modules/triggers.go.
+  type Match = 'word' | 'contains' | 'exact' | 'prefix';
+  type Rule = { phrase: string; response: string; match: Match; enabled: boolean };
+
+  const MODE_LABEL: Record<Match, string> = {
+    word: 'Whole word',
+    contains: 'Contains',
+    exact: 'Exact message',
+    prefix: 'Starts with'
+  };
+
+  function splitMode(left: string): [Match, string] {
+    const c = left.indexOf(':');
+    if (c < 0) return ['word', left];
+    const pre = left.slice(0, c).trim().toLowerCase();
+    if (pre === 'word' || pre === 'contains' || pre === 'exact' || pre === 'prefix') return [pre, left.slice(c + 1).trim()];
+    return ['word', left];
+  }
+  function parseRules(raw: string): Rule[] {
+    const out: Rule[] = [];
+    for (const line of raw.split('\n')) {
+      let ln = line.trim();
+      if (!ln) continue;
+      let on = true;
+      if (ln.startsWith('#')) {
+        const rest = ln.slice(1).trim();
+        if (!rest.includes('=>')) continue; // a plain comment, not a disabled rule
+        on = false;
+        ln = rest;
+      }
+      const sep = ln.indexOf('=>');
+      if (sep < 0) continue;
+      const [match, phrase] = splitMode(ln.slice(0, sep).trim());
+      const response = ln.slice(sep + 2).trim();
+      if (!phrase || !response) continue;
+      out.push({ phrase, response, match, enabled: on });
+    }
+    return out;
+  }
+  function serializeRules(list: Rule[]): string {
+    return list
+      .filter((r) => r.phrase.trim() && r.response.trim())
+      .map((r) => {
+        const mode = r.match === 'word' ? '' : r.match + ': ';
+        const body = `${mode}${r.phrase.trim()} => ${r.response.replace(/\s*\n\s*/g, ' ').trim()}`;
+        return r.enabled ? body : `# ${body}`;
+      })
+      .join('\n');
+  }
+
+  // Rules rendered as ReplyRow-shaped rows (label = phrase, preview = response).
+  const ruleRows: ModuleReply[] = $derived(
+    rules.map((r, i) => ({
+      key: `rule:${i}`,
+      label: r.phrase || 'New rule',
+      tagline: MODE_LABEL[r.match],
+      event: `on "${r.phrase || '…'}"`,
+      messageKey: `rule:${i}`,
+      enableKey: `rule:${i}`,
+      defaultMessage: r.response
+    }))
+  );
+
+  // Inspector draft. ruleIndex is the row being edited, -1 for a new unsaved rule,
+  // or null when no rule is open. The response reuses editMessage (shared with the
+  // reply editor's bound message).
+  let ruleIndex = $state<number | null>(null);
+  let draftPhrase = $state('');
+  let draftMatch = $state<Match>('word');
+
+  // persistRules writes the serialized list into config.rules and posts the whole
+  // draft, so the module enable and the rules save together. config is committed
+  // only on success (the caller commits `rules` too).
+  async function persistRules(next: Rule[]): Promise<boolean> {
+    const cfg = { ...config, rules: serializeRules(next) };
+    const ok = await persist(enabled, cfg);
+    if (ok) config = cfg;
+    return ok;
+  }
+
+  function openRule(i: number) {
+    if (expanded === `rule:${i}`) return closeInspector();
+    const r = rules[i];
+    ruleIndex = i;
+    draftPhrase = r.phrase;
+    draftMatch = r.match;
+    editMessage = r.response;
+    expanded = `rule:${i}`;
+  }
+  function addRule() {
+    ruleIndex = -1;
+    draftPhrase = '';
+    draftMatch = 'word';
+    editMessage = '';
+    expanded = 'rule:new';
+  }
+
+  async function saveRule() {
+    if (ruleIndex === null) return;
+    const keepOn = ruleIndex === -1 ? true : (rules[ruleIndex]?.enabled ?? true);
+    const draft: Rule = { phrase: draftPhrase.trim(), response: editMessage, match: draftMatch, enabled: keepOn };
+    const next = ruleIndex === -1 ? [...rules, draft] : rules.map((r, i) => (i === ruleIndex ? draft : r));
+    const key = expanded ?? 'rule';
+    busy = true;
+    setStatus(key, 'saving');
+    const ok = await persistRules(next);
+    busy = false;
+    if (ok) {
+      rules = next;
+      closeInspector();
+      toast('ok', t('modules.saved', { label: def.label }));
+    } else {
+      flagError(key);
+      toast('err', t('modules.saveFailed'));
+    }
+  }
+
+  async function deleteRule(i: number) {
+    const next = rules.filter((_, idx) => idx !== i);
+    setStatus(`rule:${i}`, 'saving');
+    if (await persistRules(next)) {
+      rules = next;
+      if (expanded === `rule:${i}`) closeInspector();
+      toast('ok', t('modules.saved', { label: def.label }));
+    } else {
+      flagError(`rule:${i}`);
+      toast('err', t('modules.saveFailed'));
+    }
+  }
+
+  async function toggleRule(i: number) {
+    const next = rules.map((r, idx) => (idx === i ? { ...r, enabled: !r.enabled } : r));
+    setStatus(`rule:${i}`, 'saving');
+    if (await persistRules(next)) {
+      rules = next;
+      ackSaved(`rule:${i}`);
+    } else {
+      flagError(`rule:${i}`);
+      toast('err', t('modules.couldNotToggle', { label: rules[i].phrase }));
+    }
+  }
+
+  // The inspector is open whenever a row (reply or rule) is expanded.
+  const editing = $derived(!!expanded);
+  const inspectorTitle = $derived(
+    isTriggers ? (ruleIndex === -1 ? 'New trigger' : 'Edit trigger') : selectedReply ? selectedReply.label : t('modules.inspector')
+  );
+
   function onKey(e: KeyboardEvent) {
     if (e.key !== 'Escape' || !expanded) return;
     const el = e.target as HTMLElement | null;
@@ -248,9 +416,38 @@
   <!-- The deck: reply ledger + docked builder inspector (same as commands). A
        commands-only module (no editable replies) drops the inspector column and
        lists its chat commands read-only instead. -->
-  <div class="deck {expanded ? 'inspecting' : ''} {enabled ? '' : 'muted'} {hasReplies ? '' : 'commands-only'}">
+  <div class="deck {editing ? 'inspecting' : ''} {enabled ? '' : 'muted'} {hasInspector ? '' : 'commands-only'}">
     <Card style="padding:6px 0 0" class="deck-list">
-      {#if hasReplies}
+      {#if isTriggers}
+        <div class="rules-head">
+          <div class="rh-text">
+            <span class="rh-title">Trigger rules</span>
+            <span class="rh-hint">Reply when a message matches a phrase — no "!" needed. First match wins.</span>
+          </div>
+          <button class="add-rule" type="button" onclick={addRule}><Icon name="plus" size={13} /> Add rule</button>
+        </div>
+        {#if ruleRows.length}
+          <div class="list">
+            {#each ruleRows as reply, i (reply.key)}
+              <ReplyRow
+                {reply}
+                message={rules[i].response}
+                index={i + 1}
+                status={modStatus[reply.key] ?? 'idle'}
+                expanded={expanded === reply.key}
+                enabled={rules[i].enabled}
+                onExpand={() => openRule(i)}
+                onToggle={() => toggleRule(i)}
+              />
+            {/each}
+          </div>
+        {:else}
+          <div class="rules-empty">
+            <span class="re-glyph"><Icon name="caps" size={18} /></span>
+            <p>No trigger words yet. Add a rule to reply automatically when a word shows up in chat.</p>
+          </div>
+        {/if}
+      {:else if hasReplies}
         <div class="list">
           {#each def.replies as reply, i (reply.key)}
             <ReplyRow
@@ -280,25 +477,46 @@
       {/if}
     </Card>
 
-    {#if hasReplies}
+    {#if hasInspector}
     <!-- svelte-ignore a11y_no_static_element_interactions -->
     <div
       class="inspector-backdrop"
-      class:open={!!expanded}
+      class:open={editing}
       role="presentation"
       onclick={closeInspector}
       onkeydown={(e) => { if (e.key === 'Enter') closeInspector(); }}
     ></div>
-    <aside class="inspector" class:open={!!expanded} aria-label="Reply builder">
+    <aside class="inspector" class:open={editing} aria-label="Reply builder">
       <div class="inspector-head">
-        <span class="inspector-tag">{selectedReply ? selectedReply.label : t('modules.inspector')}</span>
-        {#if selectedReply}
+        <span class="inspector-tag">{inspectorTitle}</span>
+        {#if editing}
           <button class="mini" type="button" aria-label={t('modules.closeEditor')} onclick={closeInspector}>
             <Icon name="x" size={14} />
           </button>
         {/if}
       </div>
-      {#if selectedReply}
+      {#if isTriggers}
+        {#if editing}
+          <Scroller fill padding="16px" data-lenis-prevent>
+            {#key expanded}
+              <TriggerRuleEditor
+                bind:phrase={draftPhrase}
+                bind:match={draftMatch}
+                bind:message={editMessage}
+                {busy}
+                onSave={saveRule}
+                onCancel={closeInspector}
+                onDelete={() => (ruleIndex !== null && ruleIndex >= 0 ? deleteRule(ruleIndex) : closeInspector())}
+              />
+            {/key}
+          </Scroller>
+        {:else}
+          <div class="inspector-idle">
+            <span class="idle-glyph"><Icon name="caps" size={18} /></span>
+            <p>Pick a trigger to edit it, or add a new one.</p>
+          </div>
+        {/if}
+      {:else if selectedReply}
         <Scroller fill padding="16px" data-lenis-prevent>
           {#key selectedReply.key}
             <ReplyEditor reply={selectedReply} bind:message={editMessage} {busy} onCancel={closeInspector} onSave={saveReply} />
@@ -426,6 +644,63 @@
     color: var(--bb-tan);
   }
   .cmd-head-hint { font-family: var(--bb-font-body); font-size: 12px; color: var(--bb-muted); }
+
+  /* Trigger rules: a header with an add button above the add/removable rows. */
+  .rules-head {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 14px 10px;
+    border-bottom: 1px solid var(--rule);
+  }
+  .rh-text { display: flex; flex-direction: column; gap: 2px; margin-right: auto; min-width: 0; }
+  .rh-title {
+    font-family: var(--bb-font-display);
+    font-weight: 700;
+    font-size: 12px;
+    letter-spacing: 0.02em;
+    color: var(--bb-tan);
+  }
+  .rh-hint { font-family: var(--bb-font-body); font-size: 12px; color: var(--bb-muted); }
+  .add-rule {
+    flex: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    font-family: var(--bb-font-body);
+    font-size: 12px;
+    color: var(--bb-green-glow, #52b788);
+    background: rgba(82, 183, 136, 0.06);
+    border: 1px dashed rgba(82, 183, 136, 0.4);
+    border-radius: 999px;
+    padding: 5px 12px;
+    cursor: pointer;
+    transition: background var(--bb-dur-fast, 140ms) ease;
+  }
+  .add-rule:hover { background: rgba(82, 183, 136, 0.14); }
+
+  .rules-empty {
+    padding: 30px 20px;
+    text-align: center;
+    color: var(--bb-muted);
+    font-family: var(--bb-font-body);
+    font-size: 13px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
+  }
+  .re-glyph {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+    border: 1px solid var(--rule-tan);
+    border-radius: 8px;
+    color: var(--bb-tan-light);
+  }
+  .rules-empty p { margin: 0; max-width: 34ch; line-height: 1.5; }
 
   .inspector {
     position: sticky;

--- a/console/shared/lib/types.ts
+++ b/console/shared/lib/types.ts
@@ -782,19 +782,13 @@ export const MODULE_CATALOG: readonly ModuleDef[] = [
     icon: 'caps',
     category: 'Community',
     defaultEnabled: false,
-    // Trigger rules are a free-form list, which the fixed reply/settings schema
-    // cannot express as rows; the whole list rides in one textarea the sesame
-    // module parses line by line (see app/sesame/modules/triggers.go).
-    replies: [],
-    settings: [
-      {
-        key: 'rules',
-        label: 'Trigger rules',
-        type: 'textarea',
-        placeholder: 'hello => hi {user}!\ncontains: lol => lmao\nexact: gg => good game',
-        help: 'One rule per line: phrase => response. Prefix the phrase with contains:, exact: or prefix: to change matching (default is whole-word). Tokens: {user}, {random}, {choice:a,b,c}. Lines starting with # are ignored.'
-      }
-    ]
+    // Trigger rules are a free-form list of phrase→response pairs the author grows,
+    // so the module page renders them as add/removable ReplyRows with a bespoke
+    // rule inspector (see the def.id === 'triggers' branch in the module page).
+    // The whole list is persisted as one "rules" string the sesame module parses
+    // line by line (a disabled rule is stored as a "#" comment, which the parser
+    // skips). See app/sesame/modules/triggers.go.
+    replies: []
   },
   // Channel Points and Timers are full modules (their own enable flag + config
   // blob in the modules service, read by sesame), but their setup cannot be


### PR DESCRIPTION
Redesign of the trigger-words config to reuse the stream-alerts reply system instead of the raw textarea from #289.

## What
- The trigger module now renders on the standard `/modules/[id]` page: same shell, `Enabled` card, deck and docked inspector as alerts/shoutout. Fixes the earlier bespoke `/triggers` route that broke the **Modules** nav active-state (fell back to Overview).
- Each rule is an add/removable `ReplyRow` with a per-row enable toggle (same component alerts uses).
- The inspector reuses the command builder — `ResponseEditor` (variable palette: `{user}`, `{random}`, `{choice:a,b,c}`) + `ChatPreview` rehearsal — plus two trigger-specific fields: the **phrase** and the **match mode** (whole word / contains / exact / starts with).
- `ChatPreview` gains an optional `viewerText` prop so the rehearsal shows a plain chat message firing the reply (no `!`).

## Storage (no backend change)
The list still persists as the one `rules` string the sesame module already parses (`app/sesame/modules/triggers.go`). A disabled rule is stored as a `#`-commented line, which the parser already skips — so the per-row toggle needs no new backend field.

## Verified
`svelte-check` 0 errors, dashboard `vite build` clean. Driven live in DEMO: add/edit/delete rules, per-row toggle, `{user}` rehearsal expansion, nav stays on Modules.