### PR TITLE
feat(loyalty): create reward counters inline + live-only gate + cleaner editor

### DIFF
--- a/app/sesame/modules/channelpoints.go
+++ b/app/sesame/modules/channelpoints.go
@@ -69,6 +69,11 @@ type rewardBinding struct {
 	// per redemption — channel points buying channel currency. Exposed to
 	// Message as {points}.
 	Points int64 `json:"points"`
+	// LiveOnly gates the loyalty writes (counter bump + points award) to when
+	// the broadcaster is live, so channel points redeemed offline cannot farm
+	// currency or inflate a counter. The chat reply and queue resolution still
+	// run either way.
+	LiveOnly bool `json:"liveOnly"`
 }
 
 // redemptionEvent is the subset of the redemption.add EventSub payload we use.
@@ -119,14 +124,34 @@ func ChannelPoints(d engine.Deps) module.Module {
 			return nil
 		}
 
-		awardRewardPoints(d, c, binding, ev)
-		counterValue := bumpRewardCounter(ctx, d, c, binding, ev)
+		// Loyalty writes are the only live-gated part; the chat reply and queue
+		// resolution always run. Skipping the counter bump also skips its
+		// {counter} value, so the template renders without the token — the same
+		// as an unbound counter.
+		var counterValue string
+		if loyaltyLive(ctx, d, c.BroadcasterID, binding.LiveOnly) {
+			awardRewardPoints(d, c, binding, ev)
+			counterValue = bumpRewardCounter(ctx, d, c, binding, ev)
+		}
 		emitRewardAction(binding, ev, counterValue, emit)
 		emitRedemptionResolution(binding, ev, emit)
 		return nil
 	})
 
 	return m.Build()
+}
+
+// loyaltyLive reports whether the binding's loyalty writes may run: always
+// when the binding is not live-gated, otherwise only while the broadcaster is
+// live. A live-check error fails closed (skip the writes) so an offline redeem
+// is never credited on a transient read failure. A nil live store passes (the
+// gate has nothing to consult).
+func loyaltyLive(ctx context.Context, d engine.Deps, broadcasterID uint64, liveOnly bool) bool {
+	if !liveOnly || d.Live == nil {
+		return true
+	}
+	live, err := d.Live.IsLive(ctx, broadcasterID)
+	return err == nil && live
 }
 
 // awardRewardPoints hands the binding's loyalty-point award (if any) to the

--- a/app/sesame/modules/loyalty_test.go
+++ b/app/sesame/modules/loyalty_test.go
@@ -296,6 +296,28 @@ func TestChannelPointsPointsAward(t *testing.T) {
 	assert.Equal(t, "CoolViewer bought 250 points!", col.out[0].Text)
 }
 
+func TestChannelPointsLoyaltyLiveOnly(t *testing.T) {
+	cfg := `{"rewards":[{"id":"r1","action":"chat","message":"{user} +1","counter":"deaths","points":50,"liveOnly":true}]}`
+	ev := `{"id":"red1","broadcaster_user_id":"2","user_id":"7","user_name":"CoolViewer","user_login":"coolviewer","reward":{"id":"r1","title":"+1 death","cost":100}}`
+
+	// Offline: the chat reply still fires, but no counter bump and no points.
+	offline := &fakeLoyalty{}
+	m := ChannelPoints(engine.Deps{Loyalty: offline, Live: &fakeLive{live: false}, Log: zap.NewNop()})
+	var col collector
+	require.NoError(t, m.Events[redemptionAddType](context.Background(), loyaltyCtx(redemptionAddType, ev, cfg), col.emit))
+	assert.Empty(t, offline.bumps, "offline redeem must not bump the counter")
+	assert.Empty(t, offline.earns, "offline redeem must not award points")
+	require.Len(t, col.out, 1, "chat reply still runs offline")
+
+	// Live: both loyalty writes happen.
+	online := &fakeLoyalty{}
+	m = ChannelPoints(engine.Deps{Loyalty: online, Live: &fakeLive{live: true}, Log: zap.NewNop()})
+	col = collector{}
+	require.NoError(t, m.Events[redemptionAddType](context.Background(), loyaltyCtx(redemptionAddType, ev, cfg), col.emit))
+	assert.Len(t, online.bumps, 1, "live redeem bumps the counter")
+	assert.Len(t, online.earns, 1, "live redeem awards points")
+}
+
 func TestChannelPointsCounterBinding(t *testing.T) {
 	fake := &fakeLoyalty{}
 	m := ChannelPoints(engine.Deps{Loyalty: fake, Log: zap.NewNop()})

--- a/console/dashboard/src/lib/components/channelpoints/RewardEditor.svelte
+++ b/console/dashboard/src/lib/components/channelpoints/RewardEditor.svelte
@@ -4,7 +4,7 @@
   // travels as one JSON field; the server validates and normalizes it.
   import { enhance } from '$app/forms';
   import type { SubmitFunction } from '@sveltejs/kit';
-  import { Icon, getI18n, type ChannelPointReward } from '@bagel/shared';
+  import { Icon, RadioGroup, getI18n, type ChannelPointReward, type CounterScope } from '@bagel/shared';
   import CheckButton from '$lib/components/CheckButton.svelte';
   import ResponseEditor from '$lib/components/commands/ResponseEditor.svelte';
   import ChatPreview from '$lib/components/commands/ChatPreview.svelte';
@@ -60,6 +60,27 @@
     counter: '42',
     points: String(draft.points || 0)
   });
+
+  // Loyalty hooks are opt-in per reward: two toggles gate the counter and the
+  // points award, so an ordinary reward's editor stays clean. Toggling off
+  // clears the underlying value, so a hidden field never saves a stale binding.
+  let counterOn = $state(!!draft.counter.trim());
+  let pointsOn = $state(draft.points > 0);
+  $effect(() => {
+    if (!counterOn && draft.counter) draft.counter = '';
+  });
+  $effect(() => {
+    if (!pointsOn && draft.points) draft.points = 0;
+  });
+
+  // Scope choices for a NEW counter, in the order a reward usually wants them.
+  const SCOPES: readonly { value: CounterScope; label: string; desc: string }[] = [
+    { value: 'viewer_command', label: t('rewardCounter.scopeViewerReward'), desc: t('rewardCounter.scopeViewerRewardDesc') },
+    { value: 'viewer', label: t('rewardCounter.scopeViewer'), desc: t('rewardCounter.scopeViewerDesc') },
+    { value: 'channel', label: t('rewardCounter.scopeChannel'), desc: t('rewardCounter.scopeChannelDesc') }
+  ];
+  const scopeOptions = SCOPES.map((s) => ({ value: s.value, label: s.label }));
+  const scopeDesc = $derived(SCOPES.find((s) => s.value === draft.counterScope)?.desc ?? '');
 </script>
 
 <form method="POST" action={isNew ? '?/create' : '?/update'} class="editor" novalidate use:enhance={onSubmit}>
@@ -118,20 +139,61 @@
     <small>{t('channelpoints.queueHint')}</small>
   </label>
 
-  <!-- Loyalty hooks: bump a counter and/or award channel currency per redemption. -->
-  <div class="limits">
-    <span class="limits-title">{t('channelpoints.loyaltyTitle')}</span>
-    <label class="field" style="margin-bottom:0">
-      <span>{t('channelpoints.fieldCounter')} <small>{t('common.optional')}</small></span>
-      <input class="search" placeholder={t('channelpoints.fieldCounterPh')} maxlength="64" bind:value={draft.counter} />
-      <small>{t('channelpoints.fieldCounterHint')}</small>
-    </label>
-    <label class="field" style="margin-bottom:0">
-      <span>{t('channelpoints.fieldPoints')} <small>{t('common.optional')}</small></span>
-      <input class="search num" type="number" min="0" bind:value={draft.points} />
-      <small>{t('channelpoints.fieldPointsHint')}</small>
-    </label>
-  </div>
+  <!-- Loyalty hooks: an opt-in counter and/or a points award per redemption.
+       Each is a toggle that reveals its own controls, so a plain reward's
+       editor never shows loyalty plumbing it isn't using. -->
+  <section class="hooks">
+    <header class="hooks-head">
+      <Icon name="gem" size={13} />
+      <span>{t('channelpoints.loyaltyTitle')}</span>
+    </header>
+
+    <div class="hook">
+      <CheckButton bind:checked={counterOn} label={t('rewardCounter.enable')} />
+      {#if counterOn}
+        <div class="hook-body">
+          <label class="field">
+            <span>{t('rewardCounter.nameLabel')}</span>
+            <input class="search" placeholder={t('channelpoints.fieldCounterPh')} maxlength="64" bind:value={draft.counter} />
+            <small>{t('rewardCounter.nameHint')}</small>
+          </label>
+
+          <div class="field">
+            <span class="field-label">{t('rewardCounter.scopeLabel')}</span>
+            <RadioGroup name="counterScope" bind:value={draft.counterScope} options={scopeOptions} label={t('rewardCounter.scopeLabel')} />
+            <small>{scopeDesc}</small>
+          </div>
+
+          <p class="token-note">{t('rewardCounter.tokenNote')}</p>
+        </div>
+      {/if}
+    </div>
+
+    <div class="hook">
+      <CheckButton bind:checked={pointsOn} label={t('rewardCounter.pointsEnable')} />
+      {#if pointsOn}
+        <div class="hook-body">
+          <label class="field points-field">
+            <span>{t('rewardCounter.pointsLabel')}</span>
+            <div class="points-input">
+              <span class="plus">+</span>
+              <input class="search num" type="number" min="1" bind:value={draft.points} />
+            </div>
+            <small>{t('rewardCounter.pointsHint')}</small>
+          </label>
+        </div>
+      {/if}
+    </div>
+
+    {#if counterOn || pointsOn}
+      <!-- Live-only gate: offline redeems still reply in chat, but don't touch
+           the counter or grant points. Only meaningful when a hook is on. -->
+      <div class="hook live-gate">
+        <CheckButton bind:checked={draft.liveOnly} label={t('rewardCounter.liveOnly')} />
+        <small class="live-hint">{t('rewardCounter.liveOnlyHint')}</small>
+      </div>
+    {/if}
+  </section>
 
   <div class="limits">
     <span class="limits-title">{t('channelpoints.limits')}</span>
@@ -202,6 +264,79 @@
 
   .check { margin: 4px 0 14px; }
   .check :global(.cb) { align-items: center; }
+
+  /* ── Loyalty hooks: two toggle-gated blocks ───────────────────────────── */
+  .hooks {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    border: 1px solid var(--rule, rgba(240, 236, 228, 0.08));
+    border-radius: 10px;
+    padding: 14px;
+    margin-bottom: 14px;
+  }
+  .hooks-head {
+    display: flex;
+    align-items: center;
+    gap: 7px;
+    font-family: var(--bb-font-body);
+    font-size: 12.5px;
+    letter-spacing: 0.02em;
+    color: var(--bb-muted);
+    margin-bottom: 4px;
+  }
+  .hook { display: flex; flex-direction: column; }
+  .hook + .hook { border-top: 1px solid rgba(240, 236, 228, 0.06); padding-top: 12px; margin-top: 6px; }
+  .hook :global(.cb) { align-items: center; }
+
+  /* Revealed controls sit indented under their toggle, with a soft rail so the
+     grouping reads at a glance. */
+  .hook-body {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    margin: 12px 0 4px;
+    padding-left: 14px;
+    border-left: 2px solid var(--ui-accent-soft, rgba(240, 236, 228, 0.1));
+  }
+  .hook-body .field { margin-bottom: 0; }
+  .field-label {
+    font-family: var(--bb-font-body);
+    font-size: 12.5px;
+    color: var(--bb-muted);
+    letter-spacing: 0.01em;
+  }
+
+  .token-note {
+    margin: 0;
+    font-family: var(--bb-font-mono);
+    font-size: 11.5px;
+    color: var(--bb-muted);
+    background: rgba(0, 0, 0, 0.28);
+    border: 1px solid var(--bb-border);
+    border-radius: 7px;
+    padding: 8px 10px;
+    line-height: 1.5;
+  }
+
+  .live-gate { gap: 4px; }
+  .live-hint {
+    color: var(--bb-muted);
+    opacity: 0.75;
+    font-size: 11px;
+    font-family: var(--bb-font-body);
+    margin: 2px 0 0 26px;
+  }
+
+  .points-field { max-width: 220px; }
+  .points-input { display: flex; align-items: center; gap: 8px; }
+  .points-input .plus {
+    font-family: var(--bb-font-display);
+    font-size: 17px;
+    color: var(--bb-muted);
+    line-height: 1;
+  }
+  .points-input .num { width: 120px; }
 
   .limits {
     display: flex;

--- a/console/dashboard/src/lib/server/channelpoints-store.ts
+++ b/console/dashboard/src/lib/server/channelpoints-store.ts
@@ -18,6 +18,7 @@ import { rpc } from '@bagel/shared/server/nats';
 import type { ChannelPointReward } from '@bagel/shared';
 import { SUB, publishEventSubEnsureOptional } from './services';
 import { listModules, upsertModule } from './commands-store';
+import { createCounter } from './loyalty-store';
 
 const CP_MODULE = 'channelpoints';
 
@@ -104,8 +105,24 @@ function mergeTwitch(tw: RewardWire, local: ChannelPointReward): ChannelPointRew
     message: local.message,
     onRedeem: local.onRedeem,
     counter: local.counter,
-    points: local.points
+    counterScope: local.counterScope,
+    points: local.points,
+    liveOnly: local.liveOnly
   };
+}
+
+// ensureRewardCounter creates the reward's bound counter with the chosen scope
+// if it doesn't exist yet, so a broadcaster can make the counter straight from
+// the reward editor. Best-effort: the reward binding is the authoritative save,
+// so a loyalty-service blip (or the service not yet deployed) must not fail the
+// reward write. Create is idempotent — an existing counter keeps its scope.
+async function ensureRewardCounter(userId: string, reward: ChannelPointReward): Promise<void> {
+  if (!reward.counter) return;
+  try {
+    await createCounter(userId, reward.counter, reward.counterScope);
+  } catch (e) {
+    console.error('[channelpoints] ensure counter failed:', e instanceof Error ? (e.stack ?? e.message) : e);
+  }
 }
 
 // readRewards loads the current bindings blob (enable flag + reward records).
@@ -136,6 +153,7 @@ export async function createReward(userId: string, draft: ChannelPointReward): P
   // later adds preserve whatever enable state the broadcaster set.
   const enabled = cur.rewards.length === 0 ? true : cur.enabled;
   await writeRewards(userId, enabled, [...cur.rewards, created]);
+  await ensureRewardCounter(userId, created);
   await publishEventSubEnsureOptional(userId);
   return { ok: true, reward: created };
 }
@@ -150,6 +168,7 @@ export async function updateReward(userId: string, draft: ChannelPointReward): P
   const cur = await readRewards(userId);
   const rewards = cur.rewards.map((r) => (r.id === draft.id ? updated : r));
   await writeRewards(userId, cur.enabled, rewards);
+  await ensureRewardCounter(userId, updated);
   return { ok: true, reward: updated };
 }
 

--- a/console/dashboard/src/routes/(app)/channelpoints/+page.server.ts
+++ b/console/dashboard/src/routes/(app)/channelpoints/+page.server.ts
@@ -1,6 +1,6 @@
 import type { Actions, PageServerLoad } from './$types';
-import type { ChannelPointReward, RewardActionKind, RewardOnRedeem } from '@bagel/shared';
-import { REWARD_ACTIONS, REWARD_ON_REDEEM, blankReward } from '@bagel/shared';
+import type { ChannelPointReward, CounterScope, RewardActionKind, RewardOnRedeem } from '@bagel/shared';
+import { COUNTER_SCOPES, REWARD_ACTIONS, REWARD_ON_REDEEM, blankReward } from '@bagel/shared';
 import {
   readRewards,
   createReward,
@@ -105,7 +105,11 @@ function parseReward(raw: string): ChannelPointReward | null {
     // Loyalty hooks. The counter name mirrors sesame's normalization (bare
     // key, lower-cased); points are clamped to the same ceiling as a mod grant.
     counter: String(obj.counter ?? '').trim().replace(/^!/, '').toLowerCase().slice(0, 64),
-    points: clampInt(obj.points, 0, 100_000_000, 0)
+    counterScope: COUNTER_SCOPES.includes(obj.counterScope as CounterScope)
+      ? (obj.counterScope as CounterScope)
+      : 'viewer_command',
+    points: clampInt(obj.points, 0, 100_000_000, 0),
+    liveOnly: obj.liveOnly === true
   };
 }
 

--- a/console/dashboard/src/routes/(app)/loyalty/+page.svelte
+++ b/console/dashboard/src/routes/(app)/loyalty/+page.svelte
@@ -81,6 +81,8 @@
         <span class="master-hint">{t('loyalty.botOnHint')}</span>
       </span>
     </form>
+    <div class="grow"></div>
+    <a class="btn ghost" href="/counters"><Icon name="modules" size={14} /> {t('loyalty.countersLink')}</a>
   </div>
 
   <div class="grid">

--- a/console/shared/lib/i18n/en.ts
+++ b/console/shared/lib/i18n/en.ts
@@ -367,6 +367,8 @@ export const en = {
     fieldCounter: 'Bump a counter',
     fieldCounterPh: 'e.g. deaths',
     fieldCounterHint: 'Each redemption adds 1 to this counter (create it on the Counters page).',
+    fieldCounterScope: 'Count the reward per…',
+    fieldCounterScopeHint: 'Only used when creating the counter here. Reward title separates each reward’s per-user tally.',
     fieldPoints: 'Award loyalty points',
     fieldPointsHint: 'Points the redeemer earns per redemption. 0 awards nothing.',
     // actions + toasts
@@ -417,9 +419,29 @@ export const en = {
     chatTitle: 'Chat commands',
     chatPoints: 'Viewers check their balance and watch time.',
     chatPointsMod: 'Mods set or grant points to a viewer.',
-    chatCounter: 'Mods manage counters (also on the Counters page).'
+    chatCounter: 'Mods manage counters (also on the Counters page).',
+    countersLink: 'Manage counters',
   },
 
+
+  rewardCounter: {
+    enable: 'Keep a counter',
+    nameLabel: 'Counter name',
+    nameHint: 'Type a new name to create it here, or an existing counter to add to it.',
+    scopeLabel: 'What each redemption counts toward',
+    scopeViewerReward: 'Per viewer, per reward',
+    scopeViewerRewardDesc: 'Each viewer gets their own tally for this reward. Best for most rewards.',
+    scopeViewer: 'Per viewer',
+    scopeViewerDesc: 'Each viewer gets one tally, shared across every reward that uses this counter.',
+    scopeChannel: 'Whole channel',
+    scopeChannelDesc: 'One running total for the whole channel.',
+    tokenNote: 'Use {counter} in the chat reply to show the new total.',
+    pointsEnable: 'Give loyalty points',
+    pointsLabel: 'Points per redemption',
+    pointsHint: 'Use {points} in the chat reply to show the amount.',
+    liveOnly: 'Only while I’m live',
+    liveOnlyHint: 'Offline redeems still reply in chat, but don’t count or grant points.',
+  },
   counters: {
     eyebrow: 'Manage',
     titlePre: 'Channel ',

--- a/console/shared/lib/i18n/fr.ts
+++ b/console/shared/lib/i18n/fr.ts
@@ -366,6 +366,8 @@ export const fr = {
     fieldCounter: 'Incrémenter un compteur',
     fieldCounterPh: 'ex. morts',
     fieldCounterHint: 'Chaque échange ajoute 1 à ce compteur (créez-le sur la page Compteurs).',
+    fieldCounterScope: 'Compter la récompense par…',
+    fieldCounterScopeHint: 'Utilisé seulement à la création. Le titre de la récompense sépare le décompte par utilisateur de chaque récompense.',
     fieldPoints: 'Attribuer des points de fidélité',
     fieldPointsHint: 'Points gagnés par le viewer à chaque échange. 0 n’attribue rien.',
     // actions + toasts
@@ -416,9 +418,29 @@ export const fr = {
     chatTitle: 'Commandes de chat',
     chatPoints: 'Les viewers consultent leur solde et leur temps de visionnage.',
     chatPointsMod: 'Les modérateurs définissent ou accordent des points à un viewer.',
-    chatCounter: 'Les modérateurs gèrent les compteurs (aussi sur la page Compteurs).'
+    chatCounter: 'Les modérateurs gèrent les compteurs (aussi sur la page Compteurs).',
+    countersLink: 'Gérer les compteurs',
   },
 
+
+  rewardCounter: {
+    enable: 'Tenir un compteur',
+    nameLabel: 'Nom du compteur',
+    nameHint: 'Tapez un nouveau nom pour le créer ici, ou un compteur existant pour l’incrémenter.',
+    scopeLabel: 'Ce que compte chaque échange',
+    scopeViewerReward: 'Par viewer, par récompense',
+    scopeViewerRewardDesc: 'Chaque viewer a son propre décompte pour cette récompense. Idéal dans la plupart des cas.',
+    scopeViewer: 'Par viewer',
+    scopeViewerDesc: 'Chaque viewer a un décompte, partagé entre toutes les récompenses liées à ce compteur.',
+    scopeChannel: 'Toute la chaîne',
+    scopeChannelDesc: 'Un total unique pour toute la chaîne.',
+    tokenNote: 'Utilisez {counter} dans la réponse pour afficher le nouveau total.',
+    pointsEnable: 'Donner des points de fidélité',
+    pointsLabel: 'Points par échange',
+    pointsHint: 'Utilisez {points} dans la réponse pour afficher le montant.',
+    liveOnly: 'Seulement quand je suis en live',
+    liveOnlyHint: 'Les échanges hors ligne répondent dans le chat, mais ne comptent pas et n’accordent pas de points.',
+  },
   counters: {
     eyebrow: 'Gérer',
     titlePre: 'Compteurs de ',

--- a/console/shared/lib/types.ts
+++ b/console/shared/lib/types.ts
@@ -1075,7 +1075,18 @@ export interface ChannelPointReward {
   // (the reward title keys a per-user+command counter's bucket); points, when
   // positive, awards that many loyalty points to the redeemer.
   counter: string;
+  // counterScope is the scope to CREATE the counter with when it doesn't exist
+  // yet, so a broadcaster can make the counter straight from the reward editor
+  // instead of the Counters page. Ignored when counter is empty, or when the
+  // counter already exists (create is idempotent — it never changes a stored
+  // scope). Defaults to per user + reward, the scope a reward-linked counter
+  // almost always wants.
+  counterScope: CounterScope;
   points: number;
+  // liveOnly gates the loyalty writes (counter bump + points award) to when
+  // the broadcaster is live, so channel points redeemed offline can't farm
+  // currency or inflate a counter. The chat reply always runs.
+  liveOnly: boolean;
 }
 
 // blankReward is the default draft for the "new reward" form.
@@ -1099,7 +1110,9 @@ export function blankReward(): ChannelPointReward {
     message: '',
     onRedeem: 'fulfill',
     counter: '',
-    points: 0
+    counterScope: 'viewer_command',
+    points: 0,
+    liveOnly: false
   };
 }
 


### PR DESCRIPTION
Follow-up to the loyalty feature, addressing usability feedback on the channel-point → counter/points flow.

## Create the counter from the reward editor
Previously a broadcaster had to create the counter on the Counters page first, or sesame would auto-create it as plain channel scope. Now binding a counter in the reward editor offers a **scope picker**, and saving the reward creates the counter with that scope if it doesn't exist. Idempotent — an existing counter keeps its scope.

## Cleaner Loyalty hooks UX
The section was a stack of raw fields. It's now two opt-in toggles (**Keep a counter** / **Give loyalty points**) that reveal their controls, so an ordinary reward's editor shows no loyalty plumbing. Scope is radio pills with a plain-English description of the selected option and a `{counter}` token hint, not a bare dropdown.

## Live-only gate
New per-reward toggle **"Only while I'm live"**: redemptions made offline still reply in chat but don't bump the counter or grant points — so channel points can't farm currency or inflate a counter off-stream. Fails closed on a live-check error. Backed by `data.liveOnly` on the binding + `loyaltyLive()` in sesame's channelpoints module.

## Discoverability
The Loyalty page now links to the Counters page (the prior "can't find Counters" gap).

## Testing
Go build/test/vet green; new sesame test asserts offline redeems skip both loyalty writes while online redeems perform them. Console svelte-check 0 errors. Editor states verified in the browser (collapsed default, revealed counter with scope pills, live-only gate).

> Note: the loyalty service is still deploy-gated (`loyalty.yaml` commented in the kustomization), so these dashboard actions surface "unavailable" until the service is deployed. Nothing here changes that gate.