### PR TITLE
fix(outgress): auto-enroll new channels, spill enroll budget, throttle redundant enrolls

### DIFF
--- a/app/outgress/internal/channels/registry.go
+++ b/app/outgress/internal/channels/registry.go
@@ -322,6 +322,27 @@ const enrollLockPrefix = "outgress:enroll:lock:"
 
 const modCheckLockPrefix = "outgress:mod-check:lock:"
 
+const enrollCooldownPrefix = "outgress:enroll:cooldown:"
+
+// ArmEnrollCooldown records that a full enroll (enable or reconnect) just
+// completed for the broadcaster. While the key lives, an identical incoming
+// job is redundant — everything it would create already exists on the conduit
+// — so the workers can acknowledge it without spending Helix budget.
+func (r *Registry) ArmEnrollCooldown(ctx context.Context, broadcasterID string, ttl time.Duration) error {
+	return r.client.Do(ctx,
+		r.client.B().Set().Key(enrollCooldownPrefix+broadcasterID).Value("1").PxMilliseconds(ttl.Milliseconds()).Build(),
+	).Error()
+}
+
+// EnrollCooldownActive reports whether ArmEnrollCooldown ran within its ttl.
+func (r *Registry) EnrollCooldownActive(ctx context.Context, broadcasterID string) (bool, error) {
+	n, err := r.client.Do(ctx, r.client.B().Exists().Key(enrollCooldownPrefix+broadcasterID).Build()).AsInt64()
+	if err != nil {
+		return false, err
+	}
+	return n > 0, nil
+}
+
 // AcquireEnrollLock tries to set a Valkey NX key as a distributed lock.
 // Returns true if this caller owns the lock, false if another replica holds it.
 func (r *Registry) AcquireEnrollLock(ctx context.Context, broadcasterID, owner string, ttl time.Duration) (bool, error) {

--- a/app/outgress/internal/worker/buckets.go
+++ b/app/outgress/internal/worker/buckets.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"ItsBagelBot/app/outgress/internal/twitch"
@@ -102,11 +103,21 @@ func (w *Worker) takeGeneralHelix(ctx context.Context, payload outgress.Message)
 	return w.take(ctx, shared)
 }
 
-// takeSystemHelix consumes one token from the reserved system partition.
-// Only the system lane pays here, so dashboard EventSub jobs always have
-// their reserved capacity and can never spend the general api budget.
+// takeSystemHelix consumes one token for a system-lane Helix call. The
+// reserved partition is tried first, so EventSub enroll jobs always keep
+// their guaranteed floor no matter how busy chat/api traffic is. When the
+// reserve is momentarily drained (an onboarding burst, back-to-back
+// reconnects) the call spills over into the general app partition instead of
+// blocking the channel's enrollment. The reverse never happens — chat/api
+// traffic still cannot touch the reserve — and every spilled token is one the
+// general partition would have spent anyway, so the fleet stays within the
+// real 800/min Helix limit.
 func (w *Worker) takeSystemHelix(ctx context.Context) error {
-	return w.take(ctx, helixSystemSpec.ForKey("ratelimit:helix:system"))
+	err := w.take(ctx, helixSystemSpec.ForKey("ratelimit:helix:system"))
+	if !errors.Is(err, errRateLimitShared) {
+		return err
+	}
+	return w.take(ctx, helixGeneralSpec.ForKey("ratelimit:helix:app"))
 }
 
 // take consumes one token or returns an error that nacks the message, so the

--- a/app/outgress/internal/worker/buckets_test.go
+++ b/app/outgress/internal/worker/buckets_test.go
@@ -1,0 +1,86 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"ItsBagelBot/pkg/ratelimit"
+
+	"go.uber.org/zap"
+)
+
+// scriptedLimiter answers Allow per key: denied keys report exhaustion,
+// error keys report an infra failure, everything else is admitted. Keys are
+// recorded in call order so tests can assert the reserve-then-general draw.
+type scriptedLimiter struct {
+	denied map[string]bool
+	errs   map[string]error
+	calls  []string
+}
+
+func (s *scriptedLimiter) Allow(_ context.Context, req ratelimit.Request) (bool, error) {
+	s.calls = append(s.calls, req.Key)
+	if err := s.errs[req.Key]; err != nil {
+		return false, err
+	}
+	return !s.denied[req.Key], nil
+}
+
+func (s *scriptedLimiter) AllowOrdered(context.Context, ratelimit.Request, ratelimit.Request) (uint8, error) {
+	return 0, nil
+}
+
+func systemLaneWorker(limiter ratelimit.Manager) *Worker {
+	return New(Config{Log: zap.NewNop(), Limiter: limiter, Lane: LaneSystem})
+}
+
+func TestTakeSystemHelixPrefersReserve(t *testing.T) {
+	limiter := &scriptedLimiter{}
+	w := systemLaneWorker(limiter)
+
+	if err := w.takeSystemHelix(context.Background()); err != nil {
+		t.Fatalf("takeSystemHelix() = %v, want nil", err)
+	}
+	if len(limiter.calls) != 1 || limiter.calls[0] != "ratelimit:helix:system" {
+		t.Fatalf("calls = %v, want only the system reserve", limiter.calls)
+	}
+}
+
+func TestTakeSystemHelixSpillsToGeneralWhenReserveDrained(t *testing.T) {
+	limiter := &scriptedLimiter{denied: map[string]bool{"ratelimit:helix:system": true}}
+	w := systemLaneWorker(limiter)
+
+	if err := w.takeSystemHelix(context.Background()); err != nil {
+		t.Fatalf("takeSystemHelix() = %v, want nil via general spillover", err)
+	}
+	want := []string{"ratelimit:helix:system", "ratelimit:helix:app"}
+	if len(limiter.calls) != 2 || limiter.calls[0] != want[0] || limiter.calls[1] != want[1] {
+		t.Fatalf("calls = %v, want %v", limiter.calls, want)
+	}
+}
+
+func TestTakeSystemHelixDeniedWhenBothDrained(t *testing.T) {
+	limiter := &scriptedLimiter{denied: map[string]bool{
+		"ratelimit:helix:system": true,
+		"ratelimit:helix:app":    true,
+	}}
+	w := systemLaneWorker(limiter)
+
+	if err := w.takeSystemHelix(context.Background()); !errors.Is(err, errRateLimitShared) {
+		t.Fatalf("takeSystemHelix() = %v, want errRateLimitShared", err)
+	}
+}
+
+func TestTakeSystemHelixInfraErrorDoesNotSpill(t *testing.T) {
+	boom := errors.New("valkey down")
+	limiter := &scriptedLimiter{errs: map[string]error{"ratelimit:helix:system": boom}}
+	w := systemLaneWorker(limiter)
+
+	if err := w.takeSystemHelix(context.Background()); !errors.Is(err, boom) {
+		t.Fatalf("takeSystemHelix() = %v, want infra error passthrough", err)
+	}
+	if len(limiter.calls) != 1 {
+		t.Fatalf("calls = %v, want no spillover on infra error", limiter.calls)
+	}
+}

--- a/app/outgress/internal/worker/buckets_test.go
+++ b/app/outgress/internal/worker/buckets_test.go
@@ -3,6 +3,7 @@ package worker
 import (
 	"context"
 	"errors"
+	"slices"
 	"testing"
 
 	"ItsBagelBot/pkg/ratelimit"
@@ -42,7 +43,7 @@ func TestTakeSystemHelixPrefersReserve(t *testing.T) {
 	if err := w.takeSystemHelix(context.Background()); err != nil {
 		t.Fatalf("takeSystemHelix() = %v, want nil", err)
 	}
-	if len(limiter.calls) != 1 || limiter.calls[0] != "ratelimit:helix:system" {
+	if !slices.Equal(limiter.calls, []string{"ratelimit:helix:system"}) {
 		t.Fatalf("calls = %v, want only the system reserve", limiter.calls)
 	}
 }
@@ -55,7 +56,7 @@ func TestTakeSystemHelixSpillsToGeneralWhenReserveDrained(t *testing.T) {
 		t.Fatalf("takeSystemHelix() = %v, want nil via general spillover", err)
 	}
 	want := []string{"ratelimit:helix:system", "ratelimit:helix:app"}
-	if len(limiter.calls) != 2 || limiter.calls[0] != want[0] || limiter.calls[1] != want[1] {
+	if !slices.Equal(limiter.calls, want) {
 		t.Fatalf("calls = %v, want %v", limiter.calls, want)
 	}
 }

--- a/app/outgress/internal/worker/eventsub.go
+++ b/app/outgress/internal/worker/eventsub.go
@@ -9,11 +9,20 @@ import (
 
 	"ItsBagelBot/app/outgress/internal/twitch"
 	"ItsBagelBot/internal/domain/outgress"
+	"ItsBagelBot/internal/domain/rpc/manage"
 
 	"github.com/bytedance/sonic"
 
 	"go.uber.org/zap"
 )
+
+// enrollCooldownTTL bounds how often a channel's full enroll may re-run while
+// its subscriptions are verified healthy. A dashboard user spamming restart
+// (or double-submitting enable) otherwise costs ~13-24 reserved Helix calls
+// per click; within this window the redundant job is acknowledged without
+// touching Twitch. Repair paths are unaffected: the skip requires sub_state
+// "ok", so a failing, pending, or cleared channel always gets its enroll.
+const enrollCooldownTTL = 2 * time.Minute
 
 // enrollment identifies one channel's EventSub enrollment on our conduit: the
 // broadcaster whose subscriptions are managed and the conduit they route to.
@@ -101,6 +110,39 @@ func (w *Worker) underEnrollLock(ctx context.Context, op string, e enrollment, f
 	return fn()
 }
 
+// skipFreshEnroll acknowledges a redundant enroll: the channel completed a
+// full enroll inside the cooldown window and the registry still reports it
+// healthy, so re-running would only spend Helix budget re-creating (409) what
+// already exists — the signature of a user spamming the dashboard's restart
+// button. Any read error fails open and runs the enroll; wrongly skipping a
+// repair is worse than wrongly spending budget.
+func (w *Worker) skipFreshEnroll(ctx context.Context, e enrollment, op string) bool {
+	active, err := w.registry.EnrollCooldownActive(ctx, e.broadcasterID)
+	if err != nil || !active {
+		return false
+	}
+	ch, found, err := w.registry.Get(ctx, e.broadcasterID)
+	if err != nil || !redundantEnroll(ch, found) {
+		return false
+	}
+	w.log.Info(op+" skipped: subscriptions freshly enrolled and healthy",
+		zap.String("broadcaster_id", e.broadcasterID))
+	return true
+}
+
+// redundantEnroll trusts the cooldown only while the registry still reports
+// the enrollment healthy; any other state means there is real work to do.
+func redundantEnroll(ch manage.Channel, found bool) bool {
+	return found && ch.SubState == "ok"
+}
+
+// recordEnrollSuccess persists the healthy outcome and arms the cooldown that
+// lets an immediately repeated enable/reconnect be skipped.
+func (w *Worker) recordEnrollSuccess(ctx context.Context, e enrollment) {
+	_ = w.registry.SetSubState(ctx, e.broadcasterID, "ok", "")
+	_ = w.registry.ArmEnrollCooldown(ctx, e.broadcasterID, enrollCooldownTTL)
+}
+
 // retryTransient runs fn up to three times with a growing back-off, stopping
 // early on success, a permanent rejection, or context cancellation.
 func retryTransient(ctx context.Context, fn func() error) error {
@@ -133,13 +175,16 @@ func retryTransient(ctx context.Context, fn func() error) error {
 // with a persisted "failing" state surfaces the problem to the dashboard instead.
 func (w *Worker) enableEventSubs(ctx context.Context, e enrollment) error {
 	return w.underEnrollLock(ctx, "enable", e, func() error {
+		if w.skipFreshEnroll(ctx, e, "enable") {
+			return nil
+		}
 		_ = w.registry.SetSubState(ctx, e.broadcasterID, "pending", "")
 
 		err := retryTransient(ctx, func() error {
 			return w.createAllEventSubs(ctx, e)
 		})
 		if err == nil {
-			_ = w.registry.SetSubState(ctx, e.broadcasterID, "ok", "")
+			w.recordEnrollSuccess(ctx, e)
 			w.log.Info("eventsub subscriptions created", zap.String("broadcaster_id", e.broadcasterID))
 			return nil
 		}
@@ -185,6 +230,9 @@ func (w *Worker) disableChannel(ctx context.Context, e enrollment) error {
 // polling Twitch.
 func (w *Worker) reconnectEventSubs(ctx context.Context, e enrollment) error {
 	return w.underEnrollLock(ctx, "reconnect", e, func() error {
+		if w.skipFreshEnroll(ctx, e, "reconnect") {
+			return nil
+		}
 		_ = w.registry.SetSubState(ctx, e.broadcasterID, "pending", "")
 
 		// Best-effort drop: if listing/deleting fails we still try to recreate;
@@ -199,7 +247,7 @@ func (w *Worker) reconnectEventSubs(ctx context.Context, e enrollment) error {
 			return w.createAllEventSubs(ctx, e)
 		})
 		if err == nil {
-			_ = w.registry.SetSubState(ctx, e.broadcasterID, "ok", "")
+			w.recordEnrollSuccess(ctx, e)
 			w.log.Info("reconnect: all eventsubs accepted",
 				zap.String("broadcaster_id", e.broadcasterID))
 			return nil

--- a/app/outgress/internal/worker/eventsub_test.go
+++ b/app/outgress/internal/worker/eventsub_test.go
@@ -1,0 +1,29 @@
+package worker
+
+import (
+	"testing"
+
+	"ItsBagelBot/internal/domain/rpc/manage"
+)
+
+// The cooldown skip must only ever fire for a channel whose enrollment is
+// verified healthy; every other state is a repair the enroll must run for.
+func TestRedundantEnrollRequiresHealthyState(t *testing.T) {
+	cases := []struct {
+		name  string
+		ch    manage.Channel
+		found bool
+		want  bool
+	}{
+		{"ok state", manage.Channel{SubState: "ok"}, true, true},
+		{"failing state", manage.Channel{SubState: "failing"}, true, false},
+		{"pending state", manage.Channel{SubState: "pending"}, true, false},
+		{"cleared state", manage.Channel{}, true, false},
+		{"unknown channel", manage.Channel{SubState: "ok"}, false, false},
+	}
+	for _, tc := range cases {
+		if got := redundantEnroll(tc.ch, tc.found); got != tc.want {
+			t.Errorf("%s: redundantEnroll = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}

--- a/console/dashboard/src/lib/server/services.ts
+++ b/console/dashboard/src/lib/server/services.ts
@@ -264,8 +264,8 @@ export async function channelSubState(broadcasterId: string): Promise<ChannelSub
       found: boolean;
       channel?: { sub_state: string; sub_error: string; sub_checked_at: string };
     }>(`${SUB.outgressRpc}.channel.get`, { broadcaster_id: broadcasterId }, 2000);
-    const c = r.channel;
-    if (!r.found || !c || !isKnownSubState(c.sub_state)) {
+    const c = r.found ? r.channel : undefined;
+    if (!c || !isKnownSubState(c.sub_state)) {
       return { state: 'unenrolled', error: '', checkedAt: null };
     }
     return {

--- a/console/dashboard/src/lib/server/services.ts
+++ b/console/dashboard/src/lib/server/services.ts
@@ -238,7 +238,7 @@ export async function publishEventSubEnsureOptional(broadcasterId: string): Prom
 }
 
 export type ChannelSubState = {
-  state: 'ok' | 'pending' | 'failing' | 'unknown';
+  state: 'ok' | 'pending' | 'failing' | 'unenrolled' | 'unknown';
   error: string;
   checkedAt: string | null;
 };
@@ -251,10 +251,13 @@ function isKnownSubState(s: string): s is 'ok' | 'pending' | 'failing' {
   return s === 'ok' || s === 'pending' || s === 'failing';
 }
 
-// Read the persisted EventSub enroll state for a channel. Fails safe: returns
-// 'unknown' on RPC error so a transient outage never blocks page render. The
-// fail-open catch doesn't fit defineRead cleanly (no cache involved either), so
-// this stays hand-written.
+// Read the persisted EventSub enroll state for a channel. Two distinct
+// negatives: 'unenrolled' means outgress answered and holds no enrollment for
+// this channel (never enrolled, or cleared by a disconnect) — callers may
+// safely (re)enroll on it. 'unknown' is reserved for transport failure and
+// fails safe: a transient outage never blocks page render and must never
+// trigger writes. The fail-open catch doesn't fit defineRead cleanly (no cache
+// involved either), so this stays hand-written.
 export async function channelSubState(broadcasterId: string): Promise<ChannelSubState> {
   try {
     const r = await rpc<{
@@ -262,9 +265,11 @@ export async function channelSubState(broadcasterId: string): Promise<ChannelSub
       channel?: { sub_state: string; sub_error: string; sub_checked_at: string };
     }>(`${SUB.outgressRpc}.channel.get`, { broadcaster_id: broadcasterId }, 2000);
     const c = r.channel;
-    if (!r.found || !c) return unknownSubState();
+    if (!r.found || !c || !isKnownSubState(c.sub_state)) {
+      return { state: 'unenrolled', error: '', checkedAt: null };
+    }
     return {
-      state: isKnownSubState(c.sub_state) ? c.sub_state : 'unknown',
+      state: c.sub_state,
       error: c.sub_error || '',
       checkedAt: c.sub_checked_at || null
     };

--- a/console/dashboard/src/routes/(app)/+page.server.ts
+++ b/console/dashboard/src/routes/(app)/+page.server.ts
@@ -29,6 +29,11 @@ export type ConnState = {
 // Resolve the bot connection state in one round trip (grant presence + the
 // coalesced active/tier state_get + channel enroll state). allSettled keeps a
 // slow or down responder from failing the whole render.
+//
+// "Receiving" is grounded in outgress's own enroll state, not just the users
+// service's active flag: is_active defaults to true at signup, so trusting it
+// alone showed brand-new channels as connected while they had zero EventSub
+// subscriptions (and hid the only button that would have created them).
 async function connState(uid: string): Promise<ConnState> {
   const [grant, state, sub] = await Promise.allSettled([
     hasGrant(uid),
@@ -36,10 +41,24 @@ async function connState(uid: string): Promise<ConnState> {
     channelSubState(uid)
   ]);
   const enabled = grant.status === 'fulfilled' && grant.value;
-  const receiving = enabled && state.status === 'fulfilled' && state.value.active;
+  const active = enabled && state.status === 'fulfilled' && state.value.active;
   const status: AccountStatus = state.status === 'fulfilled' ? state.value.status : 'free';
-  const subState: ChannelSubState['state'] = sub.status === 'fulfilled' ? sub.value.state : 'unknown';
+  let subState: ChannelSubState['state'] = sub.status === 'fulfilled' ? sub.value.state : 'unknown';
   const subError: string = sub.status === 'fulfilled' ? sub.value.error : '';
+
+  // Self-heal: a channel the users service says is active but outgress has no
+  // enrollment for (fresh signup, or one predating auto-enroll) gets its
+  // EventSub enable job published right here on page load. Safe to repeat:
+  // outgress single-flights the enroll and creates are 409-idempotent. Only
+  // 'unenrolled' triggers this — 'unknown' (outgress RPC down) must not spam
+  // enables. Report 'pending' so the UI shows the enroll in flight; the
+  // substate poll takes over with the real outcome.
+  if (active && subState === 'unenrolled' && uid !== 'demo') {
+    publishEventSub(uid, true).catch(() => {});
+    subState = 'pending';
+  }
+
+  const receiving = active && subState !== 'unenrolled';
   return { enabled, receiving, status, subState, subError };
 }
 

--- a/console/dashboard/src/routes/(app)/+page.server.ts
+++ b/console/dashboard/src/routes/(app)/+page.server.ts
@@ -26,6 +26,28 @@ export type ConnState = {
   subError: string;
 };
 
+function settled<T>(r: PromiseSettledResult<T>): T | undefined {
+  return r.status === 'fulfilled' ? r.value : undefined;
+}
+
+// Self-heal: a channel the users service says is active but outgress has no
+// enrollment for (fresh signup, or one predating auto-enroll) gets its
+// EventSub enable job published right here on page load. Safe to repeat:
+// outgress single-flights the enroll and creates are 409-idempotent. Only
+// 'unenrolled' triggers this — 'unknown' (outgress RPC down) must not spam
+// enables. Reports 'pending' so the UI shows the enroll in flight; the
+// substate poll takes over with the real outcome.
+function healSubState(
+  uid: string,
+  active: boolean,
+  subState: ChannelSubState['state']
+): ChannelSubState['state'] {
+  if (subState !== 'unenrolled' || uid === 'demo') return subState;
+  if (!active) return subState;
+  publishEventSub(uid, true).catch(() => {});
+  return 'pending';
+}
+
 // Resolve the bot connection state in one round trip (grant presence + the
 // coalesced active/tier state_get + channel enroll state). allSettled keeps a
 // slow or down responder from failing the whole render.
@@ -40,26 +62,18 @@ async function connState(uid: string): Promise<ConnState> {
     accountState(uid),
     channelSubState(uid)
   ]);
-  const enabled = grant.status === 'fulfilled' && grant.value;
-  const active = enabled && state.status === 'fulfilled' && state.value.active;
-  const status: AccountStatus = state.status === 'fulfilled' ? state.value.status : 'free';
-  let subState: ChannelSubState['state'] = sub.status === 'fulfilled' ? sub.value.state : 'unknown';
-  const subError: string = sub.status === 'fulfilled' ? sub.value.error : '';
-
-  // Self-heal: a channel the users service says is active but outgress has no
-  // enrollment for (fresh signup, or one predating auto-enroll) gets its
-  // EventSub enable job published right here on page load. Safe to repeat:
-  // outgress single-flights the enroll and creates are 409-idempotent. Only
-  // 'unenrolled' triggers this — 'unknown' (outgress RPC down) must not spam
-  // enables. Report 'pending' so the UI shows the enroll in flight; the
-  // substate poll takes over with the real outcome.
-  if (active && subState === 'unenrolled' && uid !== 'demo') {
-    publishEventSub(uid, true).catch(() => {});
-    subState = 'pending';
-  }
-
-  const receiving = active && subState !== 'unenrolled';
-  return { enabled, receiving, status, subState, subError };
+  const account = settled(state);
+  const subHealth = settled(sub);
+  const enabled = settled(grant) === true;
+  const active = enabled && account?.active === true;
+  const subState = healSubState(uid, active, subHealth?.state ?? 'unknown');
+  return {
+    enabled,
+    receiving: active && subState !== 'unenrolled',
+    status: account?.status ?? 'free',
+    subState,
+    subError: subHealth?.error ?? ''
+  };
 }
 
 // Parse the uses counter for ranking: the backend sends a plain number, while

--- a/console/dashboard/src/routes/(app)/+page.svelte
+++ b/console/dashboard/src/routes/(app)/+page.svelte
@@ -108,14 +108,17 @@
     return 'unknown';
   }
 
-  // Poll while pending, backstopped at ~30s so a stuck job stops spinning.
+  // Poll while the enroll is unsettled, backstopped at ~30s so a stuck job
+  // stops spinning. 'unenrolled' counts as unsettled here: a just-published
+  // enroll job reads as 'unenrolled' until outgress picks it up and writes
+  // 'pending', and stopping in that gap would freeze the pill mid-flight.
   function startPolling() {
     stopPolling();
     let ticks = 0;
     pollTimer = setInterval(async () => {
       ticks += 1;
       const state = await refreshSub();
-      if (state !== 'pending' || ticks >= 12) stopPolling();
+      if ((state !== 'pending' && state !== 'unenrolled') || ticks >= 12) stopPolling();
     }, 2500);
   }
 
@@ -126,8 +129,12 @@
   }
 
   onMount(() => {
-    refreshSub().then((state) => {
-      if (state === 'pending') startPolling();
+    refreshSub().then(async (state) => {
+      if (state === 'pending') return startPolling();
+      // The load-time self-heal reports 'pending' before outgress has written
+      // anything, so a fresh poll can still read 'unenrolled'. Poll through
+      // that gap only when the server said an enroll is actually in flight.
+      if (state === 'unenrolled' && (await data.conn).subState === 'pending') startPolling();
     });
     return stopPolling;
   });


### PR DESCRIPTION
## Problem

New channels never received their EventSub subscriptions. The enable job's only producer was the dashboard Enable button, hidden whenever "receiving" is true, and receiving was derived from the users service's is_active flag, which defaults to true at signup. A fresh channel rendered as connected with zero subscriptions. Only manual reconnects created the full set, and back-to-back reconnects drained the per-pod share of the reserved system Helix partition, so operators needed several attempts.

Verified in production: 48h of system-lane logs across all three outgress pods contained zero enable jobs; a new channel carried only the optional channel-points subscription until an operator reconnect.

## Changes

**Truthful connection state.** channel.get consumers now distinguish 'unenrolled' (outgress answered, no enrollment) from 'unknown' (transport failure, fail-safe). The dashboard grounds "receiving" in outgress's own enroll state instead of is_active.

**Self-heal on page load.** An active channel with no enrollment gets its enable job published during connState resolution. Idempotent: single-flight enroll lock, 409 creates. The post-login redirect lands on this page, so signup auto-enrolls, and existing silently-broken channels heal on their owner's next visit. The substate poll rides through the publish-to-pending gap.

**System bucket spillover.** System-lane Helix calls try the reserved partition first and spill into the general app partition when the reserve is drained, so enrollment is never blocked while general budget sits idle. The reverse remains impossible (chat/api cannot touch the reserve), keeping the fleet under Twitch's 800/min. Infra errors do not spill; they propagate for nack/redelivery.

**Redundant-enroll cooldown.** Every successful full enroll arms a 2-minute per-broadcaster cooldown. An enable/reconnect arriving inside the window while sub_state is still "ok" is acknowledged without touching Twitch, so restart-button spam costs two Valkey reads instead of ~13-24 Helix calls per click. Failing, pending, or cleared channels always run their enroll; Valkey read errors fail open into doing the work.

## Tests

- takeSystemHelix: reserve-first, spillover, both-drained denial, no-spill-on-infra-error
- redundantEnroll: skip fires only for the healthy state
- go vet clean, svelte-check 0 errors