### PR TITLE
fix(firewall): keep flannel/CNI interfaces trusted across reboots

### DIFF
--- a/deploy/ansible/roles/firewall/files/fleet-cni-trust.service
+++ b/deploy/ansible/roles/firewall/files/fleet-cni-trust.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=Bind flannel/CNI interfaces to the firewalld trusted zone
+# Needs firewalld running to issue firewall-cmd, and k3s up to have created the
+# interfaces. k3s.service / k3s-agent.service: whichever this node runs (the
+# other is simply ignored). The script also waits for the interfaces, so this
+# ordering is a hint, not a hard dependency.
+Wants=firewalld.service
+After=firewalld.service k3s.service k3s-agent.service
+# Retry indefinitely (below) until the CNI interfaces exist; never rate-limit it
+# out of ever binding them.
+StartLimitIntervalSec=0
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/local/sbin/fleet-cni-trust.sh
+# A slow CNI bring-up must not permanently strand the interfaces in the public
+# zone; keep retrying until the bind succeeds.
+Restart=on-failure
+RestartSec=15
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/ansible/roles/firewall/files/fleet-cni-trust.sh
+++ b/deploy/ansible/roles/firewall/files/fleet-cni-trust.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+# Pin the flannel/CNI interfaces to firewalld's trusted zone.
+#
+# firewalld starts at boot BEFORE k3s creates cni0 and the flannel transport, so
+# those interfaces are born into the default (public) zone every boot. firewalld
+# does not retro-apply a permanent zone binding to an interface that appears
+# later, so without this they stay in public and firewalld drops the cross-node
+# pod traffic that rides them -- including the NATS leaf-to-leaf cluster on 6222
+# that carries the outgress rate-limit permit borrow. A dropped bind silently
+# fails the fleet's quota sharing open.
+#
+# The pod/service CIDR *sources* are trusted permanently in the firewall role,
+# which covers INPUT; this closes the interface/FORWARD gap and survives reboots
+# because the unit runs on every boot. Bind permanently (so a firewalld --reload
+# keeps it) and at runtime (so it takes effect now).
+set -eu
+
+# Candidate interfaces. cni0 (bridge) is always present; the flannel transport is
+# flannel.1 on vxlan nodes OR flannel-wg on wireguard-backend nodes -- bind
+# whichever exist, never require a specific one.
+CANDIDATES="cni0 flannel.1 flannel-wg"
+
+# bind_iface trusts one interface idempotently: --add-interface errors with a
+# non-zero ALREADY_ENABLED on re-runs (which set -e would treat as fatal), so add
+# to the permanent config only when absent; --change-interface is a no-op-safe
+# move for the runtime binding.
+bind_iface() {
+    _iface="$1"
+    if ! firewall-cmd --permanent --zone=trusted --query-interface="${_iface}" >/dev/null 2>&1; then
+        firewall-cmd --permanent --zone=trusted --add-interface="${_iface}" >/dev/null
+    fi
+    firewall-cmd --zone=trusted --change-interface="${_iface}" >/dev/null
+    echo "fleet-cni-trust: bound ${_iface} to trusted zone"
+}
+
+iface_exists() { [ -e "/sys/class/net/$1" ]; }
+
+# Wait (bounded) for the bridge and a flannel transport to come up after k3s
+# starts; never hang a boot indefinitely (the unit retries on failure).
+tries=0
+while :; do
+    if iface_exists cni0 && { iface_exists flannel.1 || iface_exists flannel-wg; }; then
+        break
+    fi
+    tries=$((tries + 1))
+    if [ "${tries}" -ge 90 ]; then
+        break
+    fi
+    sleep 1
+done
+
+bound_any=0
+for iface in ${CANDIDATES}; do
+    if iface_exists "${iface}"; then
+        bind_iface "${iface}"
+        bound_any=1
+    fi
+done
+
+if [ "${bound_any}" -eq 0 ]; then
+    echo "fleet-cni-trust: no CNI/flannel interface present yet; will retry" >&2
+    exit 1
+fi
+exit 0

--- a/deploy/ansible/roles/firewall/handlers/main.yml
+++ b/deploy/ansible/roles/firewall/handlers/main.yml
@@ -1,0 +1,10 @@
+---
+# Flushed at the end of the play, after k3s_agent has brought flannel up, so the
+# binder trusts cni0/flannel.1 during this run too, not only on the next boot.
+# On an existing node (a --tags firewall re-run) k3s is already up, so it binds
+# immediately.
+- name: apply cni trust
+  ansible.builtin.systemd:
+    name: fleet-cni-trust.service
+    state: restarted
+    daemon_reload: true

--- a/deploy/ansible/roles/firewall/tasks/main.yml
+++ b/deploy/ansible/roles/firewall/tasks/main.yml
@@ -73,3 +73,37 @@
   loop:
     - cockpit
     - dhcpv6-client
+
+# --- Keep the flannel/CNI interfaces trusted across reboots ------------------
+# The pod/service CIDR sources above are trusted for INPUT, but firewalld starts
+# before k3s creates cni0/flannel.1, so on every boot those interfaces land in
+# the default (public) zone until something re-binds them, and firewalld does not
+# retro-apply a permanent binding to an interface that appears later. A missed
+# bind drops the cross-node pod traffic that rides them -- including the NATS
+# leaf-to-leaf cluster on 6222 that carries the outgress rate-limit permit borrow
+# -- which silently fails the fleet's quota sharing open. A boot-time oneshot
+# waits for the interfaces and binds them; installing it here is why this belongs
+# in the firewall role rather than k3s_agent.
+- name: Install the CNI trusted-zone binder script
+  ansible.builtin.copy:
+    src: fleet-cni-trust.sh
+    dest: /usr/local/sbin/fleet-cni-trust.sh
+    owner: root
+    group: root
+    mode: "0755"
+  notify: apply cni trust
+
+- name: Install the CNI trusted-zone binder unit
+  ansible.builtin.copy:
+    src: fleet-cni-trust.service
+    dest: /etc/systemd/system/fleet-cni-trust.service
+    owner: root
+    group: root
+    mode: "0644"
+  notify: apply cni trust
+
+- name: Enable the CNI trusted-zone binder on boot
+  ansible.builtin.systemd:
+    name: fleet-cni-trust.service
+    enabled: true
+    daemon_reload: true

--- a/deploy/ansible/site.yml
+++ b/deploy/ansible/site.yml
@@ -34,7 +34,11 @@
   roles:
     - role: base
     - role: selinux
+    # Tagged so the firewall policy can be re-applied to an already-provisioned
+    # node in isolation (e.g. to roll out the CNI trusted-zone binder):
+    #   doppler run -- ansible-playbook site.yml --tags firewall -e target_host=<tailnet-ip>
     - role: firewall
+      tags: [firewall]
     - role: tailscale
     - role: k3s_agent
     - role: ssh_removal


### PR DESCRIPTION
## Problem

firewalld starts at boot **before** k3s creates `cni0` and the flannel transport, and it does not retro-apply a permanent zone binding to an interface that appears later. So every boot those interfaces land in the default (`public`) zone and firewalld drops the cross-node pod traffic that rides them — including the NATS leaf-to-leaf cluster on `6222` that carries the outgress rate-limit **permit borrow**. With borrow unreachable the fleet cannot share Twitch quota, so under burst it fails open and Twitch returns **429s**. This is the root cause behind the lease `members: 1` / borrow failure; the reboot incident was previously patched live-only.

## Fix

A boot-time oneshot in the `firewall` role that waits for the interfaces and binds whichever exist (`cni0` + `flannel.1` on vxlan nodes **or** `flannel-wg` on wireguard-backend nodes) to the `trusted` zone — **permanent** so a firewalld `--reload` keeps them, **runtime** so it takes effect now. It retries on failure so a slow CNI bring-up can't strand them, and the bind is idempotent across reboots. Why a oneshot and not just `--permanent --add-interface`: permanent-alone doesn't survive the boot ordering (firewalld up before flannel), which is the whole bug.

Tagged so it rolls out to the existing fleet in isolation:

```
doppler run -- ansible-playbook site.yml --tags firewall -e target_host=<tailnet-ip> -e target_user=<opc|almalinux>
```

`deploy/ansible` is not watched by Flux, so merging lands the code but does not auto-apply — the operator runs the playbook per node.

## Verification

- `sh -n` + `ansible-playbook --syntax-check` + `ansible-lint` (clean for these files)
- Functional test of the binder with a stubbed `firewall-cmd`: vxlan (`cni0`+`flannel.1`), wireguard (`cni0`+`flannel-wg`), none-present (retry `rc=1`), idempotent re-run (no duplicate permanent add)

Complements the app-level lease safety in #299 (merged); this restores cross-node borrow at the root.