### PR TITLE
feat(valkey): add verified native TLS clients

### DIFF
--- a/console/admin/src/hooks.server.ts
+++ b/console/admin/src/hooks.server.ts
@@ -29,7 +29,14 @@ export const init: ServerInit = async () => {
   // Register the caching-layer config (Valkey read tier + invalidation bus) so
   // shared infra resolves it without touching $env itself.
   registerServerConfig({
-    valkey: env.VALKEY_ADDR ? { addr: env.VALKEY_ADDR, password: env.VALKEY_PASSWORD } : undefined,
+    valkey: env.VALKEY_ADDR
+      ? {
+          addr: env.VALKEY_ADDR,
+          password: env.VALKEY_PASSWORD,
+          tlsCa: env.VALKEY_TLS_CA_PEM,
+          tlsServerName: env.VALKEY_TLS_SERVER_NAME
+        }
+      : undefined,
     cacheInvalidationPrefix: env.NATS_CACHE_INVALIDATION_PREFIX ?? 'bagel.cache.invalidate'
   });
 

--- a/console/dashboard/src/hooks.server.ts
+++ b/console/dashboard/src/hooks.server.ts
@@ -38,7 +38,9 @@ export const init: ServerInit = async () => {
           // tracks the elected master across failovers instead of pinning a
           // node-local instance that may be a read-only replica.
           sentinelAddr: env.VALKEY_SENTINEL_ADDR,
-          sentinelMaster: env.VALKEY_MASTER_SET
+          sentinelMaster: env.VALKEY_MASTER_SET,
+          tlsCa: env.VALKEY_TLS_CA_PEM,
+          tlsServerName: env.VALKEY_TLS_SERVER_NAME
         }
       : undefined,
     cacheInvalidationPrefix: env.NATS_CACHE_INVALIDATION_PREFIX ?? 'bagel.cache.invalidate'

--- a/console/shared/lib/server/config.ts
+++ b/console/shared/lib/server/config.ts
@@ -29,6 +29,10 @@ export interface ValkeyConfig {
   sentinelAddr?: string;
   /** Sentinel master set name. Defaults to "myprimary" (the fleet's set). */
   sentinelMaster?: string;
+  /** Fleet CA PEM enables verified native TLS for data and Sentinel sockets. */
+  tlsCa?: string;
+  /** Expected server identity; defaults to the stable in-cluster Service DNS. */
+  tlsServerName?: string;
 }
 
 export interface ServerConfig {

--- a/console/shared/lib/server/rate-limit.ts
+++ b/console/shared/lib/server/rate-limit.ts
@@ -18,6 +18,13 @@
 // failure mode is a looser (per-pod) limit for a few seconds.
 
 import Redis from 'iovalkey';
+import {
+  VALKEY_TLS_DATA_PORT,
+  VALKEY_TLS_SENTINEL_PORT,
+  valkeyEndpoint,
+  valkeySentinelNAT,
+  valkeyTLSOptions
+} from './valkey-connection';
 import { getServerConfig, hasServerConfig } from './config';
 import { CircuitBreaker, withTimeout } from './resilience';
 
@@ -196,17 +203,22 @@ function getWriteClient(): RateLimitClient | null {
     return null;
   }
 
+  const tls = valkeyTLSOptions(cfg);
   let client: Redis;
   if (cfg.sentinelAddr) {
-    const [host, portStr] = cfg.sentinelAddr.split(':');
+    const endpoint = valkeyEndpoint(cfg.sentinelAddr, Boolean(tls), VALKEY_TLS_SENTINEL_PORT);
     client = new Redis({
-      sentinels: [{ host: host || '127.0.0.1', port: portStr ? Number(portStr) : 26379 }],
+      sentinels: [endpoint],
       // `||` not `??`: an empty VALKEY_MASTER_SET (unset in Doppler comes
       // through as "") must fall back to the sentinel's monitored name, not be
       // used verbatim — a blank master name never resolves, so every write
       // (rate-limit AND single-use claimOnce) would silently time out.
       name: cfg.sentinelMaster || 'myprimary',
       password: cfg.password || undefined,
+      tls,
+      sentinelTLS: tls,
+      enableTLSForSentinelMode: Boolean(tls),
+      natMap: tls ? valkeySentinelNAT : undefined,
       // Fail fast, never queue: an unreachable master must degrade to the
       // per-pod fallback immediately, not grow an unbounded command queue.
       enableOfflineQueue: false,
@@ -216,11 +228,12 @@ function getWriteClient(): RateLimitClient | null {
       sentinelRetryStrategy: (times: number) => Math.min(times * 200, 2000)
     });
   } else {
-    const [host, portStr] = cfg.addr.split(':');
+    const endpoint = valkeyEndpoint(cfg.addr, Boolean(tls), VALKEY_TLS_DATA_PORT);
     client = new Redis({
-      host: host || '127.0.0.1',
-      port: portStr ? Number(portStr) : 6379,
+      host: endpoint.host,
+      port: endpoint.port,
       password: cfg.password || undefined,
+      tls,
       enableOfflineQueue: false,
       maxRetriesPerRequest: 1,
       connectTimeout: 1000,

--- a/console/shared/lib/server/valkey-connection.test.ts
+++ b/console/shared/lib/server/valkey-connection.test.ts
@@ -1,0 +1,31 @@
+// @ts-ignore Bun supplies this module at test runtime; it is not a production dependency.
+import { describe, expect, test } from 'bun:test';
+import {
+  VALKEY_TLS_DATA_PORT,
+  VALKEY_TLS_SENTINEL_PORT,
+  valkeyEndpoint,
+  valkeySentinelNAT,
+  valkeyTLSOptions
+} from './valkey-connection';
+
+describe('Valkey native TLS connection policy', () => {
+  test('moves data and Sentinel endpoints onto their TLS listeners', () => {
+    expect(valkeyEndpoint('valkey.valkey.svc.cluster.local:6379', true, VALKEY_TLS_DATA_PORT)).toEqual({
+      host: 'valkey.valkey.svc.cluster.local',
+      port: 6380
+    });
+    expect(
+      valkeyEndpoint('valkey.valkey.svc.cluster.local:26379', true, VALKEY_TLS_SENTINEL_PORT)
+    ).toEqual({ host: 'valkey.valkey.svc.cluster.local', port: 26380 });
+  });
+
+  test('verifies the fleet CA and remaps stale Sentinel data ports', () => {
+    expect(valkeyTLSOptions({ addr: 'valkey:6379', tlsCa: 'pem' })).toMatchObject({
+      ca: 'pem',
+      servername: 'valkey.valkey.svc.cluster.local',
+      minVersion: 'TLSv1.2'
+    });
+    expect(valkeySentinelNAT('100.99.41.21:6379')).toEqual({ host: '100.99.41.21', port: 6380 });
+    expect(valkeySentinelNAT('100.99.41.21:6380')).toBeNull();
+  });
+});

--- a/console/shared/lib/server/valkey-connection.ts
+++ b/console/shared/lib/server/valkey-connection.ts
@@ -1,0 +1,38 @@
+import type { ConnectionOptions } from 'node:tls';
+import type { ValkeyConfig } from './config';
+
+export const VALKEY_TLS_DATA_PORT = 6380;
+export const VALKEY_TLS_SENTINEL_PORT = 26380;
+const DEFAULT_SERVER_NAME = 'valkey.valkey.svc.cluster.local';
+
+export function valkeyTLSOptions(cfg: ValkeyConfig): ConnectionOptions | undefined {
+  if (!cfg.tlsCa) return undefined;
+  return {
+    ca: cfg.tlsCa,
+    servername: cfg.tlsServerName || DEFAULT_SERVER_NAME,
+    minVersion: 'TLSv1.2'
+  };
+}
+
+export function valkeyEndpoint(
+  address: string,
+  tlsEnabled: boolean,
+  tlsPort: number
+): { host: string; port: number } {
+  const separator = address.lastIndexOf(':');
+  const host = separator >= 0 ? address.slice(0, separator) : address;
+  const parsedPort = separator >= 0 ? Number(address.slice(separator + 1)) : 0;
+  return {
+    host: host || '127.0.0.1',
+    port: tlsEnabled ? tlsPort : parsedPort || (tlsPort === VALKEY_TLS_SENTINEL_PORT ? 26379 : 6379)
+  };
+}
+
+// During the guarded dual-listener rollout an older Sentinel may briefly
+// report the plaintext data port. A TLS-enabled client always translates that
+// stale endpoint to the native TLS listener; current 6380 replies pass through.
+export function valkeySentinelNAT(key: string): { host: string; port: number } | null {
+  const separator = key.lastIndexOf(':');
+  if (separator < 0 || key.slice(separator + 1) !== '6379') return null;
+  return { host: key.slice(0, separator), port: VALKEY_TLS_DATA_PORT };
+}

--- a/console/shared/lib/server/valkey-store.ts
+++ b/console/shared/lib/server/valkey-store.ts
@@ -23,6 +23,7 @@ import Redis from 'iovalkey';
 import type { CommandView } from '../types';
 import { getServerConfig } from './config';
 import { CircuitBreaker, withTimeout } from './resilience';
+import { VALKEY_TLS_DATA_PORT, valkeyEndpoint, valkeyTLSOptions } from './valkey-connection';
 
 const SETTINGS_PREFIX = 'settings:';
 const OP_TIMEOUT_MS = 200;
@@ -65,11 +66,13 @@ function get(): Redis | null {
     disabled = true;
     return null;
   }
-  const [host, portStr] = cfg.addr.split(':');
+  const tls = valkeyTLSOptions(cfg);
+  const endpoint = valkeyEndpoint(cfg.addr, Boolean(tls), VALKEY_TLS_DATA_PORT);
   client = new Redis({
-    host: host || '127.0.0.1',
-    port: portStr ? Number(portStr) : 6379,
+    host: endpoint.host,
+    port: endpoint.port,
     password: cfg.password || undefined,
+    tls,
     // No offline queue: while Valkey is unreachable, ops fail immediately and
     // readers fall through to RPC (op() returns the miss sentinel). Queueing
     // would buy nothing here — every op is already bounded by OP_TIMEOUT_MS —

--- a/deploy/flux/clusters/production/newrelic.yaml
+++ b/deploy/flux/clusters/production/newrelic.yaml
@@ -167,9 +167,15 @@ spec:
                 - -c
                 - |
                   export PASSWORD="$(cat /secrets/valkey/VALKEY_CORE_PASSWORD)"
-                  export HOSTNAME="${discovery.ip}"
-                  export PORT="6379"
+                  # Node-local native TLS endpoint. nodeIP is the stable
+                  # Tailscale address present in the Valkey server cert SANs;
+                  # SSL_CERT_FILE extends Go's system roots with the fleet CA.
+                  export HOSTNAME="${discovery.nodeIP}"
+                  export PORT="6380"
+                  export USE_TLS="true"
+                  export SSL_CERT_FILE="/secrets/fleet-ca/ca.pem"
                   export METRICS="true"
+                  export REMOTE_MONITORING="true"
                   exec /var/db/newrelic-infra/newrelic-integrations/bin/nri-redis
 
       # The kubelet `agent` container needs the valkey password file mounted at
@@ -194,9 +200,15 @@ spec:
             secret:
               secretName: valkey-core-secret
               defaultMode: 0400
+          - name: fleet-ca
+            configMap:
+              name: fleet-ca
         extraVolumeMounts:
           - name: valkey-core-secret
             mountPath: /secrets/valkey
+            readOnly: true
+          - name: fleet-ca
+            mountPath: /secrets/fleet-ca
             readOnly: true
 
       # Control-plane scraping is OFF: k3s embeds etcd(kine)/scheduler/

--- a/deploy/flux/clusters/production/valkey.yaml
+++ b/deploy/flux/clusters/production/valkey.yaml
@@ -11,6 +11,8 @@ metadata:
   namespace: flux-system
 spec:
   interval: 1h
+  dependsOn:
+    - name: pki
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/deploy/infra/pki/certificates.yaml
+++ b/deploy/infra/pki/certificates.yaml
@@ -102,3 +102,42 @@ spec:
   dnsNames:
     - console-admin
     - console-admin.production.svc.cluster.local
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: valkey-server-tls
+  namespace: valkey
+spec:
+  secretName: valkey-server-tls
+  duration: 2160h # 90d
+  renewBefore: 360h # 15d
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: fleet-ca-issuer
+    kind: ClusterIssuer
+    group: cert-manager.io
+  # Clients dial the Service name, a node's stable tailnet IP (node-local reads,
+  # replication and monitoring), or a StatefulSet peer name. One shared cert is
+  # intentional: the four servers form one trusted Valkey service and continue
+  # to authenticate users with ACL passwords rather than client certificates.
+  dnsNames:
+    - valkey
+    - valkey.valkey
+    - valkey.valkey.svc
+    - valkey.valkey.svc.cluster.local
+    - valkey-headless
+    - valkey-headless.valkey.svc.cluster.local
+    - valkey-node-0.valkey-headless.valkey.svc.cluster.local
+    - valkey-node-1.valkey-headless.valkey.svc.cluster.local
+    - valkey-node-2.valkey-headless.valkey.svc.cluster.local
+    - valkey-node-3.valkey-headless.valkey.svc.cluster.local
+    - localhost
+  ipAddresses:
+    - 127.0.0.1
+    - 100.98.67.104 # node1
+    - 100.95.95.9   # node2
+    - 100.99.41.21  # node3
+    - 100.104.223.54 # worker1

--- a/deploy/infra/pki/trust.yaml
+++ b/deploy/infra/pki/trust.yaml
@@ -1,5 +1,7 @@
 # trust-manager distributes the public CA (no private key) as a ConfigMap named
-# fleet-ca into the production namespace. Apps read it as NATS_CA_PEM
+# fleet-ca into the application, Valkey, and New Relic namespaces. Apps read it
+# as NATS_CA_PEM/VALKEY_TLS_CA_PEM, Valkey uses it for server/replication TLS,
+# and nri-redis verifies each node certificate without disabling validation.
 # (configMapKeyRef fleet-ca/ca.pem) and Traefik reads it as a ServersTransport
 # rootCAs, so every client can verify the NATS and console server certs without
 # shipping a private key around.
@@ -20,5 +22,7 @@ spec:
     configMap:
       key: ca.pem
     namespaceSelector:
-      matchLabels:
-        kubernetes.io/metadata.name: production
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: In
+          values: [production, valkey, newrelic]

--- a/deploy/infra/valkey/config/sentinel.conf
+++ b/deploy/infra/valkey/config/sentinel.conf
@@ -1,4 +1,12 @@
 port 26379
+# Sentinel serves verified TLS on 26380 for upgraded clients. Monitoring and
+# peer links move in the second phase after those clients are live; 26379 stays
+# available as the guarded rollback path during this first rollout.
+tls-port 26380
+tls-cert-file /etc/valkey/tls/tls.crt
+tls-key-file /etc/valkey/tls/tls.key
+tls-ca-cert-file /etc/valkey/tls/ca.crt
+tls-auth-clients no
 # Monitor the master by its stable node Tailscale IP. The four in-cluster
 # Sentinels and Valkey replicas use that same private node plane, which is also
 # the cluster's CNI transport. Pods announce their node's Tailscale IP so a

--- a/deploy/infra/valkey/config/valkey.conf
+++ b/deploy/infra/valkey/config/valkey.conf
@@ -1,4 +1,12 @@
 port 6379
+# Native TLS runs alongside the old listener during the guarded cutover. Fleet
+# clients move to 6380 first; replication follows only after every client image
+# is verified, so 6379 remains available as a rollback path in this phase.
+tls-port 6380
+tls-cert-file /etc/valkey/tls/tls.crt
+tls-key-file /etc/valkey/tls/tls.key
+tls-ca-cert-file /etc/valkey/tls/ca.crt
+tls-auth-clients no
 bind 0.0.0.0
 loglevel notice
 appendonly yes

--- a/deploy/infra/valkey/services.yaml
+++ b/deploy/infra/valkey/services.yaml
@@ -17,6 +17,14 @@ spec:
     port: 26379
     protocol: TCP
     targetPort: valkey-sentinel
+  - name: tls-redis
+    port: 6380
+    protocol: TCP
+    targetPort: redis-tls
+  - name: tls-sentinel
+    port: 26380
+    protocol: TCP
+    targetPort: sentinel-tls
   selector:
     app.kubernetes.io/component: node
     app.kubernetes.io/instance: valkey
@@ -41,6 +49,14 @@ spec:
     port: 26379
     protocol: TCP
     targetPort: valkey-sentinel
+  - name: redis-tls
+    port: 6380
+    protocol: TCP
+    targetPort: redis-tls
+  - name: sentinel-tls
+    port: 26380
+    protocol: TCP
+    targetPort: sentinel-tls
   publishNotReadyAddresses: true
   selector:
     app.kubernetes.io/component: node

--- a/deploy/infra/valkey/statefulset.yaml
+++ b/deploy/infra/valkey/statefulset.yaml
@@ -23,11 +23,10 @@ spec:
   template:
     metadata:
       annotations:
-        # De-meshed. Valkey/sentinel traffic already bypassed the proxy
-        # (skip-inbound/outbound on 6379,26379) and rides the tailnet — nodes
-        # announce their Tailscale IP and sentinel tracks the master by node
-        # address — so removing the proxy changes nothing on the wire (traffic
-        # stays WireGuard-encrypted). Native Valkey TLS is a follow-up.
+        # De-meshed. Nodes still announce stable Tailscale IPs for Sentinel and
+        # node-local reads, while native Valkey TLS adds end-to-end identity and
+        # encryption independent of the transport. Dual listeners make the
+        # cutover reversible; TLS traffic uses 6380/26380.
         linkerd.io/inject: disabled
         secrets.doppler.com/reload: 'true'
       labels:
@@ -200,6 +199,23 @@ spec:
         - "6379"
         - --masterauth
         - $(CORE)
+        # Command-line policy is authoritative even for retained PVC configs
+        # written before these limits existed. This fixes failover replicas
+        # that were still maxmemory=0/noeviction while preserving their role.
+        - --maxmemory
+        - 512mb
+        - --maxmemory-policy
+        - volatile-lru
+        - --tls-port
+        - "6380"
+        - --tls-cert-file
+        - /etc/valkey/tls/tls.crt
+        - --tls-key-file
+        - /etc/valkey/tls/tls.key
+        - --tls-ca-cert-file
+        - /etc/valkey/tls/ca.crt
+        - --tls-auth-clients
+        - "no"
         env:
         - name: HOST_IP
           valueFrom:
@@ -222,7 +238,12 @@ spec:
             command:
             - valkey-cli
             - -p
-            - "6379"
+            - "6380"
+            - --tls
+            - --cacert
+            - /etc/valkey/tls/ca.crt
+            - --sni
+            - valkey.valkey.svc.cluster.local
             - ping
           failureThreshold: 3
           initialDelaySeconds: 20
@@ -235,12 +256,21 @@ spec:
           hostPort: 6379
           name: redis
           protocol: TCP
+        - containerPort: 6380
+          hostPort: 6380
+          name: redis-tls
+          protocol: TCP
         readinessProbe:
           exec:
             command:
             - valkey-cli
             - -p
-            - "6379"
+            - "6380"
+            - --tls
+            - --cacert
+            - /etc/valkey/tls/ca.crt
+            - --sni
+            - valkey.valkey.svc.cluster.local
             - ping
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -274,10 +304,23 @@ spec:
         - mountPath: /config
           name: valkey-config
           readOnly: true
+        - mountPath: /etc/valkey/tls
+          name: valkey-tls
+          readOnly: true
       - command:
         - valkey-server
         - /data/sentinel.conf
         - --sentinel
+        - --tls-port
+        - "26380"
+        - --tls-cert-file
+        - /etc/valkey/tls/tls.crt
+        - --tls-key-file
+        - /etc/valkey/tls/tls.key
+        - --tls-ca-cert-file
+        - /etc/valkey/tls/ca.crt
+        - --tls-auth-clients
+        - "no"
         env:
         - name: REDISCLI_AUTH
           valueFrom:
@@ -291,7 +334,12 @@ spec:
             command:
             - valkey-cli
             - -p
-            - "26379"
+            - "26380"
+            - --tls
+            - --cacert
+            - /etc/valkey/tls/ca.crt
+            - --sni
+            - valkey.valkey.svc.cluster.local
             - ping
           failureThreshold: 3
           initialDelaySeconds: 20
@@ -304,12 +352,21 @@ spec:
           hostPort: 26379
           name: valkey-sentinel
           protocol: TCP
+        - containerPort: 26380
+          hostPort: 26380
+          name: sentinel-tls
+          protocol: TCP
         readinessProbe:
           exec:
             command:
             - valkey-cli
             - -p
-            - "26379"
+            - "26380"
+            - --tls
+            - --cacert
+            - /etc/valkey/tls/ca.crt
+            - --sni
+            - valkey.valkey.svc.cluster.local
             - ping
           failureThreshold: 3
           initialDelaySeconds: 15
@@ -337,6 +394,9 @@ spec:
         volumeMounts:
         - mountPath: /data
           name: valkey-data
+        - mountPath: /etc/valkey/tls
+          name: valkey-tls
+          readOnly: true
       dnsPolicy: ClusterFirst
       priorityClassName: infra-low
       restartPolicy: Always
@@ -375,6 +435,10 @@ spec:
         name: valkey-config
       - name: shared-tmp
         emptyDir: {}
+      - name: valkey-tls
+        secret:
+          defaultMode: 288
+          secretName: valkey-server-tls
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:

--- a/deploy/k8s/console-admin.yaml
+++ b/deploy/k8s/console-admin.yaml
@@ -128,6 +128,13 @@ spec:
                 configMapKeyRef:
                   name: fleet-ca
                   key: ca.pem
+            - name: VALKEY_TLS_CA_PEM
+              valueFrom:
+                configMapKeyRef:
+                  name: fleet-ca
+                  key: ca.pem
+            - name: VALKEY_TLS_SERVER_NAME
+              value: valkey.valkey.svc.cluster.local
             - name: NATS_RPC_URL
               value: nats://nats-leaf:4222
             - name: NATS_LEAF_URL

--- a/deploy/k8s/console-dashboard.yaml
+++ b/deploy/k8s/console-dashboard.yaml
@@ -147,6 +147,13 @@ spec:
                 configMapKeyRef:
                   name: fleet-ca
                   key: ca.pem
+            - name: VALKEY_TLS_CA_PEM
+              valueFrom:
+                configMapKeyRef:
+                  name: fleet-ca
+                  key: ca.pem
+            - name: VALKEY_TLS_SERVER_NAME
+              value: valkey.valkey.svc.cluster.local
             - name: NATS_RPC_URL
               value: nats://nats-leaf:4222
             - name: NATS_LEAF_URL

--- a/deploy/k8s/gateway.yaml
+++ b/deploy/k8s/gateway.yaml
@@ -110,6 +110,13 @@ spec:
                 configMapKeyRef:
                   name: fleet-ca
                   key: ca.pem
+            - name: VALKEY_TLS_CA_PEM
+              valueFrom:
+                configMapKeyRef:
+                  name: fleet-ca
+                  key: ca.pem
+            - name: VALKEY_TLS_SERVER_NAME
+              value: valkey.valkey.svc.cluster.local
             - name: NATS_RPC_URL
               value: nats://nats-leaf:4222
             - name: NATS_LEAF_URL

--- a/deploy/k8s/network-policies.yaml
+++ b/deploy/k8s/network-policies.yaml
@@ -52,10 +52,10 @@ spec:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: valkey
-    # Valkey sentinel and replicas announce their node's Tailscale IP (so the
-    # external witness can reach them), so the valkey-go client must dial those
-    # tailnet addresses (CGNAT 100.64.0.0/10) for replica reads and sentinel
-    # monitoring. The namespaceSelector above only covers valkey pod IPs.
+    # Valkey Sentinel and replicas announce stable node Tailscale IPs. The Go
+    # client dials those addresses for node-local reads and the elected master;
+    # the namespaceSelector above only covers Valkey pod IPs. Keep both legacy
+    # and guarded-cutover TLS ports until plaintext is removed after validation.
     - to:
         - ipBlock:
             cidr: 100.64.0.0/10
@@ -63,6 +63,10 @@ spec:
         - port: 6379
           protocol: TCP
         - port: 26379
+          protocol: TCP
+        - port: 6380
+          protocol: TCP
+        - port: 26380
           protocol: TCP
     # Allow outbound HTTPS for Twitch OAuth
     - ports:

--- a/deploy/k8s/outgress.yaml
+++ b/deploy/k8s/outgress.yaml
@@ -133,6 +133,13 @@ spec:
                 configMapKeyRef:
                   name: fleet-ca
                   key: ca.pem
+            - name: VALKEY_TLS_CA_PEM
+              valueFrom:
+                configMapKeyRef:
+                  name: fleet-ca
+                  key: ca.pem
+            - name: VALKEY_TLS_SERVER_NAME
+              value: valkey.valkey.svc.cluster.local
             - name: NATS_RPC_URL
               value: nats://nats-leaf:4222
             - name: NATS_LEAF_URL

--- a/deploy/k8s/projector.yaml
+++ b/deploy/k8s/projector.yaml
@@ -95,6 +95,13 @@ spec:
                 configMapKeyRef:
                   name: fleet-ca
                   key: ca.pem
+            - name: VALKEY_TLS_CA_PEM
+              valueFrom:
+                configMapKeyRef:
+                  name: fleet-ca
+                  key: ca.pem
+            - name: VALKEY_TLS_SERVER_NAME
+              value: valkey.valkey.svc.cluster.local
             - name: NATS_RPC_URL
               value: nats://nats-leaf:4222
             - name: NATS_LEAF_URL

--- a/deploy/k8s/sesame.yaml
+++ b/deploy/k8s/sesame.yaml
@@ -142,6 +142,13 @@ spec:
                 configMapKeyRef:
                   name: fleet-ca
                   key: ca.pem
+            - name: VALKEY_TLS_CA_PEM
+              valueFrom:
+                configMapKeyRef:
+                  name: fleet-ca
+                  key: ca.pem
+            - name: VALKEY_TLS_SERVER_NAME
+              value: valkey.valkey.svc.cluster.local
             - name: NATS_RPC_URL
               value: tls://nats-leaf:4222
             - name: NATS_LEAF_URL

--- a/pkg/valkey/client.go
+++ b/pkg/valkey/client.go
@@ -2,17 +2,13 @@ package valkey
 
 import (
 	"context"
+	"crypto/tls"
 	"log"
 	"net"
 	"os"
-	"strings"
 
 	valkey_go "github.com/valkey-io/valkey-go"
 )
-
-// localReadPort is the port every Valkey instance binds on its node's host
-// (hostPort 6379). Combined with NODE_IP it addresses the node-local instance.
-const localReadPort = "6379"
 
 // BuildClientOption constructs the Valkey client option for the master/write
 // path. For a Sentinel deployment (detected via the :26379 port) it configures
@@ -22,7 +18,7 @@ const localReadPort = "6379"
 //
 // Exported for testing.
 func BuildClientOption(address, password string) valkey_go.ClientOption {
-	return buildOption(address, password, true)
+	return buildOption(address, password, true, nil)
 }
 
 // buildOption builds a Valkey client option. replicaReads enables the
@@ -34,17 +30,25 @@ func BuildClientOption(address, password string) valkey_go.ClientOption {
 // replica — pins the subscription to a node that never emits them, silently
 // dropping every expiry. Reads still offload via the node-local client (Do),
 // so the pub/sub client losing replica-reads costs nothing.
-func buildOption(address, password string, replicaReads bool) valkey_go.ClientOption {
+func buildOption(address, password string, replicaReads bool, tlsConfig *tls.Config) valkey_go.ClientOption {
 	opts := valkey_go.ClientOption{
 		InitAddress:  []string{address},
 		Password:     password,
 		DisableCache: true,
+		TLSConfig:    cloneTLSConfig(tlsConfig),
+	}
+	if tlsConfig != nil {
+		// During the guarded rollout older Sentinels can briefly report 6379.
+		// Rewrite that discovered endpoint to the native TLS listener before
+		// dialing; current 6380/26380 addresses pass through unchanged.
+		opts.DialCtxFn = nativeTLSDial
 	}
 
-	if strings.HasSuffix(address, ":26379") {
+	if isSentinelAddress(address) {
 		opts.Sentinel = valkey_go.SentinelOption{
 			MasterSet: "myprimary",
 			Password:  password,
+			TLSConfig: cloneTLSConfig(tlsConfig),
 		}
 		if replicaReads {
 			// Without a node-local read client, fall back to sending read-only
@@ -140,20 +144,25 @@ func allReadOnly(multi []valkey_go.Completed) bool {
 // hop. Otherwise reads fall back to a Sentinel replica (or the single
 // instance, for a standalone address).
 func NewClient(address, password string) (valkey_go.Client, error) {
-	master, err := valkey_go.NewClient(BuildClientOption(address, password))
+	tlsConfig, err := clientTLSConfig()
+	if err != nil {
+		return nil, err
+	}
+	address = secureAddress(address, tlsConfig != nil)
+	master, err := valkey_go.NewClient(buildOption(address, password, true, tlsConfig))
 	if err != nil {
 		return nil, err
 	}
 
 	// Standalone (dev / single instance): that one node is the master, so its
 	// own Do/Receive already land on the right place. No wrapper needed.
-	if !strings.HasSuffix(address, ":26379") {
+	if !isSentinelAddress(address) {
 		return master, nil
 	}
 
 	// Sentinel: pub/sub must be pinned to the master (no SendToReplicas) or the
 	// expiry watchers subscribe to a replica that never emits expired events.
-	pubsub, err := valkey_go.NewClient(buildOption(address, password, false))
+	pubsub, err := valkey_go.NewClient(buildOption(address, password, false, tlsConfig))
 	if err != nil {
 		master.Close()
 		return nil, err
@@ -167,10 +176,15 @@ func NewClient(address, password string) (valkey_go.Client, error) {
 		return wrapped, nil
 	}
 
+	localPort := plainDataPort
+	if tlsConfig != nil {
+		localPort = tlsDataPort
+	}
 	local, err := valkey_go.NewClient(valkey_go.ClientOption{
-		InitAddress:  []string{net.JoinHostPort(nodeIP, localReadPort)},
+		InitAddress:  []string{net.JoinHostPort(nodeIP, localPort)},
 		Password:     password,
 		DisableCache: true,
+		TLSConfig:    cloneTLSConfig(tlsConfig),
 	})
 	if err != nil {
 		// Local instance unreachable at startup: degrade to Sentinel-only
@@ -180,7 +194,7 @@ func NewClient(address, password string) (valkey_go.Client, error) {
 		return wrapped, nil
 	}
 
-	log.Printf("valkey: reading from node-local instance %s:%s", nodeIP, localReadPort)
+	log.Printf("valkey: reading from node-local instance %s:%s", nodeIP, localPort)
 	wrapped.local = local
 	return wrapped, nil
 }

--- a/pkg/valkey/client_test.go
+++ b/pkg/valkey/client_test.go
@@ -1,6 +1,7 @@
 package valkey
 
 import (
+	"crypto/tls"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -19,9 +20,27 @@ func TestReadScaling_IsReadOnly(t *testing.T) {
 		opts := BuildClientOption("valkey.svc.cluster.local:26379", "password")
 		assert.NotNil(t, opts.SendToReplicas, "SendToReplicas must be configured for Sentinel to enforce local preferred reads")
 
-		// We can't easily construct a valkey_go.Completed without a real client, 
+		// We can't easily construct a valkey_go.Completed without a real client,
 		// but we can assert the option was configured and the master set logic applied.
 		assert.Equal(t, "myprimary", opts.Sentinel.MasterSet)
 		assert.Equal(t, "password", opts.Sentinel.Password)
 	})
+}
+
+func TestTLSOptionSecuresSentinelAndDataConnections(t *testing.T) {
+	config := &tls.Config{ServerName: defaultTLSServerName, MinVersion: tls.VersionTLS12}
+	opts := buildOption("valkey.valkey.svc.cluster.local:26380", "password", true, config)
+
+	assert.NotNil(t, opts.TLSConfig)
+	assert.NotSame(t, config, opts.TLSConfig)
+	assert.Equal(t, defaultTLSServerName, opts.TLSConfig.ServerName)
+	assert.NotNil(t, opts.Sentinel.TLSConfig)
+	assert.NotSame(t, opts.TLSConfig, opts.Sentinel.TLSConfig)
+	assert.NotNil(t, opts.DialCtxFn)
+}
+
+func TestSecureAddressUsesNativeTLSPorts(t *testing.T) {
+	assert.Equal(t, "valkey.valkey.svc.cluster.local:6380", secureAddress("valkey.valkey.svc.cluster.local:6379", true))
+	assert.Equal(t, "valkey.valkey.svc.cluster.local:26380", secureAddress("valkey.valkey.svc.cluster.local:26379", true))
+	assert.Equal(t, "valkey.valkey.svc.cluster.local:26379", secureAddress("valkey.valkey.svc.cluster.local:26379", false))
 }

--- a/pkg/valkey/tls.go
+++ b/pkg/valkey/tls.go
@@ -1,0 +1,80 @@
+package valkey
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net"
+	"os"
+)
+
+const (
+	plainDataPort        = "6379"
+	tlsDataPort          = "6380"
+	plainSentinelPort    = "26379"
+	tlsSentinelPort      = "26380"
+	defaultTLSServerName = "valkey.valkey.svc.cluster.local"
+)
+
+func clientTLSConfig() (*tls.Config, error) {
+	caPEM := os.Getenv("VALKEY_TLS_CA_PEM")
+	if caPEM == "" {
+		return nil, nil
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM([]byte(caPEM)) {
+		return nil, fmt.Errorf("valkey: VALKEY_TLS_CA_PEM contains no certificates")
+	}
+	serverName := os.Getenv("VALKEY_TLS_SERVER_NAME")
+	if serverName == "" {
+		serverName = defaultTLSServerName
+	}
+	return &tls.Config{
+		RootCAs:    pool,
+		ServerName: serverName,
+		MinVersion: tls.VersionTLS12,
+	}, nil
+}
+
+func cloneTLSConfig(config *tls.Config) *tls.Config {
+	if config == nil {
+		return nil
+	}
+	return config.Clone()
+}
+
+func isSentinelAddress(address string) bool {
+	_, port, err := net.SplitHostPort(address)
+	return err == nil && (port == plainSentinelPort || port == tlsSentinelPort)
+}
+
+func secureAddress(address string, enabled bool) string {
+	if !enabled {
+		return address
+	}
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return address
+	}
+	switch port {
+	case plainDataPort:
+		port = tlsDataPort
+	case plainSentinelPort:
+		port = tlsSentinelPort
+	}
+	return net.JoinHostPort(host, port)
+}
+
+func nativeTLSDial(ctx context.Context, address string, dialer *net.Dialer, config *tls.Config) (net.Conn, error) {
+	connection, err := dialer.DialContext(ctx, "tcp", secureAddress(address, true))
+	if err != nil || config == nil {
+		return connection, err
+	}
+	tlsConnection := tls.Client(connection, config.Clone())
+	if err := tlsConnection.HandshakeContext(ctx); err != nil {
+		_ = connection.Close()
+		return nil, err
+	}
+	return tlsConnection, nil
+}


### PR DESCRIPTION
## Summary
- issue a fleet-CA Valkey server certificate for service, peer, and node-local addresses
- add guarded native TLS listeners on 6380/26380 without removing rollback listeners
- enable verified TLS in valkey-go, iovalkey, probes, and New Relic
- make retained-PVC maxmemory/eviction policy authoritative on every boot

## Rollout safety
- application clients remap stale Sentinel 6379 replies to TLS 6380
- replication and Sentinel peer links remain on the old ports for this first phase
- a follow-up cutover moves internal links after every client image is verified

## Tests
- `go test ./...`
- `bun test shared`
- `bun run check`
- rendered PKI, Valkey, and production Kustomizations
- Valkey 9.0.4 verified TLS smoke test against the issued fleet certificate