### PR TITLE
fix(codescene): backport chat tools and delegation fixes

### DIFF
--- a/app/users/repository/delegations.go
+++ b/app/users/repository/delegations.go
@@ -67,6 +67,11 @@ func (r *Users) GetDelegation(ctx context.Context, token string) (DelegationView
 // gated on consumed_at IS NULL so two concurrent racers cannot both win: at most
 // one UPDATE flips the row, the loser sees zero affected rows and errors out.
 // Expiry is checked first (an expired link is dead even if never consumed).
+//
+// Reclaim: if the invitee already manages this owner's board, a second link is
+// redundant. Rather than mint a duplicate grant, the redundant link is
+// discarded and the grant they already hold is returned, so re-opening a fresh
+// share link for the same dashboard just lands them back on it.
 func (r *Users) ConsumeDelegation(ctx context.Context, token string, delegateID uint64, delegateLogin string) (DelegationView, error) {
 	now := time.Now()
 
@@ -85,11 +90,46 @@ func (r *Users) ConsumeDelegation(ctx context.Context, token string, delegateID 
 		return DelegationView{}, errors.New("link already used")
 	}
 
-	// Atomic single-use: only succeeds while consumed_at is still NULL.
+	if grant := r.reclaimExisting(ctx, d.OwnerID, delegateID, token); grant != nil {
+		return toDelegationView(grant), nil
+	}
+
+	return r.bindDelegation(ctx, d, delegateID, delegateLogin, now)
+}
+
+// reclaimExisting returns the invitee's current consumed grant for ownerID when
+// they already hold one, after discarding the now-redundant link `token`. It
+// returns nil when the invitee has no access yet (a first, real claim the
+// caller must bind). The discard is best-effort: a failed delete only leaves a
+// dead row to sweep later, never a duplicate live grant.
+func (r *Users) reclaimExisting(ctx context.Context, ownerID, delegateID uint64, token string) *ent.Delegation {
+	grant, err := db.WithQuery(ctx, func(ctx context.Context) (*ent.Delegation, error) {
+		return r.client.Delegation.Query().
+			Where(
+				delegation.OwnerIDEQ(ownerID),
+				delegation.DelegateIDEQ(delegateID),
+				delegation.ConsumedAtNotNil(),
+			).
+			First(ctx)
+	})
+	if err != nil || grant == nil {
+		return nil
+	}
+	_ = db.WithExec(ctx, func(ctx context.Context) error {
+		_, derr := r.client.Delegation.Delete().Where(delegation.TokenEQ(token)).Exec(ctx)
+		return derr
+	})
+	return grant
+}
+
+// bindDelegation performs the atomic single-use bind on the unconsumed row d,
+// succeeding only while consumed_at is still NULL so concurrent racers cannot
+// both win. The caller has already ruled out expiry and prior consumption.
+func (r *Users) bindDelegation(ctx context.Context, d *ent.Delegation, delegateID uint64, delegateLogin string, now time.Time) (DelegationView, error) {
 	n, err := db.WithQuery(ctx, func(ctx context.Context) (int, error) {
 		return r.client.Delegation.Update().
 			Where(
-				delegation.TokenEQ(token),
+				delegation.TokenEQ(d.Token),
 				delegation.ConsumedAtIsNil(),
 			).
 			SetDelegateID(delegateID).

--- a/app/users/repository/users_test.go
+++ b/app/users/repository/users_test.go
@@ -332,3 +332,44 @@ func TestDelegateOptOutIgnoresPendingLinks(t *testing.T) {
 
 	require.Error(t, repo.OptOutDelegation(ctx, 1001, 2002), "pending invite should remain owner-managed")
 }
+
+func TestConsumeReclaimsInsteadOfDuplicatingForSameBoard(t *testing.T) {
+	_, _, repo := setup(t)
+	ctx := context.Background()
+
+	require.NoError(t, repo.CreateDelegation(ctx, "link-one", 1001, "owner", []string{"commands"}, nil))
+	require.NoError(t, repo.CreateDelegation(ctx, "link-two", 1001, "owner", []string{"timers"}, nil))
+
+	first, err := repo.ConsumeDelegation(ctx, "link-one", 2002, "delegate")
+	require.NoError(t, err)
+
+	// Second link for a board the invitee already manages: reclaim returns the
+	// grant they already hold and never mints a duplicate.
+	second, err := repo.ConsumeDelegation(ctx, "link-two", 2002, "delegate")
+	require.NoError(t, err)
+	assert.Equal(t, first.Sections, second.Sections, "reclaim returns the existing grant, not the new link")
+
+	access, err := repo.ListAccessByDelegate(ctx, 2002)
+	require.NoError(t, err)
+	require.Len(t, access, 1, "no duplicate grant for the same board")
+
+	_, err = repo.GetDelegation(ctx, "link-two")
+	require.Error(t, err, "the redundant link is discarded from the db")
+}
+
+func TestConsumeStillBindsDistinctBoards(t *testing.T) {
+	_, _, repo := setup(t)
+	ctx := context.Background()
+
+	require.NoError(t, repo.CreateDelegation(ctx, "board-a", 1001, "alpha", []string{"commands"}, nil))
+	require.NoError(t, repo.CreateDelegation(ctx, "board-b", 3003, "beta", []string{"timers"}, nil))
+
+	_, err := repo.ConsumeDelegation(ctx, "board-a", 2002, "delegate")
+	require.NoError(t, err)
+	_, err = repo.ConsumeDelegation(ctx, "board-b", 2002, "delegate")
+	require.NoError(t, err)
+
+	access, err := repo.ListAccessByDelegate(ctx, 2002)
+	require.NoError(t, err)
+	assert.Len(t, access, 2, "different owners are separate grants, not a reclaim")
+}

--- a/console/dashboard/src/routes/(app)/modules/+page.svelte
+++ b/console/dashboard/src/routes/(app)/modules/+page.svelte
@@ -85,6 +85,10 @@
     })).filter(c => c.modules.length > 0)
   );
 
+  function moduleHref(m: ModuleState): string {
+    return m.def.href ?? `/modules/${m.def.id}`;
+  }
+
   // Scrollspy logic
   let root = $state<HTMLElement | null>(null);
   let currentCategoryId = $state('');
@@ -177,7 +181,7 @@
           <div class="grid">
             {#each cat.modules as m (m.def.id)}
               <div class="tile {m.enabled ? 'on' : 'off'}">
-                <a class="tile-main" href={`/modules/${m.def.id}`}>
+                <a class="tile-main" href={moduleHref(m)}>
                   <span class="tile-icon"><Icon name={m.def.icon} size={20} /></span>
                   <span class="tile-text">
                     <span class="tile-label">{m.def.label}</span>
@@ -185,7 +189,7 @@
                   </span>
                 </a>
                 <div class="tile-foot">
-                  <a class="open" href={`/modules/${m.def.id}`}><Icon name="settings" size={13} /> {t('modules.configure')}</a>
+                  <a class="open" href={moduleHref(m)}><Icon name="settings" size={13} /> {t('modules.configure')}</a>
                   <span class="grow"></span>
                   <SaveStatus state={modStatus[m.def.id] ?? 'idle'} />
                   <form method="POST" action="?/toggle" use:enhance={toggleSubmit(m)}>
@@ -427,4 +431,3 @@
 
   .empty { text-align: center; color: var(--bb-muted); font-family: var(--bb-font-body); font-size: 13px; }
 </style>
-

--- a/console/dashboard/src/routes/auth/callback/+server.ts
+++ b/console/dashboard/src/routes/auth/callback/+server.ts
@@ -144,12 +144,17 @@ export const GET: RequestHandler = async ({ url, cookies }) => {
     // every login; the admin panel re-bans authoritatively.
     if (await isBanned(identity.userId)) throw redirect(302, '/login?e=banned');
 
-    await acceptPendingDelegation(cookies, url, identity);
-
-    // Real account email (user:read:email consent). Null on any failure —
+    // Register BEFORE the delegation accept can seal a delegate session and
+    // redirect: a brand-new invitee whose first ever login is a share link still
+    // needs their own user row, or the ghost-session gate reads it as a deleted
+    // account and wipes the delegate session on the very next request.
+    //
+    // Real account email (user:read:email consent). Null on any failure -
     // capture is best-effort and the users service stores it encrypted.
     const email = await fetchAccountEmail(tokens.accessToken());
     await registerUser(identity, email);
+
+    await acceptPendingDelegation(cookies, url, identity);
 
     setSessionCookie(cookies, url, streamerSession(identity));
 

--- a/console/shared/lib/types.ts
+++ b/console/shared/lib/types.ts
@@ -272,6 +272,9 @@ export interface ModuleDef {
   // Plain non-reply settings (rendered in the settings strip). Optional; the
   // current modules have none beyond their master enable + per-reply toggles.
   settings?: ModuleField[];
+  // href overrides the tile's link when a module needs a bespoke inspector
+  // instead of the generic /modules/[id] reply page.
+  href?: string;
 }
 
 // A module's current state as shown on the dashboard: catalog metadata merged
@@ -308,6 +311,46 @@ const BW_SESSION_SAMPLES: Record<string, string> = {
 };
 
 export const MODULE_CATALOG: readonly ModuleDef[] = [
+  // Chat Tools: the bot's viewer-facing chat features, surfaced first. Channel
+  // Points and Timers own bespoke pages (opened via href); Trigger Words uses
+  // the generic reply inspector with its rule editor.
+  {
+    id: 'channelpoints',
+    label: 'Channel Points',
+    tagline: 'Turn channel-point redemptions into bot actions.',
+    description:
+      'Create the custom rewards viewers redeem with channel points and bind each one to a bot action, like posting a chat line. Choose whether each redemption is fulfilled, refunded, or left for a mod.',
+    icon: 'activity',
+    category: 'Chat Tools',
+    defaultEnabled: false,
+    href: '/channelpoints',
+    replies: []
+  },
+  {
+    id: 'timers',
+    label: 'Timers',
+    tagline: 'Post repeating chat messages on a schedule while you are live.',
+    description:
+      'Set messages the bot repeats on a schedule while you are live: announcements, socials, reminders. Each timer keeps its own interval and only fires during the stream.',
+    icon: 'clock',
+    category: 'Chat Tools',
+    defaultEnabled: false,
+    href: '/timers',
+    replies: []
+  },
+  {
+    id: 'triggers',
+    label: 'Trigger Words',
+    tagline: 'Auto-reply when a word shows up in chat - no "!" needed.',
+    description:
+      'Give the bot a list of words or phrases and the line to post when it sees one in ordinary chat - no command prefix required. Write one rule per line as "phrase => response". Prefix the phrase with contains:, exact: or prefix: to change how it matches. Responses support {user}, {random} and {choice:a,b,c}.',
+    icon: 'caps',
+    category: 'Chat Tools',
+    defaultEnabled: false,
+    // Trigger rules are a free-form list of phrase=>response pairs the author
+    // grows, stored as one "rules" string parsed by sesame's triggers module.
+    replies: []
+  },
   {
     id: 'automod',
     label: 'AutoMod',


### PR DESCRIPTION
## Summary
- backport the Chat Tools module grouping from #294 into the dashboard module catalog
- backport the delegation accept/reclaim fixes from #295
- add delegation reclaim regression coverage

## Verification
- go test ./app/users/...
- bun run --filter dashboard check (0 errors; existing CSS warnings only)

Note: this PR targets the current feature branch context because origin/main already contains the complete merged #294/#295 changes; opening this branch directly against main would compare stale feature-branch files and conflict.