### PR TITLE
chore(valkey): enforce unpartitioned Sentinel config

### DIFF
--- a/deploy/infra/valkey/config/valkey.conf
+++ b/deploy/infra/valkey/config/valkey.conf
@@ -8,6 +8,12 @@ tls-ca-cert-file /etc/valkey/tls/ca.crt
 tls-auth-clients no
 tls-replication yes
 bind 0.0.0.0
+# This fleet is intentionally one Sentinel-managed keyspace, not Valkey
+# Cluster. Keep replicas read-only so Sentinel is the only authority that can
+# promote a writable primary. The StatefulSet repeats both values as command
+# flags so an older CONFIG REWRITE on a retained PVC cannot override them.
+cluster-enabled no
+replica-read-only yes
 loglevel notice
 # Valkey 9.1 uses lock-free queues between the main thread and I/O workers.
 # Two threads fit the 2-CPU container budget on the 6/8-core data-plane nodes;

--- a/deploy/infra/valkey/kustomization.yaml
+++ b/deploy/infra/valkey/kustomization.yaml
@@ -2,6 +2,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: valkey
 
+# This is deliberately an unpartitioned Sentinel topology. The actual Valkey
+# settings live in config/valkey.conf and are repeated as authoritative
+# container flags for retained PVCs. topology_test.go is discovered by the
+# repository's normal `go test ./...` CI run and rejects configuration drift.
 resources:
   - serviceaccount.yaml
   - rbac.yaml

--- a/deploy/infra/valkey/statefulset.yaml
+++ b/deploy/infra/valkey/statefulset.yaml
@@ -1,6 +1,10 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
+  annotations:
+    # One logical keyspace with one Sentinel-elected writable primary.
+    itsbagelbot.dev/valkey-partitioning: disabled
+    itsbagelbot.dev/valkey-topology: sentinel-single-primary
   labels:
     app.kubernetes.io/component: node
     app.kubernetes.io/instance: valkey
@@ -12,7 +16,9 @@ spec:
     whenDeleted: Retain
     whenScaled: Retain
   podManagementPolicy: OrderedReady
-  replicas: 4 # one valkey+sentinel pod per node (hostPort + one-per-node spread): worker1, node2, node1, node3
+  # Four colocated Valkey+Sentinel voters produce one writable primary and
+  # three replicas. This count is a CI-enforced configuration invariant.
+  replicas: 4
   revisionHistoryLimit: 10
   selector:
     matchLabels:
@@ -240,6 +246,13 @@ spec:
         - "6380"
         - --masterauth
         - $(CORE)
+        # Keep the fleet unpartitioned and replicas read-only. These flags are
+        # authoritative over retained /data/valkey.conf files that Valkey may
+        # have rewritten before the policy was committed to the repository.
+        - --cluster-enabled
+        - "no"
+        - --replica-read-only
+        - "yes"
         # Command-line policy is authoritative even for retained PVC configs
         # written before these limits existed. This fixes failover replicas
         # that were still maxmemory=0/noeviction while preserving their role.

--- a/deploy/infra/valkey/topology_test.go
+++ b/deploy/infra/valkey/topology_test.go
@@ -1,0 +1,78 @@
+package valkeyinfra_test
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	topologyMarker    = "itsbagelbot.dev/valkey-topology: sentinel-single-primary"
+	partitioningGuard = "itsbagelbot.dev/valkey-partitioning: disabled"
+)
+
+func TestSentinelSinglePrimaryTopologyIsConfigured(t *testing.T) {
+	statefulSet := readFile(t, "statefulset.yaml")
+	valkeyConfig := readFile(t, "config/valkey.conf")
+
+	assert.Regexp(t, `(?m)^  replicas: 4$`, statefulSet, "four Valkey+Sentinel pods")
+	assert.Contains(t, statefulSet, topologyMarker)
+	assert.Contains(t, statefulSet, partitioningGuard)
+	assert.Contains(t, statefulSet, "- --sentinel")
+	assert.Contains(t, statefulSet, "sentinel monitor myprimary")
+	assert.Contains(t, statefulSet, `echo "replica-priority 0"`)
+	assert.Regexp(t, `(?m)^        - --cluster-enabled\n        - "no"$`, statefulSet, "authoritative Cluster-mode disable flag")
+	assert.Regexp(t, `(?m)^        - --replica-read-only\n        - "yes"$`, statefulSet, "authoritative read-only replica flag")
+	assert.Regexp(t, `(?m)^cluster-enabled no$`, valkeyConfig, "Cluster mode disabled in base config")
+	assert.Regexp(t, `(?m)^replica-read-only yes$`, valkeyConfig, "read-only replicas in base config")
+
+	allSources := infrastructureSources(t)
+	statefulSets := regexp.MustCompile(`(?m)^kind: StatefulSet$`).FindAllStringIndex(allSources, -1)
+	assert.Len(t, statefulSets, 1, "one unpartitioned Valkey failover set")
+	assert.NotRegexp(t,
+		`(?i)cluster-enabled[ =]+yes|cluster-config-file|cluster-announce-|cluster-require-full-coverage|cluster\s+meet`,
+		allSources,
+		"partitioning configuration must remain disabled",
+	)
+}
+
+func TestLocalReadServiceRemainsNodeLocal(t *testing.T) {
+	services := readFile(t, "services.yaml")
+	localService := regexp.MustCompile(`(?s)name: valkey-local\n.*?internalTrafficPolicy: Local\n.*?port: 6380`).FindString(services)
+	if localService == "" {
+		t.Fatal("valkey-local must retain internalTrafficPolicy: Local on TLS port 6380")
+	}
+}
+
+func infrastructureSources(t *testing.T) string {
+	t.Helper()
+	paths := append(glob(t, "*.yaml"), glob(t, "config/*.conf")...)
+	var sources strings.Builder
+	for _, path := range paths {
+		sources.WriteString("\n# source: " + filepath.ToSlash(path) + "\n")
+		sources.WriteString(readFile(t, path))
+	}
+	return sources.String()
+}
+
+func glob(t *testing.T, pattern string) []string {
+	t.Helper()
+	paths, err := filepath.Glob(pattern)
+	if err != nil {
+		t.Fatalf("glob %q: %v", pattern, err)
+	}
+	return paths
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(contents)
+}


### PR DESCRIPTION
## Summary
- explicitly set `cluster-enabled no` and `replica-read-only yes` in the Valkey base configuration
- repeat both settings as authoritative StatefulSet flags so retained PVC rewrites cannot override them
- mark the StatefulSet as `sentinel-single-primary` with partitioning disabled
- add a configuration guard executed automatically by the existing `go test ./...` CI job

## Validation
- production Valkey 9.1 image reports `cluster-enabled=no` and `replica-read-only=yes`
- `go test ./...`
- `go test -race ./deploy/infra/valkey ./pkg/valkey`
- `kubectl kustomize deploy/infra/valkey`

No ADR and no partitioning. The runtime topology remains one Sentinel-elected primary with three read-only replicas.