### PR TITLE
fix(deploy): per-ReplicaSet spread so rollouts keep one pod per node

### DIFF
--- a/deploy/k8s/outgress.yaml
+++ b/deploy/k8s/outgress.yaml
@@ -77,9 +77,18 @@ spec:
                     operator: NotIn
                     values: [node1]
       topologySpreadConstraints:
+        # matchLabelKeys scopes the skew to the CURRENT ReplicaSet: during a
+        # maxSurge=0 roll the outgoing pods no longer count, so every rollout
+        # re-spreads one-per-node instead of piling onto whichever node freed
+        # capacity first (bit the ingress on 2026-07-10: 3/0/1). Soft constraint
+        # stays soft, so a node outage never wedges scheduling; the KEDA floor
+        # (>= one per hot-path node) plus the ReplicaSet downscaler's
+        # remove-co-located-duplicates-first ranking keep steady state at
+        # >= 1 per node.
         - maxSkew: 1
           topologyKey: kubernetes.io/hostname
           whenUnsatisfiable: ScheduleAnyway
+          matchLabelKeys: [pod-template-hash]
           labelSelector:
             matchLabels:
               app: outgress

--- a/deploy/k8s/sesame.yaml
+++ b/deploy/k8s/sesame.yaml
@@ -77,9 +77,18 @@ spec:
                     operator: NotIn
                     values: [node1]
       topologySpreadConstraints:
+        # matchLabelKeys scopes the skew to the CURRENT ReplicaSet: during a
+        # maxSurge=0 roll the outgoing pods no longer count, so every rollout
+        # re-spreads one-per-node instead of piling onto whichever node freed
+        # capacity first (bit the ingress on 2026-07-10: 3/0/1). Soft constraint
+        # stays soft, so a node outage never wedges scheduling; the KEDA floor
+        # (>= one per hot-path node) plus the ReplicaSet downscaler's
+        # remove-co-located-duplicates-first ranking keep steady state at
+        # >= 1 per node.
         - maxSkew: 1
           topologyKey: kubernetes.io/hostname
           whenUnsatisfiable: ScheduleAnyway
+          matchLabelKeys: [pod-template-hash]
           labelSelector:
             matchLabels:
               app: sesame

--- a/deploy/k8s/twitch-ingress.yaml
+++ b/deploy/k8s/twitch-ingress.yaml
@@ -45,7 +45,7 @@ metadata:
   annotations:
     secrets.doppler.com/reload: "true"
 spec:
-  replicas: 4 # node1 excluded via hot-path anti-affinity; soft even spread across node2/worker1 (2,2)
+  replicas: 4 # node1 excluded via hot-path anti-affinity; soft spread over node2/node3/worker1, double biased to node3 (2,1,1)
   revisionHistoryLimit: 3
   strategy:
     type: RollingUpdate
@@ -115,9 +115,18 @@ spec:
                     operator: In
                     values: [node3]
       topologySpreadConstraints:
+        # matchLabelKeys scopes the skew to the CURRENT ReplicaSet: during a
+        # maxSurge=0 roll the outgoing pods no longer count, so every rollout
+        # re-spreads one-per-node instead of piling onto whichever node freed
+        # capacity first (bit the ingress on 2026-07-10: 3/0/1). Soft constraint
+        # stays soft, so a node outage never wedges scheduling; the KEDA floor
+        # (>= one per hot-path node) plus the ReplicaSet downscaler's
+        # remove-co-located-duplicates-first ranking keep steady state at
+        # >= 1 per node.
         - maxSkew: 1
           topologyKey: kubernetes.io/hostname
           whenUnsatisfiable: ScheduleAnyway
+          matchLabelKeys: [pod-template-hash]
           labelSelector:
             matchLabels:
               app: twitch-ingress


### PR DESCRIPTION
Guarantees the "at least one sesame/outgress per hot-path node" invariant across rollouts.

Total-count floor already exists: KEDA `minReplicaCount` (sesame 4, outgress 3) is a hard floor, so scale-to-zero is impossible. The gap was distribution during rollouts: soft topology spread counts the OUTGOING ReplicaSet's pods while each replacement schedules under maxSurge=0, so new pods pile onto whichever node freed capacity first — the mechanism that produced ingress 3/0/1 earlier today.

`matchLabelKeys: [pod-template-hash]` (stable in this cluster's k8s version) scopes skew to the incoming ReplicaSet, so every rollout re-spreads one-per-node from scratch. Applied to sesame, outgress, and twitch-ingress.

Constraints deliberately stay `ScheduleAnyway`: a hard spread would wedge scheduling during a node outage, exactly when capacity is needed. Steady state is held by the KEDA floors plus the ReplicaSet downscaler's built-in preference for removing co-located duplicates first.

Also refreshes the stale ingress replicas comment (still described the 2-node era).