### PR TITLE
fix(web): replace Astro favicon with bot logo

### DIFF
--- a/web/public/favicon.svg
+++ b/web/public/favicon.svg
@@ -1,9 +1,23 @@
-<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 128 128">
-    <path d="M50.4 78.5a75.1 75.1 0 0 0-28.5 6.9l24.2-65.7c.7-2 1.9-3.2 3.4-3.2h29c1.5 0 2.7 1.2 3.4 3.2l24.2 65.7s-11.6-7-28.5-7L67 45.5c-.4-1.7-1.6-2.8-2.9-2.8-1.3 0-2.5 1.1-2.9 2.7L50.4 78.5Zm-1.1 28.2Zm-4.2-20.2c-2 6.6-.6 15.8 4.2 20.2a17.5 17.5 0 0 1 .2-.7 5.5 5.5 0 0 1 5.7-4.5c2.8.1 4.3 1.5 4.7 4.7.2 1.1.2 2.3.2 3.5v.4c0 2.7.7 5.2 2.2 7.4a13 13 0 0 0 5.7 4.9v-.3l-.2-.3c-1.8-5.6-.5-9.5 4.4-12.8l1.5-1a73 73 0 0 0 3.2-2.2 16 16 0 0 0 6.8-11.4c.3-2 .1-4-.6-6l-.8.6-1.6 1a37 37 0 0 1-22.4 2.7c-5-.7-9.7-2-13.2-6.2Z" />
-    <style>
-        path { fill: #000; }
-        @media (prefers-color-scheme: dark) {
-            path { fill: #FFF; }
-        }
-    </style>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-label="ItsBagelBot">
+  <defs>
+    <linearGradient id="tan" x1="22" y1="18" x2="112" y2="112" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#f5d29a"/>
+      <stop offset="1" stop-color="#c9a87c"/>
+    </linearGradient>
+    <linearGradient id="green" x1="101" y1="14" x2="25" y2="112" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#5f9c83"/>
+      <stop offset="1" stop-color="#2d6a4f"/>
+    </linearGradient>
+  </defs>
+  <path d="M104 22c-24-15-57-11-77 11C5 58 10 95 38 114" fill="none" stroke="url(#green)" stroke-width="16" stroke-linecap="round"/>
+  <path d="M23 53c17-31 61-43 90-16" fill="none" stroke="url(#tan)" stroke-width="16" stroke-linecap="round"/>
+  <path d="M29 92c25 29 70 25 88-8" fill="none" stroke="url(#tan)" stroke-width="16" stroke-linecap="round"/>
+  <path d="M25 80c21 28 61 34 87 8" fill="none" stroke="url(#green)" stroke-width="16" stroke-linecap="round"/>
+  <rect x="43" y="57" width="42" height="28" rx="8" fill="url(#tan)"/>
+  <rect x="34" y="63" width="10" height="17" rx="5" fill="#e2bd83"/>
+  <rect x="84" y="63" width="10" height="17" rx="5" fill="#e2bd83"/>
+  <path d="M64 57V47" stroke="#c9a87c" stroke-width="5" stroke-linecap="round"/>
+  <circle cx="64" cy="42" r="5" fill="#e2bd83"/>
+  <circle cx="55" cy="71" r="6" fill="#f28c45" stroke="#0a0a0a" stroke-width="4"/>
+  <circle cx="73" cy="71" r="6" fill="#f28c45" stroke="#0a0a0a" stroke-width="4"/>
 </svg>

--- a/web/src/layouts/Layout.astro
+++ b/web/src/layouts/Layout.astro
@@ -1,6 +1,5 @@
 ---
 import '../styles/style.css';
-import logoImage from '../assets/LogoBOT.png';
 
 import { ClientRouter } from 'astro:transitions';
 import Cursor from '../components/ui/Cursor.astro'
@@ -157,8 +156,6 @@ const contentSecurityPolicy = [
     <meta name="theme-color" content="#0a0a0a"/>
     <meta name="color-scheme" content="dark"/>
 
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg"/>
-    <link rel="icon" type="image/png" href={logoImage.src}/>
     <meta name="generator" content={Astro.generator}/>
 
     <link rel="preconnect" href="https://fonts.googleapis.com"/>
@@ -166,9 +163,10 @@ const contentSecurityPolicy = [
     <link href="https://fonts.googleapis.com/css2?family=Syne:wght@400;600;700;800&family=DM+Mono:wght@400;500&family=DM+Sans:ital,wght@0,400;1,400&family=Caveat:wght@500;600&display=swap"
           rel="stylesheet"/>
 
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=bot-1">
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png?v=bot-1">
+    <link rel="shortcut icon" href="/favicon.ico?v=bot-1">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
     <link rel="manifest" href="/site.webmanifest">
 
     <meta name="description" content={description} />

--- a/web/tests/site.spec.js
+++ b/web/tests/site.spec.js
@@ -162,8 +162,9 @@ test.describe('ItsBagelBot site', () => {
     test('production assets referenced by the document are emitted', async ({ page, request }) => {
         await page.goto('/');
 
-        const favicon = await page.locator('link[rel="icon"][type="image/png"]').first().getAttribute('href');
-        expect(favicon).toBeTruthy();
+        await expect(page.locator('link[rel="icon"][type="image/svg+xml"]')).toHaveCount(0);
+        const favicon = await page.locator('link[rel="icon"][sizes="32x32"]').getAttribute('href');
+        expect(favicon).toBe('/favicon-32x32.png?v=bot-1');
         const response = await request.get(favicon);
         expect(response.ok()).toBeTruthy();
     });


### PR DESCRIPTION
## What changed

- remove the stock Astro SVG from the browser favicon candidates
- use the existing 32px and 16px ItsBagelBot logo files with a cache-busting URL
- replace the legacy `/favicon.svg` contents with an ItsBagelBot mark
- add a browser regression assertion for the selected favicon

## Why

The shared Astro layout advertised the starter `favicon.svg` on every route. Browsers preferred that scalable icon over the bot-logo PNG fallbacks, so the Astro icon appeared site-wide. The versioned PNG URLs also bypass persistent browser and CDN favicon caches.

## Validation

- `bun run build`
- `bunx playwright test --grep 'production assets referenced by the document are emitted'`
