### PR TITLE
test(valkey): add fleet p99 acceptance

### DIFF
--- a/deploy/k8s/valkey-live-acceptance/2026-07-13-results.md
+++ b/deploy/k8s/valkey-live-acceptance/2026-07-13-results.md
@@ -1,0 +1,27 @@
+# Valkey p99 acceptance — 2026-07-13
+
+Environment: Valkey 9.1.0, native TLS, one Sentinel primary plus three replicas,
+shared `pkg/valkey` Go client, five concurrent callers, 2,000 warmup requests and
+20,000 measured requests per operation. Reads use the node-local
+`internalTrafficPolicy: Local` Service; writes wait for the Sentinel primary on
+node2.
+
+| Source node | Read p99 | Read rate | Write p99 | Write rate | 2 ms result |
+| --- | ---: | ---: | ---: | ---: | --- |
+| node1 | 0.718 ms | 25,249/s | 4.668 ms | 1,940/s | read only |
+| node2 | 0.789 ms | 20,376/s | 1.765 ms | 9,017/s | pass |
+| node3 | 1.057 ms | 17,331/s | 4.576 ms | 3,207/s | read only |
+| worker1 | 0.328 ms | 50,188/s | 9.854 ms | 762/s | read only |
+
+Every node-local read route passes. The node2 write route also passes because
+the elected primary is local. Remote synchronous writes cannot pass: their p99
+tracks physical node-to-primary RTT, while Valkey's own command histogram is in
+microseconds.
+
+No primary relocation can make every node local. Valkey OSS replication is
+single-primary, and its [replication documentation](https://valkey.io/topics/replication/)
+explicitly warns that writable replica changes are local-only, inconsistent,
+and may be discarded during resync. The
+correct path to fleet-wide sub-2 ms synchronous writes therefore requires a
+key-owner boundary: partition primaries and route each channel's handler to the
+node that owns its keys. Enabling writes on the existing replicas is rejected.

--- a/deploy/k8s/valkey-live-acceptance/README.md
+++ b/deploy/k8s/valkey-live-acceptance/README.md
@@ -1,0 +1,28 @@
+# Valkey fleet p99 acceptance
+
+This probe measures the real shared Go client from every production node. It
+separates the two routes that have different physical limits:
+
+- `read-local` uses the TLS `valkey-local` Service and its same-node endpoint;
+- `write-master` uses Sentinel and waits for the elected primary.
+
+The isolated key has a five-minute TTL and is deleted after each run. Temporary
+pods are pinned to the requested node, use the production CA and ACL password,
+match Sesame's two-CPU limit, and are cleaned up automatically.
+
+Run a diagnostic fleet pass without failing on a missed target:
+
+```sh
+deploy/k8s/valkey-live-acceptance/run.sh
+```
+
+Make sub-2 ms p99 a hard acceptance gate:
+
+```sh
+REQUIRE_TARGET=true TARGET=2ms deploy/k8s/valkey-live-acceptance/run.sh
+```
+
+`NODES`, `CONCURRENCY`, `REQUESTS`, `WARMUP`, and `MODE=read|write|both` are
+configurable. A write failure on a remote node is an architectural signal, not
+a reason to enable replica writes: those writes are local-only and can be lost
+or overwritten during resynchronization.

--- a/deploy/k8s/valkey-live-acceptance/main.go
+++ b/deploy/k8s/valkey-live-acceptance/main.go
@@ -1,0 +1,215 @@
+// Command valkey-live-acceptance measures the shared Go client's production
+// read and write routes from one Kubernetes node. It uses an isolated TTL key
+// and reports client-observed percentiles, including network and queueing time.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	shared "ItsBagelBot/pkg/valkey"
+	valkey "github.com/valkey-io/valkey-go"
+)
+
+type config struct {
+	address       string
+	caFile        string
+	mode          string
+	node          string
+	concurrency   int
+	requests      int
+	warmup        int
+	timeout       time.Duration
+	target        time.Duration
+	requireTarget bool
+}
+
+type operation struct {
+	name string
+	key  string
+}
+
+type result struct {
+	Node               string  `json:"node"`
+	Operation          string  `json:"operation"`
+	Concurrency        int     `json:"concurrency"`
+	Requests           int     `json:"requests"`
+	Throughput         float64 `json:"throughput_per_second"`
+	P50Microseconds    float64 `json:"p50_us"`
+	P95Microseconds    float64 `json:"p95_us"`
+	P99Microseconds    float64 `json:"p99_us"`
+	MaxMicroseconds    float64 `json:"max_us"`
+	Errors             int64   `json:"errors"`
+	TargetMicroseconds float64 `json:"target_us"`
+	Passed             bool    `json:"passed"`
+}
+
+type measurement struct {
+	latencies []time.Duration
+	elapsed   time.Duration
+	errors    int64
+}
+
+func main() {
+	cfg := parseFlags()
+	if err := installCA(cfg.caFile); err != nil {
+		fatal(err)
+	}
+
+	client, err := shared.NewClient(cfg.address, os.Getenv("REDISCLI_AUTH"))
+	if err != nil {
+		fatal(err)
+	}
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), cfg.timeout)
+	defer cancel()
+	key := fmt.Sprintf("acceptance:valkey:p99:%s:%d", cfg.node, time.Now().UnixNano())
+	if err := seed(ctx, client, key); err != nil {
+		fatal(err)
+	}
+	defer client.Do(context.Background(), client.B().Del().Key(key).Build())
+
+	failed := false
+	for _, op := range cfg.operations(key) {
+		run(ctx, client, cfg, op, cfg.warmup)
+		measured := run(ctx, client, cfg, op, cfg.requests)
+		report := summarize(cfg, op, measured)
+		if err := json.NewEncoder(os.Stdout).Encode(report); err != nil {
+			fatal(err)
+		}
+		failed = failed || !report.Passed
+	}
+	if cfg.requireTarget && failed {
+		os.Exit(1)
+	}
+}
+
+func parseFlags() config {
+	var cfg config
+	flag.StringVar(&cfg.address, "address", "valkey.valkey.svc.cluster.local:26380", "Sentinel address")
+	flag.StringVar(&cfg.caFile, "ca-file", "/etc/valkey/tls/ca.crt", "fleet CA file")
+	flag.StringVar(&cfg.mode, "mode", "both", "read, write, or both")
+	flag.StringVar(&cfg.node, "node", os.Getenv("NODE_NAME"), "source node label")
+	flag.IntVar(&cfg.concurrency, "concurrency", 5, "concurrent callers")
+	flag.IntVar(&cfg.requests, "requests", 100000, "requests per measured operation")
+	flag.IntVar(&cfg.warmup, "warmup", 5000, "warmup requests per operation")
+	flag.DurationVar(&cfg.timeout, "timeout", 5*time.Minute, "whole-run timeout")
+	flag.DurationVar(&cfg.target, "target", 2*time.Millisecond, "maximum accepted p99")
+	flag.BoolVar(&cfg.requireTarget, "require-target", false, "exit non-zero when any p99 misses target")
+	flag.Parse()
+	if cfg.node == "" || cfg.concurrency < 1 || cfg.requests < 1 || cfg.warmup < 0 || cfg.target <= 0 {
+		fatal(errors.New("invalid benchmark configuration"))
+	}
+	if cfg.mode != "read" && cfg.mode != "write" && cfg.mode != "both" {
+		fatal(errors.New("mode must be read, write, or both"))
+	}
+	return cfg
+}
+
+func installCA(path string) error {
+	pem, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read CA: %w", err)
+	}
+	return os.Setenv("VALKEY_TLS_CA_PEM", string(pem))
+}
+
+func (cfg config) operations(key string) []operation {
+	if cfg.mode == "read" {
+		return []operation{{name: "read-local", key: key}}
+	}
+	if cfg.mode == "write" {
+		return []operation{{name: "write-master", key: key}}
+	}
+	return []operation{{name: "read-local", key: key}, {name: "write-master", key: key}}
+}
+
+func seed(ctx context.Context, client valkey.Client, key string) error {
+	cmd := client.B().Set().Key(key).Value("01234567890123456789012345678901").ExSeconds(300).Build()
+	if err := client.Do(ctx, cmd).Error(); err != nil {
+		return fmt.Errorf("seed key: %w", err)
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if err := client.Do(ctx, client.B().Get().Key(key).Build()).Error(); err == nil {
+			return nil
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return errors.New("seed did not reach node-local replica")
+}
+
+func run(ctx context.Context, client valkey.Client, cfg config, op operation, requests int) measurement {
+	latencies := make([]time.Duration, requests)
+	var next atomic.Int64
+	var failures atomic.Int64
+	start := make(chan struct{})
+	var workers sync.WaitGroup
+	workers.Add(cfg.concurrency)
+	started := time.Now()
+	for range cfg.concurrency {
+		go func() {
+			defer workers.Done()
+			<-start
+			for {
+				i := int(next.Add(1) - 1)
+				if i >= requests {
+					return
+				}
+				began := time.Now()
+				if execute(ctx, client, op).Error() != nil {
+					failures.Add(1)
+				}
+				latencies[i] = time.Since(began)
+			}
+		}()
+	}
+	close(start)
+	workers.Wait()
+	return measurement{latencies: latencies, elapsed: time.Since(started), errors: failures.Load()}
+}
+
+func execute(ctx context.Context, client valkey.Client, op operation) valkey.ValkeyResult {
+	if op.name == "read-local" {
+		return client.Do(ctx, client.B().Get().Key(op.key).Build())
+	}
+	return client.Do(ctx, client.B().Set().Key(op.key).Value("01234567890123456789012345678901").ExSeconds(300).Build())
+}
+
+func summarize(cfg config, op operation, measured measurement) result {
+	sort.Slice(measured.latencies, func(i, j int) bool { return measured.latencies[i] < measured.latencies[j] })
+	p99 := percentile(measured.latencies, 99)
+	return result{
+		Node: cfg.node, Operation: op.name, Concurrency: cfg.concurrency, Requests: len(measured.latencies),
+		Throughput:      float64(len(measured.latencies)) / measured.elapsed.Seconds(),
+		P50Microseconds: micros(percentile(measured.latencies, 50)),
+		P95Microseconds: micros(percentile(measured.latencies, 95)),
+		P99Microseconds: micros(p99), MaxMicroseconds: micros(measured.latencies[len(measured.latencies)-1]),
+		Errors: measured.errors, TargetMicroseconds: micros(cfg.target),
+		Passed: measured.errors == 0 && p99 <= cfg.target,
+	}
+}
+
+func percentile(values []time.Duration, percent int) time.Duration {
+	index := (len(values)*percent + 99) / 100
+	if index < 1 {
+		index = 1
+	}
+	return values[index-1]
+}
+
+func micros(value time.Duration) float64 { return float64(value) / float64(time.Microsecond) }
+
+func fatal(err error) {
+	fmt.Fprintln(os.Stderr, err)
+	os.Exit(2)
+}

--- a/deploy/k8s/valkey-live-acceptance/main.go
+++ b/deploy/k8s/valkey-live-acceptance/main.go
@@ -58,6 +58,13 @@ type measurement struct {
 	errors    int64
 }
 
+type operationRunner struct {
+	ctx    context.Context
+	client valkey.Client
+	cfg    config
+	op     operation
+}
+
 func main() {
 	cfg := parseFlags()
 	if err := installCA(cfg.caFile); err != nil {
@@ -80,8 +87,9 @@ func main() {
 
 	failed := false
 	for _, op := range cfg.operations(key) {
-		run(ctx, client, cfg, op, cfg.warmup)
-		measured := run(ctx, client, cfg, op, cfg.requests)
+		runner := operationRunner{ctx: ctx, client: client, cfg: cfg, op: op}
+		runner.run(cfg.warmup)
+		measured := runner.run(cfg.requests)
 		report := summarize(cfg, op, measured)
 		if err := json.NewEncoder(os.Stdout).Encode(report); err != nil {
 			fatal(err)
@@ -94,7 +102,30 @@ func main() {
 }
 
 func parseFlags() config {
-	var cfg config
+	cfg := defaultConfig()
+	bindFlags(&cfg)
+	flag.Parse()
+	if err := cfg.validate(); err != nil {
+		fatal(err)
+	}
+	return cfg
+}
+
+func defaultConfig() config {
+	return config{
+		address:     "valkey.valkey.svc.cluster.local:26380",
+		caFile:      "/etc/valkey/tls/ca.crt",
+		mode:        "both",
+		node:        os.Getenv("NODE_NAME"),
+		concurrency: 5,
+		requests:    100000,
+		warmup:      5000,
+		timeout:     5 * time.Minute,
+		target:      2 * time.Millisecond,
+	}
+}
+
+func bindFlags(cfg *config) {
 	flag.StringVar(&cfg.address, "address", "valkey.valkey.svc.cluster.local:26380", "Sentinel address")
 	flag.StringVar(&cfg.caFile, "ca-file", "/etc/valkey/tls/ca.crt", "fleet CA file")
 	flag.StringVar(&cfg.mode, "mode", "both", "read, write, or both")
@@ -105,14 +136,30 @@ func parseFlags() config {
 	flag.DurationVar(&cfg.timeout, "timeout", 5*time.Minute, "whole-run timeout")
 	flag.DurationVar(&cfg.target, "target", 2*time.Millisecond, "maximum accepted p99")
 	flag.BoolVar(&cfg.requireTarget, "require-target", false, "exit non-zero when any p99 misses target")
-	flag.Parse()
-	if cfg.node == "" || cfg.concurrency < 1 || cfg.requests < 1 || cfg.warmup < 0 || cfg.target <= 0 {
-		fatal(errors.New("invalid benchmark configuration"))
+}
+
+func (cfg config) validate() error {
+	if cfg.node == "" {
+		return errors.New("node is required")
 	}
-	if cfg.mode != "read" && cfg.mode != "write" && cfg.mode != "both" {
-		fatal(errors.New("mode must be read, write, or both"))
+	if cfg.concurrency < 1 {
+		return errors.New("concurrency must be positive")
 	}
-	return cfg
+	if cfg.requests < 1 {
+		return errors.New("requests must be positive")
+	}
+	if cfg.warmup < 0 {
+		return errors.New("warmup cannot be negative")
+	}
+	if cfg.target <= 0 {
+		return errors.New("target must be positive")
+	}
+	switch cfg.mode {
+	case "read", "write", "both":
+		return nil
+	default:
+		return errors.New("mode must be read, write, or both")
+	}
 }
 
 func installCA(path string) error {
@@ -148,15 +195,15 @@ func seed(ctx context.Context, client valkey.Client, key string) error {
 	return errors.New("seed did not reach node-local replica")
 }
 
-func run(ctx context.Context, client valkey.Client, cfg config, op operation, requests int) measurement {
+func (r operationRunner) run(requests int) measurement {
 	latencies := make([]time.Duration, requests)
 	var next atomic.Int64
 	var failures atomic.Int64
 	start := make(chan struct{})
 	var workers sync.WaitGroup
-	workers.Add(cfg.concurrency)
+	workers.Add(r.cfg.concurrency)
 	started := time.Now()
-	for range cfg.concurrency {
+	for range r.cfg.concurrency {
 		go func() {
 			defer workers.Done()
 			<-start
@@ -166,7 +213,7 @@ func run(ctx context.Context, client valkey.Client, cfg config, op operation, re
 					return
 				}
 				began := time.Now()
-				if execute(ctx, client, op).Error() != nil {
+				if r.execute().Error() != nil {
 					failures.Add(1)
 				}
 				latencies[i] = time.Since(began)
@@ -178,11 +225,12 @@ func run(ctx context.Context, client valkey.Client, cfg config, op operation, re
 	return measurement{latencies: latencies, elapsed: time.Since(started), errors: failures.Load()}
 }
 
-func execute(ctx context.Context, client valkey.Client, op operation) valkey.ValkeyResult {
-	if op.name == "read-local" {
-		return client.Do(ctx, client.B().Get().Key(op.key).Build())
+func (r operationRunner) execute() valkey.ValkeyResult {
+	if r.op.name == "read-local" {
+		return r.client.Do(r.ctx, r.client.B().Get().Key(r.op.key).Build())
 	}
-	return client.Do(ctx, client.B().Set().Key(op.key).Value("01234567890123456789012345678901").ExSeconds(300).Build())
+	cmd := r.client.B().Set().Key(r.op.key).Value("01234567890123456789012345678901").ExSeconds(300).Build()
+	return r.client.Do(r.ctx, cmd)
 }
 
 func summarize(cfg config, op operation, measured measurement) result {

--- a/deploy/k8s/valkey-live-acceptance/main.go
+++ b/deploy/k8s/valkey-live-acceptance/main.go
@@ -65,40 +65,69 @@ type operationRunner struct {
 	op     operation
 }
 
+type application struct {
+	cfg    config
+	client valkey.Client
+	ctx    context.Context
+	cancel context.CancelFunc
+	key    string
+}
+
 func main() {
 	cfg := parseFlags()
-	if err := installCA(cfg.caFile); err != nil {
-		fatal(err)
-	}
+	app := newApplication(cfg)
+	code := app.exitCode()
+	app.close()
+	os.Exit(code)
+}
 
+func newApplication(cfg config) *application {
+	installCAMust(cfg.caFile)
 	client, err := shared.NewClient(cfg.address, os.Getenv("REDISCLI_AUTH"))
 	if err != nil {
 		fatal(err)
 	}
-	defer client.Close()
-
 	ctx, cancel := context.WithTimeout(context.Background(), cfg.timeout)
-	defer cancel()
-	key := fmt.Sprintf("acceptance:valkey:p99:%s:%d", cfg.node, time.Now().UnixNano())
-	if err := seed(ctx, client, key); err != nil {
+	return &application{
+		cfg: cfg, client: client, ctx: ctx, cancel: cancel,
+		key: fmt.Sprintf("acceptance:valkey:p99:%s:%d", cfg.node, time.Now().UnixNano()),
+	}
+}
+
+func (app *application) exitCode() int {
+	if err := seed(app.ctx, app.client, app.key); err != nil {
 		fatal(err)
 	}
-	defer client.Do(context.Background(), client.B().Del().Key(key).Build())
+	failed := app.reportOperations()
+	if app.cfg.requireTarget && failed {
+		return 1
+	}
+	return 0
+}
 
+func (app *application) reportOperations() bool {
 	failed := false
-	for _, op := range cfg.operations(key) {
-		runner := operationRunner{ctx: ctx, client: client, cfg: cfg, op: op}
-		runner.run(cfg.warmup)
-		measured := runner.run(cfg.requests)
-		report := summarize(cfg, op, measured)
-		if err := json.NewEncoder(os.Stdout).Encode(report); err != nil {
-			fatal(err)
-		}
+	for _, op := range app.cfg.operations(app.key) {
+		runner := operationRunner{ctx: app.ctx, client: app.client, cfg: app.cfg, op: op}
+		runner.run(app.cfg.warmup)
+		measured := runner.run(app.cfg.requests)
+		report := summarize(app.cfg, op, measured)
+		emit(report)
 		failed = failed || !report.Passed
 	}
-	if cfg.requireTarget && failed {
-		os.Exit(1)
+	return failed
+}
+
+func emit(report result) {
+	if err := json.NewEncoder(os.Stdout).Encode(report); err != nil {
+		fatal(err)
 	}
+}
+
+func (app *application) close() {
+	app.client.Do(context.Background(), app.client.B().Del().Key(app.key).Build())
+	app.client.Close()
+	app.cancel()
 }
 
 func parseFlags() config {
@@ -168,6 +197,12 @@ func installCA(path string) error {
 		return fmt.Errorf("read CA: %w", err)
 	}
 	return os.Setenv("VALKEY_TLS_CA_PEM", string(pem))
+}
+
+func installCAMust(path string) {
+	if err := installCA(path); err != nil {
+		fatal(err)
+	}
 }
 
 func (cfg config) operations(key string) []operation {

--- a/deploy/k8s/valkey-live-acceptance/run.sh
+++ b/deploy/k8s/valkey-live-acceptance/run.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Fleet-wide production Valkey p99 acceptance. Temporary probe pods and binaries
+# are removed even when a node misses the target.
+set -euo pipefail
+
+namespace=${NAMESPACE:-valkey}
+nodes=${NODES:-"node1 node2 node3 worker1"}
+requests=${REQUESTS:-100000}
+warmup=${WARMUP:-5000}
+concurrency=${CONCURRENCY:-5}
+mode=${MODE:-both}
+target=${TARGET:-2ms}
+require_target=${REQUIRE_TARGET:-false}
+image=${BENCH_IMAGE:-alpine:3.22}
+run_id=$(date -u +%Y%m%d%H%M%S)
+declare -a pods=()
+amd64_binary="/tmp/valkey-live-acceptance-amd64-${run_id}"
+arm64_binary="/tmp/valkey-live-acceptance-arm64-${run_id}"
+
+cleanup() {
+  for pod in "${pods[@]}"; do
+    kubectl -n "$namespace" delete pod "$pod" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+  done
+  rm -f "$amd64_binary" "$arm64_binary"
+}
+trap cleanup EXIT INT TERM
+
+GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -trimpath \
+  -o "$amd64_binary" ./deploy/k8s/valkey-live-acceptance
+GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -trimpath \
+  -o "$arm64_binary" ./deploy/k8s/valkey-live-acceptance
+
+status=0
+for node in $nodes; do
+  arch=$(kubectl get node "$node" -o jsonpath='{.status.nodeInfo.architecture}')
+  if [[ $arch == arm64 ]]; then
+    binary=$arm64_binary
+  else
+    binary=$amd64_binary
+  fi
+  pod="valkey-p99-${node}-${run_id}"
+  pods+=("$pod")
+
+  overrides=$(jq -nc --arg pod "$pod" --arg node "$node" --arg image "$image" '{
+    spec:{nodeName:$node,restartPolicy:"Never",containers:[{
+      name:$pod,image:$image,command:["sleep","1800"],
+      env:[
+        {name:"NODE_NAME",valueFrom:{fieldRef:{fieldPath:"spec.nodeName"}}},
+        {name:"NODE_IP",valueFrom:{fieldRef:{fieldPath:"status.hostIP"}}},
+        {name:"VALKEY_LOCAL_ADDR",value:"valkey-local.valkey.svc.cluster.local:6380"},
+        {name:"REDISCLI_AUTH",valueFrom:{secretKeyRef:{name:"valkey-core-secret",key:"valkey-password"}}}
+      ],
+      volumeMounts:[{name:"tls",mountPath:"/etc/valkey/tls",readOnly:true}],
+      resources:{requests:{cpu:"500m",memory:"128Mi"},limits:{cpu:"2",memory:"768Mi"}},
+      securityContext:{runAsUser:999,runAsGroup:999,allowPrivilegeEscalation:false,capabilities:{drop:["ALL"]}}
+    }],volumes:[{name:"tls",secret:{secretName:"valkey-server-tls"}}],
+    securityContext:{runAsNonRoot:true,runAsUser:999,runAsGroup:999,seccompProfile:{type:"RuntimeDefault"}}
+  }}')
+
+  kubectl -n "$namespace" run "$pod" --image="$image" --restart=Never --overrides="$overrides" -- sleep 1800 >/dev/null
+  kubectl -n "$namespace" wait --for=condition=Ready "pod/$pod" --timeout=120s >/dev/null
+  kubectl -n "$namespace" cp "$binary" "$pod:/tmp/valkey-live-acceptance"
+
+  args=(
+    -node "$node" -mode "$mode" -requests "$requests" -warmup "$warmup"
+    -concurrency "$concurrency" -target "$target"
+  )
+  if [[ $require_target == true ]]; then
+    args+=(-require-target)
+  fi
+  if ! kubectl -n "$namespace" exec "$pod" -- /tmp/valkey-live-acceptance "${args[@]}"; then
+    status=1
+  fi
+  kubectl -n "$namespace" delete pod "$pod" --wait=false >/dev/null
+done
+
+exit "$status"


### PR DESCRIPTION
## Summary
- add a self-cleaning, architecture-aware live Valkey p99 probe for all four nodes
- measure the actual shared Go client read-local and write-master routes separately
- provide a hard `REQUIRE_TARGET=true TARGET=2ms` acceptance gate
- record the 2026-07-13 production matrix

## Production result (c=5)
- every node-local read passes: 0.328-1.057 ms p99
- node2 local write passes: 1.765 ms p99
- remote writes miss: node1 4.668 ms, node3 4.576 ms, worker1 9.854 ms

## Validation
- `go test ./deploy/k8s/valkey-live-acceptance ./pkg/valkey`
- `bash -n deploy/k8s/valkey-live-acceptance/run.sh`
- full fleet diagnostic run
- full fleet hard-gated read run (all four passed)