### PR TITLE
fix(ingress): encode date/time structs in native JSON (unstick rollout)

### DIFF
--- a/app/ingress/lib/ingress/json.ex
+++ b/app/ingress/lib/ingress/json.ex
@@ -23,5 +23,17 @@ defmodule Ingress.JSON do
   # Elixir uses nil where Erlang's native JSON mapping uses the atom `null`.
   # Preserve Jason-compatible wire semantics for optional Twitch fields.
   defp encode_value(nil, _encode), do: "null"
+  # Native :json has no protocol dispatch, so Elixir date/time structs would be
+  # treated as plain maps and crash on their tuple `:microsecond` field
+  # (:unsupported_type). Encode them as ISO 8601 strings, matching the
+  # Jason.Encoder semantics the payloads relied on before the native-json
+  # migration — e.g. status events carry `since: DateTime.utc_now()`.
+  defp encode_value(%DateTime{} = value, encode), do: encode_value(DateTime.to_iso8601(value), encode)
+
+  defp encode_value(%NaiveDateTime{} = value, encode),
+    do: encode_value(NaiveDateTime.to_iso8601(value), encode)
+
+  defp encode_value(%Date{} = value, encode), do: encode_value(Date.to_iso8601(value), encode)
+  defp encode_value(%Time{} = value, encode), do: encode_value(Time.to_iso8601(value), encode)
   defp encode_value(value, encode), do: :json.encode_value(value, encode)
 end

--- a/app/ingress/lib/ingress/nats.ex
+++ b/app/ingress/lib/ingress/nats.ex
@@ -31,17 +31,36 @@ defmodule Ingress.Nats do
 
   @spec publish(String.t(), map()) :: :ok | {:error, term()}
   def publish(subject, payload) do
-    json = JSON.encode(payload)
+    case safe_encode(payload) do
+      {:ok, json} ->
+        case Process.whereis(@connection) do
+          nil ->
+            Metrics.count("Nats/PublishDropped")
+            Metrics.count("Nats/PublishNotConnected")
+            {:error, :not_connected}
 
-    case Process.whereis(@connection) do
-      nil ->
+          _pid ->
+            Gnat.pub(@connection, subject, json)
+        end
+
+      {:error, reason} ->
+        # Status/telemetry is fire-and-forget: an unencodable payload must never
+        # crash the shard that emitted it. A DateTime tuple field once raised here
+        # and cascaded into a shard restart storm that wedged the whole rollout.
         Metrics.count("Nats/PublishDropped")
-        Metrics.count("Nats/PublishNotConnected")
-        {:error, :not_connected}
-
-      _pid ->
-        Gnat.pub(@connection, subject, json)
+        Metrics.count("Nats/PublishEncodeError")
+        {:error, {:encode, reason}}
     end
+  end
+
+  # Encoding must not propagate as an exit from the caller (see publish/2). Lane
+  # events (publish_acked) stay strict — their payloads are decoded Twitch maps.
+  defp safe_encode(payload) do
+    {:ok, JSON.encode(payload)}
+  rescue
+    error -> {:error, error}
+  catch
+    kind, reason -> {:error, {kind, reason}}
   end
 
   @doc """

--- a/app/ingress/test/json_test.exs
+++ b/app/ingress/test/json_test.exs
@@ -1,0 +1,34 @@
+defmodule Ingress.JSONTest do
+  use ExUnit.Case, async: true
+
+  alias Ingress.JSON
+
+  defp encode(term), do: term |> JSON.encode() |> IO.iodata_to_binary()
+
+  test "encodes date/time structs as ISO 8601 strings, not raw struct maps" do
+    # Regression: native :json has no protocol dispatch, so a DateTime's tuple
+    # :microsecond field raised {:unsupported_type, {_, 6}} and crashed the shard
+    # publishing twitch.ingress.status.shard.up (since: DateTime.utc_now()).
+    dt = ~U[2026-07-12 18:23:44.211650Z]
+    assert encode(%{since: dt}) == ~s({"since":"2026-07-12T18:23:44.211650Z"})
+
+    assert encode(%{at: ~N[2026-07-12 18:23:44.211650]}) ==
+             ~s({"at":"2026-07-12T18:23:44.211650"})
+
+    assert encode(%{d: ~D[2026-07-12]}) == ~s({"d":"2026-07-12"})
+    assert encode(%{t: ~T[18:23:44.211650]}) == ~s({"t":"18:23:44.211650"})
+  end
+
+  test "still encodes the plain map/list/binary shapes the firehose uses" do
+    assert encode(%{"a" => 1, "b" => [true, nil, "x"]}) in [
+             ~s({"a":1,"b":[true,null,"x"]}),
+             ~s({"b":[true,null,"x"],"a":1})
+           ]
+  end
+
+  test "round-trips a status-shaped payload" do
+    json = encode(%{shard_id: 1, node: "ingress@10.0.0.1", since: DateTime.utc_now()})
+    assert {:ok, %{"shard_id" => 1, "since" => since}} = JSON.decode(json)
+    assert {:ok, _, _} = DateTime.from_iso8601(since)
+  end
+end


### PR DESCRIPTION
fix(ingress): encode date/time structs in native JSON (unstick rollout)

The native OTP :json migration dropped Jason's protocol dispatch, so a DateTime's
tuple :microsecond field raised {:unsupported_type, {_, 6}} when encoding status
payloads — twitch.ingress.status.shard.up carries since: DateTime.utc_now(). The
raise killed the shard, and as a permanent Horde child it exhausted restart
intensity and took the whole app down: every new ingress pod crashlooped, wedging
the rollout with the old ReplicaSet still serving.

- Ingress.JSON: encode DateTime/NaiveDateTime/Date/Time as ISO 8601 strings,
  matching the Jason.Encoder semantics the payloads relied on before the migration.
- Ingress.Nats.publish/2 (fire-and-forget status/telemetry): drop + count on an
  encode error instead of letting it propagate, so a bad telemetry payload can
  never again crash the emitting shard. Lane events (publish_acked) stay strict.
