### PR TITLE
perf(gateway): share urchin tags/uuid lookup behind one cache

### DIFF
--- a/app/gateway/internal/providers/urchin/urchin.go
+++ b/app/gateway/internal/providers/urchin/urchin.go
@@ -26,13 +26,12 @@ import (
 )
 
 // Cache TTLs. Session deltas move while the player is online, so they stay
-// short; blacklist state can lag a little. The uuid resolution never changes
-// for a username short of a Mojang rename, so it is cached long.
+// short; blacklist state can lag a little. The tags fetch (tagsTTL) doubles as
+// the sniper endpoint's uuid source, so the two share one window.
 const (
 	sessionTTL  = 2 * time.Minute
 	sniperTTL   = 10 * time.Minute
 	tagsTTL     = 10 * time.Minute
-	uuidTTL     = 24 * time.Hour
 	negativeTTL = 5 * time.Minute
 
 	httpTimeout = 10 * time.Second
@@ -230,6 +229,22 @@ func (p *Provider) fetchTags(ctx context.Context, acct account) (tagsResponse, e
 	return resp, p.http.GetJSON(ctx, "/v3/player/tags", url.Values{"player": {acct.String()}}, &resp)
 }
 
+// playerTags fetches the Coral tags response for acct behind a shared cache.
+// Both the tags command and the sniper endpoint's uuid resolution read through
+// it, so a player queried by either costs one /v3/player/tags call rather than
+// two, and a missing player negative-caches once and satisfies both. It spends
+// one rate-limit token only on a real upstream fetch (the enforce lives inside
+// the cache's fill, so a hit costs nothing).
+func (p *Provider) playerTags(ctx context.Context, acct account, isPremium bool) (tagsResponse, error) {
+	key := core.Key(p.Name(), "playertags", acct.cacheKey())
+	return core.Cached(ctx, p.cache, key, tagsTTL, negativeTTL, func(ctx context.Context) (tagsResponse, error) {
+		if err := p.buckets.Enforce(ctx, p.deps.Limiter, isPremium); err != nil {
+			return tagsResponse{}, err
+		}
+		return p.fetchTags(ctx, acct)
+	})
+}
+
 func (p *Provider) tags(ctx context.Context, req gatewayrpc.Request) any {
 	acct := account(strings.TrimSpace(req.Account))
 	if acct.empty() {
@@ -239,10 +254,7 @@ func (p *Provider) tags(ctx context.Context, req gatewayrpc.Request) any {
 	b, err := core.CachedBytes(ctx, p.cache, key, func(ctx context.Context) ([]byte, time.Duration, error) {
 		return core.BuildReply(ctx, tagsTTL, negativeTTL,
 			func(ctx context.Context) (any, error) {
-				if err := p.buckets.Enforce(ctx, p.deps.Limiter, req.IsPremium); err != nil {
-					return nil, err
-				}
-				resp, err := p.fetchTags(ctx, acct)
+				resp, err := p.playerTags(ctx, acct, req.IsPremium)
 				if err != nil {
 					return nil, err
 				}
@@ -274,25 +286,20 @@ type cubelifyResponse struct {
 	Tags []json.RawMessage `json:"tags"`
 }
 
-// resolveUUID turns a username into the canonical uuid via the tags endpoint,
-// cached for a day. An empty uuid on a 200 is shaped like a 404 so it negative
-// caches instead of being stored as a "successful" blank that would poison the
-// downstream cubelify call.
+// resolveUUID turns a username into the canonical uuid, reading through the
+// shared tags cache (playerTags) so it reuses a lookup the tags command may
+// already have made instead of dialing Coral again. An empty uuid on a 200 is
+// shaped like a 404 so the downstream cubelify call is never made with a blank
+// id.
 func (p *Provider) resolveUUID(ctx context.Context, acct account, isPremium bool) (string, error) {
-	key := core.Key(p.Name(), "uuid", acct.cacheKey())
-	return core.Cached(ctx, p.cache, key, uuidTTL, negativeTTL, func(ctx context.Context) (string, error) {
-		if err := p.buckets.Enforce(ctx, p.deps.Limiter, isPremium); err != nil {
-			return "", err
-		}
-		resp, err := p.fetchTags(ctx, acct)
-		if err != nil {
-			return "", err
-		}
-		if strings.TrimSpace(resp.UUID) == "" {
-			return "", &core.UpstreamError{Status: 404, Message: "player not found"}
-		}
-		return resp.UUID, nil
-	})
+	resp, err := p.playerTags(ctx, acct, isPremium)
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(resp.UUID) == "" {
+		return "", &core.UpstreamError{Status: 404, Message: "player not found"}
+	}
+	return resp.UUID, nil
 }
 
 func (p *Provider) sniper(ctx context.Context, req gatewayrpc.Request) any {

--- a/app/gateway/internal/providers/urchin/urchin_test.go
+++ b/app/gateway/internal/providers/urchin/urchin_test.go
@@ -234,6 +234,33 @@ func TestTagsParsing(t *testing.T) {
 	assert.Equal(t, gatewayrpc.UrchinTag{Type: "sniper"}, reply.Tags[1])
 }
 
+// !tag and !sniper both need /v3/player/tags — !tag for the blacklist tags,
+// !sniper only for the uuid it feeds cubelify. The shared cache must collapse
+// them onto ONE upstream fetch regardless of which command runs first.
+func TestTagsAndSniperShareUpstreamFetch(t *testing.T) {
+	run := func(t *testing.T, first, second string) {
+		var tagsHits, cubelifyHits int
+		p := newTestProvider(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/v3/player/tags":
+				tagsHits++
+				_, _ = w.Write([]byte(`{"uuid":"deadbeef","displayname":"Aim","tags":[]}`))
+			case "/v3/cubelify":
+				cubelifyHits++
+				_, _ = w.Write([]byte(`{"score":{"value":3,"mode":"ok"},"tags":[]}`))
+			default:
+				t.Errorf("unexpected path %s", r.URL.Path)
+			}
+		}))
+		_ = endpoint(t, p, first)(context.Background(), gatewayrpc.Request{Account: "Aim"})
+		_ = endpoint(t, p, second)(context.Background(), gatewayrpc.Request{Account: "Aim"})
+		assert.Equal(t, 1, tagsHits, "the /v3/player/tags fetch must be shared, not repeated")
+		assert.Equal(t, 1, cubelifyHits)
+	}
+	t.Run("tag then sniper", func(t *testing.T) { run(t, "tags", "sniper") })
+	t.Run("sniper then tag", func(t *testing.T) { run(t, "sniper", "tags") })
+}
+
 func TestMissingAccount(t *testing.T) {
 	p := newTestProvider(t, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
 		t.Error("no upstream call expected")


### PR DESCRIPTION
## What

`!sniper` resolved the player UUID by re-fetching `/v3/player/tags` — the exact call `!tag` already makes — while the `urchin:tags` and `urchin:uuid` caches never shared. A player queried by both commands cost **two identical upstream fetches**.

## Change

Introduce `playerTags`: one `core.Cached` `/v3/player/tags` fetch that both the `tags` handler and `resolveUUID` read through.

- Either command order now costs a **single** Coral call.
- A missing player (404/400) **negative-caches once** and satisfies both commands.
- Drops the separate `urchin:uuid` entry and its 24h TTL; the shared entry rides `tagsTTL` (the tags payload is the freshness constraint).

## Sesame

Reply shapes (`UrchinTagsReply`, `UrchinSniperReply`) and the friendly-error envelope are unchanged, so sesame's RPC decode path is identical.

## Verification

- `go test ./app/gateway/... ./app/sesame/modules/...` — pass, incl. new `TestTagsAndSniperShareUpstreamFetch` (both orders, asserts one `/v3/player/tags` hit).
- `go vet`, `gofmt` — clean.
- CodeScene `cs delta` — no issues, health 10.00.