### PR TITLE
perf(valkey): bound the master write pool

### DIFF
--- a/pkg/valkey/client.go
+++ b/pkg/valkey/client.go
@@ -6,8 +6,21 @@ import (
 	"log"
 	"net"
 	"os"
+	"time"
 
 	valkey_go "github.com/valkey-io/valkey-go"
+)
+
+const (
+	// Writes always cross the network to the elected primary. A bounded
+	// dedicated pool avoids large automatic pipeline batches under bursts.
+	// Production-path tests at concurrency 50 improved write p95, p99 and
+	// throughput; smaller pools produced long acquisition tails. Small buffers
+	// keep the maximum per-process connection footprint predictable.
+	writePoolSize       = 64
+	writePoolMinSize    = 4
+	writePoolBufferSize = 32 << 10
+	writePoolIdleTime   = 30 * time.Second
 )
 
 // BuildClientOption constructs the Valkey client option for the master/write
@@ -18,7 +31,17 @@ import (
 //
 // Exported for testing.
 func BuildClientOption(address, password string) valkey_go.ClientOption {
-	return buildOption(address, password, true, nil)
+	return withWritePool(buildOption(address, password, true, nil))
+}
+
+func withWritePool(opts valkey_go.ClientOption) valkey_go.ClientOption {
+	opts.DisableAutoPipelining = true
+	opts.BlockingPoolSize = writePoolSize
+	opts.BlockingPoolCleanup = writePoolIdleTime
+	opts.BlockingPoolMinSize = writePoolMinSize
+	opts.ReadBufferEachConn = writePoolBufferSize
+	opts.WriteBufferEachConn = writePoolBufferSize
+	return opts
 }
 
 // buildOption builds a Valkey client option. replicaReads enables the
@@ -149,7 +172,7 @@ func NewClient(address, password string) (valkey_go.Client, error) {
 		return nil, err
 	}
 	address = secureAddress(address, tlsConfig != nil)
-	master, err := valkey_go.NewClient(buildOption(address, password, true, tlsConfig))
+	master, err := valkey_go.NewClient(withWritePool(buildOption(address, password, true, tlsConfig)))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/valkey/client_test.go
+++ b/pkg/valkey/client_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	valkey_go "github.com/valkey-io/valkey-go"
 )
 
 // TestReadScaling verifies that the Valkey client option configuration correctly
@@ -14,6 +15,7 @@ func TestReadScaling_IsReadOnly(t *testing.T) {
 	t.Run("Standard Address", func(t *testing.T) {
 		opts := BuildClientOption("valkey:6379", "password")
 		assert.Nil(t, opts.SendToReplicas, "SendToReplicas should be nil for standard connections")
+		assertWritePool(t, opts)
 	})
 
 	t.Run("Sentinel Address", func(t *testing.T) {
@@ -24,7 +26,18 @@ func TestReadScaling_IsReadOnly(t *testing.T) {
 		// but we can assert the option was configured and the master set logic applied.
 		assert.Equal(t, "myprimary", opts.Sentinel.MasterSet)
 		assert.Equal(t, "password", opts.Sentinel.Password)
+		assertWritePool(t, opts)
 	})
+}
+
+func assertWritePool(t *testing.T, opts valkey_go.ClientOption) {
+	t.Helper()
+	assert.True(t, opts.DisableAutoPipelining)
+	assert.Equal(t, writePoolSize, opts.BlockingPoolSize)
+	assert.Equal(t, writePoolMinSize, opts.BlockingPoolMinSize)
+	assert.Equal(t, writePoolIdleTime, opts.BlockingPoolCleanup)
+	assert.Equal(t, writePoolBufferSize, opts.ReadBufferEachConn)
+	assert.Equal(t, writePoolBufferSize, opts.WriteBufferEachConn)
 }
 
 func TestTLSOptionSecuresSentinelAndDataConnections(t *testing.T) {


### PR DESCRIPTION
## Summary
- use a bounded dedicated connection pool only for the master/write path
- retain automatic pipelining for node-local reads
- cap pool buffers at 32 KiB and reap idle connections after 30 seconds
- cover the shared option so every Go user receives the same behavior

## Live production-path result (node2 -> node3, native TLS, concurrency 50)
- current auto-pipeline: 6,811 writes/s, p95 11.48 ms, p99 18.02 ms
- bounded pool: 10,244 writes/s, p95 8.37 ms, p99 10.33 ms
- zero command failures

Smaller 16/32 connection pools were rejected because they produced 75-181 ms p99 acquisition tails. Eight-way automatic multiplexing was also rejected because it did not materially lower p95.

## Validation
- `go test ./pkg/valkey`
- `go test ./...`