### PR TITLE
feat: add cached followage command

### DIFF
--- a/app/outgress/internal/twitch/client.go
+++ b/app/outgress/internal/twitch/client.go
@@ -276,6 +276,36 @@ func (c *Client) UserIDByLogin(ctx context.Context, login string) (string, error
 	return payload.Data[0].ID, nil
 }
 
+// FollowedAt returns when targetID followed broadcasterID. found is false when
+// the Twitch user exists but does not currently follow the channel. The call
+// uses the bot's moderator-scoped user token.
+func (c *Client) FollowedAt(ctx context.Context, broadcasterID, targetID string) (time.Time, bool, error) {
+	q := url.Values{}
+	q.Set("broadcaster_id", broadcasterID)
+	q.Set("user_id", targetID)
+	res, err := c.ExecuteAs(ctx, IdentityBot, broadcasterID, getCall("/helix/channels/followers?"+q.Encode()))
+	if err != nil {
+		return time.Time{}, false, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(res.Body, 2048))
+		return time.Time{}, false, &StatusError{Status: res.StatusCode, Body: string(body)}
+	}
+	var payload struct {
+		Data []struct {
+			FollowedAt time.Time `json:"followed_at"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&payload); err != nil {
+		return time.Time{}, false, err
+	}
+	if len(payload.Data) == 0 {
+		return time.Time{}, false, nil
+	}
+	return payload.Data[0].FollowedAt, true, nil
+}
+
 // IsModerator reports whether the bot account moderates broadcasterID,
 // paging through the channels the bot's user token can see. Requires the
 // user:read:moderated_channels scope.

--- a/app/outgress/rpc/manage.go
+++ b/app/outgress/rpc/manage.go
@@ -64,25 +64,46 @@ func SubscribeManage(nc *nats.Conn, registry *channels.Registry, tw *twitch.Clie
 }
 
 func (m *Manage) handleFollowage(ctx context.Context, req outgressrpc.FollowageRequest) outgressrpc.FollowageReply {
-	if req.BroadcasterID == "" || (req.TargetID == "" && req.TargetLogin == "") {
+	if !validFollowageRequest(req) {
 		return outgressrpc.FollowageReply{Error: "bad request"}
 	}
-	targetID := req.TargetID
-	if targetID == "" {
-		var err error
-		targetID, err = m.twitch.UserIDByLogin(ctx, req.TargetLogin)
-		if err != nil {
-			m.log.Warn("followage target resolve failed", zap.Error(err))
-			return outgressrpc.FollowageReply{Error: "lookup failed"}
-		}
+	targetID, err := m.resolveFollowageTarget(ctx, req)
+	if err != nil {
+		return outgressrpc.FollowageReply{Error: "lookup failed"}
 	}
+	return m.readFollowage(ctx, req.BroadcasterID, targetID)
+}
+
+func validFollowageRequest(req outgressrpc.FollowageRequest) bool {
+	if req.BroadcasterID == "" {
+		return false
+	}
+	return req.TargetID != "" || req.TargetLogin != ""
+}
+
+func (m *Manage) resolveFollowageTarget(ctx context.Context, req outgressrpc.FollowageRequest) (string, error) {
+	if req.TargetID != "" {
+		return req.TargetID, nil
+	}
+	targetID, err := m.twitch.UserIDByLogin(ctx, req.TargetLogin)
+	if err != nil {
+		m.log.Warn("followage target resolve failed", zap.Error(err))
+	}
+	return targetID, err
+}
+
+func (m *Manage) readFollowage(ctx context.Context, broadcasterID, targetID string) outgressrpc.FollowageReply {
 	if targetID == "" {
 		return outgressrpc.FollowageReply{UserFound: false}
 	}
-	if targetID == req.BroadcasterID {
+	if targetID == broadcasterID {
 		return outgressrpc.FollowageReply{TargetID: targetID, UserFound: true}
 	}
-	followedAt, following, err := m.twitch.FollowedAt(ctx, req.BroadcasterID, targetID)
+	return m.fetchFollowage(ctx, broadcasterID, targetID)
+}
+
+func (m *Manage) fetchFollowage(ctx context.Context, broadcasterID, targetID string) outgressrpc.FollowageReply {
+	followedAt, following, err := m.twitch.FollowedAt(ctx, broadcasterID, targetID)
 	if err != nil {
 		m.log.Warn("followage lookup failed", zap.Error(err))
 		return outgressrpc.FollowageReply{TargetID: targetID, UserFound: true, Error: "lookup failed"}

--- a/app/outgress/rpc/manage.go
+++ b/app/outgress/rpc/manage.go
@@ -11,6 +11,7 @@ import (
 	"ItsBagelBot/app/outgress/internal/channels"
 	"ItsBagelBot/app/outgress/internal/twitch"
 	"ItsBagelBot/internal/domain/rpc/manage"
+	outgressrpc "ItsBagelBot/internal/domain/rpc/outgress"
 	"ItsBagelBot/pkg/bus"
 
 	"github.com/newrelic/go-agent/v3/newrelic"
@@ -21,6 +22,7 @@ import (
 )
 
 const handleTimeout = 1500 * time.Millisecond
+const followageHandleTimeout = 4 * time.Second
 
 type Manage struct {
 	registry *channels.Registry
@@ -51,11 +53,43 @@ func SubscribeManage(nc *nats.Conn, registry *channels.Registry, tw *twitch.Clie
 	if err := bus.QueueSubscribeJSON[struct{}, manage.SystemStatusReply](nc, prefix+".system.status", queueGroup, handleTimeout, app, log, m.handleSystemStatus); err != nil {
 		return err
 	}
+	if err := bus.QueueSubscribeJSON[outgressrpc.FollowageRequest, outgressrpc.FollowageReply](nc, prefix+".followage.get", queueGroup, followageHandleTimeout, app, log, m.handleFollowage); err != nil {
+		return err
+	}
 	if err := bus.QueueSubscribeJSON[manage.SystemPauseRequest, manage.SystemPauseReply](nc, prefix+".system.pause", queueGroup, handleTimeout, app, log, m.handleSystemPause); err != nil {
 		return err
 	}
 
 	return nil
+}
+
+func (m *Manage) handleFollowage(ctx context.Context, req outgressrpc.FollowageRequest) outgressrpc.FollowageReply {
+	if req.BroadcasterID == "" || (req.TargetID == "" && req.TargetLogin == "") {
+		return outgressrpc.FollowageReply{Error: "bad request"}
+	}
+	targetID := req.TargetID
+	if targetID == "" {
+		var err error
+		targetID, err = m.twitch.UserIDByLogin(ctx, req.TargetLogin)
+		if err != nil {
+			m.log.Warn("followage target resolve failed", zap.Error(err))
+			return outgressrpc.FollowageReply{Error: "lookup failed"}
+		}
+	}
+	if targetID == "" {
+		return outgressrpc.FollowageReply{UserFound: false}
+	}
+	if targetID == req.BroadcasterID {
+		return outgressrpc.FollowageReply{TargetID: targetID, UserFound: true}
+	}
+	followedAt, following, err := m.twitch.FollowedAt(ctx, req.BroadcasterID, targetID)
+	if err != nil {
+		m.log.Warn("followage lookup failed", zap.Error(err))
+		return outgressrpc.FollowageReply{TargetID: targetID, UserFound: true, Error: "lookup failed"}
+	}
+	return outgressrpc.FollowageReply{
+		TargetID: targetID, UserFound: true, Following: following, FollowedAt: followedAt,
+	}
 }
 
 func (m *Manage) handleChannelGet(ctx context.Context, req manage.ChannelRequest) manage.ChannelReply {

--- a/app/sesame/engine/deps.go
+++ b/app/sesame/engine/deps.go
@@ -49,16 +49,17 @@ type QuotesStore interface {
 // builds its Module. main constructs it once and hands it to modules.All. Not
 // every module uses every field; unused ones are harmless.
 type Deps struct {
-	Proj     projection.Reader
-	Live     LiveStore
-	Greet    GreetStore
-	Cooldown CooldownStore
-	Dedup    DedupStore
-	Special  *SpecialSet
-	Pub      message.Publisher
-	Commands CommandManager
-	Gateway  GatewayCaller
-	Log      *zap.Logger
+	Proj      projection.Reader
+	Live      LiveStore
+	Greet     GreetStore
+	Cooldown  CooldownStore
+	Dedup     DedupStore
+	Special   *SpecialSet
+	Pub       message.Publisher
+	Commands  CommandManager
+	Gateway   GatewayCaller
+	Followage FollowageLookup
+	Log       *zap.Logger
 	// Timers arms/disarms a broadcaster's repeating chat-message timers for the
 	// length of one stream; ValkeyTimerStore is the default. nil disables it (the
 	// live module's stream.online/offline hooks skip the calls).

--- a/app/sesame/engine/followage_rpc.go
+++ b/app/sesame/engine/followage_rpc.go
@@ -1,0 +1,78 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	outgressrpc "ItsBagelBot/internal/domain/rpc/outgress"
+	"ItsBagelBot/pkg/bus"
+	"ItsBagelBot/pkg/cache"
+
+	"github.com/nats-io/nats.go"
+)
+
+const (
+	followageRPCTimeout  = 3500 * time.Millisecond
+	followagePositiveTTL = 15 * time.Minute
+	followageNegativeTTL = time.Minute
+)
+
+type FollowageResult struct {
+	TargetID   string
+	UserFound  bool
+	Following  bool
+	FollowedAt time.Time
+}
+
+type FollowageLookup interface {
+	Lookup(ctx context.Context, broadcasterID, targetID, targetLogin string) (FollowageResult, error)
+}
+
+// FollowageRPC is Sesame's cached followage reader. Outgress supplies only the
+// authenticated Twitch read; command freshness, singleflight and cache policy
+// live here with the command runtime.
+type FollowageRPC struct {
+	cache   *cache.Cache[FollowageResult]
+	request func(context.Context, outgressrpc.FollowageRequest) (outgressrpc.FollowageReply, error)
+}
+
+func NewFollowageRPC(nc *nats.Conn, prefix string) *FollowageRPC {
+	subject := strings.TrimSuffix(prefix, ".") + ".followage.get"
+	return &FollowageRPC{
+		cache: cache.New[FollowageResult](cache.DefaultCapacity, followageNegativeTTL),
+		request: func(ctx context.Context, req outgressrpc.FollowageRequest) (outgressrpc.FollowageReply, error) {
+			return bus.RequestJSONTimeout[outgressrpc.FollowageReply](ctx, nc, subject, req, followageRPCTimeout)
+		},
+	}
+}
+
+func (f *FollowageRPC) Close() { f.cache.Close() }
+
+func (f *FollowageRPC) Lookup(ctx context.Context, broadcasterID, targetID, targetLogin string) (FollowageResult, error) {
+	keyTarget := targetID
+	if keyTarget == "" {
+		keyTarget = "login:" + strings.ToLower(strings.TrimPrefix(targetLogin, "@"))
+	}
+	return f.cache.GetOrLoadTTL(ctx, broadcasterID+":"+keyTarget, func(ctx context.Context) (FollowageResult, time.Duration, error) {
+		reply, err := f.request(ctx, outgressrpc.FollowageRequest{
+			BroadcasterID: broadcasterID, TargetID: targetID, TargetLogin: targetLogin,
+		})
+		if err != nil {
+			return FollowageResult{}, 0, err
+		}
+		if reply.Error != "" {
+			return FollowageResult{}, 0, errors.New(reply.Error)
+		}
+		result := FollowageResult{
+			TargetID: reply.TargetID, UserFound: reply.UserFound,
+			Following: reply.Following, FollowedAt: reply.FollowedAt,
+		}
+		ttl := followageNegativeTTL
+		if result.Following {
+			ttl = followagePositiveTTL
+		}
+		return result, ttl, nil
+	})
+}

--- a/app/sesame/engine/followage_rpc.go
+++ b/app/sesame/engine/followage_rpc.go
@@ -48,8 +48,6 @@ func NewFollowageRPC(nc *nats.Conn, prefix string) *FollowageRPC {
 	}
 }
 
-func (f *FollowageRPC) Close() { f.cache.Close() }
-
 func (f *FollowageRPC) Lookup(ctx context.Context, broadcasterID, targetID, targetLogin string) (FollowageResult, error) {
 	keyTarget := targetID
 	if keyTarget == "" {

--- a/app/sesame/engine/followage_rpc_test.go
+++ b/app/sesame/engine/followage_rpc_test.go
@@ -24,7 +24,7 @@ func TestFollowageLookupCachesInSesame(t *testing.T) {
 			}, nil
 		},
 	}
-	defer f.Close()
+	defer f.cache.Close()
 
 	for range 2 {
 		result, err := f.Lookup(context.Background(), "channel", "viewer", "")

--- a/app/sesame/engine/followage_rpc_test.go
+++ b/app/sesame/engine/followage_rpc_test.go
@@ -1,0 +1,35 @@
+package engine
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	outgressrpc "ItsBagelBot/internal/domain/rpc/outgress"
+	"ItsBagelBot/pkg/cache"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFollowageLookupCachesInSesame(t *testing.T) {
+	var calls atomic.Int32
+	f := &FollowageRPC{
+		cache: cache.New[FollowageResult](100, time.Minute),
+		request: func(_ context.Context, req outgressrpc.FollowageRequest) (outgressrpc.FollowageReply, error) {
+			calls.Add(1)
+			return outgressrpc.FollowageReply{
+				TargetID: req.TargetID, UserFound: true, Following: true,
+				FollowedAt: time.Date(2024, time.January, 1, 0, 0, 0, 0, time.UTC),
+			}, nil
+		},
+	}
+	defer f.Close()
+
+	for range 2 {
+		result, err := f.Lookup(context.Background(), "channel", "viewer", "")
+		require.NoError(t, err)
+		require.True(t, result.Following)
+	}
+	require.Equal(t, int32(1), calls.Load(), "the second command lookup must be served by Sesame's cache")
+}

--- a/app/sesame/main.go
+++ b/app/sesame/main.go
@@ -123,14 +123,7 @@ func main() {
 		go reloadLexicon(ctx, dir, guard, log)
 	}
 
-	pipe := engine.NewPipeline(deps, registry, engine.Config{
-		BotID:            cfg.BotUserID,
-		OutgressPremium:  cfg.OutgressPremiumSubject,
-		OutgressStandard: cfg.OutgressStandardSubject,
-		CountUses:        true,
-		AutomodEnforce:   cfg.AutomodEnforce,
-		ShieldEnabled:    cfg.ShieldEnabled,
-	})
+	pipe := newPipeline(deps, registry, cfg)
 	defer pipe.Close() // flushes pending use-counter ticks on shutdown
 
 	if err := newConsumer(sub, nrApp, cfg, log).Start(ctx, pipe.Process); err != nil {
@@ -154,6 +147,17 @@ func main() {
 	<-ctx.Done()
 
 	log.Info("sesame shutting down")
+}
+
+func newPipeline(deps engine.Deps, registry *engine.Registry, cfg *config.Config) *engine.Pipeline {
+	return engine.NewPipeline(deps, registry, engine.Config{
+		BotID:            cfg.BotUserID,
+		OutgressPremium:  cfg.OutgressPremiumSubject,
+		OutgressStandard: cfg.OutgressStandardSubject,
+		CountUses:        true,
+		AutomodEnforce:   cfg.AutomodEnforce,
+		ShieldEnabled:    cfg.ShieldEnabled,
+	})
 }
 
 // emoteRefreshInterval is how often the global third-party emote sets are

--- a/app/sesame/main.go
+++ b/app/sesame/main.go
@@ -89,8 +89,6 @@ func main() {
 	// guard is the inline automod gate; hoisted so the emote refresher can install
 	// its false-positive-suppression sets onto the same instance.
 	guard := automod.New()
-	followage := engine.NewFollowageRPC(nc, cfg.OutgressRPCPrefix)
-	defer followage.Close()
 
 	deps := engine.Deps{
 		Proj:       proj,
@@ -103,7 +101,7 @@ func main() {
 		Commands:   engine.NewCommandsRPC(nc, cfg.CommandsDashboardPrefix),
 		Quotes:     engine.NewQuotesRPC(nc, cfg.ModulesRPCPrefix),
 		Gateway:    engine.NewGatewayRPC(nc, cfg.GatewayRPCPrefix),
-		Followage:  followage,
+		Followage:  engine.NewFollowageRPC(nc, cfg.OutgressRPCPrefix),
 		Log:        log,
 		Automod:    guard,
 		Reputation: engine.NewValkeyReputation(valkeyClient, 6*time.Hour, log),

--- a/app/sesame/main.go
+++ b/app/sesame/main.go
@@ -89,6 +89,8 @@ func main() {
 	// guard is the inline automod gate; hoisted so the emote refresher can install
 	// its false-positive-suppression sets onto the same instance.
 	guard := automod.New()
+	followage := engine.NewFollowageRPC(nc, cfg.OutgressRPCPrefix)
+	defer followage.Close()
 
 	deps := engine.Deps{
 		Proj:       proj,
@@ -101,6 +103,7 @@ func main() {
 		Commands:   engine.NewCommandsRPC(nc, cfg.CommandsDashboardPrefix),
 		Quotes:     engine.NewQuotesRPC(nc, cfg.ModulesRPCPrefix),
 		Gateway:    engine.NewGatewayRPC(nc, cfg.GatewayRPCPrefix),
+		Followage:  followage,
 		Log:        log,
 		Automod:    guard,
 		Reputation: engine.NewValkeyReputation(valkeyClient, 6*time.Hour, log),

--- a/app/sesame/modules/all.go
+++ b/app/sesame/modules/all.go
@@ -17,6 +17,7 @@ func All(d engine.Deps) []module.Module {
 		Shoutout(d),
 		Alerts(d),
 		Clip(d),
+		Followage(d),
 		Urchin(d),
 		Mcsr(d),
 		Fortnite(d),

--- a/app/sesame/modules/followage.go
+++ b/app/sesame/modules/followage.go
@@ -28,48 +28,61 @@ func Followage(d engine.Deps) module.Module {
 		log = zap.NewNop()
 	}
 	m := module.NewModule("", module.KindCore)
-	m.Command("followage").Everyone().Cooldown(followageCooldown).Run(func(ctx context.Context, c *module.Context, args string, emit module.Emit) error {
+	m.Command("followage").Everyone().Cooldown(followageCooldown).Run(followageRun(d, log))
+	return m.Build()
+}
+
+type followageTarget struct {
+	login string
+	name  string
+	id    string
+}
+
+func followageRun(d engine.Deps, log *zap.Logger) module.RunFunc {
+	return func(ctx context.Context, c *module.Context, args string, emit module.Emit) error {
 		if !followageEnabled(ctx, d, c.BroadcasterID, log) {
 			return nil
 		}
-		targetLogin := ""
-		if fields := strings.Fields(args); len(fields) > 0 {
-			targetLogin = strings.TrimPrefix(fields[0], "@")
-		}
-		targetName, targetID := targetLogin, ""
-		if targetLogin == "" {
-			targetLogin = c.Env.ChatterUserLogin
-			targetName = c.Env.ChatterName()
-			targetID = c.Env.ChatterUserID
-		}
-		if targetName == "" {
-			targetName = targetLogin
-		}
-		if d.Followage == nil {
-			emitFollowage(c, "Followage is unavailable right now.", emit)
-			return nil
-		}
-		result, err := d.Followage.Lookup(ctx, c.Env.BroadcasterUserID, targetID, targetLogin)
-		if err != nil {
-			log.Warn("followage: lookup failed", zap.Error(err))
-			emitFollowage(c, "Followage is unavailable right now.", emit)
-			return nil
-		}
-		var reply string
-		switch {
-		case !result.UserFound:
-			reply = fmt.Sprintf("@%s is not a Twitch user.", targetName)
-		case result.TargetID == c.Env.BroadcasterUserID:
-			reply = fmt.Sprintf("@%s is the broadcaster.", targetName)
-		case !result.Following:
-			reply = fmt.Sprintf("@%s is not following this channel.", targetName)
-		default:
-			reply = fmt.Sprintf("@%s has followed for %s.", targetName, humanizeFollowage(time.Since(result.FollowedAt)))
-		}
-		emitFollowage(c, reply, emit)
+		target := parseFollowageTarget(args, c)
+		emitFollowage(c, followageText(ctx, d.Followage, target, c.Env.BroadcasterUserID, log), emit)
 		return nil
-	})
-	return m.Build()
+	}
+}
+
+func parseFollowageTarget(args string, c *module.Context) followageTarget {
+	fields := strings.Fields(args)
+	if len(fields) > 0 {
+		login := strings.TrimPrefix(fields[0], "@")
+		if login != "" {
+			return followageTarget{login: login, name: login}
+		}
+	}
+	return followageTarget{login: c.Env.ChatterUserLogin, name: c.Env.ChatterName(), id: c.Env.ChatterUserID}
+}
+
+func followageText(ctx context.Context, lookup engine.FollowageLookup, target followageTarget, broadcasterID string, log *zap.Logger) string {
+	if lookup == nil {
+		return "Followage is unavailable right now."
+	}
+	result, err := lookup.Lookup(ctx, broadcasterID, target.id, target.login)
+	if err != nil {
+		log.Warn("followage: lookup failed", zap.Error(err))
+		return "Followage is unavailable right now."
+	}
+	return formatFollowageResult(target.name, broadcasterID, result)
+}
+
+func formatFollowageResult(targetName, broadcasterID string, result engine.FollowageResult) string {
+	if !result.UserFound {
+		return fmt.Sprintf("@%s is not a Twitch user.", targetName)
+	}
+	if result.TargetID == broadcasterID {
+		return fmt.Sprintf("@%s is the broadcaster.", targetName)
+	}
+	if !result.Following {
+		return fmt.Sprintf("@%s is not following this channel.", targetName)
+	}
+	return fmt.Sprintf("@%s has followed for %s.", targetName, humanizeFollowage(time.Since(result.FollowedAt)))
 }
 
 func emitFollowage(c *module.Context, text string, emit module.Emit) {

--- a/app/sesame/modules/followage.go
+++ b/app/sesame/modules/followage.go
@@ -1,0 +1,123 @@
+package modules
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"ItsBagelBot/app/sesame/engine"
+	"ItsBagelBot/app/sesame/module"
+	"ItsBagelBot/internal/domain/outgress"
+
+	"go.uber.org/zap"
+)
+
+const (
+	followageModuleName = "followage"
+	followageCooldown   = 15 * time.Second
+)
+
+// Followage owns the complete built-in !followage [user] command: target
+// normalization, cached lookup through Sesame's Followage service, result
+// formatting, and the chat reply. Outgress only performs the authenticated
+// Twitch read behind that request/reply boundary.
+func Followage(d engine.Deps) module.Module {
+	log := d.Log
+	if log == nil {
+		log = zap.NewNop()
+	}
+	m := module.NewModule("", module.KindCore)
+	m.Command("followage").Everyone().Cooldown(followageCooldown).Run(func(ctx context.Context, c *module.Context, args string, emit module.Emit) error {
+		if !followageEnabled(ctx, d, c.BroadcasterID, log) {
+			return nil
+		}
+		targetLogin := ""
+		if fields := strings.Fields(args); len(fields) > 0 {
+			targetLogin = strings.TrimPrefix(fields[0], "@")
+		}
+		targetName, targetID := targetLogin, ""
+		if targetLogin == "" {
+			targetLogin = c.Env.ChatterUserLogin
+			targetName = c.Env.ChatterName()
+			targetID = c.Env.ChatterUserID
+		}
+		if targetName == "" {
+			targetName = targetLogin
+		}
+		if d.Followage == nil {
+			emitFollowage(c, "Followage is unavailable right now.", emit)
+			return nil
+		}
+		result, err := d.Followage.Lookup(ctx, c.Env.BroadcasterUserID, targetID, targetLogin)
+		if err != nil {
+			log.Warn("followage: lookup failed", zap.Error(err))
+			emitFollowage(c, "Followage is unavailable right now.", emit)
+			return nil
+		}
+		var reply string
+		switch {
+		case !result.UserFound:
+			reply = fmt.Sprintf("@%s is not a Twitch user.", targetName)
+		case result.TargetID == c.Env.BroadcasterUserID:
+			reply = fmt.Sprintf("@%s is the broadcaster.", targetName)
+		case !result.Following:
+			reply = fmt.Sprintf("@%s is not following this channel.", targetName)
+		default:
+			reply = fmt.Sprintf("@%s has followed for %s.", targetName, humanizeFollowage(time.Since(result.FollowedAt)))
+		}
+		emitFollowage(c, reply, emit)
+		return nil
+	})
+	return m.Build()
+}
+
+func emitFollowage(c *module.Context, text string, emit module.Emit) {
+	emit(&module.Output{Type: outgress.TypeChat, BroadcasterID: c.Env.BroadcasterUserID, Text: text})
+}
+
+func humanizeFollowage(d time.Duration) string {
+	if d < 0 {
+		d = 0
+	}
+	minutes := int64(d / time.Minute)
+	if minutes < 1 {
+		return "less than a minute"
+	}
+	units := []struct {
+		minutes int64
+		name    string
+	}{{365 * 24 * 60, "year"}, {30 * 24 * 60, "month"}, {24 * 60, "day"}, {60, "hour"}, {1, "minute"}}
+	parts := make([]string, 0, 2)
+	for _, unit := range units {
+		if n := minutes / unit.minutes; n > 0 {
+			name := unit.name
+			if n != 1 {
+				name += "s"
+			}
+			parts = append(parts, fmt.Sprintf("%d %s", n, name))
+			minutes %= unit.minutes
+			if len(parts) == 2 {
+				break
+			}
+		}
+	}
+	return strings.Join(parts, ", ")
+}
+
+func followageEnabled(ctx context.Context, d engine.Deps, broadcasterID uint64, log *zap.Logger) bool {
+	if d.Proj == nil {
+		return true
+	}
+	views, err := d.Proj.Modules(ctx, broadcasterID)
+	if err != nil {
+		log.Warn("followage: module state read failed, allowing", zap.Uint64("broadcaster_id", broadcasterID), zap.Error(err))
+		return true
+	}
+	for _, v := range views {
+		if v.Name == followageModuleName {
+			return v.IsEnabled
+		}
+	}
+	return true
+}

--- a/app/sesame/modules/followage.go
+++ b/app/sesame/modules/followage.go
@@ -27,9 +27,15 @@ func Followage(d engine.Deps) module.Module {
 	if log == nil {
 		log = zap.NewNop()
 	}
+	runtime := followageRuntime{lookup: d.Followage, log: log}
 	m := module.NewModule("", module.KindCore)
-	m.Command("followage").Everyone().Cooldown(followageCooldown).Run(followageRun(d, log))
+	m.Command("followage").Everyone().Cooldown(followageCooldown).Run(followageRun(d, runtime))
 	return m.Build()
+}
+
+type followageRuntime struct {
+	lookup engine.FollowageLookup
+	log    *zap.Logger
 }
 
 type followageTarget struct {
@@ -38,13 +44,13 @@ type followageTarget struct {
 	id    string
 }
 
-func followageRun(d engine.Deps, log *zap.Logger) module.RunFunc {
+func followageRun(d engine.Deps, runtime followageRuntime) module.RunFunc {
 	return func(ctx context.Context, c *module.Context, args string, emit module.Emit) error {
-		if !followageEnabled(ctx, d, c.BroadcasterID, log) {
+		if !followageEnabled(ctx, d, c.BroadcasterID, runtime.log) {
 			return nil
 		}
 		target := parseFollowageTarget(args, c)
-		emitFollowage(c, followageText(ctx, d.Followage, target, c.Env.BroadcasterUserID, log), emit)
+		emitFollowage(c, runtime.text(ctx, target, c.Env.BroadcasterUserID), emit)
 		return nil
 	}
 }
@@ -60,13 +66,13 @@ func parseFollowageTarget(args string, c *module.Context) followageTarget {
 	return followageTarget{login: c.Env.ChatterUserLogin, name: c.Env.ChatterName(), id: c.Env.ChatterUserID}
 }
 
-func followageText(ctx context.Context, lookup engine.FollowageLookup, target followageTarget, broadcasterID string, log *zap.Logger) string {
-	if lookup == nil {
+func (r followageRuntime) text(ctx context.Context, target followageTarget, broadcasterID string) string {
+	if r.lookup == nil {
 		return "Followage is unavailable right now."
 	}
-	result, err := lookup.Lookup(ctx, broadcasterID, target.id, target.login)
+	result, err := r.lookup.Lookup(ctx, broadcasterID, target.id, target.login)
 	if err != nil {
-		log.Warn("followage: lookup failed", zap.Error(err))
+		r.log.Warn("followage: lookup failed", zap.Error(err))
 		return "Followage is unavailable right now."
 	}
 	return formatFollowageResult(target.name, broadcasterID, result)

--- a/app/sesame/modules/followage_test.go
+++ b/app/sesame/modules/followage_test.go
@@ -1,0 +1,90 @@
+package modules
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"ItsBagelBot/app/sesame/engine"
+	"ItsBagelBot/app/sesame/module"
+	"ItsBagelBot/internal/domain/event/lane"
+	"ItsBagelBot/internal/domain/outgress"
+	"ItsBagelBot/internal/projection"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+type fakeFollowage struct {
+	result engine.FollowageResult
+	err    error
+	got    struct{ broadcasterID, targetID, targetLogin string }
+}
+
+func (f *fakeFollowage) Lookup(_ context.Context, broadcasterID, targetID, targetLogin string) (engine.FollowageResult, error) {
+	f.got = struct{ broadcasterID, targetID, targetLogin string }{broadcasterID, targetID, targetLogin}
+	return f.result, f.err
+}
+
+func followageCommand(t *testing.T, d engine.Deps) module.Command {
+	t.Helper()
+	for _, cmd := range Followage(d).Commands {
+		if cmd.Name == "followage" {
+			return cmd
+		}
+	}
+	t.Fatal("followage command not found")
+	return module.Command{}
+}
+
+func followageContext() *module.Context {
+	return &module.Context{Env: lane.Envelope{
+		BroadcasterUserID: "5", ChatterUserID: "9", ChatterUserLogin: "viewer", ChatterUserName: "Viewer",
+	}, BroadcasterID: 5}
+}
+
+func TestFollowageDefaultsToChatter(t *testing.T) {
+	lookup := &fakeFollowage{result: engine.FollowageResult{
+		TargetID: "9", UserFound: true, Following: true, FollowedAt: time.Now().Add(-40 * 24 * time.Hour),
+	}}
+	cmd := followageCommand(t, engine.Deps{Followage: lookup, Log: zap.NewNop()})
+	var col collector
+	require.NoError(t, cmd.Run(context.Background(), followageContext(), "", col.emit))
+	require.Len(t, col.out, 1)
+	assert.Equal(t, outgress.TypeChat, col.out[0].Type)
+	assert.Equal(t, "@Viewer has followed for 1 month, 10 days.", col.out[0].Text)
+	assert.Equal(t, "9", lookup.got.targetID)
+	assert.Equal(t, followageCooldown, cmd.Cooldown)
+}
+
+func TestFollowageAcceptsTargetLogin(t *testing.T) {
+	lookup := &fakeFollowage{result: engine.FollowageResult{TargetID: "10", UserFound: true}}
+	cmd := followageCommand(t, engine.Deps{Followage: lookup, Log: zap.NewNop()})
+	var col collector
+	require.NoError(t, cmd.Run(context.Background(), followageContext(), "@Other ignored", col.emit))
+	require.Len(t, col.out, 1)
+	assert.Equal(t, "Other", lookup.got.targetLogin)
+	assert.Equal(t, "@Other is not following this channel.", col.out[0].Text)
+}
+
+func TestFollowageLookupFailureRepliesUnavailable(t *testing.T) {
+	cmd := followageCommand(t, engine.Deps{Followage: &fakeFollowage{err: errors.New("boom")}, Log: zap.NewNop()})
+	var col collector
+	require.NoError(t, cmd.Run(context.Background(), followageContext(), "", col.emit))
+	require.Len(t, col.out, 1)
+	assert.Equal(t, "Followage is unavailable right now.", col.out[0].Text)
+}
+
+func TestFollowageToggleSuppressesCommand(t *testing.T) {
+	reader := clipReader{modules: []projection.ModuleView{{Name: "followage", IsEnabled: false}}}
+	cmd := followageCommand(t, engine.Deps{Proj: reader, Log: zap.NewNop()})
+	var col collector
+	require.NoError(t, cmd.Run(context.Background(), followageContext(), "", col.emit))
+	assert.Empty(t, col.out)
+}
+
+func TestHumanizeFollowage(t *testing.T) {
+	assert.Equal(t, "2 years, 3 months", humanizeFollowage((2*365+3*30+4)*24*time.Hour))
+}

--- a/console/shared/lib/types.ts
+++ b/console/shared/lib/types.ts
@@ -85,6 +85,21 @@ export interface BuiltinCommandDef {
 
 export const BUILTIN_COMMANDS: readonly BuiltinCommandDef[] = [
   {
+    id: 'followage',
+    label: 'Followage',
+    summary: 'Built-in · shows how long a viewer has followed the channel.',
+    description:
+      'Shows how long you or another Twitch user has followed the channel. Add a username to look up someone else.',
+    usage: ['!followage', '!followage <user>'],
+    preview: '@{target} has followed for 8 months.',
+    previewArgs: 'viewer',
+    previewSamples: { target: 'viewer' },
+    defaultActive: true,
+    defaultPerm: 'everyone',
+    defaultCooldown: 15,
+    liveOnly: false
+  },
+  {
     id: 'clip',
     label: 'Clip',
     summary: 'Built-in · clips the last moments of the stream and posts the link.',

--- a/internal/domain/rpc/outgress/outgress.go
+++ b/internal/domain/rpc/outgress/outgress.go
@@ -1,0 +1,19 @@
+// Package outgress defines request/reply contracts for authenticated Twitch
+// reads exposed by the outgress service to Sesame.
+package outgress
+
+import "time"
+
+type FollowageRequest struct {
+	BroadcasterID string `json:"broadcaster_id"`
+	TargetID      string `json:"target_id,omitempty"`
+	TargetLogin   string `json:"target_login,omitempty"`
+}
+
+type FollowageReply struct {
+	TargetID   string    `json:"target_id,omitempty"`
+	UserFound  bool      `json:"user_found"`
+	Following  bool      `json:"following"`
+	FollowedAt time.Time `json:"followed_at,omitempty"`
+	Error      string    `json:"error,omitempty"`
+}

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -45,30 +45,34 @@ func New[V any](capacity int64, ttl time.Duration) *Cache[V] {
 // Only one loader runs per key at a time, regardless of how many goroutines
 // miss concurrently; the others wait and share the same result.
 func (c *Cache[V]) GetOrLoad(ctx context.Context, key string, loader func(context.Context) (V, error)) (V, error) {
+	return c.GetOrLoadTTL(ctx, key, func(ctx context.Context) (V, time.Duration, error) {
+		value, err := loader(ctx)
+		return value, c.ttl, err
+	})
+}
+
+// GetOrLoadTTL is GetOrLoad with a loader-selected TTL. It is useful when
+// positive and negative results need different freshness windows. Failed loads
+// are never cached, and concurrent misses remain singleflight-collapsed.
+func (c *Cache[V]) GetOrLoadTTL(ctx context.Context, key string, loader func(context.Context) (V, time.Duration, error)) (V, error) {
 	if value, ok := c.client.Get(key); ok {
 		return value, nil
 	}
-
 	result, err, _ := c.group.Do(key, func() (any, error) {
-		// A previous flight may have filled the key while we queued.
 		if value, ok := c.client.Get(key); ok {
 			return value, nil
 		}
-
-		value, err := loader(ctx)
+		value, ttl, err := loader(ctx)
 		if err != nil {
 			return value, err
 		}
-
-		c.Set(key, value)
+		c.SetFor(key, value, ttl)
 		return value, nil
 	})
-
 	if err != nil {
 		var zero V
 		return zero, err
 	}
-
 	return result.(V), nil
 }
 
@@ -76,6 +80,13 @@ func (c *Cache[V]) GetOrLoad(ctx context.Context, key string, loader func(contex
 func (c *Cache[V]) Set(key string, value V) {
 	jitteredTTL := c.ttl + rand.N(c.jitter+1)
 	c.client.SetWithTTL(key, value, 1, jitteredTTL)
+}
+
+// SetFor stores value with a caller-selected TTL and the same 0–10% expiry
+// jitter as Set.
+func (c *Cache[V]) SetFor(key string, value V, ttl time.Duration) {
+	jitter := ttl / 10
+	c.client.SetWithTTL(key, value, 1, ttl+rand.N(jitter+1))
 }
 
 // Invalidate drops key from the cache and forgets any in-flight load for it,

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -87,6 +87,29 @@ func TestGetOrLoadDoesNotCacheErrors(t *testing.T) {
 	assert.Equal(t, int32(2), calls.Load(), "errors must not be cached")
 }
 
+func TestGetOrLoadTTLUsesLoaderTTL(t *testing.T) {
+	c := New[string](1000, time.Minute)
+	defer c.Close()
+
+	var calls atomic.Int32
+	loader := func(context.Context) (string, time.Duration, error) {
+		calls.Add(1)
+		return "value", 20 * time.Millisecond, nil
+	}
+
+	for range 2 {
+		value, err := c.GetOrLoadTTL(context.Background(), "key", loader)
+		require.NoError(t, err)
+		require.Equal(t, "value", value)
+	}
+	require.Equal(t, int32(1), calls.Load())
+
+	time.Sleep(30 * time.Millisecond) // past selected TTL plus maximum jitter
+	_, err := c.GetOrLoadTTL(context.Background(), "key", loader)
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), calls.Load())
+}
+
 func TestEntriesExpire(t *testing.T) {
 	c := New[string](1000, 20*time.Millisecond)
 	defer c.Close()


### PR DESCRIPTION
## What changed

- adds the built-in `!followage [user]` command to Sesame and the dashboard catalog
- keeps command ownership, response formatting, cooldowns, toggles, and caching in Sesame
- exposes a narrow authenticated follower lookup from Outgress
- caches positive follower results for 15 minutes and negative results for 1 minute with singleflight miss collapsing

## Why

Followage needs Twitch's moderator-scoped follower data, but command behavior belongs in Sesame. This split keeps OAuth-bound reads in Outgress while avoiding repeated Helix requests from active chats.

## Validation

- `go test ./...`
- `bun run check` (no errors; existing CSS warnings only)
- `bun test shared` (40 passed, 1 integration test skipped)
