### PR TITLE
refactor(loyalty): flatten the code paths CodeScene flagged

### DIFF
--- a/app/loyalty/repository/loyalty.go
+++ b/app/loyalty/repository/loyalty.go
@@ -252,6 +252,33 @@ func (r *Loyalty) drain() (map[balKey]*earnSum, map[bumpKey]*bumpSum) {
 	return earn, bumps
 }
 
+// upsertRows lands one logical bulk write: rows are chunked, each chunk is
+// rendered as "INSERT ... VALUES (...),(...) <suffix>" and executed. A failed
+// chunk is logged and dropped (loss-tolerant deltas; retrying would
+// double-apply the successful chunks around it).
+func (r *Loyalty) upsertRows(ctx context.Context, txn *newrelic.Transaction, label, insert, placeholder, suffix string, rows [][]any) {
+	for start := 0; start < len(rows); start += upsertChunk {
+		chunk := rows[start:min(start+upsertChunk, len(rows))]
+
+		var sb strings.Builder
+		sb.WriteString(insert)
+		args := make([]any, 0, len(chunk)*len(chunk[0]))
+		for i, row := range chunk {
+			if i > 0 {
+				sb.WriteByte(',')
+			}
+			sb.WriteString(placeholder)
+			args = append(args, row...)
+		}
+		sb.WriteString(suffix)
+
+		if _, err := r.sqldb.ExecContext(ctx, sb.String(), args...); err != nil {
+			txn.NoticeError(err)
+			r.log.Warn("loyalty: failed to flush "+label, zap.Int("rows", len(chunk)), zap.Error(err))
+		}
+	}
+}
+
 // flushEarned lands the balance deltas: one multi-row upsert per chunk with
 // additive points/watch columns. Identity columns only overwrite when the
 // window actually carried a value (IF(VALUES(col) = empty, keep, new)).
@@ -259,137 +286,104 @@ func (r *Loyalty) flushEarned(ctx context.Context, txn *newrelic.Transaction, ea
 	if len(earn) == 0 {
 		return
 	}
-	const cols = 8
 	now := time.Now()
-
-	keys := make([]balKey, 0, len(earn))
-	for k := range earn {
-		keys = append(keys, k)
+	rows := make([][]any, 0, len(earn))
+	for k, s := range earn {
+		rows = append(rows, []any{k.userID, k.viewerID, s.login, s.name, s.points, s.watchSeconds, now, now})
 	}
-	for start := 0; start < len(keys); start += upsertChunk {
-		chunk := keys[start:min(start+upsertChunk, len(keys))]
-
-		var sb strings.Builder
-		sb.WriteString("INSERT INTO balances (user_id, viewer_id, viewer_login, viewer_name, points, watch_seconds, created_at, updated_at) VALUES ")
-		args := make([]any, 0, len(chunk)*cols)
-		for i, k := range chunk {
-			if i > 0 {
-				sb.WriteByte(',')
-			}
-			sb.WriteString("(?, ?, ?, ?, ?, ?, ?, ?)")
-			s := earn[k]
-			args = append(args, k.userID, k.viewerID, s.login, s.name, s.points, s.watchSeconds, now, now)
-		}
-		sb.WriteString(" ON DUPLICATE KEY UPDATE" +
-			" points = points + VALUES(points)," +
-			" watch_seconds = watch_seconds + VALUES(watch_seconds)," +
-			" viewer_login = IF(VALUES(viewer_login) = '', viewer_login, VALUES(viewer_login))," +
-			" viewer_name = IF(VALUES(viewer_name) = '', viewer_name, VALUES(viewer_name))," +
-			" updated_at = VALUES(updated_at)")
-
-		if _, err := r.sqldb.ExecContext(ctx, sb.String(), args...); err != nil {
-			txn.NoticeError(err)
-			r.log.Warn("loyalty: failed to flush balance chunk", zap.Int("rows", len(chunk)), zap.Error(err))
-		}
-	}
+	r.upsertRows(ctx, txn, "balances",
+		"INSERT INTO balances (user_id, viewer_id, viewer_login, viewer_name, points, watch_seconds, created_at, updated_at) VALUES ",
+		"(?, ?, ?, ?, ?, ?, ?, ?)",
+		" ON DUPLICATE KEY UPDATE"+
+			" points = points + VALUES(points),"+
+			" watch_seconds = watch_seconds + VALUES(watch_seconds),"+
+			" viewer_login = IF(VALUES(viewer_login) = '', viewer_login, VALUES(viewer_login)),"+
+			" viewer_name = IF(VALUES(viewer_name) = '', viewer_name, VALUES(viewer_name)),"+
+			" updated_at = VALUES(updated_at)",
+		rows)
 }
 
 // flushBumps lands the counter deltas. Channel-scope bumps upsert the counter
 // row itself (auto-creating it on first use; an existing row keeps its stored
-// scope). Viewer-scope bumps first ensure the definition row exists, then
-// upsert the per-viewer entries.
+// scope). Entry-scope bumps first ensure the definition row exists, then
+// upsert the per-viewer buckets.
 func (r *Loyalty) flushBumps(ctx context.Context, txn *newrelic.Transaction, bumps map[bumpKey]*bumpSum) {
-	if len(bumps) == 0 {
-		return
+	channel, entries := splitBumps(bumps)
+	r.flushChannelBumps(ctx, txn, channel, bumps)
+	if len(entries) > 0 {
+		r.ensureEntryDefs(ctx, txn, entries, bumps)
+		r.flushEntryBumps(ctx, txn, entries, bumps)
 	}
-	now := time.Now()
+}
 
-	var channel, viewer []bumpKey
+// splitBumps separates the window's bumps by where their value lives: the
+// counter row (channel scope) or a counter_entries bucket (the entry scopes).
+func splitBumps(bumps map[bumpKey]*bumpSum) (channel, entries []bumpKey) {
 	for k, s := range bumps {
 		switch s.scope {
 		case data.CounterScopeViewer, data.CounterScopeViewerCommand:
-			viewer = append(viewer, k)
+			entries = append(entries, k)
 		default:
 			channel = append(channel, k)
 		}
 	}
+	return channel, entries
+}
 
-	for start := 0; start < len(channel); start += upsertChunk {
-		chunk := channel[start:min(start+upsertChunk, len(channel))]
-		var sb strings.Builder
-		sb.WriteString("INSERT INTO counters (user_id, name, scope, value, created_at, updated_at) VALUES ")
-		args := make([]any, 0, len(chunk)*6)
-		for i, k := range chunk {
-			if i > 0 {
-				sb.WriteByte(',')
-			}
-			sb.WriteString("(?, ?, ?, ?, ?, ?)")
-			args = append(args, k.userID, k.name, data.CounterScopeChannel, bumps[k].delta, now, now)
-		}
-		sb.WriteString(" ON DUPLICATE KEY UPDATE value = value + VALUES(value), updated_at = VALUES(updated_at)")
-		if _, err := r.sqldb.ExecContext(ctx, sb.String(), args...); err != nil {
-			txn.NoticeError(err)
-			r.log.Warn("loyalty: failed to flush counter chunk", zap.Int("rows", len(chunk)), zap.Error(err))
-		}
-	}
-
-	if len(viewer) == 0 {
+func (r *Loyalty) flushChannelBumps(ctx context.Context, txn *newrelic.Transaction, keys []bumpKey, bumps map[bumpKey]*bumpSum) {
+	if len(keys) == 0 {
 		return
 	}
+	now := time.Now()
+	rows := make([][]any, 0, len(keys))
+	for _, k := range keys {
+		rows = append(rows, []any{k.userID, k.name, data.CounterScopeChannel, bumps[k].delta, now, now})
+	}
+	r.upsertRows(ctx, txn, "counters",
+		"INSERT INTO counters (user_id, name, scope, value, created_at, updated_at) VALUES ",
+		"(?, ?, ?, ?, ?, ?)",
+		" ON DUPLICATE KEY UPDATE value = value + VALUES(value), updated_at = VALUES(updated_at)",
+		rows)
+}
 
-	// Definition rows first: one INSERT IGNORE per distinct (user, name), so a
-	// counter bumped straight from a command template exists for list/get. The
-	// bump's own scope (viewer vs viewer+command) seeds the definition.
+// ensureEntryDefs writes one INSERT IGNORE definition row per distinct
+// (user, name), so a counter bumped straight from a command template exists
+// for list/get. The bump's own scope seeds the definition; an existing row
+// keeps its stored scope.
+func (r *Loyalty) ensureEntryDefs(ctx context.Context, txn *newrelic.Transaction, keys []bumpKey, bumps map[bumpKey]*bumpSum) {
 	type defKey struct {
 		userID uint64
 		name   string
 	}
+	now := time.Now()
 	defs := map[defKey]string{}
-	for _, k := range viewer {
+	for _, k := range keys {
 		if _, seen := defs[defKey{k.userID, k.name}]; !seen {
 			defs[defKey{k.userID, k.name}] = bumps[k].scope
 		}
 	}
-	defList := make([]defKey, 0, len(defs))
-	for d := range defs {
-		defList = append(defList, d)
+	rows := make([][]any, 0, len(defs))
+	for d, scope := range defs {
+		rows = append(rows, []any{d.userID, d.name, scope, now, now})
 	}
-	for start := 0; start < len(defList); start += upsertChunk {
-		chunk := defList[start:min(start+upsertChunk, len(defList))]
-		var sb strings.Builder
-		sb.WriteString("INSERT IGNORE INTO counters (user_id, name, scope, value, created_at, updated_at) VALUES ")
-		args := make([]any, 0, len(chunk)*6)
-		for i, d := range chunk {
-			if i > 0 {
-				sb.WriteByte(',')
-			}
-			sb.WriteString("(?, ?, ?, 0, ?, ?)")
-			args = append(args, d.userID, d.name, defs[d], now, now)
-		}
-		if _, err := r.sqldb.ExecContext(ctx, sb.String(), args...); err != nil {
-			txn.NoticeError(err)
-			r.log.Warn("loyalty: failed to ensure counter defs", zap.Int("rows", len(chunk)), zap.Error(err))
-		}
-	}
+	r.upsertRows(ctx, txn, "counter defs",
+		"INSERT IGNORE INTO counters (user_id, name, scope, value, created_at, updated_at) VALUES ",
+		"(?, ?, ?, 0, ?, ?)",
+		"",
+		rows)
+}
 
-	for start := 0; start < len(viewer); start += upsertChunk {
-		chunk := viewer[start:min(start+upsertChunk, len(viewer))]
-		var sb strings.Builder
-		sb.WriteString("INSERT INTO counter_entries (user_id, name, command, viewer_id, value, updated_at) VALUES ")
-		args := make([]any, 0, len(chunk)*6)
-		for i, k := range chunk {
-			if i > 0 {
-				sb.WriteByte(',')
-			}
-			sb.WriteString("(?, ?, ?, ?, ?, ?)")
-			args = append(args, k.userID, k.name, k.command, k.viewerID, bumps[k].delta, now)
-		}
-		sb.WriteString(" ON DUPLICATE KEY UPDATE value = value + VALUES(value), updated_at = VALUES(updated_at)")
-		if _, err := r.sqldb.ExecContext(ctx, sb.String(), args...); err != nil {
-			txn.NoticeError(err)
-			r.log.Warn("loyalty: failed to flush counter entries", zap.Int("rows", len(chunk)), zap.Error(err))
-		}
+func (r *Loyalty) flushEntryBumps(ctx context.Context, txn *newrelic.Transaction, keys []bumpKey, bumps map[bumpKey]*bumpSum) {
+	now := time.Now()
+	rows := make([][]any, 0, len(keys))
+	for _, k := range keys {
+		rows = append(rows, []any{k.userID, k.name, k.command, k.viewerID, bumps[k].delta, now})
 	}
+	r.upsertRows(ctx, txn, "counter entries",
+		"INSERT INTO counter_entries (user_id, name, command, viewer_id, value, updated_at) VALUES ",
+		"(?, ?, ?, ?, ?, ?)",
+		" ON DUPLICATE KEY UPDATE value = value + VALUES(value), updated_at = VALUES(updated_at)",
+		rows)
 }
 
 // Close stops the ticker and flushes what is pending.

--- a/app/loyalty/repository/queries.go
+++ b/app/loyalty/repository/queries.go
@@ -69,17 +69,11 @@ func (r *Loyalty) BalanceGet(ctx context.Context, userID, viewerID uint64) (*ent
 
 // Top returns the channel's top standings by points.
 func (r *Loyalty) Top(ctx context.Context, userID uint64, limit int) ([]*ent.Balance, error) {
-	if limit <= 0 {
-		limit = defaultTopLimit
-	}
-	if limit > maxTopLimit {
-		limit = maxTopLimit
-	}
 	return db.WithQuery(ctx, func(ctx context.Context) ([]*ent.Balance, error) {
 		return r.client.Balance.Query().
 			Where(balance.UserIDEQ(userID)).
 			Order(balance.ByPoints(entsql.OrderDesc()), balance.ByViewerID()).
-			Limit(limit).
+			Limit(clampLimit(limit)).
 			All(ctx)
 	})
 }
@@ -117,6 +111,14 @@ func (r *Loyalty) BalanceAdjust(ctx context.Context, userID uint64, viewerLogin 
 	})
 }
 
+// clampLimit bounds a caller-provided page size, defaulting a missing one.
+func clampLimit(limit int) int {
+	if limit <= 0 {
+		return defaultTopLimit
+	}
+	return min(limit, maxTopLimit)
+}
+
 // CounterEntries lists an entry-scoped counter's stored buckets, highest
 // value first, with each viewer's login resolved from their balance row (the
 // dashboard's per-counter leaderboard).
@@ -125,31 +127,32 @@ func (r *Loyalty) CounterEntries(ctx context.Context, userID uint64, name string
 	if err != nil {
 		return nil, nil, err
 	}
-	if limit <= 0 {
-		limit = defaultTopLimit
-	}
-	if limit > maxTopLimit {
-		limit = maxTopLimit
-	}
 	rows, err := db.WithQuery(ctx, func(ctx context.Context) ([]*ent.CounterEntry, error) {
 		return r.client.CounterEntry.Query().
 			Where(counterentry.UserIDEQ(userID), counterentry.NameEQ(n)).
 			Order(counterentry.ByValue(entsql.OrderDesc()), counterentry.ByViewerID()).
-			Limit(limit).
+			Limit(clampLimit(limit)).
 			All(ctx)
 	})
 	if err != nil || len(rows) == 0 {
 		return rows, nil, err
 	}
+	return rows, r.viewerLogins(ctx, userID, rows), nil
+}
 
-	ids := make([]uint64, 0, len(rows))
+// viewerLogins resolves the display login for each distinct viewer in rows
+// from their balance row. Best-effort: logins are cosmetic, the entries
+// themselves are the answer, so a read failure returns an empty map.
+func (r *Loyalty) viewerLogins(ctx context.Context, userID uint64, rows []*ent.CounterEntry) map[uint64]string {
 	seen := map[uint64]struct{}{}
+	ids := make([]uint64, 0, len(rows))
 	for _, e := range rows {
 		if _, dup := seen[e.ViewerID]; !dup {
 			seen[e.ViewerID] = struct{}{}
 			ids = append(ids, e.ViewerID)
 		}
 	}
+
 	logins := map[uint64]string{}
 	bals, err := db.WithQuery(ctx, func(ctx context.Context) ([]*ent.Balance, error) {
 		return r.client.Balance.Query().
@@ -157,15 +160,14 @@ func (r *Loyalty) CounterEntries(ctx context.Context, userID uint64, name string
 			All(ctx)
 	})
 	if err != nil {
-		// Logins are cosmetic; the entries themselves are the answer.
-		return rows, logins, nil
+		return logins
 	}
 	for _, b := range bals {
 		if b.ViewerLogin != "" {
 			logins[b.ViewerID] = b.ViewerLogin
 		}
 	}
-	return rows, logins, nil
+	return logins
 }
 
 // CounterGet resolves one counter: the definition, plus the effective value —

--- a/app/sesame/engine/loyalty_reporter.go
+++ b/app/sesame/engine/loyalty_reporter.go
@@ -168,9 +168,6 @@ func (r *LoyaltyReporter) flush(ctx context.Context) {
 }
 
 func (r *LoyaltyReporter) publishEarned(ctx context.Context, earn map[earnKey]*earnAgg) {
-	if len(earn) == 0 {
-		return
-	}
 	perUser := map[uint64][]data.LoyaltyEarnEntry{}
 	for key, agg := range earn {
 		perUser[key.broadcasterID] = append(perUser[key.broadcasterID], data.LoyaltyEarnEntry{
@@ -181,27 +178,12 @@ func (r *LoyaltyReporter) publishEarned(ctx context.Context, earn map[earnKey]*e
 			WatchSeconds: agg.watchSeconds,
 		})
 	}
-	for userID, entries := range perUser {
-		for start := 0; start < len(entries); start += loyaltyChunk {
-			chunk := entries[start:min(start+loyaltyChunk, len(entries))]
-			if err := bus.PublishJSON(ctx, r.pub, data.SubjectLoyaltyEarned, data.LoyaltyEarnedDTO{
-				UserID:  userID,
-				Entries: chunk,
-			}); err != nil {
-				r.log.Debug("failed to publish loyalty earned",
-					zap.Uint64("broadcaster_id", userID),
-					zap.Int("entries", len(chunk)),
-					zap.Error(err),
-				)
-			}
-		}
-	}
+	publishPerUser(ctx, r, perUser, data.SubjectLoyaltyEarned, func(userID uint64, chunk []data.LoyaltyEarnEntry) any {
+		return data.LoyaltyEarnedDTO{UserID: userID, Entries: chunk}
+	})
 }
 
 func (r *LoyaltyReporter) publishBumps(ctx context.Context, bumps map[counterAgg]int64) {
-	if len(bumps) == 0 {
-		return
-	}
 	perUser := map[uint64][]data.CounterBumpEntry{}
 	for key, delta := range bumps {
 		perUser[key.broadcasterID] = append(perUser[key.broadcasterID], data.CounterBumpEntry{
@@ -212,16 +194,23 @@ func (r *LoyaltyReporter) publishBumps(ctx context.Context, bumps map[counterAgg
 			Delta:    delta,
 		})
 	}
+	publishPerUser(ctx, r, perUser, data.SubjectLoyaltyCounters, func(userID uint64, chunk []data.CounterBumpEntry) any {
+		return data.CounterBumpedDTO{UserID: userID, Bumps: chunk}
+	})
+}
+
+// publishPerUser publishes one window's aggregates: per broadcaster, chunked
+// so a big channel's watch tick never approaches the broker payload ceiling.
+// A failed publish is logged and dropped (loss-tolerant deltas).
+func publishPerUser[E any](ctx context.Context, r *LoyaltyReporter, perUser map[uint64][]E, subject string, wrap func(uint64, []E) any) {
 	for userID, entries := range perUser {
 		for start := 0; start < len(entries); start += loyaltyChunk {
 			chunk := entries[start:min(start+loyaltyChunk, len(entries))]
-			if err := bus.PublishJSON(ctx, r.pub, data.SubjectLoyaltyCounters, data.CounterBumpedDTO{
-				UserID: userID,
-				Bumps:  chunk,
-			}); err != nil {
-				r.log.Debug("failed to publish counter bumps",
+			if err := bus.PublishJSON(ctx, r.pub, subject, wrap(userID, chunk)); err != nil {
+				r.log.Debug("failed to publish loyalty window",
+					zap.String("subject", subject),
 					zap.Uint64("broadcaster_id", userID),
-					zap.Int("bumps", len(chunk)),
+					zap.Int("entries", len(chunk)),
 					zap.Error(err),
 				)
 			}

--- a/app/sesame/engine/loyalty_tick.go
+++ b/app/sesame/engine/loyalty_tick.go
@@ -251,10 +251,7 @@ func (s *ValkeyLoyaltyClock) liveBroadcasters(ctx context.Context) []uint64 {
 			return ids
 		}
 		for _, k := range entry.Elements {
-			if strings.HasPrefix(k, recheckKeyPrefix) {
-				continue
-			}
-			if id, err := strconv.ParseUint(strings.TrimPrefix(k, livekey.KeyPrefix), 10, 64); err == nil && id != 0 {
+			if id, ok := parseLiveKey(k); ok {
 				ids = append(ids, id)
 			}
 		}
@@ -263,6 +260,16 @@ func (s *ValkeyLoyaltyClock) liveBroadcasters(ctx context.Context) []uint64 {
 			return ids
 		}
 	}
+}
+
+// parseLiveKey extracts the broadcaster id from one live:<id> key, rejecting
+// the live:recheck: guard keys that share the prefix.
+func parseLiveKey(key string) (uint64, bool) {
+	if strings.HasPrefix(key, recheckKeyPrefix) {
+		return 0, false
+	}
+	id, err := strconv.ParseUint(strings.TrimPrefix(key, livekey.KeyPrefix), 10, 64)
+	return id, err == nil && id != 0
 }
 
 // onExpired handles one expired key. The real work runs on its own goroutine:
@@ -324,17 +331,22 @@ func (s *ValkeyLoyaltyClock) accrue(ctx context.Context, broadcasterID uint64, c
 	points := cfg.EffectiveWatchPointsPerTick()
 	seconds := uint64(watchTickInterval.Seconds())
 	for _, ch := range chatters {
-		if ch.ID == s.botID {
-			continue
+		if viewerID, ok := s.chatterViewerID(ch.ID); ok {
+			s.reporter.Earn(broadcasterID, viewerID, ch.Login, "", points, seconds)
 		}
-		viewerID, err := strconv.ParseUint(ch.ID, 10, 64)
-		if err != nil || viewerID == 0 {
-			continue
-		}
-		s.reporter.Earn(broadcasterID, viewerID, ch.Login, "", points, seconds)
 	}
 	s.log.Debug("loyalty: watch tick accrued",
 		zap.Uint64("broadcaster_id", broadcasterID), zap.Int("chatters", len(chatters)))
+}
+
+// chatterViewerID parses one chatter's id, dropping the bot's own account (it
+// sits in every chat it serves and must not farm points).
+func (s *ValkeyLoyaltyClock) chatterViewerID(id string) (uint64, bool) {
+	if id == s.botID {
+		return 0, false
+	}
+	viewerID, err := strconv.ParseUint(id, 10, 64)
+	return viewerID, err == nil && viewerID != 0
 }
 
 // fetchChatters asks outgress for the current chatter list. A missing-scope

--- a/app/sesame/engine/loyalty_valkey.go
+++ b/app/sesame/engine/loyalty_valkey.go
@@ -234,25 +234,34 @@ func (s *ValkeyLoyaltyStore) CounterPeek(ctx context.Context, broadcasterID uint
 	scope := s.scope(ctx, broadcasterID, name)
 	command = NormalizeCounterName(command)
 
-	if scope != data.CounterScopeChannel && viewerID != 0 {
-		field := entryField(scope, viewerID, command)
-		v, err := s.client.Do(ctx, s.client.B().Hget().Key(counterViewerKey(broadcasterID, name)).Field(field).Build()).AsInt64()
-		if err == nil {
-			return loyaltyrpc.Counter{Name: name, Scope: scope, Value: v}, true, nil
-		}
-		if !valkey.IsValkeyNil(err) {
-			s.log.Debug("loyalty: counter hash read failed", zap.String("counter", name), zap.Error(err))
-		}
-	} else {
-		v, err := s.client.Do(ctx, s.client.B().Get().Key(counterChannelKey(broadcasterID, name)).Build()).AsInt64()
-		if err == nil {
-			return loyaltyrpc.Counter{Name: name, Scope: scope, Value: v}, true, nil
-		}
-		if !valkey.IsValkeyNil(err) {
-			s.log.Debug("loyalty: counter read failed", zap.String("counter", name), zap.Error(err))
-		}
+	if v, ok := s.peekView(ctx, broadcasterID, name, scope, viewerID, command); ok {
+		return loyaltyrpc.Counter{Name: name, Scope: scope, Value: v}, true, nil
 	}
 	return s.rpc.CounterGet(ctx, broadcasterID, name, viewerID, command)
+}
+
+// peekView reads the live Valkey view of one counter value: the entry hash
+// field for the entry scopes (when a viewer is known), the plain string
+// otherwise. ok=false means the view is cold (or unreadable) and the caller
+// should fall back to the service.
+func (s *ValkeyLoyaltyStore) peekView(ctx context.Context, broadcasterID uint64, name, scope string, viewerID uint64, command string) (int64, bool) {
+	var (
+		v   int64
+		err error
+	)
+	if scope != data.CounterScopeChannel && viewerID != 0 {
+		field := entryField(scope, viewerID, command)
+		v, err = s.client.Do(ctx, s.client.B().Hget().Key(counterViewerKey(broadcasterID, name)).Field(field).Build()).AsInt64()
+	} else {
+		v, err = s.client.Do(ctx, s.client.B().Get().Key(counterChannelKey(broadcasterID, name)).Build()).AsInt64()
+	}
+	if err != nil {
+		if !valkey.IsValkeyNil(err) {
+			s.log.Debug("loyalty: counter view read failed", zap.String("counter", name), zap.Error(err))
+		}
+		return 0, false
+	}
+	return v, true
 }
 
 // CounterInvalidate drops a counter's live view (both shapes) and the local

--- a/app/sesame/engine/vars.go
+++ b/app/sesame/engine/vars.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"slices"
 	"strings"
 
 	"ItsBagelBot/app/sesame/module"
@@ -70,17 +71,7 @@ func counterTokenNames(tmpl string) []string {
 		}
 		name := NormalizeCounterName(rest[:end])
 		rest = rest[end+1:]
-		if name == "" {
-			continue
-		}
-		dup := false
-		for _, n := range names {
-			if n == name {
-				dup = true
-				break
-			}
-		}
-		if !dup {
+		if name != "" && !slices.Contains(names, name) {
 			names = append(names, name)
 		}
 	}

--- a/app/sesame/modules/loyalty.go
+++ b/app/sesame/modules/loyalty.go
@@ -69,130 +69,54 @@ func Loyalty(d engine.Deps) module.Module {
 
 	m := module.NewModule(engine.LoyaltyModuleName, module.KindOptIn)
 
-	m.On("channel.subscribe", func(_ context.Context, c *module.Context, _ module.Emit) error {
-		var cfg engine.LoyaltyModuleConfig
-		_ = c.Decode(&cfg)
-		if d.Loyalty == nil || len(c.Env.Event) == 0 {
-			return nil
-		}
-		var ev loyaltySubEvent
-		if err := json.Unmarshal(c.Env.Event, &ev); err != nil {
-			return err
-		}
-		earn(d, c, ev.UserID, ev.UserLogin, ev.UserName, cfg.EffectiveSubPoints()*engine.TierMultiplier(ev.Tier))
-		return nil
-	})
+	m.On("channel.subscribe", onAccrual(d, func(cfg engine.LoyaltyModuleConfig, ev loyaltySubEvent) accrual {
+		return accrual{ev.UserID, ev.UserLogin, ev.UserName, cfg.EffectiveSubPoints() * engine.TierMultiplier(ev.Tier)}
+	}))
 
-	m.On("channel.subscription.message", func(_ context.Context, c *module.Context, _ module.Emit) error {
-		var cfg engine.LoyaltyModuleConfig
-		_ = c.Decode(&cfg)
-		if d.Loyalty == nil || len(c.Env.Event) == 0 {
-			return nil
-		}
-		var ev loyaltySubEvent
-		if err := json.Unmarshal(c.Env.Event, &ev); err != nil {
-			return err
-		}
-		earn(d, c, ev.UserID, ev.UserLogin, ev.UserName, cfg.EffectiveResubPoints()*engine.TierMultiplier(ev.Tier))
-		return nil
-	})
+	m.On("channel.subscription.message", onAccrual(d, func(cfg engine.LoyaltyModuleConfig, ev loyaltySubEvent) accrual {
+		return accrual{ev.UserID, ev.UserLogin, ev.UserName, cfg.EffectiveResubPoints() * engine.TierMultiplier(ev.Tier)}
+	}))
 
-	m.On("channel.subscription.gift", func(_ context.Context, c *module.Context, _ module.Emit) error {
-		var cfg engine.LoyaltyModuleConfig
-		_ = c.Decode(&cfg)
-		if d.Loyalty == nil || len(c.Env.Event) == 0 {
-			return nil
-		}
-		var ev loyaltyGiftEvent
-		if err := json.Unmarshal(c.Env.Event, &ev); err != nil {
-			return err
-		}
+	// Gift recipients earn through their own channel.subscribe events; this
+	// credits the gifter (an anonymous one has nobody to credit).
+	m.On("channel.subscription.gift", onAccrual(d, func(cfg engine.LoyaltyModuleConfig, ev loyaltyGiftEvent) accrual {
 		if ev.IsAnonymous || ev.Total <= 0 {
-			return nil // nobody to credit; recipients earn via their own channel.subscribe
+			return accrual{}
 		}
-		earn(d, c, ev.UserID, ev.UserLogin, ev.UserName, cfg.EffectiveGiftSubPoints()*int64(ev.Total))
-		return nil
-	})
+		return accrual{ev.UserID, ev.UserLogin, ev.UserName, cfg.EffectiveGiftSubPoints() * int64(ev.Total)}
+	}))
 
-	m.On("channel.cheer", func(_ context.Context, c *module.Context, _ module.Emit) error {
-		var cfg engine.LoyaltyModuleConfig
-		_ = c.Decode(&cfg)
-		if d.Loyalty == nil || len(c.Env.Event) == 0 {
-			return nil
-		}
-		var ev loyaltyCheerEvent
-		if err := json.Unmarshal(c.Env.Event, &ev); err != nil {
-			return err
-		}
+	m.On("channel.cheer", onAccrual(d, func(cfg engine.LoyaltyModuleConfig, ev loyaltyCheerEvent) accrual {
 		if ev.IsAnonymous || ev.Bits <= 0 {
-			return nil
+			return accrual{}
 		}
-		earn(d, c, ev.UserID, ev.UserLogin, ev.UserName, cfg.EffectiveCheerPointsPer100()*int64(ev.Bits)/100)
-		return nil
-	})
+		return accrual{ev.UserID, ev.UserLogin, ev.UserName, cfg.EffectiveCheerPointsPer100() * int64(ev.Bits) / 100}
+	}))
 
 	// The watch tick follows the stream lifecycle, mirroring the timers module:
 	// online arms it (the clock re-checks the module's enable state itself),
 	// offline stops it immediately.
-	m.On("stream.online", func(_ context.Context, c *module.Context, _ module.Emit) error {
-		if d.LoyaltyTick == nil {
-			return nil
-		}
-		id := c.BroadcasterID
-		go func() {
-			wctx, cancel := context.WithTimeout(context.Background(), loyaltyTickTimeout)
-			defer cancel()
-			d.LoyaltyTick.Arm(wctx, id)
-		}()
-		return nil
-	})
-
-	m.On("stream.offline", func(_ context.Context, c *module.Context, _ module.Emit) error {
-		if d.LoyaltyTick == nil {
-			return nil
-		}
-		id := c.BroadcasterID
-		go func() {
-			wctx, cancel := context.WithTimeout(context.Background(), loyaltyTickTimeout)
-			defer cancel()
-			d.LoyaltyTick.Disarm(wctx, id)
-		}()
-		return nil
-	})
+	m.On("stream.online", onStreamTick(d, true))
+	m.On("stream.offline", onStreamTick(d, false))
 
 	m.Command("points").Everyone().Cooldown(5 * time.Second).Run(
 		func(ctx context.Context, c *module.Context, args string, emit module.Emit) error {
 			if d.Loyalty == nil {
 				return nil
 			}
+			lc := loyaltyCmd{d, c, emit, log}
 			// Mod grants: "!points set @user 500" / "!points add @user -100".
 			// Gated here (not on the command) so plain "!points" stays open to
 			// everyone while the mutating verbs need at least moderator.
 			if fields := strings.Fields(args); len(fields) == 3 && c.Chatter().Allows(module.RoleModerator) {
 				switch strings.ToLower(fields[0]) {
 				case "set":
-					return pointsAdjust(ctx, d, c, fields[1], fields[2], true, emit, log)
+					return lc.pointsAdjust(ctx, fields[1], fields[2], true)
 				case "add", "give":
-					return pointsAdjust(ctx, d, c, fields[1], fields[2], false, emit, log)
+					return lc.pointsAdjust(ctx, fields[1], fields[2], false)
 				}
 			}
-			viewerID, err := strconv.ParseUint(c.Env.ChatterUserID, 10, 64)
-			if err != nil || viewerID == 0 {
-				return nil
-			}
-			bal, err := d.Loyalty.BalanceGet(ctx, c.BroadcasterID, viewerID)
-			if err != nil {
-				log.Warn("loyalty: balance read failed", zap.Uint64("broadcaster_id", c.BroadcasterID), zap.Error(err))
-				return nil
-			}
-			var cfg engine.LoyaltyModuleConfig
-			_ = c.Decode(&cfg)
-			loyaltyReply(c, emit, "loyalty.points",
-				"points", strconv.FormatInt(bal.Points, 10),
-				"name", cfg.Name(),
-				"hours", strconv.FormatFloat(float64(bal.WatchSeconds)/3600, 'f', 1, 64),
-			)
-			return nil
+			return lc.pointsShow(ctx)
 		})
 
 	m.Command("counter").Mod().Run(
@@ -200,10 +124,70 @@ func Loyalty(d engine.Deps) module.Module {
 			if d.Loyalty == nil {
 				return nil
 			}
-			return runCounterCommand(ctx, d, c, args, emit, log)
+			return loyaltyCmd{d, c, emit, log}.runCounter(ctx, args)
 		})
 
 	return m.Build()
+}
+
+// accrual is one event's award: who earns and how much. A zero value (no
+// viewer or nothing earned) is dropped by earn.
+type accrual struct {
+	userID, login, name string
+	points              int64
+}
+
+// onAccrual builds the shared event-handler shell for every point source:
+// decode the module config and the event subset, ask award what it is worth,
+// and hand the result to the store. The per-event logic shrinks to the award
+// closure.
+func onAccrual[T any](d engine.Deps, award func(cfg engine.LoyaltyModuleConfig, ev T) accrual) module.EventHandler {
+	return func(_ context.Context, c *module.Context, _ module.Emit) error {
+		var cfg engine.LoyaltyModuleConfig
+		_ = c.Decode(&cfg)
+		if d.Loyalty == nil || len(c.Env.Event) == 0 {
+			return nil
+		}
+		var ev T
+		if err := json.Unmarshal(c.Env.Event, &ev); err != nil {
+			return err
+		}
+		a := award(cfg, ev)
+		earn(d, c, a.userID, a.login, a.name, a.points)
+		return nil
+	}
+}
+
+// onStreamTick builds the stream.online/offline handlers: the watch tick
+// follows the stream lifecycle, mirroring the timers module. Fire-and-forget
+// on a Background-derived context, like the live module's writes.
+func onStreamTick(d engine.Deps, arm bool) module.EventHandler {
+	return func(_ context.Context, c *module.Context, _ module.Emit) error {
+		if d.LoyaltyTick == nil {
+			return nil
+		}
+		id := c.BroadcasterID
+		go func() {
+			wctx, cancel := context.WithTimeout(context.Background(), loyaltyTickTimeout)
+			defer cancel()
+			if arm {
+				d.LoyaltyTick.Arm(wctx, id)
+			} else {
+				d.LoyaltyTick.Disarm(wctx, id)
+			}
+		}()
+		return nil
+	}
+}
+
+// loyaltyCmd bundles the per-invocation state the !points/!counter helpers
+// share, so each helper reads as (ctx, arguments) instead of a six-way
+// parameter list — the same shape as the queue module's queueCmd.
+type loyaltyCmd struct {
+	d    engine.Deps
+	c    *module.Context
+	emit module.Emit
+	log  *zap.Logger
 }
 
 // pointsAdjustMax bounds one mod grant so a typo cannot warp a balance beyond
@@ -214,34 +198,55 @@ const pointsAdjustMax = 100_000_000
 // addressed by login; the loyalty service resolves it against the balances it
 // has seen, so a viewer with no accrual yet cannot be granted (they get a row
 // the moment they chat while live, sub, or cheer).
-func pointsAdjust(ctx context.Context, d engine.Deps, c *module.Context, target, amount string, absolute bool, emit module.Emit, log *zap.Logger) error {
+func (lc loyaltyCmd) pointsAdjust(ctx context.Context, target, amount string, absolute bool) error {
 	value, err := strconv.ParseInt(amount, 10, 64)
 	if err != nil || value > pointsAdjustMax || value < -pointsAdjustMax {
-		loyaltyReply(c, emit, "loyalty.points.usage")
+		lc.reply("loyalty.points.usage")
 		return nil
 	}
 	login := strings.ToLower(strings.TrimPrefix(target, "@"))
 	if login == "" {
-		loyaltyReply(c, emit, "loyalty.points.usage")
+		lc.reply("loyalty.points.usage")
 		return nil
 	}
 	var cfg engine.LoyaltyModuleConfig
-	_ = c.Decode(&cfg)
+	_ = lc.c.Decode(&cfg)
 
-	bal, found, err := d.Loyalty.BalanceAdjust(ctx, c.BroadcasterID, login, value, absolute)
+	bal, found, err := lc.d.Loyalty.BalanceAdjust(ctx, lc.c.BroadcasterID, login, value, absolute)
 	if err != nil {
-		log.Warn("loyalty: balance adjust failed", zap.Uint64("broadcaster_id", c.BroadcasterID), zap.Error(err))
-		loyaltyReply(c, emit, "loyalty.counter.err")
+		lc.log.Warn("loyalty: balance adjust failed", zap.Uint64("broadcaster_id", lc.c.BroadcasterID), zap.Error(err))
+		lc.reply("loyalty.counter.err")
 		return nil
 	}
 	if !found {
-		loyaltyReply(c, emit, "loyalty.points.unknown", "target", login)
+		lc.reply("loyalty.points.unknown", "target", login)
 		return nil
 	}
-	loyaltyReply(c, emit, "loyalty.points.adjusted",
+	lc.reply("loyalty.points.adjusted",
 		"target", login,
 		"points", strconv.FormatInt(bal.Points, 10),
 		"name", cfg.Name(),
+	)
+	return nil
+}
+
+// pointsShow answers a plain "!points": the caller's own standing.
+func (lc loyaltyCmd) pointsShow(ctx context.Context) error {
+	viewerID, err := strconv.ParseUint(lc.c.Env.ChatterUserID, 10, 64)
+	if err != nil || viewerID == 0 {
+		return nil
+	}
+	bal, err := lc.d.Loyalty.BalanceGet(ctx, lc.c.BroadcasterID, viewerID)
+	if err != nil {
+		lc.log.Warn("loyalty: balance read failed", zap.Uint64("broadcaster_id", lc.c.BroadcasterID), zap.Error(err))
+		return nil
+	}
+	var cfg engine.LoyaltyModuleConfig
+	_ = lc.c.Decode(&cfg)
+	lc.reply("loyalty.points",
+		"points", strconv.FormatInt(bal.Points, 10),
+		"name", cfg.Name(),
+		"hours", strconv.FormatFloat(float64(bal.WatchSeconds)/3600, 'f', 1, 64),
 	)
 	return nil
 }
@@ -262,10 +267,10 @@ func earn(d engine.Deps, c *module.Context, userID, login, name string, points i
 
 // runCounterCommand routes "!counter ..." — a bare name shows it, the
 // management verbs mutate through the loyalty service.
-func runCounterCommand(ctx context.Context, d engine.Deps, c *module.Context, args string, emit module.Emit, log *zap.Logger) error {
+func (lc loyaltyCmd) runCounter(ctx context.Context, args string) error {
 	fields := strings.Fields(args)
 	if len(fields) == 0 {
-		loyaltyReply(c, emit, "loyalty.counter.usage")
+		lc.reply("loyalty.counter.usage")
 		return nil
 	}
 
@@ -273,31 +278,31 @@ func runCounterCommand(ctx context.Context, d engine.Deps, c *module.Context, ar
 	rest := fields[1:]
 	switch verb {
 	case "create":
-		return counterCreate(ctx, d, c, rest, emit, log)
+		return lc.counterCreate(ctx, rest)
 	case "add":
-		return counterAdd(ctx, d, c, rest, emit, log)
+		return lc.counterAdd(ctx, rest)
 	case "set":
-		return counterSet(ctx, d, c, rest, emit, log)
+		return lc.counterSet(ctx, rest)
 	case "reset":
-		return counterReset(ctx, d, c, rest, emit, log)
+		return lc.counterReset(ctx, rest)
 	case "delete", "del", "remove":
-		return counterDelete(ctx, d, c, rest, emit, log)
+		return lc.counterDelete(ctx, rest)
 	case "list":
-		return counterListCmd(ctx, d, c, emit, log)
+		return lc.counterList(ctx)
 	default:
 		// "!counter <name> [source...]": the optional trailing words select a
 		// viewer+command counter's bucket — a command trigger or a
 		// channel-point reward title (which may span several words).
-		return counterShow(ctx, d, c, verb, strings.Join(rest, " "), emit, log)
+		return lc.counterShow(ctx, verb, strings.Join(rest, " "))
 	}
 }
 
 // counterCreate makes a counter one of the three ways, all per channel:
 // "!counter create <name>" a single global value, "... <name> user" one value
 // per viewer, "... <name> user+command" one value per viewer per command.
-func counterCreate(ctx context.Context, d engine.Deps, c *module.Context, rest []string, emit module.Emit, log *zap.Logger) error {
+func (lc loyaltyCmd) counterCreate(ctx context.Context, rest []string) error {
 	if len(rest) == 0 {
-		loyaltyReply(c, emit, "loyalty.counter.usage")
+		lc.reply("loyalty.counter.usage")
 		return nil
 	}
 	scope := data.CounterScopeChannel
@@ -309,11 +314,11 @@ func counterCreate(ctx context.Context, d engine.Deps, c *module.Context, rest [
 			scope = data.CounterScopeViewerCommand
 		}
 	}
-	counter, err := d.Loyalty.CounterCreate(ctx, c.BroadcasterID, rest[0], scope)
+	counter, err := lc.d.Loyalty.CounterCreate(ctx, lc.c.BroadcasterID, rest[0], scope)
 	if err != nil {
-		return counterFail(c, emit, log, "create", err)
+		return lc.fail("create", err)
 	}
-	loyaltyReply(c, emit, "loyalty.counter.created", "counter", counter.Name, "scope", scopeLabel(counter.Scope))
+	lc.reply("loyalty.counter.created", "counter", counter.Name, "scope", scopeLabel(counter.Scope))
 	return nil
 }
 
@@ -329,16 +334,16 @@ func scopeLabel(scope string) string {
 	}
 }
 
-func counterAdd(ctx context.Context, d engine.Deps, c *module.Context, rest []string, emit module.Emit, log *zap.Logger) error {
+func (lc loyaltyCmd) counterAdd(ctx context.Context, rest []string) error {
 	if len(rest) == 0 {
-		loyaltyReply(c, emit, "loyalty.counter.usage")
+		lc.reply("loyalty.counter.usage")
 		return nil
 	}
 	delta := int64(1)
 	if len(rest) > 1 {
 		n, err := strconv.ParseInt(rest[1], 10, 64)
 		if err != nil || n == 0 || n > counterAddMax || n < -counterAddMax {
-			loyaltyReply(c, emit, "loyalty.counter.usage")
+			lc.reply("loyalty.counter.usage")
 			return nil
 		}
 		delta = n
@@ -350,75 +355,75 @@ func counterAdd(ctx context.Context, d engine.Deps, c *module.Context, rest []st
 	if len(rest) > 2 {
 		command = strings.Join(rest[2:], " ")
 	}
-	viewerID, _ := strconv.ParseUint(c.Env.ChatterUserID, 10, 64)
-	value, err := d.Loyalty.CounterBump(ctx, c.BroadcasterID, rest[0], viewerID, command, delta)
+	viewerID, _ := strconv.ParseUint(lc.c.Env.ChatterUserID, 10, 64)
+	value, err := lc.d.Loyalty.CounterBump(ctx, lc.c.BroadcasterID, rest[0], viewerID, command, delta)
 	if err != nil {
-		return counterFail(c, emit, log, "add", err)
+		return lc.fail("add", err)
 	}
-	loyaltyReply(c, emit, "loyalty.counter.set",
+	lc.reply("loyalty.counter.set",
 		"counter", engine.NormalizeCounterName(rest[0]), "value", strconv.FormatInt(value, 10))
 	return nil
 }
 
-func counterSet(ctx context.Context, d engine.Deps, c *module.Context, rest []string, emit module.Emit, log *zap.Logger) error {
+func (lc loyaltyCmd) counterSet(ctx context.Context, rest []string) error {
 	if len(rest) < 2 {
-		loyaltyReply(c, emit, "loyalty.counter.usage")
+		lc.reply("loyalty.counter.usage")
 		return nil
 	}
 	value, err := strconv.ParseInt(rest[1], 10, 64)
 	if err != nil {
-		loyaltyReply(c, emit, "loyalty.counter.usage")
+		lc.reply("loyalty.counter.usage")
 		return nil
 	}
-	found, err := d.Loyalty.CounterSet(ctx, c.BroadcasterID, rest[0], 0, "", value)
+	found, err := lc.d.Loyalty.CounterSet(ctx, lc.c.BroadcasterID, rest[0], 0, "", value)
 	if err != nil {
-		return counterFail(c, emit, log, "set", err)
+		return lc.fail("set", err)
 	}
 	if !found {
-		loyaltyReply(c, emit, "loyalty.counter.not_found", "counter", engine.NormalizeCounterName(rest[0]))
+		lc.reply("loyalty.counter.not_found", "counter", engine.NormalizeCounterName(rest[0]))
 		return nil
 	}
-	loyaltyReply(c, emit, "loyalty.counter.set",
+	lc.reply("loyalty.counter.set",
 		"counter", engine.NormalizeCounterName(rest[0]), "value", strconv.FormatInt(value, 10))
 	return nil
 }
 
-func counterReset(ctx context.Context, d engine.Deps, c *module.Context, rest []string, emit module.Emit, log *zap.Logger) error {
+func (lc loyaltyCmd) counterReset(ctx context.Context, rest []string) error {
 	if len(rest) == 0 {
-		loyaltyReply(c, emit, "loyalty.counter.usage")
+		lc.reply("loyalty.counter.usage")
 		return nil
 	}
-	found, err := d.Loyalty.CounterSet(ctx, c.BroadcasterID, rest[0], 0, "", 0)
+	found, err := lc.d.Loyalty.CounterSet(ctx, lc.c.BroadcasterID, rest[0], 0, "", 0)
 	if err != nil {
-		return counterFail(c, emit, log, "reset", err)
+		return lc.fail("reset", err)
 	}
 	if !found {
-		loyaltyReply(c, emit, "loyalty.counter.not_found", "counter", engine.NormalizeCounterName(rest[0]))
+		lc.reply("loyalty.counter.not_found", "counter", engine.NormalizeCounterName(rest[0]))
 		return nil
 	}
-	loyaltyReply(c, emit, "loyalty.counter.reset", "counter", engine.NormalizeCounterName(rest[0]))
+	lc.reply("loyalty.counter.reset", "counter", engine.NormalizeCounterName(rest[0]))
 	return nil
 }
 
-func counterDelete(ctx context.Context, d engine.Deps, c *module.Context, rest []string, emit module.Emit, log *zap.Logger) error {
+func (lc loyaltyCmd) counterDelete(ctx context.Context, rest []string) error {
 	if len(rest) == 0 {
-		loyaltyReply(c, emit, "loyalty.counter.usage")
+		lc.reply("loyalty.counter.usage")
 		return nil
 	}
-	if err := d.Loyalty.CounterDelete(ctx, c.BroadcasterID, rest[0]); err != nil {
-		return counterFail(c, emit, log, "delete", err)
+	if err := lc.d.Loyalty.CounterDelete(ctx, lc.c.BroadcasterID, rest[0]); err != nil {
+		return lc.fail("delete", err)
 	}
-	loyaltyReply(c, emit, "loyalty.counter.deleted", "counter", engine.NormalizeCounterName(rest[0]))
+	lc.reply("loyalty.counter.deleted", "counter", engine.NormalizeCounterName(rest[0]))
 	return nil
 }
 
-func counterListCmd(ctx context.Context, d engine.Deps, c *module.Context, emit module.Emit, log *zap.Logger) error {
-	counters, err := d.Loyalty.CounterList(ctx, c.BroadcasterID)
+func (lc loyaltyCmd) counterList(ctx context.Context) error {
+	counters, err := lc.d.Loyalty.CounterList(ctx, lc.c.BroadcasterID)
 	if err != nil {
-		return counterFail(c, emit, log, "list", err)
+		return lc.fail("list", err)
 	}
 	if len(counters) == 0 {
-		loyaltyReply(c, emit, "loyalty.counter.list.empty")
+		lc.reply("loyalty.counter.list.empty")
 		return nil
 	}
 	var b strings.Builder
@@ -438,53 +443,53 @@ func counterListCmd(ctx context.Context, d engine.Deps, c *module.Context, emit 
 			b.WriteString(")")
 		}
 	}
-	loyaltyReply(c, emit, "loyalty.counter.list", "list", b.String())
+	lc.reply("loyalty.counter.list", "list", b.String())
 	return nil
 }
 
-func counterShow(ctx context.Context, d engine.Deps, c *module.Context, name, command string, emit module.Emit, log *zap.Logger) error {
-	viewerID, _ := strconv.ParseUint(c.Env.ChatterUserID, 10, 64)
-	counter, found, err := d.Loyalty.CounterPeek(ctx, c.BroadcasterID, name, viewerID, command)
+func (lc loyaltyCmd) counterShow(ctx context.Context, name, command string) error {
+	viewerID, _ := strconv.ParseUint(lc.c.Env.ChatterUserID, 10, 64)
+	counter, found, err := lc.d.Loyalty.CounterPeek(ctx, lc.c.BroadcasterID, name, viewerID, command)
 	if err != nil {
-		return counterFail(c, emit, log, "show", err)
+		return lc.fail("show", err)
 	}
 	if !found {
-		loyaltyReply(c, emit, "loyalty.counter.not_found", "counter", engine.NormalizeCounterName(name))
+		lc.reply("loyalty.counter.not_found", "counter", engine.NormalizeCounterName(name))
 		return nil
 	}
 	key := "loyalty.counter.show"
 	if counter.Scope != data.CounterScopeChannel {
 		key = "loyalty.counter.show.viewer"
 	}
-	loyaltyReply(c, emit, key, "counter", counter.Name, "value", strconv.FormatInt(counter.Value, 10))
+	lc.reply(key, "counter", counter.Name, "value", strconv.FormatInt(counter.Value, 10))
 	return nil
 }
 
-// counterFail logs the failure and posts the generic error line; the error is
+// fail logs the failure and posts the generic error line; the error is
 // swallowed (the pipeline would only drop it anyway).
-func counterFail(c *module.Context, emit module.Emit, log *zap.Logger, op string, err error) error {
-	log.Warn("loyalty: counter "+op+" failed", zap.Uint64("broadcaster_id", c.BroadcasterID), zap.Error(err))
-	loyaltyReply(c, emit, "loyalty.counter.err")
+func (lc loyaltyCmd) fail(op string, err error) error {
+	lc.log.Warn("loyalty: counter "+op+" failed", zap.Uint64("broadcaster_id", lc.c.BroadcasterID), zap.Error(err))
+	lc.reply("loyalty.counter.err")
 	return nil
 }
 
-// loyaltyReply emits one localized chat line. kv are {token},value pairs;
-// {user} (the invoking chatter) and the dynamic vars are always available.
-func loyaltyReply(c *module.Context, emit module.Emit, key string, kv ...string) {
-	text := module.ExpandString(i18n.T(c.Locale, key), func(k string) (string, bool) {
+// reply emits one localized chat line. kv are {token},value pairs; {user}
+// (the invoking chatter) and the dynamic vars are always available.
+func (lc loyaltyCmd) reply(key string, kv ...string) {
+	text := module.ExpandString(i18n.T(lc.c.Locale, key), func(k string) (string, bool) {
 		for i := 0; i+1 < len(kv); i += 2 {
 			if kv[i] == k {
 				return kv[i+1], true
 			}
 		}
 		if k == "user" {
-			return c.Env.ChatterUserLogin, true
+			return lc.c.Env.ChatterUserLogin, true
 		}
 		return module.ParseDynamic(k)
 	})
-	emit(&module.Output{
+	lc.emit(&module.Output{
 		Type:          outgress.TypeChat,
-		BroadcasterID: c.Env.BroadcasterUserID,
+		BroadcasterID: lc.c.Env.BroadcasterUserID,
 		Text:          text,
 	})
 }

--- a/console/dashboard/src/routes/(app)/counters/+page.server.ts
+++ b/console/dashboard/src/routes/(app)/counters/+page.server.ts
@@ -60,69 +60,56 @@ export const load: PageServerLoad = async ({ locals, url }) => {
   }
 };
 
-export const actions: Actions = {
-  create: async ({ request, locals }) => {
+// mutate wraps one POST action with the shared boilerplate: gate, session,
+// demo short-circuit, error mapping and the impersonation audit line. run
+// returns the audit detail, or null for a validation failure.
+type Mutation = (uid: string, f: FormData) => Promise<string | null>;
+
+function mutate(op: string, run: Mutation) {
+  return async ({ request, locals }: Parameters<NonNullable<Actions[string]>>[0]) => {
     gate(locals.session);
     const uid = effectiveId(locals.session);
     if (env.DEMO !== '1' && !locals.session) return fail(401, { ok: false, error: 'Not signed in.' });
 
     const f = await request.formData();
+    if (env.DEMO === '1') return { ok: true };
+    let detail: string | null;
+    try {
+      detail = await run(uid, f);
+    } catch (e) {
+      console.error(`[counters] ${op} failed:`, e instanceof Error ? (e.stack ?? e.message) : e);
+      return fail(400, { ok: false, error: `${op} failed` });
+    }
+    if (detail === null) return fail(400, { ok: false, error: 'Invalid counter.' });
+    auditDashboardImpersonation(locals.session, `counters:${op}`, detail);
+    return { ok: true };
+  };
+}
+
+export const actions: Actions = {
+  create: mutate('create', async (uid, f) => {
     const name = normalizeName(f.get('name'));
     const scope = String(f.get('scope') ?? 'channel') as CounterScope;
-    if (!name || !COUNTER_SCOPES.includes(scope)) return fail(400, { ok: false, error: 'Invalid counter.' });
-    if (env.DEMO === '1') return { ok: true };
-
-    try {
-      await createCounter(uid, name, scope);
-    } catch (e) {
-      console.error('[counters] create failed:', e instanceof Error ? (e.stack ?? e.message) : e);
-      return fail(400, { ok: false, error: 'create failed' });
-    }
-    auditDashboardImpersonation(locals.session, 'counters:create', `${name} (${scope})`);
-    return { ok: true };
-  },
+    if (!name || !COUNTER_SCOPES.includes(scope)) return null;
+    await createCounter(uid, name, scope);
+    return `${name} (${scope})`;
+  }),
 
   // Absolute value for a channel counter; on entry scopes value 0 doubles as
   // the reset (the service deletes every stored bucket).
-  set: async ({ request, locals }) => {
-    gate(locals.session);
-    const uid = effectiveId(locals.session);
-    if (env.DEMO !== '1' && !locals.session) return fail(401, { ok: false, error: 'Not signed in.' });
-
-    const f = await request.formData();
+  set: mutate('set', async (uid, f) => {
     const name = normalizeName(f.get('name'));
     const value = Math.trunc(Number(f.get('value')));
-    if (!name || !Number.isFinite(value)) return fail(400, { ok: false, error: 'Invalid value.' });
-    if (env.DEMO === '1') return { ok: true };
+    if (!name || !Number.isFinite(value)) return null;
+    const found = await setCounter(uid, name, value);
+    if (!found) throw new Error('unknown counter');
+    return `${name}=${value}`;
+  }),
 
-    try {
-      const found = await setCounter(uid, name, value);
-      if (!found) return fail(404, { ok: false, error: 'unknown counter' });
-    } catch (e) {
-      console.error('[counters] set failed:', e instanceof Error ? (e.stack ?? e.message) : e);
-      return fail(400, { ok: false, error: 'set failed' });
-    }
-    auditDashboardImpersonation(locals.session, 'counters:set', `${name}=${value}`);
-    return { ok: true };
-  },
-
-  delete: async ({ request, locals }) => {
-    gate(locals.session);
-    const uid = effectiveId(locals.session);
-    if (env.DEMO !== '1' && !locals.session) return fail(401, { ok: false, error: 'Not signed in.' });
-
-    const f = await request.formData();
+  delete: mutate('delete', async (uid, f) => {
     const name = normalizeName(f.get('name'));
-    if (!name) return fail(400, { ok: false, error: 'Missing counter name.' });
-    if (env.DEMO === '1') return { ok: true };
-
-    try {
-      await deleteCounter(uid, name);
-    } catch (e) {
-      console.error('[counters] delete failed:', e instanceof Error ? (e.stack ?? e.message) : e);
-      return fail(400, { ok: false, error: 'delete failed' });
-    }
-    auditDashboardImpersonation(locals.session, 'counters:delete', name);
-    return { ok: true };
-  }
+    if (!name) return null;
+    await deleteCounter(uid, name);
+    return name;
+  })
 };


### PR DESCRIPTION
Behavior-preserving cleanup of the CodeScene findings from #328 (Bumpy Road in 5 files, Complex Method, duplication).

- **repository**: one `upsertRows` helper renders + executes every chunked bulk statement; `flushBumps` split into `splitBumps` / `flushChannelBumps` / `ensureEntryDefs` / `flushEntryBumps`; `CounterEntries` delegates login resolution to `viewerLogins`; `Top`/`CounterEntries` share `clampLimit`.
- **sesame module**: the four accrual handlers collapse into a generic `onAccrual` builder — each event is now just its award closure; stream online/offline share `onStreamTick`; the `!points`/`!counter` helpers become `loyaltyCmd` methods (the queue module's `queueCmd` idiom), cutting the six-way parameter lists.
- **engine**: `counterTokenNames` drops its nested dedup loop for `slices.Contains`; `CounterPeek` reads the live view through one `peekView` helper; the watch tick extracts `parseLiveKey`/`chatterViewerID`; the reporter's twin publishers share a generic `publishPerUser`.
- **console**: the counters page actions share one `mutate` wrapper (gate, session, demo short-circuit, audit, error mapping).

No wire, schema or i18n changes. Full Go suite + vet green, svelte-check 0 errors, all tests unchanged.