### PR TITLE
fix(valkey): deduplicate migrated Sentinel topology

### DIFF
--- a/deploy/infra/valkey/statefulset.yaml
+++ b/deploy/infra/valkey/statefulset.yaml
@@ -175,6 +175,20 @@ spec:
             -e 's/^(sentinel known-replica myprimary [^ ]+) 6379$/\1 6380/' \
             -e 's/^(sentinel known-sentinel myprimary [^ ]+) 26379 (.+)$/\1 26380 \2/' \
             /data/sentinel.conf
+          # A mixed-listener rollout can leave both the old endpoint and the
+          # newly auto-discovered TLS endpoint in Sentinel's persisted state.
+          # Port migration collapses those into the same address, which 9.1
+          # correctly rejects as a duplicate. Keep the first stable identity;
+          # Sentinel refreshes run IDs and topology through hello messages.
+          awk '
+            $1 == "sentinel" && ($2 == "known-replica" || $2 == "known-sentinel") && $3 == "myprimary" {
+              endpoint = $2 FS $4 FS $5
+              if (seen[endpoint]++) next
+            }
+            { print }
+          ' /data/sentinel.conf > /data/sentinel.conf.dedup
+          mv /data/sentinel.conf.dedup /data/sentinel.conf
+          chmod 600 /data/sentinel.conf
         env:
         - name: HOST_IP
           valueFrom:


### PR DESCRIPTION
## Summary
- deduplicate persisted `known-replica` and `known-sentinel` endpoints after the TLS port migration
- preserve the first stable identity and allow Sentinel hello traffic to refresh run IDs
- keep the migration idempotent for retained PVCs and restores

## Production finding
During the guarded mixed-listener rollout, Sentinel had already auto-discovered a 6380 endpoint while retaining the same replica at 6379. Migrating 6379 to 6380 collapsed those entries, and Valkey 9.1 correctly refused the duplicate. OrderedReady stopped the rollout. The affected persisted files were deduplicated, all four pods are Ready, node2 remains primary, and all three replicas are current over TLS.

## Validation
- representative duplicate replica and Sentinel endpoints collapse to one line
- `kubectl kustomize deploy/infra/valkey`
- rendered resources pass `kubectl apply --dry-run=server`