### PR TITLE
perf(valkey): keep local reads on pod network

### DIFF
--- a/deploy/infra/valkey/services.yaml
+++ b/deploy/infra/valkey/services.yaml
@@ -27,6 +27,31 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
+    app.kubernetes.io/component: node
+    app.kubernetes.io/instance: valkey
+    app.kubernetes.io/name: valkey
+  name: valkey-local
+  namespace: valkey
+spec:
+  # kube-proxy selects only the endpoint on the caller's node. This keeps
+  # node-local reads on the pod network instead of looping through the node's
+  # Tailnet address and hostPort.
+  internalTrafficPolicy: Local
+  ports:
+  - name: tls-redis
+    port: 6380
+    protocol: TCP
+    targetPort: redis-tls
+  selector:
+    app.kubernetes.io/component: node
+    app.kubernetes.io/instance: valkey
+    app.kubernetes.io/name: valkey
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
     app.kubernetes.io/instance: valkey
     app.kubernetes.io/name: valkey
   name: valkey-headless

--- a/deploy/k8s/gateway.yaml
+++ b/deploy/k8s/gateway.yaml
@@ -125,11 +125,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-            # Node-local Valkey TLS reads (NODE_IP:6380); writes ride Sentinel.
+            # Node-local Valkey TLS reads stay on the pod network; writes ride Sentinel.
             - name: NODE_IP
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: VALKEY_LOCAL_ADDR
+              value: valkey-local.valkey.svc.cluster.local:6380
             - name: GOMEMLIMIT
               value: 96MiB
           envFrom:

--- a/deploy/k8s/outgress.yaml
+++ b/deploy/k8s/outgress.yaml
@@ -152,6 +152,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: VALKEY_LOCAL_ADDR
+              value: valkey-local.valkey.svc.cluster.local:6380
             - name: GOMEMLIMIT
               value: 512MiB
             # Sized for the 50-100k firehose (see sesame.yaml). A high MIN keeps

--- a/deploy/k8s/projector.yaml
+++ b/deploy/k8s/projector.yaml
@@ -113,6 +113,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: VALKEY_LOCAL_ADDR
+              value: valkey-local.valkey.svc.cluster.local:6380
             - name: NATS_PROJECTOR_DASHBOARD_SUBJECT_PREFIX
               value: bagel.rpc.projector.dashboard
             - name: PROJECTOR_WRITE_CONCURRENCY

--- a/deploy/k8s/sesame.yaml
+++ b/deploy/k8s/sesame.yaml
@@ -162,6 +162,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: VALKEY_LOCAL_ADDR
+              value: valkey-local.valkey.svc.cluster.local:6380
             - name: GOMEMLIMIT
               value: 512MiB
             # Reuse the worker's shared lane consumer so this is a true drop-in:

--- a/pkg/valkey/client.go
+++ b/pkg/valkey/client.go
@@ -205,8 +205,16 @@ func NewClient(address, password string) (valkey_go.Client, error) {
 		return wrapped, nil
 	}
 
-	localAddress := localReadAddress(nodeIP, os.Getenv("VALKEY_LOCAL_ADDR"), tlsConfig != nil)
-	local, err := valkey_go.NewClient(localReadOption(localAddress, password, tlsConfig))
+	localAddress := (localEndpoint{
+		nodeIP:     nodeIP,
+		configured: os.Getenv("VALKEY_LOCAL_ADDR"),
+		tlsEnabled: tlsConfig != nil,
+	}).address()
+	local, err := valkey_go.NewClient((localReadConfig{
+		address:   localAddress,
+		password:  password,
+		tlsConfig: tlsConfig,
+	}).option())
 	if err != nil {
 		// Local instance unreachable at startup: degrade to Sentinel-only
 		// rather than fail the service. Reads go to a Sentinel replica;
@@ -220,25 +228,37 @@ func NewClient(address, password string) (valkey_go.Client, error) {
 	return wrapped, nil
 }
 
-func localReadOption(address, password string, tlsConfig *tls.Config) valkey_go.ClientOption {
+type localReadConfig struct {
+	address   string
+	password  string
+	tlsConfig *tls.Config
+}
+
+func (c localReadConfig) option() valkey_go.ClientOption {
 	return valkey_go.ClientOption{
-		InitAddress:         []string{address},
-		Password:            password,
+		InitAddress:         []string{c.address},
+		Password:            c.password,
 		DisableCache:        true,
-		TLSConfig:           cloneTLSConfig(tlsConfig),
+		TLSConfig:           cloneTLSConfig(c.tlsConfig),
 		PipelineMultiplex:   localPipelineMultiplex,
 		ReadBufferEachConn:  localBufferSize,
 		WriteBufferEachConn: localBufferSize,
 	}
 }
 
-func localReadAddress(nodeIP, configured string, tlsEnabled bool) string {
-	if configured != "" {
-		return secureAddress(configured, tlsEnabled)
+type localEndpoint struct {
+	nodeIP     string
+	configured string
+	tlsEnabled bool
+}
+
+func (e localEndpoint) address() string {
+	if e.configured != "" {
+		return secureAddress(e.configured, e.tlsEnabled)
 	}
 	port := plainDataPort
-	if tlsEnabled {
+	if e.tlsEnabled {
 		port = tlsDataPort
 	}
-	return net.JoinHostPort(nodeIP, port)
+	return net.JoinHostPort(e.nodeIP, port)
 }

--- a/pkg/valkey/client.go
+++ b/pkg/valkey/client.go
@@ -21,6 +21,12 @@ const (
 	writePoolMinSize    = 4
 	writePoolBufferSize = 32 << 10
 	writePoolIdleTime   = 30 * time.Second
+
+	// Local reads stay auto-pipelined, but spread over 32 small-buffer
+	// connections. Production-path A/B tests improved throughput without the
+	// memory cost of valkey-go's default 512 KiB buffers per direction.
+	localPipelineMultiplex = 5
+	localBufferSize        = 8 << 10
 )
 
 // BuildClientOption constructs the Valkey client option for the master/write
@@ -87,9 +93,10 @@ func buildOption(address, password string, replicaReads bool, tlsConfig *tls.Con
 // Client routes writes to the Sentinel-elected master and read-only commands
 // to the node-local Valkey instance.
 //
-// Topology: each Kubernetes node runs one Valkey pod that binds TLS port 6380 on the
-// host (hostPort). Whatever role that local instance holds (master on the
-// primary node, a replica everywhere else) it is always the lowest-latency
+// Topology: each Kubernetes node runs one Valkey pod. The valkey-local Service
+// has internalTrafficPolicy=Local, so kube-proxy selects that node's endpoint
+// without a Tailnet or hostPort loop. Whatever role that local instance holds
+// (master on the primary node, a replica elsewhere) it is the lowest-latency
 // instance for pods on that node. So:
 //
 //   - writes and topology  -> the embedded Sentinel client, which always tracks
@@ -97,8 +104,7 @@ func buildOption(address, password string, replicaReads bool, tlsConfig *tls.Con
 //   - pub/sub (Receive)     -> a dedicated master-pinned Sentinel client with no
 //     replica-read offload, so expiry notifications (master-only) are actually
 //     received;
-//   - read-only commands    -> a direct TLS connection to NODE_IP:6380, the local
-//     instance, with no cross-node hop.
+//   - read-only commands    -> valkey-local over TLS, with no cross-node hop.
 //
 // valkey-go's Sentinel client cannot prefer a local replica on its own:
 // ReadNodeSelector is cluster-mode only, and the Sentinel path picks a replica
@@ -162,10 +168,10 @@ func allReadOnly(multi []valkey_go.Completed) bool {
 // NewClient initializes a Valkey client.
 //
 // Writes always go to the Sentinel-elected master. For a Sentinel deployment
-// with NODE_IP set, read-only commands go to the node-local instance
-// (NODE_IP:6380) so each node reads from its own Valkey without a cross-node
-// hop. Otherwise reads fall back to a Sentinel replica (or the single
-// instance, for a standalone address).
+// with NODE_IP set, read-only commands go to VALKEY_LOCAL_ADDR when configured,
+// otherwise to NODE_IP. The production Service uses internalTrafficPolicy=Local
+// so each node reads its own Valkey without a cross-node hop. Otherwise reads
+// fall back to a Sentinel replica (or the single instance, for standalone).
 func NewClient(address, password string) (valkey_go.Client, error) {
 	tlsConfig, err := clientTLSConfig()
 	if err != nil {
@@ -199,16 +205,8 @@ func NewClient(address, password string) (valkey_go.Client, error) {
 		return wrapped, nil
 	}
 
-	localPort := plainDataPort
-	if tlsConfig != nil {
-		localPort = tlsDataPort
-	}
-	local, err := valkey_go.NewClient(valkey_go.ClientOption{
-		InitAddress:  []string{net.JoinHostPort(nodeIP, localPort)},
-		Password:     password,
-		DisableCache: true,
-		TLSConfig:    cloneTLSConfig(tlsConfig),
-	})
+	localAddress := localReadAddress(nodeIP, os.Getenv("VALKEY_LOCAL_ADDR"), tlsConfig != nil)
+	local, err := valkey_go.NewClient(localReadOption(localAddress, password, tlsConfig))
 	if err != nil {
 		// Local instance unreachable at startup: degrade to Sentinel-only
 		// rather than fail the service. Reads go to a Sentinel replica;
@@ -217,7 +215,30 @@ func NewClient(address, password string) (valkey_go.Client, error) {
 		return wrapped, nil
 	}
 
-	log.Printf("valkey: reading from node-local instance %s:%s", nodeIP, localPort)
+	log.Printf("valkey: reading from node-local instance %s", localAddress)
 	wrapped.local = local
 	return wrapped, nil
+}
+
+func localReadOption(address, password string, tlsConfig *tls.Config) valkey_go.ClientOption {
+	return valkey_go.ClientOption{
+		InitAddress:         []string{address},
+		Password:            password,
+		DisableCache:        true,
+		TLSConfig:           cloneTLSConfig(tlsConfig),
+		PipelineMultiplex:   localPipelineMultiplex,
+		ReadBufferEachConn:  localBufferSize,
+		WriteBufferEachConn: localBufferSize,
+	}
+}
+
+func localReadAddress(nodeIP, configured string, tlsEnabled bool) string {
+	if configured != "" {
+		return secureAddress(configured, tlsEnabled)
+	}
+	port := plainDataPort
+	if tlsEnabled {
+		port = tlsDataPort
+	}
+	return net.JoinHostPort(nodeIP, port)
 }

--- a/pkg/valkey/client_test.go
+++ b/pkg/valkey/client_test.go
@@ -61,14 +61,18 @@ func TestSecureAddressUsesNativeTLSPorts(t *testing.T) {
 func TestLocalReadAddressPrefersLocalService(t *testing.T) {
 	assert.Equal(t,
 		"valkey-local.valkey.svc.cluster.local:6380",
-		localReadAddress("100.95.95.9", "valkey-local.valkey.svc.cluster.local:6379", true),
+		(localEndpoint{nodeIP: "100.95.95.9", configured: "valkey-local.valkey.svc.cluster.local:6379", tlsEnabled: true}).address(),
 	)
-	assert.Equal(t, "100.95.95.9:6380", localReadAddress("100.95.95.9", "", true))
-	assert.Equal(t, "100.95.95.9:6379", localReadAddress("100.95.95.9", "", false))
+	assert.Equal(t, "100.95.95.9:6380", (localEndpoint{nodeIP: "100.95.95.9", tlsEnabled: true}).address())
+	assert.Equal(t, "100.95.95.9:6379", (localEndpoint{nodeIP: "100.95.95.9"}).address())
 }
 
 func TestLocalReadOptionUsesSmallMultiplexedConnections(t *testing.T) {
-	opts := localReadOption("valkey-local:6380", "password", &tls.Config{MinVersion: tls.VersionTLS12})
+	opts := (localReadConfig{
+		address:   "valkey-local:6380",
+		password:  "password",
+		tlsConfig: &tls.Config{MinVersion: tls.VersionTLS12},
+	}).option()
 	assert.Equal(t, []string{"valkey-local:6380"}, opts.InitAddress)
 	assert.False(t, opts.DisableAutoPipelining)
 	assert.Equal(t, localPipelineMultiplex, opts.PipelineMultiplex)

--- a/pkg/valkey/client_test.go
+++ b/pkg/valkey/client_test.go
@@ -57,3 +57,22 @@ func TestSecureAddressUsesNativeTLSPorts(t *testing.T) {
 	assert.Equal(t, "valkey.valkey.svc.cluster.local:26380", secureAddress("valkey.valkey.svc.cluster.local:26379", true))
 	assert.Equal(t, "valkey.valkey.svc.cluster.local:26379", secureAddress("valkey.valkey.svc.cluster.local:26379", false))
 }
+
+func TestLocalReadAddressPrefersLocalService(t *testing.T) {
+	assert.Equal(t,
+		"valkey-local.valkey.svc.cluster.local:6380",
+		localReadAddress("100.95.95.9", "valkey-local.valkey.svc.cluster.local:6379", true),
+	)
+	assert.Equal(t, "100.95.95.9:6380", localReadAddress("100.95.95.9", "", true))
+	assert.Equal(t, "100.95.95.9:6379", localReadAddress("100.95.95.9", "", false))
+}
+
+func TestLocalReadOptionUsesSmallMultiplexedConnections(t *testing.T) {
+	opts := localReadOption("valkey-local:6380", "password", &tls.Config{MinVersion: tls.VersionTLS12})
+	assert.Equal(t, []string{"valkey-local:6380"}, opts.InitAddress)
+	assert.False(t, opts.DisableAutoPipelining)
+	assert.Equal(t, localPipelineMultiplex, opts.PipelineMultiplex)
+	assert.Equal(t, localBufferSize, opts.ReadBufferEachConn)
+	assert.Equal(t, localBufferSize, opts.WriteBufferEachConn)
+	assert.NotNil(t, opts.TLSConfig)
+}


### PR DESCRIPTION
## Summary
- add a node-local Valkey Service using `internalTrafficPolicy: Local`
- route every shared Go client read through the local pod-network endpoint instead of the Tailnet hostPort loop
- use 32 small-buffer auto-pipeline connections for local read throughput while preserving Sentinel master writes

## Production A/B
- verified the local Service resolves to the matching Valkey run ID on all four nodes
- shared Go client, c=5: read p99 ~0.90 ms
- shared Go client, c=25: throughput 28.6k/s, p99 3.07 ms (remaining saturation tail is tracked separately)

## Validation
- `go test ./...`
- Valkey and application kustomize renders
- server-side dry-run for both render sets