### PR TITLE
fix(outgress): derive lease membership from Valkey, not NATS discovery

### DIFF
--- a/app/outgress/main.go
+++ b/app/outgress/main.go
@@ -273,7 +273,7 @@ func (d *deps) newLeaseLimiter(ctx context.Context) (ratelimit.Manager, func()) 
 		ratelimit.WithLeaseIdentity(d.cfg.RateRegion, d.host))
 	permitSvc.SetGrantor(limiter)
 
-	coordinator := ratelimit.NewLeaseCoordinator(d.nc, d.valkey, limiter, d.cfg.RateRegion, d.host,
+	coordinator := ratelimit.NewLeaseCoordinator(d.valkey, limiter, d.cfg.RateRegion, d.host,
 		ratelimit.CoordinatorConfig{
 			Epoch: d.cfg.LeaseEpoch, Guard: d.cfg.LeaseGuard, MinMembers: d.cfg.LeaseMinMembers,
 			Replicas: d.cfg.LeaseReplicas, ReplicaTimeout: d.cfg.LeaseReplicaTimeout,

--- a/deploy/k8s/NATS-CROSS-NODE.md
+++ b/deploy/k8s/NATS-CROSS-NODE.md
@@ -1,0 +1,96 @@
+# NATS cross-node interest — diagnosis & remediation
+
+Operator runbook for the one traffic class the fleet has that genuinely needs
+**cross-node, non-local, non-queue** delivery on a `*_RPC` account: the outgress
+lease **permit borrow** (`bagel.outgress.permit.v2.<region>.<podID>`, a plain sub
+per [borrow.go](../../pkg/ratelimit/borrow.go)).
+
+Every other RPC in the fleet is a **queue** group with an instance on every node,
+so the leaf mesh answers it on-node (zero hops) and its cross-node path is never
+exercised. Borrow is the first path that must reach a *specific remote* pod, so it
+is the first to expose any cross-node interest-propagation gap. The old lease
+membership discovery (`$SRV.INFO` scatter-gather) hit the same wall and reported
+`members: 1`; that half is now fixed by moving membership to Valkey
+([lease_client.go](../../pkg/ratelimit/lease_client.go)), so **correctness no
+longer depends on this** — a lone pod divides quota by member count and the fleet
+stays ≤100%. Borrow is pure burst efficiency and fails safe to the shared
+emergency partition. Fix this to *recover the burst headroom*, not to stop 429s.
+
+## The config is already correct — do not blind-edit it
+
+Confirmed wiring (leave as-is unless a step below proves otherwise):
+
+- Leaf cluster: `cluster{ name: nats-leaf, port: 6222, routes: nats-leaf-peers:6222, no_advertise }` ([nats-leaf-server.conf](nats-leaf-server.conf)); `nats-leaf-peers` is headless + `publishNotReadyAddresses` ([nats-leaf.yaml](nats-leaf.yaml)).
+- Hub cluster: 3-replica StatefulSet, routes on `nats-headless:6222`; per-account leafnode listener on `7422` ([nats.yaml](nats.yaml), [nats-server.conf](nats-server.conf)).
+- `OUTGRESS_RPC` has no per-user subject ACL (default-allow **within** the account), so `bagel.outgress.permit.v2.>` and `$SRV.>` are unrestricted account-internal subjects.
+- `network-policies.yaml` `default-deny-apps` selects only app pods, **not** `nats`/`nats-leaf`, so NATS pods are NetworkPolicy-unrestricted. `linkerd-auth.yaml` defines no `Server` for NATS, so its ports are not locked to default-deny. `opaque-ports` covers `4222,6222,7422`.
+
+So the break is **runtime**, on one of: leaf↔leaf routes (6222), leaf→hub leafnode (7422), or hub↔hub interest relay.
+
+## Diagnose (live cluster)
+
+Run from the operator context (`k8s-operator.tail451e6d.ts.net`).
+
+1. **Leaf mesh formed?** Each leaf should hold a route to every *other* leaf.
+   ```sh
+   for p in $(kubectl -n production get pod -l app=nats-leaf -o name); do
+     echo "$p:"; kubectl -n production exec "$p" -c nats -- \
+       wget -qO- localhost:8222/routez | grep -E '"num_routes"'
+   done   # expect num_routes == (leaf count - 1) on every leaf
+   ```
+   Prometheus equivalent: `gnatsd_varz_routes{app="nats-leaf"}`.
+
+2. **Leafnode links up?** Each leaf opens one remote per account (13).
+   ```sh
+   kubectl -n production exec <a-leaf-pod> -c nats -- \
+     wget -qO- localhost:8222/leafz | grep -E '"leafnodes"|OUTGRESS'
+   ```
+
+3. **Does interest actually cross?** Sub on one node's leaf, pub from another's,
+   with the OUTGRESS_RPC (`outgress_rpc`) creds:
+   ```sh
+   # terminal A — on the leaf co-located with outgress pod B's node
+   nats --server nats://nats-leaf.<nodeB>:4222 --user outgress_rpc --password $PW \
+     sub 'bagel.outgress.permit.v2.probe'
+   # terminal B — on outgress pod A's node
+   nats --server nats://nats-leaf.<nodeA>:4222 --user outgress_rpc --password $PW \
+     pub 'bagel.outgress.permit.v2.probe' hi
+   ```
+   Arrives ⇒ cross-node interest works, borrow is fine (watch the borrow logs at
+   `outgress ... leases`). Silent ⇒ continue.
+
+4. **App-visible signal:** after the Valkey membership fix ships, a healthy fleet
+   logs `lease plan committed members=3`. If borrow still never succeeds under a
+   single-node burst while members=3, cross-node delivery is the culprit.
+
+## Remediate by outcome
+
+- **Step 1 shows `num_routes: 0` (leaf mesh not formed):** cross-node `6222` is
+  blocked. Almost always the known firewalld regression — a node reboot drops the
+  runtime-only `cni0`/`flannel.1` interfaces from the `trusted` zone, so
+  pod-to-pod cross-node dies. Re-add them **`--permanent`**:
+  ```sh
+  firewall-cmd --permanent --zone=trusted --add-interface=cni0
+  firewall-cmd --permanent --zone=trusted --add-interface=flannel.1
+  firewall-cmd --reload
+  ```
+  Also confirm `nats-leaf-peers` resolves every leaf pod IP
+  (`kubectl -n production get endpoints nats-leaf-peers`) and that Linkerd keeps
+  `6222` opaque (a proxy that protocol-detects `6222` would stall the route).
+
+- **Step 2 shows the OUTGRESS leaf remote missing/flapping:** `7422` to
+  `nats:7422` is blocked or the `leaf_outgress` cred is wrong — check
+  `nats-auth-env` and the leafnode authorization user in [nats-server.conf](nats-server.conf).
+
+- **Steps 1–2 healthy but step 3 is silent:** genuine NATS leaf+cluster hybrid
+  interest gap. Validate the hub relay in isolation by pointing the probe sub/pub
+  at the **hub** (`nats:4222`) instead of the leaves; if that works but leaf↔leaf
+  does not, prefer the hub path for this account, or revisit `no_advertise` on the
+  leaf cluster so a post-rollout leaf is re-dialed into the mesh.
+
+## Why not just re-route borrow through the hub in code
+
+Because the fix belongs at the layer that is broken. Correctness is already safe
+(Valkey membership + `OUTGRESS_LEASE_MIN_MEMBERS=2`); reworking borrow to avoid
+cross-node NATS would mask a fleet-wide infra fault that also degrades any future
+cross-node RPC. Restore cross-node interest, keep borrow simple.

--- a/deploy/k8s/outgress.yaml
+++ b/deploy/k8s/outgress.yaml
@@ -148,8 +148,17 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-                  # Remaining lease tuning (minimum members, replicas, epoch, etc.)
-                  # may be supplied by outgress-env via Doppler.
+                  # Remaining lease tuning (replicas, epoch, etc.) may be supplied
+                  # by outgress-env via Doppler.
+            # Reject a quota plan that does not reflect a real multi-pod fleet.
+            # Two is the safe floor: a lone member borrows from nobody and would
+            # claim the full Twitch quota (fail open -> 429s), whereas any plan of
+            # 2+ divides the leased share so the fleet total stays <= 100%. Below
+            # this floor the coordinator defers and every pod runs on the shared,
+            # serialized emergency partition (fail closed). 2 (not 3) still forms a
+            # valid plan during a maxUnavailable:1 rollout, when only 2 pods are up.
+            - name: OUTGRESS_LEASE_MIN_MEMBERS
+              value: "2"
           envFrom:
             - secretRef:
                 name: outgress-env

--- a/pkg/ratelimit/coordinator.go
+++ b/pkg/ratelimit/coordinator.go
@@ -7,20 +7,16 @@ import (
 	"sync"
 	"time"
 
-	"github.com/bytedance/sonic"
-	"github.com/nats-io/nats.go"
-	"github.com/nats-io/nats.go/micro"
 	"github.com/valkey-io/valkey-go"
 	"go.uber.org/zap"
 )
 
 type CoordinatorConfig struct {
-	Epoch           time.Duration
-	Guard           time.Duration
-	DiscoveryWindow time.Duration
-	MinMembers      int
-	Replicas        int
-	ReplicaTimeout  time.Duration
+	Epoch          time.Duration
+	Guard          time.Duration
+	MinMembers     int
+	Replicas       int
+	ReplicaTimeout time.Duration
 }
 
 func (c CoordinatorConfig) withDefaults() CoordinatorConfig {
@@ -29,9 +25,6 @@ func (c CoordinatorConfig) withDefaults() CoordinatorConfig {
 	}
 	if c.Guard <= 0 {
 		c.Guard = 250 * time.Millisecond
-	}
-	if c.DiscoveryWindow <= 0 {
-		c.DiscoveryWindow = 250 * time.Millisecond
 	}
 	if c.MinMembers <= 0 {
 		c.MinMembers = 1
@@ -43,13 +36,14 @@ func (c CoordinatorConfig) withDefaults() CoordinatorConfig {
 }
 
 type LeaseCoordinator struct {
-	nc      *nats.Conn
 	client  *LeaseClient
 	manager *LeaseManager
-	region  string
-	podID   string
+	self    Member
 	config  CoordinatorConfig
 	log     *zap.Logger
+
+	heartbeatEvery time.Duration
+	memberTTL      time.Duration
 
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
@@ -59,30 +53,53 @@ const (
 	leaseReconcileInterval = 2 * time.Second
 	leaseMissingPlanRetry  = 250 * time.Millisecond
 	leaseMinimumWake       = 10 * time.Millisecond
+	membershipWriteTimeout = 2 * time.Second
 )
 
-func NewLeaseCoordinator(nc *nats.Conn, client valkey.Client, manager *LeaseManager, region, podID string, config CoordinatorConfig, log *zap.Logger) *LeaseCoordinator {
+func NewLeaseCoordinator(client valkey.Client, manager *LeaseManager, region, podID string, config CoordinatorConfig, log *zap.Logger) *LeaseCoordinator {
 	if log == nil {
 		log = zap.NewNop()
 	}
+	config = config.withDefaults()
+	heartbeatEvery, memberTTL := membershipCadence(config.Epoch)
 	return &LeaseCoordinator{
-		nc: nc, client: NewLeaseClient(client), manager: manager,
-		region: region, podID: podID,
-		config: config.withDefaults(), log: log,
+		client: NewLeaseClient(client), manager: manager,
+		self:   Member{PodID: podID, Region: region},
+		config: config, log: log,
+		heartbeatEvery: heartbeatEvery, memberTTL: memberTTL,
 	}
+}
+
+// membershipCadence derives the heartbeat interval and presence ttl from the
+// epoch. The interval is a bounded fraction of the epoch (neither chatty nor
+// sluggish); the ttl spans three intervals, so a live pod survives two missed
+// refreshes while a crashed one is pruned within the ttl.
+func membershipCadence(epoch time.Duration) (every, ttl time.Duration) {
+	every = epoch / 6
+	if every < 3*time.Second {
+		every = 3 * time.Second
+	}
+	if every > 10*time.Second {
+		every = 10 * time.Second
+	}
+	return every, 3 * every
 }
 
 func (c *LeaseCoordinator) Start(parent context.Context) error {
 	ctx, cancel := context.WithCancel(parent)
 	c.cancel = cancel
+	// Register self before the first reconcile so this pod counts itself in any
+	// plan it proposes on the very first pass.
+	c.heartbeat(ctx)
 	var activated, proposed uint64
 	next, err := c.reconcile(ctx, &activated, &proposed)
 	if err != nil {
 		cancel()
 		return err
 	}
-	c.wg.Add(1)
+	c.wg.Add(2)
 	go c.loop(ctx, activated, proposed, next)
+	go c.heartbeatLoop(ctx)
 	return nil
 }
 
@@ -91,6 +108,35 @@ func (c *LeaseCoordinator) Close() {
 		c.cancel()
 	}
 	c.wg.Wait()
+	// Deregister only after the loops stop, so no in-flight heartbeat can re-add
+	// self. Best-effort on a fresh context because the parent is already cancelled.
+	ctx, cancel := context.WithTimeout(context.Background(), membershipWriteTimeout)
+	defer cancel()
+	if err := c.client.RemoveMember(ctx, c.self); err != nil {
+		c.log.Debug("membership deregister failed", zap.Error(err))
+	}
+}
+
+func (c *LeaseCoordinator) heartbeat(ctx context.Context) {
+	hbCtx, cancel := context.WithTimeout(ctx, membershipWriteTimeout)
+	defer cancel()
+	if err := c.client.Heartbeat(hbCtx, c.self, time.Now(), c.memberTTL); err != nil {
+		c.log.Debug("membership heartbeat failed", zap.Error(err))
+	}
+}
+
+func (c *LeaseCoordinator) heartbeatLoop(ctx context.Context) {
+	defer c.wg.Done()
+	ticker := time.NewTicker(c.heartbeatEvery)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			c.heartbeat(ctx)
+		}
+	}
 }
 
 func (c *LeaseCoordinator) loop(ctx context.Context, activated, proposed uint64, next time.Duration) {
@@ -153,12 +199,21 @@ func (c *LeaseCoordinator) reconcile(ctx context.Context, activated, proposed *u
 	if *proposed == nextEpoch || serverNow.UnixMilli() < nextBoundary-10_000 {
 		return next, nil
 	}
-	members, err := c.discoverMembers(ctx)
+	members, err := c.listMembers(ctx)
 	if err != nil {
 		return leaseReconcileInterval, err
 	}
 	if len(members) < c.config.MinMembers {
-		return leaseReconcileInterval, errors.New("ratelimit: insufficient permit-service members")
+		// Membership under-counted the fleet. Committing a plan now would hand the
+		// known members a full local share (a lone member borrows from nobody and
+		// claims the whole Twitch quota) -- fail open. Defer instead: with no fresh
+		// plan every pod stays on the globally serialized emergency partition (fail
+		// closed, no over-send). Return nil, not an error, so this expected degraded
+		// state neither crashes startup through Start's Fatal nor hides at Debug
+		// like a transient fault.
+		c.log.Warn("insufficient permit-service members; deferring lease proposal",
+			zap.Int("discovered", len(members)), zap.Int("min_members", c.config.MinMembers))
+		return leaseReconcileInterval, nil
 	}
 	plan, err := BuildPlan(nextEpoch, nextBoundary, nextBoundary+epochMS, members)
 	if err != nil {
@@ -195,65 +250,22 @@ func nextLeaseReconcileDelay(serverNow time.Time, nextBoundaryMS int64, uncertai
 	return delay
 }
 
-func (c *LeaseCoordinator) discoverMembers(ctx context.Context) ([]Member, error) {
-	// NATS FlushWithContext rejects a context without a deadline. The
-	// coordinator is driven by the service's long-lived root context, so bound
-	// the discovery exchange explicitly to the same window used to collect
-	// replies. A stalled NATS connection then defers this reconciliation instead
-	// of crashing startup or preventing every epoch proposal.
-	discoveryCtx, cancel := context.WithTimeout(ctx, c.config.DiscoveryWindow)
-	defer cancel()
-
-	subject, err := micro.ControlSubject(micro.InfoVerb, permitServiceName, "")
+// listMembers reads the live fleet from the Valkey presence registry and
+// guarantees self is included. Deriving membership from the same store that owns
+// the quota plans means every pod sees the identical fleet without relying on
+// NATS discovery fan-out, and a stale replica or a just-missed heartbeat can
+// never make a pod disown itself.
+func (c *LeaseCoordinator) listMembers(ctx context.Context) ([]Member, error) {
+	members, err := c.client.ListMembers(ctx, time.Now())
 	if err != nil {
 		return nil, err
 	}
-	inbox := c.nc.NewInbox()
-	subscription, err := c.nc.SubscribeSync(inbox)
-	if err != nil {
-		return nil, err
-	}
-	defer subscription.Unsubscribe()
-	if err := subscription.AutoUnsubscribe(1024); err != nil {
-		return nil, err
-	}
-	if err := c.nc.PublishRequest(subject, inbox, nil); err != nil {
-		return nil, err
-	}
-	if err := c.nc.FlushWithContext(discoveryCtx); err != nil {
-		return nil, err
-	}
-
-	deadline := time.Now().Add(c.config.DiscoveryWindow)
-	byPod := make(map[string]Member, c.config.MinMembers)
-	for {
-		remaining := time.Until(deadline)
-		if remaining <= 0 {
-			break
-		}
-		message, err := subscription.NextMsg(remaining)
-		if err != nil {
-			if errors.Is(err, nats.ErrTimeout) {
-				break
-			}
-			return nil, err
-		}
-		var info micro.Info
-		if sonic.Unmarshal(message.Data, &info) != nil {
-			continue
-		}
-		member := Member{PodID: info.Metadata["pod_id"], Region: info.Metadata["region"]}
-		if member.PodID != "" && member.Region != "" {
-			byPod[member.PodID] = member
+	for i := range members {
+		if members[i].PodID == c.self.PodID {
+			return members, nil
 		}
 	}
-	if _, exists := byPod[c.podID]; !exists {
-		byPod[c.podID] = Member{PodID: c.podID, Region: c.region}
-	}
-	members := make([]Member, 0, len(byPod))
-	for _, member := range byPod {
-		members = append(members, member)
-	}
+	members = append(members, c.self)
 	sort.Slice(members, func(i, j int) bool { return members[i].PodID < members[j].PodID })
 	return members, nil
 }

--- a/pkg/ratelimit/lease_client.go
+++ b/pkg/ratelimit/lease_client.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/valkey-io/valkey-go"
@@ -17,6 +19,65 @@ type LeaseClient struct {
 
 func NewLeaseClient(client valkey.Client) *LeaseClient {
 	return &LeaseClient{client: client}
+}
+
+const (
+	// memberSetKey is the Valkey sorted set that is the fleet's membership
+	// authority: score is each pod's presence expiry (unix millis), member is its
+	// encoded identity. It lives in the same store as the quota plans so every pod
+	// derives an identical fleet view without depending on NATS discovery fan-out.
+	memberSetKey    = "outgress:members:v2"
+	memberSeparator = "|"
+)
+
+// encodeMember packs a pod's stable identity into one sorted-set member. Pod IDs
+// and regions are Kubernetes object names (a pod name and a node name), so the
+// separator can never occur inside either half.
+func encodeMember(m Member) string { return m.PodID + memberSeparator + m.Region }
+
+func decodeMember(entry string) (Member, bool) {
+	podID, region, ok := strings.Cut(entry, memberSeparator)
+	if !ok || podID == "" || region == "" {
+		return Member{}, false
+	}
+	return Member{PodID: podID, Region: region}, true
+}
+
+// Heartbeat records self as a live member whose presence expires ttl in the
+// future. The coordinator refreshes it on an interval well under ttl; a crashed
+// pod stops refreshing and is pruned once its score falls into the past, which
+// is the self-healing property.
+func (c *LeaseClient) Heartbeat(ctx context.Context, self Member, now time.Time, ttl time.Duration) error {
+	score := float64(now.Add(ttl).UnixMilli())
+	return c.client.Do(ctx, c.client.B().Zadd().Key(memberSetKey).ScoreMember().ScoreMember(score, encodeMember(self)).Build()).Error()
+}
+
+// ListMembers returns the pods whose presence has not expired as of now and
+// prunes the rest. A live member's score sits a full ttl ahead, so a read served
+// by a lagging replica still sees it; only genuinely dead pods fall out.
+func (c *LeaseClient) ListMembers(ctx context.Context, now time.Time) ([]Member, error) {
+	nowMS := strconv.FormatInt(now.UnixMilli(), 10)
+	// Best-effort housekeeping: the score filter below already ignores expired
+	// rows, so a prune failure only leaves them to be pruned on a later pass.
+	_ = c.client.Do(ctx, c.client.B().Zremrangebyscore().Key(memberSetKey).Min("-inf").Max("("+nowMS).Build()).Error()
+	entries, err := c.client.Do(ctx, c.client.B().Zrangebyscore().Key(memberSetKey).Min(nowMS).Max("+inf").Build()).AsStrSlice()
+	if err != nil {
+		return nil, err
+	}
+	members := make([]Member, 0, len(entries))
+	for _, entry := range entries {
+		if member, ok := decodeMember(entry); ok {
+			members = append(members, member)
+		}
+	}
+	sort.Slice(members, func(i, j int) bool { return members[i].PodID < members[j].PodID })
+	return members, nil
+}
+
+// RemoveMember drops self from the registry on graceful shutdown so the fleet
+// re-divides quota at the next epoch rather than waiting out the presence ttl.
+func (c *LeaseClient) RemoveMember(ctx context.Context, self Member) error {
+	return c.client.Do(ctx, c.client.B().Zrem().Key(memberSetKey).Member(encodeMember(self)).Build()).Error()
 }
 
 // ProposePlan attempts to publish a new plan for the epoch.

--- a/pkg/ratelimit/lease_client.go
+++ b/pkg/ratelimit/lease_client.go
@@ -37,7 +37,10 @@ func encodeMember(m Member) string { return m.PodID + memberSeparator + m.Region
 
 func decodeMember(entry string) (Member, bool) {
 	podID, region, ok := strings.Cut(entry, memberSeparator)
-	if !ok || podID == "" || region == "" {
+	if !ok {
+		return Member{}, false
+	}
+	if podID == "" || region == "" {
 		return Member{}, false
 	}
 	return Member{PodID: podID, Region: region}, true

--- a/pkg/ratelimit/membership_test.go
+++ b/pkg/ratelimit/membership_test.go
@@ -49,6 +49,33 @@ func TestEncodeDecodeMember(t *testing.T) {
 // This test is opt-in because presence expiry and pruning need a real Valkey
 // sorted set, not a command mock. Run with VALKEY_TEST_ADDR.
 func TestMembershipRegistryIntegration(t *testing.T) {
+	registry := newMembershipRegistryTest(t)
+
+	now := time.Now()
+	alive := []Member{{PodID: "pod-a", Region: "node2"}, {PodID: "pod-b", Region: "worker1"}}
+	registry.heartbeat(now, time.Minute, alive...)
+
+	// A pod that stopped refreshing: its presence already lies in the past.
+	stale := Member{PodID: "pod-dead", Region: "node2"}
+	registry.heartbeat(now.Add(-time.Hour), time.Minute, stale)
+
+	registry.assertMembers(now, alive, "stale pod must be excluded")
+	registry.assertCardinality(2)
+
+	// Graceful shutdown deregisters immediately instead of waiting out the ttl.
+	registry.remove(alive[0])
+	registry.assertMembers(now, alive[1:], "after remove")
+}
+
+type membershipRegistryTest struct {
+	t      *testing.T
+	ctx    context.Context
+	client valkey.Client
+	lc     *LeaseClient
+}
+
+func newMembershipRegistryTest(t *testing.T) *membershipRegistryTest {
+	t.Helper()
 	address := os.Getenv("VALKEY_TEST_ADDR")
 	if address == "" {
 		t.Skip("VALKEY_TEST_ADDR is not set")
@@ -60,56 +87,63 @@ func TestMembershipRegistryIntegration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer client.Close()
+	t.Cleanup(client.Close)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
+	t.Cleanup(cancel)
 
-	lc := NewLeaseClient(client)
-	// The registry key is fixed, so isolate this test by clearing it around the run.
-	clear := func() { client.Do(context.Background(), client.B().Del().Key(memberSetKey).Build()) }
-	clear()
-	defer clear()
+	registry := &membershipRegistryTest{t: t, ctx: ctx, client: client, lc: NewLeaseClient(client)}
+	registry.clear()
+	return registry
+}
 
-	now := time.Now()
-	alive := []Member{{PodID: "pod-a", Region: "node2"}, {PodID: "pod-b", Region: "worker1"}}
-	for _, m := range alive {
-		if err := lc.Heartbeat(ctx, m, now, time.Minute); err != nil {
-			t.Fatalf("heartbeat %s: %v", m.PodID, err)
+func (r *membershipRegistryTest) clear() {
+	r.t.Helper()
+	r.mustClear()
+	r.t.Cleanup(r.mustClear)
+}
+
+func (r *membershipRegistryTest) mustClear() {
+	r.t.Helper()
+	if err := r.client.Do(context.Background(), r.client.B().Del().Key(memberSetKey).Build()).Error(); err != nil {
+		r.t.Fatalf("clear membership registry: %v", err)
+	}
+}
+
+func (r *membershipRegistryTest) heartbeat(now time.Time, ttl time.Duration, members ...Member) {
+	r.t.Helper()
+	for _, m := range members {
+		if err := r.lc.Heartbeat(r.ctx, m, now, ttl); err != nil {
+			r.t.Fatalf("heartbeat %s: %v", m.PodID, err)
 		}
 	}
-	// A pod that stopped refreshing: its presence already lies in the past.
-	stale := Member{PodID: "pod-dead", Region: "node2"}
-	if err := lc.Heartbeat(ctx, stale, now.Add(-time.Hour), time.Minute); err != nil {
-		t.Fatal(err)
-	}
+}
 
-	got, err := lc.ListMembers(ctx, now)
+func (r *membershipRegistryTest) assertMembers(now time.Time, want []Member, reason string) {
+	r.t.Helper()
+	got, err := r.lc.ListMembers(r.ctx, now)
 	if err != nil {
-		t.Fatal(err)
+		r.t.Fatal(err)
 	}
-	if !reflect.DeepEqual(got, alive) {
-		t.Fatalf("members = %v, want %v (stale pod must be excluded)", got, alive)
+	if !reflect.DeepEqual(got, want) {
+		r.t.Fatalf("members = %v, want %v (%s)", got, want, reason)
 	}
+}
 
-	// The stale entry must have been pruned from the set, not merely filtered out.
-	remaining, err := client.Do(ctx, client.B().Zcard().Key(memberSetKey).Build()).AsInt64()
+func (r *membershipRegistryTest) assertCardinality(want int64) {
+	r.t.Helper()
+	got, err := r.client.Do(r.ctx, r.client.B().Zcard().Key(memberSetKey).Build()).AsInt64()
 	if err != nil {
-		t.Fatal(err)
+		r.t.Fatal(err)
 	}
-	if remaining != 2 {
-		t.Fatalf("set cardinality = %d, want 2 after prune", remaining)
+	if got != want {
+		r.t.Fatalf("set cardinality = %d, want %d after prune", got, want)
 	}
+}
 
-	// Graceful shutdown deregisters immediately instead of waiting out the ttl.
-	if err := lc.RemoveMember(ctx, alive[0]); err != nil {
-		t.Fatal(err)
-	}
-	got, err = lc.ListMembers(ctx, now)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(got) != 1 || got[0] != alive[1] {
-		t.Fatalf("after remove members = %v, want [%v]", got, alive[1])
+func (r *membershipRegistryTest) remove(member Member) {
+	r.t.Helper()
+	if err := r.lc.RemoveMember(r.ctx, member); err != nil {
+		r.t.Fatal(err)
 	}
 }

--- a/pkg/ratelimit/membership_test.go
+++ b/pkg/ratelimit/membership_test.go
@@ -1,0 +1,115 @@
+package ratelimit
+
+import (
+	"context"
+	"os"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/valkey-io/valkey-go"
+)
+
+func TestMembershipCadence(t *testing.T) {
+	tests := []struct {
+		name      string
+		epoch     time.Duration
+		wantEvery time.Duration
+		wantTTL   time.Duration
+	}{
+		{name: "default epoch", epoch: 30 * time.Second, wantEvery: 5 * time.Second, wantTTL: 15 * time.Second},
+		{name: "tiny epoch clamps up", epoch: 6 * time.Second, wantEvery: 3 * time.Second, wantTTL: 9 * time.Second},
+		{name: "huge epoch clamps down", epoch: 120 * time.Second, wantEvery: 10 * time.Second, wantTTL: 30 * time.Second},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			every, ttl := membershipCadence(tc.epoch)
+			if every != tc.wantEvery || ttl != tc.wantTTL {
+				t.Fatalf("cadence(%s) = (%s, %s), want (%s, %s)", tc.epoch, every, ttl, tc.wantEvery, tc.wantTTL)
+			}
+		})
+	}
+}
+
+func TestEncodeDecodeMember(t *testing.T) {
+	m := Member{PodID: "outgress-abc123", Region: "node2"}
+	if got, ok := decodeMember(encodeMember(m)); !ok || got != m {
+		t.Fatalf("round trip = %v, %v; want %v", got, ok, m)
+	}
+	// A separator can never appear inside a pod name or node name, so anything
+	// that does not split cleanly into two non-empty halves is discarded rather
+	// than admitted as a phantom member.
+	for _, bad := range []string{"", "nopipe", "|only-region", "only-pod|", "|"} {
+		if _, ok := decodeMember(bad); ok {
+			t.Fatalf("decodeMember(%q) accepted a malformed entry", bad)
+		}
+	}
+}
+
+// This test is opt-in because presence expiry and pruning need a real Valkey
+// sorted set, not a command mock. Run with VALKEY_TEST_ADDR.
+func TestMembershipRegistryIntegration(t *testing.T) {
+	address := os.Getenv("VALKEY_TEST_ADDR")
+	if address == "" {
+		t.Skip("VALKEY_TEST_ADDR is not set")
+	}
+	client, err := valkey.NewClient(valkey.ClientOption{
+		InitAddress: []string{address},
+		Password:    os.Getenv("VALKEY_TEST_PASSWORD"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	lc := NewLeaseClient(client)
+	// The registry key is fixed, so isolate this test by clearing it around the run.
+	clear := func() { client.Do(context.Background(), client.B().Del().Key(memberSetKey).Build()) }
+	clear()
+	defer clear()
+
+	now := time.Now()
+	alive := []Member{{PodID: "pod-a", Region: "node2"}, {PodID: "pod-b", Region: "worker1"}}
+	for _, m := range alive {
+		if err := lc.Heartbeat(ctx, m, now, time.Minute); err != nil {
+			t.Fatalf("heartbeat %s: %v", m.PodID, err)
+		}
+	}
+	// A pod that stopped refreshing: its presence already lies in the past.
+	stale := Member{PodID: "pod-dead", Region: "node2"}
+	if err := lc.Heartbeat(ctx, stale, now.Add(-time.Hour), time.Minute); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := lc.ListMembers(ctx, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got, alive) {
+		t.Fatalf("members = %v, want %v (stale pod must be excluded)", got, alive)
+	}
+
+	// The stale entry must have been pruned from the set, not merely filtered out.
+	remaining, err := client.Do(ctx, client.B().Zcard().Key(memberSetKey).Build()).AsInt64()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if remaining != 2 {
+		t.Fatalf("set cardinality = %d, want 2 after prune", remaining)
+	}
+
+	// Graceful shutdown deregisters immediately instead of waiting out the ttl.
+	if err := lc.RemoveMember(ctx, alive[0]); err != nil {
+		t.Fatal(err)
+	}
+	got, err = lc.ListMembers(ctx, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0] != alive[1] {
+		t.Fatalf("after remove members = %v, want [%v]", got, alive[1])
+	}
+}


### PR DESCRIPTION
## Problem

The rate-limit lease coordinator derived fleet membership by scatter-gathering NATS micro `\$SRV.INFO.outgress-permit-v2` on the `OUTGRESS_RPC` account. That broadcast interest did **not** propagate cross-pod over the leaf-cluster + per-account hub-leafnode topology, so every outgress pod discovered only itself (`members: 1`) despite 3 running.

A one-member plan makes `localShare` hand the sole member the full ~90% Twitch quota (borrowing is disabled below 2 members). Under burst the fleet **fails open** and gets 429s / dropped replies. This is on the hot send path.

## Fix — membership from Valkey, not NATS fan-out

Membership now comes from a **Valkey presence registry** — the same store that already owns the quota plans:

- Sorted set `outgress:members:v2`, score = presence expiry (ms), member = `podID|region`.
- Each pod heartbeats every `epoch/6` (clamped 3–10s) with a `3×` TTL, always counts itself, and `ZREM`s on graceful shutdown.
- `ListMembers` prunes expired entries and returns the live fleet.

Every pod derives an **identical** view without any NATS fan-out dependency; the plan commit (`WATCH`/`MULTI`) still serializes one winner per epoch.

### Properties
- **Adaptable** — member count auto-tracks the fleet; scale up/down/crash reflected in the next epoch's plan, no config.
- **Self-healing** — crashed pod pruned within TTL (~15s at a 30s epoch); graceful drain `ZREM`s immediately.
- **HA** — authority is Valkey (Sentinel-HA), identical to plan storage; no dependency on the NATS path that was broken.
- **Hot-path-safe** — heartbeat is a tiny periodic `ZADD` off the send path; membership is read once per epoch in reconcile. `Allow` is untouched.
- **Correctness no longer needs cross-node NATS** — 3 members → each takes 1/3 local share → fleet total ≤ 100% by division alone.

### Defense in depth
- `OUTGRESS_LEASE_MIN_MEMBERS=2` in the manifest (config default stays `1` for single-pod dev).
- Below the floor the coordinator **defers** (Warn, not error) → fails closed to the shared serialized emergency partition instead of fail-open, and never crashes startup via `Start`'s `Fatal`.
- `2` (not `3`) so a `maxUnavailable:1` rollout still forms a plan.

## Still on NATS
Peer capacity **borrow** still uses NATS addressed request/reply (`bagel.outgress.permit.v2.<region>.<podID>`). Correctness no longer depends on it (division keeps the fleet ≤100%); if the same topology blocks it, borrow fails safe to the emergency partition. Tracked separately as an efficiency (not safety) follow-up.

## Verification
- `go build ./...` (whole module, incl. gateway which also imports `pkg/ratelimit`) — clean
- `go vet ./pkg/ratelimit/... ./app/outgress/...` — clean
- Unit tests: cadence clamps, `encode`/`decode` round-trip + malformed rejection
- **Integration against a real Valkey**: heartbeat → list excludes past-expiry pod → prune confirmed (`ZCARD`) → `RemoveMember` deregisters — PASS