### PR TITLE
fix(ingress): stop orphan shards instead of bind-looping forever

### DIFF
--- a/app/ingress/lib/ingress/conduit_manager.ex
+++ b/app/ingress/lib/ingress/conduit_manager.ex
@@ -22,6 +22,8 @@ defmodule Ingress.ConduitManager do
 
   @reconcile_interval_ms 30_000
   @retry_interval_ms 5_000
+  # How long a direct stop of an unsupervised (orphan) shard may take.
+  @orphan_stop_timeout_ms 5_000
 
   def start_link(_opts) do
     GenServer.start_link(__MODULE__, [], name: via())
@@ -172,6 +174,9 @@ defmodule Ingress.ConduitManager do
             :ok ->
               :ok
 
+            {:error, :not_found} ->
+              stop_orphan_shard(shard_id, pid)
+
             {:error, reason} ->
               Logger.warning("stop shard #{shard_id} failed: #{inspect(reason)}")
           end
@@ -179,6 +184,24 @@ defmodule Ingress.ConduitManager do
         [] ->
           :ok
       end
+    end
+  end
+
+  # `terminate_child` answers :not_found for a shard the supervisor does not
+  # track: duplicate-shard takeover re-registers the surviving process directly
+  # in the registry, so the supervisor CRDT never learns its pid and the shard
+  # would otherwise outlive every scale-down, bind-looping against a conduit
+  # that has no slot for it. Stop the process itself. GenServer.stop rather
+  # than an exit signal: the session traps exits and would absorb a :shutdown
+  # signal as an info message.
+  defp stop_orphan_shard(shard_id, pid) do
+    Logger.warning("stopping orphan shard #{shard_id} (registered but unsupervised)")
+
+    try do
+      GenServer.stop(pid, :normal, @orphan_stop_timeout_ms)
+    catch
+      :exit, reason ->
+        Logger.warning("orphan shard #{shard_id} stop failed: #{inspect(reason)}")
     end
   end
 

--- a/app/ingress/lib/ingress/shard_session.ex
+++ b/app/ingress/lib/ingress/shard_session.ex
@@ -426,8 +426,16 @@ defmodule Ingress.ShardSession do
         {:noreply, pet_watchdog(state)}
 
       {:error, reason} ->
-        Logger.error("shard bind failed: #{inspect(reason)}; reconnecting")
-        {:noreply, reconnect(state)}
+        if permanent_bind_error?(reason) do
+          Logger.warning(
+            "shard bind rejected as permanent: #{inspect(reason)}; stopping (reconciler restarts the shard only while it fits the conduit)"
+          )
+
+          {:stop, :normal, stand_down(state)}
+        else
+          Logger.error("shard bind failed: #{inspect(reason)}; reconnecting")
+          {:noreply, reconnect(state)}
+        end
     end
   end
 
@@ -478,6 +486,19 @@ defmodule Ingress.ShardSession do
     Logger.debug("unhandled eventsub message_type #{type}")
     {:noreply, pet_watchdog(state)}
   end
+
+  # A bind rejected with `invalid_parameter` cannot succeed by retrying: the
+  # shard id lies outside the conduit's current shard_count, i.e. this shard is
+  # excess after a scale-down. Other shard errors (websocket_disconnected,
+  # failed ping-pong) are transient session problems a fresh reconnect fixes.
+  # Stopping :normal removes the registry entry and, with :transient restart,
+  # keeps the supervisor from bringing the shard back on its own.
+  @doc false
+  def permanent_bind_error?({:shard_errors, errors}) when is_list(errors) do
+    Enum.any?(errors, &(&1["code"] == "invalid_parameter"))
+  end
+
+  def permanent_bind_error?(_reason), do: false
 
   # Announce that this shard (re)established its binding: "fresh" after a
   # full connect + Helix bind, "moved" after a session_reconnect handshake

--- a/app/ingress/test/shard_session_test.exs
+++ b/app/ingress/test/shard_session_test.exs
@@ -1,0 +1,43 @@
+defmodule Ingress.ShardSessionTest do
+  use ExUnit.Case, async: true
+
+  alias Ingress.ShardSession
+
+  describe "permanent_bind_error?/1" do
+    test "invalid shard id is permanent" do
+      errors = [
+        %{
+          "code" => "invalid_parameter",
+          "id" => "5",
+          "message" => "invalid shard id, must be a number greater or equal to 0 and less than 5"
+        }
+      ]
+
+      assert ShardSession.permanent_bind_error?({:shard_errors, errors})
+    end
+
+    test "mixed errors count as permanent when any is invalid_parameter" do
+      errors = [
+        %{"code" => "websocket_disconnected", "id" => "3", "message" => "socket gone"},
+        %{"code" => "invalid_parameter", "id" => "5", "message" => "invalid shard id"}
+      ]
+
+      assert ShardSession.permanent_bind_error?({:shard_errors, errors})
+    end
+
+    test "transient session errors are not permanent" do
+      errors = [
+        %{"code" => "websocket_disconnected", "id" => "2", "message" => "socket gone"},
+        %{"code" => "websocket_failed_ping_pong", "id" => "2", "message" => "no pong"}
+      ]
+
+      refute ShardSession.permanent_bind_error?({:shard_errors, errors})
+    end
+
+    test "non-shard errors (transport, HTTP) are not permanent" do
+      refute ShardSession.permanent_bind_error?(:timeout)
+      refute ShardSession.permanent_bind_error?({:http_error, 500})
+      refute ShardSession.permanent_bind_error?({:shard_errors, []})
+    end
+  end
+end


### PR DESCRIPTION
## Problem

After the Jul 10 rollout, shard 5 survived as a registered-but-unsupervised orphan: duplicate-shard takeover re-registers the surviving process directly in `Horde.Registry`, so the supervisor CRDT never learns its pid. `Horde.DynamicSupervisor.terminate_child/2` resolves pids through its own `process_pid_to_id` table and answered `:not_found` on every reconcile (2188 attempts / 18h), while the shard bind-looped against a 5-slot conduit — Twitch 400 `invalid shard id` every ~61s, 800+ attempts.

## Fix

- **ShardSession**: classify `invalid_parameter` shard errors as permanent → `{:stop, :normal}` instead of reconnecting. Registry entry clears; `:transient` restart means the supervisor leaves it down; the reconciler starts the shard again only while it fits the conduit. Transient codes (`websocket_disconnected`, ping-pong) keep the reconnect path.
- **ConduitManager**: on `terminate_child` → `:not_found`, fall back to `GenServer.stop(pid, :normal, 5s)` on the registry pid. `GenServer.stop` rather than an exit signal: the session traps exits and absorbs `:shutdown` as an info message.

## Tests

- 4 new tests for the permanent-error classifier, including the exact prod error shape.
- `mix test`: 84 tests, 0 failures.

Note for the deploy: the rollout surge itself briefly creates an excess shard on the old code; with this image it self-stops on the first 400 — one `shard bind rejected as permanent` log during the roll is expected.