### PR TITLE
fix(live): seed stream status on mid-stream enroll

### DIFF
--- a/app/outgress/internal/worker/eventsub.go
+++ b/app/outgress/internal/worker/eventsub.go
@@ -141,6 +141,10 @@ func (w *Worker) enableEventSubs(ctx context.Context, e enrollment) error {
 		if err == nil {
 			_ = w.registry.SetSubState(ctx, e.broadcasterID, "ok", "")
 			w.log.Info("eventsub subscriptions created", zap.String("broadcaster_id", e.broadcasterID))
+			// A channel enrolled mid-stream gets no stream.online for the session
+			// already running, so resolve the live state now instead of leaving
+			// live-gated commands offline until the next stream.
+			w.seedLiveStatus(ctx, e.broadcasterID)
 			return nil
 		}
 
@@ -202,6 +206,9 @@ func (w *Worker) reconnectEventSubs(ctx context.Context, e enrollment) error {
 			_ = w.registry.SetSubState(ctx, e.broadcasterID, "ok", "")
 			w.log.Info("reconnect: all eventsubs accepted",
 				zap.String("broadcaster_id", e.broadcasterID))
+			// The rebuilt subscriptions missed any go-live that happened while the
+			// channel was between sub sets; re-resolve the live state directly.
+			w.seedLiveStatus(ctx, e.broadcasterID)
 			return nil
 		}
 

--- a/app/outgress/internal/worker/streamstatus.go
+++ b/app/outgress/internal/worker/streamstatus.go
@@ -50,6 +50,41 @@ func (w *Worker) processStreamStatus(ctx context.Context, payload outgress.Messa
 	return nil
 }
 
+// seedLiveStatus resolves the broadcaster's current live state right after an
+// EventSub enroll. Twitch only delivers stream.online for sessions that start
+// after the subscription exists, so a channel enrolled (or re-enrolled) while
+// its stream is already running never receives the go-live event for the
+// session in progress; without this seed the live projection stays cold and
+// every live-gated command reads offline until the next stream. Best-effort:
+// the enroll itself already succeeded, and the worker's cold-miss escalation
+// remains the safety net when the seed fails.
+func (w *Worker) seedLiveStatus(ctx context.Context, broadcasterID string) {
+	if w.live == nil {
+		return
+	}
+	if err := w.takeSystemHelix(ctx); err != nil {
+		w.log.Warn("live seed: no system budget, skipping",
+			zap.String("broadcaster_id", broadcasterID), zap.Error(err))
+		return
+	}
+	isLive, err := w.twitch.IsStreamLive(ctx, broadcasterID)
+	if err != nil {
+		w.log.Warn("live seed: stream check failed",
+			zap.String("broadcaster_id", broadcasterID), zap.Error(err))
+		return
+	}
+	if err := w.live.Write(ctx, broadcasterID, isLive); err != nil {
+		w.log.Warn("live seed: projection write failed",
+			zap.String("broadcaster_id", broadcasterID), zap.Error(err))
+		return
+	}
+	if isLive {
+		w.scheduleModStatus(broadcasterID, "")
+	}
+	w.log.Info("live state seeded after enroll",
+		zap.String("broadcaster_id", broadcasterID), zap.Bool("live", isLive))
+}
+
 // streamStatusFailure drops permanent Twitch rejections (retrying can never
 // fix them) and nacks the rest so the paced redelivery retries.
 func (w *Worker) streamStatusFailure(ctx context.Context, broadcasterID string, err error) error {

--- a/deploy/k8s/nats-auth.conf
+++ b/deploy/k8s/nats-auth.conf
@@ -81,12 +81,14 @@ accounts: {
       },
       {
         # projector: folds data.> events into Valkey, consumes the stream.online
-        # event, requests reproject. (Its dashboard/status RPCs live in
-        # PROJECTOR_RPC.)
+        # event, requests reproject, and escalates a cold live query onto the
+        # outgress system lane (rpc/live.go) so a channel with no projected live
+        # state gets re-checked against Twitch instead of staying offline. (Its
+        # dashboard/status RPCs live in PROJECTOR_RPC.)
         user: "projector_bus"
         password: $NATS_BCRYPT_PROJECTOR_BUS
         permissions: {
-          publish:   { allow: ["data.reproject.request", "$JS.>"] }
+          publish:   { allow: ["data.reproject.request", "twitch.outgress.system", "$JS.>"] }
           subscribe: {
             allow: [
               "data.users.>",


### PR DESCRIPTION
## Problem

A streamer that creates their account mid-stream and adds a live-only command gets no working live gate for the entire session:

1. **Dead escalation (ACL gap):** `projector_bus` had publish permission only on `data.reproject.request` + `$JS.>`. The projector's cold live-query escalation (`app/projector/rpc/live.go`) publishes a `stream_status` job to `twitch.outgress.system`, which NATS silently denied (warn log only). With the settings hash carrying no `live` field, every sesame read came back offline and nothing ever corrected it — same silent-reject pattern as the `data.commands.used` counter gap.
2. **No go-live event for a running stream:** EventSub only delivers `stream.online` for sessions that start after the subscription exists, so a channel enrolled mid-stream never receives the event for the stream in progress.

## Fix

- Add `twitch.outgress.system` to `projector_bus` publish allow in `deploy/k8s/nats-auth.conf` (hot ACL reload on Flux push).
- Seed the live state right after a successful EventSub enable/reconnect: outgress resolves Helix Get Streams, writes the `live:<id>` key through `LiveWriter` (invalidation broadcast included), and schedules the mod-status re-verify when live. Best-effort; the cold-miss escalation remains the safety net.

## Verification

- `go build ./...`, `go vet`, and tests for `app/outgress/internal/worker`, `app/projector/...`, `app/sesame/engine` all pass.
- Deploy note: ACL change applies on config push; the seed needs an outgress image rollout.