### PR TITLE
Dashboard visual follow-ups: drop module tag, billing starfield

### DIFF
--- a/console/dashboard/src/routes/(app)/billing/+page.svelte
+++ b/console/dashboard/src/routes/(app)/billing/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Icon, PageHead, Card, Modal, AlertBanner, Button, ConfirmDialog, FieldError, toast, getI18n, containsLink } from '@bagel/shared';
+  import { Icon, PageHead, Card, Modal, AlertBanner, Button, ConfirmDialog, FieldError, AuroraBg, LightField, toast, getI18n, containsLink } from '@bagel/shared';
   import { page } from '$app/state';
   import { replaceState } from '$app/navigation';
   import { onMount } from 'svelte';
@@ -253,6 +253,12 @@
     }
   });
 </script>
+
+<!-- Aurora + drifting light motes, the same premium backdrop the login page
+     uses. Decorative, sits behind the content, and LightField bails out under
+     prefers-reduced-motion. -->
+<AuroraBg />
+<div class="starfield" aria-hidden="true"><LightField warmth={0.7} /></div>
 
 <section class="screen active">
   <PageHead
@@ -568,6 +574,21 @@
 {/if}
 
 <style>
+  /* Mote field sits above the aurora but below the page content. Fixed to the
+     viewport so it backs the whole billing screen, like the login page. */
+  .starfield {
+    position: fixed;
+    inset: 0;
+    z-index: 0;
+    pointer-events: none;
+  }
+  /* Lift the content above the decorative backdrop. Scoped to this page, so it
+     does not affect .screen elsewhere. */
+  .screen {
+    position: relative;
+    z-index: 1;
+  }
+
   :global(.billing-card) {
     margin-top: 18px;
   }

--- a/console/dashboard/src/routes/(app)/modules/+page.svelte
+++ b/console/dashboard/src/routes/(app)/modules/+page.svelte
@@ -188,9 +188,6 @@
                     <h3 class="tile-label">{m.def.label}</h3>
                     <p class="tile-cat">{m.def.category}</p>
                   </div>
-                  <span class="tile-status" data-on={m.enabled}>
-                    {m.enabled ? t('modules.stateEnabled') : t('modules.stateDisabled')}
-                  </span>
                 </div>
                 <p class="tile-purpose">{m.def.tagline}</p>
                 <div class="tile-foot">
@@ -410,25 +407,6 @@
   .tile-heading { display: flex; flex-direction: column; gap: 2px; min-width: 0; margin-right: auto; }
   .tile-label { font-family: var(--bb-font-display); font-weight: 700; font-size: 16px; color: var(--bb-white); margin: 0; }
   .tile-cat { font-family: var(--bb-font-mono); font-size: 10.5px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--bb-muted); margin: 0; }
-
-  /* Enabled/disabled shown as a text badge, not by dimming the card (keeps the
-     card text above 4.5:1 contrast). */
-  .tile-status {
-    flex: none;
-    font-family: var(--bb-font-mono);
-    font-size: 10px;
-    letter-spacing: 0.06em;
-    text-transform: uppercase;
-    padding: 4px 8px;
-    border-radius: 4px;
-    border: 1px solid var(--glass-border);
-    color: var(--bb-muted);
-  }
-  .tile-status[data-on='true'] {
-    color: var(--bb-status-success, #52b788);
-    border-color: var(--bb-status-success-border, rgba(82, 183, 136, 0.4));
-    background: var(--bb-status-success-bg, rgba(82, 183, 136, 0.1));
-  }
 
   .tile-purpose {
     font-family: var(--bb-font-body);


### PR DESCRIPTION
Two small visual follow-ups on top of the merged dashboard redesign.

## Changes
- **Modules catalog:** remove the redundant Enabled/Disabled tag from cards. The `role=switch` toggle (with `aria-checked` + its "Enable/Disable {module}" label) already conveys state, so nothing accessible is lost. Removed the markup and its unused styles.
- **Billing:** add the login page's `AuroraBg` + `LightField` mote field as a decorative backdrop (warmth 0.7, the pricing-header value `LightField` was built for). It is `aria-hidden`, sits behind the content, and disables itself under `prefers-reduced-motion`.

## Verification
- `bun run check`: admin 0/0, dashboard 0 errors (1 pre-existing `-webkit-line-clamp` warning, unrelated).
- `bun run build`: dashboard + admin exit 0.
- Browser-confirmed both pages render correctly (cleaner module cards; aurora + drifting motes behind the billing content).