### PR TITLE
fix(sesame): drain in-flight events on shutdown

### DIFF
--- a/app/outgress/main.go
+++ b/app/outgress/main.go
@@ -360,26 +360,28 @@ func (d *deps) laneSubscribers() (premiumSub, standardSub, systemSub message.Sub
 // single routine budget partitioned by weight so premium drains ahead without
 // starving standard.
 func (d *deps) startChatLanes(ctx context.Context, lanes []bus.WeightedLane) {
-	fatalIf(d.log, bus.ConsumeWeighted(ctx, d.nrApp, lanes, bus.ScalePolicy{
+	_, err := bus.ConsumeWeighted(ctx, d.nrApp, lanes, bus.ScalePolicy{
 		MinRoutines:    d.cfg.MinRoutines,
 		MaxRoutines:    d.cfg.MaxRoutines,
 		MaxConsumers:   d.cfg.MaxConsumers,
 		ScaleUpAfter:   d.cfg.ScaleUpAfter,
 		ScaleDownAfter: d.cfg.ScaleDownAfter,
-	}, d.log), "failed to consume premium/standard lanes")
+	}, d.log)
+	fatalIf(d.log, err, "failed to consume premium/standard lanes")
 }
 
 // startSystemLane keeps the system lane on its own independent consumer, off
 // the weighted budget, so onboarding bursts never compete for the chat/api
 // routines. It runs a fixed pool (min == max, single consumer), no autoscaling.
 func (d *deps) startSystemLane(ctx context.Context, sub message.Subscriber, system *worker.Worker) {
-	fatalIf(d.log, bus.ConsumeWeighted(ctx, d.nrApp, []bus.WeightedLane{
+	_, err := bus.ConsumeWeighted(ctx, d.nrApp, []bus.WeightedLane{
 		{Sub: sub, Subject: d.cfg.SystemSubject, Handle: system.Process},
 	}, bus.ScalePolicy{
 		MinRoutines:  d.cfg.SystemWorkers,
 		MaxRoutines:  d.cfg.SystemWorkers,
 		MaxConsumers: 1,
-	}, d.log), "failed to consume system lane")
+	}, d.log)
+	fatalIf(d.log, err, "failed to consume system lane")
 }
 
 // startStreamLane binds a durable consumer for the real Twitch stream.online /

--- a/app/sesame/internal/config/config.go
+++ b/app/sesame/internal/config/config.go
@@ -46,6 +46,13 @@ type Config struct {
 	ScaleDownAfter time.Duration
 	PremiumReserve int
 
+	// DrainTimeout bounds how long shutdown waits for handlers already dispatched
+	// to finish after SIGTERM stops the consumer pulling. Keep it below the pod's
+	// terminationGracePeriodSeconds so the drain completes before the kubelet
+	// SIGKILLs the process. A handler that outlives the deadline is abandoned and
+	// its event redelivered (the dedup claim is released on the nack path).
+	DrainTimeout time.Duration
+
 	// Outgress lane subjects the pipeline publishes onto, chosen from the event's
 	// regress status (premium vs standard).
 	OutgressPremiumSubject  string
@@ -151,6 +158,8 @@ func Load() *Config {
 		ScaleUpAfter:   env.GetDuration("SESAME_SCALE_UP_AFTER", 5*time.Second),
 		ScaleDownAfter: env.GetDuration("SESAME_SCALE_DOWN_AFTER", 30*time.Second),
 		PremiumReserve: env.GetInt("SESAME_PREMIUM_RESERVE_PERCENT", 25),
+
+		DrainTimeout: env.GetDuration("SESAME_DRAIN_TIMEOUT", 25*time.Second),
 
 		OutgressPremiumSubject:  env.Get("NATS_OUTGRESS_PREMIUM_SUBJECT", "twitch.outgress.premium"),
 		OutgressStandardSubject: env.Get("NATS_OUTGRESS_STANDARD_SUBJECT", "twitch.outgress.standard"),

--- a/app/sesame/internal/consumer/consumer.go
+++ b/app/sesame/internal/consumer/consumer.go
@@ -52,8 +52,9 @@ func New(sub message.Subscriber, nrApp *newrelic.Application, cfg Config, log *z
 }
 
 // Start binds both lanes to handle and begins draining. It returns once the first
-// consumer is running; the pool and autoscaler stop when ctx is cancelled.
-func (c *Consumer) Start(ctx context.Context, handle Handler) error {
+// consumer is running; the pool and autoscaler stop when ctx is cancelled. The
+// returned *bus.Weighted lets the caller drain in-flight handlers on shutdown.
+func (c *Consumer) Start(ctx context.Context, handle Handler) (*bus.Weighted, error) {
 	return bus.ConsumeWeighted(ctx, c.nrApp, []bus.WeightedLane{
 		{Sub: c.sub, Subject: c.cfg.Lanes.PremiumSubject, Handle: handle, Reserve: c.cfg.PremiumReserve},
 		{Sub: c.sub, Subject: c.cfg.Lanes.StandardSubject, Handle: handle},

--- a/app/sesame/main.go
+++ b/app/sesame/main.go
@@ -126,7 +126,8 @@ func main() {
 	pipe := newPipeline(deps, registry, cfg)
 	defer pipe.Close() // flushes pending use-counter ticks on shutdown
 
-	if err := newConsumer(sub, nrApp, cfg, log).Start(ctx, pipe.Process); err != nil {
+	weighted, err := newConsumer(sub, nrApp, cfg, log).Start(ctx, pipe.Process)
+	if err != nil {
 		log.Fatal("failed to start consumer", zap.Error(err))
 	}
 
@@ -146,7 +147,20 @@ func main() {
 
 	<-ctx.Done()
 
-	log.Info("sesame shutting down")
+	// SIGTERM cancelled ctx, so the consumer has stopped pulling from the lanes.
+	// Wait for the handlers it already dispatched to run to completion before the
+	// deferred Close calls below flush the reporters and shut the publishers: a
+	// handler killed mid-flight would leave its dedup claim written (released only
+	// on the error path) while its event is acked, so partial multi-output work
+	// would be dropped on the floor instead of redelivered.
+	log.Info("sesame shutting down, draining in-flight events", zap.Duration("timeout", cfg.DrainTimeout))
+	drainCtx, cancelDrain := context.WithTimeout(context.Background(), cfg.DrainTimeout)
+	defer cancelDrain()
+	if err := weighted.Drain(drainCtx); err != nil {
+		log.Warn("drain deadline exceeded; in-flight events left for redelivery", zap.Error(err))
+	} else {
+		log.Info("in-flight events drained")
+	}
 }
 
 func newPipeline(deps engine.Deps, registry *engine.Registry, cfg *config.Config) *engine.Pipeline {

--- a/app/sesame/main.go
+++ b/app/sesame/main.go
@@ -146,21 +146,24 @@ func main() {
 	)
 
 	<-ctx.Done()
+	drainInflight(weighted, cfg.DrainTimeout, log)
+}
 
-	// SIGTERM cancelled ctx, so the consumer has stopped pulling from the lanes.
-	// Wait for the handlers it already dispatched to run to completion before the
-	// deferred Close calls below flush the reporters and shut the publishers: a
-	// handler killed mid-flight would leave its dedup claim written (released only
-	// on the error path) while its event is acked, so partial multi-output work
-	// would be dropped on the floor instead of redelivered.
-	log.Info("sesame shutting down, draining in-flight events", zap.Duration("timeout", cfg.DrainTimeout))
-	drainCtx, cancelDrain := context.WithTimeout(context.Background(), cfg.DrainTimeout)
-	defer cancelDrain()
-	if err := weighted.Drain(drainCtx); err != nil {
+// drainInflight waits for the handlers the consumer already dispatched to run to
+// completion before main returns and its deferred Close calls flush the reporters
+// and shut the publishers. SIGTERM cancelled the consumer's context, so no new
+// work is being pulled; a handler killed mid-flight would leave its dedup claim
+// written (released only on the error path) while its event is acked, so partial
+// multi-output work would be dropped on the floor instead of redelivered.
+func drainInflight(weighted *bus.Weighted, timeout time.Duration, log *zap.Logger) {
+	log.Info("sesame shutting down, draining in-flight events", zap.Duration("timeout", timeout))
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	if err := weighted.Drain(ctx); err != nil {
 		log.Warn("drain deadline exceeded; in-flight events left for redelivery", zap.Error(err))
-	} else {
-		log.Info("in-flight events drained")
+		return
 	}
+	log.Info("in-flight events drained")
 }
 
 func newPipeline(deps engine.Deps, registry *engine.Registry, cfg *config.Config) *engine.Pipeline {

--- a/pkg/bus/weighted.go
+++ b/pkg/bus/weighted.go
@@ -41,7 +41,9 @@ import (
 // retry budget is preserved. Handlers must be safe for concurrent use.
 //
 // ConsumeWeighted returns once the first unit is running; the units and the
-// supervisor stop when ctx is cancelled.
+// supervisor stop when ctx is cancelled. The returned *Weighted lets a graceful
+// shutdown wait for handlers already dispatched to finish (Drain) before the
+// publishers they emit onto are closed.
 type WeightedLane struct {
 	Sub     message.Subscriber
 	Subject string
@@ -61,7 +63,7 @@ type ScalePolicy struct {
 	ScaleDownAfter time.Duration // sustained calm before shrinking a step
 }
 
-func ConsumeWeighted(ctx context.Context, app *newrelic.Application, lanes []WeightedLane, policy ScalePolicy, log *zap.Logger) error {
+func ConsumeWeighted(ctx context.Context, app *newrelic.Application, lanes []WeightedLane, policy ScalePolicy, log *zap.Logger) (*Weighted, error) {
 
 	policy = policy.normalized()
 
@@ -71,24 +73,58 @@ func ConsumeWeighted(ctx context.Context, app *newrelic.Application, lanes []Wei
 	}
 
 	s := &supervisor{
-		ctx:      ctx,
-		app:      app,
-		lanes:    lanes,
-		reserves: reserves,
-		policy:   policy,
-		log:      log,
+		ctx:        ctx,
+		app:        app,
+		lanes:      lanes,
+		reserves:   reserves,
+		policy:     policy,
+		log:        log,
+		dispatched: &sync.WaitGroup{},
 	}
 
 	// The first unit starts synchronously so a Subscribe error surfaces here.
 	first, err := s.startUnit()
 	if err != nil {
-		return err
+		return nil, err
 	}
 	s.units = []*consumerUnit{first}
 
 	go s.run()
 
-	return nil
+	return &Weighted{dispatched: s.dispatched}, nil
+}
+
+// Weighted is the handle ConsumeWeighted returns; Drain is its only method.
+type Weighted struct {
+	// dispatched counts every reader loop and every dispatched handler goroutine
+	// across all units. It starts positive (the first unit's readers are added
+	// before ConsumeWeighted returns, so before any Drain) and stays positive
+	// while any reader is alive, so a handler's Add never races Drain's Wait: the
+	// counter only reaches zero once every reader has exited and every handler has
+	// returned.
+	dispatched *sync.WaitGroup
+}
+
+// Drain blocks until every reader loop has exited and every handler goroutine
+// already dispatched has returned, or until ctx is done, whichever comes first.
+//
+// Call it only after the context passed to ConsumeWeighted has been cancelled,
+// so the readers have stopped pulling new messages; Drain then converges as the
+// last in-flight handlers run to completion and ack. It returns nil when
+// everything drained, or ctx.Err() when the deadline hit first (in which case
+// some handlers may still be running and their events will be redelivered).
+func (w *Weighted) Drain(ctx context.Context) error {
+	done := make(chan struct{})
+	go func() {
+		w.dispatched.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 // supervisor owns the set of consumer units and scales their count between 1
@@ -100,6 +136,11 @@ type supervisor struct {
 	reserves []int
 	policy   ScalePolicy
 	log      *zap.Logger
+
+	// dispatched counts every reader loop and every dispatched handler across all
+	// units (including retired ones), so Drain can wait for in-flight work on
+	// shutdown. See Weighted for why the counting is race-free.
+	dispatched *sync.WaitGroup
 
 	units []*consumerUnit
 }
@@ -184,7 +225,7 @@ func (s *supervisor) startUnit() (*consumerUnit, error) {
 		pool.close()
 	}()
 
-	wg, err := startReaders(uctx, s.app, s.lanes, pool, s.log)
+	wg, err := startReaders(uctx, s.app, s.lanes, pool, s.dispatched, s.log)
 	if err != nil {
 		cancel()
 		return nil, err
@@ -276,7 +317,12 @@ func (p ScalePolicy) normalized() ScalePolicy {
 // WaitGroup is done when every reader loop has exited (ctx cancelled, channels
 // closed); messages already dispatched keep running and release their slot on
 // completion. A Subscribe failure aborts: ctx is left to the caller to cancel.
-func startReaders(ctx context.Context, app *newrelic.Application, lanes []WeightedLane, pool *routinePool, log *zap.Logger) (*sync.WaitGroup, error) {
+//
+// dispatched counts both the reader loops and the dispatched handlers so a
+// graceful shutdown can wait for in-flight work (see Weighted.Drain). Counting
+// the reader in the same group keeps the count positive while the reader can
+// still add handlers, so a handler's Add never races the Wait.
+func startReaders(ctx context.Context, app *newrelic.Application, lanes []WeightedLane, pool *routinePool, dispatched *sync.WaitGroup, log *zap.Logger) (*sync.WaitGroup, error) {
 
 	var wg sync.WaitGroup
 
@@ -287,15 +333,19 @@ func startReaders(ctx context.Context, app *newrelic.Application, lanes []Weight
 		}
 
 		wg.Add(1)
+		dispatched.Add(1)
 		go func(lane int, subject string, handle func(*message.Message) error, msgs <-chan *message.Message) {
 			defer wg.Done()
+			defer dispatched.Done()
 			for msg := range msgs {
 				if !pool.acquire(lane) {
 					// Pool is shutting down: hand the message back unprocessed.
 					msg.Nack()
 					return
 				}
+				dispatched.Add(1)
 				go func(m *message.Message) {
+					defer dispatched.Done()
 					defer pool.release(lane)
 					process(app, subject, m, handle, log)
 				}(msg)

--- a/pkg/bus/weighted_test.go
+++ b/pkg/bus/weighted_test.go
@@ -133,7 +133,7 @@ func TestConsumeWeightedProcessesAndScales(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	err := ConsumeWeighted(ctx, nil, []WeightedLane{
+	_, err := ConsumeWeighted(ctx, nil, []WeightedLane{
 		{Sub: sub, Subject: "premium", Handle: handle, Reserve: 25},
 		{Sub: sub, Subject: "standard", Handle: handle},
 	}, ScalePolicy{
@@ -166,4 +166,96 @@ func TestConsumeWeightedProcessesAndScales(t *testing.T) {
 		case <-time.After(5 * time.Millisecond):
 		}
 	}
+}
+
+// TestConsumeWeightedDrainWaitsForInflight pins the shutdown contract P1 depends
+// on: after the consumer's context is cancelled (SIGTERM), Drain must not return
+// until a handler that was already dispatched has run to completion, so main can
+// flush reporters and close publishers without abandoning in-flight work.
+func TestConsumeWeightedDrainWaitsForInflight(t *testing.T) {
+	sub := &fakeSub{ch: make(chan *message.Message)}
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var finished int64
+	handle := func(m *message.Message) error {
+		close(started) // exactly one message is sent, so handle runs once
+		<-release
+		atomic.AddInt64(&finished, 1)
+		return nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	w, err := ConsumeWeighted(ctx, nil, []WeightedLane{
+		{Sub: sub, Subject: "premium", Handle: handle, Reserve: 25},
+		{Sub: sub, Subject: "standard", Handle: handle},
+	}, ScalePolicy{MinRoutines: 1, MaxRoutines: 2, MaxConsumers: 1}, zap.NewNop())
+	if err != nil {
+		t.Fatalf("ConsumeWeighted: %v", err)
+	}
+
+	sub.ch <- message.NewMessage("id", nil)
+	<-started // the handler is in-flight, blocked on release
+
+	cancel() // stop pulling, as SIGTERM does
+
+	drained := make(chan error, 1)
+	go func() { drained <- w.Drain(context.Background()) }()
+
+	// Drain must block while the handler is still running.
+	select {
+	case <-drained:
+		t.Fatal("Drain returned before the in-flight handler finished")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(release) // let the handler complete
+
+	select {
+	case err := <-drained:
+		if err != nil {
+			t.Fatalf("Drain: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Drain did not return after the handler finished")
+	}
+	if got := atomic.LoadInt64(&finished); got != 1 {
+		t.Fatalf("finished = %d, want 1", got)
+	}
+}
+
+// TestConsumeWeightedDrainDeadline pins the other half: a handler that outlives
+// the drain deadline does not hang shutdown forever; Drain returns the context
+// error so main can log and exit, leaving the event for redelivery.
+func TestConsumeWeightedDrainDeadline(t *testing.T) {
+	sub := &fakeSub{ch: make(chan *message.Message)}
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	handle := func(m *message.Message) error {
+		close(started)
+		<-release // never released before the deadline
+		return nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	w, err := ConsumeWeighted(ctx, nil, []WeightedLane{
+		{Sub: sub, Subject: "premium", Handle: handle},
+	}, ScalePolicy{MinRoutines: 1, MaxRoutines: 1, MaxConsumers: 1}, zap.NewNop())
+	if err != nil {
+		t.Fatalf("ConsumeWeighted: %v", err)
+	}
+
+	sub.ch <- message.NewMessage("id", nil)
+	<-started
+	cancel()
+
+	dctx, dcancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer dcancel()
+	if err := w.Drain(dctx); err == nil {
+		t.Fatal("Drain returned nil, want a deadline error")
+	}
+
+	close(release) // unblock the handler so the goroutine does not leak
 }


### PR DESCRIPTION
## Problem (P1)
On SIGTERM `main` returned as soon as `ctx` was cancelled ([app/sesame/main.go](../blob/main/app/sesame/main.go)). The weighted consumer stopped its readers but never waited for the handler goroutines it had already dispatched ([pkg/bus/weighted.go](../blob/main/pkg/bus/weighted.go)), and main's deferred `Close` calls then flushed the reporters and closed the publishers out from under that in-flight work.

A handler killed mid multi-output left its dedup claim written (released only on the error path) while its event was acked — so partial work was dropped permanently instead of being redelivered.

## Fix
- Track every reader loop **and** dispatched handler in a shared `sync.WaitGroup`, exposed via a new `Weighted` handle returned by `ConsumeWeighted`. Counting the reader in the same group keeps the counter positive while a reader can still dispatch, so a handler's `Add` never races the drain `Wait` (holds under dynamic unit add/retire).
- `Weighted.Drain(ctx)` blocks until readers exited and handlers returned, or the deadline.
- On shutdown `main` waits for `Drain` (bounded by `SESAME_DRAIN_TIMEOUT`, default 25s — keep below pod `terminationGracePeriodSeconds`) **before** the deferred reporter flush + publisher close. Deadline exceeded → warn, event left for redelivery.
- Callers updated: `consumer.Start` returns the handle; outgress's two `ConsumeWeighted` calls unwrapped from `fatalIf` (behavior unchanged, no drain wired there).

## Tests
Added `TestConsumeWeightedDrainWaitsForInflight` and `TestConsumeWeightedDrainDeadline`. `go test -race -count=3 ./pkg/bus/` green; `go vet` clean.

## Out of scope
health.go `/drain` preStop sleep (LB/endpoint drain, orthogonal); P2 containerized Valkey/NATS integration tests; P2 config validation; P3 docs/benchmark.