### PR TITLE
fix(valkey): require native TLS cluster-wide

### DIFF
--- a/console/shared/lib/server/config.ts
+++ b/console/shared/lib/server/config.ts
@@ -17,11 +17,11 @@
 // deadlock-safe); it is intentionally not routed through here.
 
 export interface ValkeyConfig {
-  /** host:port of the node-local read instance, e.g. "127.0.0.1:6379". */
+  /** host:port of the node-local read instance, e.g. "127.0.0.1:6380". */
   addr: string;
   password?: string;
   /**
-   * host:port of a Sentinel endpoint, e.g. "valkey.valkey.svc:26379". When set,
+   * host:port of a Sentinel endpoint, e.g. "valkey.valkey.svc:26380". When set,
    * write-path clients (rate limiter) connect through Sentinel so they always
    * track the elected master across failovers; when absent, writes go to
    * `addr` directly (single-instance/dev setups).

--- a/deploy/infra/valkey/config/sentinel.conf
+++ b/deploy/infra/valkey/config/sentinel.conf
@@ -1,6 +1,6 @@
-port 26379
+port 0
 # Sentinel clients, primary monitoring, and Sentinel peers use native TLS on
-# 26380. The old listener remains only for the guarded rollback window.
+# 26380. Plaintext is disabled.
 tls-port 26380
 tls-cert-file /etc/valkey/tls/tls.crt
 tls-key-file /etc/valkey/tls/tls.key

--- a/deploy/infra/valkey/config/valkey.conf
+++ b/deploy/infra/valkey/config/valkey.conf
@@ -1,7 +1,6 @@
-port 6379
-# Native TLS is authoritative for clients and replication. The old listener is
-# retained for one final rollback window and is removed after all replicas and
-# Sentinels report the TLS ports.
+port 0
+# Native TLS is authoritative for clients and replication. Plaintext is
+# disabled; every client, replica, and Sentinel reaches Valkey on 6380.
 tls-port 6380
 tls-cert-file /etc/valkey/tls/tls.crt
 tls-key-file /etc/valkey/tls/tls.key

--- a/deploy/infra/valkey/services.yaml
+++ b/deploy/infra/valkey/services.yaml
@@ -9,14 +9,6 @@ metadata:
   namespace: valkey
 spec:
   ports:
-  - name: tcp-redis
-    port: 6379
-    protocol: TCP
-    targetPort: redis
-  - name: tcp-sentinel
-    port: 26379
-    protocol: TCP
-    targetPort: valkey-sentinel
   - name: tls-redis
     port: 6380
     protocol: TCP
@@ -41,14 +33,6 @@ metadata:
   namespace: valkey
 spec:
   ports:
-  - name: redis
-    port: 6379
-    protocol: TCP
-    targetPort: redis
-  - name: valkey-sentinel
-    port: 26379
-    protocol: TCP
-    targetPort: valkey-sentinel
   - name: redis-tls
     port: 6380
     protocol: TCP

--- a/deploy/infra/valkey/statefulset.yaml
+++ b/deploy/infra/valkey/statefulset.yaml
@@ -25,8 +25,8 @@ spec:
       annotations:
         # De-meshed. Nodes still announce stable Tailscale IPs for Sentinel and
         # node-local reads, while native Valkey TLS adds end-to-end identity and
-        # encryption independent of the transport. Dual listeners make the
-        # cutover reversible; TLS traffic uses 6380/26380.
+        # encryption independent of the transport. Only the native TLS
+        # listeners are exposed: data on 6380 and Sentinel on 26380.
         linkerd.io/inject: disabled
         secrets.doppler.com/reload: 'true'
       labels:
@@ -247,6 +247,10 @@ spec:
         - 512mb
         - --maxmemory-policy
         - volatile-lru
+        # Retained PVCs may contain an older plaintext port. Command-line
+        # policy is authoritative so a restore cannot reopen it.
+        - --port
+        - "0"
         - --tls-port
         - "6380"
         - --tls-cert-file
@@ -295,10 +299,6 @@ spec:
           timeoutSeconds: 5
         name: valkey
         ports:
-        - containerPort: 6379
-          hostPort: 6379
-          name: redis
-          protocol: TCP
         - containerPort: 6380
           hostPort: 6380
           name: redis-tls
@@ -369,6 +369,9 @@ spec:
         - valkey-server
         - /data/sentinel.conf
         - --sentinel
+        # Override Sentinel's rewritten PVC config as well as the ConfigMap.
+        - --port
+        - "0"
         - --tls-port
         - "26380"
         - --tls-cert-file
@@ -408,10 +411,6 @@ spec:
           timeoutSeconds: 5
         name: sentinel
         ports:
-        - containerPort: 26379
-          hostPort: 26379
-          name: valkey-sentinel
-          protocol: TCP
         - containerPort: 26380
           hostPort: 26380
           name: sentinel-tls

--- a/deploy/k8s/gateway.yaml
+++ b/deploy/k8s/gateway.yaml
@@ -125,7 +125,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-            # Node-local Valkey reads (NODE_IP:6379); writes ride Sentinel.
+            # Node-local Valkey TLS reads (NODE_IP:6380); writes ride Sentinel.
             - name: NODE_IP
               valueFrom:
                 fieldRef:

--- a/deploy/k8s/network-policies.yaml
+++ b/deploy/k8s/network-policies.yaml
@@ -54,16 +54,12 @@ spec:
               kubernetes.io/metadata.name: valkey
     # Valkey Sentinel and replicas announce stable node Tailscale IPs. The Go
     # client dials those addresses for node-local reads and the elected master;
-    # the namespaceSelector above only covers Valkey pod IPs. Keep both legacy
-    # and guarded-cutover TLS ports until plaintext is removed after validation.
+    # the namespaceSelector above only covers Valkey pod IPs. Native TLS is
+    # mandatory on both data and Sentinel paths.
     - to:
         - ipBlock:
             cidr: 100.64.0.0/10
       ports:
-        - port: 6379
-          protocol: TCP
-        - port: 26379
-          protocol: TCP
         - port: 6380
           protocol: TCP
         - port: 26380

--- a/deploy/k8s/outgress.yaml
+++ b/deploy/k8s/outgress.yaml
@@ -45,13 +45,13 @@ spec:
         config.linkerd.io/proxy-cpu-limit: 1000m
         config.linkerd.io/proxy-memory-request: 16Mi
         config.linkerd.io/proxy-memory-limit: 128Mi
-        # Valkey (6379/26379) and the Twitch Helix egress (443) skip the proxy.
+        # The Twitch Helix egress (443) skips the proxy.
         # Outgress's hot path is a synchronous POST to api.twitch.tv; routing it
         # through the linkerd sidecar adds a proxy hop per send for an external,
         # already-TLS destination the mesh cannot mTLS anyway. twitch-ingress
         # skips 443 for the same reason. 4222 is NATS — now out of the mesh, so its
         # own TLS encrypts the wire and the proxy would only tax it.
-        config.linkerd.io/skip-outbound-ports: 6379,26379,443,4222
+        config.linkerd.io/skip-outbound-ports: "443,4222"
     spec:
       tolerations:
         - key: itsbagelbot.dev/pool

--- a/deploy/k8s/projector.yaml
+++ b/deploy/k8s/projector.yaml
@@ -42,9 +42,8 @@ spec:
         config.linkerd.io/proxy-cpu-limit: 750m
         config.linkerd.io/proxy-memory-request: 16Mi
         config.linkerd.io/proxy-memory-limit: 96Mi
-        # Valkey (6379/26379) and NATS (4222 — now out of the mesh, its own TLS
-        # encrypts the wire) skip the proxy.
-        config.linkerd.io/skip-outbound-ports: 6379,26379,4222
+        # NATS is out of the mesh and encrypts the wire with native TLS.
+        config.linkerd.io/skip-outbound-ports: "4222"
     spec:
       tolerations:
         - key: itsbagelbot.dev/pool

--- a/deploy/k8s/sesame.yaml
+++ b/deploy/k8s/sesame.yaml
@@ -50,9 +50,8 @@ spec:
         config.linkerd.io/proxy-cpu-limit: 1000m
         config.linkerd.io/proxy-memory-request: 16Mi
         config.linkerd.io/proxy-memory-limit: 128Mi
-        # Valkey (6379/26379) and NATS (4222 — now out of the mesh, its own TLS
-        # encrypts the wire) skip the proxy.
-        config.linkerd.io/skip-outbound-ports: 6379,26379,4222
+        # NATS is out of the mesh and encrypts the wire with native TLS.
+        config.linkerd.io/skip-outbound-ports: "4222"
     spec:
       tolerations:
         - key: itsbagelbot.dev/pool

--- a/pkg/valkey/client.go
+++ b/pkg/valkey/client.go
@@ -87,7 +87,7 @@ func buildOption(address, password string, replicaReads bool, tlsConfig *tls.Con
 // Client routes writes to the Sentinel-elected master and read-only commands
 // to the node-local Valkey instance.
 //
-// Topology: each Kubernetes node runs one Valkey pod that binds 6379 on the
+// Topology: each Kubernetes node runs one Valkey pod that binds TLS port 6380 on the
 // host (hostPort). Whatever role that local instance holds (master on the
 // primary node, a replica everywhere else) it is always the lowest-latency
 // instance for pods on that node. So:
@@ -97,7 +97,7 @@ func buildOption(address, password string, replicaReads bool, tlsConfig *tls.Con
 //   - pub/sub (Receive)     -> a dedicated master-pinned Sentinel client with no
 //     replica-read offload, so expiry notifications (master-only) are actually
 //     received;
-//   - read-only commands    -> a direct connection to NODE_IP:6379, the local
+//   - read-only commands    -> a direct TLS connection to NODE_IP:6380, the local
 //     instance, with no cross-node hop.
 //
 // valkey-go's Sentinel client cannot prefer a local replica on its own:
@@ -163,7 +163,7 @@ func allReadOnly(multi []valkey_go.Completed) bool {
 //
 // Writes always go to the Sentinel-elected master. For a Sentinel deployment
 // with NODE_IP set, read-only commands go to the node-local instance
-// (NODE_IP:6379) so each node reads from its own Valkey without a cross-node
+// (NODE_IP:6380) so each node reads from its own Valkey without a cross-node
 // hop. Otherwise reads fall back to a Sentinel replica (or the single
 // instance, for a standalone address).
 func NewClient(address, password string) (valkey_go.Client, error) {
@@ -193,7 +193,7 @@ func NewClient(address, password string) (valkey_go.Client, error) {
 	wrapped := &Client{Client: master, pubsub: pubsub}
 
 	// Node-local read path: a Sentinel deployment where every node hosts a
-	// Valkey instance on NODE_IP:6379.
+	// Valkey instance on NODE_IP:6380 in production.
 	nodeIP := os.Getenv("NODE_IP")
 	if nodeIP == "" {
 		return wrapped, nil


### PR DESCRIPTION
## Summary
- disable plaintext Valkey and Sentinel listeners, including retained-PVC overrides
- expose and allow only native TLS ports 6380/26380 in production
- clean stale plaintext deployment annotations and documentation

## Validation
- `kubectl kustomize deploy/infra/valkey`
- server-side dry-run of Valkey resources
- `kubectl kustomize deploy/k8s` and server-side dry-run
- `go test ./pkg/valkey`
- `bun test shared` (77 pass, 1 integration skip)
- Svelte checks (0 errors)