### PR TITLE
fix(nats): let worker_bus publish data.commands.used

### DIFF
--- a/deploy/k8s/nats-auth.conf
+++ b/deploy/k8s/nats-auth.conf
@@ -105,7 +105,12 @@ accounts: {
         user: "worker_bus"
         password: $NATS_BCRYPT_WORKER_BUS
         permissions: {
-          publish:   { allow: ["twitch.outgress.>", "$JS.>"] }
+          # data.commands.used: the worker-side use-counter (sesame's useReporter)
+          # publishes summed command-execution ticks; the commands service folds
+          # them into uses = uses + n. Least-privilege: only .used, never the full
+          # data.commands.> tree — command CRUD/change events are the commands
+          # service's to emit, not the worker's.
+          publish:   { allow: ["twitch.outgress.>", "data.commands.used", "$JS.>"] }
           subscribe: {
             allow: [
               "twitch.ingress.event.premium",


### PR DESCRIPTION
## Problem

Command usage counts (`uses` column) stayed at **0** in the DB and dashboard, even though the whole counter pipeline is correct in code:

1. `sesame` `runCustom` calls `useReporter.Record` on every successful custom-command run (`app/sesame/engine/dispatch.go`)
2. `useReporter` sums per command and publishes `data.commands.used` every 5s (`app/sesame/engine/use_reporter.go`)
3. the `commands` service consumes it and calls `RecordUse` (`app/commands/main.go`)
4. `flushUses` does `uses = uses + n` every 30s (`app/commands/repository/commands.go`)

Names are normalized on both ends and the `(user_id, name)` keys match, so the pipeline is sound.

## Root cause

`sesame` publishes on the `worker_bus` NATS account, whose publish ACL in `deploy/k8s/nats-auth.conf` was:

```
publish: { allow: ["twitch.outgress.>", "$JS.>"] }
```

No `data.commands.*`. A JetStream publish needs publish permission on the **message subject** itself — `$JS.>` covers only the JetStream API. So every `data.commands.used` publish was rejected by NATS and dropped. The failure is silent because `useReporter.flush` logs it at `Debug` only.

## Fix

Add `data.commands.used` to the `worker_bus` publish allow list. Least-privilege: only `.used`, **not** the full `data.commands.>` tree, since command CRUD/change events belong to the `commands` service.

NATS conf is Flux `configMapGenerator` + `config-reloader` SIGHUP, so merge/deploy = hot ACL reload, no restart.