### PR TITLE
legal: update terms of service regarding organization streamers and self-hosting

### DIFF
--- a/web/src/pages/fr/terms.astro
+++ b/web/src/pages/fr/terms.astro
@@ -5,9 +5,9 @@ import LegalShell from '../../components/legal/LegalShell.astro';
 
 const sections = [
     { id: 'agreement', heading: 'Acceptation', plain: 'En utilisant le bot, vous acceptez les présentes conditions.' },
-    { id: 'service', heading: 'Le service', plain: 'Un bot Twitch de modération, de commandes et de participation, fourni tel quel.' },
+    { id: 'service', heading: 'Le service', plain: 'Un bot Twitch de modération, de commandes et de participation, fourni tel quel. Les organisations doivent utiliser le forfait Entreprise ou un code de créateur.' },
     { id: 'account', heading: 'Votre compte', plain: 'Votre chaîne, votre connexion et votre responsabilité.' },
-    { id: 'acceptable-use', heading: 'Utilisation acceptable', plain: 'Respectez les autres, les règles de Twitch et le service.' },
+    { id: 'acceptable-use', heading: 'Utilisation acceptable', plain: "Respectez les autres, les règles de Twitch, pas d'auto-hébergement et respectez le service." },
     { id: 'license', heading: 'Licence à code source disponible', plain: 'Vous pouvez consulter le code, mais pas le revendre.' },
     { id: 'payments', heading: 'Paiements, remboursements et rétrofacturations', plain: 'Tebex traite les achats. Les ventes sont définitives; une rétrofacturation entraîne l’exclusion immédiate.' },
     { id: 'liability', heading: 'Limitation de responsabilité', plain: 'Nous corrigerons les problèmes, mais ne pouvons être tenus responsables des dommages.' },
@@ -27,7 +27,7 @@ const sections = [
         </Fragment>
 
         <Fragment slot="service">
-            <p>ItsBagelBot fournit aux diffuseurs Twitch des outils automatisés de modération du clavardage, de commandes et de participation. Le service est fourni tel quel.</p>
+            <p>ItsBagelBot fournit aux diffuseurs Twitch des outils automatisés de modération du clavardage, de commandes et de participation. Le service est fourni tel quel. Les utilisateurs individuels peuvent utiliser le service hébergé sur leurs diffusions dans la mesure souhaitée sans abus. Les diffuseurs représentant des organisations, des marques ou des équipes doivent utiliser le forfait Entreprise, à moins de détenir un code de créateur ItsBagelBot valide.</p>
         </Fragment>
 
         <Fragment slot="account">
@@ -41,7 +41,7 @@ const sections = [
                 <li>harceler autrui ou lui causer du tort;</li>
                 <li>diffuser des pourriels ou utiliser le service de façon abusive;</li>
                 <li>tenter de perturber ou de surcharger le service, ou d’y accéder sans autorisation;</li>
-                <li>redistribuer le logiciel ou l’utiliser en dehors des conditions de sa licence à code source disponible.</li>
+                <li>redistribuer le logiciel, l'auto-héberger ou exécuter votre propre instance du bot dans n'importe quel environnement.</li>
             </ul>
         </Fragment>
 

--- a/web/src/pages/terms.astro
+++ b/web/src/pages/terms.astro
@@ -5,9 +5,9 @@ import LegalShell from '../components/legal/LegalShell.astro';
 
 const sections = [
     { id: 'agreement', heading: 'Agreement', plain: 'Using the bot means you accept these rules.' },
-    { id: 'service', heading: 'The Service', plain: 'A Twitch bot: moderation, commands, engagement. Provided as-is.' },
+    { id: 'service', heading: 'The Service', plain: 'A Twitch bot: moderation, commands, engagement. Provided as-is. Organizations require Enterprise or a Creator Code.' },
     { id: 'account', heading: 'Your Account', plain: 'Your channel, your connection, your responsibility.' },
-    { id: 'acceptable-use', heading: 'Acceptable Use', plain: "Don't be a jerk, don't break Twitch's rules, don't abuse the service." },
+    { id: 'acceptable-use', heading: 'Acceptable Use', plain: "Don't be a jerk, don't break Twitch's rules, don't abuse the service, no self-hosting." },
     { id: 'license', heading: 'Source Available License', plain: 'You can read the code. You cannot resell it.' },
     { id: 'payments', heading: 'Payments, Refunds & Chargebacks', plain: 'Purchases are handled by Tebex. All sales are final. Chargebacks result in an immediate ban.' },
     { id: 'liability', heading: 'Limitation of Liability', plain: "If something breaks, we fix it, but we can't owe you damages." },
@@ -29,7 +29,7 @@ const sections = [
         <Fragment slot="service">
             <p>
                 ItsBagelBot provides automated chat moderation, commands, and engagement tools for Twitch
-                streamers. The service is provided as-is.
+                streamers. The service is provided as-is. Normal users are welcome to use the hosted service on their streams to any extent without abuse. Streamers representing organizations, brands, or teams must use the Enterprise tier, unless they hold a valid ItsBagelBot creator code.
             </p>
         </Fragment>
 
@@ -47,7 +47,7 @@ const sections = [
                 <li>Harass or harm others</li>
                 <li>Spam or abuse the service</li>
                 <li>Attempt to disrupt, overload, or gain unauthorized access to the service</li>
-                <li>Redistribute the software or use it outside the terms of its source-available license</li>
+                <li>Redistribute the software, self-host the service, or run your own instance of the bot in any environment</li>
             </ul>
         </Fragment>
 


### PR DESCRIPTION
Updates terms of service to specify that organizational/brand/team streamers must use the Enterprise tier (unless they hold a creator code) and explicitly prohibits self-hosting.