### PR TITLE
fix(dashboard): constrain cursor bounding box on management rows

### DIFF
--- a/console/shared/components/Cursor.svelte
+++ b/console/shared/components/Cursor.svelte
@@ -84,7 +84,11 @@
     const sel = 'a, button, .search, [data-cursor]';
     const over = (e: PointerEvent) => {
       const el = (e.target as Element | null)?.closest<HTMLElement>(sel);
-      if (el) {
+      // `data-cursor="off"` opts an element out of the box morph: the ring keeps
+      // its small dot instead of stamping the whole element. Used on big list
+      // rows, where filling the row with a tan box read ambiguously against the
+      // nav dock.
+      if (el && !el.closest('[data-cursor="off"]')) {
         target = el;
         start();
       }

--- a/console/shared/components/ManagementRow.svelte
+++ b/console/shared/components/ManagementRow.svelte
@@ -32,6 +32,7 @@
   <button
     class="mrow-primary"
     type="button"
+    data-cursor="off"
     aria-expanded={expanded}
     aria-controls={controls}
     aria-current={selected ? 'true' : undefined}


### PR DESCRIPTION
The custom cursor no longer stamps its ring onto the big command/module row boxes — over a row you now get the small tan dot (plus the row's own subtle :hover tint), so it no longer reads ambiguously against the nav dock. Because every command and module-detail row is a ManagementRow, one change covers both. The switch and delete controls keep their small morph.

How: added a data-cursor="off" opt-out to the Cursor component and tagged ManagementRow's primary disclosure button with it. Shared change, so admin's management rows benefit too.