### PR TITLE
feat(nats): async sharded ingress publisher + BUS direct-to-hub (stage 1)

### DIFF
--- a/app/ingress/config/runtime.exs
+++ b/app/ingress/config/runtime.exs
@@ -116,41 +116,51 @@ config :ingress,
 # server; the production broker requires them and Gnat only sends them when
 # the server asks (auth_required in the INFO handshake).
 #
-# Two planes on two accounts (per-account isolation):
+# Two planes on two accounts (per-account isolation), and they connect to
+# DIFFERENT servers:
 #   * :nats     — the twitch_ingress RPC account (NATS_RPC_USER/PASSWORD): admin
 #     shard control, conduit RPC, broadcaster-status request, cache invalidation.
+#     Stays on the node-local leaf — low-latency request/reply, and the per-service
+#     RPC accounts are presented by the leaf.
 #   * :nats_bus — the shared BUS account (NATS_USER/PASSWORD): the twitch.ingress.*
-#     firehose publishes captured by the JetStream streams.
-#
-# Both are leaf-first: each is a list of servers (leaf, then hub) that Gnat tries
-# in order, so the node-local leaf is the priority path with the hub as fallback.
+#     firehose captured by the JetStream streams. Connects DIRECT to the hub,
+#     bypassing the leaf. The leaf runs no JetStream, so for the firehose it is
+#     only a forwarding hop to the same hub streams; at the firehose rate that hop
+#     is pure overhead, and the PubAcks come straight from the hub. Trade-off: a
+#     hub roll re-pins this connection (Gnat reconnects); the RPC path is
+#     untouched. In dev NATS_HUB_HOST is unset and falls back to the leaf host, so
+#     both planes collapse onto one local server.
 nats_leaf_host = System.get_env("NATS_LEAF_HOST") || System.get_env("NATS_HOST", "127.0.0.1")
-nats_hub_host = System.get_env("NATS_HUB_HOST", nats_leaf_host)
+nats_hub_host = System.get_env("NATS_HUB_HOST") || nats_leaf_host
 nats_port = String.to_integer(System.get_env("NATS_PORT", "4222"))
 
-nats_servers = fn user, pass ->
-  for host <- Enum.uniq([nats_leaf_host, nats_hub_host]) do
-    base = %{host: host, port: nats_port}
+nats_server = fn host, user, pass ->
+  base = %{host: host, port: nats_port}
 
-    if is_binary(user) and is_binary(pass) do
-      Map.merge(base, %{username: user, password: pass})
-    else
-      base
-    end
+  if is_binary(user) and is_binary(pass) do
+    Map.merge(base, %{username: user, password: pass})
+  else
+    base
   end
 end
 
 config :ingress,
-  nats:
-    nats_servers.(
+  # RPC: leaf only.
+  nats: [
+    nats_server.(
+      nats_leaf_host,
       System.get_env("NATS_RPC_USER") || System.get_env("NATS_USER"),
       System.get_env("NATS_RPC_PASSWORD") || System.get_env("NATS_PASSWORD")
-    ),
-  nats_bus:
-    nats_servers.(
+    )
+  ],
+  # BUS firehose: hub only.
+  nats_bus: [
+    nats_server.(
+      nats_hub_host,
       System.get_env("NATS_USER"),
       System.get_env("NATS_PASSWORD")
     )
+  ]
 
 if level = System.get_env("LOG_LEVEL") do
   config :logger, level: String.to_existing_atom(level)

--- a/app/ingress/lib/ingress/application.ex
+++ b/app/ingress/lib/ingress/application.ex
@@ -20,6 +20,11 @@ defmodule Ingress.Application do
       account), registered as `:gnat`.
     * `Gnat.ConnectionSupervisor` - BUS-plane NATS connection (shared BUS
       account), registered as `:gnat_bus`; carries the twitch.ingress.* firehose.
+    * `Ingress.Nats.PublisherPool` - a pool of asynchronous, pipelined JetStream
+      publishers + ack multiplexers for the lane firehose, sharded across N BUS
+      connections so publish throughput scales past one connection's process
+      ceiling and is bounded by the in-flight window, not one blocked worker per
+      PubAck.
     * `Gnat.ConsumerSupervisor` (invalidation) - subscription to cache
       invalidation subject.
     * `Gnat.ConsumerSupervisor` (admin) - request-reply read endpoint for
@@ -66,16 +71,23 @@ defmodule Ingress.Application do
          # of the default hash ring, which clusters them (4/1 observed).
          distribution_strategy: Ingress.ShardDistribution
        ]},
-      # RPC plane (:gnat): the twitch_ingress account. Carries the admin/scale/
-      # autoscale/conduit RPC endpoints, the cache-invalidation consumer and the
-      # broadcaster-status request. Leaf-first server list comes from config.
+      # RPC plane (:gnat): the twitch_ingress account, on the node-local leaf.
+      # Carries the admin/scale/autoscale/conduit RPC endpoints, the
+      # cache-invalidation consumer and the broadcaster-status request.
       connection_child(:nats_connection, :gnat, Config.nats()),
-      # BUS plane (:gnat_bus): the shared BUS account. Carries only the
-      # twitch.ingress.* firehose publishes (Ingress.Nats), which the JetStream
-      # streams capture. Kept separate so ingress holds no JetStream/event-plane
-      # rights on its RPC account.
+      # BUS plane (:gnat_bus): the shared BUS account, connected DIRECT to the hub
+      # (not the leaf) since it carries only the twitch.ingress.* firehose
+      # publishes (Ingress.Nats) captured by the hub's JetStream streams. Kept a
+      # separate account so ingress holds no JetStream/event-plane rights on its
+      # RPC account. Ingress.Nats.PublisherPool opens further hub connections for
+      # the acked firehose; this one carries the fire-and-forget status publishes.
       connection_child(:nats_bus_connection, :gnat_bus, Config.nats_bus()),
       Ingress.NatsFailback,
+      # Sharded asynchronous ack multiplexer for lane publishes
+      # (Ingress.Nats.publish_acked): a pool of BUS connections + collectors so
+      # publish throughput scales past a single connection's process ceiling.
+      # Must start before the Dispatcher and Squash, which publish through it.
+      Ingress.Nats.PublisherPool,
       {Task.Supervisor, name: Ingress.BroadcasterCache.TaskSupervisor},
       # Runs squash-cohort publishes (JetStream-acked) off the Squash process,
       # so a slow broker never stalls the sweep.

--- a/app/ingress/lib/ingress/config.ex
+++ b/app/ingress/lib/ingress/config.ex
@@ -82,7 +82,8 @@ defmodule Ingress.Config do
   def dispatcher_broadcaster_sweep_ms,
     do: Application.get_env(:ingress, :dispatcher_broadcaster_sweep_ms, 60_000)
 
-  # How long one JetStream lane publish waits for its PubAck before retrying.
+  # How long an outstanding async lane publish waits for its PubAck before the
+  # collector re-publishes it (see Ingress.Nats.Publisher).
   def publish_ack_timeout_ms,
     do: Application.get_env(:ingress, :publish_ack_timeout_ms, 2_000)
 
@@ -90,6 +91,23 @@ defmodule Ingress.Config do
   # Nats-Msg-Id dedup header makes retries safe.
   def publish_attempts,
     do: Application.get_env(:ingress, :publish_attempts, 3)
+
+  # Ceiling on outstanding (un-acked) async lane publishes per publisher shard.
+  # This is the publisher's backpressure valve: at the measured PubAck latency
+  # it sets peak publish throughput (publish_connections × max_pending /
+  # ack_latency), and it bounds the memory held for in-flight events when the
+  # broker stalls. Once reached, further publishes routed to that shard are shed
+  # as overloaded rather than buffered without limit.
+  def publish_max_pending,
+    do: Application.get_env(:ingress, :publish_max_pending, 8_192)
+
+  # Number of independent BUS connections (each with its own ack collector) the
+  # lane firehose is sharded across. Every publish is a GenServer.call into one
+  # Gnat connection process and every PubAck is handled by one collector, so a
+  # single connection tops out well below a 150-200k/s target; sharding spreads
+  # both across N processes and cores. Publishes are routed by scheduler id.
+  def publish_connections,
+    do: Application.get_env(:ingress, :publish_connections, 4)
 
   # Gnat connection_settings (a leaf-first list of server maps) for the two
   # planes: :nats is the twitch_ingress RPC account, :nats_bus the shared BUS

--- a/app/ingress/lib/ingress/nats.ex
+++ b/app/ingress/lib/ingress/nats.ex
@@ -4,12 +4,15 @@ defmodule Ingress.Nats do
   disciplines:
 
     * `publish_acked/3` — lane events (the traffic that must not be silently
-      lost). A JetStream publish: the request blocks on the broker's PubAck,
-      retries a bounded number of times, and carries a `Nats-Msg-Id` so the
-      stream's duplicate window collapses retries and Twitch's own EventSub
-      redeliveries into one stored copy. Callers are dispatcher workers, so a
-      slow broker occupies pool slots and the dispatcher sheds at its bound —
-      the intended backpressure — instead of a fast, invisible black hole.
+      lost). An asynchronous, pipelined JetStream publish (see
+      `Ingress.Nats.Publisher`): the event goes on the wire immediately carrying
+      a private reply subject and a `Nats-Msg-Id`, and its PubAck is reconciled
+      later by a single ack multiplexer. Up to `publish_max_pending` publishes
+      are outstanding at once, so a slow broker no longer parks a worker per
+      event; instead the window fills and further publishes are shed at that
+      bound. The `Nats-Msg-Id` collapses retries and Twitch's own EventSub
+      redeliveries into one stored copy, so re-publishing a missing/errored ack
+      is safe.
 
     * `publish/2` — status/telemetry events. Fire-and-forget core publish; if
       the connection is down the message is dropped with a warning. We prefer
@@ -23,12 +26,9 @@ defmodule Ingress.Nats do
 
   require Logger
 
-  alias Ingress.{Config, Metrics}
+  alias Ingress.{Metrics, Nats.Publisher}
 
   @connection :gnat_bus
-  # Pause between PubAck retry attempts: long enough to ride out a broker
-  # hiccup, short enough that a dispatcher worker slot is never parked long.
-  @retry_backoff_ms 250
 
   @spec publish(String.t(), map()) :: :ok | {:error, term()}
   def publish(subject, payload) do
@@ -46,65 +46,41 @@ defmodule Ingress.Nats do
   end
 
   @doc """
-  JetStream-acked publish with broker-side dedup.
+  Asynchronous JetStream publish with broker-side dedup.
 
   `dedup_id` becomes the message's `Nats-Msg-Id`: within the stream's
   duplicate window the broker stores the first copy and acks the rest as
-  duplicates, which makes retrying on a missing PubAck safe and absorbs
+  duplicates, which makes re-publishing on a missing PubAck safe and absorbs
   Twitch's at-least-once EventSub redeliveries without any consumer work.
-  `nil` skips the header (no dedup) but still waits for the ack.
+  `nil` skips the header (no dedup) but the publish is still ack-tracked.
 
-  A connection that is down drops immediately — the connection supervisor's
-  reconnect backoff is longer than the whole retry budget, so spinning here
-  could never succeed and would only park the worker.
+  Returns `:ok` once the event is on the wire (its PubAck is now awaited
+  asynchronously by `Ingress.Nats.Publisher`), or `{:error, reason}` when the
+  event was dropped at admission — `:overloaded` when the in-flight window is
+  full, `:not_connected` when the publisher or its BUS connection is down.
   """
   @spec publish_acked(String.t(), map(), String.t() | nil) :: :ok | {:error, term()}
   def publish_acked(subject, payload, dedup_id) do
     json = Jason.encode!(payload)
-    attempt(subject, json, request_opts(dedup_id), 1)
-  end
 
-  defp request_opts(nil), do: [receive_timeout: Config.publish_ack_timeout_ms()]
-
-  defp request_opts(dedup_id) do
-    [
-      receive_timeout: Config.publish_ack_timeout_ms(),
-      headers: [{"Nats-Msg-Id", dedup_id}]
-    ]
-  end
-
-  defp attempt(subject, json, opts, n) do
-    case request_ack(subject, json, opts) do
+    case Publisher.enqueue(subject, json, dedup_id) do
       :ok ->
         :ok
 
+      {:error, :overloaded} = error ->
+        Metrics.count("Nats/PublishDropped")
+        Metrics.count("Nats/PublishOverloaded")
+        error
+
       {:error, :not_connected} = error ->
-        Logger.warning("NATS connection down; dropping message on #{subject}")
+        Logger.warning("NATS publisher unavailable; dropping message on #{subject}")
         Metrics.count("Nats/PublishDropped")
         error
 
-      {:error, reason} = error ->
-        if n < Config.publish_attempts() do
-          Metrics.count("Nats/PublishRetried")
-          Process.sleep(@retry_backoff_ms)
-          attempt(subject, json, opts, n + 1)
-        else
-          Logger.warning("publish on #{subject} failed after #{n} attempts: #{inspect(reason)}")
-          Metrics.count("Nats/PublishFailed")
-          error
-        end
+      {:error, _reason} = error ->
+        Metrics.count("Nats/PublishDropped")
+        error
     end
-  end
-
-  defp request_ack(subject, json, opts) do
-    case Gnat.request(@connection, subject, json, opts) do
-      {:ok, %{body: body}} -> parse_pub_ack(body)
-      {:error, reason} -> {:error, reason}
-    end
-  catch
-    # The connection process is gone (registered name unbound, or it died
-    # mid-call). Its supervisor is already reconnecting on its own backoff.
-    :exit, _ -> {:error, :not_connected}
   end
 
   @doc false

--- a/app/ingress/lib/ingress/nats/publisher.ex
+++ b/app/ingress/lib/ingress/nats/publisher.ex
@@ -1,0 +1,341 @@
+defmodule Ingress.Nats.Publisher do
+  @moduledoc """
+  One shard of the asynchronous, pipelined JetStream publisher for the lane
+  firehose. `Ingress.Nats.PublisherPool` runs `publish_connections` of these,
+  each bound to its own BUS connection.
+
+  ## Why async, and why sharded
+
+  The synchronous `Gnat.request/4` path capped in-flight publishes at the
+  dispatcher's worker-pool size: each worker blocked on one broker PubAck, so
+  peak throughput was `pool_size / ack_latency` — at ~100 ms PubAck only a few
+  thousand events/second, no matter how many shards or pods, because every
+  connection converged on the same shared JetStream ceiling.
+
+  Async publishing decouples in-flight count from the worker pool: each publish
+  is a core NATS `pub` carrying a private reply subject and a `Nats-Msg-Id`
+  dedup header, and the broker's PubAck lands asynchronously on that reply
+  subject. `max_pending` publishes ride the wire at once, so ack latency no
+  longer throttles throughput — it only sets how many acks are outstanding
+  (`max_pending / ack_latency` events/second).
+
+  But a single async publisher still funnels every `Gnat.pub` through one Gnat
+  connection process, and every PubAck through one collector process — one BEAM
+  process tops out well below a 150-200k/s target. So the pool shards the load
+  across N independent connections, each with its own collector, pending table
+  and inbox namespace. `enqueue/3` picks a shard by scheduler id, spreading
+  publishes across cores without a shared round-robin hotspot.
+
+  ## Backpressure and reliability
+
+  Backpressure is an explicit per-shard bound: once `max_pending` publishes are
+  outstanding on a shard, further publishes routed there are refused
+  (`{:error, :overloaded}`) and the caller drops, so memory stays bounded under
+  a broker stall instead of buffering without limit. The `Nats-Msg-Id` still
+  collapses retries and Twitch redeliveries at the broker, so a PubAck that
+  errors or never arrives within `ack_timeout_ms` is safely re-published (up to
+  `publish_attempts`) before the event is dropped with a metric.
+
+  ## Per-shard shape
+
+    * a public `:ordered_set` ETS table, one row per outstanding publish, owned
+      by the collector so it is torn down if the collector dies.
+    * an `:atomics` array holding the outstanding count and a monotonic id
+      allocator, so the hot `enqueue/3` path admits/refuses without a message
+      round-trip to the collector.
+    * a `:persistent_term` context (`{__MODULE__, :ctx, index}`) so `enqueue/3`,
+      called from many workers concurrently, reads the counter, prefix, table
+      and connection without copying.
+    * the collector `GenServer` owns the reply-subject subscription, applies
+      acks, and runs the timeout sweep.
+  """
+
+  use GenServer
+
+  require Logger
+
+  alias Ingress.{Config, Metrics, Nats}
+
+  # `:atomics` indexes: outstanding publishes, and the monotonic reply-id
+  # allocator.
+  @idx_pending 1
+  @idx_next_id 2
+
+  # Reply subjects live under `_INBOX.>`, which the BUS account already permits
+  # (the old `Gnat.request` path used the same namespace); the random token
+  # keeps one shard's acks from landing on another shard's or pod's collector.
+  @inbox_prefix "_INBOX.ingresspub."
+
+  @sweep_interval_ms 500
+  @gauge_interval_ms 5_000
+
+  ## Hot path (runs in the caller — dispatcher workers, squash tasks)
+
+  @doc """
+  Admit one publish into a shard's in-flight window, or refuse it.
+
+  The shard is chosen by scheduler id, so publishes spread across the pool's
+  connections without a shared counter. Returns `:ok` once the event is on the
+  wire (its PubAck is now awaited asynchronously), `{:error, :overloaded}` when
+  the chosen shard's window is full, or `{:error, :not_connected}` when the pool
+  or the chosen shard's BUS connection is unavailable.
+  """
+  @spec enqueue(String.t(), binary(), String.t() | nil) :: :ok | {:error, term()}
+  def enqueue(subject, json, dedup_id) do
+    case :persistent_term.get({__MODULE__, :n}, 0) do
+      0 ->
+        {:error, :not_connected}
+
+      n ->
+        index = rem(:erlang.system_info(:scheduler_id) - 1, n)
+
+        case :persistent_term.get({__MODULE__, :ctx, index}, nil) do
+          nil -> {:error, :not_connected}
+          ctx -> admit(ctx, subject, json, dedup_id)
+        end
+    end
+  end
+
+  defp admit(%{counter: counter, max_pending: max_pending} = ctx, subject, json, dedup_id) do
+    if :atomics.add_get(counter, @idx_pending, 1) > max_pending do
+      :atomics.sub(counter, @idx_pending, 1)
+      {:error, :overloaded}
+    else
+      do_publish(ctx, subject, json, dedup_id)
+    end
+  end
+
+  defp do_publish(%{counter: counter, prefix: prefix, table: table, conn: conn}, subject, json, dedup_id) do
+    id = :atomics.add_get(counter, @idx_next_id, 1)
+    now = System.monotonic_time(:millisecond)
+    :ets.insert(table, {id, subject, json, dedup_id, 1, now})
+
+    case pub(conn, subject, json, reply_subject(prefix, id), dedup_id) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        :ets.delete(table, id)
+        :atomics.sub(counter, @idx_pending, 1)
+        {:error, reason}
+    end
+  rescue
+    # The collector died and took its ETS table with it (or a stale context is
+    # briefly live during its restart). Treat as a transient outage and undo the
+    # admission on the same counter the hot path incremented.
+    ArgumentError ->
+      :atomics.sub(counter, @idx_pending, 1)
+      {:error, :not_connected}
+  end
+
+  defp pub(conn, subject, json, reply, dedup_id) do
+    Gnat.pub(conn, subject, json, [reply_to: reply] ++ dedup_headers(dedup_id))
+  catch
+    # The BUS connection process is gone; its supervisor reconnects on its own
+    # backoff and the sweep will retry this id.
+    :exit, _ -> {:error, :not_connected}
+  end
+
+  defp dedup_headers(nil), do: []
+  defp dedup_headers(dedup_id), do: [headers: [{"Nats-Msg-Id", dedup_id}]]
+
+  defp reply_subject(prefix, id), do: prefix <> Integer.to_string(id)
+
+  @doc false
+  # Parse the reply id back out of a PubAck's topic, or nil if it does not
+  # belong to this collector's inbox namespace.
+  @spec id_from_topic(String.t(), String.t()) :: non_neg_integer() | nil
+  def id_from_topic(topic, prefix) do
+    plen = byte_size(prefix)
+
+    case topic do
+      <<^prefix::binary-size(plen), rest::binary>> ->
+        case Integer.parse(rest) do
+          {id, ""} -> id
+          _ -> nil
+        end
+
+      _ ->
+        nil
+    end
+  end
+
+  ## Collector
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts) do
+    index = Keyword.fetch!(opts, :index)
+    GenServer.start_link(__MODULE__, opts, name: process_name(index))
+  end
+
+  @doc false
+  def process_name(index), do: :"#{__MODULE__}.#{index}"
+
+  @impl true
+  def init(opts) do
+    index = Keyword.fetch!(opts, :index)
+    conn = Keyword.fetch!(opts, :conn)
+    table = :"ingress_pub_pending_#{index}"
+
+    :ets.new(table, [
+      :named_table,
+      :public,
+      :ordered_set,
+      read_concurrency: true,
+      write_concurrency: true
+    ])
+
+    counter = :atomics.new(2, signed: false)
+    token = :crypto.strong_rand_bytes(9) |> Base.url_encode64(padding: false)
+    prefix = @inbox_prefix <> token <> "."
+    max_pending = Config.publish_max_pending()
+
+    :persistent_term.put(
+      {__MODULE__, :ctx, index},
+      %{counter: counter, prefix: prefix, table: table, conn: conn, max_pending: max_pending}
+    )
+
+    state = %{
+      index: index,
+      conn: conn,
+      table: table,
+      counter: counter,
+      prefix: prefix,
+      sub_topic: prefix <> "*",
+      sid: nil,
+      conn_ref: nil,
+      max_pending: max_pending,
+      ack_timeout_ms: Config.publish_ack_timeout_ms(),
+      max_attempts: Config.publish_attempts()
+    }
+
+    send(self(), :connect)
+    schedule(:sweep, @sweep_interval_ms)
+    schedule(:gauge, @gauge_interval_ms)
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_info(:connect, state), do: {:noreply, ensure_subscribed(state)}
+
+  # The BUS connection died: our reply-subject subscription went with it. Drop
+  # the stale sid and resubscribe once the connection supervisor reconnects.
+  def handle_info({:DOWN, ref, :process, _pid, _reason}, %{conn_ref: ref} = state) do
+    send(self(), :connect)
+    {:noreply, %{state | sid: nil, conn_ref: nil}}
+  end
+
+  def handle_info({:DOWN, _ref, :process, _pid, _reason}, state), do: {:noreply, state}
+
+  # A PubAck (or JetStream error) for one outstanding publish.
+  def handle_info({:msg, %{topic: topic, body: body}}, state) do
+    case id_from_topic(topic, state.prefix) do
+      nil -> {:noreply, state}
+      id -> {:noreply, apply_ack(id, body, state)}
+    end
+  end
+
+  def handle_info(:sweep, state) do
+    deadline = System.monotonic_time(:millisecond) - state.ack_timeout_ms
+
+    match = [
+      {{:"$1", :"$2", :"$3", :"$4", :"$5", :"$6"}, [{:"=<", :"$6", deadline}],
+       [{{:"$1", :"$2", :"$3", :"$4", :"$5"}}]}
+    ]
+
+    for {id, subject, json, dedup_id, attempts} <- :ets.select(state.table, match) do
+      retry_or_drop(id, subject, json, dedup_id, attempts, :ack_timeout, state)
+    end
+
+    schedule(:sweep, @sweep_interval_ms)
+    {:noreply, state}
+  end
+
+  def handle_info(:gauge, state) do
+    pending = :atomics.get(state.counter, @idx_pending)
+
+    Metrics.event("Nats/PublishInflight", %{
+      shard: state.index,
+      pending: pending,
+      max_pending: state.max_pending,
+      utilization_pct: round(pending * 100 / state.max_pending)
+    })
+
+    schedule(:gauge, @gauge_interval_ms)
+    {:noreply, state}
+  end
+
+  defp ensure_subscribed(state) do
+    case Process.whereis(state.conn) do
+      nil ->
+        schedule(:connect, 500)
+        state
+
+      pid ->
+        ref = Process.monitor(pid)
+
+        case Gnat.sub(state.conn, self(), state.sub_topic) do
+          {:ok, sid} ->
+            Logger.info("nats async publisher #{state.index} awaiting acks on #{state.sub_topic}")
+            %{state | sid: sid, conn_ref: ref}
+
+          other ->
+            Process.demonitor(ref, [:flush])
+            Logger.warning("nats async publisher #{state.index} subscribe failed: #{inspect(other)}")
+            schedule(:connect, 500)
+            state
+        end
+    end
+  catch
+    :exit, _ ->
+      schedule(:connect, 500)
+      state
+  end
+
+  defp apply_ack(id, body, state) do
+    case :ets.lookup(state.table, id) do
+      # Already resolved — a timeout retry raced this ack, or it is a stray.
+      [] ->
+        state
+
+      [{^id, subject, json, dedup_id, attempts, _ts}] ->
+        case Nats.parse_pub_ack(body) do
+          :ok ->
+            resolve(id, state)
+
+          {:error, reason} ->
+            retry_or_drop(id, subject, json, dedup_id, attempts, reason, state)
+        end
+
+        state
+    end
+  end
+
+  defp resolve(id, state) do
+    :ets.delete(state.table, id)
+    :atomics.sub(state.counter, @idx_pending, 1)
+    Metrics.count("Nats/PublishAcked")
+  end
+
+  # Re-publish under the same reply id and `Nats-Msg-Id` (dedup makes the retry
+  # a no-op at the broker if the first copy did land) until the attempt budget
+  # is spent, then drop with a metric so the outstanding count stays honest.
+  defp retry_or_drop(id, subject, json, dedup_id, attempts, reason, state) do
+    if attempts < state.max_attempts do
+      :ets.insert(state.table, {id, subject, json, dedup_id, attempts + 1, now_ms()})
+      Metrics.count("Nats/PublishRetried")
+      _ = pub(state.conn, subject, json, reply_subject(state.prefix, id), dedup_id)
+      :ok
+    else
+      :ets.delete(state.table, id)
+      :atomics.sub(state.counter, @idx_pending, 1)
+      Metrics.count("Nats/PublishFailed")
+      Logger.warning("publish on #{subject} dropped after #{attempts} attempts: #{inspect(reason)}")
+      :ok
+    end
+  end
+
+  defp now_ms, do: System.monotonic_time(:millisecond)
+
+  defp schedule(msg, ms), do: Process.send_after(self(), msg, ms)
+end

--- a/app/ingress/lib/ingress/nats/publisher_pool.ex
+++ b/app/ingress/lib/ingress/nats/publisher_pool.ex
@@ -1,0 +1,61 @@
+defmodule Ingress.Nats.PublisherPool do
+  @moduledoc """
+  Supervises the sharded async lane publisher: `publish_connections` independent
+  BUS connections, each paired with one `Ingress.Nats.Publisher` collector.
+
+  Sharding the publish path is what lifts throughput past a single connection's
+  ceiling. Every `Gnat.pub` is a `GenServer.call` into one Gnat connection
+  process, and every PubAck is handled by one collector process; one BEAM
+  process cannot sustain a 150-200k/s firehose. N connections spread both the
+  publish `call`s and the ack handling across N processes (and cores).
+
+  The pool records the shard count in `:persistent_term` before any collector
+  starts, so `Ingress.Nats.Publisher.enqueue/3` — invoked from dispatcher
+  workers and squash tasks the moment they come up — can route to a shard even
+  during a partial pool restart (a shard whose context is not yet present just
+  reports `:not_connected`, and the caller drops that one event).
+
+  Each shard's BUS connection uses the same shared-BUS credentials as the
+  status-plane `:gnat_bus` connection; they are separate TCP connections so the
+  firehose never contends with status/telemetry publishes.
+  """
+
+  use Supervisor
+
+  alias Ingress.Config
+
+  @spec start_link(term()) :: Supervisor.on_start()
+  def start_link(_opts), do: Supervisor.start_link(__MODULE__, [], name: __MODULE__)
+
+  @impl true
+  def init(_opts) do
+    n = Config.publish_connections()
+    :persistent_term.put({Ingress.Nats.Publisher, :n}, n)
+
+    children =
+      Enum.flat_map(0..(n - 1), fn i ->
+        conn = connection_name(i)
+
+        [
+          Supervisor.child_spec(
+            {Gnat.ConnectionSupervisor,
+             %{name: conn, backoff_period: 4_000, connection_settings: Config.nats_bus()}},
+            id: {:pub_conn, i}
+          ),
+          Supervisor.child_spec(
+            {Ingress.Nats.Publisher, [index: i, conn: conn]},
+            id: {:publisher, i}
+          )
+        ]
+      end)
+
+    # one_for_one: shards are independent, and a collector re-subscribes its
+    # reply inbox on its own when its BUS connection flaps (it monitors the
+    # connection and retries), so a connection restart never needs to cascade
+    # into sibling shards.
+    Supervisor.init(children, strategy: :one_for_one)
+  end
+
+  @doc false
+  def connection_name(index), do: :"gnat_bus_pub_#{index}"
+end

--- a/app/ingress/lib/ingress/shard_scaler/policy.ex
+++ b/app/ingress/lib/ingress/shard_scaler/policy.ex
@@ -19,6 +19,28 @@ defmodule Ingress.ShardScaler.Policy do
 
   Hysteresis state is a `%{low: n, high: n}` map of consecutive ticks spent
   needing more/fewer shards; at most one side is non-zero at any time.
+
+  ## Socket rating vs. the shared NATS budget
+
+  Two capacities gate the pipeline and they are NOT the same number, so the
+  dashboard shows them independently:
+
+    * The websocket read+decode+enqueue path is rated far above
+      `@shard_rated_eps` — benchmarks put one shard's decode/dispatch near
+      12,500 ev/s, with a 10,000 ev/s (80%) operational target. That is a
+      *per-shard* ceiling that grows with shard count.
+    * JetStream publish is a *shared* ceiling: every shard and pod converges on
+      the same broker, so adding shards does not add publish capacity. Its safe
+      aggregate is measured per deployment.
+
+  `@shard_rated_eps` stays deliberately low here. Raising it to the 12,500
+  socket ceiling would make the autoscaler run fewer, hotter shards on the
+  assumption that shard count buys end-to-end capacity — false while NATS is the
+  bottleneck. It is only safe to raise after a sustained 50k/60s acceptance test
+  passes (0 publish errors, PubAck p95 < 20 ms, consumer lag < 1 s), once the
+  async publisher (`Ingress.Nats.Publisher`) and memory-backed streams have
+  lifted the shared ceiling. Until then the socket rating and the NATS budget
+  are surfaced for observability only, not fed into the shard-count math.
   """
 
   # Sustained events/second one shard is rated for. Conservative ~5-10% of

--- a/app/ingress/test/nats_publisher_test.exs
+++ b/app/ingress/test/nats_publisher_test.exs
@@ -1,0 +1,70 @@
+defmodule Ingress.Nats.PublisherTest do
+  # async: false — the publisher uses a named process, a named ETS table and a
+  # global persistent_term context, so it cannot share the VM with a parallel
+  # instance of itself.
+  use ExUnit.Case, async: false
+
+  alias Ingress.Nats.Publisher
+
+  describe "id_from_topic/2" do
+    @prefix "_INBOX.ingresspub.abc123."
+
+    test "extracts the reply id under this collector's prefix" do
+      assert Publisher.id_from_topic(@prefix <> "42", @prefix) == 42
+    end
+
+    test "ignores a subject outside the prefix" do
+      assert Publisher.id_from_topic("twitch.ingress.event.premium", @prefix) == nil
+    end
+
+    test "ignores a non-integer or trailing-garbage suffix" do
+      assert Publisher.id_from_topic(@prefix <> "nope", @prefix) == nil
+      assert Publisher.id_from_topic(@prefix <> "4x", @prefix) == nil
+      assert Publisher.id_from_topic(@prefix, @prefix) == nil
+    end
+  end
+
+  describe "enqueue/3 admission" do
+    setup do
+      prev = Application.get_env(:ingress, :publish_max_pending)
+      Application.put_env(:ingress, :publish_max_pending, 2)
+
+      # Stand in for PublisherPool: one shard, its BUS connection deliberately
+      # absent so the underlying pub never leaves the VM.
+      start_supervised!({Publisher, [index: 0, conn: :gnat_bus_pub_test]})
+      :persistent_term.put({Publisher, :n}, 1)
+
+      on_exit(fn ->
+        :persistent_term.erase({Publisher, :n})
+
+        if prev do
+          Application.put_env(:ingress, :publish_max_pending, prev)
+        else
+          Application.delete_env(:ingress, :publish_max_pending)
+        end
+      end)
+
+      %{ctx: :persistent_term.get({Publisher, :ctx, 0})}
+    end
+
+    test "refuses once the in-flight window is full and does not leak a slot", %{ctx: ctx} do
+      # Index 1 is the outstanding-publish count. Saturate it directly.
+      :atomics.put(ctx.counter, 1, 2)
+
+      assert Publisher.enqueue("twitch.ingress.event.standard", "{}", nil) ==
+               {:error, :overloaded}
+
+      # A refused admission must roll its increment back.
+      assert :atomics.get(ctx.counter, 1) == 2
+    end
+
+    test "drops to :not_connected when the shard's BUS connection is absent", %{ctx: ctx} do
+      # The shard's connection is not registered, so the underlying pub exits and
+      # the publish is undone rather than left outstanding.
+      assert Publisher.enqueue("twitch.ingress.event.standard", "{}", nil) ==
+               {:error, :not_connected}
+
+      assert :atomics.get(ctx.counter, 1) == 0
+    end
+  end
+end

--- a/console/admin/src/routes/(admin)/shards/+page.svelte
+++ b/console/admin/src/routes/(admin)/shards/+page.svelte
@@ -125,12 +125,28 @@
   // normalise against a generous nominal shard capacity for the bar, and show
   // the honest absolute throughput (events/sec) alongside it.
   //
-  // LOAD_WINDOW_S mirrors ingress @load_window_ms (60s). SHARD_CAPACITY_EPS is
-  // a display-only ceiling: a single shard handles far more than the
-  // autoscaler's scale-up trigger (~0.83 ev/s), so we size the "full" bar at
-  // 100 ev/s. This is for human gauge only; it does not drive autoscaling.
+  // Two INDEPENDENT capacity ceilings gate the pipeline; they are not one
+  // number, so each gets its own gauge (per-shard socket below, fleet-wide NATS
+  // budget in the overview). Values mirror Ingress.ShardScaler.Policy.
+  //
+  // LOAD_WINDOW_S mirrors ingress @load_window_seconds (60s).
   const LOAD_WINDOW_S = 60;
-  const SHARD_CAPACITY_EPS = 100; // events/sec considered a full bar
+
+  // Per-shard websocket read/decode/enqueue ceiling. Benchmarked ~12,500 ev/s;
+  // 10,000 is the 80% operational target. Real per-shard rates sit far below
+  // this, so the bar stays green — which is correct: the socket is not the
+  // bottleneck. (This is the true rating; the autoscaler still sizes shards
+  // against a deliberately conservative rating, see the Policy moduledoc.)
+  const SHARD_RATED_EPS = 12_500;
+  const SHARD_TARGET_EPS = 10_000;
+
+  // Shared JetStream publish budget for the WHOLE fleet (aggregate, not per
+  // shard): every shard and pod converges on the same broker, so this ceiling
+  // does NOT grow with shard count. Sized to the current deployment's safe
+  // aggregate; warn/saturation bracket it.
+  const NATS_SAFE_EPS = 3_000;
+  const NATS_WARN_EPS = 2_400;
+  const NATS_SATURATION_EPS = 4_200;
 
   function evRate(load?: number): number {
     if (load == null || load <= 0) return 0;
@@ -140,7 +156,7 @@
   function loadBar(load?: number): number {
     const rate = evRate(load);
     if (rate <= 0) return 0;
-    return Math.min(100, Math.round((rate / SHARD_CAPACITY_EPS) * 100));
+    return Math.min(100, Math.round((rate / SHARD_RATED_EPS) * 100));
   }
 
   function loadLabel(load?: number): string {
@@ -152,10 +168,34 @@
 
   function loadTone(load?: number): string {
     if (load == null) return 'muted';
-    const frac = evRate(load) / SHARD_CAPACITY_EPS;
-    if (frac >= 0.75) return 'err';
-    if (frac >= 0.5) return 'warn';
+    const rate = evRate(load);
+    if (rate >= SHARD_TARGET_EPS) return 'err';
+    if (rate >= SHARD_TARGET_EPS * 0.5) return 'warn';
     return 'green';
+  }
+
+  // Fleet-aggregate offered rate = the load NATS actually sees, summed across
+  // shards (Twitch load-balances events, so the sum is the firehose into the
+  // shared broker).
+  const aggregateEps = $derived(
+    (snap.shards ?? []).reduce((sum: number, s: any) => sum + evRate(s.load), 0)
+  );
+
+  function natsBar(eps: number): number {
+    if (eps <= 0) return 0;
+    return Math.min(100, Math.round((eps / NATS_SATURATION_EPS) * 100));
+  }
+
+  function natsTone(eps: number): string {
+    if (eps >= NATS_SAFE_EPS) return 'err';
+    if (eps >= NATS_WARN_EPS) return 'warn';
+    return 'green';
+  }
+
+  function natsLabel(eps: number): string {
+    if (eps <= 0) return '0 ev/s';
+    if (eps < 1) return `${eps.toFixed(2)} ev/s`;
+    return `${eps.toFixed(eps < 10 ? 1 : 0)} ev/s`;
   }
 
   function podIndex(raw?: string): string {
@@ -191,6 +231,29 @@
           <span>conduit {cm?.conduit_id ?? '—'}</span>
         </div>
       </div>
+    </div>
+  </div>
+
+  <!-- Shared NATS publish budget: fleet-aggregate offered rate against the
+       broker's shared JetStream ceiling. Distinct from per-shard socket load —
+       this ceiling does not grow with shard count, so it is gauged separately. -->
+  <div class="card conduit-card">
+    <div class="card-head">
+      <h3>NATS publish budget</h3>
+      <span class="more">shared JetStream ceiling</span>
+    </div>
+    <div class="load-row">
+      <div class="load-bar-track">
+        <div class="load-bar-fill {natsTone(aggregateEps)}" style="width:{natsBar(aggregateEps)}%"></div>
+      </div>
+      <span class="load-pct {natsTone(aggregateEps)}">
+        {natsLabel(aggregateEps)} · {natsBar(aggregateEps)}% of {NATS_SAFE_EPS.toLocaleString()} ev/s safe budget
+      </span>
+    </div>
+    <div class="shard-meta">
+      <span>warn {NATS_WARN_EPS.toLocaleString()} ev/s</span>
+      <span>critical {NATS_SAFE_EPS.toLocaleString()} ev/s</span>
+      <span>saturation ≈ {NATS_SATURATION_EPS.toLocaleString()} ev/s</span>
     </div>
   </div>
 

--- a/deploy/flux/clusters/production/flux-system/kustomization.yaml
+++ b/deploy/flux/clusters/production/flux-system/kustomization.yaml
@@ -4,6 +4,22 @@ resources:
 - gotk-components.yaml
 - gotk-sync.yaml
 patches:
+# Keep every Flux controller off node1. node1 is a 2-core, infra-loaded ARM host
+# being freed for its DB role (see node1-to-db-RUNBOOK.md); the controllers are
+# stateless (caches self-rebuild) so node2/node3 host them without a data move.
+- target:
+    kind: Deployment
+  patch: |-
+    - op: add
+      path: /spec/template/spec/affinity
+      value:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: NotIn
+                    values: [node1]
 # Memory-limit trims. Upstream gotk-components ships every controller with
 # limits.memory: 1Gi, and GOMEMLIMIT is wired to limits.memory via
 # resourceFieldRef, so the Go GC happily lets the heap coast toward 1Gi.

--- a/deploy/flux/clusters/production/nats-worker1-topology-RUNBOOK.md
+++ b/deploy/flux/clusters/production/nats-worker1-topology-RUNBOOK.md
@@ -1,0 +1,139 @@
+# NATS topology migration + prod e2e test
+
+Move the JetStream hub off the 2-core node1 and onto worker1, free node1 of
+Flux, then validate the new topology end to end on prod **before** raising any
+resource limits. "200k" is a direction, not an SLA: the gate is a healthy,
+non-degrading bus under real load, not a specific number.
+
+## What changes (already staged in the branch)
+
+- `deploy/k8s/nats.yaml`: hub affinity `NotIn worker1` -> `NotIn node1`, plus a
+  toleration for `itsbagelbot.dev/pool=worker-pool`. Members move to
+  node2 / node3 / worker1. Resources stay modest (cpu 500m/2000m, mem 2Gi/2.5Gi)
+  until the test passes.
+- `deploy/flux/clusters/production/flux-system/kustomization.yaml`: nodeAffinity
+  `NotIn node1` on every Flux controller.
+- `pkg/bus/provision.go`: TWITCH_INGRESS + TWITCH_OUTGRESS memory-backed
+  (create-only: existing streams must be recreated to convert).
+- `app/ingress/.../nats/publisher*.ex`: sharded async publisher.
+
+## Constraints that shape the steps
+
+- **Storage is node-pinned.** `jetstream-data-*` are `local-path` PVCs bound to
+  a node's disk. Moving the node1 member means deleting `jetstream-data-nats-2`
+  so a fresh PVC provisions on worker1. That member's local stream data is lost
+  and re-syncs: R3 streams (TWITCH_INGRESS, TWITCH_OUTGRESS_SYSTEM) rebuild from
+  their peers; **R1 streams (BAGEL_DATA, TWITCH_OUTGRESS) lose their buffer if
+  their single copy sat on nats-2** — perishable (5m / 5s), but confirm before
+  deleting.
+- **worker1 rides home wifi.** With 3 voters a blip keeps node2+node3 as a 2/3
+  quorum, so R3 survives. An **R1** stream whose one replica lands on worker1
+  stalls while the link blips — the key thing the soak test must expose.
+- **Flux watches `main`.** These manifest changes reach prod only when merged to
+  main. The PVC/stream/pod steps below are manual `kubectl`/`nats` ops that Flux
+  does not perform.
+
+## Phase A — Flux off node1 (low risk, independent, do first)
+
+1. Merge the flux-system kustomization change to main.
+2. Flux reschedules its own controllers. Verify none remain on node1 and
+   reconciliation still works:
+   ```
+   kubectl -n flux-system get pods -o wide          # none on node1
+   flux get kustomizations                           # all Ready, reconciling
+   ```
+
+## Phase B — NATS onto worker1
+
+3. Pre-flight snapshot (so you can tell re-sync from loss afterwards):
+   ```
+   nats stream ls
+   for s in TWITCH_INGRESS TWITCH_OUTGRESS TWITCH_OUTGRESS_SYSTEM BAGEL_DATA; do
+     nats stream info "$s" --json | jq '{name:.config.name,replicas:.config.num_replicas,msgs:.state.messages,leader:.cluster.leader,peers:[.cluster.replicas[].name]}'
+   done
+   kubectl get nodes -o wide                          # node2/node3/worker1 headroom
+   ```
+   If BAGEL_DATA / TWITCH_OUTGRESS are R1 with their copy on nats-2 and the
+   buffer matters, temporarily raise them to R3 first (`nats stream edit --replicas 3`).
+4. Merge the nats.yaml affinity/toleration change to main. (A StatefulSet does
+   not reschedule running pods on an affinity change — nats-2 stays on node1
+   until step 5.)
+5. Move the node1 member. Its PVC is pinned to node1, so the PVC must go too:
+   ```
+   kubectl -n production delete pvc jetstream-data-nats-2
+   kubectl -n production delete pod nats-2
+   ```
+   The one-per-node spread (node2=nats-1, node3=nats-0) pushes the fresh nats-2
+   onto worker1.
+6. Verify:
+   ```
+   kubectl -n production get pod nats-2 -o wide       # Running on worker1
+   nats server report jetstream                        # 3 peers, all current
+   nats stream info TWITCH_INGRESS --json | jq '.cluster'   # replica caught up
+   ```
+
+## Phase C — convert transient streams to memory (create-only)
+
+7. Deploy the new `pkg/bus` image first (so `EnsureStreams` specs say memory),
+   then recreate the two streams during the window so they come back
+   memory-backed (perishable, safe to drop briefly):
+   ```
+   nats stream rm TWITCH_INGRESS
+   nats stream rm TWITCH_OUTGRESS
+   # EnsureStreams (running in the services) recreates them; confirm storage:
+   nats stream info TWITCH_INGRESS --json | jq '.config.storage'   # "memory"
+   ```
+   Keep TWITCH_INGRESS **R1** for throughput unless the soak shows worker1
+   stalls the firehose, in which case make it R3.
+
+## Phase D — async ingress publisher (BUS now direct to hub)
+
+The ingress firehose plane (`:gnat_bus` + the PublisherPool connections) now
+dials the hub `nats` service directly, not `nats-leaf` (NATS_HUB_HOST=nats). RPC
+stays on the leaf. So this deploy both switches to the async publisher and moves
+the firehose off the leafnode hop.
+
+8. Deploy the new ingress image + twitch-ingress.yaml env. Confirm health and
+   that publishes flow to the hub:
+   ```
+   kubectl -n production rollout status statefulset/twitch-ingress
+   # Confirm BUS connections land on hub pods, not the leaf:
+   kubectl -n production exec nats-0 -c nats -- \
+     wget -qO- localhost:8222/connz | grep -c ingresspub   # inbox subs present
+   # New Relic: Nats/PublishAcked climbing, Nats/PublishInflight bounded,
+   # Nats/PublishOverloaded == 0, Nats/PublishFailed == 0
+   ```
+
+## Phase E — END-TO-END TEST (the gate before any bump)
+
+9. **Functional:** in a test channel, exercise a real round-trip — a `!`command
+   and a plain chat line that should trip automod — and confirm the bot responds
+   (ingress -> sesame -> outgress -> Twitch).
+10. **Soak (>= 15-30 min, to catch worker1 wifi blips):** drive elevated volume
+    (or ride an organic peak) and watch:
+    - publish errors == 0; `Nats/PublishOverloaded` == 0; dispatcher drops == 0
+    - PubAck p50/p95/p99 (latency probe + `Nats/PublishInflight`)
+    - consumer lag non-growing and small — KEDA `nats-jetstream` trigger, or
+      `nats consumer info TWITCH_INGRESS worker_twitch_ingress_event_standard`
+    - RAFT stability: `nats server report jetstream` shows no repeated leader
+      changes; no quorum-loss log lines when worker1's link wobbles
+11. **Gate:** all green -> Phase F. If worker1 flakiness causes R1 firehose
+    stalls or RAFT churn -> pin the hot stream off worker1 / keep it R3, or roll
+    back (below).
+
+## Phase F — bump resources (only after Phase E passes)
+
+12. Raise, still modestly (not 4 cores): `nats.yaml` requests/limits, `max_mem`
+    in nats-server.conf, and TWITCH_INGRESS `MaxBytes`/`MaxMsgsPer`. MaxBytes is
+    updatable in place (reconcile handles it); `max_mem` and pod limits need a
+    NATS roll. Re-run the Phase E soak after each step.
+
+## Rollback
+
+- `git revert` the two manifest changes -> Flux restores `NotIn worker1` and
+  Flux-on-node1. nats-2 reschedules to node1 (delete `jetstream-data-nats-2`
+  again to unpin).
+- If memory storage misbehaves, recreate the streams as file (revert
+  provision.go's `Storage` and recreate).
+- Perishable streams re-provision themselves via `EnsureStreams`; no replay to
+  restore.

--- a/deploy/k8s/outgress.yaml
+++ b/deploy/k8s/outgress.yaml
@@ -135,10 +135,13 @@ spec:
                   fieldPath: status.hostIP
             - name: GOMEMLIMIT
               value: 512MiB
+            # Sized for the 50-100k firehose (see sesame.yaml). A high MIN keeps
+            # send concurrency resident so throughput does not wait on the slow
+            # +1-per-tick autoscaler to climb from a cold floor under a burst.
             - name: OUTGRESS_MIN_ROUTINES
-              value: "8"
+              value: "50"
             - name: OUTGRESS_MAX_ROUTINES
-              value: "48"
+              value: "250"
             - name: OUTGRESS_MAX_CONSUMERS
               value: "3"
             - name: OUTGRESS_SCALE_UP_AFTER

--- a/deploy/k8s/sesame.yaml
+++ b/deploy/k8s/sesame.yaml
@@ -147,10 +147,15 @@ spec:
             # double-processing.
             - name: SESAME_CONSUMER_NAME
               value: worker
+            # Sized for the 50-100k firehose: the per-message path (Valkey
+            # lookups, automod, outgress publish) is ~5-20ms, so sustaining tens
+            # of thousands of events/second needs thousands of in-flight
+            # routines. A high MIN keeps that concurrency resident instead of
+            # waiting on the +1-per-tick autoscaler to climb from a cold floor.
             - name: SESAME_MIN_ROUTINES
-              value: "4"
+              value: "50"
             - name: SESAME_MAX_ROUTINES
-              value: "25"
+              value: "200"
             - name: SESAME_MAX_CONSUMERS
               value: "4"
             - name: SESAME_SCALE_UP_AFTER

--- a/deploy/k8s/twitch-ingress.yaml
+++ b/deploy/k8s/twitch-ingress.yaml
@@ -171,10 +171,15 @@ spec:
           env:
             - name: NATS_HOST
               value: nats
-            # Apps connect only to the node-local leaf cluster; the hub is reached
-            # over the leafnode link. No hub host, so a leaf roll can't pin to hub.
+            # The RPC plane (:gnat) stays on the node-local leaf. The BUS firehose
+            # plane (:gnat_bus) connects DIRECT to the hub (NATS_HUB_HOST) instead:
+            # the leaf runs no JetStream, so for the firehose it is only a
+            # forwarding hop to the same hub streams. A hub roll re-pins the BUS
+            # connection (Gnat reconnect); the RPC path is unaffected.
             - name: NATS_LEAF_HOST
               value: nats-leaf
+            - name: NATS_HUB_HOST
+              value: nats
             - name: POD_IP
               valueFrom:
                 fieldRef:

--- a/pkg/bus/bus.go
+++ b/pkg/bus/bus.go
@@ -210,16 +210,22 @@ func carryAckFloor(desired *nats.ConsumerConfig, info *nats.ConsumerInfo) {
 // leaves AckWait as the sole in-flight redelivery clock.
 func laneConsumerConfig(subject, group, name string, maxDeliveries int) *nats.ConsumerConfig {
 	return &nats.ConsumerConfig{
-		Durable:        name,
-		Name:           name,
-		Description:    "ItsBagelBot bounded work-queue lane consumer",
-		DeliverPolicy:  nats.DeliverAllPolicy,
-		AckPolicy:      nats.AckExplicitPolicy,
-		AckWait:        30 * time.Second,
-		MaxDeliver:     maxDeliveries,
-		FilterSubject:  subject,
-		ReplayPolicy:   nats.ReplayInstantPolicy,
-		MaxAckPending:  1000,
+		Durable:       name,
+		Name:          name,
+		Description:   "ItsBagelBot bounded work-queue lane consumer",
+		DeliverPolicy: nats.DeliverAllPolicy,
+		AckPolicy:     nats.AckExplicitPolicy,
+		AckWait:       30 * time.Second,
+		MaxDeliver:    maxDeliveries,
+		FilterSubject: subject,
+		ReplayPolicy:  nats.ReplayInstantPolicy,
+		// Ceiling on unacked messages the server will push to this queue group at
+		// once. It must exceed the group's aggregate in-flight concurrency
+		// (routines × replicas × per-message latency × target rate) or the server
+		// stops delivering and the pipeline stalls below that rate. At ~15 ms/event
+		// a 100k/s target needs ~1,500 in flight; 20,000 leaves headroom for
+		// latency spikes and burst scale-up without re-tuning per deploy.
+		MaxAckPending:  20000,
 		DeliverSubject: "_INBOX.BAGEL." + subjectToken(name),
 		DeliverGroup:   group,
 		Metadata:       map[string]string{managedConsumerMetadata: "true"},

--- a/pkg/bus/provision.go
+++ b/pkg/bus/provision.go
@@ -35,6 +35,13 @@ type StreamSpec struct {
 	// window, so a high-rate stream wants it as short as its producers' retry
 	// horizon, not the default.
 	Duplicates time.Duration
+	// Storage selects the backing store. The zero value is nats.FileStorage
+	// (on disk). A transient, size-capped, short-retention stream should use
+	// nats.MemoryStorage: the per-message disk write (and, for replicas, the
+	// synchronous consensus flush) is the dominant publish-side cost, so a
+	// perishable firehose that never needs to survive a broker restart is far
+	// cheaper in memory. Storage is fixed at creation — see reconcileStream.
+	Storage nats.StorageType
 }
 
 // OutgressStream carries the perishable chat lanes (premium/standard). It is
@@ -52,6 +59,10 @@ var OutgressStream = StreamSpec{
 	// late) and removes an orphan if no consumer is available during a rollout.
 	MaxAge:   5 * time.Second,
 	MaxBytes: 256 << 20, // 256 MiB
+	// A 5s work queue never outlives a broker restart, so paying disk I/O per
+	// send is pure overhead. Memory-backed removes the write bottleneck; the
+	// 256 MiB MaxBytes caps the memory it can hold.
+	Storage: nats.MemoryStorage,
 }
 
 // OutgressSystemStream carries the outgress control lane: EventSub enroll
@@ -86,21 +97,35 @@ var DataStreams = []StreamSpec{
 		Name:     "TWITCH_INGRESS",
 		Subjects: []string{"twitch.ingress.event.>", "twitch.ingress.status.>"},
 		MaxAge:   5 * time.Minute,
-		MaxBytes: 256 << 20, // 256 MiB
+		// Memory-backed: the stream is perishable (a replay window that never
+		// needs to survive a restart), so memory storage drops the per-event disk
+		// write that capped synchronous PubAck throughput to a few thousand
+		// events/second. Keep it R1: R3 RAFT consensus is leader-bound and, with a
+		// replica on the 2-core node1, that voter would gate the whole cluster; a
+		// lost leader drops only in-flight perishable chat. Requires the server
+		// max_mem headroom in nats-server.conf.
+		//
+		// MaxBytes is 1 GiB so the memory-backed stream fits the broker's 2GB
+		// max_mem (capped by node1) alongside TWITCH_OUTGRESS and dedup state.
+		// MaxAge is moot under load: MaxBytes (stream-wide, oldest-first) evicts
+		// first, and 1 GiB is the consumer lag budget in bytes (~6 s at 100k/s).
+		// Raising toward the 150-200k target means larger MaxBytes, which needs
+		// the broker off node1 and on >=8GiB nodes first.
+		Storage:  nats.MemoryStorage,
+		MaxBytes: 1 << 30, // 1 GiB
 		// The premium, standard and stream lanes are distinct literal subjects
 		// sharing this stream, and MaxBytes eviction is stream-wide oldest-first:
 		// without a per-subject cap a standard-lane flood fills the stream and
-		// evicts retained premium and stream.online events. 50k messages per lane
-		// (≈100 MiB at typical event size, well past any backlog the consumers
-		// could still catch up on before MaxAge) makes a flooded lane wrap itself
-		// while the other lanes keep their full retention.
-		MaxMsgsPer: 50_000,
+		// evicts retained premium and stream.online events. 400k messages per
+		// lane makes a flooded lane wrap itself while the other lanes keep their
+		// retention (and stays within the 1 GiB stream cap).
+		MaxMsgsPer: 400_000,
 		// Ingress publishes carry Nats-Msg-Id (derived from Twitch's message id)
 		// so publish retries and Twitch's own EventSub redeliveries collapse at
-		// the broker. Both happen within seconds; 30s covers them while keeping
-		// the broker's dedup-id state bounded on the firehose (the 2m default
-		// would track minutes of chat ids on the small hub).
-		Duplicates: 30 * time.Second,
+		// the broker. Both happen within seconds; 10s covers them while bounding
+		// the broker's dedup-id state on the firehose — at 200k/s a 30s window
+		// would track ~6M ids, a 10s window ~2M.
+		Duplicates: 10 * time.Second,
 	},
 }
 
@@ -189,6 +214,21 @@ func reconcileStream(js nats.JetStreamManager, spec StreamSpec, log *zap.Logger)
 	info, err := js.StreamInfo(spec.Name)
 	switch {
 	case err == nil:
+		if info.Config.Storage != desired.Storage {
+			// Storage type is fixed at creation; NATS rejects changing it via
+			// UpdateStream. Converting a live stream (e.g. one created before its
+			// spec moved to memory) means a delete+recreate in a maintenance
+			// window, which drops whatever it currently holds — safe for these
+			// perishable streams but disruptive enough that it is a deliberate
+			// operator step, not something the guardian does under traffic. Warn
+			// so the drift is visible; keep serving the existing stream.
+			log.Warn("jetstream stream storage differs from spec; manual recreate required to converge",
+				zap.String("stream", spec.Name),
+				zap.String("current", info.Config.Storage.String()),
+				zap.String("desired", desired.Storage.String()),
+			)
+		}
+
 		if streamMatches(info.Config, *desired) {
 			return nil
 		}
@@ -204,7 +244,14 @@ func reconcileStream(js nats.JetStreamManager, spec StreamSpec, log *zap.Logger)
 			return add()
 		}
 
-		if _, err := js.UpdateStream(desired); err != nil {
+		// Never attempt to flip storage in place — NATS rejects it, which would
+		// wedge this reconcile on every reconnect. Converge every other drifted
+		// field against the stream's existing storage; the drift warning above
+		// covers the storage difference until it is recreated by hand.
+		update := *desired
+		update.Storage = info.Config.Storage
+
+		if _, err := js.UpdateStream(&update); err != nil {
 			// A work-queue stream is perishable, so replacing it is safe when an
 			// in-place update is rejected — notably narrowing subjects out from
 			// under an existing consumer's filter (the one-time migration that
@@ -244,10 +291,15 @@ func streamConfig(spec StreamSpec) *nats.StreamConfig {
 		// NATS rejects a duplicate window longer than the stream's MaxAge.
 		duplicateWindow = spec.MaxAge
 	}
+	// Zero value is nats.FileStorage; a spec opts into memory explicitly.
+	storage := nats.FileStorage
+	if spec.Storage != 0 {
+		storage = spec.Storage
+	}
 	return &nats.StreamConfig{
 		Name:              spec.Name,
 		Subjects:          spec.Subjects,
-		Storage:           nats.FileStorage,
+		Storage:           storage,
 		Retention:         spec.Retention,
 		Discard:           nats.DiscardOld,
 		MaxAge:            spec.MaxAge,


### PR DESCRIPTION
Stage 1 of the NATS throughput work: code + consumer tuning on the existing 3-node NATS. The disruptive node/memory-storage migration is deferred to a coordinated step (see `deploy/flux/clusters/production/nats-worker1-topology-RUNBOOK.md`).

## What deploys
- **Ingress**: sync `Gnat.request` PubAck replaced by a sharded async publisher (`Ingress.Nats.PublisherPool`), in-flight bound instead of one blocked worker per ack. BUS firehose now dials the hub directly (`NATS_HUB_HOST`); RPC stays on the leaf.
- **Consumers**: `MaxAckPending` 1000→20000; sesame/outgress routine floors/ceilings raised.
- **provision.go**: adds `StreamSpec.Storage` (memory spec dormant until streams are recreated) + larger TWITCH_INGRESS caps.
- **Ops**: Flux controllers off node1; shards dashboard splits socket vs NATS gauges.

## Not in this PR (Stage 2, maintenance window)
`nats.yaml` (move hub off node1 onto worker1) and `nats-server.conf` (max_mem) — they force a StatefulSet roll that would strand `nats-2` Pending without the coordinated PVC/stream steps.

## Verification
ingress `mix test` 89 pass; `go build ./...`, `go vet`, pkg/bus tests; `svelte-check` 0 errors.