### PR TITLE
refactor: address quote CodeScene advisories

### DIFF
--- a/app/modules/repository/quotes.go
+++ b/app/modules/repository/quotes.go
@@ -57,28 +57,29 @@ func quoteView(q *ent.Quote) *modulesrpc.Quote {
 	}
 }
 
+// QuoteDraft is the complete input for a new quote. CreatedAt is optional:
+// chat saves leave it zero to use the current time, while the dashboard can
+// preserve the day on which the quote was originally said.
+type QuoteDraft struct {
+	Text      string
+	AddedBy   string
+	CreatedAt time.Time
+}
+
 // Add saves a new quote under the channel's next number (max+1) and returns
 // it. Removing a quote leaves a hole, so a number chat has already seen is
 // never reassigned to different text — except the top number, which max+1
 // reuses after a remove.
-func (q *Quotes) Add(ctx context.Context, userID uint64, text, addedBy string) (*modulesrpc.Quote, error) {
-	return q.add(ctx, userID, text, addedBy, time.Now())
-}
-
-// AddAt is the dashboard variant of Add. Chat saves still use Add and get the
-// current timestamp; the dashboard may supply the day on which the quote was
-// originally said.
-func (q *Quotes) AddAt(ctx context.Context, userID uint64, text, addedBy string, createdAt time.Time) (*modulesrpc.Quote, error) {
-	return q.add(ctx, userID, text, addedBy, createdAt)
-}
-
-func (q *Quotes) add(ctx context.Context, userID uint64, text, addedBy string, createdAt time.Time) (*modulesrpc.Quote, error) {
-	text = strings.TrimSpace(text)
-	if text == "" {
+func (q *Quotes) Add(ctx context.Context, userID uint64, draft QuoteDraft) (*modulesrpc.Quote, error) {
+	draft.Text = strings.TrimSpace(draft.Text)
+	if draft.Text == "" {
 		return nil, ErrQuoteEmpty
 	}
-	if len(text) > QuoteTextMaxLen {
+	if len(draft.Text) > QuoteTextMaxLen {
 		return nil, ErrQuoteTooLong
+	}
+	if draft.CreatedAt.IsZero() {
+		draft.CreatedAt = time.Now()
 	}
 
 	var lastErr error
@@ -90,9 +91,9 @@ func (q *Quotes) add(ctx context.Context, userID uint64, text, addedBy string, c
 		row, err := q.client.Quote.Create().
 			SetUserID(userID).
 			SetNumber(next).
-			SetText(text).
-			SetAddedBy(addedBy).
-			SetCreatedAt(createdAt.UTC()).
+			SetText(draft.Text).
+			SetAddedBy(draft.AddedBy).
+			SetCreatedAt(draft.CreatedAt.UTC()).
 			Save(ctx)
 		if err == nil {
 			return quoteView(row), nil

--- a/app/modules/repository/quotes_test.go
+++ b/app/modules/repository/quotes_test.go
@@ -25,12 +25,12 @@ func setupQuotes(t *testing.T) *repository.Quotes {
 	return repository.NewQuotes(client, zap.NewNop())
 }
 
-func TestQuoteAddAtUsesChosenDate(t *testing.T) {
+func TestQuoteAddUsesChosenDate(t *testing.T) {
 	repo := setupQuotes(t)
 	ctx := context.Background()
 	chosen := time.Date(2024, time.February, 29, 12, 0, 0, 0, time.UTC)
 
-	saved, err := repo.AddAt(ctx, 1001, "a leap-day quote", "dashboard", chosen)
+	saved, err := repo.Add(ctx, 1001, repository.QuoteDraft{Text: "a leap-day quote", AddedBy: "dashboard", CreatedAt: chosen})
 	require.NoError(t, err)
 	assert.Equal(t, "2024-02-29T12:00:00Z", saved.CreatedAt)
 
@@ -44,18 +44,18 @@ func TestQuoteAddNumbersSequentially(t *testing.T) {
 	repo := setupQuotes(t)
 	ctx := context.Background()
 
-	first, err := repo.Add(ctx, 1001, "never trust a ferret", "mod_amy")
+	first, err := repo.Add(ctx, 1001, repository.QuoteDraft{Text: "never trust a ferret", AddedBy: "mod_amy"})
 	require.NoError(t, err)
 	assert.Equal(t, uint64(1), first.Number)
 	assert.Equal(t, "mod_amy", first.AddedBy)
 	assert.NotEmpty(t, first.CreatedAt)
 
-	second, err := repo.Add(ctx, 1001, "the bagels are sentient", "mod_amy")
+	second, err := repo.Add(ctx, 1001, repository.QuoteDraft{Text: "the bagels are sentient", AddedBy: "mod_amy"})
 	require.NoError(t, err)
 	assert.Equal(t, uint64(2), second.Number)
 
 	// Another channel starts its own numbering.
-	other, err := repo.Add(ctx, 2002, "hello from elsewhere", "mod_bob")
+	other, err := repo.Add(ctx, 2002, repository.QuoteDraft{Text: "hello from elsewhere", AddedBy: "mod_bob"})
 	require.NoError(t, err)
 	assert.Equal(t, uint64(1), other.Number)
 }
@@ -64,10 +64,13 @@ func TestQuoteAddValidates(t *testing.T) {
 	repo := setupQuotes(t)
 	ctx := context.Background()
 
-	_, err := repo.Add(ctx, 1001, "   ", "mod_amy")
+	_, err := repo.Add(ctx, 1001, repository.QuoteDraft{Text: "   ", AddedBy: "mod_amy"})
 	assert.ErrorIs(t, err, repository.ErrQuoteEmpty)
 
-	_, err = repo.Add(ctx, 1001, strings.Repeat("x", repository.QuoteTextMaxLen+1), "mod_amy")
+	_, err = repo.Add(ctx, 1001, repository.QuoteDraft{
+		Text:    strings.Repeat("x", repository.QuoteTextMaxLen+1),
+		AddedBy: "mod_amy",
+	})
 	assert.ErrorIs(t, err, repository.ErrQuoteTooLong)
 }
 
@@ -75,7 +78,7 @@ func TestQuoteGet(t *testing.T) {
 	repo := setupQuotes(t)
 	ctx := context.Background()
 
-	saved, err := repo.Add(ctx, 1001, "never trust a ferret", "mod_amy")
+	saved, err := repo.Add(ctx, 1001, repository.QuoteDraft{Text: "never trust a ferret", AddedBy: "mod_amy"})
 	require.NoError(t, err)
 
 	got, found, err := repo.Get(ctx, 1001, saved.Number)
@@ -101,11 +104,11 @@ func TestQuoteList(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, list)
 
-	_, err = repo.Add(ctx, 1001, "one", "m")
+	_, err = repo.Add(ctx, 1001, repository.QuoteDraft{Text: "one", AddedBy: "m"})
 	require.NoError(t, err)
-	_, err = repo.Add(ctx, 1001, "two", "m")
+	_, err = repo.Add(ctx, 1001, repository.QuoteDraft{Text: "two", AddedBy: "m"})
 	require.NoError(t, err)
-	_, err = repo.Add(ctx, 1001, "three", "m")
+	_, err = repo.Add(ctx, 1001, repository.QuoteDraft{Text: "three", AddedBy: "m"})
 	require.NoError(t, err)
 	removed, err := repo.Remove(ctx, 1001, 2)
 	require.NoError(t, err)
@@ -133,7 +136,7 @@ func TestQuoteRandom(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, found)
 
-	_, err = repo.Add(ctx, 1001, "only one saved", "mod_amy")
+	_, err = repo.Add(ctx, 1001, repository.QuoteDraft{Text: "only one saved", AddedBy: "mod_amy"})
 	require.NoError(t, err)
 
 	got, found, err := repo.Random(ctx, 1001)
@@ -146,11 +149,11 @@ func TestQuoteRemoveLeavesHole(t *testing.T) {
 	repo := setupQuotes(t)
 	ctx := context.Background()
 
-	_, err := repo.Add(ctx, 1001, "one", "m")
+	_, err := repo.Add(ctx, 1001, repository.QuoteDraft{Text: "one", AddedBy: "m"})
 	require.NoError(t, err)
-	_, err = repo.Add(ctx, 1001, "two", "m")
+	_, err = repo.Add(ctx, 1001, repository.QuoteDraft{Text: "two", AddedBy: "m"})
 	require.NoError(t, err)
-	_, err = repo.Add(ctx, 1001, "three", "m")
+	_, err = repo.Add(ctx, 1001, repository.QuoteDraft{Text: "three", AddedBy: "m"})
 	require.NoError(t, err)
 
 	found, err := repo.Remove(ctx, 1001, 2)
@@ -162,7 +165,7 @@ func TestQuoteRemoveLeavesHole(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, found)
 
-	next, err := repo.Add(ctx, 1001, "four", "m")
+	next, err := repo.Add(ctx, 1001, repository.QuoteDraft{Text: "four", AddedBy: "m"})
 	require.NoError(t, err)
 	assert.Equal(t, uint64(4), next.Number)
 
@@ -176,9 +179,9 @@ func TestQuoteDeleteAllForUser(t *testing.T) {
 	repo := setupQuotes(t)
 	ctx := context.Background()
 
-	_, err := repo.Add(ctx, 1001, "mine", "m")
+	_, err := repo.Add(ctx, 1001, repository.QuoteDraft{Text: "mine", AddedBy: "m"})
 	require.NoError(t, err)
-	kept, err := repo.Add(ctx, 2002, "theirs", "m")
+	kept, err := repo.Add(ctx, 2002, repository.QuoteDraft{Text: "theirs", AddedBy: "m"})
 	require.NoError(t, err)
 
 	require.NoError(t, repo.DeleteAllForUser(ctx, 1001))

--- a/app/modules/rpc/quotes.go
+++ b/app/modules/rpc/quotes.go
@@ -81,15 +81,15 @@ func errReply(err error, ok modulesrpc.QuoteReply) modulesrpc.QuoteReply {
 
 func (q *quotesRPC) handleAdd(ctx context.Context, req modulesrpc.QuoteRequest) modulesrpc.QuoteReply {
 	return q.withUserID(req, func(id uint64) modulesrpc.QuoteReply {
-		if req.CreatedAt == "" {
-			view, err := q.repo.Add(ctx, id, req.Text, req.AddedBy)
-			return errReply(err, modulesrpc.QuoteReply{Quote: view, Found: true})
+		draft := repository.QuoteDraft{Text: req.Text, AddedBy: req.AddedBy}
+		if req.CreatedAt != "" {
+			createdAt, err := time.Parse(time.RFC3339, req.CreatedAt)
+			if err != nil {
+				return modulesrpc.QuoteReply{Error: "invalid quote date"}
+			}
+			draft.CreatedAt = createdAt
 		}
-		createdAt, err := time.Parse(time.RFC3339, req.CreatedAt)
-		if err != nil {
-			return modulesrpc.QuoteReply{Error: "invalid quote date"}
-		}
-		view, err := q.repo.AddAt(ctx, id, req.Text, req.AddedBy, createdAt)
+		view, err := q.repo.Add(ctx, id, draft)
 		return errReply(err, modulesrpc.QuoteReply{Quote: view, Found: true})
 	})
 }


### PR DESCRIPTION
## Summary
- replace primitive quote creation parameters with a typed `QuoteDraft` value
- fold the dashboard timestamp path into the same repository method
- update quote repository tests and RPC adaptation

## CodeScene
Addresses the Primitive Obsession and Excess Number of Function Arguments advisories reported on PR #341.

## Verification
- `go test ./app/modules/repository ./app/modules/rpc ./app/sesame/engine ./app/sesame/modules`