### PR TITLE
fix(deploy): add keda namespace, widen image build selection

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -182,7 +182,11 @@ jobs:
               .containerignore|go.mod|go.sum|pkg/*)
                 add_root_go_services
                 ;;
-              internal/domain/*|internal/utils/*)
+              # Any shared internal package rebuilds every root Go service: a
+              # narrower list already missed internal/projection (imported by
+              # projector, sesame and the data services), which shipped a
+              # sesame image without its matching projector.
+              internal/*)
                 add_root_go_services
                 ;;
               app/commands/*)

--- a/deploy/infra/keda/kustomization.yaml
+++ b/deploy/infra/keda/kustomization.yaml
@@ -6,4 +6,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - namespace.yaml
   - release.yaml

--- a/deploy/infra/keda/namespace.yaml
+++ b/deploy/infra/keda/namespace.yaml
@@ -1,0 +1,11 @@
+# The HelmRelease in release.yaml lives in namespace "keda", and
+# kustomize-controller cannot apply an object into a namespace that does not
+# exist — install.createNamespace only covers the RELEASE namespace at
+# helm-install time, never the HelmRelease object's own. Without this manifest
+# the keda Kustomization fails ("namespaces \"keda\" not found") and the apps
+# Kustomization (dependsOn: keda) freezes the whole production deploy train
+# with it.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: keda


### PR DESCRIPTION
## Two production-blocking gaps

**1. keda namespace missing → deploy train frozen.** The `keda` Flux Kustomization (added earlier today) applies a `HelmRelease` into namespace `keda`, but nothing creates that Namespace. `install.createNamespace: true` only creates the release namespace at helm-install time; the HelmRelease object's own namespace must pre-exist for kustomize-controller to apply it. Result: keda stuck `ReconciliationFailed` ("namespaces \"keda\" not found"), and `apps` (`dependsOn: keda`) froze all production deploys for ~6h.

Already mitigated live (`kubectl create namespace keda` at 23:29Z; keda is now Ready and apps unblocked). This manifest makes it rebuild-safe and git-owned.

**2. Image selection missed `internal/projection`.** `publish-images.yml` mapped only `internal/domain/*` and `internal/utils/*` to the root Go services. #311 changed `internal/projection/*` and shipped a sesame image with no matching projector build (mitigated via `workflow_dispatch service=projector`). Selection now rebuilds all root Go services on any `internal/*` change.

Note: this PR touches the workflow file itself, so its merge triggers one full all-services rebuild. Builds queue, nothing cancels.