### PR TITLE
fix(deploy): sync default-deny-apps selector with live workloads

### DIFF
--- a/deploy/k8s/network-policies.yaml
+++ b/deploy/k8s/network-policies.yaml
@@ -9,7 +9,7 @@ spec:
     matchExpressions:
       - key: app
         operator: In
-        values: [users, commands, modules, transactions, projector, worker, admin, twitch-ingress, outgress, console-dashboard, console-admin, gateway]
+        values: [users, commands, modules, transactions, projector, sesame, twitch-ingress, outgress, console-dashboard, console-admin, gateway, notifications]
   policyTypes:
     - Ingress
     - Egress


### PR DESCRIPTION
## Summary
- `default-deny-apps` NetworkPolicy selector still listed `worker` and `admin`, both dead since the console rewrite/sesame cutover (replaced by `sesame` and `console-admin`)
- `notifications` (live since 2026-07-02) was never added
- Pods with labels outside the selector's `In[]` list get zero NetworkPolicy enforcement, so `sesame` and `notifications` were running fully open on ingress/egress

## Fix
Replace `worker`→`sesame`, drop stale `admin`, add `notifications`. Verified against every `app:` label under `deploy/k8s/*.yaml` Deployments; `nats`/`nats-leaf` and the `notifications-cleanup` CronJob remain intentionally excluded (documented un-meshed/NATS-creds-only in-repo).

## Test plan
- [x] Diffed selector values against all live Deployment `app:` labels in deploy/k8s/