### PR TITLE
fix(nats): import outgress followage.get into WORKER_RPC

### DIFF
--- a/deploy/k8s/nats-auth.conf
+++ b/deploy/k8s/nats-auth.conf
@@ -375,6 +375,9 @@ accounts: {
       # Chatters listing for the loyalty watch tick — scoped to the one verb,
       # not the whole outgress management surface.
       { service: { account: "OUTGRESS_RPC", subject: "bagel.rpc.outgress.chatters.get" } }
+      # Followage read for the !followage command — the authenticated Twitch
+      # Get Channel Followers behind outgress, scoped to the one verb.
+      { service: { account: "OUTGRESS_RPC", subject: "bagel.rpc.outgress.followage.get" } }
       { stream: { account: "USERS_RPC",     subject: "bagel.cache.invalidate.status" } }
       { stream: { account: "USERS_RPC",     subject: "bagel.cache.invalidate.grant" } }
       { stream: { account: "USERS_RPC",     subject: "bagel.cache.invalidate.locale" } }


### PR DESCRIPTION
sesame's `!followage` requests `bagel.rpc.outgress.followage.get`, but `WORKER_RPC` only imported `chatters.get` from `OUTGRESS_RPC`. Every followage request hit no-responder and replied "Followage is unavailable right now." on all channels, regardless of bot mod status.

Scopes the single verb, matching the existing chatters import. #332 shipped the code + outgress handler but not this ACL import.

Deploy: config-reloader SIGHUP hot-reloads the ACL, no restart (subject import on an existing account, not a new user).