### PR TITLE
chore(deploy): enable loyalty service

### DIFF
--- a/deploy/k8s/kustomization.yaml
+++ b/deploy/k8s/kustomization.yaml
@@ -11,14 +11,10 @@ resources:
   - gateway.yaml
   # loyalty is the points/watchtime/counters data service behind sesame's
   # loyalty module (bagel.rpc.loyalty.> + the data.loyalty.* consumers).
-  # DEPLOY-GATED — uncomment once (1) the bagel_loyalty MySQL schema + user
-  # exist, (2) the Doppler project `loyalty` (DB + NATS creds) and its
-  # loyalty-doppler-token secret are provisioned, (3) nats-secrets.py has
-  # minted loyalty_bus/loyalty_rpc and the brokers picked up the new auth
-  # conf, and (4) the first loyalty image is published so the digest pin
-  # resolves. Applying earlier stalls the apps Kustomization (wait: true) on
-  # an unfillable secret/image.
-  # - loyalty.yaml
+  # Onboarded 2026-07-11: bagel_loyalty schema + loyalty_svc user, Doppler
+  # project `loyalty` (+ loyalty-doppler-token), loyalty_bus/loyalty_rpc auth,
+  # and the digest-pinned image are all in place.
+  - loyalty.yaml
   - modules.yaml
   - notifications.yaml
   - outgress.yaml


### PR DESCRIPTION
Uncomments loyalty.yaml in the apps kustomization. All four onboarding gates are done: bagel_loyalty schema + loyalty_svc user (DML+DDL, no DROP), Doppler project loyalty (DB+NATS) + loyalty-doppler-token secret, loyalty_bus/loyalty_rpc auth loaded by the brokers (hub+leaf rolled), and the digest-pinned image (main-...-13df83e). Flux applies on merge; the loyalty DopplerSecret hydrates loyalty-env and the deployment starts, auto-migrating bagel_loyalty on first boot.