### PR TITLE
feat(fortnite): split !fnstats (all-time) and !season commands

### DIFF
--- a/app/sesame/modules/fortnite.go
+++ b/app/sesame/modules/fortnite.go
@@ -23,8 +23,9 @@ const fortniteCooldown = 10 * time.Second
 // Default reply templates. The broadcaster customizes them per command on the
 // module page; blank falls back to these.
 const (
-	defaultFortniteStatsTemplate = "{player} ({window}): {wins} wins in {matches} matches · {winrate}% WR · {kills} kills · {kd} K/D · solo {solowins}W / duo {duowins}W / squad {squadwins}W"
-	defaultFortniteStoreTemplate = "Item Shop {date}: {items}"
+	defaultFortniteStatsTemplate  = "{player} all time: {wins} wins in {matches} matches · {winrate}% WR · {kills} kills · {kd} K/D · solo {solowins}W / duo {duowins}W / squad {squadwins}W"
+	defaultFortniteSeasonTemplate = "{player} this season: {wins} wins in {matches} matches · {winrate}% WR · {kills} kills · {kd} K/D · solo {solowins}W / duo {duowins}W / squad {squadwins}W"
+	defaultFortniteStoreTemplate  = "Item Shop {date}: {items}"
 )
 
 // fortniteShopBudget caps the rendered {items} list so the chat line stays
@@ -32,38 +33,61 @@ const (
 const fortniteShopBudget = 380
 
 // fortniteConfig is the module's dashboard configuration. Account is the
-// linked account name (blank = the broadcaster's own Twitch login),
-// AccountType the platform namespace it lives in (epic/psn/xbl) and TimeWindow
-// the stats window (lifetime/season) — the gateway defaults blanks to
-// epic/lifetime. The *Enabled toggles are stored "on"/"off" — empty means on,
-// matching the alerts module's semantics — and each *Message is a customized
-// template (blank = default).
+// linked account name (blank = the broadcaster's own Twitch login) and
+// AccountType the platform namespace it lives in (epic/psn/xbl). The window
+// is not configuration: !fnstats is always all-time and !season always the
+// current season. The *Enabled toggles are stored "on"/"off" — empty means
+// on, matching the alerts module's semantics — and each *Message is a
+// customized template (blank = default).
 type fortniteConfig struct {
 	Account     string `json:"account"`
 	AccountType string `json:"accountType"`
-	TimeWindow  string `json:"timeWindow"`
 
-	StatsEnabled string `json:"statsEnabled"`
-	StatsMessage string `json:"statsMessage"`
-	StoreEnabled string `json:"storeEnabled"`
-	StoreMessage string `json:"storeMessage"`
+	StatsEnabled  string `json:"statsEnabled"`
+	StatsMessage  string `json:"statsMessage"`
+	SeasonEnabled string `json:"seasonEnabled"`
+	SeasonMessage string `json:"seasonMessage"`
+	StoreEnabled  string `json:"storeEnabled"`
+	StoreMessage  string `json:"storeMessage"`
 }
 
-// Fortnite owns the Fortnite chat commands backed by fortnite-api.com through
-// the gateway service. It is a named, opt-in module (KindOptIn): off by
-// default, enabled on the dashboard, where the broadcaster links a default
-// account (name + platform) and picks the stats window. Viewers can always
-// target another player explicitly: "!fnstats Ninja".
+// Fortnite owns the Fortnite chat commands backed by the gateway service. It
+// is a named, opt-in module (KindOptIn): off by default, enabled on the
+// dashboard, where the broadcaster links a default account. Viewers can
+// always target another player explicitly: "!fnstats Ninja".
 //
-// Commands: !fnstats (Battle Royale stats with the solo/duo/squad breakdown),
-// !store (the current item-shop rotation).
+// Commands: !fnstats (all-time Battle Royale stats), !season (the current
+// season's stats — the gateway resolves the season window itself), !store
+// (the current item-shop rotation). All stats replies carry the
+// solo/duo/squad breakdown.
 func Fortnite(d engine.Deps) module.Module {
 	m := module.NewModule(fortniteModuleName, module.KindOptIn)
 	m.Command("fnstats").Everyone().Cooldown(fortniteCooldown).Aliases("fortnitestats").
-		Run(fortniteStatsRun(d))
+		Run(fortniteStatsRun(d, fortniteStatsCommand{
+			window:   "lifetime",
+			enabled:  func(c fortniteConfig) string { return c.StatsEnabled },
+			message:  func(c fortniteConfig) string { return c.StatsMessage },
+			fallback: defaultFortniteStatsTemplate,
+		}))
+	m.Command("season").Everyone().Cooldown(fortniteCooldown).Aliases("fnseason").
+		Run(fortniteStatsRun(d, fortniteStatsCommand{
+			window:   "season",
+			enabled:  func(c fortniteConfig) string { return c.SeasonEnabled },
+			message:  func(c fortniteConfig) string { return c.SeasonMessage },
+			fallback: defaultFortniteSeasonTemplate,
+		}))
 	m.Command("store").Everyone().Cooldown(fortniteCooldown).Aliases("itemshop", "fnshop").
 		Run(fortniteStoreRun(d))
 	return m.Build()
+}
+
+// fortniteStatsCommand names one stats command's wiring: the fixed window it
+// queries and where its toggle and template live in the config blob.
+type fortniteStatsCommand struct {
+	window   string
+	enabled  func(fortniteConfig) string
+	message  func(fortniteConfig) string
+	fallback string
 }
 
 // fortniteStatsTokens is the !fnstats template palette over the gateway reply.
@@ -89,16 +113,17 @@ func fortniteStatsTokens() map[string]func(*gatewayrpc.FortniteStatsReply) strin
 	}
 }
 
-// fortniteStatsRun answers !fnstats with the player's Battle Royale stats over
-// the configured window. Template tokens: {player} {window} {wins} {matches}
-// {kills} {kd} {winrate} plus the per-mode {solowins} {solomatches} {solokd}
-// {duowins} {duomatches} {duokd} {squadwins} {squadmatches} {squadkd}.
-func fortniteStatsRun(d engine.Deps) module.RunFunc {
+// fortniteStatsRun answers one stats command (!fnstats all-time, !season the
+// current season) with the player's Battle Royale stats over cmd's fixed
+// window. Template tokens: {player} {window} {wins} {matches} {kills} {kd}
+// {winrate} plus the per-mode {solowins} {solomatches} {solokd} {duowins}
+// {duomatches} {duokd} {squadwins} {squadmatches} {squadkd}.
+func fortniteStatsRun(d engine.Deps, cmd fortniteStatsCommand) module.RunFunc {
 	tokens := fortniteStatsTokens()
 	return func(ctx context.Context, c *module.Context, args string, emit module.Emit) error {
 		var cfg fortniteConfig
 		_ = c.Decode(&cfg)
-		if !alertOn(cfg.StatsEnabled) || d.Gateway == nil {
+		if !alertOn(cmd.enabled(cfg)) || d.Gateway == nil {
 			return nil
 		}
 
@@ -106,7 +131,7 @@ func fortniteStatsRun(d engine.Deps) module.RunFunc {
 		req := gatewayrpc.Request{
 			Account:     account,
 			AccountType: cfg.AccountType,
-			TimeWindow:  cfg.TimeWindow,
+			TimeWindow:  cmd.window,
 			IsPremium:   c.Regress.IsPremium(),
 		}
 		var reply gatewayrpc.FortniteStatsReply
@@ -117,7 +142,7 @@ func fortniteStatsRun(d engine.Deps) module.RunFunc {
 			return err
 		}
 
-		msg := module.ExpandString(orDefault(cfg.StatsMessage, defaultFortniteStatsTemplate), func(key string) (string, bool) {
+		msg := module.ExpandString(orDefault(cmd.message(cfg), cmd.fallback), func(key string) (string, bool) {
 			if field, ok := tokens[key]; ok {
 				return field(&reply), true
 			}

--- a/app/sesame/modules/fortnite_test.go
+++ b/app/sesame/modules/fortnite_test.go
@@ -46,15 +46,30 @@ func TestFnstatsDefaultTemplate(t *testing.T) {
 	assert.Equal(t, outgress.TypeChat, col.out[0].Type)
 	assert.Equal(t, "2", col.out[0].BroadcasterID)
 	assert.Equal(t,
-		"Ninja (lifetime): 301 wins in 6232 matches · 4.83% WR · 21679 kills · 3.66 K/D · solo 120W / duo 90W / squad 91W",
+		"Ninja all time: 301 wins in 6232 matches · 4.83% WR · 21679 kills · 3.66 K/D · solo 120W / duo 90W / squad 91W",
 		col.out[0].Text)
 
-	// No linked account and no arg: falls back to the broadcaster's login, and
-	// blank platform/window ride to the gateway (which defaults them).
+	// No linked account and no arg: falls back to the broadcaster's login. The
+	// window is the command's, never configuration.
 	call := gw.lastCall(t)
 	assert.Equal(t, "streamer", call.req.Account)
 	assert.Empty(t, call.req.AccountType)
-	assert.Empty(t, call.req.TimeWindow)
+	assert.Equal(t, "lifetime", call.req.TimeWindow)
+}
+
+func TestSeasonDefaultTemplate(t *testing.T) {
+	reply := fortniteStatsReply()
+	reply.Window = "season"
+	gw := &fakeGateway{replies: map[string]any{"fortnite.stats": reply}}
+	cmd := fortniteCmd(t, gw, "season")
+
+	var col collector
+	require.NoError(t, cmd.Run(context.Background(), urchinCtx(""), "", col.emit))
+	require.Len(t, col.out, 1)
+	assert.Equal(t,
+		"Ninja this season: 301 wins in 6232 matches · 4.83% WR · 21679 kills · 3.66 K/D · solo 120W / duo 90W / squad 91W",
+		col.out[0].Text)
+	assert.Equal(t, "season", gw.lastCall(t).req.TimeWindow)
 }
 
 func TestFnstatsConfigPassthrough(t *testing.T) {
@@ -62,16 +77,16 @@ func TestFnstatsConfigPassthrough(t *testing.T) {
 	cmd := fortniteCmd(t, gw, "fnstats")
 
 	var col collector
-	cfg := `{"account":"LinkedAcc","accountType":"psn","timeWindow":"season"}`
+	cfg := `{"account":"LinkedAcc","accountType":"psn"}`
 	require.NoError(t, cmd.Run(context.Background(), urchinCtx(cfg), "", col.emit))
 
 	call := gw.lastCall(t)
 	assert.Equal(t, "LinkedAcc", call.req.Account)
 	assert.Equal(t, "psn", call.req.AccountType)
-	assert.Equal(t, "season", call.req.TimeWindow)
+	assert.Equal(t, "lifetime", call.req.TimeWindow)
 
-	// An explicit argument still beats the linked account; platform and window
-	// stay the configured ones.
+	// An explicit argument still beats the linked account; the platform stays
+	// the configured one.
 	require.NoError(t, cmd.Run(context.Background(), urchinCtx(cfg), "@SomePlayer extra", col.emit))
 	call = gw.lastCall(t)
 	assert.Equal(t, "SomePlayer", call.req.Account)
@@ -83,6 +98,7 @@ func TestFnstatsConfigPassthrough(t *testing.T) {
 func TestFortniteDisabledStaysSilent(t *testing.T) {
 	cases := []struct{ name, config string }{
 		{"fnstats", `{"statsEnabled":"off"}`},
+		{"season", `{"seasonEnabled":"off"}`},
 		{"store", `{"storeEnabled":"off"}`},
 	}
 	for _, tc := range cases {

--- a/console/shared/lib/types.ts
+++ b/console/shared/lib/types.ts
@@ -327,6 +327,45 @@ const BW_SESSION_SAMPLES: Record<string, string> = {
   fkdr: '7.00'
 };
 
+// Shared token palette + preview samples for the Fortnite stats commands
+// (!fnstats / !season) — same template surface, one source of truth.
+const FN_STATS_TOKENS = [
+  'player',
+  'window',
+  'wins',
+  'matches',
+  'kills',
+  'kd',
+  'winrate',
+  'solowins',
+  'solomatches',
+  'solokd',
+  'duowins',
+  'duomatches',
+  'duokd',
+  'squadwins',
+  'squadmatches',
+  'squadkd'
+];
+const FN_STATS_SAMPLES: Record<string, string> = {
+  player: 'Ninja',
+  window: 'lifetime',
+  wins: '301',
+  matches: '6232',
+  kills: '21679',
+  kd: '3.66',
+  winrate: '4.83',
+  solowins: '120',
+  solomatches: '2400',
+  solokd: '3.2',
+  duowins: '90',
+  duomatches: '1900',
+  duokd: '3.8',
+  squadwins: '91',
+  squadmatches: '1932',
+  squadkd: '4.1'
+};
+
 export const MODULE_CATALOG: readonly ModuleDef[] = [
   // Chat Tools: the bot's viewer-facing chat features, surfaced first. Channel
   // Points and Timers own bespoke pages (opened via href); Trigger Words uses
@@ -712,11 +751,14 @@ export const MODULE_CATALOG: readonly ModuleDef[] = [
     ]
   },
   {
+    // !fnstats and !season share one template surface (same tokens, same
+    // sample shape) — FN_STATS_TOKENS/FN_STATS_SAMPLES above are the one
+    // source of truth, mirroring the Bedwars session commands.
     id: 'fortnite',
     label: 'Fortnite Stats',
     tagline: 'Fortnite BR stats and the daily item shop in chat.',
     description:
-      '!fnstats shows a player\'s wins, matches, kills, K/D and win rate with a solo/duo/squad breakdown; !store lists what is in today\'s item shop. Link your Epic display name below and choose whether stats cover your lifetime or the current season. Viewers can also name any player, e.g. "!fnstats Ninja". PlayStation and Xbox name lookups are not supported yet.',
+      '!fnstats shows a player\'s all-time wins, matches, kills, K/D and win rate with a solo/duo/squad breakdown; !season shows the same for the current season (the bot tracks season rollovers automatically); !store lists what is in today\'s item shop. Link your Epic display name below. Viewers can also name any player, e.g. "!fnstats Ninja". PlayStation and Xbox name lookups are not supported yet.',
     icon: 'activity',
     category: 'Games',
     defaultEnabled: false,
@@ -724,48 +766,44 @@ export const MODULE_CATALOG: readonly ModuleDef[] = [
       {
         key: 'stats',
         label: '!fnstats',
-        tagline: 'Battle Royale stats for the linked or named player.',
+        tagline: 'All-time Battle Royale stats for the linked or named player.',
         event: '!fnstats',
         command: 'fnstats',
         enableKey: 'statsEnabled',
         messageKey: 'statsMessage',
         defaultMessage:
-          '{player} ({window}): {wins} wins in {matches} matches · {winrate}% WR · {kills} kills · {kd} K/D · solo {solowins}W / duo {duowins}W / squad {squadwins}W',
-        tokens: [
-          'player',
-          'window',
-          'wins',
-          'matches',
-          'kills',
-          'kd',
-          'winrate',
-          'solowins',
-          'solomatches',
-          'solokd',
-          'duowins',
-          'duomatches',
-          'duokd',
-          'squadwins',
-          'squadmatches',
-          'squadkd'
-        ],
+          '{player} all time: {wins} wins in {matches} matches · {winrate}% WR · {kills} kills · {kd} K/D · solo {solowins}W / duo {duowins}W / squad {squadwins}W',
+        tokens: FN_STATS_TOKENS,
+        previewSamples: FN_STATS_SAMPLES
+      },
+      {
+        key: 'season',
+        label: '!season',
+        tagline: "Current-season stats; the bot tracks season rollovers automatically.",
+        event: '!season',
+        command: 'season',
+        enableKey: 'seasonEnabled',
+        messageKey: 'seasonMessage',
+        defaultMessage:
+          '{player} this season: {wins} wins in {matches} matches · {winrate}% WR · {kills} kills · {kd} K/D · solo {solowins}W / duo {duowins}W / squad {squadwins}W',
+        tokens: FN_STATS_TOKENS,
         previewSamples: {
-          player: 'Ninja',
-          window: 'lifetime',
-          wins: '301',
-          matches: '6232',
-          kills: '21679',
-          kd: '3.66',
-          winrate: '4.83',
-          solowins: '120',
-          solomatches: '2400',
-          solokd: '3.2',
-          duowins: '90',
-          duomatches: '1900',
-          duokd: '3.8',
-          squadwins: '91',
-          squadmatches: '1932',
-          squadkd: '4.1'
+          ...FN_STATS_SAMPLES,
+          window: 'season',
+          wins: '10',
+          matches: '21',
+          kills: '163',
+          kd: '14.8',
+          winrate: '47.6',
+          solowins: '4',
+          solomatches: '7',
+          solokd: '12.0',
+          duowins: '3',
+          duomatches: '9',
+          duokd: '9.2',
+          squadwins: '3',
+          squadmatches: '5',
+          squadkd: '21.5'
         }
       },
       {
@@ -791,7 +829,7 @@ export const MODULE_CATALOG: readonly ModuleDef[] = [
         label: 'Linked account name',
         type: 'text',
         placeholder: 'Your Epic display name',
-        help: 'Default player for !fnstats. Leave blank to use your Twitch username.'
+        help: 'Default player for !fnstats and !season. Leave blank to use your Twitch username.'
       },
       {
         key: 'accountType',
@@ -804,17 +842,6 @@ export const MODULE_CATALOG: readonly ModuleDef[] = [
           { value: 'xbl', label: 'Xbox Live (coming later)' }
         ],
         help: 'Only Epic display names resolve right now; PlayStation and Xbox lookups come later. Console players: your Epic display name works.'
-      },
-      {
-        key: 'timeWindow',
-        label: 'Stats window',
-        type: 'select',
-        placeholder: 'lifetime',
-        options: [
-          { value: 'lifetime', label: 'Lifetime' },
-          { value: 'season', label: 'Current season' }
-        ],
-        help: 'Whether !fnstats reports all-time stats or the current season only.'
       }
     ]
   },


### PR DESCRIPTION
## Summary
- `!fnstats` always answers all-time stats; new `!season` (alias `!fnseason`) answers the current season. No dashboard window setting to choose — the `timeWindow` module setting is removed, each command has its own toggle + template row on the module page.
- Defaults: "{player} all time: ..." / "{player} this season: ..." over the same token palette (shared FN_STATS_TOKENS/SAMPLES in the catalog, mirroring the Bedwars session commands).
- Gateway unchanged: sesame sends the fixed window per command; season start still auto-resolves upstream.

## Prod fix riding along
The #322 "Publish Container Images" run was **cancelled** at 07:44:13Z (superseded by a pin-commit push seconds later), so the sesame image with the fortnite module never published — prod sesame predates #322 and `!fnstats`/`!store` were dead in chat while the gateway side worked. This PR touches `app/sesame/modules`, so its merge rebuilds and ships sesame with the module.

## Test plan
- [x] Module tests: all-time + season default templates, fixed window per command (config cannot override), per-command toggles incl. seasonEnabled, account/platform passthrough unchanged
- [x] go vet + sesame suites, svelte-check 0 errors
- [ ] Post-merge: verify sesame image pin + rollout, then chat smoke `!fnstats` / `!season` / `!store`