### PR TITLE
chore(nats): prune transitional worker projection imports

### DIFF
--- a/deploy/k8s/nats-auth.conf
+++ b/deploy/k8s/nats-auth.conf
@@ -340,13 +340,6 @@ accounts: {
       { service: { account: "COMMANDS_RPC", subject: "bagel.rpc.commands.>" } }
       { service: { account: "PROJECTOR_RPC", subject: "bagel.rpc.projector.dashboard.commands.get" } }
       { service: { account: "PROJECTOR_RPC", subject: "bagel.rpc.projector.dashboard.modules.get" } }
-      # TRANSITIONAL (remove after sesame rolls onto the projector-dashboard
-      # fallback): the ACL hot-reloads minutes before the new image lands, and
-      # the outgoing sesame release still cold-key-falls-back to the data
-      # services' projection verbs. Dropping these before the roll would make
-      # cold-key custom commands time out for the whole window.
-      { service: { account: "COMMANDS_RPC", subject: "bagel.rpc.internal.projection.commands.get" } }
-      { service: { account: "MODULES_RPC",  subject: "bagel.rpc.internal.projection.modules.get" } }
       { service: { account: "PROJECTOR_RPC", subject: "bagel.rpc.broadcaster.live.get" } }
       { service: { account: "GATEWAY_RPC",  subject: "bagel.rpc.gateway.>" } }
       { stream: { account: "USERS_RPC",     subject: "bagel.cache.invalidate.status" } }


### PR DESCRIPTION
Follow-up to #311/#312. The sesame fleet is fully rolled onto the projector dashboard fallback subjects, so the transitional WORKER_RPC imports of `bagel.rpc.internal.projection.{commands,modules}.get` are dead grants. Removing them completes the least-privilege goal: sesame cannot reach the modules/commands services' projection reads at all.

Deploy-only change; Flux hot-reloads the ACL on merge.