### PR TITLE
feat(valkey): encrypt replication and Sentinel links

### DIFF
--- a/deploy/infra/valkey/config/sentinel.conf
+++ b/deploy/infra/valkey/config/sentinel.conf
@@ -1,12 +1,12 @@
 port 26379
-# Sentinel serves verified TLS on 26380 for upgraded clients. Monitoring and
-# peer links move in the second phase after those clients are live; 26379 stays
-# available as the guarded rollback path during this first rollout.
+# Sentinel clients, primary monitoring, and Sentinel peers use native TLS on
+# 26380. The old listener remains only for the guarded rollback window.
 tls-port 26380
 tls-cert-file /etc/valkey/tls/tls.crt
 tls-key-file /etc/valkey/tls/tls.key
 tls-ca-cert-file /etc/valkey/tls/ca.crt
 tls-auth-clients no
+tls-replication yes
 # Monitor the master by its stable node Tailscale IP. The four in-cluster
 # Sentinels and Valkey replicas use that same private node plane, which is also
 # the cluster's CNI transport. Pods announce their node's Tailscale IP so a

--- a/deploy/infra/valkey/config/valkey.conf
+++ b/deploy/infra/valkey/config/valkey.conf
@@ -1,12 +1,13 @@
 port 6379
-# Native TLS runs alongside the old listener during the guarded cutover. Fleet
-# clients move to 6380 first; replication follows only after every client image
-# is verified, so 6379 remains available as a rollback path in this phase.
+# Native TLS is authoritative for clients and replication. The old listener is
+# retained for one final rollback window and is removed after all replicas and
+# Sentinels report the TLS ports.
 tls-port 6380
 tls-cert-file /etc/valkey/tls/tls.crt
 tls-key-file /etc/valkey/tls/tls.key
 tls-ca-cert-file /etc/valkey/tls/ca.crt
 tls-auth-clients no
+tls-replication yes
 bind 0.0.0.0
 loglevel notice
 # Valkey 9.1 uses lock-free queues between the main thread and I/O workers.

--- a/deploy/infra/valkey/statefulset.yaml
+++ b/deploy/infra/valkey/statefulset.yaml
@@ -108,21 +108,21 @@ spec:
           if [ -f /shared/master_ip ]; then
             MASTER_IP=$(cat /shared/master_ip)
           fi
-          LIVE_MASTER=$( { REDISCLI_AUTH="${CORE}" valkey-cli -h valkey.valkey.svc.cluster.local -p 26379 --no-auth-warning sentinel get-master-addr-by-name myprimary 2>/dev/null || true; } | head -n 1)
+          LIVE_MASTER=$( { REDISCLI_AUTH="${CORE}" valkey-cli -h valkey.valkey.svc.cluster.local -p 26380 --tls --cacert /etc/valkey/tls/ca.crt --sni valkey.valkey.svc.cluster.local --no-auth-warning sentinel get-master-addr-by-name myprimary 2>/dev/null || true; } | head -n 1)
           case "${LIVE_MASTER}" in *.*.*.*) MASTER_IP="${LIVE_MASTER}";; esac
           if [ ! -f /data/valkey.conf ]; then
             cp /config/valkey.conf /data/valkey.conf
             {
               echo "masterauth ${CORE}"
               echo "replica-announce-ip ${HOST_IP}"
-              echo "replica-announce-port 6379"
+              echo "replica-announce-port 6380"
             } >> /data/valkey.conf
             # First-boot seed only: every pod but the master's begins as its
             # replica; Sentinel owns all failovers afterwards. Skipped once
             # valkey has rewritten its own replication state. Empty MASTER_IP
             # (resolution failed on a true cold start) falls back to pod-0.
             if [ "${POD_INDEX}" != "0" ]; then
-              echo "replicaof ${MASTER_IP:-valkey-node-0.valkey-headless.valkey.svc.cluster.local} 6379" >> /data/valkey.conf
+              echo "replicaof ${MASTER_IP:-valkey-node-0.valkey-headless.valkey.svc.cluster.local} 6380" >> /data/valkey.conf
             fi
             # The home node (worker1, flaky wifi) keeps a read replica but must never
             # be promoted: Sentinel never elects a priority-0 replica. Keyed on the
@@ -151,17 +151,30 @@ spec:
           else
             echo "io-threads 2" >> /data/valkey.conf
           fi
+          # Retained PVCs carry Sentinel-rewritten topology. Move those live
+          # addresses to the TLS listeners before either process starts; doing
+          # this in config-init makes the migration repeatable after restores.
+          sed -i -E \
+            -e 's/^(replica-announce-port) 6379$/\1 6380/' \
+            -e 's/^(replicaof [^ ]+) 6379$/\1 6380/' \
+            /data/valkey.conf
           if [ ! -f /data/sentinel.conf ]; then
             cp /config/sentinel.conf /data/sentinel.conf
             {
               echo "requirepass ${CORE}"
               echo "sentinel auth-pass myprimary ${CORE}"
               echo "sentinel announce-ip ${HOST_IP}"
-              echo "sentinel announce-port 26379"
-              echo "sentinel monitor myprimary ${MASTER_IP} 6379 2"
+              echo "sentinel announce-port 26380"
+              echo "sentinel monitor myprimary ${MASTER_IP} 6380 2"
             } >> /data/sentinel.conf
             chmod 600 /data/sentinel.conf
           fi
+          sed -i -E \
+            -e 's/^(sentinel announce-port) 26379$/\1 26380/' \
+            -e 's/^(sentinel monitor myprimary [^ ]+) 6379 (.+)$/\1 6380 \2/' \
+            -e 's/^(sentinel known-replica myprimary [^ ]+) 6379$/\1 6380/' \
+            -e 's/^(sentinel known-sentinel myprimary [^ ]+) 26379 (.+)$/\1 26380 \2/' \
+            /data/sentinel.conf
         env:
         - name: HOST_IP
           valueFrom:
@@ -197,6 +210,9 @@ spec:
           readOnly: true
         - mountPath: /shared
           name: shared-tmp
+        - mountPath: /etc/valkey/tls
+          name: valkey-tls
+          readOnly: true
       containers:
       # valkey-server runs the seeded /data/valkey.conf directly. masterauth and
       # the Tailscale announce address come in as flags from the downward API /
@@ -207,7 +223,7 @@ spec:
         - --replica-announce-ip
         - $(HOST_IP)
         - --replica-announce-port
-        - "6379"
+        - "6380"
         - --masterauth
         - $(CORE)
         # Command-line policy is authoritative even for retained PVC configs
@@ -227,6 +243,8 @@ spec:
         - /etc/valkey/tls/ca.crt
         - --tls-auth-clients
         - "no"
+        - --tls-replication
+        - "yes"
         env:
         - name: HOST_IP
           valueFrom:
@@ -347,6 +365,8 @@ spec:
         - /etc/valkey/tls/ca.crt
         - --tls-auth-clients
         - "no"
+        - --tls-replication
+        - "yes"
         env:
         - name: REDISCLI_AUTH
           valueFrom:


### PR DESCRIPTION
## Summary
- enable `tls-replication` for Valkey replicas and Sentinel
- move advertised replica, monitored primary, and Sentinel peer ports to 6380/26380
- idempotently migrate Sentinel-rewritten retained-PVC topology before startup
- use verified TLS when config-init asks the live Sentinel for the current primary
- retain plaintext listeners only as a final rollback window

## Rollout safety
This phase does not close 6379/26379. Before Flux rolls the StatefulSet, the primary will be moved from ordinal 3/node3 to ordinal 1/node2 so the mixed-protocol rollout updates replicas first. Plaintext removal is a separate final phase after all four nodes report TLS topology.

## Validation
- migration expressions tested against representative persisted config lines
- `kubectl kustomize deploy/infra/valkey`
- rendered resources pass `kubectl apply --dry-run=server`
- official Valkey TLS documentation confirms `tls-replication` governs both replica-primary and Sentinel peer/monitor connections