### PR TITLE
chore(fleet): node3 expansion, valkey topology pin, linkerd CNI self-heal

### DIFF
--- a/app/outgress/internal/worker/buckets.go
+++ b/app/outgress/internal/worker/buckets.go
@@ -44,9 +44,7 @@ const (
 // keys remain per-broadcaster, but their numeric Lua arguments do not.
 var (
 	chatSpec              = ratelimit.NewSpec(chatCapacity, chatCapacity/chatWindow)
-	chatStandardSpec      = ratelimit.NewSpec(chatCapacity/2, chatCapacity/chatWindow/2)
 	chatModSpec           = ratelimit.NewSpec(chatModCapacity, chatModCapacity/chatWindow)
-	chatModStandardSpec   = ratelimit.NewSpec(chatModCapacity/2, chatModCapacity/chatWindow/2)
 	helixGeneralSpec      = ratelimit.NewSpec(helixGeneralCapacity, helixGeneralCapacity/helixWindow)
 	helixStandardSpec     = ratelimit.NewSpec(helixGeneralCapacity/2, helixGeneralCapacity/helixWindow/2)
 	helixSystemSpec       = ratelimit.NewSpec(helixSystemReserve, helixSystemReserve/helixWindow)
@@ -73,22 +71,22 @@ func generalHelixRequests(payload outgress.Message) (standard, shared ratelimit.
 	return standard, shared
 }
 
-// takeChat pays the per-broadcaster chat buckets, at mod capacity when the bot
-// moderates the channel. The standard lane is constrained by BOTH a restricted
-// standard bucket and the shared bucket, consumed atomically via takeOrdered:
-// a denial on either bucket leaves both untouched, avoiding token waste during
-// retry storms.
+// takeChat pays the per-broadcaster chat bucket, at mod capacity when the bot
+// moderates the channel. This bucket IS the real Twitch per-channel chat limit
+// (20/30s, or 100/30s when the bot moderates), keyed per broadcaster, so it is
+// not a pool the premium and standard lanes contend over: a standard channel
+// spending its own Twitch budget takes nothing a premium channel could have
+// used. The lane therefore does not restrict this bucket. Premium priority for
+// chat is enforced upstream at processing time, by the sesame consumer's
+// reserved routine share (premium commands get handled first under load), not by
+// throttling a standard channel's own send rate. The standard-lane half-reserve
+// stays only on the genuinely shared Helix app budget (see takeGeneralHelix).
 func (w *Worker) takeChat(ctx context.Context, broadcasterID string, isMod bool) error {
-	sharedSpec, standardSpec := chatSpec, chatStandardSpec
+	spec := chatSpec
 	if isMod {
-		sharedSpec, standardSpec = chatModSpec, chatModStandardSpec
+		spec = chatModSpec
 	}
-	shared := sharedSpec.ForDynamicKey("ratelimit:chat:", "chat", broadcasterID)
-	if w.lane != LaneStandard {
-		return w.take(ctx, shared)
-	}
-	standard := standardSpec.ForDynamicKey("ratelimit:chat:standard:", "chat:standard", broadcasterID)
-	return w.takeOrdered(ctx, standard, shared)
+	return w.take(ctx, spec.ForDynamicKey("ratelimit:chat:", "chat", broadcasterID))
 }
 
 // takeGeneralHelix consumes one token from the Helix budget backing the

--- a/deploy/ansible/group_vars/all.yml
+++ b/deploy/ansible/group_vars/all.yml
@@ -8,8 +8,8 @@
 #                 generated on first run and persisted to /etc/fleet/node-name.
 # ─────────────────────────────────────────────────────────────────────────────
 
-# --- k3s control plane (node1) -----------------------------------------------
-k3s_server_ip: "100.98.67.104"          # node1 Tailscale IPv4
+# --- k3s control plane (node2) -----------------------------------------------
+k3s_server_ip: "100.95.95.9"            # node2 Tailscale IPv4 (CP migrated node1->node2 2026-07-01)
 k3s_url: "https://{{ k3s_server_ip }}:6443"
 k3s_version: "v1.35.5+k3s1"             # pinned to running fleet; bump deliberately
 flannel_iface: "tailscale0"            # all cluster traffic stays on the tailnet
@@ -27,6 +27,7 @@ tailscale_port: 41641                   # UDP listen port
 tailscale_direct_peers:
   - node1
   - node2
+  - node3
   - worker1
 
 # --- Node identity -----------------------------------------------------------

--- a/deploy/flux/clusters/production/node1-to-db-RUNBOOK.md
+++ b/deploy/flux/clusters/production/node1-to-db-RUNBOOK.md
@@ -1,0 +1,61 @@
+# Runbook: transform node1 (OCI ARM) into a dedicated DB node
+
+Forward-looking plan. **Not started.** Captures the sequence so it is ready when
+the trigger fires. Written 2026-07-09.
+
+## Current fleet (baseline for this runbook)
+
+| Node | Host | Role today |
+|------|------|-----------|
+| node1 | OCI ARM, 2c / 12GB | Infra anchor + valkey **backup** replica + nats member. Walled off from hot-path. Destined to become DB-only. |
+| node2 | OVH, 6c | k3s server (single sqlite control plane) + hot-path + valkey **master** + nats member. |
+| node3 | OVH, 6c | Hot-path (added 2026-07-09). No valkey replica yet. |
+| worker1 | home, 8c | Disposable hot-path + valkey **read-only** replica (`replica-priority 0`, never promoted) + nats. |
+
+- DB today: managed **MySQL HeatWave** (external). Services own per-schema tables
+  (see `project_mysql_db_grants`), so migration is schema-by-schema.
+- End-state: node1 = self-hosted MySQL only; OVH 1/2/3 (node2/node3/OVH3) = etcd
+  HA control plane; worker1 = flaky disposable compute.
+
+## Do NOT start until ALL three hold
+
+1. **HeatWave is actually full** (its tier caps you; that is the trigger, not a date).
+2. **You are present** to babysit (never during travel).
+3. **OVH3 exists** (preferred) so etcd = 3 OVH and node1 is not needed as a server.
+
+## Pre-reqs
+
+- valkey has promotable replicas on **node2 AND node3** (so node1's valkey can be
+  removed without losing a compute-node master). Bump the StatefulSet + add node3.
+- nats/JetStream R3 has members on node2/node3 (+worker1) so node1's nats can drain
+  without losing quorum or stranding stream leaders.
+- Spare CPU/mem on node2/node3 to receive node1's singletons.
+
+## Sequence (each step reversible until the DB cutover in step 4)
+
+1. **Valkey off node1.** Master is already on node2 (controlled failover 2026-07-09).
+   Add a node3 replica, raise node1's `replica-priority` (de-prefer, e.g. 200) so
+   master stays on node2/node3, then remove node1 from the valkey StatefulSet.
+   Confirm: master on node2/node3, worker1 still `priority 0`, no split brain.
+2. **NATS off node1.** Confirm JetStream stream + meta leaders are on node2/node3,
+   then drain node1's `nats` + `nats-leaf`. Recheck quorum and leaders.
+3. **Relocate node1 singletons** to node2/node3, one at a time, verifying health of
+   each before moving the next: Flux controllers, cloudflared, doppler-operator,
+   tailscale operator, ts-ingress, a CoreDNS replica, linkerd control-plane pods.
+   traefik/newrelic/repair-controller are DaemonSets and follow automatically.
+4. **DB cutover (point of no return).** Snapshot HeatWave first. Stand up
+   self-hosted MySQL on node1 (per-service schemas). Migrate schema-by-schema, then
+   flip each service's DSN (Doppler) from HeatWave to node1 MySQL and validate that
+   service before the next.
+5. **Fence node1 as DB-only.** `kubectl drain node1 --ignore-daemonsets
+   --delete-emptydir-data`, label/taint `role=db:NoSchedule`, keep only the MySQL
+   workload tolerating it.
+6. **Decommission HeatWave** once every service is validated on node1 MySQL.
+
+## Safety
+
+- Steps 1-3 are reversible. Step 4 is not without the HeatWave snapshot. Never run
+  3-4 while traveling.
+- node1 is 2 cores: MySQL only, nothing else co-resident.
+- HA control-plane (sqlite -> embedded etcd, 3 OVH servers) is a **separate** project
+  from this DB move; do not couple them in the same maintenance window.

--- a/deploy/infra/cluster/kustomization.yaml
+++ b/deploy/infra/cluster/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - cloudflared.yaml
   - linkerd-ha.yaml
   - linkerd-self-healing.yaml
+  - linkerd-cni-repair-controller.yaml
   - newrelic-dopplersecrets.yaml
   - newrelic-logging.yaml
   - traefik-config.yaml

--- a/deploy/infra/cluster/linkerd-cni-repair-controller.yaml
+++ b/deploy/infra/cluster/linkerd-cni-repair-controller.yaml
@@ -1,0 +1,144 @@
+# linkerd-cni-repair-controller
+#
+# Standalone, Flux-owned deployment of Linkerd's cni-repair-controller. Upstream
+# ships it as an optional sidecar in the linkerd-cni DaemonSet (repairController.
+# enabled), but this cluster's linkerd-cni was installed out-of-band via
+# `linkerd install-cni` with the controller disabled, so its ClusterRole carries
+# only get/list/watch on pods, not the delete the controller needs. Rather than
+# mutate that out-of-band DaemonSet and ClusterRole (a linkerd reinstall would
+# revert either), the controller runs as its own per-node DaemonSet with its own
+# RBAC, tracked here so it survives linkerd upgrades.
+#
+# What it heals: when a node disruption transiently drops the linkerd plugin from
+# the CNI chain, any pod whose network sandbox is created in that window never
+# gets linkerd's iptables redirect. CrashLoopBackOff restarts the CONTAINER, not
+# the sandbox, so the pod loops on its linkerd-network-validator init forever
+# ("connection refused", the redirect probe reaching nothing) until deleted by
+# hand. This controller scans its own node, finds those pods, and deletes them so
+# the kubelet rebuilds the sandbox against the now-correct chain. See
+# deploy/infra/cluster/linkerd-self-healing.yaml for the separate control-plane
+# bootstrap services.
+#
+# It is intentionally NOT linkerd-injected: it has to run on a node whose linkerd
+# CNI path is broken, so it depends only on plain flannel pod networking (which
+# still works in that failure, the victims get flannel, they just lack linkerd's
+# iptables) to reach the API server. hostNetwork is not needed for the same
+# reason, mirroring the linkerd-cni DaemonSet which also runs on pod network.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: linkerd-cni-repair-controller
+  namespace: linkerd-cni
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: linkerd-cni-repair-controller
+rules:
+  # Scan pods to find the stuck ones (the controller filters to its own node),
+  # and remove them. delete is what upstream's controller uses; eviction is
+  # granted too so the PDB-respecting path works if the binary prefers it. A
+  # stuck pod is already not-Ready, so evicting it never trips a disruption
+  # budget it was still counting toward.
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch", "delete"]
+  - apiGroups: [""]
+    resources: ["pods/eviction"]
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: linkerd-cni-repair-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: linkerd-cni-repair-controller
+subjects:
+  - kind: ServiceAccount
+    name: linkerd-cni-repair-controller
+    namespace: linkerd-cni
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: linkerd-cni-repair-controller
+  namespace: linkerd-cni
+  labels:
+    k8s-app: linkerd-cni-repair-controller
+spec:
+  selector:
+    matchLabels:
+      k8s-app: linkerd-cni-repair-controller
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        k8s-app: linkerd-cni-repair-controller
+      annotations:
+        linkerd.io/inject: disabled
+    spec:
+      serviceAccountName: linkerd-cni-repair-controller
+      # Schedule early and resist eviction like the CNI itself; a node that just
+      # rebooted needs its healer up before the injected workloads land.
+      priorityClassName: system-node-critical
+      # Run wherever the CNI runs: every node, including worker1 (worker-pool
+      # taint) and any control-plane taint. Mirrors the linkerd-cni DaemonSet.
+      tolerations:
+        - operator: Exists
+      nodeSelector:
+        kubernetes.io/os: linux
+      containers:
+        - name: repair-controller
+          image: cr.l5d.io/linkerd/cni-plugin@sha256:943bbdeafd98e967e8102a6d2bbf2253fb9ea1b907ae2906fde25f5caa540a0f # v1.6.7, already on every node
+          imagePullPolicy: IfNotPresent
+          command: ["/usr/lib/linkerd/linkerd-cni-repair-controller"]
+          args:
+            - --admin-addr
+            - "0.0.0.0:9990" # IPv4 only; the CNI config runs ipv6:false
+            - --log-format
+            - plain
+            - --log-level
+            - linkerd_cni_repair_controller=info,warn
+          env:
+            - name: LINKERD_CNI_REPAIR_CONTROLLER_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: LINKERD_CNI_REPAIR_CONTROLLER_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          ports:
+            - containerPort: 9990
+              name: repair-admin
+          livenessProbe:
+            httpGet:
+              path: /live
+              port: repair-admin
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: repair-admin
+            initialDelaySeconds: 10
+            failureThreshold: 7
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            privileged: false
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
+      terminationGracePeriodSeconds: 10

--- a/deploy/infra/valkey/statefulset.yaml
+++ b/deploy/infra/valkey/statefulset.yaml
@@ -12,7 +12,7 @@ spec:
     whenDeleted: Retain
     whenScaled: Retain
   podManagementPolicy: OrderedReady
-  replicas: 3 # one valkey+sentinel pod per node incl worker1 (hostPort + one-per-node spread); node3 decommissioned
+  replicas: 4 # one valkey+sentinel pod per node (hostPort + one-per-node spread): worker1, node2, node1, node3
   revisionHistoryLimit: 10
   selector:
     matchLabels:
@@ -90,6 +90,16 @@ spec:
         - /bin/sh
         - -ec
         - |
+          # Resolve the CURRENT master: ask a live Sentinel first (the fleet may
+          # have failed over any number of times since pod-0 was master), falling
+          # back to the /shared pod-0 seed only for a full cold start where no
+          # Sentinel answers. Blindly seeding replicaof from pod-0 chains a new
+          # replica under whatever pod-0 happens to be — on worker1 that is the
+          # fenced priority-0 replica — creating a sub-replica that Sentinel
+          # neither discovers nor manages (hit live on the 2026-07-09 scale-out).
+          MASTER_IP=$(cat /shared/master_ip)
+          LIVE_MASTER=$(REDISCLI_AUTH="${CORE}" valkey-cli -h valkey.valkey.svc.cluster.local -p 26379 --no-auth-warning sentinel get-master-addr-by-name myprimary 2>/dev/null | head -n 1)
+          case "${LIVE_MASTER}" in *.*.*.*) MASTER_IP="${LIVE_MASTER}";; esac
           if [ ! -f /data/valkey.conf ]; then
             cp /config/valkey.conf /data/valkey.conf
             {
@@ -97,16 +107,29 @@ spec:
               echo "replica-announce-ip ${HOST_IP}"
               echo "replica-announce-port 6379"
             } >> /data/valkey.conf
-            # Cold-start seed only: every node but pod-0 begins as its replica;
-            # Sentinel owns all failovers afterwards. Skipped once valkey has
-            # rewritten its own replication state.
+            # First-boot seed only: every pod but the master's begins as its
+            # replica; Sentinel owns all failovers afterwards. Skipped once
+            # valkey has rewritten its own replication state.
             if [ "${POD_INDEX}" != "0" ]; then
-              echo "replicaof valkey-node-0.valkey-headless.valkey.svc.cluster.local 6379" >> /data/valkey.conf
+              echo "replicaof ${MASTER_IP} 6379" >> /data/valkey.conf
+            fi
+            # The home node (worker1, flaky wifi) keeps a read replica but must never
+            # be promoted: Sentinel never elects a priority-0 replica. Keyed on the
+            # node, not the ordinal, so whichever pod lands on worker1 is fenced. The
+            # live cluster was set the same way via CONFIG SET + REWRITE; this only
+            # re-seeds it after a fresh-PVC disaster rebuild.
+            if [ "${NODE_NAME}" = "worker1" ]; then
+              echo "replica-priority 0" >> /data/valkey.conf
+            fi
+            # node1 (2-core, future DB node) is the last-resort master: higher
+            # number = less preferred, so failovers pick node3/node2 (100) first.
+            # Mirrors the live CONFIG SET applied 2026-07-09.
+            if [ "${NODE_NAME}" = "node1" ]; then
+              echo "replica-priority 200" >> /data/valkey.conf
             fi
             chmod 600 /data/valkey.conf
           fi
           if [ ! -f /data/sentinel.conf ]; then
-            MASTER_IP=$(cat /shared/master_ip)
             cp /config/sentinel.conf /data/sentinel.conf
             {
               echo "requirepass ${CORE}"
@@ -122,6 +145,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
         - name: POD_INDEX
           valueFrom:
             fieldRef:

--- a/internal/projection/client.go
+++ b/internal/projection/client.go
@@ -228,6 +228,16 @@ func (c *Client) User(ctx context.Context, userID uint64) (User, error) {
 	})
 }
 
+// Modules returns the broadcaster's enabled ModuleView set from the in-process
+// cache, filling a cold entry from the Valkey projection (tier 2) or the
+// projector RPC (tier 3). A genuine empty answer (projected, no modules) is
+// cached like any other; a LOAD FAILURE is not. GetOrLoad only stores the value
+// when the loader returns nil, so surfacing the RPC error here keeps a transient
+// projector blip from caching an empty set for the whole TTL, which would mask
+// automod and every per-channel module toggle until it expired. The error is
+// cheap to return: every caller already fails open or nacks on it (the pipeline
+// nacks for redelivery, clip/timers fall open per-call), and none of them cache
+// it, so each keeps its own policy instead of inheriting a poisoned entry.
 func (c *Client) Modules(ctx context.Context, userID uint64) ([]ModuleView, error) {
 	return c.modules.GetOrLoad(ctx, key("modules", userID), func(ctx context.Context) ([]ModuleView, error) {
 		if mods, projected, err := c.store.GetModules(ctx, userID); err == nil && projected {
@@ -238,7 +248,7 @@ func (c *Client) Modules(ctx context.Context, userID uint64) ([]ModuleView, erro
 			Modules []ModuleView `json:"modules"`
 		}](ctx, c.nc, c.subjects.Modules, projectionRequest(userID), c.rpcTimeout)
 		if err != nil {
-			return []ModuleView{}, nil
+			return nil, err
 		}
 		return reply.Modules, nil
 	})


### PR DESCRIPTION
## What

**Fleet: node3 (OVH mtl1, Intel 6c) joined 2026-07-09** — provisioned via `deploy/ansible` (tailnet-only, system SSH removed), no worker-pool taint, hot-path eligible.

### valkey (`deploy/infra/valkey`)
- `replicas: 3 -> 4`, one per node including node3. node-3's PVC already exists live (retained from the verified scale-out); the pod rejoins with correct state on merge.
- config-init resolves the **current master from a live Sentinel** instead of assuming pod-0: the old seed chained a new replica under whatever pod-0 is — on worker1 that's the fenced replica — creating a sub-replica Sentinel never manages (hit live during the scale-out, fixed with `REPLICAOF`).
- Priority seeds keyed on node name, mirroring live `CONFIG SET + REWRITE`: worker1 `0` (home node, never promoted), node1 `200` (last resort — CPU-tight, future DB node), node2/node3 default `100`. Master currently on node2.
- **Note:** template change rolls valkey pods one-by-one on merge; expect one brief Sentinel failover when the master pod restarts (lands on node3/node2 deterministically).

### linkerd (`deploy/infra/cluster`)
- New standalone DaemonSet running upstream `linkerd-cni-repair-controller` with least-privilege RBAC (pods get/list/watch/delete + eviction). Deletes pods whose sandbox predates a CNI conflist heal (validator stuck on "connection refused"), replacing manual pod deletes after node disruptions. Already applied live and verified 3/3; Flux adopts it here. Deliberately **not** meshed — it must work when linkerd CNI is the broken piece.

### Code fixes
- **projection:** `Modules` RPC failure returned an empty list as success, which the cache stored for the full TTL — one projector blip masked automod + all module toggles. Now surfaces the error (never cached; callers already fail open or nack).
- **outgress:** dropped the standard-lane halving of per-channel chat buckets. The chat bucket *is* Twitch's per-channel limit, not a shared pool — halving it only throttled a channel's own reply budget. Lane priority stays at processing time (consumer reserve); the half-reserve remains on the genuinely shared Helix app budget.

### ansible
- k3s joins point at node2 (control plane since 2026-07-01, was stale at node1) and node3 added to the direct-UDP peer gate.

### Docs
- `node1-to-db-RUNBOOK.md`: staged plan + triggers for converting node1 (OCI) to a dedicated DB node.

## Verification
- Go: build + tests green (outgress, projection, cache, sesame engine).
- `kubectl kustomize` green on `deploy/infra/valkey` and `deploy/infra/cluster`.
- Live: node3 Ready + rebooted clean; valkey node-3 replica verified replicating from master before Flux reverted the live scale (this PR makes it stick); repair-controller 3/3 with RBAC probed.