### PR TITLE
chore(nats): de-mesh NATS + native TLS, R1 firehose, hub-direct consumers

### DIFF
--- a/app/ingress/config/runtime.exs
+++ b/app/ingress/config/runtime.exs
@@ -150,8 +150,37 @@ nats_leaf_host = System.get_env("NATS_LEAF_HOST") || System.get_env("NATS_HOST",
 nats_hub_host = System.get_env("NATS_HUB_HOST") || nats_leaf_host
 nats_port = String.to_integer(System.get_env("NATS_PORT", "4222"))
 
+# Verify the NATS server TLS cert against the fleet CA now that NATS is out of the
+# Linkerd mesh. NATS_CA_PEM is the trust-manager fleet-ca ConfigMap (PEM). Decode
+# it to the DER list :ssl expects. Server-auth only — auth stays user/password. No
+# CA (dev against a plaintext server) leaves the connection plaintext.
+nats_cacerts =
+  case System.get_env("NATS_CA_PEM") do
+    pem when is_binary(pem) and pem != "" ->
+      pem |> :public_key.pem_decode() |> Enum.map(fn {_type, der, _info} -> der end)
+
+    _ ->
+      nil
+  end
+
 nats_server = fn host, user, pass ->
   base = %{host: host, port: nats_port}
+
+  base =
+    if nats_cacerts do
+      # SNI must match a cert SAN — the Service name (nats / nats-leaf).
+      Map.merge(base, %{
+        tls: true,
+        ssl_opts: [
+          verify: :verify_peer,
+          cacerts: nats_cacerts,
+          server_name_indication: String.to_charlist(host),
+          depth: 3
+        ]
+      })
+    else
+      base
+    end
 
   if is_binary(user) and is_binary(pass) do
     Map.merge(base, %{username: user, password: pass})

--- a/console/serve-node.js
+++ b/console/serve-node.js
@@ -1,5 +1,6 @@
-import { createServer } from 'node:http';
-import { existsSync } from 'node:fs';
+import { createServer as createHttpServer } from 'node:http';
+import { createServer as createHttpsServer } from 'node:https';
+import { existsSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import sirv from 'sirv';
@@ -54,7 +55,7 @@ const prerendered = existsSync(prerenderedDir)
     })
   : undefined;
 
-const server = createServer((req, res) => {
+const requestListener = (req, res) => {
   client(req, res, () => {
     const next = () => {
       // A static asset under /_app that sirv could not find: it does not exist on
@@ -74,7 +75,19 @@ const server = createServer((req, res) => {
       next();
     }
   });
-});
+};
+
+// Serve HTTPS when a cert is provided (TLS_CERT_FILE/TLS_KEY_FILE, mounted from the
+// cert-manager console-*-tls secret). Traefik re-encrypts to this backend via a
+// ServersTransport, so the traefik->console hop is TLS end-to-end and no longer
+// depends on the Linkerd mesh — the gate for de-meshing NATS. Plain HTTP fallback
+// keeps local dev (no cert) unchanged.
+const tlsCert = process.env.TLS_CERT_FILE;
+const tlsKey = process.env.TLS_KEY_FILE;
+const server =
+  tlsCert && tlsKey
+    ? createHttpsServer({ cert: readFileSync(tlsCert), key: readFileSync(tlsKey) }, requestListener)
+    : createHttpServer(requestListener);
 
 function shutdown(signal) {
   console.log(`Received ${signal}; closing HTTP server`);
@@ -97,6 +110,6 @@ if (socketPath) {
   });
 } else {
   server.listen({ host, port }, () => {
-    console.log(`Listening on http://${host}:${port}`);
+    console.log(`Listening on ${tlsCert && tlsKey ? 'https' : 'http'}://${host}:${port}`);
   });
 }

--- a/console/shared/lib/server/nats.ts
+++ b/console/shared/lib/server/nats.ts
@@ -174,6 +174,12 @@ function options(role: Role): ConnectionOptions {
   if (user) opts.user = user;
   if (pass) opts.pass = pass;
   if (process.env.NATS_TOKEN) opts.token = process.env.NATS_TOKEN;
+  // Verify the NATS server's TLS cert against the fleet CA now that NATS is out of
+  // the Linkerd mesh (NATS_CA_PEM = the trust-manager fleet-ca ConfigMap). Setting
+  // tls upgrades the connection; server-auth only, auth stays user/password. No CA
+  // (local dev against a plaintext server) keeps the connection plaintext.
+  const caPem = process.env.NATS_CA_PEM;
+  if (caPem) opts.tls = { ca: caPem };
   return opts;
 }
 

--- a/deploy/ansible/roles/base/files/99-nats-rpc.conf
+++ b/deploy/ansible/roles/base/files/99-nats-rpc.conf
@@ -1,8 +1,11 @@
-# NATS RPC latency tuning
+# NATS RPC latency + firehose throughput tuning. rmem/wmem max raised 4MB -> 16MB
+# for the 150k-event firehose now that NATS is off the Linkerd mesh (the kernel
+# socket is the buffer, not a sidecar): larger windows keep the hub->consumer push
+# and ingress->hub publish sockets from stalling under burst on a fat/high-BDP link.
 net.core.rmem_default = 1048576
 net.core.wmem_default = 1048576
-net.core.rmem_max = 4194304
-net.core.wmem_max = 4194304
-net.ipv4.tcp_rmem = 4096 1048576 4194304
-net.ipv4.tcp_wmem = 4096 1048576 4194304
+net.core.rmem_max = 16777216
+net.core.wmem_max = 16777216
+net.ipv4.tcp_rmem = 4096 1048576 16777216
+net.ipv4.tcp_wmem = 4096 1048576 16777216
 net.ipv4.tcp_low_latency = 1

--- a/deploy/flux/clusters/production/apps.yaml
+++ b/deploy/flux/clusters/production/apps.yaml
@@ -6,6 +6,11 @@
 # ScaledObjects. Without this, a from-scratch bootstrap can apply them before
 # KEDA's CRD/webhook exist and fail until the next retry converges it anyway;
 # dependsOn makes that ordering explicit instead of relying on self-heal.
+#
+# dependsOn pki: the NATS and console pods mount cert-manager-issued cert secrets
+# (nats-hub-tls / nats-leaf-tls / console-*-tls) and read the trust-manager
+# fleet-ca ConfigMap (NATS_CA_PEM). The `pki` Kustomization provisions those, so
+# it must reconcile before `apps`, or the pods block on missing secrets/configmap.
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
@@ -15,6 +20,7 @@ metadata:
 spec:
   dependsOn:
     - name: keda
+    - name: pki
   interval: 1h
   sourceRef:
     kind: GitRepository

--- a/deploy/flux/clusters/production/cert-manager.yaml
+++ b/deploy/flux/clusters/production/cert-manager.yaml
@@ -1,0 +1,25 @@
+# cert-manager + trust-manager HelmReleases (deploy/infra/cert-manager/).
+# Separate Kustomization, same reasoning as keda.yaml: targetNamespace stays
+# unset so the HelmRepository (flux-system) and HelmReleases (cert-manager) keep
+# their own namespaces, unlike `apps` which pins everything to production.
+#
+# The `pki` Kustomization dependsOn this one (it needs cert-manager's Issuer /
+# Certificate / ClusterIssuer CRDs and trust-manager's Bundle CRD registered and
+# their webhooks up before it applies the fleet PKI). Flux's dependsOn can only
+# reference another Kustomization, not a bare HelmRelease, so cert-manager needs
+# its own Kustomization for `pki` (and transitively `apps`) to depend on.
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cert-manager
+  namespace: flux-system
+spec:
+  interval: 1h
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./deploy/infra/cert-manager
+  prune: true
+  wait: true
+  timeout: 10m

--- a/deploy/flux/clusters/production/nats-demesh-tls-RUNBOOK.md
+++ b/deploy/flux/clusters/production/nats-demesh-tls-RUNBOOK.md
@@ -1,0 +1,121 @@
+# NATS de-mesh + native TLS + R1 firehose — deploy runbook
+
+Goal: a single unsharded `TWITCH_INGRESS` stream sustains ~150k ev/s by removing
+the taxes on an **ack-bound** firehose producer (ceiling = `max_pending /
+ack_latency`): R3 RAFT consensus, the leaf forwarding hop, and the Linkerd sidecar.
+Wire encryption moves from the mesh to NATS-native TLS (cert-manager) over the
+tailnet. See the design in `~/.claude/plans/staged-squishing-hellman.md`.
+
+The manifest/code changes reach prod via Flux on merge to `main`. The steps below
+are the ordering + the manual `kubectl`/`nats` ops Flux does not perform. **Do them
+in order** — TLS must be live and verified before the mesh comes off.
+
+## The one hard constraint: the TLS cutover is atomic
+
+A bare `tls { }` block on the NATS client listener makes TLS **required**
+(`tls_required` in server INFO). The moment the NATS pods reload that config,
+every client must present TLS + trust the fleet CA (`NATS_CA_PEM`) or it cannot
+connect. There is no half-TLS window. So the NATS TLS config and the app
+`NATS_CA_PEM` env must land **together**, and a brief reconnect blip is expected as
+pods roll (the fleet tolerates it: infinite reconnect + the 32MB reconnect buffer +
+the perishable 5s/5m streams).
+
+The client code is safe to ship early: `pkg/bus` only enables TLS when
+`NATS_CA_PEM` is set, and the console/ingress do the same — so merging the code
+before the env/config does nothing until the CA is present.
+
+## Phase 1 — R1 firehose (no topology change, do first)
+
+`pkg/bus/provision.go` now declares + **enforces** replicas (streamMatches compares
+them; UpdateStream converges). On the new image the guardian converges the live
+stream automatically. To do it explicitly / immediately:
+
+```
+nats stream update TWITCH_INGRESS --replicas 1     # R3 -> R1 (the throughput win)
+nats stream update TWITCH_OUTGRESS_SYSTEM --replicas 3   # ensure the durable control lane is R3
+nats stream info TWITCH_INGRESS --json | jq '.config.num_replicas'   # -> 1
+```
+
+Soak here first (see Verification): R1 + hub-direct (Phase 2, ships with the same
+`pkg/bus`) alone may hit the target with the mesh still on.
+
+## Phase 2 — hub-direct consumers (ships with Phase 1 code)
+
+`busURL` is now hub-first via `NATS_HUB_URL`; the manifests set
+`NATS_HUB_URL=nats://nats:4222`. Nothing manual — verify the leaf sheds the
+firehose (its CPU/RSS drops; hub `connz` shows the consumer inboxes).
+
+## Phase 3 — cert-manager PKI + NATS TLS (atomic; see the constraint above)
+
+1. Merge the `deploy/infra/cert-manager` + `deploy/infra/pki` + their Flux
+   Kustomizations. **Confirm the chart version pins** in
+   `deploy/infra/cert-manager/release.yaml` are current before merge.
+2. Wait for the PKI to be ready (the `apps` Kustomization dependsOn `pki`, so it
+   blocks until these exist):
+   ```
+   kubectl -n cert-manager get pods                          # cert-manager + trust-manager Running
+   kubectl -n production get certificate                     # nats-hub-tls / nats-leaf-tls / console-* = Ready
+   kubectl -n production get configmap fleet-ca -o jsonpath='{.data.ca\.pem}' | head -c 40   # CA present
+   kubectl -n production get secret nats-hub-tls nats-leaf-tls
+   ```
+3. The same merge carries the NATS `tls{}` config + every app's `NATS_CA_PEM`. The
+   config-reloader SIGHUPs NATS to TLS; apps roll with the CA. Expect a short
+   reconnect blip. Confirm TLS is live and auth is healthy:
+   ```
+   kubectl -n production exec nats-0 -c nats -- wget -qO- localhost:8222/connz | grep -c tls_version   # > 0
+   ```
+4. Functional round-trip (a `!`command + an automod line → bot replies).
+
+## Phase 4 — console HTTPS (the de-mesh gate)
+
+Ships with Phase 3 (same CA). `console-dashboard` now serves HTTPS; Traefik
+re-encrypts via the `console-dashboard-transport` ServersTransport.
+- `console-admin` is intentionally left HTTP: it is fronted by the **Tailscale**
+  operator Ingress (tailnet WireGuard end-to-end), not Traefik, and stays meshed —
+  so it has no plaintext-behind-Linkerd hop. Serving HTTPS there would break the
+  ts-Ingress HTTP backend. (If you later want admin Linkerd-independent too, wire
+  Tailscale-Ingress backend-TLS separately.)
+- Gate check before Phase 5: load `https://dashboard.itsbagelbot.com`; confirm the
+  Traefik→pod hop is TLS (backend :3000 HTTPS, cert chains to the fleet CA). If you
+  want proof it no longer needs the mesh, temporarily `linkerd uninject` one
+  console-dashboard pod and confirm it still serves.
+
+## Phase 5 — de-mesh NATS (only after Phase 4 is green)
+
+Ships the `linkerd.io/inject: disabled` on nats/nats-leaf + `skip-outbound-ports:
+"4222"` on the apps. Confirm:
+```
+linkerd stat deploy -n production | grep -i nats || echo "nats no longer meshed (expected)"
+kubectl -n production get pod -l app=nats -o jsonpath='{.items[0].spec.containers[*].name}'   # no linkerd-proxy
+```
+If a client cannot connect after this, it is almost always a missing/renamed
+`NATS_CA_PEM` or a SAN mismatch — check the pod logs for a TLS handshake error, not
+firewalld/mesh.
+
+## Phase 6 — buffers (with or after Phase 5)
+
+`max_pending 64MB` (hub), `ReconnectBufSize 32MB` (client) ship in the manifests/
+image. The node sysctl (`99-nats-rpc.conf`, rmem/wmem 16MB) is applied by the
+ansible base role — **node-level, not Flux**: run the base role (or
+`sysctl --system`) on each NATS node. Then push `publish_max_pending` (ingress
+`Config`) up only if the soak shows sustained `Nats/PublishInflight` saturation
+without `Nats/PublishOverloaded`.
+
+## Verification (soak ≥ 15–30 min, per the existing worker1 runbook Phase E)
+
+- publish errors == 0, `Nats/PublishOverloaded` == 0, dispatcher drops == 0
+- PubAck p50/p95/p99 (`Nats/PublishInflight` bounded) — should drop sharply vs R3
+- consumer lag flat: `nats consumer info TWITCH_INGRESS worker_twitch_ingress_event_standard`
+- leaf CPU/RSS low (Phase 2), hub CPU absorbs the firehose w/o a proxy (Phase 5)
+- `nats server report jetstream` — no leader flapping (meta group only; stream R1)
+
+Load harness: `pkg/bus/bustest/publisher.go`, or ride an organic peak.
+
+## Rollback (per phase, independent)
+
+- Phase 1: `nats stream update TWITCH_INGRESS --replicas 3`.
+- Phase 5 (de-mesh): `git revert` the inject/skip-outbound change → Flux re-meshes.
+- Phase 3/4 (TLS): `git revert` the TLS config + `NATS_CA_PEM` + console HTTPS
+  together (they are atomic). cert-manager/trust-manager can stay installed inertly.
+- Streams re-provision themselves via `EnsureStreams`; the firehose is perishable,
+  no replay to restore.

--- a/deploy/flux/clusters/production/pki.yaml
+++ b/deploy/flux/clusters/production/pki.yaml
@@ -1,0 +1,21 @@
+# Fleet PKI custom resources (deploy/infra/pki/): issuers, server Certificates,
+# and the trust-manager Bundle. dependsOn cert-manager so its CRDs/webhooks are
+# ready; `apps` dependsOn this so the cert secrets + fleet-ca ConfigMap exist
+# before the NATS / console pods mount them.
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: pki
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: cert-manager
+  interval: 1h
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./deploy/infra/pki
+  prune: true
+  wait: true
+  timeout: 5m

--- a/deploy/infra/cert-manager/release.yaml
+++ b/deploy/infra/cert-manager/release.yaml
@@ -1,0 +1,126 @@
+# cert-manager + trust-manager (deploy/infra/cert-manager/). Separate
+# Kustomization (deploy/flux/clusters/production/cert-manager.yaml), same shape as
+# keda.yaml: targetNamespace stays unset so the HelmRepository (flux-system) and
+# the HelmReleases (cert-manager namespace) keep their own namespaces, unlike
+# `apps` which pins everything to production.
+#
+# WHY
+# ---
+# The fleet is de-meshing NATS off Linkerd (see nats.yaml / nats-leaf.yaml), so
+# NATS provides its own wire encryption via NATS-native TLS instead of the
+# Linkerd sidecar. cert-manager is the battle-tested, CNCF-graduated PKI that
+# issues + auto-renews the server certs; trust-manager distributes the public CA
+# to a ConfigMap the apps read (fleet-ca). The PKI custom resources (Issuer, CA,
+# Certificates, Bundle) live in deploy/infra/pki/, applied by the `pki`
+# Kustomization which dependsOn this one.
+#
+# CHART VERSIONS
+# --------------
+# Exact pins per deploy/flux/README.md's immutability rationale. CONFIRM the
+# current stable tags before first apply and bump deliberately (CRD schemas can
+# change between minors): cert-manager releases and trust-manager releases track
+# separately in the jetstack chart repo.
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: jetstack
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://charts.jetstack.io
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: cert-manager
+  namespace: cert-manager
+spec:
+  interval: 1h
+  timeout: 10m
+  releaseName: cert-manager
+  chart:
+    spec:
+      chart: cert-manager
+      version: v1.17.4 # exact pin — latest stable, validated vs this k8s 1.35 fleet; bump deliberately
+      sourceRef:
+        kind: HelmRepository
+        name: jetstack
+        namespace: flux-system
+      interval: 1h
+  install:
+    createNamespace: true
+    crds: Create
+    remediation:
+      retries: 3
+  upgrade:
+    # CreateReplace lets a future chart bump patch the cert-manager CRDs in place
+    # instead of keeping the schema this cluster was bootstrapped with (same
+    # rationale as keda.yaml).
+    crds: CreateReplace
+    remediation:
+      retries: 3
+      remediateLastFailure: true
+    cleanupOnFail: true
+  values:
+    # crds.enabled installs the CRDs via the chart (paired with install.crds
+    # above). Keep true so Flux owns them.
+    crds:
+      enabled: true
+      keep: true
+    # Trimmed for this small fleet, same as keda/newrelic. Re-widen if the
+    # controller/webhook/cainjector is throttled or OOMKilled in practice.
+    resources:
+      requests: {cpu: 25m, memory: 64Mi}
+      limits: {cpu: 250m, memory: 256Mi}
+    webhook:
+      resources:
+        requests: {cpu: 10m, memory: 32Mi}
+        limits: {cpu: 200m, memory: 128Mi}
+    cainjector:
+      resources:
+        requests: {cpu: 10m, memory: 64Mi}
+        limits: {cpu: 200m, memory: 256Mi}
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: trust-manager
+  namespace: cert-manager
+spec:
+  interval: 1h
+  timeout: 10m
+  releaseName: trust-manager
+  # trust-manager's webhook depends on cert-manager being up to issue its own
+  # serving cert, so install it after.
+  dependsOn:
+    - name: cert-manager
+  chart:
+    spec:
+      chart: trust-manager
+      version: v0.24.0 # exact pin — latest stable; bump deliberately
+      sourceRef:
+        kind: HelmRepository
+        name: jetstack
+        namespace: flux-system
+      interval: 1h
+  install:
+    crds: Create
+    remediation:
+      retries: 3
+  upgrade:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+      remediateLastFailure: true
+    cleanupOnFail: true
+  values:
+    # trust-manager watches this namespace for Bundle source secrets. The CA lives
+    # in cert-manager (where the fleet-ca Certificate writes fleet-ca-key-pair).
+    # Matches the chart default; set explicitly for clarity.
+    app:
+      trust:
+        namespace: cert-manager
+    resources:
+      requests: {cpu: 10m, memory: 32Mi}
+      limits: {cpu: 200m, memory: 128Mi}

--- a/deploy/infra/pki/certificates.yaml
+++ b/deploy/infra/pki/certificates.yaml
@@ -1,0 +1,104 @@
+# Server certs issued from the fleet CA. Each writes a tls.crt/tls.key/ca.crt
+# Secret in production; the NATS and console pods mount it as their server cert.
+# Clients verify the server against the CA (distributed as the fleet-ca ConfigMap,
+# see trust.yaml) — no per-client certs.
+#
+# SANs must cover every name a peer dials: the Service name, its FQDN, and (for
+# the hub) the per-pod headless names used by the cluster routes.
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: nats-hub-tls
+  namespace: production
+spec:
+  secretName: nats-hub-tls
+  duration: 2160h # 90d
+  renewBefore: 360h # 15d
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: fleet-ca-issuer
+    kind: ClusterIssuer
+    group: cert-manager.io
+  dnsNames:
+    - nats
+    - nats.production
+    - nats.production.svc
+    - nats.production.svc.cluster.local
+    - nats-headless
+    - nats-headless.production.svc.cluster.local
+    - nats-0.nats-headless.production.svc.cluster.local
+    - nats-1.nats-headless.production.svc.cluster.local
+    - nats-2.nats-headless.production.svc.cluster.local
+    - localhost
+  ipAddresses:
+    - 127.0.0.1
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: nats-leaf-tls
+  namespace: production
+spec:
+  secretName: nats-leaf-tls
+  duration: 2160h # 90d
+  renewBefore: 360h # 15d
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: fleet-ca-issuer
+    kind: ClusterIssuer
+    group: cert-manager.io
+  dnsNames:
+    - nats-leaf
+    - nats-leaf.production.svc.cluster.local
+    - nats-leaf-local
+    - nats-leaf-local.production.svc.cluster.local
+    - nats-leaf-peers
+    - nats-leaf-peers.production.svc.cluster.local
+    - localhost
+  ipAddresses:
+    - 127.0.0.1
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: console-dashboard-tls
+  namespace: production
+spec:
+  secretName: console-dashboard-tls
+  duration: 2160h # 90d
+  renewBefore: 360h # 15d
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: fleet-ca-issuer
+    kind: ClusterIssuer
+    group: cert-manager.io
+  dnsNames:
+    - console-dashboard
+    - console-dashboard.production.svc.cluster.local
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: console-admin-tls
+  namespace: production
+spec:
+  secretName: console-admin-tls
+  duration: 2160h # 90d
+  renewBefore: 360h # 15d
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: fleet-ca-issuer
+    kind: ClusterIssuer
+    group: cert-manager.io
+  dnsNames:
+    - console-admin
+    - console-admin.production.svc.cluster.local

--- a/deploy/infra/pki/issuers.yaml
+++ b/deploy/infra/pki/issuers.yaml
@@ -1,0 +1,40 @@
+# Fleet internal PKI root. A self-signed bootstrap issuer signs one long-lived CA,
+# and a CA ClusterIssuer issues every server cert from it. cert-manager renews the
+# leaf certs automatically, so there is no hand-rolled rotation.
+#
+# ClusterIssuers read their signing secret from cert-manager's own namespace (the
+# cluster resource namespace), which is why the CA key pair lives there.
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: fleet-selfsigned
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: fleet-ca
+  namespace: cert-manager
+spec:
+  isCA: true
+  commonName: ItsBagelBot Fleet CA
+  secretName: fleet-ca-key-pair
+  duration: 87600h # 10y root
+  renewBefore: 720h # 30d
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: fleet-selfsigned
+    kind: ClusterIssuer
+    group: cert-manager.io
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: fleet-ca-issuer
+spec:
+  ca:
+    secretName: fleet-ca-key-pair

--- a/deploy/infra/pki/kustomization.yaml
+++ b/deploy/infra/pki/kustomization.yaml
@@ -1,0 +1,12 @@
+# Fleet PKI: the cert-manager issuers, the server Certificates, and the
+# trust-manager Bundle that publishes the CA to apps. Applied by the `pki`
+# Kustomization (deploy/flux/clusters/production/pki.yaml), which dependsOn
+# cert-manager so the CRDs and webhooks exist first. `apps` in turn dependsOn
+# `pki`, so the cert secrets and the fleet-ca ConfigMap exist before the NATS and
+# console pods that consume them are applied.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - issuers.yaml
+  - certificates.yaml
+  - trust.yaml

--- a/deploy/infra/pki/trust.yaml
+++ b/deploy/infra/pki/trust.yaml
@@ -1,0 +1,24 @@
+# trust-manager distributes the public CA (no private key) as a ConfigMap named
+# fleet-ca into the production namespace. Apps read it as NATS_CA_PEM
+# (configMapKeyRef fleet-ca/ca.pem) and Traefik reads it as a ServersTransport
+# rootCAs, so every client can verify the NATS and console server certs without
+# shipping a private key around.
+#
+# The source is the CA cert inside the fleet-ca-key-pair secret, which lives in
+# cert-manager (trust-manager's configured trust namespace).
+---
+apiVersion: trust.cert-manager.io/v1alpha1
+kind: Bundle
+metadata:
+  name: fleet-ca
+spec:
+  sources:
+    - secret:
+        name: fleet-ca-key-pair
+        key: tls.crt
+  target:
+    configMap:
+      key: ca.pem
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: production

--- a/deploy/k8s/commands.yaml
+++ b/deploy/k8s/commands.yaml
@@ -38,6 +38,10 @@ spec:
         app: commands
       annotations:
         linkerd.io/inject: enabled
+        # NATS is out of the Linkerd mesh: bypass the app-side proxy for the NATS
+        # client port so the firehose / RPC traffic goes direct (NATS-native TLS
+        # provides the encryption). Without this the proxy still taxes every event.
+        config.linkerd.io/skip-outbound-ports: "4222"
         config.linkerd.io/proxy-cpu-request: 5m
         config.linkerd.io/proxy-cpu-limit: 750m
         config.linkerd.io/proxy-memory-request: 16Mi
@@ -76,11 +80,22 @@ spec:
           env:
             - name: NATS_HOST
               value: nats
-            # Apps connect only to the node-local leaf cluster (4-node HA); the
-            # hub is reached over the leafnode link for JetStream. No hub in the
-            # server list, so a leaf roll can never pin a client to the hub.
+            # Split planes: the BUS / JetStream connection dials the hub directly
+            # (NATS_HUB_URL) so stream traffic never pays a leaf forwarding hop;
+            # the RPC + cache plane (NATS_RPC_URL / NATS_LEAF_URL) stays on the
+            # node-local leaf. NATS_URL is the local-dev fallback only.
             - name: NATS_URL
               value: nats://nats-leaf:4222
+            - name: NATS_HUB_URL
+              value: nats://nats:4222
+            # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS server
+            # TLS cert now that NATS is out of the Linkerd mesh; read as RootCAs by
+            # pkg/bus (Go services) and the console nats lib (TS).
+            - name: NATS_CA_PEM
+              valueFrom:
+                configMapKeyRef:
+                  name: fleet-ca
+                  key: ca.pem
             - name: NATS_RPC_URL
               value: nats://nats-leaf:4222
             - name: NATS_LEAF_URL

--- a/deploy/k8s/console-admin.yaml
+++ b/deploy/k8s/console-admin.yaml
@@ -53,6 +53,10 @@ spec:
         app: console-admin
       annotations:
         linkerd.io/inject: enabled
+        # NATS is out of the Linkerd mesh: bypass the app-side proxy for the NATS
+        # client port so the firehose / RPC traffic goes direct (NATS-native TLS
+        # provides the encryption). Without this the proxy still taxes every event.
+        config.linkerd.io/skip-outbound-ports: "4222"
         config.linkerd.io/proxy-cpu-request: 5m
         config.linkerd.io/proxy-cpu-limit: 750m
         config.linkerd.io/proxy-memory-request: 16Mi
@@ -108,11 +112,22 @@ spec:
             # public URL instead of the internal http://:3000 origin (was 403).
             - name: ORIGIN
               value: https://admin.tail451e6d.ts.net
-            # Apps connect only to the node-local leaf cluster (4-node HA); the
-            # hub is reached over the leafnode link for JetStream. No hub in the
-            # server list, so a leaf roll can never pin a client to the hub.
+            # Split planes: the BUS / JetStream connection dials the hub directly
+            # (NATS_HUB_URL) so stream traffic never pays a leaf forwarding hop;
+            # the RPC + cache plane (NATS_RPC_URL / NATS_LEAF_URL) stays on the
+            # node-local leaf. NATS_URL is the local-dev fallback only.
             - name: NATS_URL
               value: nats://nats-leaf:4222
+            - name: NATS_HUB_URL
+              value: nats://nats:4222
+            # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS server
+            # TLS cert now that NATS is out of the Linkerd mesh; read as RootCAs by
+            # pkg/bus (Go services) and the console nats lib (TS).
+            - name: NATS_CA_PEM
+              valueFrom:
+                configMapKeyRef:
+                  name: fleet-ca
+                  key: ca.pem
             - name: NATS_RPC_URL
               value: nats://nats-leaf:4222
             - name: NATS_LEAF_URL

--- a/deploy/k8s/console-dashboard.yaml
+++ b/deploy/k8s/console-dashboard.yaml
@@ -67,6 +67,10 @@ spec:
         app: console-dashboard
       annotations:
         linkerd.io/inject: enabled
+        # NATS is out of the Linkerd mesh: bypass the app-side proxy for the NATS
+        # client port so the firehose / RPC traffic goes direct (NATS-native TLS
+        # provides the encryption). Without this the proxy still taxes every event.
+        config.linkerd.io/skip-outbound-ports: "4222"
         config.linkerd.io/proxy-cpu-request: 5m
         config.linkerd.io/proxy-cpu-limit: 750m
         config.linkerd.io/proxy-memory-request: 16Mi
@@ -113,6 +117,14 @@ spec:
           env:
             - name: PORT
               value: "3000"
+            # Serve HTTPS from adapter-node (serve-node.js) using the cert-manager
+            # console-dashboard-tls cert, so the traefik->console hop is TLS and no
+            # longer depends on the Linkerd mesh (the de-mesh gate). Traefik
+            # re-encrypts via the console-dashboard-transport ServersTransport.
+            - name: TLS_CERT_FILE
+              value: /etc/console/tls/tls.crt
+            - name: TLS_KEY_FILE
+              value: /etc/console/tls/tls.key
             - name: NODE_ENV
               value: production
             # adapter-node sits behind cloudflared+traefik; ORIGIN lets SvelteKit
@@ -123,11 +135,22 @@ spec:
             # a stale cross-namespace FQDN (nats.bagelbot...) that does not
             # resolve here; NATS_URL overrides it. Auth (NATS_USER/PASSWORD) still
             # comes from the secret.
-            # Apps connect only to the node-local leaf cluster (4-node HA); the
-            # hub is reached over the leafnode link for JetStream. No hub in the
-            # server list, so a leaf roll can never pin a client to the hub.
+            # Split planes: the BUS / JetStream connection dials the hub directly
+            # (NATS_HUB_URL) so stream traffic never pays a leaf forwarding hop;
+            # the RPC + cache plane (NATS_RPC_URL / NATS_LEAF_URL) stays on the
+            # node-local leaf. NATS_URL is the local-dev fallback only.
             - name: NATS_URL
               value: nats://nats-leaf:4222
+            - name: NATS_HUB_URL
+              value: nats://nats:4222
+            # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS server
+            # TLS cert now that NATS is out of the Linkerd mesh; read as RootCAs by
+            # pkg/bus (Go services) and the console nats lib (TS).
+            - name: NATS_CA_PEM
+              valueFrom:
+                configMapKeyRef:
+                  name: fleet-ca
+                  key: ca.pem
             - name: NATS_RPC_URL
               value: nats://nats-leaf:4222
             - name: NATS_LEAF_URL
@@ -203,6 +226,8 @@ spec:
                 name: dashboard-env
           ports:
             - containerPort: 3000
+          volumeMounts:
+            - {name: tls, mountPath: /etc/console/tls, readOnly: true}
           resources:
             requests:
               cpu: 25m
@@ -220,11 +245,12 @@ spec:
                 # Give kube-proxy / Linkerd / traefik time to drain this endpoint
                 # before SIGTERM fires. Prevents connection-refused 500s during rolls.
                 command: ["/bin/sh", "-c", "sleep 10"]
+          # scheme HTTPS: the server now terminates TLS on 3000 (see serve-node.js).
           livenessProbe:
-            httpGet: {path: /healthz, port: 3000}
+            httpGet: {path: /healthz, port: 3000, scheme: HTTPS}
             periodSeconds: 30
           readinessProbe:
-            httpGet: {path: /readyz, port: 3000}
+            httpGet: {path: /readyz, port: 3000, scheme: HTTPS}
             periodSeconds: 10
       terminationGracePeriodSeconds: 45
       tolerations:
@@ -236,6 +262,10 @@ spec:
           operator: Exists
           effect: NoExecute
           tolerationSeconds: 60
+      volumes:
+        - name: tls
+          secret:
+            secretName: console-dashboard-tls
 ---
 apiVersion: v1
 kind: Service
@@ -266,11 +296,30 @@ spec:
       services:
         - name: console-dashboard
           port: 80
+          # HTTPS to the backend: serve-node.js now terminates TLS, so traefik
+          # re-encrypts via the ServersTransport below (rootCAs = the cert's own
+          # fleet-CA ca.crt). This makes the traefik->console hop TLS end-to-end,
+          # the gate for removing NATS from the Linkerd mesh.
+          scheme: https
+          serversTransport: console-dashboard-transport
           # Route to the Service ClusterIP (not pod endpoints) so traefik
           # inherits the Service's PreferClose region routing. No sticky cookie:
           # sessions are stateless, so any in-region pod is interchangeable.
           nativeLB: true
   tls: {}
+---
+apiVersion: traefik.io/v1alpha1
+kind: ServersTransport
+metadata:
+  name: console-dashboard-transport
+  namespace: production
+spec:
+  # Verify the console pod's serve-node.js cert against the fleet CA. serverName
+  # matches the cert SAN (the Service name). rootCAsSecrets reads the CA from the
+  # cert-manager secret's ca.crt key (Traefik v3). No InsecureSkipVerify.
+  serverName: console-dashboard
+  rootCAsSecrets:
+    - console-dashboard-tls
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget

--- a/deploy/k8s/gateway.yaml
+++ b/deploy/k8s/gateway.yaml
@@ -53,6 +53,10 @@ spec:
         app: gateway
       annotations:
         linkerd.io/inject: enabled
+        # NATS is out of the Linkerd mesh: bypass the app-side proxy for the NATS
+        # client port so the firehose / RPC traffic goes direct (NATS-native TLS
+        # provides the encryption). Without this the proxy still taxes every event.
+        config.linkerd.io/skip-outbound-ports: "4222"
         config.linkerd.io/proxy-cpu-request: 5m
         config.linkerd.io/proxy-cpu-limit: 750m
         config.linkerd.io/proxy-memory-request: 16Mi
@@ -90,10 +94,22 @@ spec:
           env:
             - name: NATS_HOST
               value: nats
-            # Apps connect only to the node-local leaf cluster; the hub is
-            # reached over the leafnode link. No hub in the server list.
+            # Split planes: the BUS / JetStream connection dials the hub directly
+            # (NATS_HUB_URL) so stream traffic never pays a leaf forwarding hop;
+            # the RPC + cache plane (NATS_RPC_URL / NATS_LEAF_URL) stays on the
+            # node-local leaf. NATS_URL is the local-dev fallback only.
             - name: NATS_URL
               value: nats://nats-leaf:4222
+            - name: NATS_HUB_URL
+              value: nats://nats:4222
+            # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS server
+            # TLS cert now that NATS is out of the Linkerd mesh; read as RootCAs by
+            # pkg/bus (Go services) and the console nats lib (TS).
+            - name: NATS_CA_PEM
+              valueFrom:
+                configMapKeyRef:
+                  name: fleet-ca
+                  key: ca.pem
             - name: NATS_RPC_URL
               value: nats://nats-leaf:4222
             - name: NATS_LEAF_URL

--- a/deploy/k8s/loyalty.yaml
+++ b/deploy/k8s/loyalty.yaml
@@ -41,6 +41,10 @@ spec:
         app: loyalty
       annotations:
         linkerd.io/inject: enabled
+        # NATS is out of the Linkerd mesh: bypass the app-side proxy for the NATS
+        # client port so the firehose / RPC traffic goes direct (NATS-native TLS
+        # provides the encryption). Without this the proxy still taxes every event.
+        config.linkerd.io/skip-outbound-ports: "4222"
         config.linkerd.io/proxy-cpu-request: 5m
         config.linkerd.io/proxy-cpu-limit: 750m
         config.linkerd.io/proxy-memory-request: 16Mi
@@ -78,11 +82,22 @@ spec:
           env:
             - name: NATS_HOST
               value: nats
-            # Apps connect only to the node-local leaf cluster (4-node HA); the
-            # hub is reached over the leafnode link for JetStream. No hub in the
-            # server list, so a leaf roll can never pin a client to the hub.
+            # Split planes: the BUS / JetStream connection dials the hub directly
+            # (NATS_HUB_URL) so stream traffic never pays a leaf forwarding hop;
+            # the RPC + cache plane (NATS_RPC_URL / NATS_LEAF_URL) stays on the
+            # node-local leaf. NATS_URL is the local-dev fallback only.
             - name: NATS_URL
               value: nats://nats-leaf:4222
+            - name: NATS_HUB_URL
+              value: nats://nats:4222
+            # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS server
+            # TLS cert now that NATS is out of the Linkerd mesh; read as RootCAs by
+            # pkg/bus (Go services) and the console nats lib (TS).
+            - name: NATS_CA_PEM
+              valueFrom:
+                configMapKeyRef:
+                  name: fleet-ca
+                  key: ca.pem
             - name: NATS_RPC_URL
               value: nats://nats-leaf:4222
             - name: NATS_LEAF_URL

--- a/deploy/k8s/modules.yaml
+++ b/deploy/k8s/modules.yaml
@@ -38,6 +38,10 @@ spec:
         app: modules
       annotations:
         linkerd.io/inject: enabled
+        # NATS is out of the Linkerd mesh: bypass the app-side proxy for the NATS
+        # client port so the firehose / RPC traffic goes direct (NATS-native TLS
+        # provides the encryption). Without this the proxy still taxes every event.
+        config.linkerd.io/skip-outbound-ports: "4222"
         config.linkerd.io/proxy-cpu-request: 5m
         config.linkerd.io/proxy-cpu-limit: 750m
         config.linkerd.io/proxy-memory-request: 16Mi
@@ -76,11 +80,22 @@ spec:
           env:
             - name: NATS_HOST
               value: nats
-            # Apps connect only to the node-local leaf cluster (4-node HA); the
-            # hub is reached over the leafnode link for JetStream. No hub in the
-            # server list, so a leaf roll can never pin a client to the hub.
+            # Split planes: the BUS / JetStream connection dials the hub directly
+            # (NATS_HUB_URL) so stream traffic never pays a leaf forwarding hop;
+            # the RPC + cache plane (NATS_RPC_URL / NATS_LEAF_URL) stays on the
+            # node-local leaf. NATS_URL is the local-dev fallback only.
             - name: NATS_URL
               value: nats://nats-leaf:4222
+            - name: NATS_HUB_URL
+              value: nats://nats:4222
+            # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS server
+            # TLS cert now that NATS is out of the Linkerd mesh; read as RootCAs by
+            # pkg/bus (Go services) and the console nats lib (TS).
+            - name: NATS_CA_PEM
+              valueFrom:
+                configMapKeyRef:
+                  name: fleet-ca
+                  key: ca.pem
             - name: NATS_RPC_URL
               value: nats://nats-leaf:4222
             - name: NATS_LEAF_URL

--- a/deploy/k8s/nats-leaf-server.conf
+++ b/deploy/k8s/nats-leaf-server.conf
@@ -21,6 +21,17 @@ write_deadline: "2s"
 ping_interval: "20s"
 ping_max: 3
 
+# Client-facing TLS for leaf-local app connections (RPC plane + any BUS fallback).
+# Server-auth only: clients verify this cert against the fleet CA and authenticate
+# with bcrypt user/password. Cert secret (nats-leaf-tls) is cert-manager-issued,
+# mounted at /etc/nats/certs; the reloader watches it for renewal hot-reload.
+tls {
+  cert_file: "/etc/nats/certs/tls.crt"
+  key_file:  "/etc/nats/certs/tls.key"
+  ca_file:   "/etc/nats/certs/ca.crt"
+  timeout: 5
+}
+
 # Lame-duck graceful shutdown. The pod preStop signals LDM (SIGUSR2) before the
 # socket closes: the leaf stops accepting new connections and migrates its
 # existing clients to a healthy leaf over the drain window, so a DaemonSet roll
@@ -35,21 +46,25 @@ lame_duck_duration: "30s"
 # account's leaf user/password, e.g.
 # nats-leaf://leaf_users:<pw>@nats.production.svc.cluster.local:7422
 leafnodes {
+  # Each remote does TLS to the hub's leafnode listener: the ca_file makes the leaf
+  # verify the hub cert against the fleet CA (the hub is server-auth, so the leaf
+  # authenticates with the per-account leaf password embedded in the remote URL, no
+  # client cert). The tls block is what upgrades the nats-leaf:// dial to TLS.
   remotes = [
-    { urls: [$NATS_LEAF_REMOTE_URL_BUS],            account: "BUS" }
-    { urls: [$NATS_LEAF_REMOTE_URL_USERS],          account: "USERS_RPC" }
-    { urls: [$NATS_LEAF_REMOTE_URL_COMMANDS],       account: "COMMANDS_RPC" }
-    { urls: [$NATS_LEAF_REMOTE_URL_LOYALTY],        account: "LOYALTY_RPC" }
-    { urls: [$NATS_LEAF_REMOTE_URL_MODULES],        account: "MODULES_RPC" }
-    { urls: [$NATS_LEAF_REMOTE_URL_PROJECTOR],      account: "PROJECTOR_RPC" }
-    { urls: [$NATS_LEAF_REMOTE_URL_OUTGRESS],       account: "OUTGRESS_RPC" }
-    { urls: [$NATS_LEAF_REMOTE_URL_WORKER],         account: "WORKER_RPC" }
-    { urls: [$NATS_LEAF_REMOTE_URL_DASHBOARD],      account: "DASHBOARD_RPC" }
-    { urls: [$NATS_LEAF_REMOTE_URL_ADMIN],          account: "ADMIN_RPC" }
-    { urls: [$NATS_LEAF_REMOTE_URL_NOTIFICATIONS],  account: "NOTIFICATIONS_RPC" }
-    { urls: [$NATS_LEAF_REMOTE_URL_TWITCH_INGRESS], account: "TWITCH_INGRESS_RPC" }
-    { urls: [$NATS_LEAF_REMOTE_URL_TRANSACTIONS],   account: "TRANSACTIONS_RPC" }
-    { urls: [$NATS_LEAF_REMOTE_URL_GATEWAY],        account: "GATEWAY_RPC" }
+    { urls: [$NATS_LEAF_REMOTE_URL_BUS],            account: "BUS",                tls: { ca_file: "/etc/nats/certs/ca.crt" } }
+    { urls: [$NATS_LEAF_REMOTE_URL_USERS],          account: "USERS_RPC",          tls: { ca_file: "/etc/nats/certs/ca.crt" } }
+    { urls: [$NATS_LEAF_REMOTE_URL_COMMANDS],       account: "COMMANDS_RPC",       tls: { ca_file: "/etc/nats/certs/ca.crt" } }
+    { urls: [$NATS_LEAF_REMOTE_URL_LOYALTY],        account: "LOYALTY_RPC",        tls: { ca_file: "/etc/nats/certs/ca.crt" } }
+    { urls: [$NATS_LEAF_REMOTE_URL_MODULES],        account: "MODULES_RPC",        tls: { ca_file: "/etc/nats/certs/ca.crt" } }
+    { urls: [$NATS_LEAF_REMOTE_URL_PROJECTOR],      account: "PROJECTOR_RPC",      tls: { ca_file: "/etc/nats/certs/ca.crt" } }
+    { urls: [$NATS_LEAF_REMOTE_URL_OUTGRESS],       account: "OUTGRESS_RPC",       tls: { ca_file: "/etc/nats/certs/ca.crt" } }
+    { urls: [$NATS_LEAF_REMOTE_URL_WORKER],         account: "WORKER_RPC",         tls: { ca_file: "/etc/nats/certs/ca.crt" } }
+    { urls: [$NATS_LEAF_REMOTE_URL_DASHBOARD],      account: "DASHBOARD_RPC",      tls: { ca_file: "/etc/nats/certs/ca.crt" } }
+    { urls: [$NATS_LEAF_REMOTE_URL_ADMIN],          account: "ADMIN_RPC",          tls: { ca_file: "/etc/nats/certs/ca.crt" } }
+    { urls: [$NATS_LEAF_REMOTE_URL_NOTIFICATIONS],  account: "NOTIFICATIONS_RPC",  tls: { ca_file: "/etc/nats/certs/ca.crt" } }
+    { urls: [$NATS_LEAF_REMOTE_URL_TWITCH_INGRESS], account: "TWITCH_INGRESS_RPC", tls: { ca_file: "/etc/nats/certs/ca.crt" } }
+    { urls: [$NATS_LEAF_REMOTE_URL_TRANSACTIONS],   account: "TRANSACTIONS_RPC",   tls: { ca_file: "/etc/nats/certs/ca.crt" } }
+    { urls: [$NATS_LEAF_REMOTE_URL_GATEWAY],        account: "GATEWAY_RPC",        tls: { ca_file: "/etc/nats/certs/ca.crt" } }
   ]
 }
 
@@ -66,6 +81,15 @@ leafnodes {
 cluster {
   name: "nats-leaf"
   port: 6222
+  # Mutual TLS between leaf peers (all present the CA-signed nats-leaf cert), the
+  # wire encryption for cross-node leaf-to-leaf RPC once the mesh is gone.
+  tls {
+    cert_file: "/etc/nats/certs/tls.crt"
+    key_file:  "/etc/nats/certs/tls.key"
+    ca_file:   "/etc/nats/certs/ca.crt"
+    verify: true
+    timeout: 5
+  }
   routes: [ "nats://nats-leaf-peers.production.svc.cluster.local:6222" ]
   # DNS already resolves every leaf pod. Suppress route gossip so each pair
   # keeps one route instead of opening parallel paths that can duplicate queue

--- a/deploy/k8s/nats-leaf.yaml
+++ b/deploy/k8s/nats-leaf.yaml
@@ -24,18 +24,13 @@ spec:
   template:
     metadata:
       annotations:
-        linkerd.io/inject: enabled
-        # Cluster listener/routes cannot be introduced by a config reload;
-        # force a rolling restart when the leaf cluster topology changes.
-        itsbagelbot.dev/config-revision: "leaf-cluster-v1"
-        # NATS speaks first on the wire, so protocol detection would stall;
-        # opaque keeps Linkerd mTLS without the detection timeout. 6222 is the
-        # leaf-to-leaf cluster route port.
-        config.linkerd.io/opaque-ports: "4222,6222"
-        config.linkerd.io/proxy-cpu-request: 5m
-        config.linkerd.io/proxy-cpu-limit: 1000m
-        config.linkerd.io/proxy-memory-limit: 128Mi
-        config.linkerd.io/proxy-memory-request: 16Mi
+        # NATS (leaf tier) is out of the Linkerd mesh — see nats.yaml for the
+        # rationale. Wire encryption is NATS-native TLS (client + cluster + the
+        # leaf->hub remotes; nats-leaf-server.conf) over the tailnet.
+        linkerd.io/inject: disabled
+        # Cluster listener/routes and TLS blocks cannot be introduced by a config
+        # reload; bump this to force a rolling restart when the topology changes.
+        itsbagelbot.dev/config-revision: "leaf-cluster-v2-tls-demesh"
         prometheus.io/path: /metrics
         prometheus.io/port: "7777"
         prometheus.io/scrape: "true"
@@ -94,6 +89,7 @@ spec:
             - {containerPort: 6222, name: cluster}
           volumeMounts:
             - {name: config, mountPath: /etc/nats, readOnly: true}
+            - {name: certs, mountPath: /etc/nats/certs, readOnly: true}
             - {name: jetstream, mountPath: /data/jetstream}
             - {name: pid, mountPath: /var/run/nats}
           resources:
@@ -149,8 +145,13 @@ spec:
             - "/etc/nats/nats.conf"
             - "-config"
             - "/etc/nats/auth.conf"
+            # Watch the TLS cert so a cert-manager renewal SIGHUPs nats to reload
+            # the new cert without a pod restart.
+            - "-config"
+            - "/etc/nats/certs/tls.crt"
           volumeMounts:
             - {name: config, mountPath: /etc/nats, readOnly: true}
+            - {name: certs, mountPath: /etc/nats/certs, readOnly: true}
             - {name: pid, mountPath: /var/run/nats}
           resources:
             requests: {cpu: 5m, memory: 16Mi}
@@ -175,6 +176,9 @@ spec:
         - name: config
           configMap:
             name: nats-leaf-config
+        - name: certs
+          secret:
+            secretName: nats-leaf-tls
         - name: pid
           emptyDir: {}
         - name: jetstream

--- a/deploy/k8s/nats-server.conf
+++ b/deploy/k8s/nats-server.conf
@@ -11,7 +11,11 @@ http_port: 8222
 # Connection limits — generous for many workers
 max_connections: 1024
 max_payload: 8MB
-max_pending: 16MB
+# Per-connection outbound buffer. Raised 16MB -> 64MB for the 150k firehose: the
+# hub fans every ingress event out to the consumer push connections, and a small
+# pending buffer forces slow-consumer disconnects under burst. 64MB gives the
+# fan-out headroom now that the mesh proxy is no longer in the path.
+max_pending: 64MB
 
 # Write deadline for slow consumers — tightened from 10s for faster bad-client
 # eviction on the RPC bus; legitimate subscribers drain well under 2s.
@@ -20,6 +24,20 @@ write_deadline: "2s"
 # Detect dead clients faster
 ping_interval: "20s"
 ping_max: 3
+
+# Client-facing TLS. Since NATS is no longer in the Linkerd mesh (see nats.yaml),
+# this is the wire encryption for client connections, on top of the tailnet.
+# verify:false = server-auth only: the server presents its cert and clients verify
+# it against the fleet CA (NATS_CA_PEM), but clients authenticate with their bcrypt
+# user/password (auth.conf), not client certs — so there are no per-service certs.
+# The cert secret (nats-hub-tls) is issued by cert-manager and mounted at
+# /etc/nats/certs; the config-reloader watches it so renewals hot-reload on SIGHUP.
+tls {
+  cert_file: "/etc/nats/certs/tls.crt"
+  key_file:  "/etc/nats/certs/tls.key"
+  ca_file:   "/etc/nats/certs/ca.crt"
+  timeout: 5
+}
 
 # Leaf node listener. Each leaf carries the whole fleet, and a leafnode link
 # binds exactly one account, so there is one authorized leaf user per account:
@@ -30,6 +48,15 @@ ping_max: 3
 leafnodes {
   port: 7422
   no_advertise: true
+  # TLS for the leaf->hub links. verify:false (server-auth): the leaf verifies the
+  # hub cert against the CA and authenticates with its per-account leaf password
+  # (below), the same model as the client listener — no client certs to manage.
+  tls {
+    cert_file: "/etc/nats/certs/tls.crt"
+    key_file:  "/etc/nats/certs/tls.key"
+    ca_file:   "/etc/nats/certs/ca.crt"
+    timeout: 5
+  }
   authorization {
     users: [
       { user: "leaf_bus",            password: $NATS_BCRYPT_LEAF_BUS,            account: "BUS" }
@@ -54,6 +81,16 @@ leafnodes {
 cluster {
   name: "bagelbot"
   port: 6222
+  # Mutual TLS between the hub RAFT peers: low cardinality (3 members), all present
+  # the CA-signed cert, so verify:true is cheap defense-in-depth for the JetStream
+  # consensus traffic once the mesh is gone.
+  tls {
+    cert_file: "/etc/nats/certs/tls.crt"
+    key_file:  "/etc/nats/certs/tls.key"
+    ca_file:   "/etc/nats/certs/ca.crt"
+    verify: true
+    timeout: 5
+  }
   routes: [
     "nats-route://nats-0.nats-headless.production.svc.cluster.local:6222"
     "nats-route://nats-1.nats-headless.production.svc.cluster.local:6222"

--- a/deploy/k8s/nats.yaml
+++ b/deploy/k8s/nats.yaml
@@ -20,14 +20,12 @@ spec:
   template:
     metadata:
       annotations:
-        linkerd.io/inject: enabled
-        # NATS speaks first on the wire, so protocol detection would stall;
-        # opaque keeps Linkerd mTLS without the detection timeout.
-        config.linkerd.io/opaque-ports: "4222,7422"
-        config.linkerd.io/proxy-cpu-request: 5m
-        config.linkerd.io/proxy-cpu-limit: 1000m
-        config.linkerd.io/proxy-memory-limit: 128Mi
-        config.linkerd.io/proxy-memory-request: 16Mi
+        # NATS is intentionally OUT of the Linkerd mesh: at 150k ev/s the sidecar
+        # proxy is the dominant tax on the firehose (every message crossed a proxy
+        # on publish, on the hub, and on each consumer). Wire encryption is now
+        # NATS-native TLS (nats-server.conf) over the tailnet; meshed apps bypass
+        # the proxy for the NATS port via config.linkerd.io/skip-outbound-ports.
+        linkerd.io/inject: disabled
         prometheus.io/path: /metrics
         prometheus.io/port: "7777"
         prometheus.io/scrape: "true"
@@ -108,6 +106,7 @@ spec:
             - {containerPort: 6222, name: cluster}
           volumeMounts:
             - {name: config, mountPath: /etc/nats, readOnly: true}
+            - {name: certs, mountPath: /etc/nats/certs, readOnly: true}
             - {name: jetstream-data, mountPath: /data/jetstream}
             - {name: pid, mountPath: /var/run/nats}
           resources:
@@ -159,8 +158,13 @@ spec:
             - "/etc/nats/nats.conf"
             - "-config"
             - "/etc/nats/auth.conf"
+            # Watch the TLS cert so a cert-manager renewal SIGHUPs nats to reload
+            # the new cert without a pod restart.
+            - "-config"
+            - "/etc/nats/certs/tls.crt"
           volumeMounts:
             - {name: config, mountPath: /etc/nats, readOnly: true}
+            - {name: certs, mountPath: /etc/nats/certs, readOnly: true}
             - {name: pid, mountPath: /var/run/nats}
           resources:
             requests: {cpu: 5m, memory: 16Mi}
@@ -185,6 +189,9 @@ spec:
         - name: config
           configMap:
             name: nats-config
+        - name: certs
+          secret:
+            secretName: nats-hub-tls
         - name: pid
           emptyDir: {}
   volumeClaimTemplates:

--- a/deploy/k8s/notifications.yaml
+++ b/deploy/k8s/notifications.yaml
@@ -38,6 +38,10 @@ spec:
         app: notifications
       annotations:
         linkerd.io/inject: enabled
+        # NATS is out of the Linkerd mesh: bypass the app-side proxy for the NATS
+        # client port so the firehose / RPC traffic goes direct (NATS-native TLS
+        # provides the encryption). Without this the proxy still taxes every event.
+        config.linkerd.io/skip-outbound-ports: "4222"
         config.linkerd.io/proxy-cpu-request: 5m
         config.linkerd.io/proxy-cpu-limit: 750m
         config.linkerd.io/proxy-memory-request: 16Mi
@@ -93,6 +97,14 @@ spec:
               value: nats://nats-leaf-local:4222
             - name: NATS_HUB_URL
               value: nats://nats:4222
+            # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS server
+            # TLS cert now that NATS is out of the Linkerd mesh; read as RootCAs by
+            # pkg/bus (Go services) and the console nats lib (TS).
+            - name: NATS_CA_PEM
+              valueFrom:
+                configMapKeyRef:
+                  name: fleet-ca
+                  key: ca.pem
             - name: NODE_NAME
               valueFrom:
                 fieldRef:
@@ -203,6 +215,12 @@ spec:
                   value: nats://nats-leaf-local:4222
                 - name: NATS_HUB_URL
                   value: nats://nats:4222
+                # Fleet CA to verify the NATS server TLS cert (NATS out of the mesh).
+                - name: NATS_CA_PEM
+                  valueFrom:
+                    configMapKeyRef:
+                      name: fleet-ca
+                      key: ca.pem
               envFrom:
                 - secretRef:
                     name: notifications-env

--- a/deploy/k8s/outgress.yaml
+++ b/deploy/k8s/outgress.yaml
@@ -49,8 +49,9 @@ spec:
         # Outgress's hot path is a synchronous POST to api.twitch.tv; routing it
         # through the linkerd sidecar adds a proxy hop per send for an external,
         # already-TLS destination the mesh cannot mTLS anyway. twitch-ingress
-        # skips 443 for the same reason.
-        config.linkerd.io/skip-outbound-ports: 6379,26379,443
+        # skips 443 for the same reason. 4222 is NATS — now out of the mesh, so its
+        # own TLS encrypts the wire and the proxy would only tax it.
+        config.linkerd.io/skip-outbound-ports: 6379,26379,443,4222
     spec:
       tolerations:
         - key: itsbagelbot.dev/pool
@@ -116,11 +117,22 @@ spec:
           env:
             - name: NATS_HOST
               value: nats
-            # Apps connect only to the node-local leaf cluster (4-node HA); the
-            # hub is reached over the leafnode link for JetStream. No hub in the
-            # server list, so a leaf roll can never pin a client to the hub.
+            # Split planes: the BUS / JetStream connection dials the hub directly
+            # (NATS_HUB_URL) so stream traffic never pays a leaf forwarding hop;
+            # the RPC + cache plane (NATS_RPC_URL / NATS_LEAF_URL) stays on the
+            # node-local leaf. NATS_URL is the local-dev fallback only.
             - name: NATS_URL
               value: nats://nats-leaf:4222
+            - name: NATS_HUB_URL
+              value: nats://nats:4222
+            # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS server
+            # TLS cert now that NATS is out of the Linkerd mesh; read as RootCAs by
+            # pkg/bus (Go services) and the console nats lib (TS).
+            - name: NATS_CA_PEM
+              valueFrom:
+                configMapKeyRef:
+                  name: fleet-ca
+                  key: ca.pem
             - name: NATS_RPC_URL
               value: nats://nats-leaf:4222
             - name: NATS_LEAF_URL

--- a/deploy/k8s/projector.yaml
+++ b/deploy/k8s/projector.yaml
@@ -42,7 +42,9 @@ spec:
         config.linkerd.io/proxy-cpu-limit: 750m
         config.linkerd.io/proxy-memory-request: 16Mi
         config.linkerd.io/proxy-memory-limit: 96Mi
-        config.linkerd.io/skip-outbound-ports: 6379,26379
+        # Valkey (6379/26379) and NATS (4222 — now out of the mesh, its own TLS
+        # encrypts the wire) skip the proxy.
+        config.linkerd.io/skip-outbound-ports: 6379,26379,4222
     spec:
       tolerations:
         - key: itsbagelbot.dev/pool
@@ -77,11 +79,22 @@ spec:
           env:
             - name: NATS_HOST
               value: nats
-            # Apps connect only to the node-local leaf cluster (4-node HA); the
-            # hub is reached over the leafnode link for JetStream. No hub in the
-            # server list, so a leaf roll can never pin a client to the hub.
+            # Split planes: the BUS / JetStream connection dials the hub directly
+            # (NATS_HUB_URL) so stream traffic never pays a leaf forwarding hop;
+            # the RPC + cache plane (NATS_RPC_URL / NATS_LEAF_URL) stays on the
+            # node-local leaf. NATS_URL is the local-dev fallback only.
             - name: NATS_URL
               value: nats://nats-leaf:4222
+            - name: NATS_HUB_URL
+              value: nats://nats:4222
+            # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS server
+            # TLS cert now that NATS is out of the Linkerd mesh; read as RootCAs by
+            # pkg/bus (Go services) and the console nats lib (TS).
+            - name: NATS_CA_PEM
+              valueFrom:
+                configMapKeyRef:
+                  name: fleet-ca
+                  key: ca.pem
             - name: NATS_RPC_URL
               value: nats://nats-leaf:4222
             - name: NATS_LEAF_URL

--- a/deploy/k8s/sesame.yaml
+++ b/deploy/k8s/sesame.yaml
@@ -50,7 +50,9 @@ spec:
         config.linkerd.io/proxy-cpu-limit: 1000m
         config.linkerd.io/proxy-memory-request: 16Mi
         config.linkerd.io/proxy-memory-limit: 128Mi
-        config.linkerd.io/skip-outbound-ports: 6379,26379
+        # Valkey (6379/26379) and NATS (4222 — now out of the mesh, its own TLS
+        # encrypts the wire) skip the proxy.
+        config.linkerd.io/skip-outbound-ports: 6379,26379,4222
     spec:
       tolerations:
         - key: itsbagelbot.dev/pool
@@ -124,10 +126,23 @@ spec:
           env:
             - name: NATS_HOST
               value: nats
-            # Apps connect only to the node-local leaf cluster; the hub is reached
-            # over the leafnode link for JetStream. No hub in the server list.
+            # Split planes: the BUS / JetStream connection (the twitch.ingress
+            # firehose consumer) dials the hub directly (NATS_HUB_URL) so it never
+            # pays a leaf forwarding hop; the RPC + cache plane (NATS_RPC_URL /
+            # NATS_LEAF_URL) stays on the node-local leaf. NATS_URL is the
+            # local-dev fallback only.
             - name: NATS_URL
               value: nats://nats-leaf:4222
+            - name: NATS_HUB_URL
+              value: nats://nats:4222
+            # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS server
+            # TLS cert now that NATS is out of the Linkerd mesh; read as RootCAs by
+            # pkg/bus (Go services) and the console nats lib (TS).
+            - name: NATS_CA_PEM
+              valueFrom:
+                configMapKeyRef:
+                  name: fleet-ca
+                  key: ca.pem
             - name: NATS_RPC_URL
               value: nats://nats-leaf:4222
             - name: NATS_LEAF_URL

--- a/deploy/k8s/transactions.yaml
+++ b/deploy/k8s/transactions.yaml
@@ -38,6 +38,10 @@ spec:
         app: transactions
       annotations:
         linkerd.io/inject: enabled
+        # NATS is out of the Linkerd mesh: bypass the app-side proxy for the NATS
+        # client port so the firehose / RPC traffic goes direct (NATS-native TLS
+        # provides the encryption). Without this the proxy still taxes every event.
+        config.linkerd.io/skip-outbound-ports: "4222"
         config.linkerd.io/proxy-cpu-request: 5m
         config.linkerd.io/proxy-cpu-limit: 750m
         config.linkerd.io/proxy-memory-request: 16Mi
@@ -76,13 +80,23 @@ spec:
           env:
             - name: NATS_HOST
               value: nats
-            # Both planes (BUS JetStream publisher + TRANSACTIONS_RPC checkout
-            # responder) connect to the node-local leaf cluster; the hub is
-            # reached over the leafnode link. RPC creds (NATS_RPC_USER/PASSWORD)
-            # and the Tebex Headless secrets (TEBEX_WEBSTORE_TOKEN,
-            # TEBEX_PACKAGE_ID) ride in via envFrom from Doppler.
+            # Split planes: the BUS JetStream publisher dials the hub directly
+            # (NATS_HUB_URL) so it never pays a leaf forwarding hop; the
+            # TRANSACTIONS_RPC checkout responder stays on the node-local leaf.
+            # RPC creds (NATS_RPC_USER/PASSWORD) and the Tebex Headless secrets
+            # (TEBEX_WEBSTORE_TOKEN, TEBEX_PACKAGE_ID) ride in via envFrom from Doppler.
             - name: NATS_URL
               value: nats://nats-leaf:4222
+            - name: NATS_HUB_URL
+              value: nats://nats:4222
+            # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS server
+            # TLS cert now that NATS is out of the Linkerd mesh; read as RootCAs by
+            # pkg/bus (Go services) and the console nats lib (TS).
+            - name: NATS_CA_PEM
+              valueFrom:
+                configMapKeyRef:
+                  name: fleet-ca
+                  key: ca.pem
             - name: NATS_LEAF_URL
               value: nats://nats-leaf:4222
             - name: NODE_NAME

--- a/deploy/k8s/twitch-ingress.yaml
+++ b/deploy/k8s/twitch-ingress.yaml
@@ -76,9 +76,10 @@ spec:
         # Opaque ports for EPMD (4369) and Erlang distribution (9100-9110)
         # to prevent Linkerd protocol detection timeouts on server-speaks-first.
         config.linkerd.io/opaque-ports: "4369,9100-9110"
-        # Skip outbound port 443 to prevent mesh interference with the
-        # server-speaks-first Twitch EventSub wss:// sockets.
-        config.linkerd.io/skip-outbound-ports: "443"
+        # Skip outbound: 443 for the server-speaks-first Twitch EventSub wss://
+        # sockets, and 4222 for NATS — now out of the mesh, so NATS-native TLS
+        # provides the encryption and the proxy would otherwise tax every event.
+        config.linkerd.io/skip-outbound-ports: "443,4222"
     spec:
       tolerations:
         - key: itsbagelbot.dev/pool
@@ -180,6 +181,15 @@ spec:
               value: nats-leaf
             - name: NATS_HUB_HOST
               value: nats
+            # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS server
+            # TLS cert now that NATS is out of the Linkerd mesh; decoded to ssl_opts
+            # cacerts in config/runtime.exs. Both :gnat (leaf) and :gnat_bus (hub)
+            # verify against it.
+            - name: NATS_CA_PEM
+              valueFrom:
+                configMapKeyRef:
+                  name: fleet-ca
+                  key: ca.pem
             - name: POD_IP
               valueFrom:
                 fieldRef:

--- a/deploy/k8s/users.yaml
+++ b/deploy/k8s/users.yaml
@@ -38,6 +38,10 @@ spec:
         app: users
       annotations:
         linkerd.io/inject: enabled
+        # NATS is out of the Linkerd mesh: bypass the app-side proxy for the NATS
+        # client port so the firehose / RPC traffic goes direct (NATS-native TLS
+        # provides the encryption). Without this the proxy still taxes every event.
+        config.linkerd.io/skip-outbound-ports: "4222"
         config.linkerd.io/proxy-cpu-request: 5m
         config.linkerd.io/proxy-cpu-limit: 750m
         config.linkerd.io/proxy-memory-request: 16Mi
@@ -85,11 +89,22 @@ spec:
           env:
             - name: NATS_HOST
               value: nats
-            # Apps connect only to the node-local leaf cluster (4-node HA); the
-            # hub is reached over the leafnode link for JetStream. No hub in the
-            # server list, so a leaf roll can never pin a client to the hub.
+            # Split planes: the BUS / JetStream connection dials the hub directly
+            # (NATS_HUB_URL) so stream traffic never pays a leaf forwarding hop;
+            # the RPC + cache plane (NATS_RPC_URL / NATS_LEAF_URL) stays on the
+            # node-local leaf. NATS_URL is the local-dev fallback only.
             - name: NATS_URL
               value: nats://nats-leaf:4222
+            - name: NATS_HUB_URL
+              value: nats://nats:4222
+            # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS server
+            # TLS cert now that NATS is out of the Linkerd mesh; read as RootCAs by
+            # pkg/bus (Go services) and the console nats lib (TS).
+            - name: NATS_CA_PEM
+              valueFrom:
+                configMapKeyRef:
+                  name: fleet-ca
+                  key: ca.pem
             - name: NATS_RPC_URL
               value: nats://nats-leaf:4222
             - name: NATS_LEAF_URL

--- a/pkg/bus/connect.go
+++ b/pkg/bus/connect.go
@@ -1,6 +1,8 @@
 package bus
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"time"
 
 	"github.com/nats-io/nats.go"
@@ -15,10 +17,13 @@ import (
 //   - the durable JetStream event plane, authenticated with the shared BUS
 //     account via NATS_USER / NATS_PASSWORD.
 //
-// Both planes prefer the node-local leaf and fall back to the hub. Leaf
-// priority is enforced in code (ordered server list + DontRandomize), not just
-// by which URL a manifest happens to set, so a reconnect always retries the
-// leaf first before spilling to the hub.
+// The RPC + cache plane prefers the node-local leaf: an ordered server list plus
+// DontRandomize means a reconnect always retries the leaf first before spilling
+// to the hub. The JetStream plane instead dials the hub directly (busURL reads
+// NATS_HUB_URL): the durable streams live on the hub, so routing JetStream
+// through the leaf is only an extra forwarding hop (the leaf runs no JetStream).
+// This mirrors the console lib's rpc/bus split in
+// console/shared/lib/server/nats.ts.
 
 // JSDomain is the JetStream domain the fleet's streams live in. Clients dial the
 // leaf (whose own JetStream domain is "leaf"), so every JetStream context must be
@@ -58,7 +63,11 @@ func baseOptions(name, user, pass string) []nats.Option {
 	opts := []nats.Option{
 		nats.MaxReconnects(-1),
 		nats.ReconnectWait(2 * time.Second),
-		nats.ReconnectBufSize(8 * 1024 * 1024), // 8 MB buffer so publishes during a reconnect are not lost
+		// 32 MB buffer so publishes during a reconnect are not lost. Raised from
+		// 8 MB for the 150k firehose: a hub roll (R1 memory stream) can briefly
+		// disconnect the async publisher, and at 150k/s an 8 MB buffer fills in
+		// well under a second, dropping events the dedup window can't recover.
+		nats.ReconnectBufSize(32 * 1024 * 1024),
 		nats.PingInterval(20 * time.Second),
 		nats.MaxPingsOutstanding(3),
 		nats.Timeout(15 * time.Second),
@@ -72,6 +81,13 @@ func baseOptions(name, user, pass string) []nats.Option {
 		// env lags a credential rotation (readyz stays 503 but healthz keeps the
 		// container alive, so it never restarts on its own).
 		nats.IgnoreAuthErrorAbort(),
+	}
+
+	// Verify the broker's TLS server cert against the fleet CA when one is
+	// configured (see tlsSecureOption), the wire encryption now that NATS is out of
+	// the Linkerd mesh.
+	if option := tlsSecureOption(); option != nil {
+		opts = append(opts, option)
 	}
 
 	if name != "" {
@@ -90,6 +106,23 @@ func baseOptions(name, user, pass string) []nats.Option {
 	}
 
 	return opts
+}
+
+// tlsSecureOption returns a nats.Secure option that verifies the broker's server
+// cert against the fleet CA (NATS_CA_PEM, distributed by trust-manager as the
+// fleet-ca ConfigMap), or nil when no CA is configured — local dev against a
+// plaintext server stays plaintext. Server-auth only: the client still
+// authenticates with its bcrypt user/password, not a client cert.
+func tlsSecureOption() nats.Option {
+	caPEM := env.Get("NATS_CA_PEM", "")
+	if caPEM == "" {
+		return nil
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM([]byte(caPEM)) {
+		return nil
+	}
+	return nats.Secure(&tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS12})
 }
 
 // rpcOptions authenticate the per-service account on the RPC plane. The creds
@@ -128,8 +161,15 @@ func RPCURL(busURL string) string {
 	return env.Get("NATS_RPC_URL", busURL)
 }
 
-// busURL resolves the JetStream-plane endpoint list (leaf-first) from the url a
-// caller threads through (typically NATS_URL).
+// busURL resolves the JetStream-plane endpoint. The durable streams live on the
+// hub, so for JetStream the node-local leaf is only an extra forwarding hop:
+// dial the hub directly when NATS_HUB_URL is set (mirroring busServerList in
+// console/shared/lib/server/nats.ts). Falls back to the leaf-first serverList
+// when no hub is configured (local dev / single-endpoint deploys). RPC stays
+// leaf-first via RPCURL/serverList.
 func busURL(url string) string {
+	if hub := env.Get("NATS_HUB_URL", ""); hub != "" {
+		return hub
+	}
 	return serverList(url)
 }

--- a/pkg/bus/connect_test.go
+++ b/pkg/bus/connect_test.go
@@ -1,0 +1,44 @@
+package bus
+
+import "testing"
+
+// The JetStream plane must dial the hub directly while the RPC plane stays
+// leaf-first. In production NATS_LEAF_URL is set, so serverList prefers the leaf;
+// busURL must override that with NATS_HUB_URL, or the 150k firehose pays a leaf
+// forwarding hop on every message.
+func TestBusURLPrefersHubWhenSet(t *testing.T) {
+	t.Setenv("NATS_HUB_URL", "nats://nats:4222")
+	t.Setenv("NATS_LEAF_URL", "nats://nats-leaf:4222")
+
+	// The override (NATS_URL) and the leaf are both ignored: JetStream is hub-only.
+	if got := busURL("nats://nats-leaf:4222"); got != "nats://nats:4222" {
+		t.Fatalf("busURL = %q, want hub-only nats://nats:4222", got)
+	}
+}
+
+func TestBusURLFallsBackWhenNoHub(t *testing.T) {
+	t.Setenv("NATS_HUB_URL", "")
+
+	// Leaf configured, no hub: fall back to the leaf-first serverList.
+	t.Setenv("NATS_LEAF_URL", "nats://nats-leaf:4222")
+	if got := busURL("ignored"); got != "nats://nats-leaf:4222" {
+		t.Fatalf("busURL = %q, want leaf fallback", got)
+	}
+
+	// No split at all (local dev): honor the single endpoint the caller passes.
+	t.Setenv("NATS_LEAF_URL", "")
+	if got := busURL("nats://127.0.0.1:4222"); got != "nats://127.0.0.1:4222" {
+		t.Fatalf("busURL = %q, want local override", got)
+	}
+}
+
+// RPC stays leaf-first even once NATS_HUB_URL is set: the hub is only a reconnect
+// fallback after the node-local leaf, so request/reply keeps its node locality.
+func TestRPCServerListStaysLeafFirst(t *testing.T) {
+	t.Setenv("NATS_LEAF_URL", "nats://nats-leaf:4222")
+	t.Setenv("NATS_HUB_URL", "nats://nats:4222")
+
+	if got := serverList("nats://nats-rpc:4222"); got != "nats://nats-leaf:4222,nats://nats:4222" {
+		t.Fatalf("serverList = %q, want leaf-first with hub fallback", got)
+	}
+}

--- a/pkg/bus/provision.go
+++ b/pkg/bus/provision.go
@@ -42,6 +42,15 @@ type StreamSpec struct {
 	// perishable firehose that never needs to survive a broker restart is far
 	// cheaper in memory. Storage is fixed at creation — see reconcileStream.
 	Storage nats.StorageType
+	// Replicas is the RAFT replication factor (0 defaults to 1). Unlike Storage,
+	// replica count IS updatable in place, so reconcileStream converges a drifted
+	// stream via UpdateStream — this is the field streamMatches must compare, or a
+	// live stream hand-edited to R3 sticks at R3 forever while the spec says R1.
+	// R1 is the throughput choice for the perishable firehose: R3 makes every
+	// publish wait on a RAFT quorum before its PubAck, which is pure ack-latency
+	// inflation on an ack-bound producer. Reserve R3 for control/data streams
+	// whose loss on a single broker restart actually matters.
+	Replicas int
 }
 
 // OutgressStream carries the perishable chat lanes (premium/standard). It is
@@ -63,6 +72,9 @@ var OutgressStream = StreamSpec{
 	// send is pure overhead. Memory-backed removes the write bottleneck; the
 	// 256 MiB MaxBytes caps the memory it can hold.
 	Storage: nats.MemoryStorage,
+	// R1: perishable 5s chat work. A dropped in-flight send is re-driven by the
+	// pipeline; RAFT replication would only add ack latency to the send path.
+	Replicas: 1,
 }
 
 // OutgressSystemStream carries the outgress control lane: EventSub enroll
@@ -81,6 +93,11 @@ var OutgressSystemStream = StreamSpec{
 	Retention: nats.WorkQueuePolicy,
 	MaxAge:    5 * time.Minute,
 	MaxBytes:  64 << 20, // 64 MiB: control jobs are small and low-volume
+	// R3, unlike the chat lanes: an EventSub enroll/disable or stream re-check
+	// silently lost on a broker restart leaves a channel un-ingested with nobody
+	// the wiser. This lane is low-volume, so the RAFT cost is negligible and the
+	// durability is worth it. This is the one stream that stays replicated.
+	Replicas: 3,
 }
 
 // DataStreams backs the replayable event bus: user, command, module and
@@ -92,6 +109,10 @@ var DataStreams = []StreamSpec{
 		Subjects: []string{"data.>"},
 		MaxAge:   5 * time.Minute,
 		MaxBytes: 512 << 20, // 512 MiB
+		// R1: a low-rate, 5-minute replay buffer. A broker restart drops at most a
+		// few minutes of change events, which the projector re-derives from the
+		// data services' RPC projections — not worth a per-publish RAFT quorum.
+		Replicas: 1,
 	},
 	{
 		Name:     "TWITCH_INGRESS",
@@ -100,18 +121,20 @@ var DataStreams = []StreamSpec{
 		// Memory-backed: the stream is perishable (a replay window that never
 		// needs to survive a restart), so memory storage drops the per-event disk
 		// write that capped synchronous PubAck throughput to a few thousand
-		// events/second. Keep it R1: R3 RAFT consensus is leader-bound and, with a
-		// replica on the 2-core node1, that voter would gate the whole cluster; a
-		// lost leader drops only in-flight perishable chat. Requires the server
-		// max_mem headroom in nats-server.conf.
-		//
-		// MaxBytes is 1 GiB so the memory-backed stream fits the broker's 2GB
-		// max_mem (capped by node1) alongside TWITCH_OUTGRESS and dedup state.
-		// MaxAge is moot under load: MaxBytes (stream-wide, oldest-first) evicts
-		// first, and 1 GiB is the consumer lag budget in bytes (~6 s at 100k/s).
-		// Raising toward the 150-200k target means larger MaxBytes, which needs
-		// the broker off node1 and on >=8GiB nodes first.
-		Storage:  nats.MemoryStorage,
+		// events/second. Requires the server max_mem headroom in nats-server.conf.
+		Storage: nats.MemoryStorage,
+		// R1 (explicit, and now enforced by streamMatches). The firehose producer
+		// is async PubAck-bound — its ceiling is max_pending / ack_latency — so R3
+		// RAFT consensus per publish is pure ack-latency inflation. A lost leader
+		// drops only in-flight perishable chat (5s/5m retention), the accepted
+		// trade for the throughput. Every hub node (node2/node3/worker1) is
+		// capable, so replication buys nothing here that offsets the latency cost.
+		Replicas: 1,
+		// MaxBytes is 1 GiB so the memory-backed stream fits the broker's 4GB
+		// max_mem alongside TWITCH_OUTGRESS and dedup state. MaxAge is moot under
+		// load: MaxBytes (stream-wide, oldest-first) evicts first, and 1 GiB is the
+		// consumer lag budget in bytes (~6s at 100k/s, ~4s at 150k/s). Raising
+		// toward the 150-200k target means larger MaxBytes + more max_mem.
 		MaxBytes: 1 << 30, // 1 GiB
 		// The premium, standard and stream lanes are distinct literal subjects
 		// sharing this stream, and MaxBytes eviction is stream-wide oldest-first:
@@ -296,6 +319,12 @@ func streamConfig(spec StreamSpec) *nats.StreamConfig {
 	if spec.Storage != 0 {
 		storage = spec.Storage
 	}
+	// Zero replicas means the safe single-copy default; a spec opts into RAFT
+	// replication explicitly.
+	replicas := spec.Replicas
+	if replicas <= 0 {
+		replicas = 1
+	}
 	return &nats.StreamConfig{
 		Name:              spec.Name,
 		Subjects:          spec.Subjects,
@@ -305,7 +334,7 @@ func streamConfig(spec StreamSpec) *nats.StreamConfig {
 		MaxAge:            spec.MaxAge,
 		MaxBytes:          spec.MaxBytes,
 		MaxMsgsPerSubject: spec.MaxMsgsPer,
-		Replicas:          1,
+		Replicas:          replicas,
 		Duplicates:        duplicateWindow,
 	}
 }
@@ -316,6 +345,10 @@ func streamMatches(got, want nats.StreamConfig) bool {
 		got.MaxAge == want.MaxAge &&
 		got.MaxBytes == want.MaxBytes &&
 		got.MaxMsgsPerSubject == want.MaxMsgsPerSubject &&
+		// Replicas is updatable in place, so a drift here must trigger a reconcile
+		// (UpdateStream scales the stream); omitting it lets a live R3 stream stay
+		// R3 while the spec declares R1.
+		got.Replicas == want.Replicas &&
 		got.Duplicates == want.Duplicates
 }
 

--- a/pkg/bus/provision_test.go
+++ b/pkg/bus/provision_test.go
@@ -75,18 +75,21 @@ func TestOutgressStreamHasSingleReconciler(t *testing.T) {
 	}
 }
 
-func TestIngressStreamIsolatesLanesPerSubject(t *testing.T) {
-	var ingress *StreamSpec
+// ingressStreamSpec returns the TWITCH_INGRESS spec from DataStreams, failing the
+// test if it is missing. Shared by the tests that assert on the firehose spec.
+func ingressStreamSpec(t *testing.T) StreamSpec {
+	t.Helper()
 	for i := range DataStreams {
 		if DataStreams[i].Name == "TWITCH_INGRESS" {
-			ingress = &DataStreams[i]
+			return DataStreams[i]
 		}
 	}
-	if ingress == nil {
-		t.Fatal("TWITCH_INGRESS stream spec missing")
-	}
+	t.Fatal("TWITCH_INGRESS stream spec missing")
+	return StreamSpec{}
+}
 
-	cfg := streamConfig(*ingress)
+func TestIngressStreamIsolatesLanesPerSubject(t *testing.T) {
+	cfg := streamConfig(ingressStreamSpec(t))
 	// The premium/standard/stream lanes are distinct literal subjects on one
 	// stream; MaxBytes eviction alone is oldest-first stream-wide, letting a
 	// standard flood evict premium. The per-subject cap makes a flooded lane
@@ -102,6 +105,33 @@ func TestIngressStreamIsolatesLanesPerSubject(t *testing.T) {
 	// and the window bounds the broker's per-id tracking state.
 	if cfg.Duplicates <= 0 || cfg.Duplicates > time.Minute {
 		t.Fatalf("duplicate window = %v, want a short non-zero dedup window", cfg.Duplicates)
+	}
+}
+
+func TestStreamReplicasAreExplicitAndEnforced(t *testing.T) {
+	ingress := ingressStreamSpec(t)
+
+	// The firehose is R1: its async PubAck-bound producer must not pay a per-publish
+	// RAFT quorum. The control lane stays R3 because a lost enroll job is invisible.
+	if got := streamConfig(ingress).Replicas; got != 1 {
+		t.Fatalf("TWITCH_INGRESS replicas = %d, want 1 (R1 firehose)", got)
+	}
+	if got := streamConfig(OutgressSystemStream).Replicas; got != 3 {
+		t.Fatalf("TWITCH_OUTGRESS_SYSTEM replicas = %d, want 3 (durable control lane)", got)
+	}
+
+	// A zero-value Replicas defaults to a single copy, never 0 (which NATS rejects).
+	if got := streamConfig(StreamSpec{Name: "X", Subjects: []string{"x.>"}}).Replicas; got != 1 {
+		t.Fatalf("default replicas = %d, want 1", got)
+	}
+
+	// streamMatches must be replica-sensitive, or a live stream hand-edited to R3
+	// stays R3 while the spec declares R1 — the invisible drift this change fixes.
+	want := *streamConfig(ingress) // R1
+	drifted := want
+	drifted.Replicas = 3
+	if streamMatches(drifted, want) {
+		t.Fatal("streamMatches ignored a replica drift; live R3 would never converge to R1")
 	}
 }
 


### PR DESCRIPTION
## What

De-mesh NATS off Linkerd and replace the sidecar with NATS-native TLS
(cert-manager PKI), enforce R1 memory on the firehose, and route the JetStream
plane hub-direct so the leaf is RPC-only. Target: a single **unsharded**
`TWITCH_INGRESS` stream sustaining ~150k ev/s by removing the ack-latency taxes on
the ack-bound firehose producer.

## Why

The firehose producer is async PubAck-bound (ceiling = `max_pending / ack_latency`).
The three big ack-latency inflators were: R3 RAFT consensus per publish, the leaf
forwarding hop to reach hub streams, and the Linkerd sidecar (every event crossed
2–4 proxies). None of them is the hardware.

## Changes

- **R1 firehose** (`pkg/bus/provision.go`): `Replicas` is now a `StreamSpec` field,
  compared in `streamMatches` and converged via `UpdateStream`, so a live R3 drift
  no longer sticks silently. `TWITCH_INGRESS` R1, `TWITCH_OUTGRESS_SYSTEM` R3.
- **Hub-direct BUS plane** (`pkg/bus/connect.go` + manifests): `busURL` is hub-first
  via `NATS_HUB_URL` (RPC stays leaf-first), mirroring the console lib. The leaf
  becomes an RPC-only relay.
- **cert-manager + trust-manager** (Flux HelmRelease + PKI CRs): one CA
  `ClusterIssuer` issues and auto-renews the NATS + console certs; the `fleet-ca`
  ConfigMap distributes the CA (`NATS_CA_PEM`). No custom cert code.
- **NATS-native TLS**: client (server-auth) + leafnode + cluster listeners; Go
  `RootCAs`, Elixir `ssl_opts`, TS `tls`.
- **De-mesh**: the NATS pods leave the mesh; apps `skip-outbound-ports` the NATS
  port so the proxy is bypassed (encryption is now NATS TLS over the tailnet).
- **console-dashboard HTTPS** (Traefik `ServersTransport`); console-admin stays HTTP
  behind the Tailscale operator ingress (already tailnet-encrypted).
- **Buffers**: hub `max_pending` 64MB, client `ReconnectBufSize` 32MB, node
  rmem/wmem 16MB.

## Deploy

The TLS step is an **atomic cutover** (a bare `tls{}` block makes TLS required, so
every client needs the fleet CA at once). Ordering + the manual steps (R1 stream
update, node sysctl, soak, de-mesh gating on console HTTPS) are in
`deploy/flux/clusters/production/nats-demesh-tls-RUNBOOK.md`.

## Test

`go build ./...` + vet + `pkg/bus` tests green; Elixir config parses; `serve-node.js`
valid; all 44 manifests parse with no duplicate keys. A live soak per the runbook is
the gate before the de-mesh phase.
