### PR TITLE
fix: replace-path invalidation keys, ingress roll pacing, enroll dedupe

### DIFF
--- a/app/projector/rpc/dashboard.go
+++ b/app/projector/rpc/dashboard.go
@@ -174,9 +174,23 @@ func (d *Dashboard) writeCommandsAsync(userID uint64, commands []projection.Comm
 			d.log.Warn("projector command valkey write failed", zap.Uint64("user_id", userID), zap.Error(err))
 		}
 		if d.cacheInvalidatePrefix != "" {
-			_ = invalidate.PublishKeys(d.nc, d.cacheInvalidatePrefix, "commands", strconv.FormatUint(userID, 10))
+			// Workers evict per-command cache entries, so the broadcast must carry
+			// every name and alias the replace may have changed — an empty key list
+			// evicts nothing and the write stays invisible until the TTL expires.
+			_ = invalidate.PublishKeys(d.nc, d.cacheInvalidatePrefix, "commands", strconv.FormatUint(userID, 10), commandKeys(commands)...)
 		}
 	}()
+}
+
+// commandKeys flattens a command list into the granular invalidation key set
+// (every name plus every alias), matching what the change-event path publishes.
+func commandKeys(commands []projection.CommandView) []string {
+	keys := make([]string, 0, len(commands))
+	for _, c := range commands {
+		keys = append(keys, c.Name)
+		keys = append(keys, c.Aliases...)
+	}
+	return keys
 }
 
 func (d *Dashboard) writeModulesAsync(userID uint64, modules []projection.ModuleView) {

--- a/app/projector/rpc/dashboard_test.go
+++ b/app/projector/rpc/dashboard_test.go
@@ -1,0 +1,31 @@
+package rpc
+
+import (
+	"slices"
+	"testing"
+
+	"ItsBagelBot/internal/projection"
+)
+
+// A replace broadcast must carry every name and alias so workers evict the
+// exact per-command entries; an empty key list evicts nothing (the bug this
+// guards against).
+func TestCommandKeys(t *testing.T) {
+	commands := []projection.CommandView{
+		{Name: "uptime", Aliases: []string{"live", "up"}},
+		{Name: "socials"},
+		{Name: "lurk", Aliases: []string{"hide"}},
+	}
+
+	got := commandKeys(commands)
+	want := []string{"uptime", "live", "up", "socials", "lurk", "hide"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("commandKeys() = %v, want %v", got, want)
+	}
+}
+
+func TestCommandKeysEmpty(t *testing.T) {
+	if got := commandKeys(nil); len(got) != 0 {
+		t.Fatalf("commandKeys(nil) = %v, want empty", got)
+	}
+}

--- a/console/dashboard/src/routes/(app)/+page.server.ts
+++ b/console/dashboard/src/routes/(app)/+page.server.ts
@@ -30,6 +30,23 @@ function settled<T>(r: PromiseSettledResult<T>): T | undefined {
   return r.status === 'fulfilled' ? r.value : undefined;
 }
 
+// One enable publish per user per window, per replica. The enable action and
+// the self-heal below both publish the same job, and right after a connect
+// click the registry still reads 'unenrolled' until the worker flips it to
+// 'pending' — without this guard every page load and substate poll in that
+// window fires another full enroll (each worth ~13-24 reserved Helix calls;
+// two back-to-back full enrolls observed 2026-07-10). Per-replica memory is
+// enough: the worker-side enroll cooldown is the fleet-wide guard, this only
+// stops one replica re-publishing what it just sent.
+const ENABLE_PUBLISH_WINDOW_MS = 120_000;
+const recentEnables = new Map<string, number>();
+
+function pruneEnableStamps(now: number): void {
+  for (const [k, t] of recentEnables) {
+    if (now - t >= ENABLE_PUBLISH_WINDOW_MS) recentEnables.delete(k);
+  }
+}
+
 // Self-heal: a channel the users service says is active but outgress has no
 // enrollment for (fresh signup, or one predating auto-enroll) gets its
 // EventSub enable job published right here on page load. Safe to repeat:
@@ -37,14 +54,26 @@ function settled<T>(r: PromiseSettledResult<T>): T | undefined {
 // 'unenrolled' triggers this — 'unknown' (outgress RPC down) must not spam
 // enables. Reports 'pending' so the UI shows the enroll in flight; the
 // substate poll takes over with the real outcome.
-function healSubState(
-  uid: string,
-  active: boolean,
-  subState: ChannelSubState['state']
-): ChannelSubState['state'] {
-  if (subState !== 'unenrolled' || uid === 'demo') return subState;
-  if (!active) return subState;
-  publishEventSub(uid, true).catch(() => {});
+function healSubState(conn: {
+  uid: string;
+  active: boolean;
+  state: ChannelSubState['state'];
+}): ChannelSubState['state'] {
+  const { uid, active, state } = conn;
+  if (state !== 'unenrolled' || uid === 'demo') return state;
+  if (!active) return state;
+
+  // One publish per window (see recentEnables above): right after a connect
+  // click the registry still reads 'unenrolled', so without the stamp every
+  // load and poll here would fire another full enroll.
+  const now = Date.now();
+  const stamped = recentEnables.get(uid);
+  if (stamped !== undefined && now - stamped < ENABLE_PUBLISH_WINDOW_MS) return 'pending';
+  recentEnables.set(uid, now);
+  if (recentEnables.size > 1024) pruneEnableStamps(now);
+
+  // A failed publish must not suppress the next heal for the whole window.
+  publishEventSub(uid, true).catch(() => recentEnables.delete(uid));
   return 'pending';
 }
 
@@ -66,7 +95,7 @@ async function connState(uid: string): Promise<ConnState> {
   const subHealth = settled(sub);
   const enabled = settled(grant) === true;
   const active = enabled && account?.active === true;
-  const subState = healSubState(uid, active, subHealth?.state ?? 'unknown');
+  const subState = healSubState({ uid, active, state: subHealth?.state ?? 'unknown' });
   return {
     enabled,
     receiving: active && subState !== 'unenrolled',
@@ -199,6 +228,10 @@ export const actions: Actions = {
   enable: ownerAction('enable', true, async (uid) => {
     await setActive(uid, true);
     await publishEventSub(uid, true);
+    // The loads/polls that follow this action still read 'unenrolled' until
+    // the worker picks the job up; stamp the publish so the self-heal doesn't
+    // immediately fire a duplicate enroll.
+    recentEnables.set(uid, Date.now());
   }),
   // Restart: atomic drop + recreate of EventSub subscriptions (stays active).
   restart: ownerAction('restart', true, (uid) => publishEventSubReconnect(uid)),

--- a/deploy/k8s/twitch-ingress.yaml
+++ b/deploy/k8s/twitch-ingress.yaml
@@ -47,6 +47,14 @@ metadata:
 spec:
   replicas: 6 # node1 excluded via hot-path anti-affinity; soft spread lands 2 per node over node2/node3/worker1
   revisionHistoryLimit: 3
+  # Each pod death forces its EventSub conduit shards to rebind on a peer (new
+  # websocket session + transport update), and Twitch drops a shard's events
+  # until the rebind lands. Hold each replacement pod Ready for a full minute
+  # before killing the next old pod so the Horde registry converges and the
+  # displaced shards re-bind between swaps — the 2026-07-10 mid-stream incident
+  # was pods cycling within a minute of each other, stacking shard gaps and
+  # registry races ("registry pick unreachable") into a ~5 min chat outage.
+  minReadySeconds: 60
   strategy:
     type: RollingUpdate
     rollingUpdate:


### PR DESCRIPTION
Three fixes from the 2026-07-10 mid-stream incident investigation.

## Projector: carry command keys in replace invalidation
The dashboard replace path broadcast cache invalidation with **no keys**. Workers evict per-command entries by key, so the broadcast was a no-op: a toggled/edited/created command stayed stale in sesame until the 30s in-process TTL expired or the slower batched change event arrived. This is why toggling a command off/on appeared to do nothing for ~30s. The replaced list is now flattened into name+alias keys, matching the change-event path (`projector.go` `HandleCommandChanged`). Unit tests added.

## Deploy: pace twitch-ingress rollout with minReadySeconds
A pod death forces its EventSub conduit shards to rebind on a peer, and Twitch drops that shard's events until the rebind lands. During the 06:43Z deploy train, pods cycled within a minute of each other, stacking shard gaps and Horde registry races ("registry pick unreachable") into a ~5 min chat outage mid-stream. `minReadySeconds: 60` holds each replacement pod Ready a full minute before the next old pod dies, so shards rebind and the registry converges between swaps. Full roll now takes ~7-8 min, deliberately.

## Dashboard: dedupe eventsub enable publishes
The enable action and the `unenrolled` self-heal both publish the same enroll job, and right after a connect click the registry still reads `unenrolled` until the worker flips it to `pending` — so every page load and substate poll in that window fired another **full enroll** (~13-24 reserved Helix calls each; two back-to-back enrolls observed at 06:51:11 and 06:51:16). A per-replica 2-minute publish record suppresses the duplicate and reports `pending`; failed publishes un-record so self-heal is never suppressed by a dropped job. The worker-side enroll cooldown (#313) remains the fleet-wide guard.