### PR TITLE
feat(fortnite): !fn root command with subcommands

### DIFF
--- a/app/sesame/modules/fortnite.go
+++ b/app/sesame/modules/fortnite.go
@@ -54,31 +54,62 @@ type fortniteConfig struct {
 // Fortnite owns the Fortnite chat commands backed by the gateway service. It
 // is a named, opt-in module (KindOptIn): off by default, enabled on the
 // dashboard, where the broadcaster links a default account. Viewers can
-// always target another player explicitly: "!fnstats Ninja".
+// always target another player explicitly: "!fn Ninja".
 //
-// Commands: !fnstats (all-time Battle Royale stats), !season (the current
-// season's stats — the gateway resolves the season window itself), !store
-// (the current item-shop rotation). All stats replies carry the
-// solo/duo/squad breakdown.
+// The command surface is one root with subcommands, plus the squashed forms
+// as direct triggers:
+//
+//	!fn [player]         all-time Battle Royale stats (also !fn stats, !fnstats)
+//	!fn season [player]  the current season's stats (also !fnseason)
+//	!fn store            the current item-shop rotation (also !fnstore)
+//
+// All stats replies carry the solo/duo/squad breakdown; the gateway resolves
+// the season window itself.
 func Fortnite(d engine.Deps) module.Module {
+	statsRun := fortniteStatsRun(d, fortniteStatsCommand{
+		window:   "lifetime",
+		enabled:  func(c fortniteConfig) string { return c.StatsEnabled },
+		message:  func(c fortniteConfig) string { return c.StatsMessage },
+		fallback: defaultFortniteStatsTemplate,
+	})
+	seasonRun := fortniteStatsRun(d, fortniteStatsCommand{
+		window:   "season",
+		enabled:  func(c fortniteConfig) string { return c.SeasonEnabled },
+		message:  func(c fortniteConfig) string { return c.SeasonMessage },
+		fallback: defaultFortniteSeasonTemplate,
+	})
+	storeRun := fortniteStoreRun(d)
+
 	m := module.NewModule(fortniteModuleName, module.KindOptIn)
+	m.Command("fn").Everyone().Cooldown(fortniteCooldown).
+		Run(fortniteDispatchRun(statsRun, seasonRun, storeRun))
 	m.Command("fnstats").Everyone().Cooldown(fortniteCooldown).Aliases("fortnitestats").
-		Run(fortniteStatsRun(d, fortniteStatsCommand{
-			window:   "lifetime",
-			enabled:  func(c fortniteConfig) string { return c.StatsEnabled },
-			message:  func(c fortniteConfig) string { return c.StatsMessage },
-			fallback: defaultFortniteStatsTemplate,
-		}))
-	m.Command("season").Everyone().Cooldown(fortniteCooldown).Aliases("fnseason").
-		Run(fortniteStatsRun(d, fortniteStatsCommand{
-			window:   "season",
-			enabled:  func(c fortniteConfig) string { return c.SeasonEnabled },
-			message:  func(c fortniteConfig) string { return c.SeasonMessage },
-			fallback: defaultFortniteSeasonTemplate,
-		}))
-	m.Command("store").Everyone().Cooldown(fortniteCooldown).Aliases("itemshop", "fnshop").
-		Run(fortniteStoreRun(d))
+		Run(statsRun)
+	m.Command("fnseason").Everyone().Cooldown(fortniteCooldown).
+		Run(seasonRun)
+	m.Command("fnstore").Everyone().Cooldown(fortniteCooldown).Aliases("itemshop", "fnshop").
+		Run(storeRun)
 	return m.Build()
+}
+
+// fortniteDispatchRun routes !fn's first argument word onto the subcommand
+// runners: "stats"/"season"/"store" (and "shop") select one explicitly, and
+// anything else — nothing, or a player name — is an all-time stats lookup, so
+// "!fn Ninja" reads naturally.
+func fortniteDispatchRun(statsRun, seasonRun, storeRun module.RunFunc) module.RunFunc {
+	return func(ctx context.Context, c *module.Context, args string, emit module.Emit) error {
+		sub, rest, _ := strings.Cut(strings.TrimSpace(args), " ")
+		switch strings.ToLower(sub) {
+		case "stats":
+			return statsRun(ctx, c, rest, emit)
+		case "season":
+			return seasonRun(ctx, c, rest, emit)
+		case "store", "shop":
+			return storeRun(ctx, c, rest, emit)
+		default:
+			return statsRun(ctx, c, args, emit)
+		}
+	}
 }
 
 // fortniteStatsCommand names one stats command's wiring: the fixed window it
@@ -113,9 +144,10 @@ func fortniteStatsTokens() map[string]func(*gatewayrpc.FortniteStatsReply) strin
 	}
 }
 
-// fortniteStatsRun answers one stats command (!fnstats all-time, !season the
-// current season) with the player's Battle Royale stats over cmd's fixed
-// window. Template tokens: {player} {window} {wins} {matches} {kills} {kd}
+// fortniteStatsRun answers one stats command (!fn / !fnstats all-time,
+// !fn season / !fnseason the current season) with the player's Battle Royale
+// stats over cmd's fixed window. Template tokens: {player} {window} {wins}
+// {matches} {kills} {kd}
 // {winrate} plus the per-mode {solowins} {solomatches} {solokd} {duowins}
 // {duomatches} {duokd} {squadwins} {squadmatches} {squadkd}.
 func fortniteStatsRun(d engine.Deps, cmd fortniteStatsCommand) module.RunFunc {

--- a/app/sesame/modules/fortnite_test.go
+++ b/app/sesame/modules/fortnite_test.go
@@ -61,7 +61,7 @@ func TestSeasonDefaultTemplate(t *testing.T) {
 	reply := fortniteStatsReply()
 	reply.Window = "season"
 	gw := &fakeGateway{replies: map[string]any{"fortnite.stats": reply}}
-	cmd := fortniteCmd(t, gw, "season")
+	cmd := fortniteCmd(t, gw, "fnseason")
 
 	var col collector
 	require.NoError(t, cmd.Run(context.Background(), urchinCtx(""), "", col.emit))
@@ -97,9 +97,10 @@ func TestFnstatsConfigPassthrough(t *testing.T) {
 // gateway call, for both fortnite commands.
 func TestFortniteDisabledStaysSilent(t *testing.T) {
 	cases := []struct{ name, config string }{
+		{"fn", `{"statsEnabled":"off"}`},
 		{"fnstats", `{"statsEnabled":"off"}`},
-		{"season", `{"seasonEnabled":"off"}`},
-		{"store", `{"storeEnabled":"off"}`},
+		{"fnseason", `{"seasonEnabled":"off"}`},
+		{"fnstore", `{"storeEnabled":"off"}`},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -112,6 +113,44 @@ func TestFortniteDisabledStaysSilent(t *testing.T) {
 			gw.mu.Lock()
 			assert.Empty(t, gw.calls)
 			gw.mu.Unlock()
+		})
+	}
+}
+
+// The !fn root routes its first argument word: bare/player → all-time stats,
+// season/store select the subcommand, and the remainder is the player arg.
+func TestFnDispatch(t *testing.T) {
+	seasonReply := fortniteStatsReply()
+	seasonReply.Window = "season"
+
+	cases := []struct {
+		name, args      string
+		endpoint        string // gateway endpoint expected
+		window, account string // stats requests only
+		replyValue      any
+	}{
+		{"bare is all-time stats", "", "stats", "lifetime", "streamer", fortniteStatsReply()},
+		{"player arg is stats", "@SomePlayer extra", "stats", "lifetime", "SomePlayer", fortniteStatsReply()},
+		{"season subcommand", "season", "stats", "season", "streamer", seasonReply},
+		{"season with player", "season OtherGuy", "stats", "season", "OtherGuy", seasonReply},
+		{"store subcommand", "store", "shop", "", "", gatewayrpc.FortniteShopReply{Date: "2026-07-10"}},
+		{"shop alias, any case", "SHOP", "shop", "", "", gatewayrpc.FortniteShopReply{Date: "2026-07-10"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gw := &fakeGateway{replies: map[string]any{"fortnite." + tc.endpoint: tc.replyValue}}
+			cmd := fortniteCmd(t, gw, "fn")
+
+			var col collector
+			require.NoError(t, cmd.Run(context.Background(), urchinCtx(""), tc.args, col.emit))
+			require.Len(t, col.out, 1)
+
+			call := gw.lastCall(t)
+			assert.Equal(t, tc.endpoint, call.endpoint)
+			if tc.endpoint == "stats" {
+				assert.Equal(t, tc.window, call.req.TimeWindow)
+				assert.Equal(t, tc.account, call.req.Account)
+			}
 		})
 	}
 }
@@ -136,7 +175,7 @@ func TestStoreDefaultTemplate(t *testing.T) {
 			{Name: "Free Hat"},
 		},
 	}}}
-	cmd := fortniteCmd(t, gw, "store")
+	cmd := fortniteCmd(t, gw, "fnstore")
 
 	var col collector
 	require.NoError(t, cmd.Run(context.Background(), urchinCtx(""), "", col.emit))

--- a/console/shared/lib/types.ts
+++ b/console/shared/lib/types.ts
@@ -758,17 +758,17 @@ export const MODULE_CATALOG: readonly ModuleDef[] = [
     label: 'Fortnite Stats',
     tagline: 'Fortnite BR stats and the daily item shop in chat.',
     description:
-      '!fnstats shows a player\'s all-time wins, matches, kills, K/D and win rate with a solo/duo/squad breakdown; !season shows the same for the current season (the bot tracks season rollovers automatically); !store lists what is in today\'s item shop. Link your Epic display name below. Viewers can also name any player, e.g. "!fnstats Ninja". PlayStation and Xbox name lookups are not supported yet.',
+      'One command, three looks: !fn shows a player\'s all-time wins, matches, kills, K/D and win rate with a solo/duo/squad breakdown; !fn season shows the same for the current season (the bot tracks season rollovers automatically); !fn store lists what is in today\'s item shop. The squashed forms !fnstats, !fnseason and !fnstore work too. Link your Epic display name below. Viewers can also name any player, e.g. "!fn Ninja". PlayStation and Xbox name lookups are not supported yet.',
     icon: 'activity',
     category: 'Games',
     defaultEnabled: false,
     replies: [
       {
         key: 'stats',
-        label: '!fnstats',
-        tagline: 'All-time Battle Royale stats for the linked or named player.',
-        event: '!fnstats',
-        command: 'fnstats',
+        label: '!fn',
+        tagline: 'All-time Battle Royale stats — !fn, !fn stats or !fnstats.',
+        event: '!fn',
+        command: 'fn',
         enableKey: 'statsEnabled',
         messageKey: 'statsMessage',
         defaultMessage:
@@ -778,10 +778,10 @@ export const MODULE_CATALOG: readonly ModuleDef[] = [
       },
       {
         key: 'season',
-        label: '!season',
-        tagline: "Current-season stats; the bot tracks season rollovers automatically.",
-        event: '!season',
-        command: 'season',
+        label: '!fn season',
+        tagline: 'Current-season stats (also !fnseason); season rollovers are tracked automatically.',
+        event: '!fn season',
+        command: 'fn season',
         enableKey: 'seasonEnabled',
         messageKey: 'seasonMessage',
         defaultMessage:
@@ -808,10 +808,10 @@ export const MODULE_CATALOG: readonly ModuleDef[] = [
       },
       {
         key: 'store',
-        label: '!store',
-        tagline: "Today's item-shop rotation.",
-        event: '!store',
-        command: 'store',
+        label: '!fn store',
+        tagline: "Today's item-shop rotation (also !fnstore).",
+        event: '!fn store',
+        command: 'fn store',
         enableKey: 'storeEnabled',
         messageKey: 'storeMessage',
         defaultMessage: 'Item Shop {date}: {items}',
@@ -829,7 +829,7 @@ export const MODULE_CATALOG: readonly ModuleDef[] = [
         label: 'Linked account name',
         type: 'text',
         placeholder: 'Your Epic display name',
-        help: 'Default player for !fnstats and !season. Leave blank to use your Twitch username.'
+        help: 'Default player for the stats commands. Leave blank to use your Twitch username.'
       },
       {
         key: 'accountType',


### PR DESCRIPTION
## Summary
- `!fn [player]` answers all-time stats; `!fn season [player]` the current season; `!fn store` (or `shop`) the item shop. First argument word routes the subcommand; anything else (nothing, or a player name) reads as a stats lookup, so `!fn Ninja` works.
- Squashed forms stay as direct triggers: `!fnstats` (alias fortnitestats), `!fnseason`, `!fnstore` (aliases itemshop, fnshop).
- Generic `!season` / `!store` triggers removed (too collision-prone as bare words).
- Same dispatch pattern as the play queue's `!queue` root. Toggles/templates unchanged (statsEnabled/seasonEnabled/storeEnabled); the dashboard rows now read `!fn`, `!fn season`, `!fn store`.

## Test plan
- [x] Dispatcher table test: bare, player-arg, season, season+player, store, case-insensitive shop
- [x] Squashed triggers + per-command toggles (incl. `!fn` following statsEnabled)
- [x] go vet + full sesame suite, svelte-check 0 errors