### PR TITLE
feat(cache): right-size in-process cache capacities per service

### DIFF
--- a/app/commands/repository/commands.go
+++ b/app/commands/repository/commands.go
@@ -81,6 +81,12 @@ const (
 
 	commandsCacheTTL = 5 * time.Minute
 
+	// commandsCacheCapacity ceilings the view cache. It is keyed one entry per
+	// user (the whole command list), so a few thousand covers the users read
+	// within the 5m TTL without holding the generic cache.DefaultCapacity ten
+	// thousand resident at rest.
+	commandsCacheCapacity int64 = 4096
+
 	flushInterval = 2 * time.Second
 	flushMaxSize  = 256
 
@@ -129,7 +135,7 @@ func NewCommands(client *ent.Client, pub message.Publisher, app *newrelic.Applic
 
 	r := &Commands{
 		client:   client,
-		views:    cache.New[[]CommandView](cache.DefaultCapacity, commandsCacheTTL),
+		views:    cache.New[[]CommandView](commandsCacheCapacity, commandsCacheTTL),
 		pub:      pub,
 		app:      app,
 		log:      log,

--- a/app/modules/repository/modules.go
+++ b/app/modules/repository/modules.go
@@ -29,6 +29,12 @@ const (
 
 	modulesCacheTTL = 5 * time.Minute
 
+	// modulesCacheCapacity ceilings the view cache. It is keyed one entry per
+	// user (the whole module list), so a few thousand covers the users read
+	// within the 5m TTL without holding the generic cache.DefaultCapacity ten
+	// thousand resident at rest.
+	modulesCacheCapacity int64 = 4096
+
 	flushInterval = 2 * time.Second
 	flushMaxSize  = 256
 )
@@ -63,7 +69,7 @@ func NewModules(client *ent.Client, pub message.Publisher, app *newrelic.Applica
 
 	r := &Modules{
 		client: client,
-		views:  cache.New[[]ModuleView](cache.DefaultCapacity, modulesCacheTTL),
+		views:  cache.New[[]ModuleView](modulesCacheCapacity, modulesCacheTTL),
 		pub:    pub,
 		app:    app,
 		log:    log,

--- a/app/projector/rpc/status.go
+++ b/app/projector/rpc/status.go
@@ -16,6 +16,12 @@ import (
 	"ItsBagelBot/pkg/cache"
 )
 
+// statusCacheCapacity ceilings the resolved-status cache. It is keyed one entry
+// per broadcaster with a 30s TTL, so a few thousand covers the distinct
+// broadcasters a projector pod answers for within the window without holding the
+// generic cache.DefaultCapacity ten thousand at rest.
+const statusCacheCapacity int64 = 4096
+
 // statusEntry is the cached per-broadcaster decision: the resolved tier plus
 // whether the broadcaster is banned from the service.
 type statusEntry struct {
@@ -34,7 +40,7 @@ type statusRPC struct {
 func SubscribeStatus(nc *nats.Conn, valkey *projection.Store, subject, usersTopic, invalidateSubject, queueGroup string, app *newrelic.Application, log *zap.Logger) error {
 	s := &statusRPC{
 		valkey:     valkey,
-		views:      cache.New[statusEntry](cache.DefaultCapacity, 30*time.Second), // short lived in-process cache
+		views:      cache.New[statusEntry](statusCacheCapacity, 30*time.Second), // short lived in-process cache
 		nc:         nc,
 		usersTopic: usersTopic,
 		log:        log,

--- a/app/sesame/engine/followage_rpc.go
+++ b/app/sesame/engine/followage_rpc.go
@@ -17,6 +17,13 @@ const (
 	followageRPCTimeout  = 3500 * time.Millisecond
 	followagePositiveTTL = 15 * time.Minute
 	followageNegativeTTL = time.Minute
+
+	// followageCacheCapacity ceilings the followage cache. It is keyed per
+	// (broadcaster, viewer), so it grows with distinct viewers who run
+	// !followage, not just broadcasters; it gets a larger ceiling than the
+	// per-broadcaster caches but still well under the generic
+	// cache.DefaultCapacity so viewer churn cannot pin ten thousand entries.
+	followageCacheCapacity int64 = 8192
 )
 
 type FollowageResult struct {
@@ -41,7 +48,7 @@ type FollowageRPC struct {
 func NewFollowageRPC(nc *nats.Conn, prefix string) *FollowageRPC {
 	subject := strings.TrimSuffix(prefix, ".") + ".followage.get"
 	return &FollowageRPC{
-		cache: cache.New[FollowageResult](cache.DefaultCapacity, followageNegativeTTL),
+		cache: cache.New[FollowageResult](followageCacheCapacity, followageNegativeTTL),
 		request: func(ctx context.Context, req outgressrpc.FollowageRequest) (outgressrpc.FollowageReply, error) {
 			return bus.RequestJSONTimeout[outgressrpc.FollowageReply](ctx, nc, subject, req, followageRPCTimeout)
 		},

--- a/app/sesame/engine/live_valkey.go
+++ b/app/sesame/engine/live_valkey.go
@@ -25,6 +25,12 @@ import (
 // deliberately sorts under the shared live: prefix; onExpired skips it.
 const recheckKeyPrefix = "live:recheck:"
 
+// liveCacheCapacity ceilings the resolved-live cache. It is keyed one entry per
+// broadcaster with a short TTL, so a few thousand covers the live broadcasters a
+// pod tracks in the window without holding the generic cache.DefaultCapacity ten
+// thousand at rest.
+const liveCacheCapacity int64 = 4096
+
 // LiveConfig wires the Valkey-backed live store.
 type LiveConfig struct {
 	// TTL bounds how long a live key survives without a refresh; on expiry the
@@ -81,7 +87,7 @@ func NewValkeyLiveStore(client valkey.Client, nc *nats.Conn, pub message.Publish
 		pub:        pub,
 		cfg:        cfg,
 		log:        log,
-		cache:      cache.NewKeyed[uint64, bool](cache.DefaultCapacity, cfg.CacheTTL, livekey.Key),
+		cache:      cache.NewKeyed[uint64, bool](liveCacheCapacity, cfg.CacheTTL, livekey.Key),
 		rpcTimeout: 1500 * time.Millisecond,
 	}
 }

--- a/app/sesame/engine/loyalty_valkey.go
+++ b/app/sesame/engine/loyalty_valkey.go
@@ -46,6 +46,11 @@ const balanceTTL = time.Minute
 // OTHER replicas is acceptable; the acting replica invalidates its own.
 const scopeCacheTTL = 5 * time.Minute
 
+// scopeCacheCapacity ceilings that cache. It is keyed per (broadcaster, counter),
+// a handful per broadcaster, so a few thousand covers the working set within the
+// TTL without holding the generic cache.DefaultCapacity ten thousand at rest.
+const scopeCacheCapacity int64 = 4096
+
 // ValkeyLoyaltyStore is the worker-side loyalty surface: counter bumps/reads
 // with a Valkey live view over the loyalty service, cached balance peeks, and
 // pass-through management verbs. It implements LoyaltyStore.
@@ -67,7 +72,7 @@ func NewValkeyLoyaltyStore(client valkey.Client, rpc *LoyaltyRPC, reporter *Loya
 		client:   client,
 		rpc:      rpc,
 		reporter: reporter,
-		scopes:   cache.New[string](cache.DefaultCapacity, scopeCacheTTL),
+		scopes:   cache.New[string](scopeCacheCapacity, scopeCacheTTL),
 		log:      log,
 	}
 }

--- a/app/sesame/main.go
+++ b/app/sesame/main.go
@@ -33,6 +33,11 @@ const serviceName = "sesame"
 // in sesame before the next read re-checks Valkey and the projector.
 const projectionCacheTTL = 30 * time.Second
 
+// cacheOccupancyInterval is how often sesame logs how full its projection caches
+// run, so their capacities can be tuned to the observed working set. Slow enough
+// to be noise-free at info level (one line per pod per interval).
+const cacheOccupancyInterval = 5 * time.Minute
+
 func main() {
 	log := logger.New(env.Get("APP_ENV", "development")).Named(serviceName)
 	defer func() { _ = log.Sync() }()
@@ -66,7 +71,7 @@ func main() {
 
 	in := infra{nc: nc, pub: pub, sub: sub, vc: valkeyClient}
 
-	proj := newProjection(in, cfg, log)
+	proj := newProjection(ctx, in, cfg, log)
 	defer proj.Close()
 
 	live := newLive(ctx, in, cfg, log)
@@ -310,7 +315,7 @@ func dialNATS(cfg *config.Config, log *zap.Logger) (*nats.Conn, message.Publishe
 // newProjection builds the settings-projection reader (in-process cache fronting
 // Valkey, with a projector RPC fallback) and starts its cache invalidation
 // listener.
-func newProjection(in infra, cfg *config.Config, log *zap.Logger) *projection.Client {
+func newProjection(ctx context.Context, in infra, cfg *config.Config, log *zap.Logger) *projection.Client {
 	proj := projection.NewClient(projection.Config{
 		Store: projection.NewStore(in.vc),
 		NC:    in.nc,
@@ -323,6 +328,7 @@ func newProjection(in infra, cfg *config.Config, log *zap.Logger) *projection.Cl
 		Log: log,
 	})
 	proj.StartInvalidationListener(cfg.CacheInvalidationPrefix)
+	proj.StartOccupancyLogger(ctx, cacheOccupancyInterval)
 	return proj
 }
 

--- a/app/users/repository/users.go
+++ b/app/users/repository/users.go
@@ -25,6 +25,11 @@ const (
 	userKeyPrefix = "user:"
 
 	userCacheTTL = 5 * time.Minute
+
+	// userCacheCapacity ceilings the view cache. It is keyed one entry per user,
+	// so a few thousand covers the users read within the 5m TTL without holding
+	// the generic cache.DefaultCapacity ten thousand resident at rest.
+	userCacheCapacity int64 = 4096
 )
 
 // UserView is the read model served from the in-process cache. It carries no
@@ -59,7 +64,7 @@ type Users struct {
 func NewUsers(client *ent.Client, packer domaincrypto.Packer, pub message.Publisher) *Users {
 	return &Users{
 		client: client,
-		views:  cache.New[UserView](cache.DefaultCapacity, userCacheTTL),
+		views:  cache.New[UserView](userCacheCapacity, userCacheTTL),
 		packer: packer,
 		pub:    pub,
 	}

--- a/internal/projection/client.go
+++ b/internal/projection/client.go
@@ -34,6 +34,21 @@ import (
 	"go.uber.org/zap"
 )
 
+// Cache capacities are ceilings on resident entries, sized to each cache's
+// working set rather than the generic cache.DefaultCapacity so an always-on
+// worker pod does not hold ten thousand entries per cache at rest.
+//
+//   - users/modules are keyed one entry per broadcaster, so a few thousand
+//     covers the distinct broadcasters a pod serves within the short TTL.
+//   - commands is keyed per command name AND caches negative "no such command"
+//     entries, so unknown "!word" spam grows it fastest; it gets the larger
+//     ceiling to keep legitimate commands from being evicted by that churn.
+const (
+	usersCacheCapacity    int64 = 4096
+	modulesCacheCapacity  int64 = 4096
+	commandsCacheCapacity int64 = 8192
+)
+
 // User is the projected tier state of one broadcaster. Live state is NOT here:
 // the worker reads it from the dedicated live:<id> store (module.IsLiveChecker),
 // never from this projection.
@@ -131,9 +146,9 @@ func NewClient(cfg Config) *Client {
 		nc:         cfg.NC,
 		subjects:   cfg.Subjects,
 		log:        cfg.Log,
-		users:      cache.New[User](cache.DefaultCapacity, cfg.TTL),
-		modules:    cache.New[[]ModuleView](cache.DefaultCapacity, cfg.TTL),
-		commands:   cache.New[commandEntry](cache.DefaultCapacity, cfg.TTL),
+		users:      cache.New[User](usersCacheCapacity, cfg.TTL),
+		modules:    cache.New[[]ModuleView](modulesCacheCapacity, cfg.TTL),
+		commands:   cache.New[commandEntry](commandsCacheCapacity, cfg.TTL),
 		rpcTimeout: 1500 * time.Millisecond,
 	}
 }
@@ -146,6 +161,17 @@ func (c *Client) Close() {
 	c.users.Close()
 	c.modules.Close()
 	c.commands.Close()
+}
+
+// StartOccupancyLogger logs how full the three projection caches run every
+// interval until ctx is cancelled, so their capacities can be tuned to the
+// observed working set. A non-positive interval disables it.
+func (c *Client) StartOccupancyLogger(ctx context.Context, interval time.Duration) {
+	cache.StartOccupancyLogger(ctx, c.log, interval, map[string]cache.OccupancySource{
+		"projection_users":    c.users,
+		"projection_modules":  c.modules,
+		"projection_commands": c.commands,
+	})
 }
 
 // StartInvalidationListener subscribes to push invalidation messages on

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -9,8 +9,14 @@ import (
 	"golang.org/x/sync/singleflight"
 )
 
-// DefaultCapacity is the default maximum number of entries for a cache, used
-// when a caller has no reason to size the cache differently.
+// DefaultCapacity is the fallback maximum number of entries for a cache, used
+// when a caller has no reason to size the cache differently (tests, cold paths,
+// development). It is deliberately generous so it is always safe; hot, always-on
+// services should size their caches to their working set instead (see the
+// per-cache capacity constants next to each cache's TTL) so a spam- or
+// churn-driven fill cannot pin this many resident entries. theine allocates in
+// proportion to live occupancy, so capacity is a ceiling on resident entries,
+// not an up-front reservation.
 const DefaultCapacity int64 = 10000
 
 // Cache is an in-process TTL cache wrapper around theine-go. Concurrent misses
@@ -21,8 +27,9 @@ type Cache[V any] struct {
 	client *theine.Cache[string, V]
 	group  singleflight.Group
 
-	ttl    time.Duration
-	jitter time.Duration
+	capacity int64
+	ttl      time.Duration
+	jitter   time.Duration
 }
 
 // New creates a cache with a maximum capacity whose entries live for ttl plus
@@ -35,11 +42,21 @@ func New[V any](capacity int64, ttl time.Duration) *Cache[V] {
 	}
 
 	return &Cache[V]{
-		client: client,
-		ttl:    ttl,
-		jitter: ttl / 10,
+		client:   client,
+		capacity: capacity,
+		ttl:      ttl,
+		jitter:   ttl / 10,
 	}
 }
+
+// Len returns the current number of live entries in the cache. It is a
+// point-in-time occupancy reading, useful for logging how full a cache runs
+// against its capacity so the capacity can be tuned to the observed working set.
+func (c *Cache[V]) Len() int { return c.client.Len() }
+
+// Capacity returns the configured maximum number of entries (the ceiling passed
+// to New), the denominator for an occupancy ratio.
+func (c *Cache[V]) Capacity() int64 { return c.capacity }
 
 // GetOrLoad returns the cached value for key, or runs loader to fill it.
 // Only one loader runs per key at a time, regardless of how many goroutines

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -140,6 +140,21 @@ func TestInvalidate(t *testing.T) {
 	assert.Equal(t, "fresh", value)
 }
 
+func TestLenAndCapacity(t *testing.T) {
+	c := New[int](128, time.Minute)
+	defer c.Close()
+
+	assert.Equal(t, int64(128), c.Capacity(), "Capacity reports the configured ceiling")
+	assert.Equal(t, 0, c.Len(), "a fresh cache is empty")
+
+	c.Set("a", 1)
+	c.Set("b", 2)
+	c.client.Wait() // let theine's async write buffer drain before counting
+
+	assert.Equal(t, 2, c.Len(), "Len reports live entries")
+	assert.Equal(t, int64(128), c.Capacity(), "Capacity is unaffected by occupancy")
+}
+
 func TestUserKey(t *testing.T) {
 	assert.Equal(t, "user:0", UserKey("user:", 0))
 	assert.Equal(t, "modules:123456", UserKey("modules:", 123456))

--- a/pkg/cache/keyed.go
+++ b/pkg/cache/keyed.go
@@ -23,8 +23,9 @@ type Keyed[K comparable, V any] struct {
 	group  singleflight.Group
 	keyFn  func(K) string
 
-	ttl    time.Duration
-	jitter time.Duration
+	capacity int64
+	ttl      time.Duration
+	jitter   time.Duration
 }
 
 // NewKeyed creates a K-keyed cache. keyFn maps a key to the stable string
@@ -36,12 +37,21 @@ func NewKeyed[K comparable, V any](capacity int64, ttl time.Duration, keyFn func
 		panic("failed to build theine cache: " + err.Error())
 	}
 	return &Keyed[K, V]{
-		client: client,
-		keyFn:  keyFn,
-		ttl:    ttl,
-		jitter: ttl / 10,
+		client:   client,
+		keyFn:    keyFn,
+		capacity: capacity,
+		ttl:      ttl,
+		jitter:   ttl / 10,
 	}
 }
+
+// Len returns the current number of live entries in the cache, a point-in-time
+// occupancy reading for logging how full the cache runs against its capacity.
+func (c *Keyed[K, V]) Len() int { return c.client.Len() }
+
+// Capacity returns the configured maximum number of entries (the ceiling passed
+// to NewKeyed), the denominator for an occupancy ratio.
+func (c *Keyed[K, V]) Capacity() int64 { return c.capacity }
 
 // GetOrLoad returns the cached value for key, or runs loader to fill it. A hit
 // touches only theine's Get (no allocation, no keyFn). Only one loader runs per

--- a/pkg/cache/occupancy.go
+++ b/pkg/cache/occupancy.go
@@ -1,0 +1,62 @@
+package cache
+
+import (
+	"context"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// OccupancySource reports how full a cache runs: its live entry count against
+// the ceiling it was built with. Both *Cache and *Keyed satisfy it, so a service
+// can log occupancy across a mix of caches without caring about their element
+// types.
+type OccupancySource interface {
+	Len() int
+	Capacity() int64
+}
+
+// LogOccupancy emits one structured line summarising the fill of every named
+// cache: its live entry count and configured ceiling. It is a point-in-time
+// snapshot with no goroutine of its own, so callers drive the cadence. Logging
+// at info keeps the reading visible in production (where debug is dropped), which
+// is where the working set that the capacities should be tuned to actually shows.
+func LogOccupancy(log *zap.Logger, caches map[string]OccupancySource) {
+	if log == nil || len(caches) == 0 {
+		return
+	}
+	fields := make([]zap.Field, 0, len(caches)*2)
+	for name, c := range caches {
+		fields = append(fields,
+			zap.Int(name+"_entries", c.Len()),
+			zap.Int64(name+"_capacity", c.Capacity()),
+		)
+	}
+	log.Info("cache occupancy", fields...)
+}
+
+// StartOccupancyLogger logs the occupancy of the given caches every interval
+// until ctx is cancelled, running in its own goroutine. It is the opt-in an
+// always-on service wires in main to observe how full its in-process caches run
+// over time, so the per-cache capacities can be tuned to the real working set.
+// A non-positive interval disables it (no goroutine is started).
+func StartOccupancyLogger(ctx context.Context, log *zap.Logger, interval time.Duration, caches map[string]OccupancySource) {
+	if interval <= 0 {
+		return
+	}
+	if log == nil || len(caches) == 0 {
+		return
+	}
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				LogOccupancy(log, caches)
+			}
+		}
+	}()
+}

--- a/pkg/cache/occupancy_test.go
+++ b/pkg/cache/occupancy_test.go
@@ -1,0 +1,83 @@
+package cache
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestLogOccupancyEmitsPerCacheFields(t *testing.T) {
+	core, logs := observer.New(zap.InfoLevel)
+	log := zap.New(core)
+
+	users := New[int](4096, time.Minute)
+	defer users.Close()
+	commands := New[int](8192, time.Minute)
+	defer commands.Close()
+
+	users.Set("a", 1)
+	users.client.Wait() // drain the async write buffer so Len is accurate
+
+	LogOccupancy(log, map[string]OccupancySource{
+		"users":    users,
+		"commands": commands,
+	})
+
+	entries := logs.All()
+	require.Len(t, entries, 1)
+	assert.Equal(t, "cache occupancy", entries[0].Message)
+
+	fields := entries[0].ContextMap()
+	assert.Equal(t, int64(1), fields["users_entries"])
+	assert.Equal(t, int64(4096), fields["users_capacity"])
+	assert.Equal(t, int64(0), fields["commands_entries"])
+	assert.Equal(t, int64(8192), fields["commands_capacity"])
+}
+
+func TestLogOccupancyNoCachesNoLine(t *testing.T) {
+	core, logs := observer.New(zap.InfoLevel)
+	LogOccupancy(zap.New(core), map[string]OccupancySource{})
+	assert.Empty(t, logs.All(), "no caches means no log line")
+}
+
+func TestLogOccupancyNilLoggerIsSafe(t *testing.T) {
+	assert.NotPanics(t, func() {
+		LogOccupancy(nil, map[string]OccupancySource{"x": New[int](1, time.Minute)})
+	})
+}
+
+func TestStartOccupancyLoggerTicksThenStops(t *testing.T) {
+	core, logs := observer.New(zap.InfoLevel)
+	log := zap.New(core)
+
+	c := New[int](16, time.Minute)
+	defer c.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	StartOccupancyLogger(ctx, log, 10*time.Millisecond, map[string]OccupancySource{"c": c})
+
+	assert.Eventually(t, func() bool {
+		return logs.Len() >= 1
+	}, time.Second, 5*time.Millisecond, "logger should emit at least one line")
+
+	cancel()
+	time.Sleep(30 * time.Millisecond)
+	settled := logs.Len()
+	time.Sleep(40 * time.Millisecond)
+	assert.Equal(t, settled, logs.Len(), "no more lines after ctx is cancelled")
+}
+
+func TestStartOccupancyLoggerDisabledInterval(t *testing.T) {
+	core, logs := observer.New(zap.InfoLevel)
+	c := New[int](16, time.Minute)
+	defer c.Close()
+
+	StartOccupancyLogger(context.Background(), zap.New(core), 0, map[string]OccupancySource{"c": c})
+	time.Sleep(30 * time.Millisecond)
+	assert.Empty(t, logs.All(), "a non-positive interval starts no logger")
+}


### PR DESCRIPTION
Closes #212

## Problem
`pkg/cache` defaulted every in-process cache to `DefaultCapacity = 10000`, regardless of the cache's shape. On always-on pods that lets spam- or churn-driven fills pin ten thousand resident entries per cache (e.g. sesame's projection users/modules/commands each got a 10k cache).

## Change
Per-cache capacity ceilings sized to each cache's working set, replacing `cache.DefaultCapacity` at every hot call site. theine allocates in proportion to live occupancy, so capacity is a **ceiling on resident entries** that bounds worst-case growth, not an up-front reservation.

| Cache | Cap | Rationale |
|---|---|---|
| projection users / modules | 4096 | one entry per broadcaster |
| projection commands | 8192 | per-name + negative `!word` spam entries |
| projector status | 4096 | per-broadcaster, 30s TTL |
| users / commands / modules repo views | 4096 | one entry per user |
| loyalty scopes | 4096 | per (broadcaster, counter) |
| live | 4096 | per-broadcaster, short TTL |
| followage | 8192 | per (broadcaster, viewer) — grows with viewers |

Each is a named `xxxCacheCapacity` const beside its TTL (matches the existing `channelCacheCapacity = 4096` convention), with a rationale comment recording the chosen value. `DefaultCapacity` stays as the dev-safe fallback for tests and cold paths.

## Occupancy observability (to tune from)
- `Cache.Len()/Capacity()` and `Keyed.Len()/Capacity()`.
- `cache.LogOccupancy` (snapshot) and `cache.StartOccupancyLogger` (interval goroutine, ctx-bound).
- Sesame wires it onto its projection caches: one info line per pod every 5m (`projection_users_entries`, `_capacity`, …), visible in production where the real working set shows, so capacities can be tuned from observed occupancy.

## Acceptance criteria
- [x] Hot services configure cache capacity independently (per-cache named consts).
- [x] Existing defaults remain safe for development (`DefaultCapacity` retained).
- [x] Chosen values recorded (documented consts with sizing rationale).
- [x] Basic cache occupancy logging added.

## Testing
- New tests: `Len`/`Capacity`, `LogOccupancy` fields, `StartOccupancyLogger` tick/ctx-stop/disabled-interval/nil-safe.
- `go build ./...`, `go vet`, `gofmt` clean; all affected package tests pass (pkg/cache, projection, sesame, projector, users/commands/modules repos).