### PR TITLE
chore(deploy): de-mesh app workloads + traefik off Linkerd

### DIFF
--- a/deploy/infra/cluster/traefik-config.yaml
+++ b/deploy/infra/cluster/traefik-config.yaml
@@ -31,7 +31,11 @@ spec:
     deployment:
       kind: DaemonSet
       podAnnotations:
-        linkerd.io/inject: ingress
+        # De-meshed as part of removing Linkerd. cloudflared->traefik:443 is
+        # already TLS + un-meshed; traefik->console-dashboard is HTTPS via the
+        # ServersTransport; console-admin is the tailscale operator. No hop here
+        # still depends on the mesh.
+        linkerd.io/inject: disabled
     service:
       type: ClusterIP
       spec:

--- a/deploy/k8s/commands.yaml
+++ b/deploy/k8s/commands.yaml
@@ -37,7 +37,7 @@ spec:
       labels:
         app: commands
       annotations:
-        linkerd.io/inject: enabled
+        linkerd.io/inject: disabled
         # NATS is out of the Linkerd mesh: bypass the app-side proxy for the NATS
         # client port so the firehose / RPC traffic goes direct (NATS-native TLS
         # provides the encryption). Without this the proxy still taxes every event.

--- a/deploy/k8s/console-admin.yaml
+++ b/deploy/k8s/console-admin.yaml
@@ -52,7 +52,7 @@ spec:
       labels:
         app: console-admin
       annotations:
-        linkerd.io/inject: enabled
+        linkerd.io/inject: disabled
         # NATS is out of the Linkerd mesh: bypass the app-side proxy for the NATS
         # client port so the firehose / RPC traffic goes direct (NATS-native TLS
         # provides the encryption). Without this the proxy still taxes every event.

--- a/deploy/k8s/gateway.yaml
+++ b/deploy/k8s/gateway.yaml
@@ -52,7 +52,7 @@ spec:
       labels:
         app: gateway
       annotations:
-        linkerd.io/inject: enabled
+        linkerd.io/inject: disabled
         # NATS is out of the Linkerd mesh: bypass the app-side proxy for the NATS
         # client port so the firehose / RPC traffic goes direct (NATS-native TLS
         # provides the encryption). Without this the proxy still taxes every event.

--- a/deploy/k8s/loyalty.yaml
+++ b/deploy/k8s/loyalty.yaml
@@ -40,7 +40,7 @@ spec:
       labels:
         app: loyalty
       annotations:
-        linkerd.io/inject: enabled
+        linkerd.io/inject: disabled
         # NATS is out of the Linkerd mesh: bypass the app-side proxy for the NATS
         # client port so the firehose / RPC traffic goes direct (NATS-native TLS
         # provides the encryption). Without this the proxy still taxes every event.

--- a/deploy/k8s/modules.yaml
+++ b/deploy/k8s/modules.yaml
@@ -37,7 +37,7 @@ spec:
       labels:
         app: modules
       annotations:
-        linkerd.io/inject: enabled
+        linkerd.io/inject: disabled
         # NATS is out of the Linkerd mesh: bypass the app-side proxy for the NATS
         # client port so the firehose / RPC traffic goes direct (NATS-native TLS
         # provides the encryption). Without this the proxy still taxes every event.

--- a/deploy/k8s/notifications.yaml
+++ b/deploy/k8s/notifications.yaml
@@ -37,7 +37,7 @@ spec:
       labels:
         app: notifications
       annotations:
-        linkerd.io/inject: enabled
+        linkerd.io/inject: disabled
         # NATS is out of the Linkerd mesh: bypass the app-side proxy for the NATS
         # client port so the firehose / RPC traffic goes direct (NATS-native TLS
         # provides the encryption). Without this the proxy still taxes every event.

--- a/deploy/k8s/outgress.yaml
+++ b/deploy/k8s/outgress.yaml
@@ -40,7 +40,7 @@ spec:
       labels:
         app: outgress
       annotations:
-        linkerd.io/inject: enabled
+        linkerd.io/inject: disabled
         config.linkerd.io/proxy-cpu-request: 5m
         config.linkerd.io/proxy-cpu-limit: 1000m
         config.linkerd.io/proxy-memory-request: 16Mi

--- a/deploy/k8s/projector.yaml
+++ b/deploy/k8s/projector.yaml
@@ -37,7 +37,7 @@ spec:
       labels:
         app: projector
       annotations:
-        linkerd.io/inject: enabled
+        linkerd.io/inject: disabled
         config.linkerd.io/proxy-cpu-request: 5m
         config.linkerd.io/proxy-cpu-limit: 750m
         config.linkerd.io/proxy-memory-request: 16Mi

--- a/deploy/k8s/sesame.yaml
+++ b/deploy/k8s/sesame.yaml
@@ -45,7 +45,7 @@ spec:
       labels:
         app: sesame
       annotations:
-        linkerd.io/inject: enabled
+        linkerd.io/inject: disabled
         config.linkerd.io/proxy-cpu-request: 5m
         config.linkerd.io/proxy-cpu-limit: 1000m
         config.linkerd.io/proxy-memory-request: 16Mi

--- a/deploy/k8s/transactions.yaml
+++ b/deploy/k8s/transactions.yaml
@@ -37,7 +37,7 @@ spec:
       labels:
         app: transactions
       annotations:
-        linkerd.io/inject: enabled
+        linkerd.io/inject: disabled
         # NATS is out of the Linkerd mesh: bypass the app-side proxy for the NATS
         # client port so the firehose / RPC traffic goes direct (NATS-native TLS
         # provides the encryption). Without this the proxy still taxes every event.

--- a/deploy/k8s/twitch-ingress.yaml
+++ b/deploy/k8s/twitch-ingress.yaml
@@ -68,7 +68,7 @@ spec:
       labels:
         app: twitch-ingress
       annotations:
-        linkerd.io/inject: enabled
+        linkerd.io/inject: disabled
         config.linkerd.io/proxy-cpu-request: 5m
         config.linkerd.io/proxy-cpu-limit: 750m
         config.linkerd.io/proxy-memory-request: 16Mi

--- a/deploy/k8s/users.yaml
+++ b/deploy/k8s/users.yaml
@@ -37,7 +37,7 @@ spec:
       labels:
         app: users
       annotations:
-        linkerd.io/inject: enabled
+        linkerd.io/inject: disabled
         # NATS is out of the Linkerd mesh: bypass the app-side proxy for the NATS
         # client port so the firehose / RPC traffic goes direct (NATS-native TLS
         # provides the encryption). Without this the proxy still taxes every event.


### PR DESCRIPTION
Second step of removing Linkerd: de-mesh the 12 app services + traefik. NATS-native TLS + tailnet + console HTTPS cover the hops the mesh secured. Valkey (fragile HA) and the control-plane teardown are handled separately.