### PR TITLE
Confirm before leaving shared dashboards

### DIFF
--- a/console/dashboard/src/routes/(app)/settings/+page.svelte
+++ b/console/dashboard/src/routes/(app)/settings/+page.svelte
@@ -113,6 +113,11 @@
   let revokeTarget = $state<DelegationGrant | null>(null);
   let revokeForm = $state<HTMLFormElement | null>(null);
 
+  // Leaving a shared dashboard removes this user's access. Confirm the choice
+  // before submitting the existing opt-out action.
+  let leaveTarget = $state<{ owner_user_id: string; owner_login: string } | null>(null);
+  let leaveForm = $state<HTMLFormElement | null>(null);
+
   // Delete: a destructive ConfirmDialog that spells out the consequence and
   // opens with Cancel focused. It submits a hidden form to ?/delete (the server
   // contract is unchanged; the action redirects to /goodbye on success).
@@ -257,10 +262,13 @@
               <span class="owner"><Icon name="overview" size={14} /> {r.owner_login}</span>
               <span class="actions">
                 <ButtonLink href={`/delegate/enter?owner=${r.owner_user_id}`} variant="ghost" class="sm">{t('common.open')}</ButtonLink>
-                <form method="POST" action="?/optOut" use:enhance>
-                  <input type="hidden" name="owner_user_id" value={r.owner_user_id} />
-                  <Button type="submit" variant="destructive" class="sm" aria-label={t('settings.leaveDashboardAria', { login: r.owner_login })}>{t('common.leave')}</Button>
-                </form>
+                <Button
+                  type="button"
+                  variant="destructive"
+                  class="sm"
+                  aria-label={t('settings.leaveDashboardAria', { login: r.owner_login })}
+                  onclick={() => (leaveTarget = r)}
+                >{t('common.leave')}</Button>
               </span>
             </div>
             <div class="grant-sections">
@@ -344,6 +352,26 @@
 {#if revokeTarget}
   <form method="POST" action="?/revoke" use:enhance bind:this={revokeForm} hidden>
     <input type="hidden" name="token" value={revokeTarget.token} />
+  </form>
+{/if}
+
+<!-- Leave shared dashboard confirm -->
+<ConfirmDialog
+  open={leaveTarget !== null}
+  title={t('settings.leaveTitle', { login: leaveTarget?.owner_login ?? '' })}
+  body={t('settings.leaveBody')}
+  confirmLabel={t('common.leave')}
+  cancelLabel={t('common.cancel')}
+  danger
+  onCancel={() => (leaveTarget = null)}
+  onConfirm={() => {
+    leaveForm?.requestSubmit();
+    leaveTarget = null;
+  }}
+/>
+{#if leaveTarget}
+  <form method="POST" action="?/optOut" use:enhance bind:this={leaveForm} hidden>
+    <input type="hidden" name="owner_user_id" value={leaveTarget.owner_user_id} />
   </form>
 {/if}
 
@@ -463,8 +491,7 @@
   }
   .grant-link code { font-size: 12px; word-break: break-all; flex: 1; min-width: 0; color: var(--bb-muted); }
 
-  .actions { display: flex; gap: 10px; align-items: center; flex-wrap: wrap; }
-  .actions form { margin: 0; }
+  .actions { display: flex; gap: 16px; align-items: center; flex-wrap: wrap; }
   /* Standalone actions get a full 44px target; the dense inline "sm" buttons stay
      compact but keep a 36px target (well above the 24px AA floor) and 8px+ gaps. */
   :global(.settings-section .btn) { min-height: 44px; }

--- a/console/shared/lib/i18n/en.ts
+++ b/console/shared/lib/i18n/en.ts
@@ -198,6 +198,8 @@ export const en = {
     sectionsLegend: "Sections to share",
     pickSectionError: "Pick at least one section.",
     leaveDashboardAria: "Leave {login}’s dashboard",
+    leaveTitle: "Leave {login}’s dashboard?",
+    leaveBody: "You will lose access to this dashboard. The owner will need to share it with you again if you want to return.",
     eyebrow: 'Account',
     titlePre: 'Your ',
     titleEm: 'settings',

--- a/console/shared/lib/i18n/fr.ts
+++ b/console/shared/lib/i18n/fr.ts
@@ -197,6 +197,8 @@ export const fr = {
     sectionsLegend: "Sections à partager",
     pickSectionError: "Choisissez au moins une section.",
     leaveDashboardAria: "Quitter le tableau de bord de {login}",
+    leaveTitle: "Quitter le tableau de bord de {login} ?",
+    leaveBody: "Vous perdrez l’accès à ce tableau de bord. Son propriétaire devra le partager à nouveau avec vous si vous souhaitez y revenir.",
     eyebrow: 'Compte',
     titlePre: 'Vos ',
     titleEm: 'paramètres',


### PR DESCRIPTION
## What changed

- show a destructive confirmation dialog before leaving a shared dashboard
- name the dashboard owner and explain how access can be restored
- increase spacing between the Open and Leave actions from 10px to 16px
- add English and French confirmation copy

## Why

The adjacent actions made an accidental leave too easy, and leaving immediately removed dashboard access.

## Validation

- `bun run --filter dashboard check` (0 errors; one pre-existing CSS compatibility warning)
- `bun test shared` (64 passed, 1 skipped)

Closes #104
