### PR TITLE
feat(dashboard): add accountage built-in toggle

### DIFF
--- a/console/shared/lib/types.ts
+++ b/console/shared/lib/types.ts
@@ -85,6 +85,21 @@ export interface BuiltinCommandDef {
 
 export const BUILTIN_COMMANDS: readonly BuiltinCommandDef[] = [
   {
+    id: 'accountage',
+    label: 'Account age',
+    summary: 'Built-in · shows how long a Twitch account has existed.',
+    description:
+      'Shows how old your Twitch account is, or the age of another Twitch user\'s account when you add their username.',
+    usage: ['!accountage', '!accountage <user>'],
+    preview: "@{target}'s account is 4 years, 2 months old.",
+    previewArgs: 'viewer',
+    previewSamples: { target: 'viewer' },
+    defaultActive: true,
+    defaultPerm: 'everyone',
+    defaultCooldown: 15,
+    liveOnly: false
+  },
+  {
     id: 'followage',
     label: 'Followage',
     summary: 'Built-in · shows how long a viewer has followed the channel.',


### PR DESCRIPTION
## What changed

- add `!accountage` to the dashboard's built-in command catalog
- show its usage, description, and representative chat preview
- expose the existing built-in on/off control, persisted under the `accountage` module key

## Why

The bot already supports the toggleable `!accountage [user]` command, but the dashboard did not expose it. Broadcasters therefore had no way to discover or disable it from the command manager.

## Impact

Broadcasters can now view and enable or disable Account age alongside the other built-in commands. It defaults to enabled, matching the bot's missing-configuration behavior.

## Validation

- `bun test shared` (73 passed, 1 skipped)
- `bun run --filter dashboard check` (0 errors; one existing CSS compatibility warning)
- `git diff --check`
