### PR TITLE
fix(projection): route sesame config reads through projector

### DIFF
--- a/app/sesame/internal/config/config.go
+++ b/app/sesame/internal/config/config.go
@@ -84,8 +84,12 @@ type Config struct {
 	// LiveTTL bounds how long a live key survives without a refresh.
 	LiveTTL time.Duration
 
-	// Projection RPC subjects: the contracts sesame uses to resolve the user,
-	// modules and commands for the broadcaster an event belongs to.
+	// Projection RPC subjects: the cold-key fallbacks behind the Valkey
+	// settings projection. Modules and commands ask the PROJECTOR's dashboard
+	// get verbs — the projector owns Valkey, so its miss path hydrates the
+	// projection and the next read is a plain Valkey hit; sesame never asks
+	// the modules/commands services directly. Users still asks the users
+	// service's projection verb (the projector exposes no user-shaped read).
 	ProjectionUsersSubject    string
 	ProjectionModulesSubject  string
 	ProjectionCommandsSubject string
@@ -152,8 +156,8 @@ func Load() *Config {
 		LiveTTL: env.GetDuration("SESAME_LIVE_TTL", 12*time.Hour),
 
 		ProjectionUsersSubject:    env.Get("NATS_INTERNAL_PROJECTION_USERS_SUBJECT", "bagel.rpc.internal.projection.users.get"),
-		ProjectionModulesSubject:  env.Get("NATS_INTERNAL_PROJECTION_MODULES_SUBJECT", "bagel.rpc.internal.projection.modules.get"),
-		ProjectionCommandsSubject: env.Get("NATS_INTERNAL_PROJECTION_COMMANDS_SUBJECT", "bagel.rpc.internal.projection.commands.get"),
+		ProjectionModulesSubject:  env.Get("NATS_INTERNAL_PROJECTION_MODULES_SUBJECT", "bagel.rpc.projector.dashboard.modules.get"),
+		ProjectionCommandsSubject: env.Get("NATS_INTERNAL_PROJECTION_COMMANDS_SUBJECT", "bagel.rpc.projector.dashboard.commands.get"),
 
 		CacheInvalidationPrefix: env.Get("NATS_CACHE_INVALIDATION_PREFIX", "bagel.cache.invalidate"),
 

--- a/deploy/k8s/nats-auth.conf
+++ b/deploy/k8s/nats-auth.conf
@@ -253,6 +253,10 @@ accounts: {
       { service: "bagel.rpc.broadcaster.live.get" }
       { stream: "bagel.cache.invalidate.commands" }
       { stream: "bagel.cache.invalidate.modules" }
+      # Live-state pings from the stream-event fold (broadcastLiveInvalidate):
+      # without this export the worker's live cache only hears its own
+      # replicas, never the projector's go-live/offline fan-out.
+      { stream: "bagel.cache.invalidate.live" }
     ]
     imports: [
       { service: { account: "USERS_RPC",    subject: "bagel.rpc.internal.projection.users.get" } }
@@ -320,15 +324,26 @@ accounts: {
     ]
   }
 
-  # WORKER_RPC requests the data services' projections to resolve action state;
-  # imports the cache-invalidation sections it caches (status, grant, commands,
-  # modules).
+  # WORKER_RPC resolves config through the PROJECTOR (Valkey owner): module and
+  # command cold-key fallbacks hit the projector's dashboard get verbs, which
+  # hydrate the projection so the next read is a Valkey hit. The only data
+  # services it still reaches are users (projection read; the projector has no
+  # user-shaped verb) and commands' CRUD verbs (the !cmd chat saves — a write
+  # path, not a config read). Imports the cache-invalidation sections it caches
+  # (status, grant, locale, commands, modules, live).
   WORKER_RPC: {
     users: [ { user: "worker_rpc", password: $NATS_BCRYPT_WORKER_RPC } ]
     imports: [
       { service: { account: "USERS_RPC",    subject: "bagel.rpc.internal.projection.users.get" } }
-      { service: { account: "COMMANDS_RPC", subject: "bagel.rpc.internal.projection.commands.get" } }
       { service: { account: "COMMANDS_RPC", subject: "bagel.rpc.commands.>" } }
+      { service: { account: "PROJECTOR_RPC", subject: "bagel.rpc.projector.dashboard.commands.get" } }
+      { service: { account: "PROJECTOR_RPC", subject: "bagel.rpc.projector.dashboard.modules.get" } }
+      # TRANSITIONAL (remove after sesame rolls onto the projector-dashboard
+      # fallback): the ACL hot-reloads minutes before the new image lands, and
+      # the outgoing sesame release still cold-key-falls-back to the data
+      # services' projection verbs. Dropping these before the roll would make
+      # cold-key custom commands time out for the whole window.
+      { service: { account: "COMMANDS_RPC", subject: "bagel.rpc.internal.projection.commands.get" } }
       { service: { account: "MODULES_RPC",  subject: "bagel.rpc.internal.projection.modules.get" } }
       { service: { account: "PROJECTOR_RPC", subject: "bagel.rpc.broadcaster.live.get" } }
       { service: { account: "GATEWAY_RPC",  subject: "bagel.rpc.gateway.>" } }
@@ -337,6 +352,7 @@ accounts: {
       { stream: { account: "USERS_RPC",     subject: "bagel.cache.invalidate.locale" } }
       { stream: { account: "PROJECTOR_RPC", subject: "bagel.cache.invalidate.commands" } }
       { stream: { account: "PROJECTOR_RPC", subject: "bagel.cache.invalidate.modules" } }
+      { stream: { account: "PROJECTOR_RPC", subject: "bagel.cache.invalidate.live" } }
     ]
   }
 

--- a/internal/projection/client.go
+++ b/internal/projection/client.go
@@ -7,8 +7,11 @@
 //
 //  1. in-process cache (theine, short TTL) - the hot path, no I/O;
 //  2. Valkey settings:<user_id> hash - the shared projection (read only);
-//  3. NATS RPC to the projector - the authority that owns Valkey, asked on a
-//     cold key. The worker never writes Valkey; the projector populates it.
+//  3. NATS RPC on a cold key. Modules and commands ask the projector's
+//     dashboard get verbs - the projector owns Valkey, so its miss path
+//     hydrates the projection and the next read is a Valkey hit. Users ask
+//     the users service's projection verb. The worker never writes Valkey;
+//     the projector populates it.
 //
 // Commands are cached per command (key command:<id>:<name>), loaded with a
 // single HGET against the projection, so editing one command never forces a
@@ -86,7 +89,9 @@ type Reader interface {
 	Command(ctx context.Context, userID uint64, name string) (Command, bool, error)
 }
 
-// Subjects names the projector RPC each read falls through to on a Valkey miss.
+// Subjects names the RPC each read falls through to on a Valkey miss:
+// Modules and Commands are the projector's dashboard get verbs, Users is the
+// users service's projection verb.
 type Subjects struct {
 	Users    string
 	Modules  string

--- a/internal/projection/valkey.go
+++ b/internal/projection/valkey.go
@@ -152,7 +152,12 @@ func (v *Store) SetStreamLive(ctx context.Context, userID uint64, live bool) err
 	)
 }
 
-// SetModule projects one module row of one user.
+// SetModule projects one module row of one user. It deliberately does NOT set
+// the modules:projected marker: a single-row event landing on a cold hash must
+// not make a partial module list read as complete. Only the full-section
+// writes (SetModules / SetModulesWithTTL) mark the section projected; until
+// one runs, readers fall through to the projector RPC, whose miss path
+// hydrates the full list.
 func (v *Store) SetModule(ctx context.Context, userID uint64, mod ModuleView) error {
 
 	defer segment(ctx, "HSET")()
@@ -162,7 +167,6 @@ func (v *Store) SetModule(ctx context.Context, userID uint64, mod ModuleView) er
 	fields := v.client.B().Hset().
 		Key(key).
 		FieldValue().
-		FieldValue("modules:projected", "1").
 		FieldValue("module:"+mod.Name+":enabled", utils.BoolField(mod.IsEnabled))
 
 	if len(mod.Configs) > 0 {
@@ -243,10 +247,7 @@ func (v *Store) SetCommand(ctx context.Context, dto data.CommandChangedDTO) erro
 	cmds := v.retireStaleAliases(ctx, key, field)
 
 	if dto.Deleted {
-		cmds = append(cmds,
-			v.client.B().Hdel().Key(key).Field(field).Build(),
-			v.client.B().Hset().Key(key).FieldValue().FieldValue("commands:projected", "1").Build(),
-		)
+		cmds = append(cmds, v.client.B().Hdel().Key(key).Field(field).Build())
 		cmds = append(cmds, v.expiryCommands(key, DefaultTTL)...)
 		return v.pipeline(ctx, cmds...)
 	}
@@ -280,7 +281,9 @@ func (v *Store) retireStaleAliases(ctx context.Context, key, field string) []val
 }
 
 // commandSetCommand builds the HSET writing the command body plus its alias
-// pointers.
+// pointers. Like SetModule, it never sets commands:projected: a single event
+// row on a cold hash must not make the command section read as complete —
+// only SetCommands / SetCommandsWithTTL (full-list writes) set the marker.
 func (v *Store) commandSetCommand(key, field, name string, dto data.CommandChangedDTO) (valkey.Completed, error) {
 	view := commandViewFromEvent(dto)
 	body, err := json.Marshal(view)
@@ -288,7 +291,6 @@ func (v *Store) commandSetCommand(key, field, name string, dto data.CommandChang
 		return valkey.Completed{}, err
 	}
 	set := v.client.B().Hset().Key(key).FieldValue().
-		FieldValue("commands:projected", "1").
 		FieldValue(field, string(body))
 	for _, a := range view.Aliases {
 		set = set.FieldValue(aliasFieldPrefix+strings.ToLower(a), name)
@@ -466,6 +468,9 @@ func (v *Store) GetModules(ctx context.Context, userID uint64) ([]ModuleView, bo
 		return nil, false, err
 	}
 
+	// projected trusts the marker alone: module rows written by single-module
+	// events (SetModule) never set it, so a partial hash correctly reads as
+	// not-yet-projected and the caller falls through to the full hydration.
 	projected := fields["modules:projected"] == "1"
 	byName := map[string]ModuleView{}
 	for field, value := range fields {
@@ -478,10 +483,8 @@ func (v *Store) GetModules(ctx context.Context, userID uint64) ([]ModuleView, bo
 		switch suffix {
 		case "enabled":
 			mod.IsEnabled = value == "1"
-			projected = true
 		case "config":
 			mod.Configs = json.RawMessage(value)
-			projected = true
 		}
 		byName[name] = mod
 	}
@@ -502,6 +505,8 @@ func (v *Store) GetCommands(ctx context.Context, userID uint64) ([]CommandView, 
 		return nil, false, err
 	}
 
+	// projected trusts the marker alone (see GetModules): per-command event
+	// rows never set it, so a partial hash falls through to full hydration.
 	projected := fields["commands:projected"] == "1"
 	out := make([]CommandView, 0)
 	for field, value := range fields {
@@ -514,7 +519,6 @@ func (v *Store) GetCommands(ctx context.Context, userID uint64) ([]CommandView, 
 			continue
 		}
 		out = append(out, cmd)
-		projected = true
 	}
 	return out, projected, nil
 }


### PR DESCRIPTION
## Problem

**Projector cached modules improperly.** Single-row event writes (`SetModule`/`SetCommand`) stamped the `modules:projected`/`commands:projected` markers, and `GetModules`/`GetCommands` additionally inferred "projected" from mere row presence. One dashboard toggle on a cold user produced a partial hash that read as the complete module/command list, so full hydration never ran and sesame served incomplete config.

**Sesame bypassed the projector on cold keys.** The modules/commands fallback subjects (`bagel.rpc.internal.projection.*`) are served by the modules/commands services directly. Nothing wrote Valkey on that path, so cold users re-RPC'd the data services every 30s cache window, forever.

**Live invalidation dropped at account boundary.** The projector publishes `bagel.cache.invalidate.live`, but PROJECTOR_RPC never exported that stream, so sesame only heard its own replicas' pings.

## Fix

- `internal/projection/valkey.go`: markers set only by full-section writes (`SetModules*`/`SetCommands*`); reads trust the marker alone. Partial hashes now escalate to the projector, whose miss path hydrates the full projection. Existing bad markers age out with the 24h TTL.
- `app/sesame/internal/config/config.go`: modules/commands cold-key fallback repointed to `bagel.rpc.projector.dashboard.{modules,commands}.get` (wire shapes field-identical; verbs trigger `EnsureAsync`). Users fallback stays on the users service (projector exposes no user-shaped read).
- `deploy/k8s/nats-auth.conf`: WORKER_RPC imports the two projector dashboard get verbs and the live invalidation stream; PROJECTOR_RPC exports `bagel.cache.invalidate.live`. Old data-service projection imports kept TRANSITIONALLY (the ACL hot-reloads minutes before the sesame image rolls); prune once sesame is on the new fallback.

## Rollout

1. Merge: NATS ACL hot-reloads via Flux configMapGenerator + SIGHUP.
2. CI builds sesame/projector images, digests get pinned, Flux rolls the deployments.
3. Follow-up: remove the transitional WORKER_RPC imports.

Verified: `go build ./...`, `go test ./internal/projection/... ./app/sesame/... ./app/projector/...` all pass.