### PR TITLE
fix(outgress): make multiline replies deterministic

### DIFF
--- a/app/outgress/internal/worker/batch.go
+++ b/app/outgress/internal/worker/batch.go
@@ -1,0 +1,86 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"ItsBagelBot/internal/domain/outgress"
+
+	"go.uber.org/zap"
+)
+
+const batchStateTTL = 2 * time.Minute
+
+const errBatchBusy expectedNackError = "ordered output batch is already owned by another worker"
+
+var (
+	errBatchStoreUnavailable = errors.New("outgress batch store unavailable")
+	errNestedBatch           = errors.New("nested outgress batch")
+)
+
+// BatchStore coordinates one at-most-once batch across outgress replicas.
+// Next is the first unclaimed item. SaveNext happens before the Twitch call:
+// retries therefore never repeat an ambiguous item, at the accepted cost that
+// a crash between checkpoint and send can lose that item.
+type BatchStore interface {
+	Acquire(context.Context, string, string, time.Duration) (bool, error)
+	Next(context.Context, string) (int, error)
+	SaveNext(context.Context, string, int, time.Duration) error
+	Release(context.Context, string, string) error
+}
+
+func (w *Worker) processBatch(ctx context.Context, batch *outgress.Batch, broadcasterID, owner string) error {
+	if !batch.Valid() {
+		w.log.Error("dropping malformed outgress batch")
+		return nil
+	}
+	if w.batch == nil {
+		return errBatchStoreUnavailable
+	}
+
+	acquired, err := w.batch.Acquire(ctx, batch.ID, owner, batchStateTTL)
+	if err != nil {
+		return err
+	}
+	if !acquired {
+		return errBatchBusy
+	}
+
+	next, runErr := w.batch.Next(ctx, batch.ID)
+	if runErr == nil && next < len(batch.Items) {
+		runErr = runBatchItems(batch.Items, next,
+			func(next int) error { return w.batch.SaveNext(ctx, batch.ID, next, batchStateTTL) },
+			func(item outgress.Message) error {
+				if item.Type == outgress.TypeBatch {
+					return errNestedBatch
+				}
+				if item.BroadcasterID == "" {
+					item.BroadcasterID = broadcasterID
+				}
+				return w.processPayload(ctx, item)
+			},
+		)
+	}
+
+	releaseCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := w.batch.Release(releaseCtx, batch.ID, owner); err != nil {
+		w.log.Warn("failed to release outgress batch lock", zap.String("batch_id", batch.ID), zap.Error(err))
+	}
+	return runErr
+}
+
+// runBatchItems checkpoints before execution. That is deliberately at-most-
+// once: an ambiguous or crashed item is skipped on retry instead of repeated.
+func runBatchItems(items []outgress.Message, start int, saveNext func(int) error, execute func(outgress.Message) error) error {
+	for i := max(start, 0); i < len(items); i++ {
+		if err := saveNext(i + 1); err != nil {
+			return err
+		}
+		if err := execute(items[i]); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/app/outgress/internal/worker/batch.go
+++ b/app/outgress/internal/worker/batch.go
@@ -24,51 +24,78 @@ var (
 // retries therefore never repeat an ambiguous item, at the accepted cost that
 // a crash between checkpoint and send can lose that item.
 type BatchStore interface {
-	Acquire(context.Context, string, string, time.Duration) (bool, error)
+	Acquire(context.Context, BatchLease, time.Duration) (bool, error)
 	Next(context.Context, string) (int, error)
 	SaveNext(context.Context, string, int, time.Duration) error
-	Release(context.Context, string, string) error
+	Release(context.Context, BatchLease) error
+}
+
+type BatchLease struct {
+	ID    string
+	Owner string
 }
 
 func (w *Worker) processBatch(ctx context.Context, batch *outgress.Batch, broadcasterID, owner string) error {
-	if !batch.Valid() {
-		w.log.Error("dropping malformed outgress batch")
-		return nil
-	}
-	if w.batch == nil {
-		return errBatchStoreUnavailable
+	lease, proceed, err := w.acquireBatch(ctx, batch, owner)
+	if err != nil || !proceed {
+		return err
 	}
 
-	acquired, err := w.batch.Acquire(ctx, batch.ID, owner, batchStateTTL)
+	runErr := w.resumeBatch(ctx, batch, broadcasterID)
+	w.releaseBatch(lease)
+	return runErr
+}
+
+func (w *Worker) acquireBatch(ctx context.Context, batch *outgress.Batch, owner string) (BatchLease, bool, error) {
+	if !batch.Valid() {
+		w.log.Error("dropping malformed outgress batch")
+		return BatchLease{}, false, nil
+	}
+	if w.batch == nil {
+		return BatchLease{}, false, errBatchStoreUnavailable
+	}
+
+	lease := BatchLease{ID: batch.ID, Owner: owner}
+	acquired, err := w.batch.Acquire(ctx, lease, batchStateTTL)
+	if err != nil {
+		return BatchLease{}, false, err
+	}
+	if !acquired {
+		return BatchLease{}, false, errBatchBusy
+	}
+	return lease, true, nil
+}
+
+func (w *Worker) resumeBatch(ctx context.Context, batch *outgress.Batch, broadcasterID string) error {
+	next, err := w.batch.Next(ctx, batch.ID)
 	if err != nil {
 		return err
 	}
-	if !acquired {
-		return errBatchBusy
+	if next >= len(batch.Items) {
+		return nil
 	}
+	return runBatchItems(batch.Items, next,
+		func(next int) error { return w.batch.SaveNext(ctx, batch.ID, next, batchStateTTL) },
+		func(item outgress.Message) error { return w.processBatchItem(ctx, item, broadcasterID) },
+	)
+}
 
-	next, runErr := w.batch.Next(ctx, batch.ID)
-	if runErr == nil && next < len(batch.Items) {
-		runErr = runBatchItems(batch.Items, next,
-			func(next int) error { return w.batch.SaveNext(ctx, batch.ID, next, batchStateTTL) },
-			func(item outgress.Message) error {
-				if item.Type == outgress.TypeBatch {
-					return errNestedBatch
-				}
-				if item.BroadcasterID == "" {
-					item.BroadcasterID = broadcasterID
-				}
-				return w.processPayload(ctx, item)
-			},
-		)
+func (w *Worker) processBatchItem(ctx context.Context, item outgress.Message, broadcasterID string) error {
+	if item.Type == outgress.TypeBatch {
+		return errNestedBatch
 	}
+	if item.BroadcasterID == "" {
+		item.BroadcasterID = broadcasterID
+	}
+	return w.processPayload(ctx, item)
+}
 
+func (w *Worker) releaseBatch(lease BatchLease) {
 	releaseCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	if err := w.batch.Release(releaseCtx, batch.ID, owner); err != nil {
-		w.log.Warn("failed to release outgress batch lock", zap.String("batch_id", batch.ID), zap.Error(err))
+	if err := w.batch.Release(releaseCtx, lease); err != nil {
+		w.log.Warn("failed to release outgress batch lock", zap.String("batch_id", lease.ID), zap.Error(err))
 	}
-	return runErr
 }
 
 // runBatchItems checkpoints before execution. That is deliberately at-most-

--- a/app/outgress/internal/worker/batch_test.go
+++ b/app/outgress/internal/worker/batch_test.go
@@ -5,44 +5,43 @@ import (
 	"testing"
 
 	"ItsBagelBot/internal/domain/outgress"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+var errAmbiguousTwitchFailure = errors.New("ambiguous twitch failure")
+
+type batchAttempt struct {
+	next     int
+	executed []string
+	failOn   string
+}
+
+func (a *batchAttempt) save(next int) error {
+	a.next = next
+	return nil
+}
+
+func (a *batchAttempt) execute(item outgress.Message) error {
+	a.executed = append(a.executed, item.Type)
+	if item.Type == a.failOn {
+		return errAmbiguousTwitchFailure
+	}
+	return nil
+}
 
 func TestBatchRetryNeverRepeatsClaimedItems(t *testing.T) {
 	items := []outgress.Message{{Type: "one"}, {Type: "two"}, {Type: "three"}}
-	next := 0
-	var firstRun []string
-	wantFailure := errors.New("ambiguous twitch failure")
+	first := &batchAttempt{failOn: "two"}
+	err := runBatchItems(items, 0, first.save, first.execute)
+	require.ErrorIs(t, err, errAmbiguousTwitchFailure)
+	assert.Equal(t, 2, first.next)
+	assert.Equal(t, []string{"one", "two"}, first.executed)
 
-	err := runBatchItems(items, next,
-		func(value int) error { next = value; return nil },
-		func(item outgress.Message) error {
-			firstRun = append(firstRun, item.Type)
-			if item.Type == "two" {
-				return wantFailure
-			}
-			return nil
-		},
-	)
-	if !errors.Is(err, wantFailure) {
-		t.Fatalf("first run error = %v, want %v", err, wantFailure)
-	}
-	if next != 2 {
-		t.Fatalf("checkpoint = %d, want 2", next)
-	}
-	if len(firstRun) != 2 || firstRun[0] != "one" || firstRun[1] != "two" {
-		t.Fatalf("first run executed %v, want [one two] in order", firstRun)
-	}
-
-	var retry []string
-	if err := runBatchItems(items, next,
-		func(value int) error { next = value; return nil },
-		func(item outgress.Message) error { retry = append(retry, item.Type); return nil },
-	); err != nil {
-		t.Fatal(err)
-	}
-	if len(retry) != 1 || retry[0] != "three" {
-		t.Fatalf("retry executed %v, want only [three]", retry)
-	}
+	retry := &batchAttempt{next: first.next}
+	require.NoError(t, runBatchItems(items, retry.next, retry.save, retry.execute))
+	assert.Equal(t, []string{"three"}, retry.executed)
 }
 
 func TestBatchCheckpointFailureDoesNotSendItem(t *testing.T) {

--- a/app/outgress/internal/worker/batch_test.go
+++ b/app/outgress/internal/worker/batch_test.go
@@ -1,0 +1,82 @@
+package worker
+
+import (
+	"errors"
+	"testing"
+
+	"ItsBagelBot/internal/domain/outgress"
+)
+
+func TestBatchRetryNeverRepeatsClaimedItems(t *testing.T) {
+	items := []outgress.Message{{Type: "one"}, {Type: "two"}, {Type: "three"}}
+	next := 0
+	var firstRun []string
+	wantFailure := errors.New("ambiguous twitch failure")
+
+	err := runBatchItems(items, next,
+		func(value int) error { next = value; return nil },
+		func(item outgress.Message) error {
+			firstRun = append(firstRun, item.Type)
+			if item.Type == "two" {
+				return wantFailure
+			}
+			return nil
+		},
+	)
+	if !errors.Is(err, wantFailure) {
+		t.Fatalf("first run error = %v, want %v", err, wantFailure)
+	}
+	if next != 2 {
+		t.Fatalf("checkpoint = %d, want 2", next)
+	}
+	if len(firstRun) != 2 || firstRun[0] != "one" || firstRun[1] != "two" {
+		t.Fatalf("first run executed %v, want [one two] in order", firstRun)
+	}
+
+	var retry []string
+	if err := runBatchItems(items, next,
+		func(value int) error { next = value; return nil },
+		func(item outgress.Message) error { retry = append(retry, item.Type); return nil },
+	); err != nil {
+		t.Fatal(err)
+	}
+	if len(retry) != 1 || retry[0] != "three" {
+		t.Fatalf("retry executed %v, want only [three]", retry)
+	}
+}
+
+func TestBatchCheckpointFailureDoesNotSendItem(t *testing.T) {
+	want := errors.New("valkey unavailable")
+	executed := false
+	err := runBatchItems([]outgress.Message{{Type: "chat"}}, 0,
+		func(int) error { return want },
+		func(outgress.Message) error { executed = true; return nil },
+	)
+	if !errors.Is(err, want) {
+		t.Fatalf("run error = %v, want %v", err, want)
+	}
+	if executed {
+		t.Fatal("item executed without an at-most-once checkpoint")
+	}
+}
+
+func TestBatchWireCodecPreservesItems(t *testing.T) {
+	body := []byte(`{"type":"batch","broadcaster_id":"123","payload":{"id":"batch-1","items":[{"type":"chat","payload":{"message":"one"}},{"type":"chat","payload":{"message":"two"}}]}}`)
+	var got outgress.Message
+	if err := decodeMessage(body, &got); err != nil {
+		t.Fatal(err)
+	}
+	var batch outgress.Batch
+	if err := decodeBatch(got.Payload, &batch); err != nil {
+		t.Fatal(err)
+	}
+	if batch.ID != "batch-1" || len(batch.Items) != 2 {
+		t.Fatalf("decoded batch = %#v", batch)
+	}
+}
+
+func TestBatchJSONDecoderPrecompiles(t *testing.T) {
+	if err := PrepareJSON(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/app/outgress/internal/worker/batch_valkey.go
+++ b/app/outgress/internal/worker/batch_valkey.go
@@ -21,8 +21,8 @@ func NewValkeyBatchStore(client valkey.Client) *ValkeyBatchStore {
 	return &ValkeyBatchStore{client: client}
 }
 
-func (s *ValkeyBatchStore) Acquire(ctx context.Context, batchID, owner string, ttl time.Duration) (bool, error) {
-	res := s.client.Do(ctx, s.client.B().Set().Key(batchLockKey(batchID)).Value(owner).Nx().Px(ttl).Build())
+func (s *ValkeyBatchStore) Acquire(ctx context.Context, lease BatchLease, ttl time.Duration) (bool, error) {
+	res := s.client.Do(ctx, s.client.B().Set().Key(batchLockKey(lease.ID)).Value(lease.Owner).Nx().Px(ttl).Build())
 	value, err := res.ToString()
 	if err != nil {
 		if valkey.IsValkeyNil(err) {
@@ -49,10 +49,10 @@ func (s *ValkeyBatchStore) SaveNext(ctx context.Context, batchID string, next in
 		Value(strconv.Itoa(next)).Px(ttl).Build()).Error()
 }
 
-func (s *ValkeyBatchStore) Release(ctx context.Context, batchID, owner string) error {
+func (s *ValkeyBatchStore) Release(ctx context.Context, lease BatchLease) error {
 	const releaseIfOwner = `if redis.call('get',KEYS[1])==ARGV[1] then return redis.call('del',KEYS[1]) else return 0 end`
 	return s.client.Do(ctx, s.client.B().Eval().Script(releaseIfOwner).
-		Numkeys(1).Key(batchLockKey(batchID)).Arg(owner).Build()).Error()
+		Numkeys(1).Key(batchLockKey(lease.ID)).Arg(lease.Owner).Build()).Error()
 }
 
 func batchLockKey(batchID string) string     { return batchKeyPrefix + batchID + ":lock" }

--- a/app/outgress/internal/worker/batch_valkey.go
+++ b/app/outgress/internal/worker/batch_valkey.go
@@ -1,0 +1,59 @@
+package worker
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/valkey-io/valkey-go"
+)
+
+const batchKeyPrefix = "outgress:batch:"
+
+// ValkeyBatchStore is the infrastructure adapter for BatchStore. Batch
+// orchestration depends only on the interface in batch.go; this file owns the
+// Valkey commands and key layout.
+type ValkeyBatchStore struct {
+	client valkey.Client
+}
+
+func NewValkeyBatchStore(client valkey.Client) *ValkeyBatchStore {
+	return &ValkeyBatchStore{client: client}
+}
+
+func (s *ValkeyBatchStore) Acquire(ctx context.Context, batchID, owner string, ttl time.Duration) (bool, error) {
+	res := s.client.Do(ctx, s.client.B().Set().Key(batchLockKey(batchID)).Value(owner).Nx().Px(ttl).Build())
+	value, err := res.ToString()
+	if err != nil {
+		if valkey.IsValkeyNil(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return value == "OK", nil
+}
+
+func (s *ValkeyBatchStore) Next(ctx context.Context, batchID string) (int, error) {
+	value, err := s.client.Do(ctx, s.client.B().Get().Key(batchProgressKey(batchID)).Build()).ToString()
+	if err != nil {
+		if valkey.IsValkeyNil(err) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	return strconv.Atoi(value)
+}
+
+func (s *ValkeyBatchStore) SaveNext(ctx context.Context, batchID string, next int, ttl time.Duration) error {
+	return s.client.Do(ctx, s.client.B().Set().Key(batchProgressKey(batchID)).
+		Value(strconv.Itoa(next)).Px(ttl).Build()).Error()
+}
+
+func (s *ValkeyBatchStore) Release(ctx context.Context, batchID, owner string) error {
+	const releaseIfOwner = `if redis.call('get',KEYS[1])==ARGV[1] then return redis.call('del',KEYS[1]) else return 0 end`
+	return s.client.Do(ctx, s.client.B().Eval().Script(releaseIfOwner).
+		Numkeys(1).Key(batchLockKey(batchID)).Arg(owner).Build()).Error()
+}
+
+func batchLockKey(batchID string) string     { return batchKeyPrefix + batchID + ":lock" }
+func batchProgressKey(batchID string) string { return batchKeyPrefix + batchID + ":next" }

--- a/app/outgress/internal/worker/codec.go
+++ b/app/outgress/internal/worker/codec.go
@@ -33,6 +33,7 @@ type wireMessage struct {
 func PrepareJSON() error {
 	return sonic.PretouchMany([]reflect.Type{
 		reflect.TypeOf(wireMessage{}),
+		reflect.TypeOf(outgress.Batch{}),
 		reflect.TypeOf(outgress.EventSubJob{}),
 		reflect.TypeOf(outgress.StreamStatusJob{}),
 	})
@@ -50,6 +51,10 @@ func decodeMessage(data []byte, destination *outgress.Message) error {
 		RewardID: wire.RewardID, RedemptionID: wire.RedemptionID, Status: wire.Status,
 	}
 	return nil
+}
+
+func decodeBatch(data []byte, destination *outgress.Batch) error {
+	return sonic.ConfigFastest.Unmarshal(data, destination)
 }
 
 // withSenderID ensures the chat body carries sender_id without disturbing the

--- a/app/outgress/internal/worker/dispatch.go
+++ b/app/outgress/internal/worker/dispatch.go
@@ -87,7 +87,21 @@ func (w *Worker) Process(msg *message.Message) error {
 	if err := w.checkPaused(ctx); err != nil {
 		return err
 	}
+	if payload.Type == outgress.TypeBatch {
+		var batch outgress.Batch
+		if err := decodeBatch(payload.Payload, &batch); err != nil {
+			w.log.Error("dropping malformed outgress batch", zap.Error(err))
+			noticeError(ctx, err)
+			return nil
+		}
+		return w.processBatch(ctx, &batch, payload.BroadcasterID, msg.UUID)
+	}
+	return w.processPayload(ctx, payload)
+}
 
+// processPayload dispatches one decoded, admitted action. Batch jobs call it
+// serially for each child; ordinary jobs call it once.
+func (w *Worker) processPayload(ctx context.Context, payload outgress.Message) error {
 	switch payload.Type {
 	case outgress.TypeEventSub:
 		return w.processEventSub(ctx, payload)

--- a/app/outgress/internal/worker/worker.go
+++ b/app/outgress/internal/worker/worker.go
@@ -71,6 +71,7 @@ type Worker struct {
 	owner    string // pod identity for the enroll lock (os.Hostname)
 	conduit  *conduit.Resolver
 	lane     Lane
+	batch    BatchStore
 	// userIDs caches login->id resolutions (shoutout targets) so a repeated
 	// /shoutout to the same channel does not re-hit Helix Get Users each time.
 	userIDs *cache.Cache[string]
@@ -92,6 +93,7 @@ type Config struct {
 	Owner    string // pod identity for the enroll lock (os.Hostname)
 	Conduit  *conduit.Resolver
 	Lane     Lane
+	Batch    BatchStore
 }
 
 func New(cfg Config) *Worker {
@@ -104,6 +106,7 @@ func New(cfg Config) *Worker {
 		owner:    cfg.Owner,
 		conduit:  cfg.Conduit,
 		lane:     cfg.Lane,
+		batch:    cfg.Batch,
 		userIDs:  userIDCache(),
 	}
 }

--- a/app/outgress/main.go
+++ b/app/outgress/main.go
@@ -300,6 +300,7 @@ func (d *deps) newLeaseLimiter(ctx context.Context) (ratelimit.Manager, func()) 
 // (stream_status jobs) and writes the result back into the live projection for
 // the worker fleet.
 func (d *deps) newLaneWorkers(tw *twitch.Client, limiter ratelimit.Manager, registry *channels.Registry) (premium, standard, system *worker.Worker, cleanup func()) {
+	batch := worker.NewValkeyBatchStore(d.valkey)
 	base := worker.Config{
 		Limiter:  limiter,
 		Registry: registry,
@@ -307,6 +308,7 @@ func (d *deps) newLaneWorkers(tw *twitch.Client, limiter ratelimit.Manager, regi
 		BotID:    d.cfg.TwitchBotUserID,
 		Owner:    d.host,
 		Conduit:  conduit.New(d.nc, d.cfg.ConduitSubject, d.cfg.TwitchConduitID, 60*time.Second, d.log.Named("conduit")),
+		Batch:    batch,
 	}
 	build := func(name string, lane worker.Lane) *worker.Worker {
 		cfg := base

--- a/app/sesame/engine/dispatch.go
+++ b/app/sesame/engine/dispatch.go
@@ -10,6 +10,7 @@ import (
 	"ItsBagelBot/internal/domain/outgress"
 	"ItsBagelBot/internal/domain/validate"
 	"ItsBagelBot/internal/projection"
+	"ItsBagelBot/internal/utils"
 
 	"go.uber.org/zap"
 )
@@ -94,7 +95,10 @@ func (p *Pipeline) runCustom(ctx context.Context, c *module.Context, name, args 
 	// "/announce" with no text, a "/shoutout" with no target) is dropped; the
 	// run counts once if anything was emitted.
 	counters := p.bumpCounterTokens(ctx, c, cc.Name, cc.Response)
-	emitted := p.emitResponse(c, cc.Response, args, counters, emit)
+	emitted, err := p.emitResponse(c, cc.Response, args, counters, emit)
+	if err != nil {
+		return err
+	}
 	if !emitted {
 		return nil
 	}
@@ -110,14 +114,12 @@ func (p *Pipeline) runCustom(ctx context.Context, c *module.Context, name, args 
 	return nil
 }
 
-// emitResponse expands a custom command's response template once, then emits
-// one chat output per non-empty line through the post-processing middleware
-// (each line gets its own slash-verb translation, so "/announce hi\nplain"
-// mixes an announcement and a chat line). The line count is capped at
-// validate.MaxResponseLines — the write path enforces it, this is the emit-side
-// backstop so an expanded token can never fan out further. Reports whether at
-// least one line was actually emitted.
-func (p *Pipeline) emitResponse(c *module.Context, response, args string, counters map[string]string, emit module.Emit) bool {
+// emitResponse expands a custom command once and prepares one action per
+// non-empty line. Multiple actions are packed into one outgress batch so one
+// worker owns their execution order; a single action keeps the ordinary wire
+// shape. Each line gets its own slash-verb translation. The line count is
+// capped at validate.MaxResponseLines as an emit-side backstop.
+func (p *Pipeline) emitResponse(c *module.Context, response, args string, counters map[string]string, emit module.Emit) (bool, error) {
 	// {user}/{sender}/{channel} render the display name (login fallback); {touser}
 	// defaults to the sender's display name and is otherwise the @mention the
 	// chatter typed, taken verbatim.
@@ -148,7 +150,7 @@ func (p *Pipeline) emitResponse(c *module.Context, response, args string, counte
 	expanded := string(buf)
 	PutBuf(buf)
 
-	emitted := false
+	outputs := make([]module.Output, 0, validate.MaxResponseLines)
 	lines := 0
 	for line := range strings.SplitSeq(expanded, "\n") {
 		if line == "" {
@@ -162,12 +164,55 @@ func (p *Pipeline) emitResponse(c *module.Context, response, args string, counte
 		out.Type = outgress.TypeChat
 		out.BroadcasterID = c.Env.BroadcasterUserID
 		out.Text = line
-		if p.emitCommand(out, emit) {
-			emitted = true
+		if p.prepareCommand(out) {
+			outputs = append(outputs, *out)
 		}
 		PutOutput(out)
 	}
-	return emitted
+	return p.emitPreparedResponse(c, outputs, emit)
+}
+
+func (p *Pipeline) emitPreparedResponse(c *module.Context, outputs []module.Output, emit module.Emit) (bool, error) {
+	switch len(outputs) {
+	case 0:
+		return false, nil
+	case 1:
+		emit(&outputs[0])
+		return true, nil
+	}
+
+	batchID := c.Env.MsgID
+	if batchID == "" {
+		id, err := utils.NewID()
+		if err != nil {
+			return false, err
+		}
+		batchID = id.String()
+	}
+	batch := GetOutput()
+	batch.Type = outgress.TypeBatch
+	batch.BroadcasterID = c.Env.BroadcasterUserID
+	batch.BatchID = batchID
+	batch.Items = outputs
+	emit(batch)
+	PutOutput(batch)
+	return true, nil
+}
+
+func (p *Pipeline) prepareCommand(o *module.Output) bool {
+	Translate(o)
+	return !isEmptyAction(o) && !p.floorSuppressed(o)
+}
+
+// emitCommand prepares and publishes one baked-command output. Custom
+// responses prepare all lines first so multiple actions can be packed into one
+// ordered batch job.
+func (p *Pipeline) emitCommand(o *module.Output, emit module.Emit) bool {
+	if !p.prepareCommand(o) {
+		return false
+	}
+	emit(o)
+	return true
 }
 
 // bumpCounterTokens resolves a response's {counter:<name>} tokens: each
@@ -202,24 +247,6 @@ func (p *Pipeline) bumpCounterTokens(ctx context.Context, c *module.Context, com
 		counters[name] = strconv.FormatInt(value, 10)
 	}
 	return counters
-}
-
-// emitCommand is the command-output post-processing middleware. Every output a
-// command produces (baked or custom) passes through it before publish: Translate
-// routes a leading slash-verb to the right outgress action (/announce -> announce
-// with color, /shoutout -> shoutout; a plain line or /me stays chat), and an
-// action left empty (an /announce with no text, a /shoutout with no target) is
-// dropped so Twitch is never sent a call it would reject. It is deliberately not
-// gated: routing an output is not a privilege, so permission is the job of the
-// command that produced the output, not of the announce/shoutout verb. It
-// reports whether the output was actually emitted.
-func (p *Pipeline) emitCommand(o *module.Output, emit module.Emit) bool {
-	Translate(o)
-	if isEmptyAction(o) {
-		return false
-	}
-	emit(o)
-	return true
 }
 
 // gateRule is the set of checks one command is gated by, so the gate takes a

--- a/app/sesame/engine/dispatch_test.go
+++ b/app/sesame/engine/dispatch_test.go
@@ -108,14 +108,19 @@ func TestCustomPlainChatStillEmits(t *testing.T) {
 // line and each line getting its own slash-verb translation.
 func TestCustomMultiLineEmitsOnePerLine(t *testing.T) {
 	p := customPipeline("first {user}\nsecond line\n/announce third", "everyone")
-	got := collectDispatch(p, chatCtx("!so", ""))
-	require.Len(t, got, 3)
-	assert.Equal(t, outgress.TypeChat, got[0].Type)
-	assert.Equal(t, "first alice", got[0].Text)
-	assert.Equal(t, outgress.TypeChat, got[1].Type)
-	assert.Equal(t, "second line", got[1].Text)
-	assert.Equal(t, outgress.TypeAnnounce, got[2].Type)
-	assert.Equal(t, "third", got[2].Text)
+	c := chatCtx("!so", "")
+	c.Env.MsgID = "event-message-1"
+	got := collectDispatch(p, c)
+	require.Len(t, got, 1)
+	assert.Equal(t, outgress.TypeBatch, got[0].Type)
+	assert.Equal(t, "event-message-1", got[0].BatchID)
+	require.Len(t, got[0].Items, 3)
+	assert.Equal(t, outgress.TypeChat, got[0].Items[0].Type)
+	assert.Equal(t, "first alice", got[0].Items[0].Text)
+	assert.Equal(t, outgress.TypeChat, got[0].Items[1].Type)
+	assert.Equal(t, "second line", got[0].Items[1].Text)
+	assert.Equal(t, outgress.TypeAnnounce, got[0].Items[2].Type)
+	assert.Equal(t, "third", got[0].Items[2].Text)
 }
 
 // TestCustomMultiLineCappedAtMax proves the emit-side backstop: a response
@@ -124,8 +129,9 @@ func TestCustomMultiLineEmitsOnePerLine(t *testing.T) {
 func TestCustomMultiLineCappedAtMax(t *testing.T) {
 	p := customPipeline("1\n2\n3\n4\n5\n6\n7", "everyone")
 	got := collectDispatch(p, chatCtx("!so", ""))
-	require.Len(t, got, 5)
-	assert.Equal(t, "5", got[4].Text)
+	require.Len(t, got, 1)
+	require.Len(t, got[0].Items, 5)
+	assert.Equal(t, "5", got[0].Items[4].Text)
 }
 
 // TestCustomMultiLineSkipsEmptyLines proves blank lines never become empty
@@ -133,10 +139,44 @@ func TestCustomMultiLineCappedAtMax(t *testing.T) {
 // suppressing its siblings.
 func TestCustomMultiLineSkipsEmptyLines(t *testing.T) {
 	p := customPipeline("one\n\n/announce\ntwo", "everyone")
-	got := collectDispatch(p, chatCtx("!so", ""))
-	require.Len(t, got, 2)
-	assert.Equal(t, "one", got[0].Text)
-	assert.Equal(t, "two", got[1].Text)
+	c := chatCtx("!so", "")
+	c.Env.MsgID = "event-message-2"
+	got := collectDispatch(p, c)
+	require.Len(t, got, 1)
+	require.Len(t, got[0].Items, 2)
+	assert.Equal(t, "one", got[0].Items[0].Text)
+	assert.Equal(t, "two", got[0].Items[1].Text)
+}
+
+func TestCustomMultiLineSuppressionDoesNotLeaveSequenceGap(t *testing.T) {
+	p := customPipeline("grabify.link/bad\nsafe line", "everyone")
+	c := chatCtx("!so", "")
+	c.Env.MsgID = "event-message-3"
+	got := collectDispatch(p, c)
+	require.Len(t, got, 1)
+	assert.Equal(t, "safe line", got[0].Text)
+	assert.Equal(t, outgress.TypeChat, got[0].Type, "one surviving line does not need a batch")
+}
+
+// TestCustomMultiLineBatchSurvivesPublish proves all lines cross the queue in
+// one job, retaining their order and action types.
+func TestCustomMultiLineBatchSurvivesPublish(t *testing.T) {
+	pub := &fakePublisher{}
+	reader := fakeReader{
+		cmd:      projection.Command{Name: "raid", Response: "line one\nline two", IsActive: true, Perm: "everyone"},
+		cmdFound: true,
+	}
+	p := newPipelineWith(pub, reader)
+
+	require.NoError(t, p.Process(chatMsg(t, "standard", "!raid")))
+	require.Len(t, pub.got, 1)
+	assert.Equal(t, outgress.TypeBatch, pub.got[0].msg.Type)
+	var batch outgress.Batch
+	require.NoError(t, sonic.Unmarshal(pub.got[0].msg.Payload, &batch))
+	assert.NotEmpty(t, batch.ID)
+	require.Len(t, batch.Items, 2)
+	assert.Equal(t, outgress.TypeChat, batch.Items[0].Type)
+	assert.Equal(t, outgress.TypeChat, batch.Items[1].Type)
 }
 
 // --- baked command dispatch + gate ---
@@ -167,7 +207,7 @@ func TestBakedCommandPermGate(t *testing.T) {
 	})
 	p := newPipelineWith(&fakePublisher{}, fakeReader{}, b.Build())
 
-	assert.Empty(t, collectDispatch(p, chatCtx("!clear", "")))             // everyone -> gated
+	assert.Empty(t, collectDispatch(p, chatCtx("!clear", "")))            // everyone -> gated
 	require.Len(t, collectDispatch(p, chatCtx("!clear", "moderator")), 1) // mod -> runs
 }
 

--- a/app/sesame/engine/outgress_build.go
+++ b/app/sesame/engine/outgress_build.go
@@ -22,18 +22,38 @@ type banData struct {
 // correctly. This runs only when a handler actually emits, so the allocation it
 // costs never touches the no-output plain-chat path.
 func buildOutgress(o *module.Output) ([]byte, error) {
-	build, ok := outgressBuilders[o.Type]
-	if !ok {
-		return sonic.Marshal(outgress.Message{
-			Type:          o.Type,
-			BroadcasterID: o.BroadcasterID,
-		})
-	}
-	msg, err := build(o)
+	msg, err := buildOutgressMessage(o)
 	if err != nil {
 		return nil, err
 	}
 	return sonic.Marshal(msg)
+}
+
+func buildOutgressMessage(o *module.Output) (outgress.Message, error) {
+	if o.Type == outgress.TypeBatch {
+		items := make([]outgress.Message, 0, len(o.Items))
+		for i := range o.Items {
+			item, err := buildOutgressMessage(&o.Items[i])
+			if err != nil {
+				return outgress.Message{}, err
+			}
+			items = append(items, item)
+		}
+		return payloadMessage(outgress.TypeBatch, o.BroadcasterID, outgress.Batch{ID: o.BatchID, Items: items})
+	}
+
+	build, ok := outgressBuilders[o.Type]
+	if !ok {
+		return outgress.Message{
+			Type:          o.Type,
+			BroadcasterID: o.BroadcasterID,
+		}, nil
+	}
+	msg, err := build(o)
+	if err != nil {
+		return outgress.Message{}, err
+	}
+	return msg, nil
 }
 
 // outgressBuilders maps each intent to its wire-message construction; types

--- a/app/sesame/module/module.go
+++ b/app/sesame/module/module.go
@@ -68,12 +68,16 @@ func (k Kind) String() string {
 //     expansion (e.g. the clip reply's {clip} token, expanded by outgress once
 //     the clip URL exists). Empty means use the default reply. Only Type clip
 //     reads it.
+//   - BatchID/Items carry a multi-message response as one outgress queue job.
+//     Items are already translated actions and execute in slice order.
 type Output struct {
 	Type          string
 	BroadcasterID string
 	Text          string
 	Color         string
 	To            string
+	BatchID       string
+	Items         []Output
 	// Duration is shared: the clip length (fractional seconds) for a clip
 	// Output, the timeout length in whole seconds for a timeout (0 = permanent
 	// ban). Template is the clip reply template.

--- a/internal/domain/outgress/message.go
+++ b/internal/domain/outgress/message.go
@@ -35,6 +35,17 @@ type Message struct {
 	Status       string `json:"status,omitempty"`
 }
 
+// Batch is the shared producer/consumer contract for an ordered, at-most-once
+// group. ID keys ownership and progress; Items execute in slice order.
+type Batch struct {
+	ID    string    `json:"id"`
+	Items []Message `json:"items"`
+}
+
+func (b *Batch) Valid() bool {
+	return b != nil && b.ID != "" && len(b.Items) > 0
+}
+
 // StreamStatusJob is the payload of a "stream_status" message: a request for
 // outgress to resolve one broadcaster's current live state from Twitch (Helix
 // Get Streams) and write it back into the shared live projection. It carries no
@@ -62,6 +73,7 @@ type EventSubJob struct {
 // Message type values. Producers set Message.Type to one of these.
 const (
 	TypeChat         = "chat"
+	TypeBatch        = "batch"
 	TypeAPI          = "api"
 	TypeEventSub     = "eventsub"
 	TypeStreamStatus = "stream_status"


### PR DESCRIPTION
## Summary
- pack multi-line custom command replies into one typed outgress batch payload
- execute batch actions serially under one distributed owner
- checkpoint each action before its Twitch call for explicit at-most-once delivery: retries may lose an ambiguous line but never repeat it
- keep batch orchestration behind a store interface with the Valkey adapter isolated

## Verification
- `go test ./...`