### PR TITLE
perf(valkey): upgrade to 9.1 and enable threaded IO

### DIFF
--- a/deploy/infra/valkey/config/valkey.conf
+++ b/deploy/infra/valkey/config/valkey.conf
@@ -9,6 +9,11 @@ tls-ca-cert-file /etc/valkey/tls/ca.crt
 tls-auth-clients no
 bind 0.0.0.0
 loglevel notice
+# Valkey 9.1 uses lock-free queues between the main thread and I/O workers.
+# Two threads fit the 2-CPU container budget on the 6/8-core data-plane nodes;
+# config-init reduces this to one on the 2-core node1 host until that replica is
+# evacuated for the database role.
+io-threads 2
 appendonly yes
 save ""
 # Bounded cache. maxmemory sits under the 1Gi container limit to leave COW and

--- a/deploy/infra/valkey/statefulset.yaml
+++ b/deploy/infra/valkey/statefulset.yaml
@@ -86,7 +86,7 @@ spec:
         - mountPath: /shared
           name: shared-tmp
       - name: config-init
-        image: valkey/valkey@sha256:8436e10bc65c94886a91d4415b6a6dfa9cb5a306fb3b996e5bb67cd2b4854193
+        image: valkey/valkey@sha256:4963247afc4cd33c7d3b2d2816b9f7f8eeebab148d29056c2ca4d7cbc966f2d9
         imagePullPolicy: IfNotPresent
         command:
         - /bin/sh
@@ -139,6 +139,17 @@ spec:
               echo "replica-priority 200" >> /data/valkey.conf
             fi
             chmod 600 /data/valkey.conf
+          fi
+          # io-threads is deliberately reconciled on every boot instead of
+          # only on fresh PVCs. CONFIG REWRITE persists old values, and node1
+          # has only two cores while the remaining data-plane hosts have 6-8.
+          # Valkey 9.1 threads both reads and writes automatically; the former
+          # io-threads-do-reads switch is deprecated and intentionally absent.
+          sed -i '/^io-threads /d' /data/valkey.conf
+          if [ "${NODE_NAME}" = "node1" ]; then
+            echo "io-threads 1" >> /data/valkey.conf
+          else
+            echo "io-threads 2" >> /data/valkey.conf
           fi
           if [ ! -f /data/sentinel.conf ]; then
             cp /config/sentinel.conf /data/sentinel.conf
@@ -231,7 +242,7 @@ spec:
             secretKeyRef:
               key: valkey-password
               name: valkey-core-secret
-        image: valkey/valkey@sha256:8436e10bc65c94886a91d4415b6a6dfa9cb5a306fb3b996e5bb67cd2b4854193
+        image: valkey/valkey@sha256:4963247afc4cd33c7d3b2d2816b9f7f8eeebab148d29056c2ca4d7cbc966f2d9
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:
@@ -277,12 +288,27 @@ spec:
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 3
+        startupProbe:
+          exec:
+            command:
+            - valkey-cli
+            - -p
+            - "6380"
+            - --tls
+            - --cacert
+            - /etc/valkey/tls/ca.crt
+            - --sni
+            - valkey.valkey.svc.cluster.local
+            - ping
+          failureThreshold: 30
+          periodSeconds: 2
+          timeoutSeconds: 3
         resources:
           limits:
-            cpu: '1'
+            cpu: '2'
             memory: 1Gi
           requests:
-            cpu: 100m
+            cpu: 250m
             memory: 256Mi
         securityContext:
           allowPrivilegeEscalation: false
@@ -327,7 +353,7 @@ spec:
             secretKeyRef:
               key: valkey-password
               name: valkey-core-secret
-        image: valkey/valkey@sha256:8436e10bc65c94886a91d4415b6a6dfa9cb5a306fb3b996e5bb67cd2b4854193
+        image: valkey/valkey@sha256:4963247afc4cd33c7d3b2d2816b9f7f8eeebab148d29056c2ca4d7cbc966f2d9
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:
@@ -373,13 +399,28 @@ spec:
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 3
+        startupProbe:
+          exec:
+            command:
+            - valkey-cli
+            - -p
+            - "26380"
+            - --tls
+            - --cacert
+            - /etc/valkey/tls/ca.crt
+            - --sni
+            - valkey.valkey.svc.cluster.local
+            - ping
+          failureThreshold: 30
+          periodSeconds: 2
+          timeoutSeconds: 3
         resources:
           limits:
-            cpu: 30m
-            memory: 32Mi
+            cpu: 100m
+            memory: 64Mi
           requests:
-            cpu: 5m
-            memory: 16Mi
+            cpu: 10m
+            memory: 32Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:


### PR DESCRIPTION
## Summary
- pin the official Valkey 9.1.0 multi-architecture image
- enable two read/write I/O threads on the 6/8-core data-plane nodes while keeping 2-core node1 single-threaded
- raise the server CPU ceiling so threaded I/O can execute
- add startup probes for bounded AOF recovery and give Sentinel enough failover headroom

## Production baseline
- TLS SET: 76,220/s, p95 15.247 ms
- TLS GET: 101,368/s, p95 10.215 ms
- 4/4 replicas healthy; zero rejected connections and evictions

## Validation
- exact digest starts as Valkey 9.1.0 on AMD64 node2 and ARM64 node1
- `io-threads 2` accepted by the 9.1 server
- `kubectl kustomize deploy/infra/valkey`
- rendered resources pass `kubectl apply --dry-run=server`

## Rollout
This deliberately keeps dual plaintext/TLS listeners. Internal replication TLS and plaintext removal follow as separate measured phases after the 9.1 benchmark.