### PR TITLE
feat(commands): add stream-long pin responses

### DIFF
--- a/app/outgress/internal/twitch/client_test.go
+++ b/app/outgress/internal/twitch/client_test.go
@@ -113,6 +113,7 @@ func TestCloudBotChatAutoRoutingUsesAppToken(t *testing.T) {
 		"/helix/chat/messages",
 		"/helix/chat/announcements?broadcaster_id=1&moderator_id=2",
 		"/helix/chat/shoutouts?from_broadcaster_id=1&to_broadcaster_id=2&moderator_id=3",
+		"/helix/chat/pins?broadcaster_id=1&moderator_id=2&message_id=abc",
 	} {
 		if got := client.sourceFor(endpoint); got != app {
 			t.Errorf("sourceFor(%q) = user token, want app token", endpoint)

--- a/app/outgress/internal/worker/dispatch.go
+++ b/app/outgress/internal/worker/dispatch.go
@@ -46,6 +46,9 @@ var typeRoutes = map[string]helixRoute{
 	// the bot's user:bot/action grants and the broadcaster's channel:bot grant.
 	outgress.TypeAnnounce: {http.MethodPost, "/helix/chat/announcements", outgress.AsApp},
 	outgress.TypeShoutout: {http.MethodPost, "/helix/chat/shoutouts", outgress.AsApp},
+	// Pin is a two-call action handled by processPin: send the chat message, then
+	// PUT its returned message id here. Both calls use the cloud-bot app token.
+	outgress.TypePin: {http.MethodPut, "/helix/chat/pins", outgress.AsApp},
 	// Shield Mode is a moderator action (PUT /helix/moderation/shield_mode → bot
 	// user token, moderator:manage:shield_mode). Like ban it needs broadcaster_id +
 	// moderator_id on the query string, handled in processShieldMode.
@@ -65,6 +68,7 @@ var helixHandlers = map[string]func(*Worker, context.Context, outgress.Message) 
 	outgress.TypeChat:       (*Worker).processChat,
 	outgress.TypeAnnounce:   (*Worker).processAnnounce,
 	outgress.TypeShoutout:   (*Worker).processShoutout,
+	outgress.TypePin:        (*Worker).processPin,
 	outgress.TypeClip:       (*Worker).processClip,
 	outgress.TypeBan:        (*Worker).processBan,
 	outgress.TypeTimeout:    (*Worker).processBan,

--- a/app/outgress/internal/worker/execute.go
+++ b/app/outgress/internal/worker/execute.go
@@ -22,6 +22,19 @@ func (w *Worker) processAPI(ctx context.Context, payload outgress.Message) error
 }
 
 func (w *Worker) execute(ctx context.Context, payload outgress.Message) error {
+	res, err := w.executeRequest(ctx, payload)
+	if err != nil {
+		return err
+	}
+	defer drainResponse(res)
+
+	return w.helixResult(ctx, payload, res)
+}
+
+// executeRequest performs one Twitch call and returns the still-open response.
+// Most actions use execute, which consumes status and drains it immediately;
+// compound actions such as /pin need to decode a successful response first.
+func (w *Worker) executeRequest(ctx context.Context, payload outgress.Message) (*http.Response, error) {
 	started := time.Now()
 	defer recordStageDuration(ctx, "outgress.twitch_ms", started)
 
@@ -29,11 +42,9 @@ func (w *Worker) execute(ctx context.Context, payload outgress.Message) error {
 		twitch.HelixCall{Method: payload.Method, Endpoint: payload.Endpoint, Body: payload.Payload})
 	if err != nil {
 		w.log.Error("twitch request failed", zap.Error(err))
-		return err
+		return nil, err
 	}
-	defer drainResponse(res)
-
-	return w.helixResult(ctx, payload, res)
+	return res, nil
 }
 
 // helixResult maps the Helix response status to the lane's ack/nack decision:

--- a/app/outgress/internal/worker/pin.go
+++ b/app/outgress/internal/worker/pin.go
@@ -1,0 +1,128 @@
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	"ItsBagelBot/internal/domain/outgress"
+
+	"go.uber.org/zap"
+)
+
+// processPin sends the command response as a normal bot chat message, reads the
+// message id Twitch assigns it, then pins that id. duration_seconds is
+// intentionally absent from pinEndpoint: Twitch therefore keeps the pin for the
+// remainder of the current stream instead of applying a 30-1800 second timer.
+func (w *Worker) processPin(ctx context.Context, payload outgress.Message) error {
+	mod, ok := w.botIdentity("pin", payload)
+	if !ok {
+		return nil
+	}
+
+	// Reserve the general Helix allowance before posting the chat line. Once the
+	// line exists, retrying the whole queue item would create a duplicate just to
+	// retry the pin, so every locally predictable wait happens before the send.
+	pin := outgress.Message{
+		Type:          outgress.TypePin,
+		BroadcasterID: payload.BroadcasterID,
+		SenderID:      payload.SenderID,
+		Endpoint:      "/helix/chat/pins",
+		Method:        http.MethodPut,
+		As:            outgress.AsApp,
+	}
+	if err := w.takeGeneralHelix(ctx, pin); err != nil {
+		return err
+	}
+
+	registryStarted := time.Now()
+	ch, found, err := w.registry.Get(ctx, payload.BroadcasterID)
+	recordStageDuration(ctx, "outgress.registry_ms", registryStarted)
+	if err != nil {
+		return err
+	}
+	if err := w.takeChat(ctx, payload.BroadcasterID, w.modStatus(ctx, payload, ch, found)); err != nil {
+		return err
+	}
+
+	chatRoute := typeRoutes[outgress.TypeChat]
+	chat := payload
+	chat.Type = outgress.TypeChat
+	chat.Endpoint = chatRoute.endpoint
+	chat.Method = chatRoute.method
+	chat.As = chatRoute.as
+	chat.Payload = withSenderID(chat.Payload, mod)
+
+	res, err := w.executeRequest(ctx, chat)
+	if err != nil {
+		return err
+	}
+	status := res.StatusCode
+	if err := w.helixResult(ctx, chat, res); err != nil {
+		drainResponse(res)
+		return err
+	}
+	if status >= http.StatusBadRequest {
+		drainResponse(res)
+		return nil
+	}
+
+	messageID, sent, decodeErr := sentChatMessageID(res.Body)
+	drainResponse(res)
+	if decodeErr != nil {
+		// Twitch accepted the send, so redelivery would duplicate it. Surface the
+		// bad response and ack this item instead of creating chat spam.
+		w.log.Error("chat sent but pin response could not be decoded",
+			zap.String("broadcaster_id", payload.BroadcasterID), zap.Error(decodeErr))
+		noticeError(ctx, decodeErr)
+		return nil
+	}
+	if !sent || messageID == "" {
+		w.log.Warn("chat message was not sent; skipping pin",
+			zap.String("broadcaster_id", payload.BroadcasterID))
+		return nil
+	}
+
+	pin.Endpoint = pinEndpoint(payload.BroadcasterID, mod, messageID)
+	if err := w.execute(ctx, pin); err != nil {
+		// The chat message already exists. Retrying this compound action would send
+		// it again, so report the pin failure but consume the queue item.
+		w.log.Warn("chat sent but pin failed; skipping unsafe redelivery",
+			zap.String("broadcaster_id", payload.BroadcasterID),
+			zap.String("message_id", messageID), zap.Error(err))
+		noticeError(ctx, err)
+	}
+	return nil
+}
+
+type sendChatReply struct {
+	Data []struct {
+		MessageID string `json:"message_id"`
+		IsSent    bool   `json:"is_sent"`
+	} `json:"data"`
+}
+
+// sentChatMessageID reads the Send Chat Message response. A successful Helix
+// response may still carry is_sent=false (for example, chat rejected the line),
+// so callers must check both return values before pinning.
+func sentChatMessageID(r io.Reader) (messageID string, sent bool, err error) {
+	var reply sendChatReply
+	if err := json.NewDecoder(io.LimitReader(r, 4096)).Decode(&reply); err != nil {
+		return "", false, err
+	}
+	if len(reply.Data) == 0 {
+		return "", false, nil
+	}
+	return reply.Data[0].MessageID, reply.Data[0].IsSent, nil
+}
+
+// pinEndpoint deliberately has no duration_seconds. Per Twitch's contract,
+// omission means the message remains pinned until the stream ends.
+func pinEndpoint(broadcasterID, moderatorID, messageID string) string {
+	return "/helix/chat/pins?broadcaster_id=" + url.QueryEscape(broadcasterID) +
+		"&moderator_id=" + url.QueryEscape(moderatorID) +
+		"&message_id=" + url.QueryEscape(messageID)
+}

--- a/app/outgress/internal/worker/pin.go
+++ b/app/outgress/internal/worker/pin.go
@@ -18,14 +18,36 @@ import (
 // intentionally absent from pinEndpoint: Twitch therefore keeps the pin for the
 // remainder of the current stream instead of applying a 30-1800 second timer.
 func (w *Worker) processPin(ctx context.Context, payload outgress.Message) error {
-	mod, ok := w.botIdentity("pin", payload)
+	pin, mod, ok, err := w.preparePin(ctx, payload)
+	if err != nil {
+		return err
+	}
 	if !ok {
 		return nil
 	}
 
-	// Reserve the general Helix allowance before posting the chat line. Once the
-	// line exists, retrying the whole queue item would create a duplicate just to
-	// retry the pin, so every locally predictable wait happens before the send.
+	messageID, err := w.sendPinChat(ctx, payload, mod)
+	if err != nil {
+		return err
+	}
+	if messageID == "" {
+		return nil
+	}
+
+	pin.Endpoint = pinEndpoint(payload.BroadcasterID, mod, messageID)
+	w.finishPin(ctx, pin, messageID)
+	return nil
+}
+
+// preparePin reserves both rate-limit paths before the chat send. Once the
+// message exists, retrying the whole queue item would duplicate it just to retry
+// the pin, so every locally predictable wait must happen first.
+func (w *Worker) preparePin(ctx context.Context, payload outgress.Message) (outgress.Message, string, bool, error) {
+	mod, ok := w.botIdentity("pin", payload)
+	if !ok {
+		return outgress.Message{}, "", false, nil
+	}
+
 	pin := outgress.Message{
 		Type:          outgress.TypePin,
 		BroadcasterID: payload.BroadcasterID,
@@ -35,19 +57,28 @@ func (w *Worker) processPin(ctx context.Context, payload outgress.Message) error
 		As:            outgress.AsApp,
 	}
 	if err := w.takeGeneralHelix(ctx, pin); err != nil {
-		return err
+		return outgress.Message{}, "", false, err
 	}
+	if err := w.takePinChat(ctx, payload); err != nil {
+		return outgress.Message{}, "", false, err
+	}
+	return pin, mod, true, nil
+}
 
+func (w *Worker) takePinChat(ctx context.Context, payload outgress.Message) error {
 	registryStarted := time.Now()
 	ch, found, err := w.registry.Get(ctx, payload.BroadcasterID)
 	recordStageDuration(ctx, "outgress.registry_ms", registryStarted)
 	if err != nil {
 		return err
 	}
-	if err := w.takeChat(ctx, payload.BroadcasterID, w.modStatus(ctx, payload, ch, found)); err != nil {
-		return err
-	}
+	return w.takeChat(ctx, payload.BroadcasterID, w.modStatus(ctx, payload, ch, found))
+}
 
+// sendPinChat posts the text through the ordinary chat route and returns the id
+// Twitch assigned. An empty id means Twitch rejected or dropped the send and the
+// pin action is safely consumed.
+func (w *Worker) sendPinChat(ctx context.Context, payload outgress.Message, mod string) (string, error) {
 	chatRoute := typeRoutes[outgress.TypeChat]
 	chat := payload
 	chat.Type = outgress.TypeChat
@@ -58,44 +89,47 @@ func (w *Worker) processPin(ctx context.Context, payload outgress.Message) error
 
 	res, err := w.executeRequest(ctx, chat)
 	if err != nil {
-		return err
+		return "", err
 	}
+	defer drainResponse(res)
+	return w.pinMessageID(ctx, payload, chat, res)
+}
+
+func (w *Worker) pinMessageID(ctx context.Context, payload, chat outgress.Message, res *http.Response) (string, error) {
 	status := res.StatusCode
 	if err := w.helixResult(ctx, chat, res); err != nil {
-		drainResponse(res)
-		return err
+		return "", err
 	}
 	if status >= http.StatusBadRequest {
-		drainResponse(res)
-		return nil
+		return "", nil
 	}
 
 	messageID, sent, decodeErr := sentChatMessageID(res.Body)
-	drainResponse(res)
 	if decodeErr != nil {
 		// Twitch accepted the send, so redelivery would duplicate it. Surface the
 		// bad response and ack this item instead of creating chat spam.
 		w.log.Error("chat sent but pin response could not be decoded",
 			zap.String("broadcaster_id", payload.BroadcasterID), zap.Error(decodeErr))
 		noticeError(ctx, decodeErr)
-		return nil
+		return "", nil
 	}
 	if !sent || messageID == "" {
 		w.log.Warn("chat message was not sent; skipping pin",
 			zap.String("broadcaster_id", payload.BroadcasterID))
-		return nil
+		return "", nil
 	}
+	return messageID, nil
+}
 
-	pin.Endpoint = pinEndpoint(payload.BroadcasterID, mod, messageID)
+func (w *Worker) finishPin(ctx context.Context, pin outgress.Message, messageID string) {
 	if err := w.execute(ctx, pin); err != nil {
 		// The chat message already exists. Retrying this compound action would send
 		// it again, so report the pin failure but consume the queue item.
 		w.log.Warn("chat sent but pin failed; skipping unsafe redelivery",
-			zap.String("broadcaster_id", payload.BroadcasterID),
+			zap.String("broadcaster_id", pin.BroadcasterID),
 			zap.String("message_id", messageID), zap.Error(err))
 		noticeError(ctx, err)
 	}
-	return nil
 }
 
 type sendChatReply struct {

--- a/app/outgress/internal/worker/worker_test.go
+++ b/app/outgress/internal/worker/worker_test.go
@@ -66,7 +66,7 @@ func TestDrainResponseIsBounded(t *testing.T) {
 }
 
 func TestCloudBotChatActionsUseAppToken(t *testing.T) {
-	for _, typ := range []string{outgress.TypeChat, outgress.TypeAnnounce, outgress.TypeShoutout} {
+	for _, typ := range []string{outgress.TypeChat, outgress.TypeAnnounce, outgress.TypeShoutout, outgress.TypePin} {
 		route := typeRoutes[typ]
 		if route.as != outgress.AsApp {
 			t.Fatalf("%s route identity = %q, want %q", typ, route.as, outgress.AsApp)
@@ -270,6 +270,54 @@ func TestShoutoutEndpoint(t *testing.T) {
 	wantEsc := "/helix/chat/shoutouts?from_broadcaster_id=a+b&to_broadcaster_id=c%26d&moderator_id=e%3Ff"
 	if got != wantEsc {
 		t.Fatalf("shoutout endpoint (escaped) = %q, want %q", got, wantEsc)
+	}
+}
+
+func TestPinRouteAndStreamLifetimeEndpoint(t *testing.T) {
+	assertRoute(t, outgress.TypePin,
+		helixRoute{http.MethodPut, "/helix/chat/pins", outgress.AsApp})
+
+	got := pinEndpoint("44322889", "987654", "abc-123")
+	want := "/helix/chat/pins?broadcaster_id=44322889&moderator_id=987654&message_id=abc-123"
+	if got != want {
+		t.Fatalf("pin endpoint = %q, want %q", got, want)
+	}
+	if strings.Contains(got, "duration_seconds") {
+		t.Fatalf("pin endpoint unexpectedly limits pin lifetime: %q", got)
+	}
+
+	escaped := pinEndpoint("a b", "c&d", "e?f")
+	wantEscaped := "/helix/chat/pins?broadcaster_id=a+b&moderator_id=c%26d&message_id=e%3Ff"
+	if escaped != wantEscaped {
+		t.Fatalf("pin endpoint (escaped) = %q, want %q", escaped, wantEscaped)
+	}
+}
+
+func TestSentChatMessageID(t *testing.T) {
+	tests := []struct {
+		name     string
+		body     string
+		wantID   string
+		wantSent bool
+		wantErr  bool
+	}{
+		{"sent", `{"data":[{"message_id":"abc-123","is_sent":true}]}`, "abc-123", true, false},
+		{"twitch dropped message", `{"data":[{"message_id":"","is_sent":false,"drop_reason":{"code":"msg_rejected"}}]}`, "", false, false},
+		{"empty data", `{"data":[]}`, "", false, false},
+		{"malformed", `{`, "", false, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotID, gotSent, err := sentChatMessageID(strings.NewReader(tc.body))
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("sentChatMessageID error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if gotID != tc.wantID || gotSent != tc.wantSent {
+				t.Fatalf("sentChatMessageID = (%q, %v), want (%q, %v)",
+					gotID, gotSent, tc.wantID, tc.wantSent)
+			}
+		})
 	}
 }
 

--- a/app/sesame/engine/dispatch_test.go
+++ b/app/sesame/engine/dispatch_test.go
@@ -96,6 +96,19 @@ func TestCustomAnnounceEmptySkipped(t *testing.T) {
 	assert.Empty(t, collectDispatch(p, chatCtx("!so", "moderator")))
 }
 
+func TestCustomPinUntilStreamEnds(t *testing.T) {
+	p := customPipeline("/pin Current speed: {args}", "everyone")
+	got := collectDispatch(p, chatCtx("!speed 42 km/h", ""))
+	require.Len(t, got, 1)
+	assert.Equal(t, outgress.TypePin, got[0].Type)
+	assert.Equal(t, "Current speed: 42 km/h", got[0].Text)
+
+	msg, err := buildOutgressMessage(&got[0])
+	require.NoError(t, err)
+	assert.Equal(t, outgress.TypePin, msg.Type)
+	assert.Equal(t, "Current speed: 42 km/h", chatMessageText(t, msg))
+}
+
 func TestCustomPlainChatStillEmits(t *testing.T) {
 	p := customPipeline("hello {sender}", "everyone")
 	got := collectDispatch(p, chatCtx("!so", ""))

--- a/app/sesame/engine/outgress_build.go
+++ b/app/sesame/engine/outgress_build.go
@@ -62,6 +62,7 @@ var outgressBuilders = map[string]func(*module.Output) (outgress.Message, error)
 	outgress.TypeChat:             chatOutgress,
 	outgress.TypeAnnounce:         announceOutgress,
 	outgress.TypeShoutout:         shoutoutOutgress,
+	outgress.TypePin:              pinOutgress,
 	outgress.TypeClip:             clipOutgress,
 	outgress.TypeBan:              banOutgress,
 	outgress.TypeTimeout:          banOutgress,
@@ -85,7 +86,18 @@ func payloadMessage(msgType, broadcasterID string, payload any) (outgress.Messag
 }
 
 func chatOutgress(o *module.Output) (outgress.Message, error) {
-	return payloadMessage(outgress.TypeChat, o.BroadcasterID, struct {
+	return textOutgress(outgress.TypeChat, o)
+}
+
+func pinOutgress(o *module.Output) (outgress.Message, error) {
+	return textOutgress(outgress.TypePin, o)
+}
+
+// textOutgress builds the Send Chat Message body shared by ordinary chat and
+// /pin. The pin worker sends this body first, then uses Twitch's returned
+// message id for the pin endpoint.
+func textOutgress(msgType string, o *module.Output) (outgress.Message, error) {
+	return payloadMessage(msgType, o.BroadcasterID, struct {
 		BroadcasterID string `json:"broadcaster_id"`
 		Message       string `json:"message"`
 	}{o.BroadcasterID, o.Text})

--- a/app/sesame/engine/pipeline.go
+++ b/app/sesame/engine/pipeline.go
@@ -289,7 +289,7 @@ func (p *Pipeline) floorSuppressed(o *module.Output) bool {
 	if o.Text == "" {
 		return false
 	}
-	if o.Type != outgress.TypeChat && o.Type != outgress.TypeAnnounce {
+	if o.Type != outgress.TypeChat && o.Type != outgress.TypeAnnounce && o.Type != outgress.TypePin {
 		return false
 	}
 	term, hit := moderation.CheckFloor(o.Text)

--- a/app/sesame/engine/pipeline.go
+++ b/app/sesame/engine/pipeline.go
@@ -289,7 +289,9 @@ func (p *Pipeline) floorSuppressed(o *module.Output) bool {
 	if o.Text == "" {
 		return false
 	}
-	if o.Type != outgress.TypeChat && o.Type != outgress.TypeAnnounce && o.Type != outgress.TypePin {
+	switch o.Type {
+	case outgress.TypeChat, outgress.TypeAnnounce, outgress.TypePin:
+	default:
 		return false
 	}
 	term, hit := moderation.CheckFloor(o.Text)

--- a/app/sesame/engine/slash.go
+++ b/app/sesame/engine/slash.go
@@ -19,6 +19,8 @@ import (
 //     /announce is "primary"); the verb is stripped from Text.
 //   - /shoutout <target> -> TypeShoutout; the first token (leading '@' stripped)
 //     becomes To and is removed from Text.
+//   - /pin <message> -> TypePin; the verb is stripped from Text. Outgress sends
+//     the message first, then pins it until the current stream ends.
 //   - /me -> left as a plain chat line; the verb is NOT stripped (Twitch chat
 //     interprets the leading "/me" itself).
 //
@@ -46,6 +48,13 @@ func Translate(out *module.Output) {
 		return
 	}
 
+	// /pin <message>
+	if rest, ok := cutVerb(text, "/pin"); ok {
+		out.Type = outgress.TypePin
+		out.Text = rest
+		return
+	}
+
 	// /me is a plain passthrough: leave Type=chat and keep the verb in Text.
 }
 
@@ -54,7 +63,7 @@ func Translate(out *module.Output) {
 // message, a /shoutout with no target, or an empty chat line.
 func isEmptyAction(out *module.Output) bool {
 	switch out.Type {
-	case outgress.TypeAnnounce, outgress.TypeChat:
+	case outgress.TypeAnnounce, outgress.TypePin, outgress.TypeChat:
 		return out.Text == ""
 	case outgress.TypeShoutout:
 		return out.To == ""

--- a/app/sesame/engine/slash_test.go
+++ b/app/sesame/engine/slash_test.go
@@ -27,6 +27,8 @@ func TestTranslate(t *testing.T) {
 		{"announce purple", "/announcepurple royal", outgress.TypeAnnounce, "royal", "purple", ""},
 		{"shoutout strips target and at", "/shoutout @cooldude check them out", outgress.TypeShoutout, "check them out", "", "cooldude"},
 		{"shoutout target only", "/shoutout cooldude", outgress.TypeShoutout, "", "", "cooldude"},
+		{"pin strips verb", "/pin speedrun rules: no glitches", outgress.TypePin, "speedrun rules: no glitches", "", ""},
+		{"pin bare verb only", "/pin", outgress.TypePin, "", "", ""},
 		{"me is plain passthrough not stripped", "/me waves", outgress.TypeChat, "/me waves", "", ""},
 		{"unknown slash unchanged", "/unknown thing", outgress.TypeChat, "/unknown thing", "", ""},
 	}
@@ -47,6 +49,8 @@ func TestIsEmptyAction(t *testing.T) {
 	assert.False(t, isEmptyAction(&module.Output{Type: outgress.TypeAnnounce, Text: "hi"}))
 	assert.True(t, isEmptyAction(&module.Output{Type: outgress.TypeShoutout, To: ""}))
 	assert.False(t, isEmptyAction(&module.Output{Type: outgress.TypeShoutout, To: "bob"}))
+	assert.True(t, isEmptyAction(&module.Output{Type: outgress.TypePin, Text: ""}))
+	assert.False(t, isEmptyAction(&module.Output{Type: outgress.TypePin, Text: "speedrun rules"}))
 	assert.True(t, isEmptyAction(&module.Output{Type: outgress.TypeChat, Text: ""}))
 	assert.False(t, isEmptyAction(&module.Output{Type: outgress.TypeChat, Text: "hi"}))
 }

--- a/console/dashboard/src/lib/components/commands/ChatPreview.svelte
+++ b/console/dashboard/src/lib/components/commands/ChatPreview.svelte
@@ -4,11 +4,12 @@
   // sample values substituted into the tokens. Re-runs (debounced) as the
   // response is edited, so authors see the real thing, not a template string.
   //
-  // When the response leads with a Twitch slash-verb (/announce…, /shoutout,
+  // When the response leads with a Twitch slash-verb (/announce…, /shoutout, /pin,
   // /me) the worker turns it into that native action instead of a plain chat
-  // line (see app/worker/module/slash.go). The rehearsal mirrors that parse so
+  // line (see app/sesame/engine/slash.go). The rehearsal mirrors that parse so
   // authors can see they're driving a Twitch command — an announcement callout,
-  // a shoutout card, or an italic /me action — with a badge naming the verb.
+  // a shoutout card, a stream-long pin, or an italic /me action — with a badge
+  // naming the verb.
   // A multi-line response (newline-delimited, up to 5 lines) is acted out as
   // the bot sending one chat message per line, in order — the same fan-out the
   // worker performs — so authors see exactly how many messages they're minting.
@@ -70,10 +71,10 @@
   const trigger = $derived('!' + (normName(name) || 'command') + (args ? ' ' + args : ''));
 
   // --- Slash-verb parse, mirrored from app/worker/module/slash.go ---------
-  // The worker recognizes a leading verb, rewrites the outgress Type, and
+  // Sesame recognizes a leading verb, rewrites the outgress Type, and
   // strips the verb from the text. We reproduce the same matching (whole-verb
   // or "verb " prefix) so the rehearsal renders the same action the bot sends.
-  type Mode = 'chat' | 'announce' | 'shoutout' | 'me';
+  type Mode = 'chat' | 'announce' | 'shoutout' | 'pin' | 'me';
   type Parsed = {
     mode: Mode;
     body: string; // text with the verb stripped (what actually gets shown)
@@ -121,6 +122,8 @@
       const remainder = sp === -1 ? '' : trimmed.slice(sp + 1).replace(/^ +/, '');
       return { mode: 'shoutout', body: remainder, verb: '/shoutout', target: rawTarget.replace(/^@/, '') };
     }
+    const pin = cutVerb(text, '/pin');
+    if (pin !== null) return { mode: 'pin', body: pin, verb: '/pin' };
     // /me is a plain passthrough on the wire (verb kept in Text), but Twitch
     // renders it as an italic action — strip the verb for display.
     const me = cutVerb(text, '/me');
@@ -265,6 +268,24 @@
           {:else}
             <span class="msg empty">{t('chatPreview.addActionAfterMe')}</span>
           {/if}
+        {:else if v.mode === 'pin'}
+          <div class="pin">
+            <span class="pin-head">
+              <span class="via" title={t('chatPreview.runsVerb', { verb: '/pin' })}>Twitch /pin</span>
+              {t('chatPreview.pinnedForStream')}
+            </span>
+            {#if v.segments.length}
+              <span class="msg reply">
+                {#each v.segments as seg, i (i)}
+                  {#if seg.kind === 'sample'}<mark>{seg.text}</mark>
+                  {:else if seg.kind === 'unknown'}<mark class="unknown" title={t('chatPreview.unknownVar')}>{seg.text}</mark>
+                  {:else}{seg.text}{/if}
+                {/each}
+              </span>
+            {:else}
+              <span class="msg empty">{t('chatPreview.addMessageAfter', { verb: '/pin' })}</span>
+            {/if}
+          </div>
         {:else}
           <span class="msg reply">
             {#each v.segments as seg, i (i)}
@@ -413,6 +434,29 @@
   }
   .shoutout .reply strong { color: var(--bb-green-glow); }
 
+  /* /pin sends a real bot message and anchors it for the current stream. */
+  .pin {
+    width: 100%;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 8px 10px;
+    border-radius: 8px;
+    border: 1px solid rgba(199, 125, 255, 0.35);
+    background: rgba(199, 125, 255, 0.07);
+    animation: reply-in 240ms var(--bb-ease-out-back, ease-out) both;
+    animation-delay: var(--reply-delay, 0ms);
+  }
+  .pin-head {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    color: var(--bb-muted);
+    font-family: var(--bb-font-display);
+    font-size: 10.5px;
+  }
+
   /* /me action: italic, tinted like the bot's name (no colon before it). */
   .msg.action { font-style: italic; color: var(--bb-green-glow); }
 
@@ -430,7 +474,7 @@
   }
 
   @media (prefers-reduced-motion: reduce) {
-    .reply, .announce, .shoutout { animation: none; }
+    .reply, .announce, .shoutout, .pin { animation: none; }
     .tdot { animation: none; }
   }
 </style>

--- a/console/shared/lib/i18n/en.ts
+++ b/console/shared/lib/i18n/en.ts
@@ -782,6 +782,7 @@ export const en = {
     addMessageAfter: '…add a message after {verb}',
     shoutsOut: 'Shouts out',
     nameChannel: '…name a channel after /shoutout',
+    pinnedForStream: 'Pinned until the stream ends',
     addActionAfterMe: '…add an action after /me',
     nothingToSay: '…the bot has nothing to say yet',
     unknownVar: 'Unknown variable'

--- a/console/shared/lib/i18n/fr.ts
+++ b/console/shared/lib/i18n/fr.ts
@@ -781,6 +781,7 @@ export const fr = {
     addMessageAfter: '…ajoutez un message après {verb}',
     shoutsOut: 'Fait un shoutout à',
     nameChannel: '…nommez une chaîne après /shoutout',
+    pinnedForStream: 'Épinglé jusqu’à la fin du stream',
     addActionAfterMe: '…ajoutez une action après /me',
     nothingToSay: '…le bot n\'a rien à dire pour le moment',
     unknownVar: 'Variable inconnue'

--- a/internal/domain/outgress/message.go
+++ b/internal/domain/outgress/message.go
@@ -85,6 +85,10 @@ const (
 	TypeClip         = "clip"
 	TypeAnnounce     = "announce"
 	TypeShoutout     = "shoutout"
+	// TypePin sends a chat message and pins the returned message id. Outgress
+	// deliberately omits duration_seconds so Twitch keeps it pinned until the
+	// current stream ends.
+	TypePin = "pin"
 	// TypeShieldMode activates a channel's Shield Mode: one PUT that gates the
 	// whole channel (blocks non-followers/new accounts) instead of banning a
 	// mass-raid account by account, which would blow the shared Helix budget.


### PR DESCRIPTION
## What changed

- recognize `/pin <message>` in Sesame custom-command responses
- send the response through Outgress, capture Twitch's message ID, and pin it until the stream ends
- add the `/pin` rehearsal state to the dashboard command inspector in English and French
- cover translation, wire routing, response decoding, endpoint construction, and app-token selection

## Why

Command authors could send announcements and shoutouts through native Twitch actions, but they could not automatically pin a command response. Twitch's pin endpoint requires an existing message ID, so Outgress now owns the two-step send-then-pin flow.

## User impact

A response such as `/pin Current speed: {args}` sends the expanded bot message and keeps it pinned for the current stream. A later mod-pinned message replaces it according to Twitch's one-pin-per-channel behavior.

Closes #108.

## Validation

- `go test ./...`
- `bun test shared`
- `bun run --filter dashboard check`
- `bun run --filter dashboard build`
