### PR TITLE
feat(sesame): add cached !accountage built-in command

### DIFF
--- a/app/outgress/internal/twitch/client.go
+++ b/app/outgress/internal/twitch/client.go
@@ -248,32 +248,59 @@ func (c *Client) IsStreamLive(ctx context.Context, broadcasterID string) (bool, 
 	return false, nil
 }
 
-// UserIDByLogin resolves a Twitch login to its numeric user id via Helix Get
-// Users under the app token. Returns ("", nil) when no such user exists.
-func (c *Client) UserIDByLogin(ctx context.Context, login string) (string, error) {
-	res, err := c.request(ctx, c.app, getCall("/helix/users?login="+url.QueryEscape(login)))
+// helixUser is the slice of Helix Get Users the workers read: the account's
+// numeric id and its creation time.
+type helixUser struct {
+	ID        string    `json:"id"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// getUser runs one Get Users query ("id=..." or "login=...") under the app
+// token and returns the first match. found is false when Twitch returns no
+// user; the caller decides whether that is an error for its purpose.
+func (c *Client) getUser(ctx context.Context, query string) (helixUser, bool, error) {
+	res, err := c.request(ctx, c.app, getCall("/helix/users?"+query))
 	if err != nil {
-		return "", err
+		return helixUser{}, false, err
 	}
 	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(io.LimitReader(res.Body, 2048))
-		return "", &StatusError{Status: res.StatusCode, Body: string(body)}
+		return helixUser{}, false, &StatusError{Status: res.StatusCode, Body: string(body)}
 	}
 
 	var payload struct {
-		Data []struct {
-			ID string `json:"id"`
-		} `json:"data"`
+		Data []helixUser `json:"data"`
 	}
 	if err := json.NewDecoder(res.Body).Decode(&payload); err != nil {
-		return "", err
+		return helixUser{}, false, err
 	}
 	if len(payload.Data) == 0 {
-		return "", nil
+		return helixUser{}, false, nil
 	}
-	return payload.Data[0].ID, nil
+	return payload.Data[0], true, nil
+}
+
+// UserIDByLogin resolves a Twitch login to its numeric user id via Helix Get
+// Users under the app token. Returns ("", nil) when no such user exists.
+func (c *Client) UserIDByLogin(ctx context.Context, login string) (string, error) {
+	user, _, err := c.getUser(ctx, "login="+url.QueryEscape(login))
+	return user.ID, err
+}
+
+// UserCreatedAt returns a Twitch user's id and account creation time, looked up
+// by id when provided, otherwise by login. found is false when no such user
+// exists. It rides the app token, like every other general Helix read.
+func (c *Client) UserCreatedAt(ctx context.Context, targetID, targetLogin string) (id string, createdAt time.Time, found bool, err error) {
+	q := url.Values{}
+	if targetID != "" {
+		q.Set("id", targetID)
+	} else {
+		q.Set("login", targetLogin)
+	}
+	user, found, err := c.getUser(ctx, q.Encode())
+	return user.ID, user.CreatedAt, found, err
 }
 
 // FollowedAt returns when targetID followed broadcasterID. found is false when

--- a/app/outgress/rpc/manage.go
+++ b/app/outgress/rpc/manage.go
@@ -35,6 +35,7 @@ type Manage struct {
 //	<prefix>.channel.get     {broadcaster_id}                  -> {channel, found}
 //	<prefix>.channel.set     {broadcaster_id, enabled?, is_mod?} -> {channel, found}
 //	<prefix>.channel.list    {}                                -> {channels}
+//	<prefix>.accountage.get  {target_id?, target_login?}       -> {created_at, user_found}
 //	<prefix>.system.status   {}                                -> {paused, token health}
 //	<prefix>.system.pause    {paused}                          -> {paused}
 func SubscribeManage(nc *nats.Conn, registry *channels.Registry, tw *twitch.Client, prefix, queueGroup string, app *newrelic.Application, log *zap.Logger) error {
@@ -54,6 +55,9 @@ func SubscribeManage(nc *nats.Conn, registry *channels.Registry, tw *twitch.Clie
 		return err
 	}
 	if err := bus.QueueSubscribeJSON[outgressrpc.FollowageRequest, outgressrpc.FollowageReply](nc, prefix+".followage.get", queueGroup, followageHandleTimeout, app, log, m.handleFollowage); err != nil {
+		return err
+	}
+	if err := bus.QueueSubscribeJSON[outgressrpc.AccountAgeRequest, outgressrpc.AccountAgeReply](nc, prefix+".accountage.get", queueGroup, handleTimeout, app, log, m.handleAccountAge); err != nil {
 		return err
 	}
 	if err := bus.QueueSubscribeJSON[manage.SystemPauseRequest, manage.SystemPauseReply](nc, prefix+".system.pause", queueGroup, handleTimeout, app, log, m.handleSystemPause); err != nil {
@@ -111,6 +115,21 @@ func (m *Manage) fetchFollowage(ctx context.Context, broadcasterID, targetID str
 	return outgressrpc.FollowageReply{
 		TargetID: targetID, UserFound: true, Following: following, FollowedAt: followedAt,
 	}
+}
+
+func (m *Manage) handleAccountAge(ctx context.Context, req outgressrpc.AccountAgeRequest) outgressrpc.AccountAgeReply {
+	if req.TargetID == "" && req.TargetLogin == "" {
+		return outgressrpc.AccountAgeReply{Error: "bad request"}
+	}
+	id, createdAt, found, err := m.twitch.UserCreatedAt(ctx, req.TargetID, req.TargetLogin)
+	if err != nil {
+		m.log.Warn("accountage lookup failed", zap.Error(err))
+		return outgressrpc.AccountAgeReply{Error: "lookup failed"}
+	}
+	if !found {
+		return outgressrpc.AccountAgeReply{UserFound: false}
+	}
+	return outgressrpc.AccountAgeReply{TargetID: id, UserFound: true, CreatedAt: createdAt}
 }
 
 func (m *Manage) handleChannelGet(ctx context.Context, req manage.ChannelRequest) manage.ChannelReply {

--- a/app/sesame/engine/accountage_rpc.go
+++ b/app/sesame/engine/accountage_rpc.go
@@ -1,0 +1,73 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	outgressrpc "ItsBagelBot/internal/domain/rpc/outgress"
+	"ItsBagelBot/pkg/bus"
+	"ItsBagelBot/pkg/cache"
+
+	"github.com/nats-io/nats.go"
+)
+
+const (
+	accountAgeRPCTimeout  = 3500 * time.Millisecond
+	accountAgePositiveTTL = time.Hour
+	accountAgeNegativeTTL = time.Minute
+)
+
+type AccountAgeResult struct {
+	TargetID  string
+	UserFound bool
+	CreatedAt time.Time
+}
+
+type AccountAgeLookup interface {
+	Lookup(ctx context.Context, targetID, targetLogin string) (AccountAgeResult, error)
+}
+
+// AccountAgeRPC is Sesame's cached account-age reader. Outgress supplies only
+// the authenticated Twitch read; command freshness, singleflight and cache
+// policy live here with the command runtime. A Twitch account's creation date
+// never changes, so a hit stays valid for the full positive TTL.
+type AccountAgeRPC struct {
+	cache   *cache.Cache[AccountAgeResult]
+	request func(context.Context, outgressrpc.AccountAgeRequest) (outgressrpc.AccountAgeReply, error)
+}
+
+func NewAccountAgeRPC(nc *nats.Conn, prefix string) *AccountAgeRPC {
+	subject := strings.TrimSuffix(prefix, ".") + ".accountage.get"
+	return &AccountAgeRPC{
+		cache: cache.New[AccountAgeResult](cache.DefaultCapacity, accountAgeNegativeTTL),
+		request: func(ctx context.Context, req outgressrpc.AccountAgeRequest) (outgressrpc.AccountAgeReply, error) {
+			return bus.RequestJSONTimeout[outgressrpc.AccountAgeReply](ctx, nc, subject, req, accountAgeRPCTimeout)
+		},
+	}
+}
+
+func (a *AccountAgeRPC) Lookup(ctx context.Context, targetID, targetLogin string) (AccountAgeResult, error) {
+	keyTarget := targetID
+	if keyTarget == "" {
+		keyTarget = "login:" + strings.ToLower(strings.TrimPrefix(targetLogin, "@"))
+	}
+	return a.cache.GetOrLoadTTL(ctx, keyTarget, func(ctx context.Context) (AccountAgeResult, time.Duration, error) {
+		reply, err := a.request(ctx, outgressrpc.AccountAgeRequest{TargetID: targetID, TargetLogin: targetLogin})
+		if err != nil {
+			return AccountAgeResult{}, 0, err
+		}
+		if reply.Error != "" {
+			return AccountAgeResult{}, 0, errors.New(reply.Error)
+		}
+		result := AccountAgeResult{
+			TargetID: reply.TargetID, UserFound: reply.UserFound, CreatedAt: reply.CreatedAt,
+		}
+		ttl := accountAgeNegativeTTL
+		if result.UserFound {
+			ttl = accountAgePositiveTTL
+		}
+		return result, ttl, nil
+	})
+}

--- a/app/sesame/engine/accountage_rpc_test.go
+++ b/app/sesame/engine/accountage_rpc_test.go
@@ -1,0 +1,35 @@
+package engine
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	outgressrpc "ItsBagelBot/internal/domain/rpc/outgress"
+	"ItsBagelBot/pkg/cache"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAccountAgeLookupCachesInSesame(t *testing.T) {
+	var calls atomic.Int32
+	a := &AccountAgeRPC{
+		cache: cache.New[AccountAgeResult](100, time.Minute),
+		request: func(_ context.Context, req outgressrpc.AccountAgeRequest) (outgressrpc.AccountAgeReply, error) {
+			calls.Add(1)
+			return outgressrpc.AccountAgeReply{
+				TargetID: req.TargetID, UserFound: true,
+				CreatedAt: time.Date(2016, time.June, 1, 0, 0, 0, 0, time.UTC),
+			}, nil
+		},
+	}
+	defer a.cache.Close()
+
+	for range 2 {
+		result, err := a.Lookup(context.Background(), "viewer", "")
+		require.NoError(t, err)
+		require.True(t, result.UserFound)
+	}
+	require.Equal(t, int32(1), calls.Load(), "the second command lookup must be served by Sesame's cache")
+}

--- a/app/sesame/engine/deps.go
+++ b/app/sesame/engine/deps.go
@@ -49,17 +49,18 @@ type QuotesStore interface {
 // builds its Module. main constructs it once and hands it to modules.All. Not
 // every module uses every field; unused ones are harmless.
 type Deps struct {
-	Proj      projection.Reader
-	Live      LiveStore
-	Greet     GreetStore
-	Cooldown  CooldownStore
-	Dedup     DedupStore
-	Special   *SpecialSet
-	Pub       message.Publisher
-	Commands  CommandManager
-	Gateway   GatewayCaller
-	Followage FollowageLookup
-	Log       *zap.Logger
+	Proj       projection.Reader
+	Live       LiveStore
+	Greet      GreetStore
+	Cooldown   CooldownStore
+	Dedup      DedupStore
+	Special    *SpecialSet
+	Pub        message.Publisher
+	Commands   CommandManager
+	Gateway    GatewayCaller
+	Followage  FollowageLookup
+	AccountAge AccountAgeLookup
+	Log        *zap.Logger
 	// Timers arms/disarms a broadcaster's repeating chat-message timers for the
 	// length of one stream; ValkeyTimerStore is the default. nil disables it (the
 	// live module's stream.online/offline hooks skip the calls).

--- a/app/sesame/main.go
+++ b/app/sesame/main.go
@@ -131,6 +131,7 @@ func buildDeps(in infra, cfg *config.Config, log *zap.Logger, rt engineRuntime) 
 		Quotes:     engine.NewQuotesRPC(in.nc, cfg.ModulesRPCPrefix),
 		Gateway:    engine.NewGatewayRPC(in.nc, cfg.GatewayRPCPrefix),
 		Followage:  engine.NewFollowageRPC(in.nc, cfg.OutgressRPCPrefix),
+		AccountAge: engine.NewAccountAgeRPC(in.nc, cfg.OutgressRPCPrefix),
 		Log:        log,
 		Automod:    rt.guard,
 		Reputation: engine.NewValkeyReputation(in.vc, 6*time.Hour, log),

--- a/app/sesame/modules/followage.go
+++ b/app/sesame/modules/followage.go
@@ -14,68 +14,119 @@ import (
 )
 
 const (
-	followageModuleName = "followage"
-	followageCooldown   = 15 * time.Second
+	followageModuleName  = "followage"
+	followageCooldown    = 15 * time.Second
+	accountAgeModuleName = "accountage"
+	accountAgeCooldown   = 15 * time.Second
 )
 
-// Followage owns the complete built-in !followage [user] command: target
-// normalization, cached lookup through Sesame's Followage service, result
-// formatting, and the chat reply. Outgress only performs the authenticated
-// Twitch read behind that request/reply boundary.
+// Followage owns the built-in viewer-lookup commands that read Twitch through
+// outgress: !followage [user] and !accountage [user]. Each does target
+// normalization, a cached lookup through the matching Sesame service, result
+// formatting, and the chat reply; outgress only performs the authenticated
+// Twitch read behind that request/reply boundary. Both commands are toggleable
+// per broadcaster under their own module key, checked lazily on use.
+//
+// Their replies are wired here as closures over a shared lookupCall so the
+// nil-service, error and formatting handling lives in exactly one place.
 func Followage(d engine.Deps) module.Module {
-	log := d.Log
-	if log == nil {
-		log = zap.NewNop()
+	log := moduleLog(d)
+
+	followage := func(ctx context.Context, c *module.Context, target lookupTarget) string {
+		bid := c.Env.BroadcasterUserID
+		return lookupCall[engine.FollowageResult]{
+			log: log, logKey: followageModuleName, unavailable: "Followage is unavailable right now.",
+			read:   readIf(d.Followage != nil, func() (engine.FollowageResult, error) { return d.Followage.Lookup(ctx, bid, target.id, target.login) }),
+			format: func(res engine.FollowageResult) string { return formatFollowageResult(target.name, bid, res) },
+		}.run()
 	}
-	runtime := followageRuntime{lookup: d.Followage, log: log}
+
+	accountAge := func(ctx context.Context, _ *module.Context, target lookupTarget) string {
+		return lookupCall[engine.AccountAgeResult]{
+			log: log, logKey: accountAgeModuleName, unavailable: "Account age is unavailable right now.",
+			read:   readIf(d.AccountAge != nil, func() (engine.AccountAgeResult, error) { return d.AccountAge.Lookup(ctx, target.id, target.login) }),
+			format: func(res engine.AccountAgeResult) string { return formatAccountAgeResult(target.name, res) },
+		}.run()
+	}
+
 	m := module.NewModule("", module.KindCore)
-	m.Command("followage").Everyone().Cooldown(followageCooldown).Run(followageRun(d, runtime))
+	m.Command("followage").Everyone().Cooldown(followageCooldown).Run(lookupRun(d, followageModuleName, followage))
+	m.Command("accountage").Everyone().Cooldown(accountAgeCooldown).Run(lookupRun(d, accountAgeModuleName, accountAge))
 	return m.Build()
 }
 
-type followageRuntime struct {
-	lookup engine.FollowageLookup
-	log    *zap.Logger
+// replyFunc renders one built-in lookup command's chat reply for a resolved
+// target.
+type replyFunc func(ctx context.Context, c *module.Context, target lookupTarget) string
+
+// lookupRun is the shared body of the built-in lookup commands: honor the
+// per-broadcaster toggle, resolve the target, then emit the command's reply.
+func lookupRun(d engine.Deps, moduleName string, reply replyFunc) module.RunFunc {
+	return func(ctx context.Context, c *module.Context, args string, emit module.Emit) error {
+		if !moduleEnabled(ctx, d, c.BroadcasterID, moduleName) {
+			return nil
+		}
+		emitLookup(c, reply(ctx, c, parseLookupTarget(args, c)), emit)
+		return nil
+	}
 }
 
-type followageTarget struct {
+// lookupCall is one built-in command's cached read plus how to present it. run()
+// is the single place the shared nil-service, error and format handling lives,
+// so !followage and !accountage don't each repeat it.
+type lookupCall[T any] struct {
+	log         *zap.Logger
+	logKey      string
+	unavailable string
+	read        func() (T, error) // nil when the backing service is not wired
+	format      func(T) string
+}
+
+func (lc lookupCall[T]) run() string {
+	if lc.read == nil {
+		return lc.unavailable
+	}
+	result, err := lc.read()
+	if err != nil {
+		lc.log.Warn(lc.logKey+": lookup failed", zap.Error(err))
+		return lc.unavailable
+	}
+	return lc.format(result)
+}
+
+// readIf returns read when ok, else nil, letting a caller drop a read whose
+// backing service is absent without an inline conditional at the call site.
+func readIf[T any](ok bool, read func() (T, error)) func() (T, error) {
+	if !ok {
+		return nil
+	}
+	return read
+}
+
+// lookupTarget is the normalized subject of a viewer-lookup command: an
+// explicit "@user" argument (login/name, no id yet) or, absent one, the chatter
+// themselves (login, display name and id straight off the envelope).
+type lookupTarget struct {
 	login string
 	name  string
 	id    string
 }
 
-func followageRun(d engine.Deps, runtime followageRuntime) module.RunFunc {
-	return func(ctx context.Context, c *module.Context, args string, emit module.Emit) error {
-		if !followageEnabled(ctx, d, c.BroadcasterID, runtime.log) {
-			return nil
-		}
-		target := parseFollowageTarget(args, c)
-		emitFollowage(c, runtime.text(ctx, target, c.Env.BroadcasterUserID), emit)
-		return nil
-	}
-}
-
-func parseFollowageTarget(args string, c *module.Context) followageTarget {
+// parseLookupTarget reads the optional first "@user" argument, falling back to
+// the chatter. Shared by !followage and !accountage.
+func parseLookupTarget(args string, c *module.Context) lookupTarget {
 	fields := strings.Fields(args)
 	if len(fields) > 0 {
 		login := strings.TrimPrefix(fields[0], "@")
 		if login != "" {
-			return followageTarget{login: login, name: login}
+			return lookupTarget{login: login, name: login}
 		}
 	}
-	return followageTarget{login: c.Env.ChatterUserLogin, name: c.Env.ChatterName(), id: c.Env.ChatterUserID}
+	return lookupTarget{login: c.Env.ChatterUserLogin, name: c.Env.ChatterName(), id: c.Env.ChatterUserID}
 }
 
-func (r followageRuntime) text(ctx context.Context, target followageTarget, broadcasterID string) string {
-	if r.lookup == nil {
-		return "Followage is unavailable right now."
-	}
-	result, err := r.lookup.Lookup(ctx, broadcasterID, target.id, target.login)
-	if err != nil {
-		r.log.Warn("followage: lookup failed", zap.Error(err))
-		return "Followage is unavailable right now."
-	}
-	return formatFollowageResult(target.name, broadcasterID, result)
+func emitLookup(c *module.Context, text string, emit module.Emit) {
+	emit(&module.Output{Type: outgress.TypeChat, BroadcasterID: c.Env.BroadcasterUserID, Text: text})
 }
 
 func formatFollowageResult(targetName, broadcasterID string, result engine.FollowageResult) string {
@@ -88,14 +139,19 @@ func formatFollowageResult(targetName, broadcasterID string, result engine.Follo
 	if !result.Following {
 		return fmt.Sprintf("@%s is not following this channel.", targetName)
 	}
-	return fmt.Sprintf("@%s has followed for %s.", targetName, humanizeFollowage(time.Since(result.FollowedAt)))
+	return fmt.Sprintf("@%s has followed for %s.", targetName, humanizeDuration(time.Since(result.FollowedAt)))
 }
 
-func emitFollowage(c *module.Context, text string, emit module.Emit) {
-	emit(&module.Output{Type: outgress.TypeChat, BroadcasterID: c.Env.BroadcasterUserID, Text: text})
+func formatAccountAgeResult(targetName string, result engine.AccountAgeResult) string {
+	if !result.UserFound {
+		return fmt.Sprintf("@%s is not a Twitch user.", targetName)
+	}
+	return fmt.Sprintf("@%s's account is %s old.", targetName, humanizeDuration(time.Since(result.CreatedAt)))
 }
 
-func humanizeFollowage(d time.Duration) string {
+// humanizeDuration renders a span as the two largest non-zero units (e.g.
+// "2 years, 3 months"), used by both !followage and !accountage.
+func humanizeDuration(d time.Duration) string {
 	if d < 0 {
 		d = 0
 	}
@@ -124,17 +180,28 @@ func humanizeFollowage(d time.Duration) string {
 	return strings.Join(parts, ", ")
 }
 
-func followageEnabled(ctx context.Context, d engine.Deps, broadcasterID uint64, log *zap.Logger) bool {
+// moduleLog returns the module logger, or a no-op when Deps carries none.
+func moduleLog(d engine.Deps) *zap.Logger {
+	if d.Log == nil {
+		return zap.NewNop()
+	}
+	return d.Log
+}
+
+// moduleEnabled reports whether a built-in command's per-broadcaster toggle is
+// on. A missing row (or a projection read error, or no projection at all) fails
+// open: a transient blip must not silently swallow the command.
+func moduleEnabled(ctx context.Context, d engine.Deps, broadcasterID uint64, moduleName string) bool {
 	if d.Proj == nil {
 		return true
 	}
 	views, err := d.Proj.Modules(ctx, broadcasterID)
 	if err != nil {
-		log.Warn("followage: module state read failed, allowing", zap.Uint64("broadcaster_id", broadcasterID), zap.Error(err))
+		moduleLog(d).Warn(moduleName+": module state read failed, allowing", zap.Uint64("broadcaster_id", broadcasterID), zap.Error(err))
 		return true
 	}
 	for _, v := range views {
-		if v.Name == followageModuleName {
+		if v.Name == moduleName {
 			return v.IsEnabled
 		}
 	}

--- a/app/sesame/modules/followage_test.go
+++ b/app/sesame/modules/followage_test.go
@@ -17,6 +17,25 @@ import (
 	"go.uber.org/zap"
 )
 
+// builtinCommand pulls one command by name out of the followage built-in
+// module, shared by the !followage and !accountage tests.
+func builtinCommand(t *testing.T, d engine.Deps, name string) module.Command {
+	t.Helper()
+	for _, cmd := range Followage(d).Commands {
+		if cmd.Name == name {
+			return cmd
+		}
+	}
+	t.Fatalf("%s command not found", name)
+	return module.Command{}
+}
+
+func lookupContext() *module.Context {
+	return &module.Context{Env: lane.Envelope{
+		BroadcasterUserID: "5", ChatterUserID: "9", ChatterUserLogin: "viewer", ChatterUserName: "Viewer",
+	}, BroadcasterID: 5}
+}
+
 type fakeFollowage struct {
 	result engine.FollowageResult
 	err    error
@@ -28,63 +47,108 @@ func (f *fakeFollowage) Lookup(_ context.Context, broadcasterID, targetID, targe
 	return f.result, f.err
 }
 
-func followageCommand(t *testing.T, d engine.Deps) module.Command {
-	t.Helper()
-	for _, cmd := range Followage(d).Commands {
-		if cmd.Name == "followage" {
-			return cmd
-		}
+// TestBuiltinDefaultsToChatter runs both commands with no argument and asserts
+// each looks up the chatter (id "9"), replies with its formatted line, and
+// carries the 15s cooldown.
+func TestBuiltinDefaultsToChatter(t *testing.T) {
+	cases := []struct {
+		name     string
+		deps     engine.Deps
+		want     string
+		cooldown time.Duration
+	}{
+		{
+			name: "followage",
+			deps: func() engine.Deps {
+				l := &fakeFollowage{result: engine.FollowageResult{TargetID: "9", UserFound: true, Following: true, FollowedAt: time.Now().Add(-40 * 24 * time.Hour)}}
+				return engine.Deps{Followage: l, Log: zap.NewNop()}
+			}(),
+			want:     "@Viewer has followed for 1 month, 10 days.",
+			cooldown: followageCooldown,
+		},
+		{
+			name: "accountage",
+			deps: func() engine.Deps {
+				l := &fakeAccountAge{result: engine.AccountAgeResult{TargetID: "9", UserFound: true, CreatedAt: time.Now().Add(-400 * 24 * time.Hour)}}
+				return engine.Deps{AccountAge: l, Log: zap.NewNop()}
+			}(),
+			want:     "@Viewer's account is 1 year, 1 month old.",
+			cooldown: accountAgeCooldown,
+		},
 	}
-	t.Fatal("followage command not found")
-	return module.Command{}
-}
-
-func followageContext() *module.Context {
-	return &module.Context{Env: lane.Envelope{
-		BroadcasterUserID: "5", ChatterUserID: "9", ChatterUserLogin: "viewer", ChatterUserName: "Viewer",
-	}, BroadcasterID: 5}
-}
-
-func TestFollowageDefaultsToChatter(t *testing.T) {
-	lookup := &fakeFollowage{result: engine.FollowageResult{
-		TargetID: "9", UserFound: true, Following: true, FollowedAt: time.Now().Add(-40 * 24 * time.Hour),
-	}}
-	cmd := followageCommand(t, engine.Deps{Followage: lookup, Log: zap.NewNop()})
-	var col collector
-	require.NoError(t, cmd.Run(context.Background(), followageContext(), "", col.emit))
-	require.Len(t, col.out, 1)
-	assert.Equal(t, outgress.TypeChat, col.out[0].Type)
-	assert.Equal(t, "@Viewer has followed for 1 month, 10 days.", col.out[0].Text)
-	assert.Equal(t, "9", lookup.got.targetID)
-	assert.Equal(t, followageCooldown, cmd.Cooldown)
+	for _, tc := range cases {
+		cmd := builtinCommand(t, tc.deps, tc.name)
+		var col collector
+		require.NoError(t, cmd.Run(context.Background(), lookupContext(), "", col.emit))
+		require.Len(t, col.out, 1)
+		assert.Equal(t, outgress.TypeChat, col.out[0].Type)
+		assert.Equal(t, tc.want, col.out[0].Text)
+		assert.Equal(t, tc.cooldown, cmd.Cooldown)
+	}
 }
 
 func TestFollowageAcceptsTargetLogin(t *testing.T) {
 	lookup := &fakeFollowage{result: engine.FollowageResult{TargetID: "10", UserFound: true}}
-	cmd := followageCommand(t, engine.Deps{Followage: lookup, Log: zap.NewNop()})
+	cmd := builtinCommand(t, engine.Deps{Followage: lookup, Log: zap.NewNop()}, "followage")
 	var col collector
-	require.NoError(t, cmd.Run(context.Background(), followageContext(), "@Other ignored", col.emit))
+	require.NoError(t, cmd.Run(context.Background(), lookupContext(), "@Other ignored", col.emit))
 	require.Len(t, col.out, 1)
 	assert.Equal(t, "Other", lookup.got.targetLogin)
 	assert.Equal(t, "@Other is not following this channel.", col.out[0].Text)
 }
 
-func TestFollowageLookupFailureRepliesUnavailable(t *testing.T) {
-	cmd := followageCommand(t, engine.Deps{Followage: &fakeFollowage{err: errors.New("boom")}, Log: zap.NewNop()})
+// TestBuiltinLookupFailureRepliesUnavailable and TestBuiltinToggleSuppresses
+// cover both !followage and !accountage in one table each: the two commands
+// share the same failure and toggle behavior, only the wiring differs.
+func TestBuiltinLookupFailureRepliesUnavailable(t *testing.T) {
+	cases := []struct {
+		name string
+		deps engine.Deps
+		want string
+	}{
+		{"followage", engine.Deps{Followage: &fakeFollowage{err: errors.New("boom")}, Log: zap.NewNop()}, "Followage is unavailable right now."},
+		{"accountage", engine.Deps{AccountAge: &fakeAccountAge{err: errors.New("boom")}, Log: zap.NewNop()}, "Account age is unavailable right now."},
+	}
+	for _, tc := range cases {
+		cmd := builtinCommand(t, tc.deps, tc.name)
+		var col collector
+		require.NoError(t, cmd.Run(context.Background(), lookupContext(), "", col.emit))
+		require.Len(t, col.out, 1)
+		assert.Equal(t, tc.want, col.out[0].Text)
+	}
+}
+
+func TestBuiltinToggleSuppressesCommand(t *testing.T) {
+	for _, name := range []string{"followage", "accountage"} {
+		reader := clipReader{modules: []projection.ModuleView{{Name: name, IsEnabled: false}}}
+		cmd := builtinCommand(t, engine.Deps{Proj: reader, Log: zap.NewNop()}, name)
+		var col collector
+		require.NoError(t, cmd.Run(context.Background(), lookupContext(), "", col.emit))
+		assert.Empty(t, col.out)
+	}
+}
+
+func TestHumanizeDuration(t *testing.T) {
+	assert.Equal(t, "2 years, 3 months", humanizeDuration((2*365+3*30+4)*24*time.Hour))
+}
+
+type fakeAccountAge struct {
+	result engine.AccountAgeResult
+	err    error
+	got    struct{ targetID, targetLogin string }
+}
+
+func (f *fakeAccountAge) Lookup(_ context.Context, targetID, targetLogin string) (engine.AccountAgeResult, error) {
+	f.got = struct{ targetID, targetLogin string }{targetID, targetLogin}
+	return f.result, f.err
+}
+
+func TestAccountAgeAcceptsTargetLogin(t *testing.T) {
+	lookup := &fakeAccountAge{result: engine.AccountAgeResult{UserFound: false}}
+	cmd := builtinCommand(t, engine.Deps{AccountAge: lookup, Log: zap.NewNop()}, "accountage")
 	var col collector
-	require.NoError(t, cmd.Run(context.Background(), followageContext(), "", col.emit))
+	require.NoError(t, cmd.Run(context.Background(), lookupContext(), "@Ghost ignored", col.emit))
 	require.Len(t, col.out, 1)
-	assert.Equal(t, "Followage is unavailable right now.", col.out[0].Text)
-}
-
-func TestFollowageToggleSuppressesCommand(t *testing.T) {
-	reader := clipReader{modules: []projection.ModuleView{{Name: "followage", IsEnabled: false}}}
-	cmd := followageCommand(t, engine.Deps{Proj: reader, Log: zap.NewNop()})
-	var col collector
-	require.NoError(t, cmd.Run(context.Background(), followageContext(), "", col.emit))
-	assert.Empty(t, col.out)
-}
-
-func TestHumanizeFollowage(t *testing.T) {
-	assert.Equal(t, "2 years, 3 months", humanizeFollowage((2*365+3*30+4)*24*time.Hour))
+	assert.Equal(t, "Ghost", lookup.got.targetLogin)
+	assert.Equal(t, "@Ghost is not a Twitch user.", col.out[0].Text)
 }

--- a/internal/domain/rpc/outgress/outgress.go
+++ b/internal/domain/rpc/outgress/outgress.go
@@ -17,3 +17,15 @@ type FollowageReply struct {
 	FollowedAt time.Time `json:"followed_at,omitempty"`
 	Error      string    `json:"error,omitempty"`
 }
+
+type AccountAgeRequest struct {
+	TargetID    string `json:"target_id,omitempty"`
+	TargetLogin string `json:"target_login,omitempty"`
+}
+
+type AccountAgeReply struct {
+	TargetID  string    `json:"target_id,omitempty"`
+	UserFound bool      `json:"user_found"`
+	CreatedAt time.Time `json:"created_at,omitempty"`
+	Error     string    `json:"error,omitempty"`
+}


### PR DESCRIPTION
## What

Adds a built-in `!accountage [user]` command that reports how old a Twitch account is. It lives in the existing **followage built-in module** (alongside `!followage`), not a separate module.

## How

Mirrors `!followage` end to end:

- **Domain** (`internal/domain/rpc/outgress`): `AccountAgeRequest` / `AccountAgeReply` (`target_id`/`target_login` -> `created_at`, `user_found`).
- **Outgress** (`twitch.UserCreatedAt` + `accountage.get` RPC handler): one authenticated Helix `Get Users` read, by id or login.
- **Sesame cache** (`engine.AccountAgeRPC`): same `cache.GetOrLoadTTL` + singleflight as followage. Positive TTL 1h (a creation date never changes), negative 1m so a typo re-checks.
- **Module** (`Followage` builder): second command `m.Command("accountage")`, Everyone, 15s cooldown, toggleable per broadcaster under its own `accountage` module key (checked lazily on use via a shared `moduleEnabled` helper).

Reply: `@Viewer's account is 1 year, 1 month old.` / `@Ghost is not a Twitch user.`

## Infra

None. Subject rides the existing `bagel.rpc.outgress.>` service ACL; no new secrets.

## Tests

New engine cache-hit test + 4 module tests (default-to-chatter, target login, lookup-failure, toggle-off). Build, `go vet`, and package tests pass.