### PR TITLE
fix(ingress): lane limits, acked deduped ingestion, replay guards

### DIFF
--- a/app/ingress/config/runtime.exs
+++ b/app/ingress/config/runtime.exs
@@ -103,7 +103,14 @@ config :ingress,
   dispatcher_max_per_broadcaster:
     String.to_integer(System.get_env("INGRESS_DISPATCHER_MAX_PER_BROADCASTER", "2048")),
   dispatcher_broadcaster_sweep_ms:
-    String.to_integer(System.get_env("INGRESS_DISPATCHER_BROADCASTER_SWEEP_MS", "60000"))
+    String.to_integer(System.get_env("INGRESS_DISPATCHER_BROADCASTER_SWEEP_MS", "60000")),
+  # JetStream lane publishes block on the broker's PubAck (from a dispatcher
+  # worker, so backpressure sheds at the dispatcher): per-attempt ack wait and
+  # the total attempt budget. Retries are deduplicated broker-side by
+  # Nats-Msg-Id, so they can never store an event twice.
+  publish_ack_timeout_ms:
+    String.to_integer(System.get_env("INGRESS_PUBLISH_ACK_TIMEOUT_MS", "2000")),
+  publish_attempts: String.to_integer(System.get_env("INGRESS_PUBLISH_ATTEMPTS", "3"))
 
 # Credentials are optional so local development can run against an open
 # server; the production broker requires them and Gnat only sends them when

--- a/app/ingress/lib/ingress/application.ex
+++ b/app/ingress/lib/ingress/application.ex
@@ -77,19 +77,34 @@ defmodule Ingress.Application do
       connection_child(:nats_bus_connection, :gnat_bus, Config.nats_bus()),
       Ingress.NatsFailback,
       {Task.Supervisor, name: Ingress.BroadcasterCache.TaskSupervisor},
+      # Runs squash-cohort publishes (JetStream-acked) off the Squash process,
+      # so a slow broker never stalls the sweep.
+      {Task.Supervisor, name: Ingress.PublishSupervisor},
       Ingress.BroadcasterCache,
       Ingress.Squash,
       Ingress.Dispatcher.Supervisor,
       Ingress.Twitch.AppToken,
-      consumer_child(:invalidation_consumer, Ingress.CacheInvalidator, Config.invalidation_subject()),
+      consumer_child(
+        :invalidation_consumer,
+        Ingress.CacheInvalidator,
+        Config.invalidation_subject()
+      ),
       # Request-reply endpoint for the admin tool.
-      consumer_child(:admin_consumer, Ingress.AdminRpc, Config.admin_subject(), queue_group: @admin_queue),
+      consumer_child(:admin_consumer, Ingress.AdminRpc, Config.admin_subject(),
+        queue_group: @admin_queue
+      ),
       # Manual shard scaling: {"count": N}.
-      consumer_child(:scale_consumer, Ingress.ScaleRpc, Config.scale_subject(), queue_group: @admin_queue),
+      consumer_child(:scale_consumer, Ingress.ScaleRpc, Config.scale_subject(),
+        queue_group: @admin_queue
+      ),
       # Toggle the load-based autoscaler: {"enabled": bool}.
-      consumer_child(:autoscale_consumer, Ingress.AutoscaleRpc, Config.autoscale_subject(), queue_group: @admin_queue),
+      consumer_child(:autoscale_consumer, Ingress.AutoscaleRpc, Config.autoscale_subject(),
+        queue_group: @admin_queue
+      ),
       # Live conduit id: body {}, replies {"conduit_id": "<uuid>"}.
-      consumer_child(:conduit_consumer, Ingress.ConduitRpc, Config.conduit_subject(), queue_group: @admin_queue),
+      consumer_child(:conduit_consumer, Ingress.ConduitRpc, Config.conduit_subject(),
+        queue_group: @admin_queue
+      ),
       Ingress.Bootstrapper
     ]
   end

--- a/app/ingress/lib/ingress/conduit_manager.ex
+++ b/app/ingress/lib/ingress/conduit_manager.ex
@@ -31,7 +31,8 @@ defmodule Ingress.ConduitManager do
 
   @impl true
   def init(_) do
-    {:ok, %{conduit_id: nil, applied_shard_count: nil}, {:continue, :reconcile}}
+    {:ok, %{conduit_id: nil, applied_shard_count: nil, adopted_scaler: nil},
+     {:continue, :reconcile}}
   end
 
   @impl true
@@ -46,15 +47,10 @@ defmodule Ingress.ConduitManager do
   def handle_info(:reconcile, state), do: {:noreply, reconcile(state)}
 
   defp reconcile(state) do
-    first_sync = is_nil(state.conduit_id)
-
     case ensure_conduit(state) do
       {:ok, conduit_id, applied_shard_count} ->
-        if first_sync, do: adopt_applied_count(applied_shard_count)
-        desired = ShardScaler.desired()
-        applied_shard_count = converge_shards(conduit_id, desired, applied_shard_count)
-        Process.send_after(self(), :reconcile, @reconcile_interval_ms)
-        %{state | conduit_id: conduit_id, applied_shard_count: applied_shard_count}
+        state = %{state | conduit_id: conduit_id, applied_shard_count: applied_shard_count}
+        converge_with_scaler(state)
 
       {:error, reason} ->
         Logger.error("conduit reconcile failed: #{inspect(reason)}")
@@ -66,18 +62,63 @@ defmodule Ingress.ConduitManager do
   defp ensure_conduit(%{conduit_id: nil}), do: Api.ensure_conduit()
   defp ensure_conduit(%{conduit_id: id, applied_shard_count: count}), do: {:ok, id, count}
 
+  # Convergence acts only on a live answer from the scaler singleton:
+  # `ShardScaler.desired/0`'s fallback is the config floor, and resizing the
+  # conduit down to that while the scaler is between homes (failover, deploy)
+  # would drop autoscaled shard bindings. Holding for a retry interval is
+  # always safe — the running shards keep serving.
+  #
+  # A scaler answering under a pid we have not adopted yet is fresh (first boot
+  # or a restart that forgot the autoscaled target), so Twitch's recorded count
+  # is adopted before its answer is allowed to converge anything.
+  defp converge_with_scaler(state) do
+    case ShardScaler.fetch_desired() do
+      {:ok, _desired, scaler} when scaler != state.adopted_scaler ->
+        adopt_then_converge(state, scaler)
+
+      {:ok, desired, _scaler} ->
+        applied = converge_shards(state.conduit_id, desired, state.applied_shard_count)
+        Process.send_after(self(), :reconcile, @reconcile_interval_ms)
+        %{state | applied_shard_count: applied}
+
+      :error ->
+        hold_convergence(state, "shard scaler unreachable")
+    end
+  end
+
+  defp adopt_then_converge(state, scaler) do
+    case adopt_applied_count(state.applied_shard_count) do
+      :ok -> converge_with_scaler(%{state | adopted_scaler: scaler})
+      :error -> hold_convergence(state, "shard target adoption failed")
+    end
+  end
+
+  defp hold_convergence(state, reason) do
+    Logger.warning("#{reason}; holding shard convergence")
+    Process.send_after(self(), :reconcile, @retry_interval_ms)
+    state
+  end
+
   # Twitch's recorded shard count is the only survivor of a singleton failover
   # or deploy: the scaler restarts at the config floor, so without adoption the
-  # first reconcile would shrink an autoscaled conduit and drop shard bindings
+  # next converge would shrink an autoscaled conduit and drop shard bindings
   # until the autoscaler climbed back. Only raises the target (set_target
   # clamps to max_shards); a count at or below the current desired changes
-  # nothing. Best-effort: an unreachable scaler just keeps its floor.
+  # nothing.
   defp adopt_applied_count(applied) do
-    if applied > ShardScaler.desired() do
-      _ = ShardScaler.set_target(applied)
-    end
+    case ShardScaler.fetch_desired() do
+      {:ok, desired, _scaler} when applied > desired ->
+        case ShardScaler.set_target(applied) do
+          :ok -> :ok
+          {:error, _} -> :error
+        end
 
-    :ok
+      {:ok, _desired, _scaler} ->
+        :ok
+
+      :error ->
+        :error
+    end
   end
 
   # Converge the Conduit (Twitch side) and local ShardSession processes to

--- a/app/ingress/lib/ingress/config.ex
+++ b/app/ingress/lib/ingress/config.ex
@@ -82,6 +82,15 @@ defmodule Ingress.Config do
   def dispatcher_broadcaster_sweep_ms,
     do: Application.get_env(:ingress, :dispatcher_broadcaster_sweep_ms, 60_000)
 
+  # How long one JetStream lane publish waits for its PubAck before retrying.
+  def publish_ack_timeout_ms,
+    do: Application.get_env(:ingress, :publish_ack_timeout_ms, 2_000)
+
+  # Total delivery attempts (first try + retries) for one lane publish. The
+  # Nats-Msg-Id dedup header makes retries safe.
+  def publish_attempts,
+    do: Application.get_env(:ingress, :publish_attempts, 3)
+
   # Gnat connection_settings (a leaf-first list of server maps) for the two
   # planes: :nats is the twitch_ingress RPC account, :nats_bus the shared BUS
   # account that carries the twitch.ingress.* firehose.

--- a/app/ingress/lib/ingress/nats.ex
+++ b/app/ingress/lib/ingress/nats.ex
@@ -1,8 +1,19 @@
 defmodule Ingress.Nats do
   @moduledoc """
-  Outbound NATS publishing of the twitch.ingress.* firehose. Fire-and-forget: if
-  the connection is down (Gnat's supervisor is reconnecting), the message is
-  dropped with a warning. We prefer drop over unbounded buffering.
+  Outbound NATS publishing of the twitch.ingress.* firehose, in two
+  disciplines:
+
+    * `publish_acked/3` — lane events (the traffic that must not be silently
+      lost). A JetStream publish: the request blocks on the broker's PubAck,
+      retries a bounded number of times, and carries a `Nats-Msg-Id` so the
+      stream's duplicate window collapses retries and Twitch's own EventSub
+      redeliveries into one stored copy. Callers are dispatcher workers, so a
+      slow broker occupies pool slots and the dispatcher sheds at its bound —
+      the intended backpressure — instead of a fast, invisible black hole.
+
+    * `publish/2` — status/telemetry events. Fire-and-forget core publish; if
+      the connection is down the message is dropped with a warning. We prefer
+      drop over unbounded buffering.
 
   Publishes ride the BUS-account connection (`:gnat_bus`) because the
   twitch.ingress.event/status.* subjects are captured by the JetStream streams,
@@ -12,7 +23,12 @@ defmodule Ingress.Nats do
 
   require Logger
 
+  alias Ingress.{Config, Metrics}
+
   @connection :gnat_bus
+  # Pause between PubAck retry attempts: long enough to ride out a broker
+  # hiccup, short enough that a dispatcher worker slot is never parked long.
+  @retry_backoff_ms 250
 
   @spec publish(String.t(), map()) :: :ok | {:error, term()}
   def publish(subject, payload) do
@@ -21,11 +37,96 @@ defmodule Ingress.Nats do
     case Process.whereis(@connection) do
       nil ->
         Logger.warning("NATS connection down; dropping message on #{subject}")
-        Ingress.Metrics.count("Nats/PublishDropped")
+        Metrics.count("Nats/PublishDropped")
         {:error, :not_connected}
 
       _pid ->
         Gnat.pub(@connection, subject, json)
+    end
+  end
+
+  @doc """
+  JetStream-acked publish with broker-side dedup.
+
+  `dedup_id` becomes the message's `Nats-Msg-Id`: within the stream's
+  duplicate window the broker stores the first copy and acks the rest as
+  duplicates, which makes retrying on a missing PubAck safe and absorbs
+  Twitch's at-least-once EventSub redeliveries without any consumer work.
+  `nil` skips the header (no dedup) but still waits for the ack.
+
+  A connection that is down drops immediately — the connection supervisor's
+  reconnect backoff is longer than the whole retry budget, so spinning here
+  could never succeed and would only park the worker.
+  """
+  @spec publish_acked(String.t(), map(), String.t() | nil) :: :ok | {:error, term()}
+  def publish_acked(subject, payload, dedup_id) do
+    json = Jason.encode!(payload)
+    attempt(subject, json, request_opts(dedup_id), 1)
+  end
+
+  defp request_opts(nil), do: [receive_timeout: Config.publish_ack_timeout_ms()]
+
+  defp request_opts(dedup_id) do
+    [
+      receive_timeout: Config.publish_ack_timeout_ms(),
+      headers: [{"Nats-Msg-Id", dedup_id}]
+    ]
+  end
+
+  defp attempt(subject, json, opts, n) do
+    case request_ack(subject, json, opts) do
+      :ok ->
+        :ok
+
+      {:error, :not_connected} = error ->
+        Logger.warning("NATS connection down; dropping message on #{subject}")
+        Metrics.count("Nats/PublishDropped")
+        error
+
+      {:error, reason} = error ->
+        if n < Config.publish_attempts() do
+          Metrics.count("Nats/PublishRetried")
+          Process.sleep(@retry_backoff_ms)
+          attempt(subject, json, opts, n + 1)
+        else
+          Logger.warning("publish on #{subject} failed after #{n} attempts: #{inspect(reason)}")
+          Metrics.count("Nats/PublishFailed")
+          error
+        end
+    end
+  end
+
+  defp request_ack(subject, json, opts) do
+    case Gnat.request(@connection, subject, json, opts) do
+      {:ok, %{body: body}} -> parse_pub_ack(body)
+      {:error, reason} -> {:error, reason}
+    end
+  catch
+    # The connection process is gone (registered name unbound, or it died
+    # mid-call). Its supervisor is already reconnecting on its own backoff.
+    :exit, _ -> {:error, :not_connected}
+  end
+
+  @doc false
+  # A JetStream PubAck: {"stream": ..., "seq": N} on success, additionally
+  # "duplicate": true when the id was already stored inside the duplicate
+  # window (success for our purposes — the event is in the stream exactly
+  # once), or {"error": {...}} when storage refused the message.
+  @spec parse_pub_ack(binary()) :: :ok | {:error, term()}
+  def parse_pub_ack(body) do
+    case Jason.decode(body) do
+      {:ok, %{"error" => error}} ->
+        {:error, {:pub_ack, error}}
+
+      {:ok, %{"duplicate" => true}} ->
+        Metrics.count("Nats/PublishDeduped")
+        :ok
+
+      {:ok, %{"seq" => _seq}} ->
+        :ok
+
+      _other ->
+        {:error, :bad_pub_ack}
     end
   end
 end

--- a/app/ingress/lib/ingress/pipeline.ex
+++ b/app/ingress/lib/ingress/pipeline.ex
@@ -74,8 +74,16 @@ defmodule Ingress.Pipeline do
 
   defp publish_one(subject, message) do
     Metrics.count("Published/#{message.lane}")
-    Nats.publish(subject, message)
+    Nats.publish_acked(subject, message, dedup_id(message))
   end
+
+  # Broker-side dedup id. Twitch's message id is unique per notification and
+  # stable across EventSub redeliveries, so a shard reconnect replaying recent
+  # notifications collapses to one stored copy per lane. The lane suffix keeps
+  # the dual-published live events (event lane + stream lane land on the same
+  # JetStream stream) from deduping each other away.
+  defp dedup_id(%{msg_id: msg_id, lane: lane}) when is_binary(msg_id), do: "#{msg_id}:#{lane}"
+  defp dedup_id(_message), do: nil
 
   @doc """
   Pure-ish routing (the only side effect is the broadcaster cache read).

--- a/app/ingress/lib/ingress/shard_scaler.ex
+++ b/app/ingress/lib/ingress/shard_scaler.ex
@@ -58,16 +58,31 @@ defmodule Ingress.ShardScaler do
   """
   @spec desired() :: non_neg_integer()
   def desired do
+    case fetch_desired() do
+      {:ok, count, _pid} -> count
+      :error -> Config.conduit_shard_count()
+    end
+  end
+
+  @doc """
+  Like `desired/0` but distinguishes an answer from an unreachable singleton,
+  so `Ingress.ConduitManager` can hold convergence instead of acting on the
+  config-floor fallback and shrinking an autoscaled conduit mid-failover. The
+  answering pid is included so the manager can spot a scaler restart (a fresh
+  scaler forgets the autoscaled target and must re-adopt Twitch's count).
+  """
+  @spec fetch_desired() :: {:ok, non_neg_integer(), pid()} | :error
+  def fetch_desired do
     case Horde.Registry.lookup(Ingress.Registry, :shard_scaler) do
       [{pid, _}] ->
         try do
-          GenServer.call(pid, :desired, 2_000)
+          {:ok, GenServer.call(pid, :desired, 2_000), pid}
         catch
-          :exit, _ -> Config.conduit_shard_count()
+          :exit, _ -> :error
         end
 
       [] ->
-        Config.conduit_shard_count()
+        :error
     end
   end
 

--- a/app/ingress/lib/ingress/squash.ex
+++ b/app/ingress/lib/ingress/squash.ex
@@ -95,7 +95,7 @@ defmodule Ingress.Squash do
       cohorts: %{},
       max_senders: Keyword.get(opts, :max_senders) || Config.squash_max_senders(),
       sweep_ms: Keyword.get(opts, :sweep_ms) || Config.squash_sweep_ms(),
-      publish: Keyword.get(opts, :publish, &Nats.publish/2)
+      publish: Keyword.get(opts, :publish, &__MODULE__.publish_cohort/2)
     }
 
     Process.send_after(self(), :sweep, state.sweep_ms)
@@ -147,9 +147,12 @@ defmodule Ingress.Squash do
   # Build and publish the cohort event onto the broadcaster's lane. It carries
   # only the DUPLICATE senders; the first occurrence already rode a normal
   # channel.chat.message, so the worker aggregates the two by text (and dedups
-  # by msg_id) with no double count.
+  # by msg_id) with no double count. The cohort's own msg_id is the earliest
+  # buffered duplicate's — never published individually, so it is free to
+  # anchor the cohort's broker-side dedup id.
   defp emit(%{base: base, senders: senders, count: count}, state) do
     distinct = senders |> Enum.map(& &1.chatter_user_id) |> Enum.uniq() |> length()
+    ordered = Enum.reverse(senders)
 
     message = %{
       type: "channel.chat.message",
@@ -157,7 +160,8 @@ defmodule Ingress.Squash do
       broadcaster_user_id: base.broadcaster_user_id,
       broadcaster_user_login: base.broadcaster_user_login,
       text: base.text,
-      senders: Enum.reverse(senders),
+      msg_id: List.first(ordered).msg_id,
+      senders: ordered,
       count: count,
       distinct_users: distinct
     }
@@ -167,6 +171,20 @@ defmodule Ingress.Squash do
     state.publish.(Config.lane_subject(base.lane), message)
     true
   end
+
+  @doc false
+  # Default cohort publisher: JetStream-acked with a cohort-scoped dedup id,
+  # run on a supervised task so the squash sweep never blocks on the broker's
+  # PubAck (a cohort carries many senders — losing one silently would blind
+  # the automod's campaign signal, so fire-and-forget is not acceptable here).
+  def publish_cohort(subject, message) do
+    Task.Supervisor.start_child(Ingress.PublishSupervisor, fn ->
+      Nats.publish_acked(subject, message, cohort_dedup_id(message))
+    end)
+  end
+
+  defp cohort_dedup_id(%{msg_id: msg_id}) when is_binary(msg_id), do: "#{msg_id}:cohort"
+  defp cohort_dedup_id(_message), do: nil
 
   defp window_ms, do: :persistent_term.get({__MODULE__, :window_ms}, 2_000)
   defp now_ms, do: System.monotonic_time(:millisecond)

--- a/app/ingress/test/ingress_test.exs
+++ b/app/ingress/test/ingress_test.exs
@@ -341,6 +341,8 @@ defmodule Ingress.SquashTest do
     assert cohort.count == 2
     assert cohort.distinct_users == 2
     assert Enum.map(cohort.senders, & &1.chatter_user_id) == ["2", "3"]
+    # The earliest buffered duplicate anchors the cohort's broker-side dedup id.
+    assert cohort.msg_id == "m2"
   end
 
   test "a cohort at the size cap flushes early without waiting for the window" do

--- a/app/ingress/test/nats_test.exs
+++ b/app/ingress/test/nats_test.exs
@@ -1,0 +1,25 @@
+defmodule Ingress.NatsTest do
+  use ExUnit.Case, async: true
+
+  alias Ingress.Nats
+
+  describe "parse_pub_ack/1" do
+    test "a stored message acks" do
+      assert Nats.parse_pub_ack(~s({"stream":"TWITCH_INGRESS","seq":42})) == :ok
+    end
+
+    test "a duplicate inside the dedup window is success (already stored once)" do
+      assert Nats.parse_pub_ack(~s({"stream":"TWITCH_INGRESS","seq":42,"duplicate":true})) == :ok
+    end
+
+    test "a JetStream error refuses the publish" do
+      body = ~s({"error":{"code":503,"description":"no responders"}})
+      assert {:error, {:pub_ack, %{"code" => 503}}} = Nats.parse_pub_ack(body)
+    end
+
+    test "an unintelligible ack is an error, not a silent success" do
+      assert Nats.parse_pub_ack("not json") == {:error, :bad_pub_ack}
+      assert Nats.parse_pub_ack(~s({"unexpected":true})) == {:error, :bad_pub_ack}
+    end
+  end
+end

--- a/deploy/k8s/sesame.yaml
+++ b/deploy/k8s/sesame.yaml
@@ -148,7 +148,13 @@ spec:
             - containerPort: 8080
           resources:
             requests:
-              cpu: 50m
+              # The KEDA cpu trigger below is Utilization, which the HPA
+              # computes against this request. At the old 50m the 75% threshold
+              # fired at 37m — background noise for a CPU-bound consumer — so
+              # the CPU trigger alone pinned sesame at maxReplicaCount. 200m
+              # puts the trigger at 150m/pod: real sustained load, while lag
+              # stays the primary scale signal.
+              cpu: 200m
               memory: 128Mi
             limits:
               cpu: "2"

--- a/pkg/bus/bus.go
+++ b/pkg/bus/bus.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -54,8 +55,20 @@ func NewPublisher(url string, log *zap.Logger) (message.Publisher, error) {
 // All instances passing the same group share one durable consumer, so a
 // message is processed by exactly one instance and survives restarts.
 func NewSubscriber(url string, group string, log *zap.Logger) (message.Subscriber, error) {
-	return newSubscriber(url, group, nil, log)
+	return newSubscriber(url, group, log)
 }
+
+// Redelivery budget for the durable consumers behind NewSubscriber (the
+// ingress lanes, the data.> event folds, the stream lane). Retries are paced
+// per message by NakWithDelay — a plain NACK redelivers immediately, so a
+// message whose handler fails deterministically would otherwise grind through
+// its whole budget in seconds, fleet-wide, at full pipeline cost. The pacing
+// also gives a transient dependency blip (~15s) time to clear; after the
+// budget the message is TERMed and ages out of the stream.
+const (
+	fleetMaxRedeliveries uint64 = 5
+	fleetNakDelay               = 3 * time.Second
+)
 
 // LaneConfig describes one bounded work-queue subscription: the stream it
 // binds to, the subject filter, the durable group that shares the consumer,
@@ -181,7 +194,7 @@ func laneConsumerConfig(subject, group, name string, maxDeliveries int) *nats.Co
 	return &nats.ConsumerConfig{
 		Durable:        name,
 		Name:           name,
-		Description:    "ItsBagelBot bounded outgress work queue",
+		Description:    "ItsBagelBot bounded work-queue lane consumer",
 		DeliverPolicy:  nats.DeliverAllPolicy,
 		AckPolicy:      nats.AckExplicitPolicy,
 		AckWait:        30 * time.Second,
@@ -227,10 +240,9 @@ func streamForTopic(topic string) (string, error) {
 }
 
 type fleetSubscriber struct {
-	url      string
-	group    string
-	nakDelay wmnats.Delay
-	log      *zap.Logger
+	url   string
+	group string
+	log   *zap.Logger
 
 	mu    sync.Mutex
 	subs  []message.Subscriber
@@ -248,6 +260,12 @@ func (s *fleetSubscriber) Subscribe(ctx context.Context, topic string) (<-chan *
 		return nil, err
 	}
 
+	messages, err := sub.Subscribe(ctx, topic)
+	if err != nil {
+		closeSubscription(sub, conn)
+		return nil, err
+	}
+
 	s.mu.Lock()
 	s.subs = append(s.subs, sub)
 	if conn != nil {
@@ -255,19 +273,49 @@ func (s *fleetSubscriber) Subscribe(ctx context.Context, topic string) (<-chan *
 	}
 	s.mu.Unlock()
 
-	return sub.Subscribe(ctx, topic)
+	// A subscription's resources live exactly as long as its ctx. The weighted
+	// consumer adds and retires units with load, each unit subscribing under
+	// its own ctx; without this a retired unit's NATS connection would sit open
+	// until process shutdown, one more per scale cycle.
+	go func() {
+		<-ctx.Done()
+		s.forget(sub, conn)
+		closeSubscription(sub, conn)
+	}()
+
+	return messages, nil
+}
+
+// forget drops a subscription's entries from the shutdown bookkeeping once its
+// own ctx has released them, so Close does not double-close.
+func (s *fleetSubscriber) forget(sub message.Subscriber, conn *nats.Conn) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.subs = slices.DeleteFunc(s.subs, func(x message.Subscriber) bool { return x == sub })
+	if conn != nil {
+		s.conns = slices.DeleteFunc(s.conns, func(x *nats.Conn) bool { return x == conn })
+	}
+}
+
+func closeSubscription(sub message.Subscriber, conn *nats.Conn) {
+	_ = sub.Close()
+	if conn != nil {
+		conn.Close()
+	}
 }
 
 // subscriberFor builds the topic's subscriber: a broadcast ephemeral consumer
 // when the group is empty, else a durable queue-group consumer bound to a
-// provisioned server-owned durable (so it survives pod disconnects).
+// provisioned server-owned durable (so it survives pod disconnects), with the
+// shared fleet redelivery budget (see fleetMaxRedeliveries).
 func (s *fleetSubscriber) subscriberFor(stream, topic string) (message.Subscriber, *nats.Conn, error) {
 	if s.group == "" {
 		sub, err := s.broadcastSubscriber()
 		return sub, nil, err
 	}
 	binding := LaneConfig{URL: s.url, Stream: stream, Subject: topic, Group: s.group}
-	return bindDurable(binding, 1000, s.nakDelay, s.log)
+	maxDeliveries := fleetMaxRedeliveries + 1
+	return bindDurable(binding, int(maxDeliveries), wmnats.NewMaxRetryDelay(fleetNakDelay, maxDeliveries), s.log)
 }
 
 // broadcastSubscriber uses an ephemeral consumer with DeliverNew to avoid
@@ -308,12 +356,11 @@ func (s *fleetSubscriber) Close() error {
 	return nil
 }
 
-func newSubscriber(url string, group string, nakDelay wmnats.Delay, log *zap.Logger) (message.Subscriber, error) {
+func newSubscriber(url string, group string, log *zap.Logger) (message.Subscriber, error) {
 	return &fleetSubscriber{
-		url:      url,
-		group:    group,
-		nakDelay: nakDelay,
-		log:      log,
+		url:   url,
+		group: group,
+		log:   log,
 	}, nil
 }
 

--- a/pkg/bus/bus.go
+++ b/pkg/bus/bus.go
@@ -161,10 +161,14 @@ func ensureConsumer(js nats.JetStreamManager, stream string, desired *nats.Consu
 	}
 
 	// Update mutable parameters, keeping the deliver subject replicas are
-	// already bound to.
+	// already bound to and the creation-time delivery position (a consumer
+	// recreated at an ack-floor start sequence must not be forced back to
+	// DeliverAll, which is not updatable and would trip a replace every boot).
 	desired.DeliverSubject = info.Config.DeliverSubject
+	desired.DeliverPolicy = info.Config.DeliverPolicy
+	desired.OptStartSeq = info.Config.OptStartSeq
 	if _, err := js.UpdateConsumer(stream, desired); err != nil {
-		return replaceConsumer(js, stream, desired, err)
+		return replaceConsumer(js, stream, desired, info, err)
 	}
 	return nil
 }
@@ -172,9 +176,16 @@ func ensureConsumer(js nats.JetStreamManager, stream string, desired *nats.Consu
 // replaceConsumer falls back to delete + recreate for transitions that are not
 // updatable in place (notably clearing a legacy BackOff schedule on older
 // servers). The deliver subject and group are deterministic, so replicas
-// already bound keep receiving from the recreated consumer, and the lanes are
-// perishable work queues with no replay to preserve.
-func replaceConsumer(js nats.JetStreamManager, stream string, desired *nats.ConsumerConfig, cause error) error {
+// already bound keep receiving from the recreated consumer.
+//
+// The successor starts at the predecessor's ack floor, not DeliverAll: on a
+// retained (limits) stream like TWITCH_INGRESS a DeliverAll recreation would
+// replay everything MaxAge still holds — up to five minutes of already-handled
+// chat — to the whole group. Everything at or below the floor is acked and
+// stays skipped; in-flight messages above it are redelivered, which is the
+// ordinary at-least-once contract.
+func replaceConsumer(js nats.JetStreamManager, stream string, desired *nats.ConsumerConfig, info *nats.ConsumerInfo, cause error) error {
+	carryAckFloor(desired, info)
 	if derr := js.DeleteConsumer(stream, desired.Name); derr != nil && !errors.Is(derr, nats.ErrConsumerNotFound) {
 		return fmt.Errorf("bus: update consumer %q: %w (replace failed: %v)", desired.Name, cause, derr)
 	}
@@ -182,6 +193,17 @@ func replaceConsumer(js nats.JetStreamManager, stream string, desired *nats.Cons
 		return fmt.Errorf("bus: recreate consumer %q: %w", desired.Name, aerr)
 	}
 	return nil
+}
+
+// carryAckFloor rewrites desired's delivery position to resume just past what
+// the predecessor consumer had fully acknowledged. A floor of zero means
+// nothing was ever acked, where starting from the beginning is correct.
+func carryAckFloor(desired *nats.ConsumerConfig, info *nats.ConsumerInfo) {
+	if info == nil || info.AckFloor.Stream == 0 {
+		return
+	}
+	desired.DeliverPolicy = nats.DeliverByStartSequencePolicy
+	desired.OptStartSeq = info.AckFloor.Stream + 1
 }
 
 // laneConsumerConfig deliberately sets no BackOff: the server clamps AckWait to

--- a/pkg/bus/bus.go
+++ b/pkg/bus/bus.go
@@ -168,7 +168,8 @@ func ensureConsumer(js nats.JetStreamManager, stream string, desired *nats.Consu
 	desired.DeliverPolicy = info.Config.DeliverPolicy
 	desired.OptStartSeq = info.Config.OptStartSeq
 	if _, err := js.UpdateConsumer(stream, desired); err != nil {
-		return replaceConsumer(js, stream, desired, info, err)
+		carryAckFloor(desired, info)
+		return replaceConsumer(js, stream, desired, err)
 	}
 	return nil
 }
@@ -176,16 +177,11 @@ func ensureConsumer(js nats.JetStreamManager, stream string, desired *nats.Consu
 // replaceConsumer falls back to delete + recreate for transitions that are not
 // updatable in place (notably clearing a legacy BackOff schedule on older
 // servers). The deliver subject and group are deterministic, so replicas
-// already bound keep receiving from the recreated consumer.
-//
-// The successor starts at the predecessor's ack floor, not DeliverAll: on a
-// retained (limits) stream like TWITCH_INGRESS a DeliverAll recreation would
-// replay everything MaxAge still holds — up to five minutes of already-handled
-// chat — to the whole group. Everything at or below the floor is acked and
-// stays skipped; in-flight messages above it are redelivered, which is the
-// ordinary at-least-once contract.
-func replaceConsumer(js nats.JetStreamManager, stream string, desired *nats.ConsumerConfig, info *nats.ConsumerInfo, cause error) error {
-	carryAckFloor(desired, info)
+// already bound keep receiving from the recreated consumer. The caller has
+// already rewritten desired's delivery position to the predecessor's ack
+// floor (see carryAckFloor), so the recreation never replays retained
+// messages the group has handled.
+func replaceConsumer(js nats.JetStreamManager, stream string, desired *nats.ConsumerConfig, cause error) error {
 	if derr := js.DeleteConsumer(stream, desired.Name); derr != nil && !errors.Is(derr, nats.ErrConsumerNotFound) {
 		return fmt.Errorf("bus: update consumer %q: %w (replace failed: %v)", desired.Name, cause, derr)
 	}

--- a/pkg/bus/provision.go
+++ b/pkg/bus/provision.go
@@ -24,11 +24,12 @@ import (
 // broker (retention window and a hard size cap) are explicit, the rest take
 // safe defaults in reconcileStream.
 type StreamSpec struct {
-	Name      string               // valid JetStream stream name (no dots/spaces/wildcards)
-	Subjects  []string             // subjects captured by the stream
-	Retention nats.RetentionPolicy // zero value is the ordinary limits policy
-	MaxAge    time.Duration        // hard lifetime limit for stored messages
-	MaxBytes  int64                // hard cap so one stream cannot exhaust the instance
+	Name       string               // valid JetStream stream name (no dots/spaces/wildcards)
+	Subjects   []string             // subjects captured by the stream
+	Retention  nats.RetentionPolicy // zero value is the ordinary limits policy
+	MaxAge     time.Duration        // hard lifetime limit for stored messages
+	MaxBytes   int64                // hard cap so one stream cannot exhaust the instance
+	MaxMsgsPer int64                // per-subject cap (0 = unlimited); lane isolation on shared streams
 }
 
 // OutgressStream carries the perishable chat lanes (premium/standard). It is
@@ -81,6 +82,14 @@ var DataStreams = []StreamSpec{
 		Subjects: []string{"twitch.ingress.event.>", "twitch.ingress.status.>"},
 		MaxAge:   5 * time.Minute,
 		MaxBytes: 256 << 20, // 256 MiB
+		// The premium, standard and stream lanes are distinct literal subjects
+		// sharing this stream, and MaxBytes eviction is stream-wide oldest-first:
+		// without a per-subject cap a standard-lane flood fills the stream and
+		// evicts retained premium and stream.online events. 50k messages per lane
+		// (≈100 MiB at typical event size, well past any backlog the consumers
+		// could still catch up on before MaxAge) makes a flooded lane wrap itself
+		// while the other lanes keep their full retention.
+		MaxMsgsPer: 50_000,
 	},
 }
 
@@ -222,15 +231,16 @@ func streamConfig(spec StreamSpec) *nats.StreamConfig {
 		duplicateWindow = spec.MaxAge
 	}
 	return &nats.StreamConfig{
-		Name:       spec.Name,
-		Subjects:   spec.Subjects,
-		Storage:    nats.FileStorage,
-		Retention:  spec.Retention,
-		Discard:    nats.DiscardOld,
-		MaxAge:     spec.MaxAge,
-		MaxBytes:   spec.MaxBytes,
-		Replicas:   1,
-		Duplicates: duplicateWindow,
+		Name:              spec.Name,
+		Subjects:          spec.Subjects,
+		Storage:           nats.FileStorage,
+		Retention:         spec.Retention,
+		Discard:           nats.DiscardOld,
+		MaxAge:            spec.MaxAge,
+		MaxBytes:          spec.MaxBytes,
+		MaxMsgsPerSubject: spec.MaxMsgsPer,
+		Replicas:          1,
+		Duplicates:        duplicateWindow,
 	}
 }
 
@@ -238,7 +248,8 @@ func streamMatches(got, want nats.StreamConfig) bool {
 	return sameSubjects(got.Subjects, want.Subjects) &&
 		got.Retention == want.Retention &&
 		got.MaxAge == want.MaxAge &&
-		got.MaxBytes == want.MaxBytes
+		got.MaxBytes == want.MaxBytes &&
+		got.MaxMsgsPerSubject == want.MaxMsgsPerSubject
 }
 
 func sameSubjects(a, b []string) bool {

--- a/pkg/bus/provision.go
+++ b/pkg/bus/provision.go
@@ -30,6 +30,11 @@ type StreamSpec struct {
 	MaxAge     time.Duration        // hard lifetime limit for stored messages
 	MaxBytes   int64                // hard cap so one stream cannot exhaust the instance
 	MaxMsgsPer int64                // per-subject cap (0 = unlimited); lane isolation on shared streams
+	// Duplicates overrides the Nats-Msg-Id dedup window (0 = the 2m default,
+	// clamped to MaxAge). The broker tracks one id per message inside the
+	// window, so a high-rate stream wants it as short as its producers' retry
+	// horizon, not the default.
+	Duplicates time.Duration
 }
 
 // OutgressStream carries the perishable chat lanes (premium/standard). It is
@@ -90,6 +95,12 @@ var DataStreams = []StreamSpec{
 		// could still catch up on before MaxAge) makes a flooded lane wrap itself
 		// while the other lanes keep their full retention.
 		MaxMsgsPer: 50_000,
+		// Ingress publishes carry Nats-Msg-Id (derived from Twitch's message id)
+		// so publish retries and Twitch's own EventSub redeliveries collapse at
+		// the broker. Both happen within seconds; 30s covers them while keeping
+		// the broker's dedup-id state bounded on the firehose (the 2m default
+		// would track minutes of chat ids on the small hub).
+		Duplicates: 30 * time.Second,
 	},
 }
 
@@ -226,6 +237,9 @@ func reconcileStream(js nats.JetStreamManager, spec StreamSpec, log *zap.Logger)
 
 func streamConfig(spec StreamSpec) *nats.StreamConfig {
 	duplicateWindow := 2 * time.Minute
+	if spec.Duplicates > 0 {
+		duplicateWindow = spec.Duplicates
+	}
 	if spec.MaxAge > 0 && spec.MaxAge < duplicateWindow {
 		// NATS rejects a duplicate window longer than the stream's MaxAge.
 		duplicateWindow = spec.MaxAge
@@ -249,7 +263,8 @@ func streamMatches(got, want nats.StreamConfig) bool {
 		got.Retention == want.Retention &&
 		got.MaxAge == want.MaxAge &&
 		got.MaxBytes == want.MaxBytes &&
-		got.MaxMsgsPerSubject == want.MaxMsgsPerSubject
+		got.MaxMsgsPerSubject == want.MaxMsgsPerSubject &&
+		got.Duplicates == want.Duplicates
 }
 
 func sameSubjects(a, b []string) bool {

--- a/pkg/bus/provision_test.go
+++ b/pkg/bus/provision_test.go
@@ -97,6 +97,41 @@ func TestIngressStreamIsolatesLanesPerSubject(t *testing.T) {
 	if cfg.MaxBytes <= 0 {
 		t.Fatal("ingress stream still needs its global byte backstop")
 	}
+	// Ingress publishes set Nats-Msg-Id so broker dedup collapses publish
+	// retries and Twitch EventSub redeliveries; both happen within seconds,
+	// and the window bounds the broker's per-id tracking state.
+	if cfg.Duplicates <= 0 || cfg.Duplicates > time.Minute {
+		t.Fatalf("duplicate window = %v, want a short non-zero dedup window", cfg.Duplicates)
+	}
+}
+
+func TestReplaceConsumerCarriesAckFloor(t *testing.T) {
+	desired := laneConsumerConfig(
+		"twitch.ingress.event.premium",
+		"worker",
+		"worker_twitch_ingress_event_premium",
+		6,
+	)
+
+	// A predecessor that acked through stream seq 41 must hand the successor a
+	// start at 42: DeliverAll here would replay every retained message (up to
+	// MaxAge) to the whole group.
+	carryAckFloor(desired, &nats.ConsumerInfo{
+		AckFloor: nats.SequenceInfo{Stream: 41},
+	})
+	if desired.DeliverPolicy != nats.DeliverByStartSequencePolicy {
+		t.Fatalf("deliver policy = %v, want by-start-sequence", desired.DeliverPolicy)
+	}
+	if desired.OptStartSeq != 42 {
+		t.Fatalf("start seq = %d, want ack floor + 1", desired.OptStartSeq)
+	}
+
+	// No acks yet: starting from the beginning is the correct resume point.
+	fresh := laneConsumerConfig("twitch.ingress.event.standard", "worker", "w", 6)
+	carryAckFloor(fresh, &nats.ConsumerInfo{})
+	if fresh.DeliverPolicy != nats.DeliverAllPolicy || fresh.OptStartSeq != 0 {
+		t.Fatal("zero ack floor must keep the original delivery policy")
+	}
 }
 
 func TestFleetSubscriberHasBoundedPacedRedelivery(t *testing.T) {

--- a/pkg/bus/provision_test.go
+++ b/pkg/bus/provision_test.go
@@ -75,6 +75,42 @@ func TestOutgressStreamHasSingleReconciler(t *testing.T) {
 	}
 }
 
+func TestIngressStreamIsolatesLanesPerSubject(t *testing.T) {
+	var ingress *StreamSpec
+	for i := range DataStreams {
+		if DataStreams[i].Name == "TWITCH_INGRESS" {
+			ingress = &DataStreams[i]
+		}
+	}
+	if ingress == nil {
+		t.Fatal("TWITCH_INGRESS stream spec missing")
+	}
+
+	cfg := streamConfig(*ingress)
+	// The premium/standard/stream lanes are distinct literal subjects on one
+	// stream; MaxBytes eviction alone is oldest-first stream-wide, letting a
+	// standard flood evict premium. The per-subject cap makes a flooded lane
+	// wrap itself instead.
+	if cfg.MaxMsgsPerSubject <= 0 {
+		t.Fatal("ingress lanes need a per-subject cap so one lane cannot evict the others")
+	}
+	if cfg.MaxBytes <= 0 {
+		t.Fatal("ingress stream still needs its global byte backstop")
+	}
+}
+
+func TestFleetSubscriberHasBoundedPacedRedelivery(t *testing.T) {
+	// A plain NACK redelivers immediately; with a four-digit budget a poison
+	// message used to grind the whole fleet. The budget must stay small and the
+	// pacing non-zero.
+	if fleetMaxRedeliveries == 0 || fleetMaxRedeliveries > 10 {
+		t.Fatalf("fleet redeliveries = %d, want a small bounded budget", fleetMaxRedeliveries)
+	}
+	if fleetNakDelay <= 0 {
+		t.Fatalf("fleet nak delay = %v, want paced redelivery", fleetNakDelay)
+	}
+}
+
 func TestLaneConsumerHasBoundedDeliveryBudget(t *testing.T) {
 	cfg := laneConsumerConfig(
 		"twitch.outgress.premium",


### PR DESCRIPTION
## What

Two commits hardening the ingress → NATS → sesame ingestion path so it scales to the shard autoscaler's rated capacity without silent loss, replay storms, or cross-lane starvation.

### Lane limits & scaling fixes (`fa34c44`)

- **TWITCH_INGRESS per-subject cap (50k msgs/lane):** the premium/standard/stream lanes are distinct literal subjects on one stream, and MaxBytes eviction is stream-wide oldest-first — a standard-lane flood could evict retained premium and stream.online events. Each lane now wraps itself; MaxBytes stays as the global backstop.
- **Bounded, paced redelivery for fleet durables:** `NewSubscriber` consumers (sesame lanes, data.> folds, stream lane) had MaxDeliver 1000 with immediate NACK redelivery — a poison message ground through 1000 full-pipeline attempts fleet-wide in seconds. Now 5 redeliveries paced 3s via per-message NakWithDelay (never consumer BackOff), then TERM.
- **Weighted-consumer unit retire no longer leaks NATS connections:** each subscription's connection is closed when its unit's ctx ends.
- **Conduit shrink guard:** ConduitManager converges only on a live ShardScaler answer (the `desired/0` fallback is the config floor, and acting on it during singleton failover resized an autoscaled conduit down and dropped bindings). Twitch's recorded count is re-adopted per scaler incarnation (pid-tracked), so a scaler restart can no longer shrink the fleet.
- **Sesame KEDA CPU trigger calibration:** utilization is computed against the request; 75% of 50m fired at 37m and pinned max replicas. Request now 200m; lag stays the primary signal.

### Acked, deduped ingestion (`fc6f2f3`)

- **JetStream pub-acks:** lane publishes were fire-and-forget core pubs — broker trouble was a silent black hole. They now block on the PubAck (from dispatcher workers, so overload sheds at the dispatcher's existing bound) with 3 paced attempts and Acked/Deduped/Retried/Failed metrics.
- **Broker-side dedup via Nats-Msg-Id:** every lane event carries `<twitch msg_id>:<lane>` (cohorts `:cohort`), so publish retries and Twitch's own EventSub redeliveries collapse to one stored copy inside a 30s duplicate window. The lane suffix keeps dual-published live events distinct.
- **Replay-free consumer replacement:** the delete-recreate fallback resumed at DeliverAll, replaying up to 5 minutes of retained chat to the whole group; it now resumes at the predecessor's ack floor + 1.
- Squash cohorts carry a top-level `msg_id` and publish acked on a supervised task so the sweep never blocks.

## Compatibility

- Watermill's NATSMarshaler explicitly skips the Nats-Msg-Id header — sesame/projector/outgress consume unchanged.
- Gnat request inbox is `_INBOX.`; hub and leaf share auth.conf with `_INBOX.>` subscribe already granted — no ACL changes.
- Durable names, queue groups, and KEDA consumer references untouched. Stream changes converge via the stream guardian on the next Go service deploy; lowering MaxDeliver is an in-place consumer update.

## Testing

- `mix test`: 80 tests, 0 failures (new PubAck parsing + cohort msg_id coverage)
- `go test ./...`: green (new lane-isolation, redelivery-budget, and ack-floor tests)

New env knobs: `INGRESS_PUBLISH_ACK_TIMEOUT_MS` (2000), `INGRESS_PUBLISH_ATTEMPTS` (3).