### PR TITLE
fix(deploy): lower ingress node3 preference weight to 25

### DIFF
--- a/deploy/k8s/twitch-ingress.yaml
+++ b/deploy/k8s/twitch-ingress.yaml
@@ -93,6 +93,12 @@ spec:
       # biases that double onto node3 (fresh 6-core, no stateful load) so the
       # normal shape is node3=2, node2=1, worker1=1 — soft only, so a node3
       # outage still lets the spread fall back to node2/worker1.
+      #
+      # Weight is deliberately LOW: the scheduler scores soft topology spread at
+      # 2x plugin weight vs 1x for node preference, so 25 is enough to break the
+      # tie toward node3 while a skew already >=1 outscores it. Weight 100
+      # proved to overpower the spread during a maxSurge=0 roll (old pods still
+      # count in the skew), piling 3 replicas onto node3 and none on node2.
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -102,7 +108,7 @@ spec:
                     operator: NotIn
                     values: [node1]
           preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
+            - weight: 25
               preference:
                 matchExpressions:
                   - key: kubernetes.io/hostname


### PR DESCRIPTION
Follow-up to #316. The weight-100 node3 preference overpowered the soft topology spread during the maxSurge=0 roll (old pods still count toward skew while each replacement schedules), producing node3=3, worker1=1, node2=0 instead of the intended 2/1/1. Soft spread scores at 2x plugin weight vs 1x for node preference, so 25 breaks ties toward node3 but yields to any existing skew. Comment documents the scoring math.