### PR TITLE
fix(commands): preserve multiline responses on save

### DIFF
--- a/console/dashboard/src/routes/(app)/commands/+page.server.ts
+++ b/console/dashboard/src/routes/(app)/commands/+page.server.ts
@@ -1,6 +1,16 @@
 import type { Actions, PageServerLoad } from './$types';
 import type { CommandView, Perm } from '@bagel/shared';
-import { PERMS, RESPONSE_MAX, normName, validateCommand, firstError, BUILTIN_COMMANDS, BUILTIN_NAMES, builtinDef } from '@bagel/shared';
+import {
+  PERMS,
+  RESPONSE_MAX,
+  normName,
+  normalizeCommandResponse,
+  validateCommand,
+  firstError,
+  BUILTIN_COMMANDS,
+  BUILTIN_NAMES,
+  builtinDef
+} from '@bagel/shared';
 import { listCommands, upsertCommand, deleteCommand, listModules, upsertModule, type ModuleView } from '$lib/server/commands-store';
 import { auditDashboardImpersonation } from '$lib/server/services';
 import type { Session } from '$lib/server/session';
@@ -112,11 +122,10 @@ function parseCommand(f: FormData) {
     aliases.push(a);
   }
 
-  // Twitch chat is single-line: a textarea lets users press Enter, but the
-  // shared validator rejects any control character (CR/LF/tab). Fold control
-  // characters to spaces and trim so a pasted multi-line note saves cleanly
-  // instead of failing validation.
-  const response = String(f.get('response') ?? '').replace(/[\u0000-\u001F]+/g, ' ').trim();
+  // The editor posts one LF-delimited response line per chat message. Preserve
+  // those separators and canonicalize the value exactly as the commands
+  // service does, so Sesame can fan the stored response out one line at a time.
+  const response = normalizeCommandResponse(String(f.get('response') ?? ''));
   const permRaw = String(f.get('perm') ?? 'everyone');
   const perm: Perm = (PERMS as readonly string[]).includes(permRaw) ? (permRaw as Perm) : 'everyone';
 

--- a/console/shared/lib/commands-validate.test.ts
+++ b/console/shared/lib/commands-validate.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from 'bun:test';
+import { normalizeCommandResponse, validateCommand } from './commands-validate';
+
+const validFields = {
+  name: 'raid',
+  aliases: [],
+  cooldown: 0,
+  allowedUserId: ''
+};
+
+describe('command response normalization', () => {
+  test('preserves message boundaries as LF separators', () => {
+    expect(normalizeCommandResponse('first message\r\nsecond message')).toBe('first message\nsecond message');
+    expect(normalizeCommandResponse('first message\rsecond message')).toBe('first message\nsecond message');
+  });
+
+  test('drops blank lines and trailing whitespace without joining messages', () => {
+    expect(normalizeCommandResponse('first  \n\nsecond\t\n')).toBe('first\nsecond');
+  });
+
+  test('rejects non-newline control characters', () => {
+    expect(validateCommand({ ...validFields, response: 'first\u0000second' }).response).toBe(
+      'Response cannot contain control characters.'
+    );
+  });
+});

--- a/console/shared/lib/commands-validate.ts
+++ b/console/shared/lib/commands-validate.ts
@@ -30,6 +30,11 @@ export function responseLines(response: string): string[] {
     .filter((l) => l !== '');
 }
 
+/** Canonical wire/storage form: one non-empty chat message per LF-delimited line. */
+export function normalizeCommandResponse(response: string): string {
+  return responseLines(response).join('\n');
+}
+
 // Linear-time right-trim of spaces/tabs (mirrors Go's TrimRight(" \t")); a
 // trailing-whitespace regex backtracks polynomially on adversarial input.
 function trimLineEnd(line: string): string {
@@ -92,6 +97,8 @@ export function validateCommand(f: CommandFields): CommandErrors {
     errors.response = `Response can be at most ${RESPONSE_MAX_LINES} lines — each line is sent as its own chat message.`;
   } else if (lines.some((l) => l.length > RESPONSE_MAX)) {
     errors.response = `Each line must be at most ${RESPONSE_MAX} characters.`;
+  } else if (lines.some(hasControlCharacter)) {
+    errors.response = 'Response cannot contain control characters.';
   }
 
   if (!Number.isFinite(f.cooldown) || f.cooldown < 0 || f.cooldown > COOLDOWN_MAX) {
@@ -105,6 +112,13 @@ export function validateCommand(f: CommandFields): CommandErrors {
   }
 
   return errors;
+}
+
+function hasControlCharacter(line: string): boolean {
+  for (const char of line) {
+    if (char.codePointAt(0)! < 0x20) return true;
+  }
+  return false;
 }
 
 /** Convenience: the first message of an error map, for single-line surfaces. */


### PR DESCRIPTION
## Summary
- preserve command response newlines through the dashboard save path
- canonicalize CRLF, blank lines, and trailing whitespace consistently with the commands service
- reject non-newline control characters and add regression coverage

## Verification
- `bun test shared`
- `bun run --filter dashboard check` (0 errors; 8 pre-existing warnings)