### PR TITLE
chore(deploy): keda headroom, ingress node3 bias, HA sets off worker1

### DIFF
--- a/deploy/infra/cluster/linkerd-ha.yaml
+++ b/deploy/infra/cluster/linkerd-ha.yaml
@@ -4,6 +4,15 @@
 #
 # This avoids copying Linkerd's generated manifests into this repo while still
 # making the installed control plane resilient to a node loss or rolling restart.
+#
+# LIVE PATCH NOT CAPTURED HERE (re-apply after every `linkerd upgrade`): the
+# three control-plane Deployments carry a nodeAffinity keeping them OFF worker1
+# (home node) so the HA trio always sits on the stable cloud nodes:
+#   for d in linkerd-destination linkerd-identity linkerd-proxy-injector; do
+#     kubectl -n linkerd patch deploy "$d" --type=strategic -p '{"spec":{"template":{"spec":{"affinity":{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/hostname","operator":"NotIn","values":["worker1"]}]}]}}}}}}}'
+#   done
+# The Deployments are managed by the linkerd CLI (no Helm release), so this
+# cannot live in Flux without forking upstream manifests.
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/deploy/k8s/nats.yaml
+++ b/deploy/k8s/nats.yaml
@@ -35,10 +35,6 @@ spec:
         app: nats
     spec:
       tolerations:
-        - key: itsbagelbot.dev/pool
-          operator: Equal
-          value: worker-pool
-          effect: NoSchedule
         - key: node.kubernetes.io/unreachable
           operator: Exists
           effect: NoExecute
@@ -47,6 +43,21 @@ spec:
           operator: Exists
           effect: NoExecute
           tolerationSeconds: 60
+      # The JetStream hub is a 3-member RAFT quorum: every member must sit on a
+      # stable cloud node. worker1 (home wifi, bandwidth-capped) blinking must
+      # never cost quorum tolerance, so it is excluded outright (the worker-pool
+      # toleration is gone for the same reason). Members land on
+      # node1/node2/node3 via the one-per-node spread below. Note the JetStream
+      # PVCs are local-path (node-bound): moving a member means deleting its PVC
+      # + pod so it reprovisions on an eligible node and RAFT re-syncs it.
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: NotIn
+                    values: [worker1]
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: kubernetes.io/hostname

--- a/deploy/k8s/outgress.yaml
+++ b/deploy/k8s/outgress.yaml
@@ -226,7 +226,9 @@ spec:
   pollingInterval: 15
   cooldownPeriod: 300
   minReplicaCount: 3
-  maxReplicaCount: 6
+  # 3 per hot-path node (node2/node3/worker1). Outgress is Twitch-rate-limited,
+  # so headroom here is for lag-driven burst drain, not sustained throughput.
+  maxReplicaCount: 9
   fallback:
     failureThreshold: 3
     replicas: 3

--- a/deploy/k8s/twitch-ingress.yaml
+++ b/deploy/k8s/twitch-ingress.yaml
@@ -86,11 +86,13 @@ spec:
           effect: NoExecute
           tolerationSeconds: 60
       # node1 (2-core ARM) is reserved for stateful/frontend + infra; keep ingress
-      # off it via nodeAffinity. That leaves node2 + worker1 as the only eligible
-      # nodes, so the spread is SOFT (ScheduleAnyway): a worker1 outage (home node)
-      # must not strand ingress with a hard maxSkew it cannot satisfy on one node.
-      # The worker-pool preference was already removed, so soft maxSkew 1 still
-      # lands 2,2 in normal operation without piling onto worker1.
+      # off it via nodeAffinity. Eligible nodes are node2/node3/worker1, and the
+      # spread is SOFT (ScheduleAnyway): a worker1 outage (home node) must not
+      # strand ingress with a hard maxSkew it cannot satisfy on fewer nodes.
+      # With 4 replicas over 3 nodes one node carries 2; the preference below
+      # biases that double onto node3 (fresh 6-core, no stateful load) so the
+      # normal shape is node3=2, node2=1, worker1=1 — soft only, so a node3
+      # outage still lets the spread fall back to node2/worker1.
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -99,6 +101,13 @@ spec:
                   - key: kubernetes.io/hostname
                     operator: NotIn
                     values: [node1]
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: In
+                    values: [node3]
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: kubernetes.io/hostname


### PR DESCRIPTION
KEDA review outcome + topology follow-up to #309/#315 now that node3 is in the fleet.

## KEDA review (no changes needed to the core)
The #300 setup is sound: per-lane JetStream lag triggers (premium tight at 30, standard loose at 150, system 20 on outgress) + CPU 75%, replicas field correctly omitted from both Deployments so the HPA owns scale, healthy fallbacks, and live state confirms the scalers resolve (READY=True, FALLBACK=False). Only sizing changed:
- **outgress maxReplicaCount 6 -> 9**: three hot-path nodes now; outgress is Twitch-rate-limited so the extra headroom is for lag-driven burst drain. sesame's 4..10 already has room.

## twitch-ingress: bias the double onto node3
4 replicas over 3 eligible nodes means one node carries 2. A soft nodeAffinity preference (weight 100) points that double at node3 (fresh 6-core, no stateful load): normal shape node3=2, node2=1, worker1=1. Soft only — a node3 outage falls back to node2/worker1.

## NATS hub off worker1
Hard nodeAffinity excluding worker1 + worker-pool toleration removed. The JetStream hub is a 3-member RAFT quorum; a home-wifi member blinking silently costs failure tolerance. Members belong on node1/node2/node3.
**Post-merge manual step** (node-bound local-path PVC): delete `jetstream-data-nats-0` + pod `nats-0` so it reprovisions on node3 and RAFT re-syncs from the two healthy members. Sequenced live with quorum checks.

## linkerd HA trio off worker1
The control-plane Deployments are linkerd-CLI-managed (no Helm, not in Flux), so the equivalent nodeAffinity is a live patch; linkerd-ha.yaml now documents the exact command and the re-apply-after-upgrade caveat. Rolls are safe: maxSurge=0/maxUnavailable=1 with hard hostname anti-affinity and exactly three eligible stable nodes.

## Verification
- `kubectl kustomize` green on `deploy/k8s` and `deploy/infra/cluster`; rendered output checked for the new affinity blocks and maxReplicaCount.