### PR TITLE
fix: keep quotes under modules navigation

### DIFF
--- a/console/dashboard/src/routes/(app)/+layout.svelte
+++ b/console/dashboard/src/routes/(app)/+layout.svelte
@@ -60,6 +60,7 @@
     path.startsWith('/commands')
       ? 'commands'
       : path.startsWith('/modules') ||
+          path.startsWith('/quotes') ||
           path.startsWith('/govee') ||
           path.startsWith('/channelpoints') ||
           path.startsWith('/timers') ||


### PR DESCRIPTION
## Summary
- classify `/quotes` as part of the Modules section in the app shell
- keep both the Modules nav item and breadcrumb active on the quote dashboard

## Verification
- `bun run check` (0 errors)