### PR TITLE
docs(valkey): record post-rollout p99 gate

### DIFF
--- a/deploy/k8s/valkey-live-acceptance/2026-07-13-results.md
+++ b/deploy/k8s/valkey-live-acceptance/2026-07-13-results.md
@@ -25,3 +25,22 @@ and may be discarded during resync. The
 correct path to fleet-wide sub-2 ms synchronous writes therefore requires a
 key-owner boundary: partition primaries and route each channel's handler to the
 node that owns its keys. Enabling writes on the existing replicas is rejected.
+
+## Post-rollout hard gate
+
+After deploying the automatic local-primary dial route from PR #394, the
+acceptance probe was repeated with 5,000 warmup requests and 50,000 measured
+requests per operation. `REQUIRE_TARGET=true` made any p99 above 2 ms fail the
+run.
+
+| Source node | Operation | p99 | Rate | Errors | Result |
+| --- | --- | ---: | ---: | ---: | --- |
+| node1 | local read | 0.914 ms | 24,570/s | 0 | pass |
+| node2 | local read | 0.971 ms | 21,122/s | 0 | pass |
+| node3 | local read | 1.158 ms | 17,939/s | 0 | pass |
+| worker1 | local read | 0.254 ms | 51,801/s | 0 | pass |
+| node2 | primary write | 1.695 ms | 10,205/s | 0 | pass |
+
+The write route improved from 9,017/s at 1.765 ms p99 to 10,205/s at
+1.695 ms p99. Sentinel still chooses the primary; the shared client only
+rewrites the dial target when that primary is on the caller's own node.


### PR DESCRIPTION
## Summary
- record the post-rollout production read p99 gate on every node
- record the elected-primary local write p99 and throughput
- preserve the remote synchronous-write RTT boundary in the acceptance report

## Verification
- production hard gate: all local reads below 2 ms p99
- production hard gate: node2 primary writes at 1.695 ms p99 and 10,205/s
- zero probe errors
- all four Sentinels report quorum and all replicas are online