### PR TITLE
feat(deploy): add KEDA autoscaling for outgress and sesame

### DIFF
--- a/deploy/flux/clusters/production/apps.yaml
+++ b/deploy/flux/clusters/production/apps.yaml
@@ -1,6 +1,11 @@
 # This Kustomization applies the digest-pinned application manifests under deploy/k8s/.
 # ImageUpdateAutomation keeps those manifests current by committing updated image digests
 # back to main. Flux then reconciles this Kustomization to roll out the new images.
+#
+# dependsOn keda: deploy/k8s/outgress.yaml and sesame.yaml now carry
+# ScaledObjects. Without this, a from-scratch bootstrap can apply them before
+# KEDA's CRD/webhook exist and fail until the next retry converges it anyway;
+# dependsOn makes that ordering explicit instead of relying on self-heal.
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
@@ -8,6 +13,8 @@ metadata:
   name: apps
   namespace: flux-system
 spec:
+  dependsOn:
+    - name: keda
   interval: 1h
   sourceRef:
     kind: GitRepository

--- a/deploy/flux/clusters/production/keda.yaml
+++ b/deploy/flux/clusters/production/keda.yaml
@@ -1,0 +1,22 @@
+# KEDA HelmRepository + HelmRelease (deploy/infra/keda/). Separate Kustomization,
+# same reason as cluster.yaml/valkey.yaml/tailscale.yaml: targetNamespace stays
+# unset here so the HelmRepository (flux-system) and HelmRelease (keda) keep
+# their own namespaces, unlike `apps` which pins everything to production.
+# wait is on: the `apps` Kustomization dependsOn this one and needs KEDA's
+# ScaledObject CRD registered (and the admission webhook up) before it applies
+# the outgress/sesame ScaledObjects.
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: keda
+  namespace: flux-system
+spec:
+  interval: 1h
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./deploy/infra/keda
+  prune: true
+  wait: true
+  timeout: 5m

--- a/deploy/infra/keda/kustomization.yaml
+++ b/deploy/infra/keda/kustomization.yaml
@@ -1,0 +1,9 @@
+# KEDA (operator + metrics-server + admission webhooks), reconciled by the Flux
+# "keda" Kustomization (deploy/flux/clusters/production/keda.yaml). No
+# `namespace:` field: targetNamespace stays unset so the HelmRepository (in
+# flux-system) and the HelmRelease (in keda, chart-created) keep their own
+# scoping.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - release.yaml

--- a/deploy/infra/keda/release.yaml
+++ b/deploy/infra/keda/release.yaml
@@ -1,0 +1,86 @@
+# KEDA: greenfield install (no prior out-of-band release to migrate, unlike
+# newrelic.yaml). Drives horizontal scaling for outgress and sesame off
+# JetStream consumer lag (see their ScaledObjects in deploy/k8s/outgress.yaml
+# and deploy/k8s/sesame.yaml) plus a CPU floor.
+#
+# Namespace "keda" does not pre-exist, so install.createNamespace is true
+# (contrast newrelic, whose namespace was created out-of-band).
+#
+# This lives in its own Kustomization (deploy/flux/clusters/production/keda.yaml)
+# rather than inline like newrelic.yaml, because the `apps` Kustomization
+# (deploy/k8s/) now contains ScaledObject resources that require KEDA's CRDs to
+# already be registered. Flux's Kustomization.dependsOn can only reference
+# another Kustomization, not a bare HelmRelease, so KEDA needed a Kustomization
+# of its own for `apps` to depend on (see apps.yaml's dependsOn).
+#
+# CHART VERSION
+# -------------
+# keda 2.20.1 (matches appVersion 2.20.1), exact pin per deploy/flux/README.md's
+# digest-immutability rationale. Bump deliberately; ScaledObject's CRD schema
+# can gain fields between versions.
+#
+# RESOURCES
+# ---------
+# Chart defaults are 100m/100Mi request, 1/1000Mi limit for EACH of
+# operator/metricsServer/webhooks (up to ~3 CPU, 3Gi limit ceiling). Trimmed
+# down for this 3-node fleet the same way newrelic's kubelet integration and
+# the flux controllers were (see newrelic.yaml, flux-system/kustomization.yaml
+# patches): these are a low-throughput personal-scale cluster with a handful of
+# ScaledObjects, not a metric being polled fleet-wide every second. Re-widen if
+# metrics-server or operator gets OOMKilled or throttled in practice.
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: kedacore
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://kedacore.github.io/charts
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: keda
+  namespace: keda
+spec:
+  interval: 1h
+  timeout: 10m
+  releaseName: keda
+  chart:
+    spec:
+      chart: keda
+      version: 2.20.1 # exact pin
+      sourceRef:
+        kind: HelmRepository
+        name: kedacore
+        namespace: flux-system
+      interval: 1h
+  install:
+    createNamespace: true
+    crds: Create
+    remediation:
+      retries: 3
+  upgrade:
+    # CreateReplace (not the install-time default Create): lets a future chart
+    # bump patch an existing ScaledObject/TriggerAuthentication CRD in place,
+    # instead of silently keeping the schema this cluster was bootstrapped with.
+    crds: CreateReplace
+    remediation:
+      retries: 3
+      remediateLastFailure: true
+    cleanupOnFail: true
+  values:
+    watchNamespace: "" # all namespaces; only production uses it today, but the fleet is single-tenant
+    operator:
+      resources:
+        requests: {cpu: 50m, memory: 64Mi}
+        limits: {cpu: 500m, memory: 256Mi}
+    metricsServer:
+      resources:
+        requests: {cpu: 50m, memory: 64Mi}
+        limits: {cpu: 500m, memory: 256Mi}
+    webhooks:
+      resources:
+        requests: {cpu: 25m, memory: 32Mi}
+        limits: {cpu: 250m, memory: 128Mi}

--- a/deploy/k8s/outgress.yaml
+++ b/deploy/k8s/outgress.yaml
@@ -21,7 +21,10 @@ metadata:
   annotations:
     secrets.doppler.com/reload: "true"
 spec:
-  replicas: 3 # one per node; 3 schedulable nodes incl worker1 (tolerates worker-pool); node3 decommissioned
+  # replicas intentionally omitted: the outgress ScaledObject below owns this
+  # field via its generated HPA (floor 3, matching the old static count).
+  # kustomize-controller stops setting it, so SSA hands ownership to the HPA
+  # instead of fighting it every reconcile.
   revisionHistoryLimit: 3
   minReadySeconds: 10
   strategy:
@@ -192,3 +195,69 @@ spec:
   selector:
     matchLabels:
       app: outgress
+---
+# Scales on whichever of the three lanes backs up worst (HPA takes the max
+# recommended replicas across triggers), plus a CPU floor for load that isn't
+# lane-shaped. minReplicaCount 3 matches the old static replicas; outgress is
+# ultimately Twitch-rate-limited (quota is tracked fleet-wide in Valkey, not
+# per-pod - see docs/microservices/outgress.md), so maxReplicaCount stays
+# modest: this buys resilience and headroom under sustained backlog, not more
+# Twitch throughput. Consumer names are bus.durableName(group, subject) from
+# app/outgress/main.go's three LaneConfigs; lag = num_pending + num_ack_pending
+# on that durable (see pkg/bus/bus.go laneConsumerConfig). Tune thresholds from
+# the admin lane-telemetry view (reads $JS.hub.API.CONSUMER.INFO.> live).
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: outgress
+  namespace: production
+spec:
+  scaleTargetRef:
+    name: outgress
+  pollingInterval: 15
+  cooldownPeriod: 300
+  minReplicaCount: 3
+  maxReplicaCount: 6
+  fallback:
+    failureThreshold: 3
+    replicas: 3
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleUp:
+          stabilizationWindowSeconds: 0
+          policies:
+            - {type: Pods, value: 2, periodSeconds: 60}
+        scaleDown:
+          stabilizationWindowSeconds: 300
+          policies:
+            - {type: Pods, value: 1, periodSeconds: 120}
+  triggers:
+    - type: cpu
+      metricType: Utilization
+      metadata:
+        value: "75"
+    - type: nats-jetstream
+      metadata:
+        natsServerMonitoringEndpoint: nats.production.svc.cluster.local:8222
+        account: BUS
+        stream: TWITCH_OUTGRESS
+        consumer: outgress-premium_twitch_outgress_premium
+        lagThreshold: "30"
+        activationLagThreshold: "5"
+    - type: nats-jetstream
+      metadata:
+        natsServerMonitoringEndpoint: nats.production.svc.cluster.local:8222
+        account: BUS
+        stream: TWITCH_OUTGRESS
+        consumer: outgress-standard_twitch_outgress_standard
+        lagThreshold: "150"
+        activationLagThreshold: "20"
+    - type: nats-jetstream
+      metadata:
+        natsServerMonitoringEndpoint: nats.production.svc.cluster.local:8222
+        account: BUS
+        stream: TWITCH_OUTGRESS_SYSTEM
+        consumer: outgress-system_twitch_outgress_system
+        lagThreshold: "20"
+        activationLagThreshold: "5"

--- a/deploy/k8s/sesame.yaml
+++ b/deploy/k8s/sesame.yaml
@@ -26,7 +26,10 @@ metadata:
   annotations:
     secrets.doppler.com/reload: "true"
 spec:
-  replicas: 4 # one per node; 4 schedulable nodes incl worker1 (tolerates worker-pool)
+  # replicas intentionally omitted: the sesame ScaledObject below owns this
+  # field via its generated HPA (floor 4, matching the old static count).
+  # kustomize-controller stops setting it, so SSA hands ownership to the HPA
+  # instead of fighting it every reconcile.
   revisionHistoryLimit: 3
   minReadySeconds: 10
   strategy:
@@ -63,7 +66,8 @@ spec:
           effect: NoExecute
           tolerationSeconds: 60
       # node1 is the 2-core ARM node reserved for stateful/frontend + infra; keep
-      # the hot-path worker off it. KEDA (later) scales onto node2/worker1.
+      # the hot-path worker off it. KEDA (see the ScaledObject below) scales
+      # onto node2/worker1.
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -179,3 +183,60 @@ spec:
   selector:
     matchLabels:
       app: sesame
+---
+# Sesame is the CPU-bound half (decode/dedup/module-dispatch/templating), so
+# unlike outgress this is real throughput headroom, not just resilience -
+# hence the wider maxReplicaCount. minReplicaCount 4 matches the old static
+# replicas. Consumer names are bus.durableName("worker", subject) - sesame
+# shares the worker's pre-existing durable via fleetSubscriber (app/sesame/main.go
+# bus.NewSubscriber(cfg.NATSURL, cfg.ConsumerName, log), ConsumerName=worker),
+# not per-lane groups like outgress. lag = num_pending + num_ack_pending on
+# that durable (see pkg/bus/bus.go laneConsumerConfig). Tune thresholds from
+# the admin lane-telemetry view (reads $JS.hub.API.CONSUMER.INFO.> live).
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: sesame
+  namespace: production
+spec:
+  scaleTargetRef:
+    name: sesame
+  pollingInterval: 15
+  cooldownPeriod: 300
+  minReplicaCount: 4
+  maxReplicaCount: 10
+  fallback:
+    failureThreshold: 3
+    replicas: 4
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleUp:
+          stabilizationWindowSeconds: 0
+          policies:
+            - {type: Pods, value: 2, periodSeconds: 60}
+        scaleDown:
+          stabilizationWindowSeconds: 300
+          policies:
+            - {type: Pods, value: 1, periodSeconds: 120}
+  triggers:
+    - type: cpu
+      metricType: Utilization
+      metadata:
+        value: "75"
+    - type: nats-jetstream
+      metadata:
+        natsServerMonitoringEndpoint: nats.production.svc.cluster.local:8222
+        account: BUS
+        stream: TWITCH_INGRESS
+        consumer: worker_twitch_ingress_event_premium
+        lagThreshold: "30"
+        activationLagThreshold: "5"
+    - type: nats-jetstream
+      metadata:
+        natsServerMonitoringEndpoint: nats.production.svc.cluster.local:8222
+        account: BUS
+        stream: TWITCH_INGRESS
+        consumer: worker_twitch_ingress_event_standard
+        lagThreshold: "150"
+        activationLagThreshold: "20"


### PR DESCRIPTION
## Summary
- Install KEDA via its own Flux Kustomization (deploy/infra/keda), with `apps` set to `dependsOn: keda` so the ScaledObject CRD exists before it's needed.
- Add ScaledObjects for outgress and sesame, dropping their static per-node `replicas:` in favor of HPA-owned scaling.
- Scale trigger: NATS JetStream consumer lag (num_pending + num_ack_pending) per lane, plus a CPU utilization floor.
  - outgress: 3 lanes (premium/standard/system), floor 3 / ceiling 6 — rate-limited by Twitch fleet-wide via Valkey, so this buys resilience/backlog headroom, not more throughput.
  - sesame: 2 lanes (shared `worker` durable), floor 4 / ceiling 10 — the actual CPU-bound pipeline, real scaling payoff.

## Test plan
- [x] `kubectl kustomize deploy/infra/keda` builds clean
- [x] `kubectl kustomize deploy/k8s` builds clean, both ScaledObjects render
- [x] `kubectl apply --dry-run=client` on the built output — only failure is the expected "no matches for kind ScaledObject" (CRD not yet installed client-side), everything else structurally valid
- [ ] Live cluster: confirm KEDA HelmRelease reconciles Ready, ScaledObjects reach Active, HPAs generated before first real load