### PR TITLE
fix(delegation): register invitee before accept and dedupe reclaims

### DIFF
--- a/app/users/repository/delegations.go
+++ b/app/users/repository/delegations.go
@@ -67,6 +67,11 @@ func (r *Users) GetDelegation(ctx context.Context, token string) (DelegationView
 // gated on consumed_at IS NULL so two concurrent racers cannot both win: at most
 // one UPDATE flips the row, the loser sees zero affected rows and errors out.
 // Expiry is checked first (an expired link is dead even if never consumed).
+//
+// Reclaim: if the invitee already manages this owner's board, a second link is
+// redundant. Rather than mint a duplicate grant, the redundant link is
+// discarded and the grant they already hold is returned, so re-opening a fresh
+// share link for the same dashboard just lands them back on it.
 func (r *Users) ConsumeDelegation(ctx context.Context, token string, delegateID uint64, delegateLogin string) (DelegationView, error) {
 	now := time.Now()
 
@@ -85,11 +90,46 @@ func (r *Users) ConsumeDelegation(ctx context.Context, token string, delegateID 
 		return DelegationView{}, errors.New("link already used")
 	}
 
-	// Atomic single-use: only succeeds while consumed_at is still NULL.
+	if grant := r.reclaimExisting(ctx, d.OwnerID, delegateID, token); grant != nil {
+		return toDelegationView(grant), nil
+	}
+
+	return r.bindDelegation(ctx, d, delegateID, delegateLogin, now)
+}
+
+// reclaimExisting returns the invitee's current consumed grant for ownerID when
+// they already hold one, after discarding the now-redundant link `token`. It
+// returns nil when the invitee has no access yet (a first, real claim the
+// caller must bind). The discard is best-effort: a failed delete only leaves a
+// dead row to sweep later, never a duplicate live grant.
+func (r *Users) reclaimExisting(ctx context.Context, ownerID, delegateID uint64, token string) *ent.Delegation {
+	grant, err := db.WithQuery(ctx, func(ctx context.Context) (*ent.Delegation, error) {
+		return r.client.Delegation.Query().
+			Where(
+				delegation.OwnerIDEQ(ownerID),
+				delegation.DelegateIDEQ(delegateID),
+				delegation.ConsumedAtNotNil(),
+			).
+			First(ctx)
+	})
+	if err != nil || grant == nil {
+		return nil
+	}
+	_ = db.WithExec(ctx, func(ctx context.Context) error {
+		_, derr := r.client.Delegation.Delete().Where(delegation.TokenEQ(token)).Exec(ctx)
+		return derr
+	})
+	return grant
+}
+
+// bindDelegation performs the atomic single-use bind on the unconsumed row d,
+// succeeding only while consumed_at is still NULL so concurrent racers cannot
+// both win. The caller has already ruled out expiry and prior consumption.
+func (r *Users) bindDelegation(ctx context.Context, d *ent.Delegation, delegateID uint64, delegateLogin string, now time.Time) (DelegationView, error) {
 	n, err := db.WithQuery(ctx, func(ctx context.Context) (int, error) {
 		return r.client.Delegation.Update().
 			Where(
-				delegation.TokenEQ(token),
+				delegation.TokenEQ(d.Token),
 				delegation.ConsumedAtIsNil(),
 			).
 			SetDelegateID(delegateID).

--- a/app/users/repository/users_test.go
+++ b/app/users/repository/users_test.go
@@ -369,3 +369,44 @@ func TestDelegateOptOutIgnoresPendingLinks(t *testing.T) {
 
 	require.Error(t, repo.OptOutDelegation(ctx, 1001, 2002), "pending invite should remain owner-managed")
 }
+
+func TestConsumeReclaimsInsteadOfDuplicatingForSameBoard(t *testing.T) {
+	_, _, repo := setup(t)
+	ctx := context.Background()
+
+	require.NoError(t, repo.CreateDelegation(ctx, "link-one", 1001, "owner", []string{"commands"}, nil))
+	require.NoError(t, repo.CreateDelegation(ctx, "link-two", 1001, "owner", []string{"timers"}, nil))
+
+	first, err := repo.ConsumeDelegation(ctx, "link-one", 2002, "delegate")
+	require.NoError(t, err)
+
+	// Second link for a board the invitee already manages: reclaim returns the
+	// grant they already hold and never mints a duplicate.
+	second, err := repo.ConsumeDelegation(ctx, "link-two", 2002, "delegate")
+	require.NoError(t, err)
+	assert.Equal(t, first.Sections, second.Sections, "reclaim returns the existing grant, not the new link")
+
+	access, err := repo.ListAccessByDelegate(ctx, 2002)
+	require.NoError(t, err)
+	require.Len(t, access, 1, "no duplicate grant for the same board")
+
+	_, err = repo.GetDelegation(ctx, "link-two")
+	require.Error(t, err, "the redundant link is discarded from the db")
+}
+
+func TestConsumeStillBindsDistinctBoards(t *testing.T) {
+	_, _, repo := setup(t)
+	ctx := context.Background()
+
+	require.NoError(t, repo.CreateDelegation(ctx, "board-a", 1001, "alpha", []string{"commands"}, nil))
+	require.NoError(t, repo.CreateDelegation(ctx, "board-b", 3003, "beta", []string{"timers"}, nil))
+
+	_, err := repo.ConsumeDelegation(ctx, "board-a", 2002, "delegate")
+	require.NoError(t, err)
+	_, err = repo.ConsumeDelegation(ctx, "board-b", 2002, "delegate")
+	require.NoError(t, err)
+
+	access, err := repo.ListAccessByDelegate(ctx, 2002)
+	require.NoError(t, err)
+	assert.Len(t, access, 2, "different owners are separate grants, not a reclaim")
+}

--- a/console/dashboard/src/routes/auth/callback/+server.ts
+++ b/console/dashboard/src/routes/auth/callback/+server.ts
@@ -233,12 +233,18 @@ async function completeLogin(cookies: Cookies, url: URL, code: string, storedNon
   // every login; the admin panel re-bans authoritatively.
   if (await isBanned(identity.userId)) throw redirect(302, '/login?e=banned');
 
-  await acceptPendingDelegation(cookies, url, identity);
-
+  // Register BEFORE the delegation accept can seal a delegate session and
+  // redirect: a brand-new invitee whose first ever login is a share link still
+  // needs their own user row, or the ghost-session gate reads it as a deleted
+  // account, wipes the delegate session on the very next request, and bounces
+  // them to /login. A returning owner just no-ops through the accept below.
+  //
   // Real account email (user:read:email consent). Null on any failure —
   // capture is best-effort and the users service stores it encrypted.
   const email = await fetchAccountEmail(tokens.accessToken());
   await registerUser(identity, email);
+
+  await acceptPendingDelegation(cookies, url, identity);
 
   setSessionCookie(cookies, url, streamerSession(identity));
   await seedLocaleCookie(cookies, url, identity.userId);


### PR DESCRIPTION
## Bugs

**New invitee never created.** A brand-new user whose first-ever login is a share link never got a user row: `acceptPendingDelegation` sealed the delegate session and threw its `/` redirect *before* `registerUser` ran. On the next request the ghost-session gate (`guard.ts`) read the missing row as a deleted account, wiped the cookie, and bounced them to `/login?e=signedout`.

**Reclaim minted duplicates.** Claiming a second link for a board the invitee already manages created a second consumed grant, so `ListAccessByDelegate` listed the board twice (and re-clicking an already-consumed link just errored).

## Fixes

- **callback**: fetch email + `registerUser` before `acceptPendingDelegation`. Owner path unchanged (accept no-ops without the pending cookie).
- **ConsumeDelegation**: reclaim path. When an existing consumed grant is found for the same owner+delegate, discard the redundant link and return the grant they already hold; the callback then seals the delegate session and lands them on the delegated dashboard. Best-effort delete: worst case a dead row, never a duplicate live grant. Atomic bind extracted into `bindDelegation` to keep the orchestrator small (CodeScene health held at 10).

## Tests

- `TestConsumeReclaimsInsteadOfDuplicatingForSameBoard` — two links, same owner+delegate resolve to one grant, existing sections returned, redundant link deleted.
- `TestConsumeStillBindsDistinctBoards` — different owners stay separate grants (no false reclaim).