### PR TITLE
feat(dashboard): hide AutoMod module from UI

### DIFF
--- a/console/dashboard/src/routes/(app)/+page.server.ts
+++ b/console/dashboard/src/routes/(app)/+page.server.ts
@@ -178,14 +178,15 @@ function commandDigest(uid: string): Promise<CommandDigest> {
 }
 
 function moduleDigest(uid: string): Promise<ModuleDigest> {
-  const catalogIds = new Set(MODULE_CATALOG.map((m) => m.id));
+  const visibleCatalog = MODULE_CATALOG.filter((m) => !m.hidden);
+  const catalogIds = new Set(visibleCatalog.map((m) => m.id));
   return listModules(uid)
     .then((rows) => ({
       on: rows.filter((r) => catalogIds.has(r.name) && r.is_enabled).length,
-      total: MODULE_CATALOG.length,
+      total: visibleCatalog.length,
       ok: true
     }))
-    .catch(() => ({ on: 0, total: MODULE_CATALOG.length, ok: false }));
+    .catch(() => ({ on: 0, total: visibleCatalog.length, ok: false }));
 }
 
 // Delegation shares only exist for owners; a delegate browsing the owner's
@@ -210,7 +211,7 @@ export const load: PageServerLoad = ({ locals }) => {
   return {
     conn: demoOr<ConnData>(demoConn, () => connState(uid)),
     commands: demoOr(demoDigest, () => commandDigest(uid)),
-    modules: demoOr<ModuleDigest>({ on: 1, total: MODULE_CATALOG.length, ok: true }, () => moduleDigest(uid)),
+    modules: demoOr<ModuleDigest>({ on: 1, total: MODULE_CATALOG.filter((m) => !m.hidden).length, ok: true }, () => moduleDigest(uid)),
     shares: demoOr<ShareDigest>({ people: 1, pending: 1, ok: true }, () => shareDigest(uid))
   };
 };

--- a/console/dashboard/src/routes/(app)/modules/+page.server.ts
+++ b/console/dashboard/src/routes/(app)/modules/+page.server.ts
@@ -33,7 +33,7 @@ function asConfig(raw: unknown): Record<string, string> {
 // Modules absent from the catalog (system, bagel, ...) are never surfaced.
 function merge(rows: ModuleView[]): ModuleState[] {
   const byName = new Map(rows.map((r) => [r.name, r]));
-  return MODULE_CATALOG.map((def) => {
+  return MODULE_CATALOG.filter((def) => !def.hidden).map((def) => {
     const row = byName.get(def.id);
     return {
       def,

--- a/console/dashboard/src/routes/(app)/modules/[id]/+page.server.ts
+++ b/console/dashboard/src/routes/(app)/modules/[id]/+page.server.ts
@@ -37,7 +37,7 @@ function asConfig(raw: unknown): { config: Record<string, string>; revision: num
 export const load: PageServerLoad = async ({ params, locals }) => {
   gateModules(locals.session);
   const def = moduleDef(params.id);
-  if (!def) throw error(404, 'Unknown module');
+  if (!def || def.hidden) throw error(404, 'Unknown module');
   // href modules (channel points, timers, govee) own a bespoke page; the generic
   // reply inspector cannot render them, so send any direct hit there.
   if (def.href) throw redirect(302, def.href);

--- a/console/dashboard/src/routes/user/[userId]/+page.server.ts
+++ b/console/dashboard/src/routes/user/[userId]/+page.server.ts
@@ -117,7 +117,7 @@ function publicCommands(rows: CommandView[]): PublicCommand[] {
 function publicModules(rows: ModuleView[]): PublicModule[] {
   const byName = new Map(rows.map((row) => [row.name, row]));
 
-  const catalogModules = MODULE_CATALOG.flatMap((def): PublicModule[] => {
+  const catalogModules = MODULE_CATALOG.filter((def) => !def.hidden).flatMap((def): PublicModule[] => {
     const row = byName.get(def.id);
     const active = row ? row.is_enabled : def.defaultEnabled;
     if (!active) return [];

--- a/console/shared/lib/types.ts
+++ b/console/shared/lib/types.ts
@@ -309,6 +309,8 @@ export interface ModuleDef {
   icon: IconName;
   category: string;
   defaultEnabled: boolean;
+  // If true, the module is hidden from the dashboard and unreachable.
+  hidden?: boolean;
   // The module's configurable chat lines (the "commands" of the module page).
   replies: ModuleReply[];
   // Read-only chat commands to list on the module page. For modules that expose
@@ -462,6 +464,7 @@ export const MODULE_CATALOG: readonly ModuleDef[] = [
     icon: 'moderation',
     category: 'Moderation',
     defaultEnabled: true,
+    hidden: true,
     // AutoMod is pure configuration: no chat reply lines, only the settings strip.
     replies: [],
     settings: [


### PR DESCRIPTION
Hides the AutoMod module from the dashboard (make it unreachable and omit from lists).