### PR TITLE
feat(fortnite): !fnstats + !store via fortnite-api.com

### DIFF
--- a/app/gateway/internal/config/config.go
+++ b/app/gateway/internal/config/config.go
@@ -44,6 +44,14 @@ type Config struct {
 	McsrEnabled   bool
 	McsrRateLimit float64
 
+	// Fortnite provider (fortnite-api.com: !fnstats + !store). Off by default —
+	// FORTNITE_ENABLED=true AND an API key turn it on — so it stays dark until
+	// tested against a real key.
+	FortniteBaseURL   string
+	FortniteAPIKey    string
+	FortniteEnabled   bool
+	FortniteRateLimit float64
+
 	// Govee smart-light provider. It holds no service key (each broadcaster
 	// brings their own, fetched from the modules service). GoveeKeySubjectPrefix
 	// is that internal RPC's subject prefix; empty disables the provider.
@@ -79,6 +87,12 @@ func Load() *Config {
 		McsrAPIKey:    env.Get("MCSR_API_KEY", ""),
 		McsrEnabled:   env.GetBool("MCSR_ENABLED", true),
 		McsrRateLimit: env.GetFloat("MCSR_RATE_LIMIT", 500.0),
+
+		FortniteBaseURL: env.Get("FORTNITE_BASE_URL", "https://fortnite-api.com"),
+		FortniteAPIKey:  env.Get("FORTNITE_API_KEY", ""),
+		FortniteEnabled: env.GetBool("FORTNITE_ENABLED", false),
+		// fortnite-api.com publishes no hard per-key budget; requests per minute.
+		FortniteRateLimit: env.GetFloat("FORTNITE_RATE_LIMIT", 120.0),
 
 		GoveeBaseURL:          env.Get("GOVEE_BASE_URL", "https://openapi.api.govee.com"),
 		GoveeRateLimit:        env.GetFloat("GOVEE_RATE_LIMIT", 8.0),

--- a/app/gateway/internal/providers/all.go
+++ b/app/gateway/internal/providers/all.go
@@ -6,6 +6,7 @@ package providers
 import (
 	"ItsBagelBot/app/gateway/internal/config"
 	"ItsBagelBot/app/gateway/internal/provider"
+	"ItsBagelBot/app/gateway/internal/providers/fortnite"
 	"ItsBagelBot/app/gateway/internal/providers/govee"
 	"ItsBagelBot/app/gateway/internal/providers/hypixel"
 	"ItsBagelBot/app/gateway/internal/providers/mcsr"
@@ -28,6 +29,7 @@ func All(cfg *config.Config, d provider.Deps) []provider.Provider {
 	out = appendUrchin(out, cfg, d, log)
 	out = appendHypixel(out, cfg, d, log)
 	out = appendMcsr(out, cfg, d, log)
+	out = appendFortnite(out, cfg, d, log)
 	out = appendGovee(out, cfg, d, log)
 	return out
 }
@@ -66,6 +68,25 @@ func appendMcsr(out []provider.Provider, cfg *config.Config, d provider.Deps, lo
 		BaseURL:   cfg.McsrBaseURL,
 		APIKey:    cfg.McsrAPIKey,
 		RateLimit: cfg.McsrRateLimit,
+	}, d))
+}
+
+// appendFortnite adds the fortnite provider. It is double-gated: the
+// FORTNITE_ENABLED flag keeps it dark until tested against a real key, and the
+// key itself is required for the stats endpoint's Authorization header.
+func appendFortnite(out []provider.Provider, cfg *config.Config, d provider.Deps, log *zap.Logger) []provider.Provider {
+	if !cfg.FortniteEnabled {
+		log.Warn("fortnite provider disabled: FORTNITE_ENABLED=false")
+		return out
+	}
+	if cfg.FortniteAPIKey == "" {
+		log.Warn("fortnite provider disabled: FORTNITE_API_KEY not set (!fnstats and !store will not answer)")
+		return out
+	}
+	return append(out, fortnite.New(fortnite.Config{
+		BaseURL:   cfg.FortniteBaseURL,
+		APIKey:    cfg.FortniteAPIKey,
+		RateLimit: cfg.FortniteRateLimit,
 	}, d))
 }
 

--- a/app/gateway/internal/providers/fortnite/fortnite.go
+++ b/app/gateway/internal/providers/fortnite/fortnite.go
@@ -1,0 +1,327 @@
+// Package fortnite is the gateway provider for fortnite-api.com: Battle
+// Royale player stats for sesame's !fnstats and the daily item shop for
+// !store.
+//
+// The stats endpoint looks a player up by display name inside a platform
+// namespace (Epic, PlayStation or Xbox) over either the lifetime or the
+// current-season window — both are dashboard settings the request carries.
+// The reply is normalized to the bot-needed values only: wins, matches,
+// kills, K/D, win rate, and the solo/duo/squad mode breakdown. All endpoints
+// are byte-flow: the reply is shaped and marshaled once on fetch, and a cache
+// hit answers with the stored wire bytes untouched.
+package fortnite
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/url"
+	"strings"
+	"time"
+
+	"ItsBagelBot/app/gateway/internal/core"
+	"ItsBagelBot/app/gateway/internal/provider"
+	gatewayrpc "ItsBagelBot/internal/domain/rpc/gateway"
+
+	"go.uber.org/zap"
+)
+
+const (
+	// statsTTL matches the other stats providers' staleness budget.
+	statsTTL    = 10 * time.Minute
+	negativeTTL = 5 * time.Minute
+	// shopTTL: the shop rotates once a day (00:00 UTC), so a 15-minute lag on
+	// rotation day is invisible against a 24h cycle.
+	shopTTL = 15 * time.Minute
+
+	httpTimeout    = 10 * time.Second
+	handlerTimeout = 15 * time.Second
+
+	// rateWindowSeconds is the budget window the configured limit spans.
+	// fortnite-api.com does not publish a hard per-key budget, so the limit
+	// stays a conservative per-minute allowance.
+	rateWindowSeconds = 60.0
+)
+
+// Config carries the provider's environment. The stats endpoint requires the
+// API key (sent as the Authorization header); main skips the provider without
+// one. RateLimit is requests per minute.
+type Config struct {
+	BaseURL   string
+	APIKey    string
+	RateLimit float64
+}
+
+// Provider implements provider.Provider for the fortnite-api.com API.
+type Provider struct {
+	http  *core.HTTPClient
+	cache *core.Cache
+	log   *zap.Logger
+
+	deps    provider.Deps
+	buckets core.Buckets
+}
+
+// New builds the fortnite provider.
+func New(cfg Config, d provider.Deps) *Provider {
+	base := strings.TrimSuffix(cfg.BaseURL, "/")
+	if base == "" {
+		base = "https://fortnite-api.com"
+	}
+	if cfg.RateLimit <= 0 {
+		cfg.RateLimit = 120
+	}
+	log := d.Log
+	if log == nil {
+		log = zap.NewNop()
+	}
+	return &Provider{
+		http:    core.NewHTTPClient(base, map[string]string{"Authorization": cfg.APIKey}, httpTimeout),
+		cache:   d.Cache,
+		log:     log,
+		deps:    d,
+		buckets: core.NewBuckets("ratelimit:gateway:fortnite", cfg.RateLimit, rateWindowSeconds),
+	}
+}
+
+func (p *Provider) Name() string { return "fortnite" }
+
+func (p *Provider) Endpoints() []provider.Endpoint {
+	return []provider.Endpoint{
+		{Name: "stats", Timeout: handlerTimeout, Handle: p.stats},
+		{Name: "shop", Timeout: handlerTimeout, Handle: p.shop},
+	}
+}
+
+// normalizeAccountType maps the dashboard's account-type setting onto the
+// upstream's accountType parameter; anything unrecognized (including blank)
+// falls back to Epic, the platform every Fortnite account ultimately lives on.
+func normalizeAccountType(t string) string {
+	switch strings.ToLower(strings.TrimSpace(t)) {
+	case "psn":
+		return "psn"
+	case "xbl":
+		return "xbl"
+	default:
+		return "epic"
+	}
+}
+
+// normalizeTimeWindow maps the dashboard's window setting onto the upstream's
+// timeWindow parameter; anything but "season" means lifetime.
+func normalizeTimeWindow(w string) string {
+	if strings.ToLower(strings.TrimSpace(w)) == "season" {
+		return "season"
+	}
+	return "lifetime"
+}
+
+// --- stats -----------------------------------------------------------------------
+
+// modeStats is the upstream per-queue stat block subset the gateway reads.
+// Queues the player never touched are null in the JSON, so the reply reads
+// them through pointers.
+type modeStats struct {
+	Wins    int64   `json:"wins"`
+	Matches int64   `json:"matches"`
+	Kills   int64   `json:"kills"`
+	KD      float64 `json:"kd"`
+	WinRate float64 `json:"winRate"`
+}
+
+// statsResponse is the /v2/stats/br/v2 envelope subset the gateway reads.
+// stats.all aggregates every input type; the per-input blocks are ignored.
+type statsResponse struct {
+	Data struct {
+		Account struct {
+			Name string `json:"name"`
+		} `json:"account"`
+		Stats struct {
+			All struct {
+				Overall *modeStats `json:"overall"`
+				Solo    *modeStats `json:"solo"`
+				Duo     *modeStats `json:"duo"`
+				Squad   *modeStats `json:"squad"`
+			} `json:"all"`
+		} `json:"stats"`
+	} `json:"data"`
+}
+
+// toReplyStats flattens a possibly-null upstream queue block.
+func toReplyStats(m *modeStats) gatewayrpc.FortniteModeStats {
+	if m == nil {
+		return gatewayrpc.FortniteModeStats{}
+	}
+	return gatewayrpc.FortniteModeStats{
+		Wins: m.Wins, Matches: m.Matches, Kills: m.Kills, KD: m.KD, WinRate: m.WinRate,
+	}
+}
+
+// privateStatsError reshapes the upstream 403 for an account whose "Public
+// Game Stats" toggle is off into a player-level 404-class failure: it chats a
+// specific message and negative-caches (private stays private for a while).
+// A 403 that does not mention the stats toggle (bad or unauthorized API key)
+// passes through and maps to the generic non-cached config-problem message.
+func privateStatsError(err error) error {
+	var ue *core.UpstreamError
+	if !errors.As(err, &ue) || ue.Status != 403 {
+		return err
+	}
+	msg := strings.ToLower(ue.Message)
+	if strings.Contains(msg, "public") || strings.Contains(msg, "private") || strings.Contains(msg, "stats") {
+		return &core.UpstreamError{Status: 404, Message: "this player's game stats are private"}
+	}
+	return err
+}
+
+// stats answers fortnite.stats (sesame's !fnstats) with the player's
+// normalized Battle Royale stats over the requested window.
+func (p *Provider) stats(ctx context.Context, req gatewayrpc.Request) any {
+	account := strings.TrimSpace(req.Account)
+	if account == "" {
+		return gatewayrpc.FortniteStatsReply{Error: "missing account"}
+	}
+	accountType := normalizeAccountType(req.AccountType)
+	window := normalizeTimeWindow(req.TimeWindow)
+
+	key := core.Key(p.Name(), "stats", accountType+":"+window+":"+strings.ToLower(account))
+	b, err := core.CachedBytes(ctx, p.cache, key, func(ctx context.Context) ([]byte, time.Duration, error) {
+		return core.BuildReply(ctx, statsTTL, negativeTTL,
+			func(ctx context.Context) (any, error) {
+				return p.fetchStats(ctx, account, accountType, window, req.IsPremium)
+			},
+			func(msg string) any { return gatewayrpc.FortniteStatsReply{Player: account, Error: msg} },
+		)
+	})
+	if err != nil {
+		p.log.Warn("fortnite stats fetch failed", zap.String("account", account), zap.Error(err))
+		return gatewayrpc.FortniteStatsReply{Player: account, Error: "stats lookup failed"}
+	}
+	// Pre-marshaled wire bytes: the engine responds with these untouched.
+	return json.RawMessage(b)
+}
+
+// fetchStats spends the budget, queries /v2/stats/br/v2 and shapes the
+// success reply.
+func (p *Provider) fetchStats(ctx context.Context, account, accountType, window string, isPremium bool) (gatewayrpc.FortniteStatsReply, error) {
+	if err := p.buckets.Enforce(ctx, p.deps.Limiter, isPremium); err != nil {
+		return gatewayrpc.FortniteStatsReply{}, err
+	}
+
+	query := url.Values{
+		"name":        {account},
+		"accountType": {accountType},
+		"timeWindow":  {window},
+		"image":       {"none"},
+	}
+	var resp statsResponse
+	if err := p.http.GetJSON(ctx, "/v2/stats/br/v2", query, &resp); err != nil {
+		return gatewayrpc.FortniteStatsReply{}, privateStatsError(err)
+	}
+
+	name := resp.Data.Account.Name
+	if name == "" {
+		name = account
+	}
+	all := resp.Data.Stats.All
+	return gatewayrpc.FortniteStatsReply{
+		Player:  name,
+		Window:  window,
+		Overall: toReplyStats(all.Overall),
+		Solo:    toReplyStats(all.Solo),
+		Duo:     toReplyStats(all.Duo),
+		Squad:   toReplyStats(all.Squad),
+	}, nil
+}
+
+// --- item shop -------------------------------------------------------------------
+
+// named is the {"name": ...} shape shop items of every kind share.
+type named struct {
+	Name string `json:"name"`
+}
+
+// titled is the {"title": ...} shape jam tracks use instead of a name.
+type titled struct {
+	Title string `json:"title"`
+}
+
+// shopEntry is one /v2/shop offer subset: the final price plus enough of each
+// item family to pick a display name.
+type shopEntry struct {
+	FinalPrice  int64    `json:"finalPrice"`
+	Bundle      *named   `json:"bundle"`
+	BrItems     []named  `json:"brItems"`
+	Instruments []named  `json:"instruments"`
+	Cars        []named  `json:"cars"`
+	LegoKits    []named  `json:"legoKits"`
+	Tracks      []titled `json:"tracks"`
+}
+
+// shopResponse is the /v2/shop envelope subset the gateway reads: the rotation
+// date plus the offers.
+type shopResponse struct {
+	Data struct {
+		Date    string      `json:"date"`
+		Entries []shopEntry `json:"entries"`
+	} `json:"data"`
+}
+
+// shop answers fortnite.shop (sesame's !store) with the current item-shop
+// rotation. The shop is global, so the cache key carries no request state.
+func (p *Provider) shop(ctx context.Context, req gatewayrpc.Request) any {
+	key := core.Key(p.Name(), "shop", "current")
+	b, err := core.CachedBytes(ctx, p.cache, key, func(ctx context.Context) ([]byte, time.Duration, error) {
+		return core.BuildReply(ctx, shopTTL, negativeTTL,
+			func(ctx context.Context) (any, error) { return p.fetchShop(ctx, req.IsPremium) },
+			func(msg string) any { return gatewayrpc.FortniteShopReply{Error: msg} },
+		)
+	})
+	if err != nil {
+		p.log.Warn("fortnite shop fetch failed", zap.Error(err))
+		return gatewayrpc.FortniteShopReply{Error: "item shop lookup failed"}
+	}
+	return json.RawMessage(b)
+}
+
+// fetchShop spends the budget, queries /v2/shop and normalizes each offer to
+// name + final price. Offers with nothing displayable are dropped.
+func (p *Provider) fetchShop(ctx context.Context, isPremium bool) (gatewayrpc.FortniteShopReply, error) {
+	if err := p.buckets.Enforce(ctx, p.deps.Limiter, isPremium); err != nil {
+		return gatewayrpc.FortniteShopReply{}, err
+	}
+
+	var resp shopResponse
+	if err := p.http.GetJSON(ctx, "/v2/shop", nil, &resp); err != nil {
+		return gatewayrpc.FortniteShopReply{}, err
+	}
+
+	entries := make([]gatewayrpc.FortniteShopEntry, 0, len(resp.Data.Entries))
+	for _, e := range resp.Data.Entries {
+		name := e.displayName()
+		if name == "" {
+			continue
+		}
+		entries = append(entries, gatewayrpc.FortniteShopEntry{Name: name, Price: e.FinalPrice})
+	}
+	// The upstream date is an ISO timestamp; the reply carries the day only.
+	date, _, _ := strings.Cut(resp.Data.Date, "T")
+	return gatewayrpc.FortniteShopReply{Date: date, Count: len(entries), Entries: entries}, nil
+}
+
+// displayName picks the offer's chat name: the bundle's own name when the
+// offer is a bundle, otherwise the lead item of the first non-empty family.
+func (e shopEntry) displayName() string {
+	if e.Bundle != nil && e.Bundle.Name != "" {
+		return e.Bundle.Name
+	}
+	for _, family := range [][]named{e.BrItems, e.Instruments, e.Cars, e.LegoKits} {
+		if len(family) > 0 && family[0].Name != "" {
+			return family[0].Name
+		}
+	}
+	if len(e.Tracks) > 0 {
+		return e.Tracks[0].Title
+	}
+	return ""
+}

--- a/app/gateway/internal/providers/fortnite/fortnite.go
+++ b/app/gateway/internal/providers/fortnite/fortnite.go
@@ -157,6 +157,10 @@ func toReplyStats(m *modeStats) gatewayrpc.FortniteModeStats {
 	}
 }
 
+// privateStatsKeywords mark a 403 body as the player's own stats-privacy
+// toggle ("public game stats disabled") rather than an API-key problem.
+var privateStatsKeywords = []string{"public", "private", "stats"}
+
 // privateStatsError reshapes the upstream 403 for an account whose "Public
 // Game Stats" toggle is off into a player-level 404-class failure: it chats a
 // specific message and negative-caches (private stays private for a while).
@@ -167,11 +171,20 @@ func privateStatsError(err error) error {
 	if !errors.As(err, &ue) || ue.Status != 403 {
 		return err
 	}
-	msg := strings.ToLower(ue.Message)
-	if strings.Contains(msg, "public") || strings.Contains(msg, "private") || strings.Contains(msg, "stats") {
+	if containsAny(strings.ToLower(ue.Message), privateStatsKeywords) {
 		return &core.UpstreamError{Status: 404, Message: "this player's game stats are private"}
 	}
 	return err
+}
+
+// containsAny reports whether s contains at least one of subs.
+func containsAny(s string, subs []string) bool {
+	for _, sub := range subs {
+		if strings.Contains(s, sub) {
+			return true
+		}
+	}
+	return false
 }
 
 // stats answers fortnite.stats (sesame's !fnstats) with the player's
@@ -181,15 +194,16 @@ func (p *Provider) stats(ctx context.Context, req gatewayrpc.Request) any {
 	if account == "" {
 		return gatewayrpc.FortniteStatsReply{Error: "missing account"}
 	}
-	accountType := normalizeAccountType(req.AccountType)
-	window := normalizeTimeWindow(req.TimeWindow)
+	q := statsQuery{
+		account:     account,
+		accountType: normalizeAccountType(req.AccountType),
+		window:      normalizeTimeWindow(req.TimeWindow),
+	}
 
-	key := core.Key(p.Name(), "stats", accountType+":"+window+":"+strings.ToLower(account))
+	key := core.Key(p.Name(), "stats", q.accountType+":"+q.window+":"+strings.ToLower(account))
 	b, err := core.CachedBytes(ctx, p.cache, key, func(ctx context.Context) ([]byte, time.Duration, error) {
 		return core.BuildReply(ctx, statsTTL, negativeTTL,
-			func(ctx context.Context) (any, error) {
-				return p.fetchStats(ctx, account, accountType, window, req.IsPremium)
-			},
+			func(ctx context.Context) (any, error) { return p.fetchStats(ctx, q, req.IsPremium) },
 			func(msg string) any { return gatewayrpc.FortniteStatsReply{Player: account, Error: msg} },
 		)
 	})
@@ -201,17 +215,25 @@ func (p *Provider) stats(ctx context.Context, req gatewayrpc.Request) any {
 	return json.RawMessage(b)
 }
 
+// statsQuery is one normalized stats lookup: the player name plus the
+// platform namespace and window the upstream call carries.
+type statsQuery struct {
+	account     string
+	accountType string
+	window      string
+}
+
 // fetchStats spends the budget, queries /v2/stats/br/v2 and shapes the
 // success reply.
-func (p *Provider) fetchStats(ctx context.Context, account, accountType, window string, isPremium bool) (gatewayrpc.FortniteStatsReply, error) {
+func (p *Provider) fetchStats(ctx context.Context, q statsQuery, isPremium bool) (gatewayrpc.FortniteStatsReply, error) {
 	if err := p.buckets.Enforce(ctx, p.deps.Limiter, isPremium); err != nil {
 		return gatewayrpc.FortniteStatsReply{}, err
 	}
 
 	query := url.Values{
-		"name":        {account},
-		"accountType": {accountType},
-		"timeWindow":  {window},
+		"name":        {q.account},
+		"accountType": {q.accountType},
+		"timeWindow":  {q.window},
 		"image":       {"none"},
 	}
 	var resp statsResponse
@@ -221,12 +243,12 @@ func (p *Provider) fetchStats(ctx context.Context, account, accountType, window 
 
 	name := resp.Data.Account.Name
 	if name == "" {
-		name = account
+		name = q.account
 	}
 	all := resp.Data.Stats.All
 	return gatewayrpc.FortniteStatsReply{
 		Player:  name,
-		Window:  window,
+		Window:  q.window,
 		Overall: toReplyStats(all.Overall),
 		Solo:    toReplyStats(all.Solo),
 		Duo:     toReplyStats(all.Duo),

--- a/app/gateway/internal/providers/fortnite/fortnite_test.go
+++ b/app/gateway/internal/providers/fortnite/fortnite_test.go
@@ -1,0 +1,269 @@
+package fortnite
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"ItsBagelBot/app/gateway/internal/core"
+	"ItsBagelBot/app/gateway/internal/provider"
+	gatewayrpc "ItsBagelBot/internal/domain/rpc/gateway"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// memStore is an in-memory core.Store for tests.
+type memStore struct {
+	mu sync.Mutex
+	m  map[string][]byte
+}
+
+func newMemStore() *memStore { return &memStore{m: map[string][]byte{}} }
+
+func (s *memStore) Get(_ context.Context, key string) ([]byte, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	b, ok := s.m[key]
+	return b, ok, nil
+}
+func (s *memStore) Set(_ context.Context, key string, val []byte, _ time.Duration) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.m[key] = append([]byte(nil), val...)
+	return nil
+}
+func (s *memStore) Del(_ context.Context, key string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.m, key)
+	return nil
+}
+
+func newTestProvider(t *testing.T, upstream http.Handler) *Provider {
+	t.Helper()
+	srv := httptest.NewServer(upstream)
+	t.Cleanup(srv.Close)
+	return New(Config{BaseURL: srv.URL, APIKey: "fortnite-key"},
+		provider.Deps{Cache: core.NewCache(newMemStore()), Log: zap.NewNop()})
+}
+
+func handle(t *testing.T, p *Provider, name string) func(context.Context, gatewayrpc.Request) any {
+	t.Helper()
+	for _, ep := range p.Endpoints() {
+		if ep.Name == name {
+			return ep.Handle
+		}
+	}
+	t.Fatalf("%s endpoint not declared", name)
+	return nil
+}
+
+// asStats decodes one stats handler result (raw wire bytes or typed guard reply).
+func asStats(t *testing.T, res any) gatewayrpc.FortniteStatsReply {
+	t.Helper()
+	if v, ok := res.(gatewayrpc.FortniteStatsReply); ok {
+		return v
+	}
+	raw, ok := res.(json.RawMessage)
+	require.True(t, ok, "unexpected handler result type %T", res)
+	var v gatewayrpc.FortniteStatsReply
+	require.NoError(t, json.Unmarshal(raw, &v))
+	return v
+}
+
+// asShop decodes one shop handler result.
+func asShop(t *testing.T, res any) gatewayrpc.FortniteShopReply {
+	t.Helper()
+	if v, ok := res.(gatewayrpc.FortniteShopReply); ok {
+		return v
+	}
+	raw, ok := res.(json.RawMessage)
+	require.True(t, ok, "unexpected handler result type %T", res)
+	var v gatewayrpc.FortniteShopReply
+	require.NoError(t, json.Unmarshal(raw, &v))
+	return v
+}
+
+const statsBody = `{
+	"status": 200,
+	"data": {
+		"account": {"id": "abc", "name": "Ninja"},
+		"stats": {"all": {
+			"overall": {"wins": 301, "matches": 6232, "kills": 21679, "kd": 3.66, "winRate": 4.83},
+			"solo": {"wins": 120, "matches": 2400, "kills": 9000, "kd": 3.2, "winRate": 5.0},
+			"duo": {"wins": 90, "matches": 1900, "kills": 7000, "kd": 3.8, "winRate": 4.7},
+			"squad": null
+		}}
+	}
+}`
+
+func TestStatsNormalizesAndPassesParams(t *testing.T) {
+	var gotAuth, gotName, gotType, gotWindow string
+	p := newTestProvider(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/v2/stats/br/v2", r.URL.Path)
+		gotAuth = r.Header.Get("Authorization")
+		q := r.URL.Query()
+		gotName, gotType, gotWindow = q.Get("name"), q.Get("accountType"), q.Get("timeWindow")
+		assert.Equal(t, "none", q.Get("image"))
+		_, _ = w.Write([]byte(statsBody))
+	}))
+
+	reply := asStats(t, handle(t, p, "stats")(context.Background(),
+		gatewayrpc.Request{Account: "Ninja", AccountType: "psn", TimeWindow: "season"}))
+	require.Empty(t, reply.Error)
+	assert.Equal(t, "fortnite-key", gotAuth)
+	assert.Equal(t, "Ninja", gotName)
+	assert.Equal(t, "psn", gotType)
+	assert.Equal(t, "season", gotWindow)
+
+	assert.Equal(t, "Ninja", reply.Player)
+	assert.Equal(t, "season", reply.Window)
+	assert.Equal(t, int64(301), reply.Overall.Wins)
+	assert.Equal(t, int64(6232), reply.Overall.Matches)
+	assert.Equal(t, int64(21679), reply.Overall.Kills)
+	assert.InDelta(t, 3.66, reply.Overall.KD, 1e-9)
+	assert.InDelta(t, 4.83, reply.Overall.WinRate, 1e-9)
+	assert.Equal(t, int64(120), reply.Solo.Wins)
+	assert.Equal(t, int64(90), reply.Duo.Wins)
+	// A queue the player never touched is null upstream and zero in the reply.
+	assert.Zero(t, reply.Squad.Wins)
+	assert.Zero(t, reply.Squad.Matches)
+}
+
+// Blank/garbage account type and window fall back to epic + lifetime.
+func TestStatsDefaultsEpicLifetime(t *testing.T) {
+	p := newTestProvider(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		assert.Equal(t, "epic", q.Get("accountType"))
+		assert.Equal(t, "lifetime", q.Get("timeWindow"))
+		_, _ = w.Write([]byte(statsBody))
+	}))
+
+	reply := asStats(t, handle(t, p, "stats")(context.Background(),
+		gatewayrpc.Request{Account: "Ninja", AccountType: "steam", TimeWindow: "weekly"}))
+	require.Empty(t, reply.Error)
+	assert.Equal(t, "lifetime", reply.Window)
+}
+
+// An unknown player 404s upstream, chats "player not found" and
+// negative-caches (the second call hits no upstream).
+func TestStatsUnknownPlayerNegativeCached(t *testing.T) {
+	var hits int
+	p := newTestProvider(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits++
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"status":404,"error":"Account not found."}`))
+	}))
+	h := handle(t, p, "stats")
+
+	reply := asStats(t, h(context.Background(), gatewayrpc.Request{Account: "Ghosty"}))
+	assert.Equal(t, "Account not found.", reply.Error)
+
+	reply = asStats(t, h(context.Background(), gatewayrpc.Request{Account: "Ghosty"}))
+	assert.Equal(t, "Account not found.", reply.Error)
+	assert.Equal(t, 1, hits, "unknown player must be served from the negative cache")
+}
+
+// A 403 for an account whose public-stats toggle is off chats the specific
+// private-stats message (and negative-caches like a missing player).
+func TestStatsPrivateAccountFriendly(t *testing.T) {
+	p := newTestProvider(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"status":403,"error":"This account's public game stats are disabled."}`))
+	}))
+
+	reply := asStats(t, handle(t, p, "stats")(context.Background(), gatewayrpc.Request{Account: "Shy"}))
+	assert.Equal(t, "this player's game stats are private", reply.Error)
+}
+
+// A 403 that is a key problem (not the stats toggle) answers the generic
+// config-flavored message and is NOT cached: the next request retries.
+func TestStatsBadKeyNotCached(t *testing.T) {
+	var hits int
+	p := newTestProvider(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits++
+		if hits == 1 {
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"status":403,"error":"Invalid authorization header."}`))
+			return
+		}
+		_, _ = w.Write([]byte(statsBody))
+	}))
+	h := handle(t, p, "stats")
+
+	reply := asStats(t, h(context.Background(), gatewayrpc.Request{Account: "Ninja"}))
+	assert.Equal(t, "stats lookup not permitted right now", reply.Error)
+
+	reply = asStats(t, h(context.Background(), gatewayrpc.Request{Account: "Ninja"}))
+	assert.Empty(t, reply.Error)
+	assert.Equal(t, int64(301), reply.Overall.Wins)
+}
+
+func TestStatsMissingAccount(t *testing.T) {
+	p := newTestProvider(t, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Error("no upstream call expected")
+	}))
+	reply := asStats(t, handle(t, p, "stats")(context.Background(), gatewayrpc.Request{}))
+	assert.Equal(t, "missing account", reply.Error)
+}
+
+const shopBody = `{
+	"status": 200,
+	"data": {
+		"date": "2026-07-09T00:00:00Z",
+		"entries": [
+			{"finalPrice": 2800, "bundle": {"name": "Peely Bundle"}, "brItems": [{"name": "Peely"}]},
+			{"finalPrice": 1200, "brItems": [{"name": "Renegade Raider"}]},
+			{"finalPrice": 500, "tracks": [{"title": "Never Gonna Give You Up"}]},
+			{"finalPrice": 400}
+		]
+	}
+}`
+
+func TestShopNormalizesAndCaches(t *testing.T) {
+	var hits int
+	p := newTestProvider(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		require.Equal(t, "/v2/shop", r.URL.Path)
+		_, _ = w.Write([]byte(shopBody))
+	}))
+	h := handle(t, p, "shop")
+
+	reply := asShop(t, h(context.Background(), gatewayrpc.Request{}))
+	require.Empty(t, reply.Error)
+	assert.Equal(t, "2026-07-09", reply.Date)
+	// The nameless entry is dropped; the bundle keeps its bundle name.
+	assert.Equal(t, 3, reply.Count)
+	require.Len(t, reply.Entries, 3)
+	assert.Equal(t, gatewayrpc.FortniteShopEntry{Name: "Peely Bundle", Price: 2800}, reply.Entries[0])
+	assert.Equal(t, gatewayrpc.FortniteShopEntry{Name: "Renegade Raider", Price: 1200}, reply.Entries[1])
+	assert.Equal(t, gatewayrpc.FortniteShopEntry{Name: "Never Gonna Give You Up", Price: 500}, reply.Entries[2])
+
+	// Second call is served from the cache.
+	reply = asShop(t, h(context.Background(), gatewayrpc.Request{}))
+	require.Empty(t, reply.Error)
+	assert.Equal(t, 1, hits)
+}
+
+func TestOddRateLimitDoesNotPanic(t *testing.T) {
+	assert.NotPanics(t, func() {
+		New(Config{APIKey: "k", RateLimit: 100.3},
+			provider.Deps{Cache: core.NewCache(newMemStore()), Log: zap.NewNop()})
+	})
+}
+
+func TestNormalizers(t *testing.T) {
+	assert.Equal(t, "epic", normalizeAccountType(""))
+	assert.Equal(t, "epic", normalizeAccountType("steam"))
+	assert.Equal(t, "psn", normalizeAccountType(" PSN "))
+	assert.Equal(t, "xbl", normalizeAccountType("xbl"))
+	assert.Equal(t, "lifetime", normalizeTimeWindow(""))
+	assert.Equal(t, "season", normalizeTimeWindow("Season"))
+	assert.Equal(t, "lifetime", normalizeTimeWindow("weekly"))
+}

--- a/app/gateway/internal/providers/fortnite/fortnite_test.go
+++ b/app/gateway/internal/providers/fortnite/fortnite_test.go
@@ -64,31 +64,24 @@ func handle(t *testing.T, p *Provider, name string) func(context.Context, gatewa
 	return nil
 }
 
-// asStats decodes one stats handler result (raw wire bytes or typed guard reply).
-func asStats(t *testing.T, res any) gatewayrpc.FortniteStatsReply {
+// asReply decodes one handler result (raw wire bytes or typed guard reply).
+func asReply[T any](t *testing.T, res any) T {
 	t.Helper()
-	if v, ok := res.(gatewayrpc.FortniteStatsReply); ok {
+	if v, ok := res.(T); ok {
 		return v
 	}
 	raw, ok := res.(json.RawMessage)
 	require.True(t, ok, "unexpected handler result type %T", res)
-	var v gatewayrpc.FortniteStatsReply
+	var v T
 	require.NoError(t, json.Unmarshal(raw, &v))
 	return v
 }
 
-// asShop decodes one shop handler result.
-func asShop(t *testing.T, res any) gatewayrpc.FortniteShopReply {
-	t.Helper()
-	if v, ok := res.(gatewayrpc.FortniteShopReply); ok {
-		return v
-	}
-	raw, ok := res.(json.RawMessage)
-	require.True(t, ok, "unexpected handler result type %T", res)
-	var v gatewayrpc.FortniteShopReply
-	require.NoError(t, json.Unmarshal(raw, &v))
-	return v
-}
+// asStats / asShop are the endpoint-typed instantiations the tests read with.
+var (
+	asStats = asReply[gatewayrpc.FortniteStatsReply]
+	asShop  = asReply[gatewayrpc.FortniteShopReply]
+)
 
 const statsBody = `{
 	"status": 200,

--- a/app/sesame/modules/all.go
+++ b/app/sesame/modules/all.go
@@ -19,6 +19,7 @@ func All(d engine.Deps) []module.Module {
 		Clip(d),
 		Urchin(d),
 		Mcsr(d),
+		Fortnite(d),
 		Queue(d),
 		Automod(d),
 		ChannelPoints(d),

--- a/app/sesame/modules/fortnite.go
+++ b/app/sesame/modules/fortnite.go
@@ -1,0 +1,193 @@
+package modules
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"time"
+
+	"ItsBagelBot/app/sesame/engine"
+	"ItsBagelBot/app/sesame/module"
+	"ItsBagelBot/internal/domain/outgress"
+	gatewayrpc "ItsBagelBot/internal/domain/rpc/gateway"
+)
+
+// fortniteModuleName is the ModuleView key; the console MODULE_CATALOG entry
+// and the dashboard module page use the same id.
+const fortniteModuleName = "fortnite"
+
+// fortniteCooldown is the shared per-command window; the gateway caches
+// upstream replies, so this only shields chat from command spam, not the API.
+const fortniteCooldown = 10 * time.Second
+
+// Default reply templates. The broadcaster customizes them per command on the
+// module page; blank falls back to these.
+const (
+	defaultFortniteStatsTemplate = "{player} ({window}): {wins} wins in {matches} matches · {winrate}% WR · {kills} kills · {kd} K/D · solo {solowins}W / duo {duowins}W / squad {squadwins}W"
+	defaultFortniteStoreTemplate = "Item Shop {date}: {items}"
+)
+
+// fortniteShopBudget caps the rendered {items} list so the chat line stays
+// inside Twitch's 500-char message limit with room for the template around it.
+const fortniteShopBudget = 380
+
+// fortniteConfig is the module's dashboard configuration. Account is the
+// linked account name (blank = the broadcaster's own Twitch login),
+// AccountType the platform namespace it lives in (epic/psn/xbl) and TimeWindow
+// the stats window (lifetime/season) — the gateway defaults blanks to
+// epic/lifetime. The *Enabled toggles are stored "on"/"off" — empty means on,
+// matching the alerts module's semantics — and each *Message is a customized
+// template (blank = default).
+type fortniteConfig struct {
+	Account     string `json:"account"`
+	AccountType string `json:"accountType"`
+	TimeWindow  string `json:"timeWindow"`
+
+	StatsEnabled string `json:"statsEnabled"`
+	StatsMessage string `json:"statsMessage"`
+	StoreEnabled string `json:"storeEnabled"`
+	StoreMessage string `json:"storeMessage"`
+}
+
+// Fortnite owns the Fortnite chat commands backed by fortnite-api.com through
+// the gateway service. It is a named, opt-in module (KindOptIn): off by
+// default, enabled on the dashboard, where the broadcaster links a default
+// account (name + platform) and picks the stats window. Viewers can always
+// target another player explicitly: "!fnstats Ninja".
+//
+// Commands: !fnstats (Battle Royale stats with the solo/duo/squad breakdown),
+// !store (the current item-shop rotation).
+func Fortnite(d engine.Deps) module.Module {
+	m := module.NewModule(fortniteModuleName, module.KindOptIn)
+	m.Command("fnstats").Everyone().Cooldown(fortniteCooldown).Aliases("fortnitestats").
+		Run(fortniteStatsRun(d))
+	m.Command("store").Everyone().Cooldown(fortniteCooldown).Aliases("itemshop", "fnshop").
+		Run(fortniteStoreRun(d))
+	return m.Build()
+}
+
+// fortniteStatsTokens is the !fnstats template palette over the gateway reply.
+func fortniteStatsTokens() map[string]func(*gatewayrpc.FortniteStatsReply) string {
+	type reply = gatewayrpc.FortniteStatsReply
+	return map[string]func(*reply) string{
+		"player":       func(r *reply) string { return r.Player },
+		"window":       func(r *reply) string { return r.Window },
+		"wins":         func(r *reply) string { return i64(r.Overall.Wins) },
+		"matches":      func(r *reply) string { return i64(r.Overall.Matches) },
+		"kills":        func(r *reply) string { return i64(r.Overall.Kills) },
+		"kd":           func(r *reply) string { return trimScore(r.Overall.KD) },
+		"winrate":      func(r *reply) string { return trimScore(r.Overall.WinRate) },
+		"solowins":     func(r *reply) string { return i64(r.Solo.Wins) },
+		"solomatches":  func(r *reply) string { return i64(r.Solo.Matches) },
+		"solokd":       func(r *reply) string { return trimScore(r.Solo.KD) },
+		"duowins":      func(r *reply) string { return i64(r.Duo.Wins) },
+		"duomatches":   func(r *reply) string { return i64(r.Duo.Matches) },
+		"duokd":        func(r *reply) string { return trimScore(r.Duo.KD) },
+		"squadwins":    func(r *reply) string { return i64(r.Squad.Wins) },
+		"squadmatches": func(r *reply) string { return i64(r.Squad.Matches) },
+		"squadkd":      func(r *reply) string { return trimScore(r.Squad.KD) },
+	}
+}
+
+// fortniteStatsRun answers !fnstats with the player's Battle Royale stats over
+// the configured window. Template tokens: {player} {window} {wins} {matches}
+// {kills} {kd} {winrate} plus the per-mode {solowins} {solomatches} {solokd}
+// {duowins} {duomatches} {duokd} {squadwins} {squadmatches} {squadkd}.
+func fortniteStatsRun(d engine.Deps) module.RunFunc {
+	tokens := fortniteStatsTokens()
+	return func(ctx context.Context, c *module.Context, args string, emit module.Emit) error {
+		var cfg fortniteConfig
+		_ = c.Decode(&cfg)
+		if !alertOn(cfg.StatsEnabled) || d.Gateway == nil {
+			return nil
+		}
+
+		account := resolveAccount(accountSources{Arg: args, Linked: cfg.Account, BroadcasterLogin: c.Env.BroadcasterUserLogin})
+		req := gatewayrpc.Request{
+			Account:     account,
+			AccountType: cfg.AccountType,
+			TimeWindow:  cfg.TimeWindow,
+			IsPremium:   c.Regress.IsPremium(),
+		}
+		var reply gatewayrpc.FortniteStatsReply
+		if err := d.Gateway.Call(ctx, "fortnite", "stats", req, &reply); err != nil {
+			if chatReplyError(c, emit, account, err) {
+				return nil
+			}
+			return err
+		}
+
+		msg := module.ExpandString(orDefault(cfg.StatsMessage, defaultFortniteStatsTemplate), func(key string) (string, bool) {
+			if field, ok := tokens[key]; ok {
+				return field(&reply), true
+			}
+			return module.ParseDynamic(key)
+		})
+		emit(&module.Output{Type: outgress.TypeChat, BroadcasterID: c.Env.BroadcasterUserID, Text: msg})
+		return nil
+	}
+}
+
+// fortniteStoreRun answers !store with the current item-shop rotation.
+// Template tokens: {date} {count} {items}.
+func fortniteStoreRun(d engine.Deps) module.RunFunc {
+	return func(ctx context.Context, c *module.Context, args string, emit module.Emit) error {
+		var cfg fortniteConfig
+		_ = c.Decode(&cfg)
+		if !alertOn(cfg.StoreEnabled) || d.Gateway == nil {
+			return nil
+		}
+
+		var reply gatewayrpc.FortniteShopReply
+		req := gatewayrpc.Request{IsPremium: c.Regress.IsPremium()}
+		if err := d.Gateway.Call(ctx, "fortnite", "shop", req, &reply); err != nil {
+			if chatReplyError(c, emit, "item shop", err) {
+				return nil
+			}
+			return err
+		}
+
+		msg := module.ExpandString(orDefault(cfg.StoreMessage, defaultFortniteStoreTemplate), func(key string) (string, bool) {
+			switch key {
+			case "date":
+				return reply.Date, true
+			case "count":
+				return strconv.Itoa(reply.Count), true
+			case "items":
+				return formatShopEntries(reply.Entries), true
+			}
+			return module.ParseDynamic(key)
+		})
+		emit(&module.Output{Type: outgress.TypeChat, BroadcasterID: c.Env.BroadcasterUserID, Text: msg})
+		return nil
+	}
+}
+
+// formatShopEntries renders the shop offers as "Name (price), ..." within the
+// chat budget; whatever does not fit collapses into "+N more". Prices are
+// V-Bucks; a zero price (a free or bugged offer) renders name-only.
+func formatShopEntries(entries []gatewayrpc.FortniteShopEntry) string {
+	if len(entries) == 0 {
+		return "empty today"
+	}
+	var b strings.Builder
+	shown := 0
+	for _, e := range entries {
+		part := e.Name
+		if e.Price > 0 {
+			part += " (" + i64(e.Price) + ")"
+		}
+		if shown > 0 && b.Len()+len(part)+2 > fortniteShopBudget {
+			break
+		}
+		if shown > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(part)
+		shown++
+	}
+	if rest := len(entries) - shown; rest > 0 {
+		b.WriteString(" +" + strconv.Itoa(rest) + " more")
+	}
+	return b.String()
+}

--- a/app/sesame/modules/fortnite_test.go
+++ b/app/sesame/modules/fortnite_test.go
@@ -78,16 +78,26 @@ func TestFnstatsConfigPassthrough(t *testing.T) {
 	assert.Equal(t, "psn", call.req.AccountType)
 }
 
-func TestFnstatsDisabledStaysSilent(t *testing.T) {
-	gw := &fakeGateway{replies: map[string]any{"fortnite.stats": fortniteStatsReply()}}
-	cmd := fortniteCmd(t, gw, "fnstats")
+// A per-command "off" toggle keeps that command silent: no chat line and no
+// gateway call, for both fortnite commands.
+func TestFortniteDisabledStaysSilent(t *testing.T) {
+	cases := []struct{ name, config string }{
+		{"fnstats", `{"statsEnabled":"off"}`},
+		{"store", `{"storeEnabled":"off"}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gw := &fakeGateway{}
+			cmd := fortniteCmd(t, gw, tc.name)
 
-	var col collector
-	require.NoError(t, cmd.Run(context.Background(), urchinCtx(`{"statsEnabled":"off"}`), "", col.emit))
-	assert.Empty(t, col.out)
-	gw.mu.Lock()
-	assert.Empty(t, gw.calls)
-	gw.mu.Unlock()
+			var col collector
+			require.NoError(t, cmd.Run(context.Background(), urchinCtx(tc.config), "", col.emit))
+			assert.Empty(t, col.out)
+			gw.mu.Lock()
+			assert.Empty(t, gw.calls)
+			gw.mu.Unlock()
+		})
+	}
 }
 
 func TestFnstatsReplyErrorChats(t *testing.T) {
@@ -118,15 +128,6 @@ func TestStoreDefaultTemplate(t *testing.T) {
 	assert.Equal(t,
 		"Item Shop 2026-07-09: Peely Bundle (2800), Renegade Raider (1200), Free Hat",
 		col.out[0].Text)
-}
-
-func TestStoreDisabledStaysSilent(t *testing.T) {
-	gw := &fakeGateway{replies: map[string]any{"fortnite.shop": gatewayrpc.FortniteShopReply{}}}
-	cmd := fortniteCmd(t, gw, "store")
-
-	var col collector
-	require.NoError(t, cmd.Run(context.Background(), urchinCtx(`{"storeEnabled":"off"}`), "", col.emit))
-	assert.Empty(t, col.out)
 }
 
 func TestFormatShopEntriesBudget(t *testing.T) {

--- a/app/sesame/modules/fortnite_test.go
+++ b/app/sesame/modules/fortnite_test.go
@@ -1,0 +1,152 @@
+package modules
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"testing"
+
+	"ItsBagelBot/app/sesame/engine"
+	"ItsBagelBot/app/sesame/module"
+	"ItsBagelBot/internal/domain/outgress"
+	gatewayrpc "ItsBagelBot/internal/domain/rpc/gateway"
+	"ItsBagelBot/pkg/bus"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func fortniteCmd(t *testing.T, gw engine.GatewayCaller, name string) module.Command {
+	t.Helper()
+	m := Fortnite(engine.Deps{Gateway: gw, Log: zap.NewNop()})
+	assert.Equal(t, "fortnite", m.Name)
+	assert.Equal(t, module.KindOptIn, m.Kind)
+	return findCmd(t, m, name)
+}
+
+func fortniteStatsReply() gatewayrpc.FortniteStatsReply {
+	return gatewayrpc.FortniteStatsReply{
+		Player:  "Ninja",
+		Window:  "lifetime",
+		Overall: gatewayrpc.FortniteModeStats{Wins: 301, Matches: 6232, Kills: 21679, KD: 3.66, WinRate: 4.83},
+		Solo:    gatewayrpc.FortniteModeStats{Wins: 120, Matches: 2400, KD: 3.2},
+		Duo:     gatewayrpc.FortniteModeStats{Wins: 90, Matches: 1900, KD: 3.8},
+		Squad:   gatewayrpc.FortniteModeStats{Wins: 91, Matches: 1932, KD: 4.1},
+	}
+}
+
+func TestFnstatsDefaultTemplate(t *testing.T) {
+	gw := &fakeGateway{replies: map[string]any{"fortnite.stats": fortniteStatsReply()}}
+	cmd := fortniteCmd(t, gw, "fnstats")
+
+	var col collector
+	require.NoError(t, cmd.Run(context.Background(), urchinCtx(""), "", col.emit))
+	require.Len(t, col.out, 1)
+	assert.Equal(t, outgress.TypeChat, col.out[0].Type)
+	assert.Equal(t, "2", col.out[0].BroadcasterID)
+	assert.Equal(t,
+		"Ninja (lifetime): 301 wins in 6232 matches · 4.83% WR · 21679 kills · 3.66 K/D · solo 120W / duo 90W / squad 91W",
+		col.out[0].Text)
+
+	// No linked account and no arg: falls back to the broadcaster's login, and
+	// blank platform/window ride to the gateway (which defaults them).
+	call := gw.lastCall(t)
+	assert.Equal(t, "streamer", call.req.Account)
+	assert.Empty(t, call.req.AccountType)
+	assert.Empty(t, call.req.TimeWindow)
+}
+
+func TestFnstatsConfigPassthrough(t *testing.T) {
+	gw := &fakeGateway{replies: map[string]any{"fortnite.stats": fortniteStatsReply()}}
+	cmd := fortniteCmd(t, gw, "fnstats")
+
+	var col collector
+	cfg := `{"account":"LinkedAcc","accountType":"psn","timeWindow":"season"}`
+	require.NoError(t, cmd.Run(context.Background(), urchinCtx(cfg), "", col.emit))
+
+	call := gw.lastCall(t)
+	assert.Equal(t, "LinkedAcc", call.req.Account)
+	assert.Equal(t, "psn", call.req.AccountType)
+	assert.Equal(t, "season", call.req.TimeWindow)
+
+	// An explicit argument still beats the linked account; platform and window
+	// stay the configured ones.
+	require.NoError(t, cmd.Run(context.Background(), urchinCtx(cfg), "@SomePlayer extra", col.emit))
+	call = gw.lastCall(t)
+	assert.Equal(t, "SomePlayer", call.req.Account)
+	assert.Equal(t, "psn", call.req.AccountType)
+}
+
+func TestFnstatsDisabledStaysSilent(t *testing.T) {
+	gw := &fakeGateway{replies: map[string]any{"fortnite.stats": fortniteStatsReply()}}
+	cmd := fortniteCmd(t, gw, "fnstats")
+
+	var col collector
+	require.NoError(t, cmd.Run(context.Background(), urchinCtx(`{"statsEnabled":"off"}`), "", col.emit))
+	assert.Empty(t, col.out)
+	gw.mu.Lock()
+	assert.Empty(t, gw.calls)
+	gw.mu.Unlock()
+}
+
+func TestFnstatsReplyErrorChats(t *testing.T) {
+	gw := &fakeGateway{err: bus.RPCReplyError{Message: "player not found"}}
+	cmd := fortniteCmd(t, gw, "fnstats")
+
+	var col collector
+	require.NoError(t, cmd.Run(context.Background(), urchinCtx(""), "Ghosty", col.emit))
+	require.Len(t, col.out, 1)
+	assert.Equal(t, "Ghosty: player not found", col.out[0].Text)
+}
+
+func TestStoreDefaultTemplate(t *testing.T) {
+	gw := &fakeGateway{replies: map[string]any{"fortnite.shop": gatewayrpc.FortniteShopReply{
+		Date:  "2026-07-09",
+		Count: 3,
+		Entries: []gatewayrpc.FortniteShopEntry{
+			{Name: "Peely Bundle", Price: 2800},
+			{Name: "Renegade Raider", Price: 1200},
+			{Name: "Free Hat"},
+		},
+	}}}
+	cmd := fortniteCmd(t, gw, "store")
+
+	var col collector
+	require.NoError(t, cmd.Run(context.Background(), urchinCtx(""), "", col.emit))
+	require.Len(t, col.out, 1)
+	assert.Equal(t,
+		"Item Shop 2026-07-09: Peely Bundle (2800), Renegade Raider (1200), Free Hat",
+		col.out[0].Text)
+}
+
+func TestStoreDisabledStaysSilent(t *testing.T) {
+	gw := &fakeGateway{replies: map[string]any{"fortnite.shop": gatewayrpc.FortniteShopReply{}}}
+	cmd := fortniteCmd(t, gw, "store")
+
+	var col collector
+	require.NoError(t, cmd.Run(context.Background(), urchinCtx(`{"storeEnabled":"off"}`), "", col.emit))
+	assert.Empty(t, col.out)
+}
+
+func TestFormatShopEntriesBudget(t *testing.T) {
+	assert.Equal(t, "empty today", formatShopEntries(nil))
+
+	// A long shop truncates within the budget and reports the remainder.
+	var entries []gatewayrpc.FortniteShopEntry
+	for i := 0; i < 60; i++ {
+		entries = append(entries, gatewayrpc.FortniteShopEntry{
+			Name: "Some Cosmetic Item " + strconv.Itoa(i), Price: 1200,
+		})
+	}
+	got := formatShopEntries(entries)
+	assert.LessOrEqual(t, len(got), fortniteShopBudget+len(" +99 more"))
+	assert.Contains(t, got, " more")
+	assert.True(t, strings.HasPrefix(got, "Some Cosmetic Item 0 (1200), "))
+
+	// The first entry always renders, even when it alone blows the budget.
+	huge := gatewayrpc.FortniteShopEntry{Name: strings.Repeat("x", fortniteShopBudget+50), Price: 100}
+	got = formatShopEntries([]gatewayrpc.FortniteShopEntry{huge, {Name: "Next", Price: 1}})
+	assert.True(t, strings.HasPrefix(got, huge.Name))
+	assert.Contains(t, got, "+1 more")
+}

--- a/console/shared/lib/types.ts
+++ b/console/shared/lib/types.ts
@@ -712,6 +712,113 @@ export const MODULE_CATALOG: readonly ModuleDef[] = [
     ]
   },
   {
+    id: 'fortnite',
+    label: 'Fortnite Stats',
+    tagline: 'Fortnite BR stats and the daily item shop in chat.',
+    description:
+      'Viewer commands backed by fortnite-api.com: !fnstats shows wins, matches, kills, K/D and win rate with a solo/duo/squad breakdown; !store lists what is in today\'s item shop. Link your account name below, pick the platform it lives on (Epic, PlayStation or Xbox) and whether stats cover your lifetime or the current season. Viewers can also name any player, e.g. "!fnstats Ninja".',
+    icon: 'activity',
+    category: 'Games',
+    defaultEnabled: false,
+    replies: [
+      {
+        key: 'stats',
+        label: '!fnstats',
+        tagline: 'Battle Royale stats for the linked or named player.',
+        event: '!fnstats',
+        command: 'fnstats',
+        enableKey: 'statsEnabled',
+        messageKey: 'statsMessage',
+        defaultMessage:
+          '{player} ({window}): {wins} wins in {matches} matches · {winrate}% WR · {kills} kills · {kd} K/D · solo {solowins}W / duo {duowins}W / squad {squadwins}W',
+        tokens: [
+          'player',
+          'window',
+          'wins',
+          'matches',
+          'kills',
+          'kd',
+          'winrate',
+          'solowins',
+          'solomatches',
+          'solokd',
+          'duowins',
+          'duomatches',
+          'duokd',
+          'squadwins',
+          'squadmatches',
+          'squadkd'
+        ],
+        previewSamples: {
+          player: 'Ninja',
+          window: 'lifetime',
+          wins: '301',
+          matches: '6232',
+          kills: '21679',
+          kd: '3.66',
+          winrate: '4.83',
+          solowins: '120',
+          solomatches: '2400',
+          solokd: '3.2',
+          duowins: '90',
+          duomatches: '1900',
+          duokd: '3.8',
+          squadwins: '91',
+          squadmatches: '1932',
+          squadkd: '4.1'
+        }
+      },
+      {
+        key: 'store',
+        label: '!store',
+        tagline: "Today's item-shop rotation.",
+        event: '!store',
+        command: 'store',
+        enableKey: 'storeEnabled',
+        messageKey: 'storeMessage',
+        defaultMessage: 'Item Shop {date}: {items}',
+        tokens: ['date', 'count', 'items'],
+        previewSamples: {
+          date: '2026-07-09',
+          count: '38',
+          items: 'Peely Bundle (2800), Renegade Raider (1200), Floss (500) +35 more'
+        }
+      }
+    ],
+    settings: [
+      {
+        key: 'account',
+        label: 'Linked account name',
+        type: 'text',
+        placeholder: 'Your Epic / PSN / Xbox name',
+        help: 'Default player for !fnstats. Leave blank to use your Twitch username.'
+      },
+      {
+        key: 'accountType',
+        label: 'Account platform',
+        type: 'select',
+        placeholder: 'epic',
+        options: [
+          { value: 'epic', label: 'Epic Games' },
+          { value: 'psn', label: 'PlayStation' },
+          { value: 'xbl', label: 'Xbox Live' }
+        ],
+        help: 'Which platform the linked name lives on. Epic covers most players.'
+      },
+      {
+        key: 'timeWindow',
+        label: 'Stats window',
+        type: 'select',
+        placeholder: 'lifetime',
+        options: [
+          { value: 'lifetime', label: 'Lifetime' },
+          { value: 'season', label: 'Current season' }
+        ],
+        help: 'Whether !fnstats reports all-time stats or the current season only.'
+      }
+    ]
+  },
+  {
     id: 'queue',
     label: 'Play Queue',
     tagline: 'Let viewers line up to play with you, first come first served.',

--- a/deploy/k8s/gateway.yaml
+++ b/deploy/k8s/gateway.yaml
@@ -1,11 +1,13 @@
 # gateway: the fleet's external-API gateway. Sesame requests third-party data
-# (urchin.gg Coral, MCSR Ranked) over NATS RPC (bagel.rpc.gateway.>); the
-# gateway fetches, normalizes, and caches replies in Valkey. It is the only
-# app that dials those external hosts.
+# (urchin.gg Coral, MCSR Ranked, fortnite-api.com) over NATS RPC
+# (bagel.rpc.gateway.>); the gateway fetches, normalizes, and caches replies in
+# Valkey. It is the only app that dials those external hosts.
 #
 # gateway-env (Doppler) carries VALKEY_*, URCHIN_API_KEY (provider disabled
 # without it), optional MCSR_API_KEY, NEW_RELIC_*, and the NATS_RPC_USER /
-# NATS_RPC_PASSWORD pair for the GATEWAY_RPC account.
+# NATS_RPC_PASSWORD pair for the GATEWAY_RPC account. The fortnite provider
+# stays dark until FORTNITE_ENABLED=true AND FORTNITE_API_KEY are both set
+# there (untested-key guard).
 apiVersion: secrets.doppler.com/v1alpha1
 kind: DopplerSecret
 metadata:

--- a/internal/domain/rpc/gateway/gateway.go
+++ b/internal/domain/rpc/gateway/gateway.go
@@ -46,6 +46,15 @@ type Request struct {
 	// powering it on and setting a colour; ColorRGB is ignored. This backs the
 	// opt-in "a viewer types off to turn the lights off" reward behaviour.
 	PowerOff bool `json:"power_off,omitempty"`
+
+	// --- fortnite (fortnite-api.com stats lookups) ---------------------------
+
+	// AccountType is the platform namespace Account lives in for fortnite.stats:
+	// "epic" (default), "psn" or "xbl". Zero on every non-fortnite request.
+	AccountType string `json:"account_type,omitempty"`
+	// TimeWindow selects the fortnite.stats window: "lifetime" (default) or
+	// "season" (the current season only).
+	TimeWindow string `json:"time_window,omitempty"`
 }
 
 // Subject builds the NATS subject for one provider endpoint under prefix.
@@ -155,6 +164,51 @@ type McsrSnapshotReply struct {
 	Nickname string `json:"nickname"`
 	Elo      int    `json:"elo"`
 	Error    string `json:"error,omitempty"`
+}
+
+// --- fortnite (fortnite-api.com) ---------------------------------------------
+
+// FortniteModeStats is one queue's normalized Battle Royale counters inside
+// FortniteStatsReply: the bot-needed subset (wins, matches, kills, K/D, win
+// rate) of the much larger upstream stat block. KD and WinRate come from the
+// upstream pre-computed; WinRate is a percentage (4.83 = 4.83%).
+type FortniteModeStats struct {
+	Wins    int64   `json:"wins"`
+	Matches int64   `json:"matches"`
+	Kills   int64   `json:"kills"`
+	KD      float64 `json:"kd"`
+	WinRate float64 `json:"win_rate"`
+}
+
+// FortniteStatsReply is the answer to fortnite.stats (sesame's !fnstats): a
+// player's Battle Royale stats over the requested window, overall plus the
+// solo/duo/squad mode breakdown. Window echoes the normalized window the
+// gateway actually queried ("lifetime" or "season").
+type FortniteStatsReply struct {
+	Player  string            `json:"player"`
+	Window  string            `json:"window"`
+	Overall FortniteModeStats `json:"overall"`
+	Solo    FortniteModeStats `json:"solo"`
+	Duo     FortniteModeStats `json:"duo"`
+	Squad   FortniteModeStats `json:"squad"`
+	Error   string            `json:"error,omitempty"`
+}
+
+// FortniteShopEntry is one item-shop offer reduced to what a chat line can
+// carry: a display name (the bundle name, or the lead item's) and the final
+// price in V-Bucks.
+type FortniteShopEntry struct {
+	Name  string `json:"name"`
+	Price int64  `json:"price"`
+}
+
+// FortniteShopReply is the answer to fortnite.shop (sesame's !store): the
+// current item-shop rotation. Date is the rotation day (YYYY-MM-DD).
+type FortniteShopReply struct {
+	Date    string              `json:"date"`
+	Count   int                 `json:"count"`
+	Entries []FortniteShopEntry `json:"entries"`
+	Error   string              `json:"error,omitempty"`
 }
 
 // --- govee (smart-light control over the broadcaster's own key) -------------


### PR DESCRIPTION
## Summary
- New gateway provider for fortnite-api.com: `stats` looks a player up by Epic/PSN/Xbox identity over the lifetime or current-season window and normalizes only the bot-needed values (wins, matches, kills, K/D, win rate, solo/duo/squad breakdown); `shop` serves the daily item-shop rotation reduced to name + V-Bucks price.
- Sesame `fortnite` module (opt-in): `!fnstats [player]` (arg > linked account > broadcaster login) and `!store` (aliases `itemshop`, `fnshop`), both fully templatable; the shop list truncates within Twitch's message cap with "+N more".
- Dashboard catalog entry with the two configurable replies plus settings: linked account name, account platform (Epic/PlayStation/Xbox), stats window (lifetime/season).
- Provider stays dark until `FORTNITE_ENABLED=true` AND `FORTNITE_API_KEY` land in Doppler `gateway` (untested-key guard); NATS ACLs unchanged (`bagel.rpc.gateway.>` wildcard covers it).

## Error handling
- 403 for an account with public game stats disabled chats "this player's game stats are private" and negative-caches; a key-problem 403 answers the generic config message and is never cached, so a fixed key retries immediately.
- Unknown players negative-cache for 5 minutes with the upstream's own message.

## Test plan
- [x] Provider tests: param passthrough (name/accountType/timeWindow/Authorization), epic+lifetime defaults, negative caching, private-account 403 vs bad-key 403, shop normalization + cache
- [x] Module tests: default templates, config passthrough, per-command toggles, reply-error chatting, shop budget truncation
- [x] go vet + full gateway/sesame/domain suites, svelte-check 0 errors
- [ ] Live smoke test once Doppler keys are set (`!fnstats ninja`, `!store`)