### PR TITLE
chore(deploy): raise ingress to 6 replicas, sesame floor to 6

### DIFF
--- a/deploy/k8s/sesame.yaml
+++ b/deploy/k8s/sesame.yaml
@@ -201,8 +201,10 @@ spec:
 ---
 # Sesame is the CPU-bound half (decode/dedup/module-dispatch/templating), so
 # unlike outgress this is real throughput headroom, not just resilience -
-# hence the wider maxReplicaCount. minReplicaCount 4 matches the old static
-# replicas. Consumer names are bus.durableName("worker", subject) - sesame
+# hence the wider maxReplicaCount. minReplicaCount 6 keeps a 2-per-node
+# baseline across the three hot-path nodes (soft spread lands 2/2/2), sized
+# for the big-CPU pair (node3 6c, worker1 8c) without waiting on a scale-up.
+# Consumer names are bus.durableName("worker", subject) - sesame
 # shares the worker's pre-existing durable via fleetSubscriber (app/sesame/main.go
 # bus.NewSubscriber(cfg.NATSURL, cfg.ConsumerName, log), ConsumerName=worker),
 # not per-lane groups like outgress. lag = num_pending + num_ack_pending on
@@ -218,11 +220,11 @@ spec:
     name: sesame
   pollingInterval: 15
   cooldownPeriod: 300
-  minReplicaCount: 4
+  minReplicaCount: 6
   maxReplicaCount: 10
   fallback:
     failureThreshold: 3
-    replicas: 4
+    replicas: 6
   advanced:
     horizontalPodAutoscalerConfig:
       behavior:

--- a/deploy/k8s/twitch-ingress.yaml
+++ b/deploy/k8s/twitch-ingress.yaml
@@ -45,7 +45,7 @@ metadata:
   annotations:
     secrets.doppler.com/reload: "true"
 spec:
-  replicas: 4 # node1 excluded via hot-path anti-affinity; soft spread over node2/node3/worker1, double biased to node3 (2,1,1)
+  replicas: 6 # node1 excluded via hot-path anti-affinity; soft spread lands 2 per node over node2/node3/worker1
   revisionHistoryLimit: 3
   strategy:
     type: RollingUpdate


### PR DESCRIPTION
Baseline capacity bump onto the big-CPU nodes (node3 6c, node2 6c, worker1 8c).

- **twitch-ingress: replicas 4 -> 6.** No KEDA here (the BEAM shard autoscaler works inside the pods); more pods = more standing shard capacity. Replicas-only change, so existing pods do not roll: the two new pods land on the under-filled nodes via the soft spread -> 2/2/2 across node2/node3/worker1.
- **sesame: minReplicaCount 4 -> 6, fallback 4 -> 6.** Guarantees a 2-per-node baseline at all times instead of waiting on a KEDA scale-up; maxReplicaCount stays 10 and KEDA owns everything above the floor. ScaledObject-only change, no rollout.

Verification: kustomize green; distributions to be confirmed live post-merge (expected 2/2/2 for both).