### PR TITLE
fix(deploy): create cert-manager namespace before its HelmReleases

### DIFF
--- a/deploy/infra/cert-manager/release.yaml
+++ b/deploy/infra/cert-manager/release.yaml
@@ -20,6 +20,15 @@
 # current stable tags before first apply and bump deliberately (CRD schemas can
 # change between minors): cert-manager releases and trust-manager releases track
 # separately in the jetstack chart repo.
+# The HelmReleases below live in the cert-manager namespace, so it must exist
+# before the Kustomization applies them (a HelmRelease cannot be created into a
+# missing namespace — the KEDA deploy-train lesson). Helm's own createNamespace
+# only covers the chart install, not the placement of the HelmRelease object.
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager
 ---
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository


### PR DESCRIPTION
Unblocks the NATS TLS cutover: the cert-manager Kustomization failed with `namespaces "cert-manager" not found` because the HelmReleases are placed in that namespace before anything creates it. Adds the Namespace manifest (per the KEDA deploy-train lesson).