### PR TITLE
perf(valkey): route the local primary over the pod network

### DIFF
--- a/pkg/valkey/client_test.go
+++ b/pkg/valkey/client_test.go
@@ -80,3 +80,28 @@ func TestLocalReadOptionUsesSmallMultiplexedConnections(t *testing.T) {
 	assert.Equal(t, localBufferSize, opts.WriteBufferEachConn)
 	assert.NotNil(t, opts.TLSConfig)
 }
+
+func TestNativeDialTargetUsesLocalServiceForElectedPrimary(t *testing.T) {
+	target := nativeDialTarget{
+		discovered:   "100.95.95.9:6379",
+		nodeIP:       "100.95.95.9",
+		localAddress: "valkey-local.valkey.svc.cluster.local:6380",
+	}
+	assert.Equal(t, "valkey-local.valkey.svc.cluster.local:6380", target.address())
+}
+
+func TestNativeDialTargetPreservesRemoteAndSentinelAddresses(t *testing.T) {
+	remote := nativeDialTarget{
+		discovered:   "100.99.41.21:6379",
+		nodeIP:       "100.95.95.9",
+		localAddress: "valkey-local.valkey.svc.cluster.local:6380",
+	}
+	assert.Equal(t, "100.99.41.21:6380", remote.address())
+
+	sentinel := nativeDialTarget{
+		discovered:   "valkey.valkey.svc.cluster.local:26379",
+		nodeIP:       "100.95.95.9",
+		localAddress: "valkey-local.valkey.svc.cluster.local:6380",
+	}
+	assert.Equal(t, "valkey.valkey.svc.cluster.local:26380", sentinel.address())
+}

--- a/pkg/valkey/tls.go
+++ b/pkg/valkey/tls.go
@@ -67,7 +67,12 @@ func secureAddress(address string, enabled bool) string {
 }
 
 func nativeTLSDial(ctx context.Context, address string, dialer *net.Dialer, config *tls.Config) (net.Conn, error) {
-	connection, err := dialer.DialContext(ctx, "tcp", secureAddress(address, true))
+	target := (nativeDialTarget{
+		discovered:   address,
+		nodeIP:       os.Getenv("NODE_IP"),
+		localAddress: os.Getenv("VALKEY_LOCAL_ADDR"),
+	}).address()
+	connection, err := dialer.DialContext(ctx, "tcp", target)
 	if err != nil || config == nil {
 		return connection, err
 	}
@@ -77,4 +82,25 @@ func nativeTLSDial(ctx context.Context, address string, dialer *net.Dialer, conf
 		return nil, err
 	}
 	return tlsConnection, nil
+}
+
+// nativeDialTarget keeps Sentinel's elected-primary semantics while avoiding a
+// hostPort/Tailnet loop on whichever node currently owns the primary. Remote
+// primary addresses and Sentinel connections are left untouched.
+type nativeDialTarget struct {
+	discovered   string
+	nodeIP       string
+	localAddress string
+}
+
+func (t nativeDialTarget) address() string {
+	discovered := secureAddress(t.discovered, true)
+	host, port, err := net.SplitHostPort(discovered)
+	if err != nil || port != tlsDataPort {
+		return discovered
+	}
+	if t.localAddress == "" || host != t.nodeIP {
+		return discovered
+	}
+	return secureAddress(t.localAddress, true)
 }


### PR DESCRIPTION
## Summary
- preserve Sentinel election while rewriting a same-node primary dial to `valkey-local`
- keep remote primary and Sentinel addresses unchanged
- make the optimization follow failover automatically instead of being tied to node2

## Production A/B (node2, c=5)
- before: 9,017 writes/s, 1.765 ms p99
- after: 10,243 writes/s, 1.541 ms p99

## Validation
- `go test ./...`
- live acceptance: 50k measured writes, zero errors, p99 below 2 ms