### PR TITLE
Tune console server L1 cache capacities

### DIFF
--- a/console/README.md
+++ b/console/README.md
@@ -117,6 +117,21 @@ The whole production topology is intentionally not reproduced by a single local 
 
 Some integration tests detect optional environment variables such as `NATS_URL` or `VALKEY_TEST_ADDR` and skip when their dependency is unavailable. Never commit credentials: production secrets are injected at runtime rather than stored in the repository.
 
+### Server-side L1 cache capacity
+
+The dashboard and admin each own a process-local `SwrCache`. Their limits are
+configured independently so the smaller admin working set does not retain the
+same warmed-at-rest footprint as the public dashboard.
+
+| Application | Environment variable | Default | Rationale |
+| --- | --- | ---: | --- |
+| Dashboard | `DASHBOARD_L1_CACHE_CAPACITY` | 1,000 | Allows roughly a dozen key families per active board while bounding per-replica RSS. |
+| Admin | `ADMIN_L1_CACHE_CAPACITY` | 250 | Covers operator snapshots and short-lived user/page reads without using the shared 5,000-entry default. |
+
+Both values must be positive decimal integers. Changing a capacity only changes
+LRU retention; push invalidation, stale-while-revalidate, single-flight, and
+stale-if-error behavior are unchanged.
+
 ***
 
 ## Documentation

--- a/console/admin/src/lib/server/config-sanity.ts
+++ b/console/admin/src/lib/server/config-sanity.ts
@@ -1,6 +1,23 @@
-import { assertCallback, assertOrigin } from '@bagel/shared/server/config-sanity';
+import {
+  assertCallback,
+  assertOrigin,
+  positiveIntegerSetting
+} from '@bagel/shared/server/config-sanity';
 
 type Env = Record<string, string | undefined>;
+
+// Admin has a small operator-only working set, mostly snapshots and short-lived
+// user/page reads, so it needs substantially fewer resident entries than the
+// public dashboard.
+export const DEFAULT_ADMIN_L1_CACHE_CAPACITY = 250;
+
+export function adminL1CacheCapacity(env: Env): number {
+  return positiveIntegerSetting(
+    'ADMIN_L1_CACHE_CAPACITY',
+    env.ADMIN_L1_CACHE_CAPACITY,
+    DEFAULT_ADMIN_L1_CACHE_CAPACITY
+  );
+}
 
 // Validate at boot (from the init hook), reading the injected env rather than
 // process.env so all runtime config flows through $env/dynamic/private.
@@ -17,4 +34,5 @@ export function assertConfigSane(env: Env): void {
       callbackPath: '/auth/bot/callback'
     });
   }
+  adminL1CacheCapacity(env);
 }

--- a/console/admin/src/lib/server/services.ts
+++ b/console/admin/src/lib/server/services.ts
@@ -8,6 +8,7 @@ import { POLICY, type CachePolicy } from '@bagel/shared/server/cache-keys';
 import { getServerConfig } from '@bagel/shared/server/config';
 import type { ScopeMap } from '@bagel/shared/server/invalidation';
 import type { ShardSnapshot, UserStats } from '@bagel/shared';
+import { adminL1CacheCapacity } from './config-sanity';
 
 // Subjects come from process.env, NOT $env/dynamic/private. This module is
 // imported at boot (hooks.server.ts -> startInvalidationListener), and reading
@@ -48,7 +49,11 @@ const SCOPES: ScopeMap = {
 // Hybrid read path facade: L1 SwrCache with push invalidation + SWR. Admin data
 // has no Valkey projection, so reads are L1 -> RPC. Policies from the shared
 // table keep the operator view ≤5s/≤3s stale while SWR makes repeat loads instant.
-const fabric = createCacheFabric({ app: 'admin', scopes: SCOPES });
+const fabric = createCacheFabric({
+  app: 'admin',
+  scopes: SCOPES,
+  capacity: adminL1CacheCapacity(process.env)
+});
 
 function cached<T>(key: string, policy: CachePolicy, load: () => Promise<T>): Promise<T> {
   return fabric.readKey(key, policy, load);

--- a/console/dashboard/src/lib/server/config-sanity.ts
+++ b/console/dashboard/src/lib/server/config-sanity.ts
@@ -1,6 +1,23 @@
-import { assertCallback, assertOrigin } from '@bagel/shared/server/config-sanity';
+import {
+  assertCallback,
+  assertOrigin,
+  positiveIntegerSetting
+} from '@bagel/shared/server/config-sanity';
 
 type Env = Record<string, string | undefined>;
+
+// A dashboard board holds roughly a dozen independently invalidated key
+// families. 1,000 entries leaves room for the active per-pod working set while
+// bounding warmed-at-rest memory far below SwrCache's general-purpose default.
+export const DEFAULT_DASHBOARD_L1_CACHE_CAPACITY = 1_000;
+
+export function dashboardL1CacheCapacity(env: Env): number {
+  return positiveIntegerSetting(
+    'DASHBOARD_L1_CACHE_CAPACITY',
+    env.DASHBOARD_L1_CACHE_CAPACITY,
+    DEFAULT_DASHBOARD_L1_CACHE_CAPACITY
+  );
+}
 
 // Validate at boot (from the init hook), reading the injected env rather than
 // process.env so all runtime config flows through $env/dynamic/private.
@@ -12,6 +29,7 @@ export function assertConfigSane(env: Env): void {
   });
   assertOptionalHTTPSURL('TEBEX_PREMIUM_CHECKOUT_URL', env.TEBEX_PREMIUM_CHECKOUT_URL);
   assertOptionalHTTPSURL('TEBEX_CANCEL_URL', env.TEBEX_CANCEL_URL);
+  dashboardL1CacheCapacity(env);
 }
 
 function assertOptionalHTTPSURL(name: string, value: string | undefined): void {

--- a/console/dashboard/src/lib/server/services.ts
+++ b/console/dashboard/src/lib/server/services.ts
@@ -10,6 +10,7 @@ import * as valkey from '@bagel/shared/server/valkey-store';
 import type { Tier } from '@bagel/shared';
 import type { Session } from './session';
 import * as liveHub from './live-hub';
+import { dashboardL1CacheCapacity } from './config-sanity';
 
 // Subjects come from process.env, NOT $env/dynamic/private. This module is
 // imported at boot (hooks.server.ts -> startInvalidationListener), and reading
@@ -62,6 +63,7 @@ const SCOPES: ScopeMap = {
 export const fabric = createCacheFabric({
   app: 'dashboard',
   scopes: SCOPES,
+  capacity: dashboardL1CacheCapacity(process.env),
   onInvalidation: (scope, id) => liveHub.publish(id, scope)
 });
 

--- a/console/shared/lib/server/cache-fabric.ts
+++ b/console/shared/lib/server/cache-fabric.ts
@@ -57,6 +57,8 @@ export interface CacheFabricOptions {
   scopes: ScopeMap;
   /** Injectable for tests/DEMO. Defaults to New Relic; pass null to disable. */
   metrics?: CacheMetrics | null;
+  /** Maximum live L1 entries. Defaults to SwrCache's general-purpose 5,000;
+   *  process-level app fabrics should set an app-specific bound. */
   capacity?: number;
   /** Tap fired for every applied invalidation (scope + broadcaster id) AFTER the
    *  local cache is evicted. The dashboard forwards it to connected browsers over

--- a/console/shared/lib/server/config-sanity.test.ts
+++ b/console/shared/lib/server/config-sanity.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from 'bun:test';
+import { positiveIntegerSetting } from './config-sanity';
+
+describe('positiveIntegerSetting', () => {
+  test('uses the documented fallback when the setting is absent', () => {
+    expect(positiveIntegerSetting('CACHE_CAPACITY', undefined, 250)).toBe(250);
+  });
+
+  test('accepts a configured positive integer', () => {
+    expect(positiveIntegerSetting('CACHE_CAPACITY', '1000', 250)).toBe(1000);
+  });
+
+  test.each(['', '0', '-1', '1.5', '1e3', 'entries'])(
+    'rejects invalid capacity %p',
+    (value) => {
+      expect(() => positiveIntegerSetting('CACHE_CAPACITY', value, 250)).toThrow(
+        'CACHE_CAPACITY must be a positive integer'
+      );
+    }
+  );
+
+  test('rejects integers outside the safe range', () => {
+    expect(() =>
+      positiveIntegerSetting('CACHE_CAPACITY', '9007199254740992', 250)
+    ).toThrow('CACHE_CAPACITY must be a safe integer');
+  });
+});

--- a/console/shared/lib/server/config-sanity.ts
+++ b/console/shared/lib/server/config-sanity.ts
@@ -34,3 +34,19 @@ export function assertCallback(name: string, value: string | undefined, expected
   if (parsed.search || parsed.hash) throw new Error(`${name} must not include query/hash`);
   return parsed;
 }
+
+/** Read an optional positive-integer setting, falling back only when it is
+ *  absent. Reject malformed values at boot instead of silently disabling a
+ *  bound or accepting a capacity that JavaScript cannot represent exactly. */
+export function positiveIntegerSetting(
+  name: string,
+  value: string | undefined,
+  fallback: number
+): number {
+  if (value === undefined) return fallback;
+  if (!/^[1-9]\d*$/.test(value)) throw new Error(`${name} must be a positive integer`);
+
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed)) throw new Error(`${name} must be a safe integer`);
+  return parsed;
+}

--- a/deploy/k8s/console-admin.yaml
+++ b/deploy/k8s/console-admin.yaml
@@ -121,6 +121,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            # Operator traffic has a much smaller working set than dashboard
+            # traffic. The default is also 250; declaring it here makes the
+            # production memory/retention tradeoff explicit and tunable.
+            - name: ADMIN_L1_CACHE_CAPACITY
+              value: "250"
             - name: NATS_ADMIN_SUBJECT
               value: twitch.ingress.admin.shards.get
             - name: NATS_STATUS_SUBJECT_PREFIX

--- a/deploy/k8s/console-dashboard.yaml
+++ b/deploy/k8s/console-dashboard.yaml
@@ -136,6 +136,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            # Per-process L1 cache bound. The default is also 1,000; keep it
+            # explicit here so production tuning is visible and independent of
+            # the admin console's smaller working set.
+            - name: DASHBOARD_L1_CACHE_CAPACITY
+              value: "1000"
             - name: NATS_PROJECTOR_DASHBOARD_SUBJECT_PREFIX
               value: bagel.rpc.projector.dashboard
             - name: NATS_NOTIFICATIONS_SUBJECT_PREFIX


### PR DESCRIPTION
## Summary

- configure dashboard and admin process-local L1 cache capacities independently
- default dashboard to 1,000 entries and admin to 250 entries
- validate capacity settings as positive safe integers at startup
- document and declare the production Kubernetes values

## Root cause

Both console apps inherited the general-purpose 5,000-entry `SwrCache` default even though their working sets differ substantially. This allowed each process to retain more warmed cache state than needed and provided no app-specific tuning control.

## Impact

Operators can tune `DASHBOARD_L1_CACHE_CAPACITY` and `ADMIN_L1_CACHE_CAPACITY` independently. The change only affects LRU retention; push invalidation, stale-while-revalidate, single-flight, and stale-if-error semantics remain unchanged.

## Validation

- `bun test shared` (73 passed, 1 optional Valkey integration test skipped)
- `bun run check` (0 errors; one pre-existing CSS compatibility warning)
- `bun run build`
- Kubernetes manifests parsed successfully as YAML

Closes #210