### PR TITLE
fix(outgress): nak enroll jobs that lose the lock instead of dropping

### DIFF
--- a/app/outgress/internal/worker/eventsub.go
+++ b/app/outgress/internal/worker/eventsub.go
@@ -92,18 +92,28 @@ func effectiveMode(job outgress.EventSubJob) string {
 	return outgress.ModeDisable
 }
 
+// errEnrollLockBusy naks a job that lost the enroll-lock race so paced
+// redelivery re-applies it after the holder finishes.
+var errEnrollLockBusy = errors.New("enroll lock busy: another operation in progress for this channel")
+
 // underEnrollLock runs fn only when this replica wins the channel's enroll
-// lock, so exactly one replica works an enable/disable/reconnect; losing the
-// race acks (the owning replica reports the outcome).
+// lock, so exactly one replica works an enable/disable/reconnect at a time.
+// Losing the race naks instead of acking: the holder may be running a
+// DIFFERENT operation (back-to-back dashboard disconnect → enable lands the
+// enable while the disable still holds the lock), so dropping the loser
+// silently discards the newer intent — the disconnect/reconnect that "needed
+// two clicks". Redelivery re-runs the job once the lock frees; a job made
+// redundant by then (a true duplicate of the same op) is absorbed by the
+// enroll cooldown / idempotent Helix calls instead of costing real budget.
 func (w *Worker) underEnrollLock(ctx context.Context, op string, e enrollment, fn func() error) error {
 	got, err := w.registry.AcquireEnrollLock(ctx, e.broadcasterID, w.owner, 60*time.Second)
 	if err != nil {
 		return err // transient valkey error: nak, let paced redelivery retry
 	}
 	if !got {
-		w.log.Info(op+" already in progress on another replica",
+		w.log.Info(op+" waiting on enroll lock, nak for paced redelivery",
 			zap.String("broadcaster_id", e.broadcasterID))
-		return nil // ack: another replica owns it
+		return errEnrollLockBusy
 	}
 	defer func() { _ = w.registry.ReleaseEnrollLock(ctx, e.broadcasterID, w.owner) }()
 


### PR DESCRIPTION
## Problem

Dashboard disconnect/reconnect needed two clicks to take effect.

`underEnrollLock` acked (dropped) any eventsub job that lost the per-channel enroll lock, assuming the holder was a duplicate of the same operation on another replica. But enable/disable/reconnect share one lock per broadcaster:

- Click **Disconnect** → disable job holds the lock for seconds (list + delete every sub on Twitch).
- Click **Enable** right after → enable job lands on another system worker → lock busy → enable silently dropped. Disable finishes: subs gone, no enable left, hero still reads online (channel.get answered from pre-disable state).
- Second click → lock free → works.

Same race in the other direction: the page-load self-heal from #313 publishes an enable on every load while unenrolled+active, so a Disconnect clicked shortly after a page load collided with the in-flight enable and got dropped. #313 made collisions much more likely, which is why this started surfacing now.

## Fix

Lock-busy now naks instead of acking. System-lane pacing makes the retry safe and prompt: NakDelay 15s, 6 redeliveries, stream MaxAge 5m, lock TTL 60s, and the holder finishes in seconds, so the redelivered job always finds the lock free and applies the user's newer intent. True same-op duplicates stay cheap on retry: `skipFreshEnroll` (2-minute cooldown) and 409/404-idempotent Helix calls absorb them. The dashboard's 30s substate poll covers the worst-case ~15-20s convergence.

## Verification

- `go build ./app/outgress/...`, `go vet`, `go test ./app/outgress/internal/worker/` green.
- Full flow needs live Twitch + Valkey + NATS; after deploy the previously-dropped case is visible in outgress logs as `"<op> waiting on enroll lock, nak for paced redelivery"`.