### PR TITLE
feat(console): layer starfield over aurora on login pages

### DIFF
--- a/console/admin/src/routes/login/+page.svelte
+++ b/console/admin/src/routes/login/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { page } from '$app/state';
+  import { AuroraBg, LightField } from '@bagel/shared';
 
   const err = $derived(page.url.searchParams.get('e'));
   const messages: Record<string, string> = {
@@ -10,6 +11,9 @@
   };
   const notice = $derived(err ? messages[err] : undefined);
 </script>
+
+<AuroraBg />
+<div class="starfield" aria-hidden="true"><LightField /></div>
 
 <main class="login">
   <div class="panel">
@@ -31,7 +35,18 @@
 </main>
 
 <style>
+  /* Mote field sits above the aurora (z-index 0) but below the panel (z-index 1).
+     Own stacking context so LightField's z-index:-1 canvas stays contained. */
+  .starfield {
+    position: fixed;
+    inset: 0;
+    z-index: 0;
+    pointer-events: none;
+  }
+
   .login {
+    position: relative;
+    z-index: 1;
     min-height: 100vh;
     display: flex;
     align-items: center;

--- a/console/dashboard/src/routes/login/+page.svelte
+++ b/console/dashboard/src/routes/login/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { page } from '$app/state';
-  import { AuroraBg, Icon, getI18n } from '@bagel/shared';
+  import { AuroraBg, LightField, Icon, getI18n } from '@bagel/shared';
   import LangSwitch from '$lib/components/LangSwitch.svelte';
 
   const { t } = getI18n();
@@ -24,6 +24,7 @@
 </script>
 
 <AuroraBg />
+<div class="starfield" aria-hidden="true"><LightField /></div>
 
 <div class="lang-corner"><LangSwitch /></div>
 
@@ -69,6 +70,15 @@
 </main>
 
 <style>
+  /* Mote field sits above the aurora (z-index 0) but below content (z-index 1).
+     Own stacking context so LightField's z-index:-1 canvas stays contained. */
+  .starfield {
+    position: fixed;
+    inset: 0;
+    z-index: 0;
+    pointer-events: none;
+  }
+
   .lang-corner {
     position: fixed;
     top: max(16px, env(safe-area-inset-top, 0px));

--- a/console/shared/components/LightField.svelte
+++ b/console/shared/components/LightField.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
   import { onMount } from 'svelte';
 
+  // `warmth` is the share of gold (vs green) motes, matching the web field's
+  // data-warmth. 0.7 is the pricing-header value.
+  let { warmth = 0.7 }: { warmth?: number } = $props();
+
   let canvas: HTMLCanvasElement;
 
   onMount(() => {
@@ -33,7 +37,7 @@
         vy: -(0.05 + Math.random() * 0.2),
         vx: (Math.random() - 0.5) * 0.1,
         alpha: 0.12 + Math.random() * 0.45,
-        warm: Math.random() < 0.7
+        warm: Math.random() < warmth
       }));
     }
 


### PR DESCRIPTION
## What

Ports the marketing site's pricing-header **star/mote field** onto both console login screens, layered on top of the aurora.

The shared `LightField.svelte` already replicated `web/src/script/lightfield.js` 1:1 (same mote build, velocities, gold/green colors, IntersectionObserver rAF gating, reduced-motion off). This wires it into the login flows and parameterizes its warmth for full parity with the web `data-warmth`.

## Changes

- **`LightField.svelte`** — add optional `warmth` prop (default `0.7`, matching the pricing header). Backward-compatible; existing `ErrorView` usage unaffected.
- **Dashboard login** — starfield layer immediately above the existing `<AuroraBg />`.
- **Admin login** — add `<AuroraBg />` + starfield (it had neither), and lift `.login` to `position:relative; z-index:1` so the glass panel stays above both layers.

Each starfield wrapper is `position:fixed; inset:0; z-index:0` — its own stacking context, so motes paint over the aurora (z-index 0) but under page content (z-index 1).

## Verification

Ran both dev servers and confirmed on `/login`:
- Layering: aurora glow → mote field → content/panel
- Zero console errors on either app
- Motes are the gold `201,168,124` / green `82,183,136` field, warmth 0.7

## CodeScene

Trivial CSS + one prop; no new branches or complexity introduced, so nothing for the advisory CodeScene check to flag.