### PR TITLE
chore(deploy): baseline shape node3=2 worker1=2 node2=1 for ingress and sesame

### DIFF
--- a/deploy/k8s/sesame.yaml
+++ b/deploy/k8s/sesame.yaml
@@ -67,7 +67,14 @@ spec:
           tolerationSeconds: 60
       # node1 is the 2-core ARM node reserved for stateful/frontend + infra; keep
       # the hot-path worker off it. KEDA (see the ScaledObject below) scales
-      # onto node2/worker1.
+      # onto node2/node3/worker1.
+      # Baseline shape at the KEDA floor of 5: node3=2, worker1=2, node2=1.
+      # node2 already carries the control plane + valkey master, so the doubles
+      # belong on the big-CPU pair; the graded preferences below pick which
+      # nodes take them (node3 first, worker1 second) while the soft skew keeps
+      # any node from being emptied. Low weights on purpose: a skew >= 1 must
+      # outscore the preference (see twitch-ingress.yaml for the pile-up this
+      # prevents). Burst pods above the floor inherit the same bias.
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -76,6 +83,19 @@ spec:
                   - key: kubernetes.io/hostname
                     operator: NotIn
                     values: [node1]
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 25
+              preference:
+                matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: In
+                    values: [node3]
+            - weight: 20
+              preference:
+                matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: In
+                    values: [worker1]
       topologySpreadConstraints:
         # matchLabelKeys scopes the skew to the CURRENT ReplicaSet: during a
         # maxSurge=0 roll the outgoing pods no longer count, so every rollout
@@ -201,9 +221,9 @@ spec:
 ---
 # Sesame is the CPU-bound half (decode/dedup/module-dispatch/templating), so
 # unlike outgress this is real throughput headroom, not just resilience -
-# hence the wider maxReplicaCount. minReplicaCount 6 keeps a 2-per-node
-# baseline across the three hot-path nodes (soft spread lands 2/2/2), sized
-# for the big-CPU pair (node3 6c, worker1 8c) without waiting on a scale-up.
+# hence the wider maxReplicaCount. minReplicaCount 5 keeps the baseline shape
+# node3=2, worker1=2, node2=1 (see the Deployment's graded node preferences)
+# without waiting on a scale-up; node2 stays light on purpose.
 # Consumer names are bus.durableName("worker", subject) - sesame
 # shares the worker's pre-existing durable via fleetSubscriber (app/sesame/main.go
 # bus.NewSubscriber(cfg.NATSURL, cfg.ConsumerName, log), ConsumerName=worker),
@@ -220,11 +240,11 @@ spec:
     name: sesame
   pollingInterval: 15
   cooldownPeriod: 300
-  minReplicaCount: 6
+  minReplicaCount: 5
   maxReplicaCount: 10
   fallback:
     failureThreshold: 3
-    replicas: 6
+    replicas: 5
   advanced:
     horizontalPodAutoscalerConfig:
       behavior:

--- a/deploy/k8s/twitch-ingress.yaml
+++ b/deploy/k8s/twitch-ingress.yaml
@@ -45,7 +45,7 @@ metadata:
   annotations:
     secrets.doppler.com/reload: "true"
 spec:
-  replicas: 6 # node1 excluded via hot-path anti-affinity; soft spread lands 2 per node over node2/node3/worker1
+  replicas: 5 # node1 excluded via hot-path anti-affinity; target shape node3=2, worker1=2, node2=1 (see affinity)
   revisionHistoryLimit: 3
   strategy:
     type: RollingUpdate
@@ -89,16 +89,19 @@ spec:
       # off it via nodeAffinity. Eligible nodes are node2/node3/worker1, and the
       # spread is SOFT (ScheduleAnyway): a worker1 outage (home node) must not
       # strand ingress with a hard maxSkew it cannot satisfy on fewer nodes.
-      # With 4 replicas over 3 nodes one node carries 2; the preference below
-      # biases that double onto node3 (fresh 6-core, no stateful load) so the
-      # normal shape is node3=2, node2=1, worker1=1 — soft only, so a node3
-      # outage still lets the spread fall back to node2/worker1.
+      # Baseline shape: node3=2, worker1=2, node2=1. node2 already carries the
+      # control plane + valkey master, so the doubles belong on the big-CPU
+      # pair (node3 6c, worker1 8c) and node2 keeps the single. The soft skew
+      # allows any 2/2/1 split; the two graded preferences below pick WHICH
+      # nodes take the doubles (node3 first, worker1 second, node2 never
+      # preferred). Soft only — a node outage re-packs onto the survivors.
       #
-      # Weight is deliberately LOW: the scheduler scores soft topology spread at
-      # 2x plugin weight vs 1x for node preference, so 25 is enough to break the
-      # tie toward node3 while a skew already >=1 outscores it. Weight 100
-      # proved to overpower the spread during a maxSurge=0 roll (old pods still
-      # count in the skew), piling 3 replicas onto node3 and none on node2.
+      # Weights are deliberately LOW: a skew >= 1 must outscore them so the
+      # spread still wins against pile-ups. Weight 100 proved to overpower the
+      # spread during a maxSurge=0 roll (old pods still count in the skew),
+      # piling 3 replicas onto node3 and none on node2. Empty-node resource
+      # scoring can still stack with these during bulk scheduling; if the shape
+      # drifts, deleting the surplus pod once re-lands it correctly.
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -114,6 +117,12 @@ spec:
                   - key: kubernetes.io/hostname
                     operator: In
                     values: [node3]
+            - weight: 20
+              preference:
+                matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: In
+                    values: [worker1]
       topologySpreadConstraints:
         # matchLabelKeys scopes the skew to the CURRENT ReplicaSet: during a
         # maxSurge=0 roll the outgoing pods no longer count, so every rollout


### PR DESCRIPTION
Refines #319 to the intended standing shape: **node3=2, worker1=2, node2=1** (5 pods each) for twitch-ingress and the sesame KEDA floor.

Rationale: node2 already carries the single control plane and the valkey master; the standing doubles belong on the big-CPU pair (node3 6c, worker1 8c) and node2 keeps one pod of each for locality.

- twitch-ingress: replicas 6 -> 5; second graded preference (worker1, weight 20) added under the existing node3 (25) one so the two 2/2/1 doubles land on node3+worker1 and node2 takes the single.
- sesame: minReplicaCount 6 -> 5, fallback 6 -> 5; same graded preference block added to the Deployment. KEDA still owns everything above the floor (max 10) and burst pods inherit the bias.

Weights stay low so a skew >= 1 outscores them (pile-up guard from the weight-100 incident). Both preference blocks are template changes, so both apps roll; matchLabelKeys re-spreads each roll and any drift is a one-pod delete away from the target shape.