### PR TITLE
fix(console): mark dashboard port 3000 opaque for linkerd

### DIFF
--- a/deploy/k8s/console-dashboard.yaml
+++ b/deploy/k8s/console-dashboard.yaml
@@ -71,6 +71,12 @@ spec:
         # client port so the firehose / RPC traffic goes direct (NATS-native TLS
         # provides the encryption). Without this the proxy still taxes every event.
         config.linkerd.io/skip-outbound-ports: "4222"
+        # serve-node.js terminates TLS on 3000 (see the console HTTPS change), so
+        # linkerd must treat 3000 as an opaque stream and pass the TLS through
+        # rather than HTTP-parsing it — otherwise the proxy answers the kubelet's
+        # HTTPS probe with an HTTP response ("server gave HTTP response to HTTPS
+        # client") and Traefik's re-encrypt fails the same way.
+        config.linkerd.io/opaque-ports: "3000"
         config.linkerd.io/proxy-cpu-request: 5m
         config.linkerd.io/proxy-cpu-limit: 750m
         config.linkerd.io/proxy-memory-request: 16Mi


### PR DESCRIPTION
Unblocks the console-dashboard rollout in the NATS TLS cutover. The dashboard now serves HTTPS on 3000 but is still meshed; linkerd HTTP-parsed the port and failed the HTTPS probes. Marks 3000 opaque so linkerd passes the TLS through.