### PR TITLE
fix(ingress): cap per-broadcaster dispatcher share, raise pod capacity

### DIFF
--- a/app/ingress/config/runtime.exs
+++ b/app/ingress/config/runtime.exs
@@ -95,8 +95,15 @@ config :ingress,
   # bounded task dispatcher. Dropping here is better than letting socket
   # mailboxes grow until Twitch keepalives/reconnects are delayed.
   dispatcher_max_running:
-    String.to_integer(System.get_env("INGRESS_DISPATCHER_MAX_RUNNING", "64")),
-  dispatcher_max_queue: String.to_integer(System.get_env("INGRESS_DISPATCHER_MAX_QUEUE", "2000"))
+    String.to_integer(System.get_env("INGRESS_DISPATCHER_MAX_RUNNING", "512")),
+  dispatcher_max_queue:
+    String.to_integer(System.get_env("INGRESS_DISPATCHER_MAX_QUEUE", "20000")),
+  # Caps one broadcaster's share of the dispatcher budget above, so a hot
+  # channel can't starve every other broadcaster sharing the pod.
+  dispatcher_max_per_broadcaster:
+    String.to_integer(System.get_env("INGRESS_DISPATCHER_MAX_PER_BROADCASTER", "2048")),
+  dispatcher_broadcaster_sweep_ms:
+    String.to_integer(System.get_env("INGRESS_DISPATCHER_BROADCASTER_SWEEP_MS", "60000"))
 
 # Credentials are optional so local development can run against an open
 # server; the production broker requires them and Gnat only sends them when

--- a/app/ingress/lib/ingress/admin_rpc.ex
+++ b/app/ingress/lib/ingress/admin_rpc.ex
@@ -14,7 +14,9 @@ defmodule Ingress.AdminRpc do
   `Ingress.ShardScaler`, not the static config value. Additional top-level
   fields (`desired_count`, `target`, `min_shards`, `autoscale`) expose the
   scaler's view so the admin console can show the full picture without a
-  separate RPC call.
+  separate RPC call. `max_load`/`max_load_shard_id` identify the single
+  hottest shard from the scaler's last autoscale sample, for spotting a
+  broadcaster concentrated on one shard even when aggregate load looks fine.
   """
 
   use Gnat.Server
@@ -75,6 +77,8 @@ defmodule Ingress.AdminRpc do
       target: scaler.target,
       min_shards: scaler.min_shards,
       autoscale: scaler.autoscale,
+      max_load: scaler.max_load,
+      max_load_shard_id: scaler.max_load_shard_id,
       conduit_manager: manager_status(),
       shards: shards
     }

--- a/app/ingress/lib/ingress/config.ex
+++ b/app/ingress/lib/ingress/config.ex
@@ -65,10 +65,22 @@ defmodule Ingress.Config do
     do: Application.get_env(:ingress, :max_chat_text_bytes, 4_096)
 
   def dispatcher_max_running,
-    do: Application.get_env(:ingress, :dispatcher_max_running, 64)
+    do: Application.get_env(:ingress, :dispatcher_max_running, 512)
 
   def dispatcher_max_queue,
-    do: Application.get_env(:ingress, :dispatcher_max_queue, 2_000)
+    do: Application.get_env(:ingress, :dispatcher_max_queue, 20_000)
+
+  # Caps how much of the pod-wide dispatcher budget (max_running + max_queue) a
+  # single broadcaster can occupy at once, so a hot/raiding channel can't starve
+  # every other broadcaster sharing the pod's shared worker pool.
+  def dispatcher_max_per_broadcaster,
+    do: Application.get_env(:ingress, :dispatcher_max_per_broadcaster, 2_048)
+
+  # How often dead (zeroed) per-broadcaster counters are swept from the
+  # dispatcher's ETS table, so a long-lived pod doesn't accumulate one entry per
+  # distinct broadcaster ever seen.
+  def dispatcher_broadcaster_sweep_ms,
+    do: Application.get_env(:ingress, :dispatcher_broadcaster_sweep_ms, 60_000)
 
   # Gnat connection_settings (a leaf-first list of server maps) for the two
   # planes: :nats is the twitch_ingress RPC account, :nats_bus the shared BUS

--- a/app/ingress/lib/ingress/dispatcher.ex
+++ b/app/ingress/lib/ingress/dispatcher.ex
@@ -5,6 +5,13 @@ defmodule Ingress.Dispatcher do
   ShardSession owns the websocket socket, so it should only decode enough to
   enqueue work. Filtering, broadcaster cache misses, JSON encoding, and NATS
   publish happen in supervised tasks behind this process.
+
+  Capacity (`max_running` + `max_queue`) is one shared pool per pod, not per
+  shard — a node can host more than one `ShardSession`. A second, per-broadcaster
+  ETS counter (`max_per_broadcaster`) caps how much of that shared pool one
+  broadcaster can consume at once, so a hot channel can't starve every other
+  broadcaster sharing the pod. Dead per-broadcaster counters are swept
+  periodically. `:name` is overridable for test isolation.
   """
 
   use GenServer
@@ -14,51 +21,103 @@ defmodule Ingress.Dispatcher do
   alias Ingress.{Config, Metrics}
 
   defstruct [
+    :name,
     :max_running,
     :max_queue,
+    :sweep_ms,
     idle_workers: :queue.new(),
     busy_workers: %{},
     queue: :queue.new()
   ]
 
   @spec start_link(keyword()) :: GenServer.on_start()
-  def start_link(opts), do: GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: Keyword.get(opts, :name, __MODULE__))
+  end
 
-  @spec dispatch(map(), map()) :: :ok
-  def dispatch(payload, meta) do
-    case Process.whereis(__MODULE__) do
+  @spec dispatch(map(), map(), GenServer.server()) :: :ok
+  def dispatch(payload, meta, server \\ __MODULE__) do
+    case Process.whereis(server) do
       nil ->
-        Metrics.count("Dispatcher/Dropped")
         Logger.warning("ingress dispatcher unavailable; dropping notification")
-        :ok
+        drop(meta, "unavailable")
 
       pid ->
-        try do
-          count = :ets.update_counter(__MODULE__, :admitted_count, {2, 1})
-          capacity = :ets.lookup_element(__MODULE__, :capacity, 2)
-
-          if count > capacity do
-            :ets.update_counter(__MODULE__, :admitted_count, {2, -1})
-            Metrics.count("Dispatcher/Dropped")
-          else
-            send(pid, {:dispatch, payload, meta})
-          end
-        catch
-          :error, :badarg ->
-            Metrics.count("Dispatcher/Dropped")
-        end
-
-        :ok
+        admit(pid, server, payload, meta)
     end
+
+    :ok
+  end
+
+  defp admit(pid, server, payload, meta) do
+    broadcaster_id = Map.get(meta, :broadcaster_id)
+
+    try do
+      if broadcaster_admitted?(server, broadcaster_id, meta) do
+        count = :ets.update_counter(server, :admitted_count, {2, 1})
+        capacity = :ets.lookup_element(server, :capacity, 2)
+
+        if count > capacity do
+          :ets.update_counter(server, :admitted_count, {2, -1})
+          release_broadcaster_slot(server, broadcaster_id)
+          drop(meta, "capacity")
+        else
+          send(pid, {:dispatch, payload, meta})
+        end
+      end
+    catch
+      :error, :badarg -> drop(meta, "unavailable")
+    end
+  end
+
+  # No broadcaster to attribute (malformed/unrecognized event shape): fail open,
+  # only the pod-wide capacity check applies.
+  defp broadcaster_admitted?(_server, nil, _meta), do: true
+
+  defp broadcaster_admitted?(server, broadcaster_id, meta) do
+    count =
+      :ets.update_counter(server, {:bc, broadcaster_id}, {2, 1}, {{:bc, broadcaster_id}, 0})
+
+    max_per_bc = :ets.lookup_element(server, :max_per_broadcaster, 2)
+
+    if count > max_per_bc do
+      :ets.update_counter(server, {:bc, broadcaster_id}, {2, -1})
+      drop(meta, "broadcaster_cap")
+      false
+    else
+      true
+    end
+  end
+
+  defp release_broadcaster_slot(_server, nil), do: :ok
+
+  defp release_broadcaster_slot(server, broadcaster_id) do
+    :ets.update_counter(server, {:bc, broadcaster_id}, {2, -1})
+  end
+
+  defp drop(meta, reason) do
+    Metrics.count("Dispatcher/Dropped")
+
+    Metrics.event("Dispatcher/Dropped", %{
+      reason: reason,
+      shard_id: Map.get(meta, :shard_id),
+      broadcaster_id: Map.get(meta, :broadcaster_id)
+    })
   end
 
   @impl true
   def init(opts) do
+    name = Keyword.get(opts, :name, __MODULE__)
     max_running = Keyword.get(opts, :max_running, Config.dispatcher_max_running())
     max_queue = Keyword.get(opts, :max_queue, Config.dispatcher_max_queue())
+
+    max_per_broadcaster =
+      Keyword.get(opts, :max_per_broadcaster, Config.dispatcher_max_per_broadcaster())
+
+    sweep_ms = Keyword.get(opts, :sweep_ms, Config.dispatcher_broadcaster_sweep_ms())
     capacity = max_running + max_queue
 
-    :ets.new(__MODULE__, [
+    :ets.new(name, [
       :named_table,
       :public,
       :set,
@@ -66,10 +125,19 @@ defmodule Ingress.Dispatcher do
       write_concurrency: true
     ])
 
-    :ets.insert(__MODULE__, {:admitted_count, 0})
-    :ets.insert(__MODULE__, {:capacity, capacity})
+    :ets.insert(name, {:admitted_count, 0})
+    :ets.insert(name, {:capacity, capacity})
+    :ets.insert(name, {:max_per_broadcaster, max_per_broadcaster})
 
-    {:ok, %__MODULE__{max_running: max_running, max_queue: max_queue}}
+    schedule_sweep(sweep_ms)
+
+    {:ok,
+     %__MODULE__{
+       name: name,
+       max_running: max_running,
+       max_queue: max_queue,
+       sweep_ms: sweep_ms
+     }}
   end
 
   @impl true
@@ -82,7 +150,7 @@ defmodule Ingress.Dispatcher do
         state = %{
           state
           | idle_workers: idle_workers,
-            busy_workers: Map.put(state.busy_workers, worker_pid, true)
+            busy_workers: Map.put(state.busy_workers, worker_pid, meta)
         }
 
         {:noreply, state}
@@ -95,12 +163,15 @@ defmodule Ingress.Dispatcher do
 
   def handle_info({:worker_ready, worker_pid}, state) do
     state =
-      if Map.has_key?(state.busy_workers, worker_pid) do
-        :ets.update_counter(__MODULE__, :admitted_count, {2, -1})
-        %{state | busy_workers: Map.delete(state.busy_workers, worker_pid)}
-      else
-        Process.monitor(worker_pid)
-        state
+      case Map.pop(state.busy_workers, worker_pid) do
+        {nil, busy_workers} ->
+          Process.monitor(worker_pid)
+          %{state | busy_workers: busy_workers}
+
+        {meta, busy_workers} ->
+          :ets.update_counter(state.name, :admitted_count, {2, -1})
+          release_broadcaster_slot(state.name, Map.get(meta, :broadcaster_id))
+          %{state | busy_workers: busy_workers}
       end
 
     case :queue.out(state.queue) do
@@ -111,7 +182,7 @@ defmodule Ingress.Dispatcher do
         state = %{
           state
           | queue: queue,
-            busy_workers: Map.put(state.busy_workers, worker_pid, true)
+            busy_workers: Map.put(state.busy_workers, worker_pid, meta)
         }
 
         {:noreply, state}
@@ -122,16 +193,36 @@ defmodule Ingress.Dispatcher do
   end
 
   def handle_info({:DOWN, _ref, :process, pid, _reason}, state) do
-    if Map.has_key?(state.busy_workers, pid) do
-      :ets.update_counter(__MODULE__, :admitted_count, {2, -1})
-      Metrics.count("Dispatcher/TaskFailed")
-    end
+    state =
+      case Map.pop(state.busy_workers, pid) do
+        {nil, busy_workers} ->
+          %{state | busy_workers: busy_workers}
 
-    state = %{state | busy_workers: Map.delete(state.busy_workers, pid)}
+        {meta, busy_workers} ->
+          :ets.update_counter(state.name, :admitted_count, {2, -1})
+          release_broadcaster_slot(state.name, Map.get(meta, :broadcaster_id))
+
+          Metrics.count("Dispatcher/TaskFailed")
+
+          Metrics.event("Dispatcher/TaskFailed", %{
+            shard_id: Map.get(meta, :shard_id),
+            broadcaster_id: Map.get(meta, :broadcaster_id)
+          })
+
+          %{state | busy_workers: busy_workers}
+      end
 
     idle_list = :queue.to_list(state.idle_workers) |> Enum.reject(&(&1 == pid))
     state = %{state | idle_workers: :queue.from_list(idle_list)}
 
     {:noreply, state}
   end
+
+  def handle_info(:sweep, state) do
+    :ets.select_delete(state.name, [{{{:bc, :"$1"}, 0}, [], [true]}])
+    schedule_sweep(state.sweep_ms)
+    {:noreply, state}
+  end
+
+  defp schedule_sweep(sweep_ms), do: Process.send_after(self(), :sweep, sweep_ms)
 end

--- a/app/ingress/lib/ingress/shard_scaler.ex
+++ b/app/ingress/lib/ingress/shard_scaler.ex
@@ -35,7 +35,7 @@ defmodule Ingress.ShardScaler do
   use GenServer
   require Logger
 
-  alias Ingress.Config
+  alias Ingress.{Config, Metrics}
   # --- tunables ---------------------------------------------------------------
 
   # How often the autoscaler evaluates load.
@@ -134,6 +134,8 @@ defmodule Ingress.ShardScaler do
   def handle_call(:status, _from, state) do
     min_s = min_shards()
     load = if state.last_sample, do: state.last_sample.aggregate_load, else: 0
+    max_load = if state.last_sample, do: state.last_sample.max_load, else: 0
+    max_load_shard_id = if state.last_sample, do: state.last_sample.max_load_shard_id, else: nil
 
     {:reply,
      %{
@@ -142,6 +144,8 @@ defmodule Ingress.ShardScaler do
        min_shards: min_s,
        desired: compute_desired(state),
        load: load,
+       max_load: max_load,
+       max_load_shard_id: max_load_shard_id,
        last_sample: state.last_sample
      }, state}
   end
@@ -201,6 +205,7 @@ defmodule Ingress.ShardScaler do
   defp evaluate_autoscale(state) do
     sample = sample_shards(state)
     state = %{state | last_sample: sample}
+    check_concentration(sample)
 
     min_s = min_shards()
 
@@ -244,14 +249,34 @@ defmodule Ingress.ShardScaler do
     %{state | target: new_target, ticks: ticks}
   end
 
+  # Independent of the scaling decision above: flags a single shard carrying a
+  # disproportionate share of load (a hot broadcaster). More shards can't fix
+  # this — Twitch owns broadcaster→shard placement — so this only surfaces it.
+  defp check_concentration(sample) do
+    if Ingress.ShardScaler.Policy.concentrated?(sample) do
+      Logger.warning(
+        "shard_scaler: shard #{sample.max_load_shard_id} concentrated at load=#{sample.max_load}/window vs avg=#{sample.avg_load}/window"
+      )
+
+      Metrics.event("ShardLoadConcentration", %{
+        shard_id: sample.max_load_shard_id,
+        max_load: sample.max_load,
+        avg_load: sample.avg_load,
+        responsive_count: sample.responsive_count
+      })
+    end
+  end
+
   defp sample_shards(state) do
     expected = compute_desired(state)
 
     if expected == 0 do
-      %{expected_count: 0, responsive_count: 0, missing_count: 0, aggregate_load: 0, avg_load: 0}
+      Ingress.ShardScaler.Policy.summarize_sample(0, [])
     else
-      results =
-        0..(expected - 1)
+      shard_ids = 0..(expected - 1)
+
+      per_shard_results =
+        shard_ids
         |> Task.async_stream(
           fn shard_id ->
             case Horde.Registry.lookup(Ingress.Registry, {:shard, shard_id}) do
@@ -271,24 +296,13 @@ defmodule Ingress.ShardScaler do
           timeout: 1_500,
           on_timeout: :kill_task
         )
-        |> Enum.to_list()
-
-      {responsive, total_load} =
-        Enum.reduce(results, {0, 0}, fn
-          {:ok, {:ok, load}}, {r, l} -> {r + 1, l + load}
-          _, {r, l} -> {r, l}
+        |> Enum.zip(shard_ids)
+        |> Enum.map(fn
+          {{:ok, result}, shard_id} -> {shard_id, result}
+          {{:exit, _reason}, shard_id} -> {shard_id, :error}
         end)
 
-      missing = expected - responsive
-      avg = if responsive > 0, do: div(total_load, responsive), else: 0
-
-      %{
-        expected_count: expected,
-        responsive_count: responsive,
-        missing_count: missing,
-        aggregate_load: total_load,
-        avg_load: avg
-      }
+      Ingress.ShardScaler.Policy.summarize_sample(expected, per_shard_results)
     end
   end
 
@@ -307,6 +321,8 @@ defmodule Ingress.ShardScaler do
       min_shards: min_shards(),
       desired: Config.conduit_shard_count(),
       load: 0,
+      max_load: 0,
+      max_load_shard_id: nil,
       last_sample: nil
     }
   end

--- a/app/ingress/lib/ingress/shard_scaler/policy.ex
+++ b/app/ingress/lib/ingress/shard_scaler/policy.ex
@@ -35,11 +35,21 @@ defmodule Ingress.ShardScaler.Policy do
   @scale_up_ticks 2
   # Consecutive ticks of overcapacity required before scaling down.
   @scale_down_ticks 3
+  # A shard is "concentrated" (one hot broadcaster, not routine unevenness)
+  # when its load is at least this many times the fleet average...
+  @concentration_ratio 3
+  # ...AND at least this percent of one shard's own rated budget. The ratio
+  # alone is noisy on a small/lightly loaded fleet (e.g. one idle shard makes
+  # any nonzero shard "infinitely" above average); the absolute floor keeps
+  # that case from alerting on routine traffic.
+  @concentration_min_pct 25
 
   def shard_rated_eps, do: @shard_rated_eps
   def target_utilization_pct, do: @target_utilization_pct
   def scale_up_ticks, do: @scale_up_ticks
   def scale_down_ticks, do: @scale_down_ticks
+  def concentration_ratio, do: @concentration_ratio
+  def concentration_min_pct, do: @concentration_min_pct
 
   @doc """
   Events per window one shard is rated for (100% utilization).
@@ -58,6 +68,64 @@ defmodule Ingress.ShardScaler.Policy do
   """
   def shards_needed(aggregate_load) do
     max(ceil(aggregate_load / budget_per_window()), 1)
+  end
+
+  @doc """
+  Reduces per-shard `{shard_id, {:ok, load} | :error}` results into the sample
+  map the rest of this module consumes, tracking which shard carried the
+  highest load alongside the existing aggregate/average.
+
+  `expected` is the shard count the caller asked for (independent of how many
+  actually responded), preserved so the returned shape is always the same
+  regardless of how many results came back.
+  """
+  @spec summarize_sample(non_neg_integer(), [{term(), {:ok, non_neg_integer()} | :error}]) ::
+          map()
+  def summarize_sample(expected, per_shard_results) do
+    {responsive, total_load, max_load, max_load_shard_id} =
+      Enum.reduce(per_shard_results, {0, 0, 0, nil}, fn
+        {shard_id, {:ok, load}}, {r, l, max_l, max_id} ->
+          if load > max_l do
+            {r + 1, l + load, load, shard_id}
+          else
+            {r + 1, l + load, max_l, max_id}
+          end
+
+        {_shard_id, :error}, acc ->
+          acc
+      end)
+
+    missing = expected - responsive
+    avg = if responsive > 0, do: div(total_load, responsive), else: 0
+
+    %{
+      expected_count: expected,
+      responsive_count: responsive,
+      missing_count: missing,
+      aggregate_load: total_load,
+      avg_load: avg,
+      max_load: max_load,
+      max_load_shard_id: max_load_shard_id
+    }
+  end
+
+  @doc """
+  True when one shard's load looks like a hot broadcaster concentrated on it
+  rather than routine unevenness: at least `@concentration_ratio`× the fleet
+  average, AND at least `@concentration_min_pct` of one shard's own rated
+  budget. Requires more than one responsive shard — "average" is meaningless
+  with just one data point, and a lone shard being the max is not
+  concentration, it's the whole fleet.
+
+  This never changes a scaling decision (see `evaluate/5`): more shards can't
+  move an already-placed hot broadcaster off the shard Twitch assigned it to.
+  It only flags that the situation exists so it can be surfaced.
+  """
+  @spec concentrated?(map()) :: boolean()
+  def concentrated?(sample) do
+    sample.responsive_count > 1 and
+      sample.max_load > sample.avg_load * @concentration_ratio and
+      sample.max_load > div(budget_per_window() * @concentration_min_pct, 100)
   end
 
   @doc """

--- a/app/ingress/lib/ingress/shard_session.ex
+++ b/app/ingress/lib/ingress/shard_session.ex
@@ -462,7 +462,8 @@ defmodule Ingress.ShardSession do
     Ingress.Dispatcher.dispatch(payload, %{
       shard_id: state.shard_id,
       msg_id: meta["message_id"],
-      ts: meta["message_timestamp"]
+      ts: meta["message_timestamp"],
+      broadcaster_id: Ingress.Pipeline.broadcaster_id(payload["event"] || %{})
     })
 
     {:noreply, state |> count_notification() |> pet_watchdog()}

--- a/app/ingress/test/dispatcher_test.exs
+++ b/app/ingress/test/dispatcher_test.exs
@@ -1,0 +1,202 @@
+defmodule Ingress.DispatcherTest do
+  use ExUnit.Case, async: true
+
+  alias Ingress.Dispatcher
+
+  defp start_dispatcher(opts \\ []) do
+    name = :"dispatcher_#{System.unique_integer([:positive])}"
+
+    defaults = [
+      name: name,
+      max_running: 2,
+      max_queue: 2,
+      max_per_broadcaster: 2,
+      sweep_ms: 60_000
+    ]
+
+    start_supervised!({Dispatcher, Keyword.merge(defaults, opts)})
+    name
+  end
+
+  # Stands in for Ingress.Dispatcher.Worker: speaks the same
+  # {:worker_ready, pid} / {:process, payload, meta} protocol without touching
+  # Pipeline/NATS. Stays parked after reporting a unit back to the test process
+  # until told to :finish, so tests can control exactly when a slot frees up.
+  # Deliberately unlinked: one test kills its worker with Process.exit(:kill),
+  # which would tear down the test process too if it were spawn_link'd (:kill
+  # propagates through links unconditionally, unlike every other exit reason).
+  defp spawn_fake_worker(dispatcher, test_pid) do
+    spawn(fn -> fake_worker_loop(dispatcher, test_pid) end)
+  end
+
+  defp fake_worker_loop(dispatcher, test_pid) do
+    send(dispatcher, {:worker_ready, self()})
+
+    receive do
+      {:"$gen_cast", {:process, payload, meta}} ->
+        send(test_pid, {:processed, self(), payload, meta})
+
+        receive do
+          :finish -> fake_worker_loop(dispatcher, test_pid)
+        end
+    end
+  end
+
+  defp meta(broadcaster_id), do: %{shard_id: 0, broadcaster_id: broadcaster_id}
+
+  defp counts(dispatcher, broadcaster_id) do
+    admitted = :ets.lookup_element(dispatcher, :admitted_count, 2)
+
+    bc =
+      case :ets.lookup(dispatcher, {:bc, broadcaster_id}) do
+        [{_, count}] -> count
+        [] -> 0
+      end
+
+    {admitted, bc}
+  end
+
+  defp eventually(fun, attempts \\ 50) do
+    cond do
+      fun.() ->
+        :ok
+
+      attempts <= 0 ->
+        flunk("condition not met in time")
+
+      true ->
+        Process.sleep(10)
+        eventually(fun, attempts - 1)
+    end
+  end
+
+  test "admits under capacity and dispatches to an idle worker" do
+    dispatcher = start_dispatcher()
+    worker = spawn_fake_worker(dispatcher, self())
+
+    assert Dispatcher.dispatch(%{text: "hi"}, meta("b1"), dispatcher) == :ok
+    assert_receive {:processed, ^worker, %{text: "hi"}, %{broadcaster_id: "b1"}}, 500
+  end
+
+  test "drops past pod-wide capacity" do
+    dispatcher = start_dispatcher(max_running: 1, max_queue: 0, max_per_broadcaster: 10)
+
+    # No worker is registered, so nothing ever frees admitted_count: the
+    # second dispatch is strictly over capacity (1 running + 0 queue).
+    assert Dispatcher.dispatch(%{n: 1}, meta("b1"), dispatcher) == :ok
+    assert Dispatcher.dispatch(%{n: 2}, meta("b1"), dispatcher) == :ok
+
+    assert counts(dispatcher, "b1") == {1, 1}
+  end
+
+  test "one broadcaster hitting its cap is rejected while another broadcaster is still admitted" do
+    dispatcher = start_dispatcher(max_running: 10, max_queue: 10, max_per_broadcaster: 1)
+    worker = spawn_fake_worker(dispatcher, self())
+
+    assert Dispatcher.dispatch(%{n: 1}, meta("hot"), dispatcher) == :ok
+    assert_receive {:processed, ^worker, %{n: 1}, _}, 500
+
+    # "hot" is now at its cap (1) and that unit is still in flight (the fake
+    # worker is parked, has not sent :finish/looped back to ready).
+    assert Dispatcher.dispatch(%{n: 2}, meta("hot"), dispatcher) == :ok
+    refute_receive {:processed, _, %{n: 2}, _}, 200
+
+    other_worker = spawn_fake_worker(dispatcher, self())
+    assert Dispatcher.dispatch(%{n: 3}, meta("other"), dispatcher) == :ok
+    assert_receive {:processed, ^other_worker, %{n: 3}, %{broadcaster_id: "other"}}, 500
+
+    send(worker, :finish)
+    send(other_worker, :finish)
+  end
+
+  test "rejection rolls both counters back to their exact pre-attempt values" do
+    dispatcher = start_dispatcher(max_running: 5, max_queue: 5, max_per_broadcaster: 1)
+    worker = spawn_fake_worker(dispatcher, self())
+
+    assert Dispatcher.dispatch(%{n: 1}, meta("b1"), dispatcher) == :ok
+    assert_receive {:processed, ^worker, %{n: 1}, _}, 500
+    assert counts(dispatcher, "b1") == {1, 1}
+
+    assert Dispatcher.dispatch(%{n: 2}, meta("b1"), dispatcher) == :ok
+    refute_receive {:processed, _, %{n: 2}, _}, 200
+    assert counts(dispatcher, "b1") == {1, 1}
+
+    send(worker, :finish)
+  end
+
+  test "completing work frees both counters so a capped broadcaster can be admitted again" do
+    dispatcher = start_dispatcher(max_running: 5, max_queue: 5, max_per_broadcaster: 1)
+    worker = spawn_fake_worker(dispatcher, self())
+
+    assert Dispatcher.dispatch(%{n: 1}, meta("b1"), dispatcher) == :ok
+    assert_receive {:processed, ^worker, %{n: 1}, _}, 500
+
+    assert Dispatcher.dispatch(%{n: 2}, meta("b1"), dispatcher) == :ok
+    refute_receive {:processed, _, %{n: 2}, _}, 200
+
+    send(worker, :finish)
+    eventually(fn -> counts(dispatcher, "b1") == {0, 0} end)
+
+    assert Dispatcher.dispatch(%{n: 3}, meta("b1"), dispatcher) == :ok
+    assert_receive {:processed, ^worker, %{n: 3}, _}, 500
+
+    send(worker, :finish)
+  end
+
+  test "a worker crash still releases both counters" do
+    dispatcher = start_dispatcher(max_running: 5, max_queue: 5, max_per_broadcaster: 1)
+    worker = spawn_fake_worker(dispatcher, self())
+
+    assert Dispatcher.dispatch(%{n: 1}, meta("b1"), dispatcher) == :ok
+    assert_receive {:processed, ^worker, %{n: 1}, _}, 500
+    assert counts(dispatcher, "b1") == {1, 1}
+
+    Process.exit(worker, :kill)
+    eventually(fn -> counts(dispatcher, "b1") == {0, 0} end)
+  end
+
+  test "nil broadcaster_id is never capped and releases without crashing" do
+    dispatcher = start_dispatcher(max_running: 5, max_queue: 5, max_per_broadcaster: 1)
+    worker = spawn_fake_worker(dispatcher, self())
+
+    assert Dispatcher.dispatch(%{n: 1}, meta(nil), dispatcher) == :ok
+    assert_receive {:processed, ^worker, %{n: 1}, %{broadcaster_id: nil}}, 500
+    send(worker, :finish)
+
+    assert Dispatcher.dispatch(%{n: 2}, meta(nil), dispatcher) == :ok
+    assert_receive {:processed, ^worker, %{n: 2}, %{broadcaster_id: nil}}, 500
+    send(worker, :finish)
+  end
+
+  test "a queued item's broadcaster is correctly attributed once it is later dispatched" do
+    dispatcher = start_dispatcher(max_running: 1, max_queue: 5, max_per_broadcaster: 5)
+    worker = spawn_fake_worker(dispatcher, self())
+
+    assert Dispatcher.dispatch(%{n: 1}, meta("b1"), dispatcher) == :ok
+    assert_receive {:processed, ^worker, %{n: 1}, _}, 500
+
+    # Only one running slot exists and it's held by b1's in-flight unit, so
+    # b2's dispatch lands in the internal queue rather than a worker.
+    assert Dispatcher.dispatch(%{n: 2}, meta("b2"), dispatcher) == :ok
+    refute_receive {:processed, _, %{n: 2}, _}, 200
+    assert counts(dispatcher, "b2") == {2, 1}
+
+    send(worker, :finish)
+    assert_receive {:processed, ^worker, %{n: 2}, %{broadcaster_id: "b2"}}, 500
+
+    send(worker, :finish)
+  end
+
+  test "the sweep removes a zeroed per-broadcaster entry" do
+    dispatcher =
+      start_dispatcher(max_running: 5, max_queue: 5, max_per_broadcaster: 5, sweep_ms: 20)
+
+    worker = spawn_fake_worker(dispatcher, self())
+
+    assert Dispatcher.dispatch(%{n: 1}, meta("b1"), dispatcher) == :ok
+    assert_receive {:processed, ^worker, %{n: 1}, _}, 500
+    send(worker, :finish)
+
+    eventually(fn -> :ets.lookup(dispatcher, {:bc, "b1"}) == [] end)
+  end
+end

--- a/app/ingress/test/shard_scaler_policy_test.exs
+++ b/app/ingress/test/shard_scaler_policy_test.exs
@@ -38,17 +38,23 @@ defmodule Ingress.ShardScaler.PolicyTest do
       # The original bug: 240 events/window aggregate on a 4-shard fleet
       # must not add capacity.
       s = sample(240)
-      assert {4, %{low: 1, high: 0}, :hold} = Policy.evaluate(s, 4, Policy.reset_ticks(), @min, @max)
+
+      assert {4, %{low: 1, high: 0}, :hold} =
+               Policy.evaluate(s, 4, Policy.reset_ticks(), @min, @max)
     end
 
     test "load within the current fleet's budget holds" do
       s = sample(Policy.budget_per_window() * 4)
-      assert {4, %{low: 0, high: 0}, :hold} = Policy.evaluate(s, 4, Policy.reset_ticks(), @min, @max)
+
+      assert {4, %{low: 0, high: 0}, :hold} =
+               Policy.evaluate(s, 4, Policy.reset_ticks(), @min, @max)
     end
 
     test "a single undercapacity tick does not scale up" do
       s = sample(Policy.budget_per_window() * 4 + 1)
-      assert {4, %{high: 1, low: 0}, :hold} = Policy.evaluate(s, 4, Policy.reset_ticks(), @min, @max)
+
+      assert {4, %{high: 1, low: 0}, :hold} =
+               Policy.evaluate(s, 4, Policy.reset_ticks(), @min, @max)
     end
 
     test "sustained undercapacity jumps straight to the needed count" do
@@ -117,6 +123,78 @@ defmodule Ingress.ShardScaler.PolicyTest do
 
       assert {5, %{low: 0, high: 0}, :hold} =
                Policy.evaluate(s, 5, %{low: 2, high: 0}, @min, @max)
+    end
+  end
+
+  describe "summarize_sample/2" do
+    test "even distribution attributes the max to the actual highest shard" do
+      results = [{0, {:ok, 10}}, {1, {:ok, 20}}, {2, {:ok, 15}}]
+
+      assert Policy.summarize_sample(3, results) == %{
+               expected_count: 3,
+               responsive_count: 3,
+               missing_count: 0,
+               aggregate_load: 45,
+               avg_load: 15,
+               max_load: 20,
+               max_load_shard_id: 1
+             }
+    end
+
+    test "one hot shard among idle ones is attributed to its own shard_id, not enumeration order" do
+      results = [{0, {:ok, 5}}, {1, {:ok, 5}}, {2, {:ok, 500}}, {3, {:ok, 5}}]
+
+      summary = Policy.summarize_sample(4, results)
+      assert summary.max_load == 500
+      assert summary.max_load_shard_id == 2
+      assert summary.aggregate_load == 515
+      assert summary.responsive_count == 4
+    end
+
+    test "all-erroring input yields a zeroed, nil-shard shape" do
+      results = [{0, :error}, {1, :error}]
+
+      assert Policy.summarize_sample(2, results) == %{
+               expected_count: 2,
+               responsive_count: 0,
+               missing_count: 2,
+               aggregate_load: 0,
+               avg_load: 0,
+               max_load: 0,
+               max_load_shard_id: nil
+             }
+    end
+
+    test "expected: 0 with no results is a consistent, zeroed shape" do
+      assert Policy.summarize_sample(0, []) == %{
+               expected_count: 0,
+               responsive_count: 0,
+               missing_count: 0,
+               aggregate_load: 0,
+               avg_load: 0,
+               max_load: 0,
+               max_load_shard_id: nil
+             }
+    end
+  end
+
+  describe "concentrated?/1" do
+    test "below both the ratio and the absolute floor is not concentrated" do
+      refute Policy.concentrated?(%{responsive_count: 4, avg_load: 1_000, max_load: 2_000})
+    end
+
+    test "above the ratio but below the absolute floor is not concentrated (small-fleet false positive guard)" do
+      # 500 is 5x a tiny average, but nowhere near a real shard's rated
+      # budget - routine unevenness on a lightly loaded fleet, not a raid.
+      refute Policy.concentrated?(%{responsive_count: 4, avg_load: 100, max_load: 500})
+    end
+
+    test "above both the ratio and the absolute floor is concentrated" do
+      assert Policy.concentrated?(%{responsive_count: 4, avg_load: 1_000, max_load: 15_000})
+    end
+
+    test "a single responsive shard is never concentrated, regardless of ratio" do
+      refute Policy.concentrated?(%{responsive_count: 1, avg_load: 100, max_load: 1_000_000})
     end
   end
 end

--- a/deploy/k8s/twitch-ingress.yaml
+++ b/deploy/k8s/twitch-ingress.yaml
@@ -158,9 +158,14 @@ spec:
             - name: NEW_RELIC_LOGS_IN_CONTEXT
               value: "forwarder"
             - name: INGRESS_DISPATCHER_MAX_RUNNING
-              value: "64"
+              value: "512"
             - name: INGRESS_DISPATCHER_MAX_QUEUE
-              value: "2000"
+              value: "20000"
+            # Shipped inert (above max_running+max_queue's realistic reach) for
+            # burn-in; tighten to "2048" once the new broadcaster_cap drop
+            # metric shows real per-broadcaster admission patterns in prod.
+            - name: INGRESS_DISPATCHER_MAX_PER_BROADCASTER
+              value: "16000"
             # The BEAM sizes schedulers from the host's logical CPUs, not the
             # cgroup quota. Cap schedulers to the CPU limit below and disable
             # scheduler busy-waiting so idle spinning never eats host cores.


### PR DESCRIPTION
## Summary
- `Ingress.Dispatcher`'s admission budget is one shared pool per pod, not per shard, and nothing capped how much of it one broadcaster could consume — a hot/raiding channel could silently and permanently drop every *other* broadcaster's notifications sharing that pod (EventSub websocket has no redelivery).
- Add a per-broadcaster admission cap (checked before the pod-wide cap, so a capped broadcaster's rejected traffic never contends the shared counter) plus dimensional drop metrics (`shard_id`/`broadcaster_id`/reason) so this is diagnosable in an incident.
- Raise `max_running`/`max_queue` (64/2000 → 512/20000) to the pod's actual resource headroom — memory and CPU both have wide margin; the real ceiling is downstream RPC fan-out to the broadcaster-status service, which same-channel raids don't multiply (`BroadcasterCache` coalesces concurrent misses per broadcaster).
- Surface per-shard load concentration through the autoscaler (`summarize_sample/2`, `concentrated?/1`, `ShardLoadConcentration` event/log). This is observability only — Twitch owns broadcaster→shard placement, so it does not and should not change any scaling decision.

## Rollout
`INGRESS_DISPATCHER_MAX_PER_BROADCASTER` ships inert (`16000`, effectively a no-op against the new ~20,512 total capacity) for burn-in. Tighten to `2048` via a config-only change once the new `broadcaster_cap` drop metric shows real per-broadcaster admission patterns in production — no code deploy needed for that step.

## Test plan
- [x] `mix test test/dispatcher_test.exs` — new file (zero prior coverage), 9 tests covering the core regression (one broadcaster capped, another unaffected), rollback exactness, release-on-completion, release-on-crash, nil-broadcaster fail-open, queued-item attribution, and the dead-counter sweep.
- [x] `mix test test/shard_scaler_policy_test.exs` — extended, 8 new tests for `summarize_sample/2`/`concentrated?/1` including a `Task.async_stream`-ordering regression case and a small-fleet false-positive guard.
- [x] `mix test` (full suite) — 76 tests, 0 failures, no regressions.
- [x] `mix format --check-formatted` clean on every touched file.