### PR TITLE
perf(nats): leader-direct dialing, atomic batch wire, lane dedup off

### DIFF
--- a/app/ingress/config/runtime.exs
+++ b/app/ingress/config/runtime.exs
@@ -138,6 +138,15 @@ config :ingress,
   publish_max_pending: String.to_integer(System.get_env("INGRESS_PUBLISH_MAX_PENDING", "16384")),
   publish_batch_size: String.to_integer(System.get_env("INGRESS_PUBLISH_BATCH_SIZE", "128")),
   publish_batch_wait_ms: String.to_integer(System.get_env("INGRESS_PUBLISH_BATCH_WAIT_MS", "1")),
+  # Cohort wire: "single" (per-event PubAck, default) or "atomic" (one ADR-050
+  # batch commit ack per cohort; NATS 2.14). Anything unrecognized stays single.
+  publish_wire:
+    (case System.get_env("INGRESS_PUBLISH_WIRE", "single") do
+       "atomic" -> :atomic
+       _ -> :single
+     end),
+  publish_batch_inflight:
+    String.to_integer(System.get_env("INGRESS_PUBLISH_BATCH_INFLIGHT", "4")),
   # Per-attempt PubAck wait and total attempt budget. Retries are deduplicated
   # broker-side by Nats-Msg-Id, so they can never store an event twice.
   publish_ack_timeout_ms:

--- a/app/ingress/config/runtime.exs
+++ b/app/ingress/config/runtime.exs
@@ -147,8 +147,15 @@ config :ingress,
      end),
   publish_batch_inflight:
     String.to_integer(System.get_env("INGRESS_PUBLISH_BATCH_INFLIGHT", "4")),
-  # Per-attempt PubAck wait and total attempt budget. Retries are deduplicated
-  # broker-side by Nats-Msg-Id, so they can never store an event twice.
+  # "off" strips the Nats-Msg-Id dedup header from lane publishes: the broker's
+  # per-message dedup insert costs ~27% of single-stream ingest capacity and
+  # EventSub websockets never redeliver. Without the header an ambiguous ack
+  # timeout drops instead of retrying (a re-publish could double-store).
+  publish_dedup: System.get_env("INGRESS_PUBLISH_DEDUP", "on") != "off",
+  # Per-attempt PubAck wait and total attempt budget. With dedup on, retries
+  # are folded broker-side by Nats-Msg-Id so they can never store an event
+  # twice; with dedup off, only definite failures (error PubAcks, socket
+  # errors) are retried and ack timeouts drop.
   publish_ack_timeout_ms:
     String.to_integer(System.get_env("INGRESS_PUBLISH_ACK_TIMEOUT_MS", "2000")),
   publish_attempts: String.to_integer(System.get_env("INGRESS_PUBLISH_ATTEMPTS", "3"))

--- a/app/ingress/lib/ingress/config.ex
+++ b/app/ingress/lib/ingress/config.ex
@@ -177,6 +177,17 @@ defmodule Ingress.Config do
   def publish_wire,
     do: Application.get_env(:ingress, :publish_wire, :single)
 
+  # Whether lane publishes carry their Nats-Msg-Id dedup header. The 2026-07-13
+  # live A/B measured the broker's per-message dedup-index insert at ~27% of
+  # the single stream's serialized ingest capacity (86k/s with, 117k/s
+  # without). Twitch EventSub's websocket transport never redelivers, so the
+  # header only ever folded this publisher's own ack-timeout retries; with
+  # dedup off those retries become drops instead (see Publisher.retry?/4) and
+  # the lanes are at-most-once on an ambiguous ack. Applies to premium and
+  # standard identically — lane processing must not diverge.
+  def publish_dedup,
+    do: Application.get_env(:ingress, :publish_dedup, true)
+
   # Ceiling on unresolved atomic batches per shard. The broker allows 50
   # in-flight batches per stream across ALL publishers, so the fleet budget is
   # shards × pods × this cap; overflow cohorts fall back to per-message

--- a/app/ingress/lib/ingress/config.ex
+++ b/app/ingress/lib/ingress/config.ex
@@ -168,6 +168,22 @@ defmodule Ingress.Config do
   def publish_batch_wait_ms,
     do: Application.get_env(:ingress, :publish_batch_wait_ms, 1)
 
+  # Wire protocol for one flushed cohort. :single publishes every event with
+  # its own JetStream PubAck (the long-standing path). :atomic writes the
+  # cohort as one ADR-050 atomic batch (NATS 2.14): a single commit PubAck
+  # per cohort instead of one per event, with per-event Nats-Msg-Id kept for
+  # broker dedup. Default stays :single so the mode ships dark and is enabled
+  # by INGRESS_PUBLISH_WIRE=atomic once the live measurements decide.
+  def publish_wire,
+    do: Application.get_env(:ingress, :publish_wire, :single)
+
+  # Ceiling on unresolved atomic batches per shard. The broker allows 50
+  # in-flight batches per stream across ALL publishers, so the fleet budget is
+  # shards × pods × this cap; overflow cohorts fall back to per-message
+  # publishes rather than risking broker-side batch rejection.
+  def publish_batch_inflight,
+    do: Application.get_env(:ingress, :publish_batch_inflight, 4)
+
   # Number of independent BUS connections (each with its own ack collector) the
   # lane firehose is sharded across. Every publish is a GenServer.call into one
   # Gnat connection process and every PubAck is handled by one collector, so a

--- a/app/ingress/lib/ingress/nats/publisher.ex
+++ b/app/ingress/lib/ingress/nats/publisher.ex
@@ -5,9 +5,13 @@ defmodule Ingress.Nats.Publisher do
   Calls arriving within `publish_batch_wait_ms` are staged as a local cohort,
   then published through Gnat on one of two wires (`Config.publish_wire/0`):
 
-    * `:single` (default) — one ordinary JetStream PubAck per event. Each event
-      retains its `Nats-Msg-Id`, so a missing PubAck is retried safely and the
-      broker folds the replay.
+    * `:single` (default) — one ordinary JetStream PubAck per event. With
+      `Config.publish_dedup/0` on, each event retains its `Nats-Msg-Id`, so a
+      missing PubAck is retried safely and the broker folds the replay. With
+      dedup off (the production setting — the dedup insert costs ~27% of
+      single-stream ingest capacity and EventSub websockets never redeliver),
+      ids are stripped at admission and an ambiguous ack timeout drops the
+      event instead of retrying; only definite failures retry.
     * `:atomic` — the cohort is written as one ADR-050 atomic batch (NATS
       2.14): sequenced `Nats-Batch-*` headers, one commit PubAck for the whole
       cohort. Events keep their `Nats-Msg-Id` (deduplication is enforced inside
@@ -82,7 +86,7 @@ defmodule Ingress.Nats.Publisher do
   end
 
   defp admit(
-         %{pid: pid, conn: conn, counter: counter, max_pending: max_pending},
+         %{pid: pid, conn: conn, counter: counter, max_pending: max_pending} = ctx,
          subject,
          json,
          dedup_id
@@ -97,10 +101,16 @@ defmodule Ingress.Nats.Publisher do
         {:error, :not_connected}
 
       true ->
-        GenServer.cast(pid, {:enqueue, subject, json, dedup_id})
+        GenServer.cast(pid, {:enqueue, subject, json, admitted_dedup_id(ctx, dedup_id)})
         :ok
     end
   end
+
+  # With dedup disabled the id is stripped at admission, so everything
+  # downstream — wire headers, retry policy, batch fallback — sees the event
+  # as unprotected and behaves at-most-once on ambiguity.
+  defp admitted_dedup_id(%{dedup: false}, _dedup_id), do: nil
+  defp admitted_dedup_id(_ctx, dedup_id), do: dedup_id
 
   ## Collector lifecycle
 
@@ -140,7 +150,8 @@ defmodule Ingress.Nats.Publisher do
         prefix: prefix,
         table: table,
         conn: conn,
-        max_pending: max_pending
+        max_pending: max_pending,
+        dedup: Config.publish_dedup()
       }
     )
 
@@ -219,7 +230,7 @@ defmodule Ingress.Nats.Publisher do
           retry_or_drop(id, subject, json, dedup_id, attempts, :ack_timeout, state)
 
         {id, :batch, entries, timestamp} when timestamp <= deadline ->
-          fallback_batch(id, entries, state)
+          expire_batch(id, entries, state)
 
         _ ->
           :ok
@@ -372,6 +383,22 @@ defmodule Ingress.Nats.Publisher do
     send_individual_entries(entries, state)
   end
 
+  # A swept batch is the cohort-shaped ack timeout: the commit may have landed
+  # with only its ack lost. Protected entries re-drive and the broker folds
+  # duplicates; unprotected entries (dedup off) are dropped whole rather than
+  # risking a double-stored cohort. Error replies never come here — they are
+  # definite rejections and take fallback_batch directly.
+  defp expire_batch(id, [{_subject, _json, nil, _from} | _] = entries, state) do
+    :ets.delete(state.table, id)
+    count = length(entries)
+    :atomics.sub(state.counter, @idx_pending, count)
+    :atomics.add(state.counter, @idx_failed, count)
+    :atomics.sub(state.counter, @idx_batch_inflight, 1)
+    state
+  end
+
+  defp expire_batch(id, entries, state), do: fallback_batch(id, entries, state)
+
   defp resolve_batch(id, entries, state) do
     :ets.delete(state.table, id)
     count = length(entries)
@@ -444,8 +471,8 @@ defmodule Ingress.Nats.Publisher do
     state
   end
 
-  defp retry_or_drop(id, subject, json, dedup_id, attempts, _reason, state) do
-    if attempts < state.max_attempts do
+  defp retry_or_drop(id, subject, json, dedup_id, attempts, reason, state) do
+    if retry?(dedup_id, attempts, reason, state) do
       :ets.insert(
         state.table,
         {id, :single, subject, json, dedup_id, attempts + 1, now_ms()}
@@ -470,6 +497,14 @@ defmodule Ingress.Nats.Publisher do
       :ok
     end
   end
+
+  # An ack timeout is ambiguous: the broker may have stored the event and only
+  # the ack was lost. Without a Nats-Msg-Id nothing folds a re-publish, so an
+  # unprotected event is dropped rather than risking a duplicate (at-most-once
+  # on ambiguity). Definite failures — error PubAcks, socket errors — mean
+  # nothing was stored, so they stay retried with or without dedup.
+  defp retry?(nil, _attempts, :ack_timeout, _state), do: false
+  defp retry?(_dedup_id, attempts, _reason, state), do: attempts < state.max_attempts
 
   defp ack_key(topic, prefix) do
     plen = byte_size(prefix)

--- a/app/ingress/lib/ingress/nats/publisher.ex
+++ b/app/ingress/lib/ingress/nats/publisher.ex
@@ -3,10 +3,19 @@ defmodule Ingress.Nats.Publisher do
   One scheduler-local, bounded JetStream cohort publisher.
 
   Calls arriving within `publish_batch_wait_ms` are staged as a local cohort,
-  then published through Gnat with one ordinary JetStream PubAck per event. Each
-  event retains its `Nats-Msg-Id`, so a missing PubAck is retried safely and the
-  broker folds the replay. No Fast-Ingest or atomic wire protocol is implemented
-  here; switching to those modes waits for an official client API.
+  then published through Gnat on one of two wires (`Config.publish_wire/0`):
+
+    * `:single` (default) — one ordinary JetStream PubAck per event. Each event
+      retains its `Nats-Msg-Id`, so a missing PubAck is retried safely and the
+      broker folds the replay.
+    * `:atomic` — the cohort is written as one ADR-050 atomic batch (NATS
+      2.14): sequenced `Nats-Batch-*` headers, one commit PubAck for the whole
+      cohort. Events keep their `Nats-Msg-Id` (deduplication is enforced inside
+      batches since 2.12.1). A rejected, abandoned or unacknowledged batch is
+      re-driven per message over the `:single` machinery: atomicity means the
+      broker stored nothing (the retry stores everything exactly once) or
+      everything (the retry folds every duplicate), so the fallback can never
+      double-store. Fast-Ingest (flow-controlled batches) stays out of scope.
 
   `Ingress.Nats.PublisherPool` runs one publisher and BUS connection per online
   BEAM scheduler. Admission and cohort assembly are serialized only inside that local
@@ -25,6 +34,8 @@ defmodule Ingress.Nats.Publisher do
   @idx_retried 4
   @idx_failed 5
   @idx_cohorts 6
+  @idx_batch_inflight 7
+  @idx_batch_fallback 8
 
   @inbox_prefix "_INBOX.ingresspub."
   @sweep_interval_ms 500
@@ -116,7 +127,7 @@ defmodule Ingress.Nats.Publisher do
       write_concurrency: true
     ])
 
-    counter = :atomics.new(6, signed: false)
+    counter = :atomics.new(8, signed: false)
     token = :crypto.strong_rand_bytes(9) |> Base.url_encode64(padding: false)
     prefix = @inbox_prefix <> token <> "."
     max_pending = Config.publish_max_pending()
@@ -139,6 +150,7 @@ defmodule Ingress.Nats.Publisher do
       table: table,
       counter: counter,
       prefix: prefix,
+      batch_token: token,
       sub_topic: prefix <> ">",
       sid: nil,
       conn_ref: nil,
@@ -147,6 +159,8 @@ defmodule Ingress.Nats.Publisher do
       max_attempts: Config.publish_attempts(),
       batch_size: Config.publish_batch_size(),
       batch_wait_ms: Config.publish_batch_wait_ms(),
+      wire: Config.publish_wire(),
+      batch_inflight_cap: Config.publish_batch_inflight(),
       queue: [],
       queue_count: 0,
       flush_token: nil
@@ -204,6 +218,9 @@ defmodule Ingress.Nats.Publisher do
         {id, :single, subject, json, dedup_id, attempts, timestamp} when timestamp <= deadline ->
           retry_or_drop(id, subject, json, dedup_id, attempts, :ack_timeout, state)
 
+        {id, :batch, entries, timestamp} when timestamp <= deadline ->
+          fallback_batch(id, entries, state)
+
         _ ->
           :ok
       end
@@ -220,6 +237,7 @@ defmodule Ingress.Nats.Publisher do
     flush_metric(state.counter, @idx_retried, "Nats/PublishRetried")
     flush_metric(state.counter, @idx_failed, "Nats/PublishFailed")
     flush_metric(state.counter, @idx_cohorts, "Nats/PublishCohorts")
+    flush_metric(state.counter, @idx_batch_fallback, "Nats/PublishBatchFallback")
 
     Metrics.event("Nats/PublishInflight", %{
       shard: state.index,
@@ -227,7 +245,8 @@ defmodule Ingress.Nats.Publisher do
       max_pending: state.max_pending,
       utilization_pct: round(pending * 100 / state.max_pending),
       queued: state.queue_count,
-      batch_size: state.batch_size
+      batch_size: state.batch_size,
+      batches_inflight: :atomics.get(state.counter, @idx_batch_inflight)
     })
 
     schedule(:gauge, @gauge_interval_ms)
@@ -250,8 +269,22 @@ defmodule Ingress.Nats.Publisher do
     entries = Enum.reverse(state.queue)
     state = %{state | queue: [], queue_count: 0, flush_token: nil}
     :atomics.add(state.counter, @idx_cohorts, 1)
-    send_individual_entries(entries, state)
+
+    if atomic_batch?(state, entries) do
+      send_atomic_batch(entries, state)
+    else
+      send_individual_entries(entries, state)
+    end
   end
+
+  # A cohort rides the atomic wire only when the mode is on, it actually
+  # amortizes something (two or more events), and this shard is under its
+  # in-flight batch budget — the broker caps in-flight batches per stream, so
+  # overflow degrades to per-message publishes instead of broker rejections.
+  defp atomic_batch?(%{wire: :atomic} = state, [_, _ | _]),
+    do: :atomics.get(state.counter, @idx_batch_inflight) < state.batch_inflight_cap
+
+  defp atomic_batch?(_state, _entries), do: false
 
   defp send_individual_entries(entries, state) do
     Enum.each(entries, fn {subject, json, dedup_id, from} ->
@@ -276,6 +309,75 @@ defmodule Ingress.Nats.Publisher do
       end
     end)
 
+    state
+  end
+
+  ## Atomic batch wire (ADR-050)
+
+  # Publishes one cohort as an atomic batch: sequenced Nats-Batch-* headers,
+  # the opening message carrying a reply (so a rejected open surfaces at once),
+  # intermediates unacknowledged, and the final message committing the batch
+  # into one PubAck. The whole cohort is tracked as a single ETS row until that
+  # commit ack, an error reply, or the sweep deadline resolves it.
+  defp send_atomic_batch(entries, state) do
+    id = :atomics.add_get(state.counter, @idx_next_id, 1)
+    batch_id = state.batch_token <> "-" <> Integer.to_string(id)
+    :ets.insert(state.table, {id, :batch, entries, now_ms()})
+    :atomics.add(state.counter, @idx_batch_inflight, 1)
+
+    case publish_batch_messages(entries, batch_id, id, state) do
+      :ok -> state
+      {:error, _reason} -> fallback_batch(id, entries, state)
+    end
+  end
+
+  defp publish_batch_messages(entries, batch_id, id, state) do
+    last = length(entries)
+
+    entries
+    |> Enum.with_index(1)
+    |> Enum.reduce_while(:ok, fn {{subject, json, dedup_id, _from}, seq}, :ok ->
+      headers = batch_headers(batch_id, seq, last, dedup_id)
+
+      case safe_pub(state.conn, subject, json, batch_pub_opts(headers, seq, last, id, state)) do
+        :ok -> {:cont, :ok}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+  end
+
+  defp batch_headers(batch_id, seq, last, dedup_id) do
+    commit = if seq == last, do: [{"Nats-Batch-Commit", "1"}], else: []
+
+    [{"Nats-Batch-Id", batch_id}, {"Nats-Batch-Sequence", Integer.to_string(seq)}] ++
+      commit ++ dedup_headers(dedup_id)
+  end
+
+  defp batch_pub_opts(headers, 1, last, id, state) when last > 1,
+    do: [reply_to: state.prefix <> "bs." <> Integer.to_string(id), headers: headers]
+
+  defp batch_pub_opts(headers, seq, last, id, state) when seq == last,
+    do: [reply_to: state.prefix <> "bc." <> Integer.to_string(id), headers: headers]
+
+  defp batch_pub_opts(headers, _seq, _last, _id, _state), do: [headers: headers]
+
+  # Re-drives a failed batch per message over the single wire. Atomicity plus
+  # per-message Nats-Msg-Id makes this converge from either half-state: an
+  # abandoned batch stored nothing, a committed batch whose ack was lost folds
+  # every re-publish as a duplicate.
+  defp fallback_batch(id, entries, state) do
+    :ets.delete(state.table, id)
+    :atomics.sub(state.counter, @idx_batch_inflight, 1)
+    :atomics.add(state.counter, @idx_batch_fallback, 1)
+    send_individual_entries(entries, state)
+  end
+
+  defp resolve_batch(id, entries, state) do
+    :ets.delete(state.table, id)
+    count = length(entries)
+    :atomics.sub(state.counter, @idx_pending, count)
+    :atomics.add(state.counter, @idx_acked, count)
+    :atomics.sub(state.counter, @idx_batch_inflight, 1)
     state
   end
 
@@ -305,6 +407,32 @@ defmodule Ingress.Nats.Publisher do
         end
 
       [] ->
+        state
+    end
+  end
+
+  # Batch-open reply: zero-byte means the broker accepted the batch and the
+  # commit ack will resolve it. A non-empty body is an immediate rejection
+  # (unsupported stream, in-flight limit, duplicate id) — fall back now instead
+  # of waiting out the sweep deadline.
+  defp apply_ack({:batch_start, _id}, "", state), do: state
+
+  defp apply_ack({:batch_start, id}, _body, state) do
+    case :ets.lookup(state.table, id) do
+      [{^id, :batch, entries, _timestamp}] -> fallback_batch(id, entries, state)
+      _ -> state
+    end
+  end
+
+  defp apply_ack({:batch_commit, id}, body, state) do
+    case :ets.lookup(state.table, id) do
+      [{^id, :batch, entries, _timestamp}] ->
+        case Nats.parse_pub_ack(body) do
+          :ok -> resolve_batch(id, entries, state)
+          {:error, _reason} -> fallback_batch(id, entries, state)
+        end
+
+      _ ->
         state
     end
   end
@@ -347,6 +475,12 @@ defmodule Ingress.Nats.Publisher do
     plen = byte_size(prefix)
 
     case topic do
+      <<^prefix::binary-size(plen), "bs.", id::binary>> ->
+        parse_tagged_id(:batch_start, id)
+
+      <<^prefix::binary-size(plen), "bc.", id::binary>> ->
+        parse_tagged_id(:batch_commit, id)
+
       <<^prefix::binary-size(plen), "s.", id::binary>> ->
         parse_single_id(id)
 
@@ -360,9 +494,11 @@ defmodule Ingress.Nats.Publisher do
     end
   end
 
-  defp parse_single_id(id) do
+  defp parse_single_id(id), do: parse_tagged_id(:single, id)
+
+  defp parse_tagged_id(tag, id) do
     case Integer.parse(id) do
-      {value, ""} -> {:single, value}
+      {value, ""} -> {tag, value}
       _ -> nil
     end
   end

--- a/app/ingress/test/nats_batch_integration_test.exs
+++ b/app/ingress/test/nats_batch_integration_test.exs
@@ -5,7 +5,59 @@ defmodule Ingress.NatsCohortIntegrationTest do
 
   @moduletag :integration
 
+  @stream "ELIXIR_BATCH_TEST"
+
   test "Gnat-managed connection receives individual PubAcks from NATS" do
+    with_integration_publisher([], fn conn, ctx ->
+      assert Publisher.enqueue("twitch.ingress.event.standard", ~s({"n":1}), "elixir-1") == :ok
+      assert Publisher.enqueue("twitch.ingress.event.standard", ~s({"n":2}), "elixir-2") == :ok
+
+      assert eventually(fn -> :atomics.get(ctx.counter, 1) == 0 end)
+      assert stream_messages(conn) == 2
+    end)
+  end
+
+  test "atomic wire lands whole cohorts with one commit PubAck" do
+    with_integration_publisher([publish_wire: :atomic, publish_batch_size: 3], fn conn, ctx ->
+      for n <- 1..3 do
+        assert Publisher.enqueue(
+                 "twitch.ingress.event.standard",
+                 ~s({"n":#{n}}),
+                 "elixir-atomic-#{n}"
+               ) == :ok
+      end
+
+      assert eventually(fn -> :atomics.get(ctx.counter, 1) == 0 end)
+      assert stream_messages(conn) == 3
+      assert :ets.info(ctx.table, :size) == 0
+    end)
+  end
+
+  test "atomic wire cannot double-store a replayed cohort" do
+    with_integration_publisher([publish_wire: :atomic, publish_batch_size: 3], fn conn, ctx ->
+      replay = fn ->
+        for n <- 1..3 do
+          assert Publisher.enqueue(
+                   "twitch.ingress.event.standard",
+                   ~s({"n":#{n}}),
+                   "elixir-replay-#{n}"
+                 ) == :ok
+        end
+
+        assert eventually(fn -> :atomics.get(ctx.counter, 1) == 0 end)
+      end
+
+      # First pass stores the cohort; the second carries ids already inside the
+      # dedup window — whether the broker folds the batch or rejects it into
+      # the per-message fallback, the stream must not grow.
+      replay.()
+      assert stream_messages(conn) == 3
+      replay.()
+      assert stream_messages(conn) == 3
+    end)
+  end
+
+  defp with_integration_publisher(overrides, run) do
     port = System.get_env("NATS_INTEGRATION_PORT")
 
     if is_nil(port) do
@@ -13,33 +65,83 @@ defmodule Ingress.NatsCohortIntegrationTest do
     else
       port = String.to_integer(port)
       conn = :gnat_batch_integration
-      previous_size = Application.get_env(:ingress, :publish_batch_size)
-      previous_wait = Application.get_env(:ingress, :publish_batch_wait_ms)
-      Application.put_env(:ingress, :publish_batch_size, 2)
-      Application.put_env(:ingress, :publish_batch_wait_ms, 100)
+
+      overrides =
+        Keyword.merge([publish_batch_size: 2, publish_batch_wait_ms: 100], overrides)
+
+      previous =
+        Enum.map(overrides, fn {key, _} -> {key, Application.get_env(:ingress, key)} end)
+
+      Enum.each(overrides, fn {key, value} -> Application.put_env(:ingress, key, value) end)
 
       {:ok, gnat} = Gnat.start_link(%{host: ~c"127.0.0.1", port: port}, name: conn)
+      ensure_stream(conn)
+      purge_stream(conn)
       start_supervised!({Publisher, [index: 0, conn: conn]})
       :persistent_term.put({Publisher, :n}, 1)
 
       on_exit(fn ->
+        # The Gnat connection is linked to the test process, so it is already
+        # gone when on_exit runs — only VM-global bookkeeping can be restored
+        # here. Broker-side cleanup happens in the `after` below, while the
+        # connection is still alive.
         if Process.alive?(gnat), do: GenServer.stop(gnat)
         :persistent_term.erase({Publisher, :n})
-        restore_env(:publish_batch_size, previous_size)
-        restore_env(:publish_batch_wait_ms, previous_wait)
+
+        Enum.each(previous, fn
+          {key, nil} -> Application.delete_env(:ingress, key)
+          {key, value} -> Application.put_env(:ingress, key, value)
+        end)
       end)
 
-      assert Publisher.enqueue("twitch.ingress.event.standard", ~s({"n":1}), "elixir-1") == :ok
-      assert Publisher.enqueue("twitch.ingress.event.standard", ~s({"n":2}), "elixir-2") == :ok
-
-      ctx = :persistent_term.get({Publisher, :ctx, 0})
-      assert eventually(fn -> :atomics.get(ctx.counter, 1) == 0 end)
-
-      assert {:ok, %{body: body}} =
-               Gnat.request(conn, "$JS.API.STREAM.INFO.ELIXIR_BATCH_TEST", "")
-
-      assert {:ok, %{"state" => %{"messages" => 2}}} = Ingress.JSON.decode(body)
+      try do
+        run.(conn, :persistent_term.get({Publisher, :ctx, 0}))
+      after
+        # Remove the isolated stream: its literal subject sits under the
+        # TWITCH_INGRESS wildcard, so a leftover makes any suite that
+        # provisions the fleet streams against this broker fail on subject
+        # overlap (and its memory reservation crowds out the 1 GiB
+        # TWITCH_INGRESS spec).
+        _ = Gnat.request(conn, "$JS.API.STREAM.DELETE." <> @stream, "")
+      end
     end
+  end
+
+  # Idempotently provisions the isolated test stream with the NATS 2.14 batch
+  # capabilities the production reconciler enables on the fleet streams.
+  defp ensure_stream(conn) do
+    config = %{
+      name: @stream,
+      subjects: ["twitch.ingress.event.standard"],
+      retention: "limits",
+      storage: "memory",
+      discard: "old",
+      max_bytes: 64 * 1024 * 1024,
+      num_replicas: 1,
+      allow_atomic: true,
+      allow_batched: true
+    }
+
+    {:ok, %{body: body}} =
+      Gnat.request(conn, "$JS.API.STREAM.CREATE." <> @stream, Ingress.JSON.encode(config))
+
+    case Ingress.JSON.decode(body) do
+      # name already in use
+      {:ok, %{"error" => %{"err_code" => 10_058}}} -> :ok
+      {:ok, %{"error" => error}} -> raise "stream create failed: #{inspect(error)}"
+      {:ok, _} -> :ok
+    end
+  end
+
+  defp purge_stream(conn) do
+    {:ok, _} = Gnat.request(conn, "$JS.API.STREAM.PURGE." <> @stream, "")
+    :ok
+  end
+
+  defp stream_messages(conn) do
+    {:ok, %{body: body}} = Gnat.request(conn, "$JS.API.STREAM.INFO." <> @stream, "")
+    {:ok, %{"state" => %{"messages" => messages}}} = Ingress.JSON.decode(body)
+    messages
   end
 
   defp eventually(check, attempts \\ 100)
@@ -57,7 +159,4 @@ defmodule Ingress.NatsCohortIntegrationTest do
         eventually(check, attempts - 1)
     end
   end
-
-  defp restore_env(key, nil), do: Application.delete_env(:ingress, key)
-  defp restore_env(key, value), do: Application.put_env(:ingress, key, value)
 end

--- a/app/ingress/test/nats_publisher_atomic_test.exs
+++ b/app/ingress/test/nats_publisher_atomic_test.exs
@@ -1,0 +1,223 @@
+defmodule Ingress.Nats.PublisherAtomicTest do
+  # async: false — the publisher uses a named process, a named ETS table and a
+  # global persistent_term context, so it cannot share the VM with a parallel
+  # instance of itself.
+  use ExUnit.Case, async: false
+
+  alias Ingress.Nats.Publisher
+
+  defmodule FakeGnat do
+    use GenServer
+
+    def start_link(opts),
+      do: GenServer.start_link(__MODULE__, opts, name: Keyword.fetch!(opts, :name))
+
+    def init(opts), do: {:ok, %{test: Keyword.fetch!(opts, :test), sid: 0}}
+
+    def handle_call({:sub, _receiver, _topic, _opts}, _from, state) do
+      {:reply, {:ok, state.sid + 1}, %{state | sid: state.sid + 1}}
+    end
+
+    def handle_call({:pub, topic, message, opts}, _from, state) do
+      send(state.test, {:pub, topic, message, opts})
+      {:reply, :ok, state}
+    end
+  end
+
+  setup do
+    conn = :gnat_bus_pub_atomic_test
+
+    overrides = [
+      publish_wire: :atomic,
+      publish_batch_size: 3,
+      publish_batch_wait_ms: 50,
+      publish_batch_inflight: 4
+    ]
+
+    previous = Enum.map(overrides, fn {key, _} -> {key, Application.get_env(:ingress, key)} end)
+    Enum.each(overrides, fn {key, value} -> Application.put_env(:ingress, key, value) end)
+
+    start_supervised!({FakeGnat, [name: conn, test: self()]})
+    start_supervised!({Publisher, [index: 0, conn: conn]})
+    :persistent_term.put({Publisher, :n}, 1)
+
+    on_exit(fn ->
+      :persistent_term.erase({Publisher, :n})
+
+      Enum.each(previous, fn
+        {key, nil} -> Application.delete_env(:ingress, key)
+        {key, value} -> Application.put_env(:ingress, key, value)
+      end)
+    end)
+
+    %{publisher: Publisher.process_name(0), ctx: :persistent_term.get({Publisher, :ctx, 0})}
+  end
+
+  defp enqueue_cohort do
+    for n <- 1..3 do
+      assert Publisher.enqueue(
+               "twitch.ingress.event.standard",
+               ~s({"n":#{n}}),
+               "msg-#{n}"
+             ) == :ok
+    end
+  end
+
+  defp collect_cohort do
+    for _ <- 1..3 do
+      assert_receive {:pub, _topic, _json, opts}, 500
+      opts
+    end
+  end
+
+  # Gnat preps headers into cowlib iodata before the connection call; decode
+  # them the same way the single-wire publisher test does.
+  defp headers_map(opts) do
+    for [key, ": ", value, "\r\n"] <- Keyword.get(opts, :headers, []), into: %{} do
+      {String.downcase(key), IO.iodata_to_binary(value)}
+    end
+  end
+
+  test "a cohort travels as one sequenced atomic batch with a single commit reply", %{
+    publisher: publisher,
+    ctx: ctx
+  } do
+    enqueue_cohort()
+    [first, middle, last] = collect_cohort()
+
+    [first_headers, middle_headers, last_headers] =
+      Enum.map([first, middle, last], &headers_map/1)
+
+    batch_id = first_headers["nats-batch-id"]
+    assert is_binary(batch_id) and byte_size(batch_id) <= 64
+    assert middle_headers["nats-batch-id"] == batch_id
+    assert last_headers["nats-batch-id"] == batch_id
+
+    assert first_headers["nats-batch-sequence"] == "1"
+    assert middle_headers["nats-batch-sequence"] == "2"
+    assert last_headers["nats-batch-sequence"] == "3"
+
+    refute Map.has_key?(first_headers, "nats-batch-commit")
+    refute Map.has_key?(middle_headers, "nats-batch-commit")
+    assert last_headers["nats-batch-commit"] == "1"
+
+    # Per-event dedup ids survive on the atomic wire.
+    assert first_headers["nats-msg-id"] == "msg-1"
+    assert middle_headers["nats-msg-id"] == "msg-2"
+    assert last_headers["nats-msg-id"] == "msg-3"
+
+    # Only the opening (start errors) and commit (PubAck) messages carry replies.
+    start_reply = Keyword.fetch!(first, :reply_to)
+    commit_reply = Keyword.fetch!(last, :reply_to)
+    assert String.contains?(start_reply, ".bs.")
+    assert String.contains?(commit_reply, ".bc.")
+    refute Keyword.has_key?(middle, :reply_to)
+
+    # Zero-byte start ack changes nothing; the commit PubAck resolves the batch.
+    send(publisher, {:msg, %{topic: start_reply, body: ""}})
+
+    send(
+      publisher,
+      {:msg,
+       %{
+         topic: commit_reply,
+         body: ~s({"stream":"TWITCH_INGRESS","seq":7,"batch":"#{batch_id}","count":3})
+       }}
+    )
+
+    _state = :sys.get_state(publisher)
+    assert :atomics.get(ctx.counter, 1) == 0
+    assert :ets.info(ctx.table, :size) == 0
+  end
+
+  test "a rejected commit falls back to per-message dedup'd publishes", %{
+    publisher: publisher,
+    ctx: ctx
+  } do
+    enqueue_cohort()
+    [_first, _middle, last] = collect_cohort()
+
+    commit_reply = Keyword.fetch!(last, :reply_to)
+
+    send(
+      publisher,
+      {:msg,
+       %{
+         topic: commit_reply,
+         body: ~s({"error":{"code":400,"err_code":10176,"description":"batch incomplete"}})
+       }}
+    )
+
+    # The cohort is re-driven as three individual publishes with their ids.
+    fallback = collect_cohort()
+
+    Enum.each(fallback, fn opts ->
+      headers = headers_map(opts)
+      refute Map.has_key?(headers, "nats-batch-id")
+      refute Map.has_key?(headers, "nats-batch-commit")
+      assert String.starts_with?(headers["nats-msg-id"], "msg-")
+      assert Keyword.fetch!(opts, :reply_to) =~ ".s."
+    end)
+
+    # Still three pending events awaiting their individual PubAcks.
+    _state = :sys.get_state(publisher)
+    assert :atomics.get(ctx.counter, 1) == 3
+    assert :ets.info(ctx.table, :size) == 3
+
+    fallback
+    |> Enum.map(&Keyword.fetch!(&1, :reply_to))
+    |> Enum.with_index(1)
+    |> Enum.each(fn {reply, sequence} ->
+      send(
+        publisher,
+        {:msg, %{topic: reply, body: ~s({"stream":"TWITCH_INGRESS","seq":#{sequence}})}}
+      )
+    end)
+
+    _state = :sys.get_state(publisher)
+    assert :atomics.get(ctx.counter, 1) == 0
+    assert :ets.info(ctx.table, :size) == 0
+  end
+
+  test "a start rejection falls back without waiting for the commit reply", %{
+    publisher: publisher,
+    ctx: ctx
+  } do
+    enqueue_cohort()
+    [first, _middle, _last] = collect_cohort()
+
+    send(
+      publisher,
+      {:msg,
+       %{
+         topic: Keyword.fetch!(first, :reply_to),
+         body:
+           ~s({"error":{"code":400,"err_code":10174,"description":"batch publish not enabled"}})
+       }}
+    )
+
+    fallback = collect_cohort()
+    assert length(fallback) == 3
+
+    _state = :sys.get_state(publisher)
+    assert :atomics.get(ctx.counter, 1) == 3
+  end
+
+  test "cohorts past the in-flight batch budget degrade to individual publishes", %{
+    ctx: ctx
+  } do
+    # Saturate the budget directly (index 7 tracks in-flight atomic batches).
+    :atomics.put(ctx.counter, 7, 4)
+
+    enqueue_cohort()
+    cohort = collect_cohort()
+
+    Enum.each(cohort, fn opts ->
+      headers = headers_map(opts)
+      refute Map.has_key?(headers, "nats-batch-id")
+      assert Keyword.fetch!(opts, :reply_to) =~ ".s."
+    end)
+
+    :atomics.put(ctx.counter, 7, 0)
+  end
+end

--- a/app/ingress/test/nats_publisher_dedup_off_test.exs
+++ b/app/ingress/test/nats_publisher_dedup_off_test.exs
@@ -1,0 +1,152 @@
+defmodule Ingress.Nats.PublisherDedupOffTest do
+  # async: false — the publisher uses a named process, a named ETS table and a
+  # global persistent_term context, so it cannot share the VM with a parallel
+  # instance of itself.
+  use ExUnit.Case, async: false
+
+  alias Ingress.Nats.Publisher
+
+  defmodule FakeGnat do
+    use GenServer
+
+    def start_link(opts),
+      do: GenServer.start_link(__MODULE__, opts, name: Keyword.fetch!(opts, :name))
+
+    def init(opts), do: {:ok, %{test: Keyword.fetch!(opts, :test), sid: 0}}
+
+    def handle_call({:sub, _receiver, _topic, _opts}, _from, state) do
+      {:reply, {:ok, state.sid + 1}, %{state | sid: state.sid + 1}}
+    end
+
+    def handle_call({:pub, topic, message, opts}, _from, state) do
+      send(state.test, {:pub, topic, message, opts})
+      {:reply, :ok, state}
+    end
+  end
+
+  setup context do
+    conn = :gnat_bus_pub_dedup_off_test
+
+    overrides =
+      [publish_dedup: false, publish_batch_size: 8, publish_batch_wait_ms: 10] ++
+        Map.get(context, :overrides, [])
+
+    previous = Enum.map(overrides, fn {key, _} -> {key, Application.get_env(:ingress, key)} end)
+    Enum.each(overrides, fn {key, value} -> Application.put_env(:ingress, key, value) end)
+
+    start_supervised!({FakeGnat, [name: conn, test: self()]})
+    start_supervised!({Publisher, [index: 0, conn: conn]})
+    :persistent_term.put({Publisher, :n}, 1)
+
+    on_exit(fn ->
+      :persistent_term.erase({Publisher, :n})
+
+      Enum.each(previous, fn
+        {key, nil} -> Application.delete_env(:ingress, key)
+        {key, value} -> Application.put_env(:ingress, key, value)
+      end)
+    end)
+
+    %{publisher: Publisher.process_name(0), ctx: :persistent_term.get({Publisher, :ctx, 0})}
+  end
+
+  defp headers_map(opts) do
+    for [key, ": ", value, "\r\n"] <- Keyword.get(opts, :headers, []), into: %{} do
+      {String.downcase(key), IO.iodata_to_binary(value)}
+    end
+  end
+
+  # Rewrites every pending row's timestamp into the past so the next sweep
+  # treats it as expired, without waiting out the real ack timeout. Ages
+  # relative to the current monotonic clock — its absolute value is an
+  # arbitrary (typically negative) offset.
+  defp age_pending_rows(ctx) do
+    expired = System.monotonic_time(:millisecond) - 10_000_000
+
+    for row <- :ets.tab2list(ctx.table) do
+      aged =
+        case row do
+          {id, :single, subject, json, dedup_id, attempts, _ts} ->
+            {id, :single, subject, json, dedup_id, attempts, expired}
+
+          {id, :batch, entries, _ts} ->
+            {id, :batch, entries, expired}
+        end
+
+      :ets.insert(ctx.table, aged)
+    end
+  end
+
+  test "the Nats-Msg-Id header is stripped at admission", %{ctx: ctx} do
+    assert Publisher.enqueue("twitch.ingress.event.standard", "{}", "msg-1") == :ok
+    assert_receive {:pub, _topic, _json, opts}, 500
+
+    refute Map.has_key?(headers_map(opts), "nats-msg-id")
+
+    # The stored row also carries no id, so retry policy sees it unprotected.
+    assert [{_id, :single, _subject, _json, nil, 1, _ts}] = :ets.tab2list(ctx.table)
+  end
+
+  test "an ambiguous ack timeout drops instead of retrying", %{publisher: publisher, ctx: ctx} do
+    assert Publisher.enqueue("twitch.ingress.event.standard", "{}", "msg-1") == :ok
+    assert_receive {:pub, _topic, _json, _opts}, 500
+
+    age_pending_rows(ctx)
+    send(publisher, :sweep)
+    _state = :sys.get_state(publisher)
+
+    # Dropped, not re-published.
+    refute_receive {:pub, _, _, _}, 100
+    assert :ets.info(ctx.table, :size) == 0
+    assert :atomics.get(ctx.counter, 1) == 0
+    # Counter 5 is failed, counter 4 is retried.
+    assert :atomics.get(ctx.counter, 5) == 1
+    assert :atomics.get(ctx.counter, 4) == 0
+  end
+
+  test "a definite error PubAck still retries without dedup", %{publisher: publisher, ctx: ctx} do
+    assert Publisher.enqueue("twitch.ingress.event.standard", "{}", "msg-1") == :ok
+    assert_receive {:pub, _topic, _json, opts}, 500
+    reply = Keyword.fetch!(opts, :reply_to)
+
+    # An error PubAck means the broker did not store the event; the retry
+    # cannot double-store even without a dedup id.
+    send(
+      publisher,
+      {:msg, %{topic: reply, body: ~s({"error":{"code":503,"description":"no responders"}})}}
+    )
+
+    assert_receive {:pub, _topic, _json, retry_opts}, 500
+    refute Map.has_key?(headers_map(retry_opts), "nats-msg-id")
+
+    _state = :sys.get_state(publisher)
+    assert :atomics.get(ctx.counter, 4) == 1
+    assert :atomics.get(ctx.counter, 1) == 1
+  end
+
+  @tag overrides: [publish_wire: :atomic, publish_batch_size: 3]
+  test "an expired unprotected atomic batch is dropped whole", %{
+    publisher: publisher,
+    ctx: ctx
+  } do
+    for n <- 1..3 do
+      assert Publisher.enqueue("twitch.ingress.event.standard", ~s({"n":#{n}}), "msg-#{n}") ==
+               :ok
+    end
+
+    for _ <- 1..3, do: assert_receive({:pub, _, _, _}, 500)
+    assert [{_id, :batch, _entries, _ts}] = :ets.tab2list(ctx.table)
+
+    age_pending_rows(ctx)
+    send(publisher, :sweep)
+    _state = :sys.get_state(publisher)
+
+    # No per-message re-drive: the commit may have landed, so an unprotected
+    # cohort must not be re-published.
+    refute_receive {:pub, _, _, _}, 100
+    assert :ets.info(ctx.table, :size) == 0
+    assert :atomics.get(ctx.counter, 1) == 0
+    assert :atomics.get(ctx.counter, 5) == 3
+    assert :atomics.get(ctx.counter, 7) == 0
+  end
+end

--- a/deploy/k8s/nats-live-acceptance/README.md
+++ b/deploy/k8s/nats-live-acceptance/README.md
@@ -79,3 +79,14 @@ deploy/k8s/nats-live-acceptance/fleet-700k.sh
 
 Override `TARGET_EPS`, `MESSAGES`, or `PAYLOAD_BYTES` as needed.
 The stream and all temporary pods are removed on success, failure, or interrupt.
+
+## Measuring the dedup cost
+
+Every production lane event carries a `Nats-Msg-Id`, and the broker pays a
+dedup-index insert per message inside the stream's serialized ingest path.
+`MSG_ID=off deploy/k8s/nats-live-acceptance/fleet-700k.sh` (or `-msg-id=false`
+on the binary) publishes without the header; the delta against a default run
+is the price of per-message deduplication at rate. The result JSON tags such
+runs with `"mode": "...+no-msg-id"`. Lane processing must stay identical
+between the standard and premium lanes, so any policy change this measurement
+motivates applies to both lanes together.

--- a/deploy/k8s/nats-live-acceptance/fleet-700k.sh
+++ b/deploy/k8s/nats-live-acceptance/fleet-700k.sh
@@ -7,6 +7,10 @@ namespace=${NAMESPACE:-production}
 target_eps=${TARGET_EPS:-700000}
 total_messages=${MESSAGES:-7000000}
 payload_bytes=${PAYLOAD_BYTES:-256}
+# MSG_ID=off publishes without Nats-Msg-Id headers. Run back-to-back with the
+# default to isolate what per-message dedup costs inside the stream's
+# serialized ingest path at production rate.
+msg_id=${MSG_ID:-on}
 image=${BENCH_IMAGE:-alpine:3.22}
 run_id=$(date -u +%Y%m%d%H%M%S)
 stream="FLEET_700K_${run_id}"
@@ -77,7 +81,12 @@ kubectl -n "$namespace" exec "${pods[1]}" -- env NATS_CA=/etc/nats-ca/ca.pem \
   -stream "$stream" -subject "$subject" -setup-only=true -cleanup=false >/dev/null
 stream_created=true
 
-echo "running ${total_messages} messages across node2/node3/worker1; target ${target_eps}/s"
+msg_id_flag="-msg-id=true"
+if [[ "$msg_id" == "off" ]]; then
+  msg_id_flag="-msg-id=false"
+fi
+
+echo "running ${total_messages} messages across node2/node3/worker1; target ${target_eps}/s (msg-id ${msg_id})"
 pids=()
 for i in "${!nodes[@]}"; do
   kubectl -n "$namespace" exec "${pods[$i]}" -- env NATS_CA=/etc/nats-ca/ca.pem \
@@ -86,7 +95,7 @@ for i in "${!nodes[@]}"; do
     -stream "$stream" -subject "$subject" -create-stream=false -cleanup=false \
     -producer-id="${nodes[$i]}" \
     -messages="${messages[$i]}" -publishers="${publishers[$i]}" \
-    -payload-bytes="$payload_bytes" \
+    -payload-bytes="$payload_bytes" "$msg_id_flag" \
     -latency-samples=0 -max-p95=1h \
     >"$results_dir/${nodes[$i]}.json" 2>"$results_dir/${nodes[$i]}.err" &
   pids+=("$!")

--- a/deploy/k8s/nats-live-acceptance/main.go
+++ b/deploy/k8s/nats-live-acceptance/main.go
@@ -42,6 +42,7 @@ type config struct {
 	cleanup        bool
 	createStream   bool
 	setupOnly      bool
+	msgID          bool
 	producerID     string
 	insecureLocal  bool
 	user           string
@@ -204,6 +205,11 @@ func parseFlags() config {
 	flag.BoolVar(&cfg.cleanup, "cleanup", true, "delete the temporary stream on exit")
 	flag.BoolVar(&cfg.createStream, "create-stream", true, "create the isolated stream before benchmarking")
 	flag.BoolVar(&cfg.setupOnly, "setup-only", false, "perform create/cleanup actions without benchmarking")
+	// Production lane events all carry a Nats-Msg-Id, and the broker pays a
+	// dedup-index insert for each one inside the stream's serialized ingest
+	// path. -msg-id=false publishes without the header, isolating that cost:
+	// the delta between the two runs is what per-message dedup costs at rate.
+	flag.BoolVar(&cfg.msgID, "msg-id", true, "attach unique Nats-Msg-Id dedup headers (false measures the no-dedup ingest path)")
 	flag.StringVar(&cfg.producerID, "producer-id", hostname(), "unique producer label for multi-node runs")
 	flag.BoolVar(&cfg.insecureLocal, "insecure-local", false, "allow an open plaintext local test server")
 	flag.Parse()
@@ -301,7 +307,11 @@ func connect(cfg config, ep endpoint, tlsConfig *tls.Config, name string) (clien
 }
 
 func benchmark(cfg config, ep endpoint, tlsConfig *tls.Config) (result, error) {
-	r := result{Endpoint: ep.label, Producer: cfg.producerID, Mode: "nats.go-async-puback", Messages: cfg.messages}
+	mode := "nats.go-async-puback"
+	if !cfg.msgID {
+		mode += "+no-msg-id"
+	}
+	r := result{Endpoint: ep.label, Producer: cfg.producerID, Mode: mode, Messages: cfg.messages}
 	clients, err := benchmarkClients(cfg, ep, tlsConfig)
 	if err != nil {
 		return r, err
@@ -458,7 +468,9 @@ func enqueueWindow(job publishJob, offset, size int) ([]pendingPublish, error) {
 		sequence := offset + i
 		msg := nats.NewMsg(job.cfg.subject)
 		msg.Data = job.payload
-		msg.Header.Set(nats.MsgIdHdr, fmt.Sprintf("live-%s-%d-%d", job.cfg.producerID, job.publisher, sequence))
+		if job.cfg.msgID {
+			msg.Header.Set(nats.MsgIdHdr, fmt.Sprintf("live-%s-%d-%d", job.cfg.producerID, job.publisher, sequence))
+		}
 		future, err := job.client.js.PublishMsgAsync(msg)
 		if err != nil {
 			job.counters.failures.Add(1)
@@ -509,7 +521,9 @@ func latencyProbe(cfg config, js nats.JetStreamContext, payload []byte) ([]time.
 	for i := 0; i < cfg.latencySamples; i++ {
 		msg := nats.NewMsg(cfg.subject)
 		msg.Data = payload
-		msg.Header.Set(nats.MsgIdHdr, fmt.Sprintf("latency-%s-%d", cfg.producerID, i))
+		if cfg.msgID {
+			msg.Header.Set(nats.MsgIdHdr, fmt.Sprintf("latency-%s-%d", cfg.producerID, i))
+		}
 		started := time.Now()
 		if _, err := js.PublishMsg(msg); err != nil {
 			errors++

--- a/deploy/k8s/outgress.yaml
+++ b/deploy/k8s/outgress.yaml
@@ -121,10 +121,15 @@ spec:
             # (NATS_HUB_URL) so stream traffic never pays a leaf forwarding hop;
             # the RPC + cache plane (NATS_RPC_URL / NATS_LEAF_URL) stays on the
             # node-local leaf. NATS_URL is the local-dev fallback only.
+            # The lane consumers dial nats-1 directly: TWITCH_OUTGRESS is
+            # placement-pinned there (pkg/bus/provision.go), so the
+            # PreferSameNode `nats` Service would route every delivery and ack
+            # through a non-leader member on other nodes. The per-pod headless
+            # name is a hub cert SAN and follows the pod across nodes.
             - name: NATS_URL
               value: nats://nats-leaf:4222
             - name: NATS_HUB_URL
-              value: nats://nats:4222
+              value: nats://nats-1.nats-headless.production.svc.cluster.local:4222
             # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS server
             # TLS cert now that NATS is out of the Linkerd mesh; read as RootCAs by
             # pkg/bus (Go services) and the console nats lib (TS).

--- a/deploy/k8s/projector.yaml
+++ b/deploy/k8s/projector.yaml
@@ -82,10 +82,14 @@ spec:
             # (NATS_HUB_URL) so stream traffic never pays a leaf forwarding hop;
             # the RPC + cache plane (NATS_RPC_URL / NATS_LEAF_URL) stays on the
             # node-local leaf. NATS_URL is the local-dev fallback only.
+            # BAGEL_DATA (both the folds it consumes and the events it
+            # publishes) is placement-pinned to nats-1 (pkg/bus/provision.go);
+            # dialing that ordinal directly skips the intra-hub route hop the
+            # PreferSameNode `nats` Service would add from a non-leader member.
             - name: NATS_URL
               value: nats://nats-leaf:4222
             - name: NATS_HUB_URL
-              value: nats://nats:4222
+              value: nats://nats-1.nats-headless.production.svc.cluster.local:4222
             # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS server
             # TLS cert now that NATS is out of the Linkerd mesh; read as RootCAs by
             # pkg/bus (Go services) and the console nats lib (TS).

--- a/deploy/k8s/sesame.yaml
+++ b/deploy/k8s/sesame.yaml
@@ -129,10 +129,20 @@ spec:
             # cluster is the independent Core NATS RPC tier only; sending stream
             # PubAcks through it adds a cross-leaf round trip and stalls large
             # windows.
+            #
+            # The two JetStream planes dial the ordinal that leads their streams
+            # (R1 placement pins from pkg/bus/provision.go), skipping the
+            # intra-hub route hop the PreferSameNode `nats` Service would add on
+            # a non-leader member: consumers (NATS_HUB_URL) sit with
+            # TWITCH_INGRESS on nats-0, the publisher pool
+            # (NATS_HUB_PUBLISH_URL) with TWITCH_OUTGRESS + BAGEL_DATA on
+            # nats-1. Both per-pod headless names are hub cert SANs.
             - name: NATS_URL
               value: tls://nats:4222
             - name: NATS_HUB_URL
-              value: tls://nats:4222
+              value: tls://nats-0.nats-headless.production.svc.cluster.local:4222
+            - name: NATS_HUB_PUBLISH_URL
+              value: tls://nats-1.nats-headless.production.svc.cluster.local:4222
             # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS server
             # TLS cert now that NATS is out of the Linkerd mesh; read as RootCAs by
             # pkg/bus (Go services) and the console nats lib (TS).

--- a/deploy/k8s/twitch-ingress.yaml
+++ b/deploy/k8s/twitch-ingress.yaml
@@ -173,14 +173,19 @@ spec:
             - name: NATS_HOST
               value: nats
             # The RPC plane (:gnat) stays on the node-local leaf. The BUS firehose
-            # plane (:gnat_bus) connects DIRECT to the hub (NATS_HUB_HOST) instead:
-            # the leaf runs no JetStream, so for the firehose it is only a
-            # forwarding hop to the same hub streams. A hub roll re-pins the BUS
-            # connection (Gnat reconnect); the RPC path is unaffected.
+            # plane (:gnat_bus) connects DIRECT to the hub member leading
+            # TWITCH_INGRESS (placement-pinned to nats-0 by the stream contract):
+            # the leaf runs no JetStream, and the PreferSameNode `nats` Service
+            # would land pods on a non-leader member, paying an intra-hub route
+            # hop per publish and PubAck. The per-pod headless name is a hub cert
+            # SAN, follows the pod across nodes, and loses no availability — an
+            # R1 stream is down with its pinned peer no matter which member the
+            # client dialed. A hub roll re-pins the BUS connection (Gnat
+            # reconnect); the RPC path is unaffected.
             - name: NATS_LEAF_HOST
               value: nats-leaf
             - name: NATS_HUB_HOST
-              value: nats
+              value: nats-0.nats-headless.production.svc.cluster.local
             # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS server
             # TLS cert now that NATS is out of the Linkerd mesh; decoded to ssl_opts
             # cacerts in config/runtime.exs. Both :gnat (leaf) and :gnat_bus (hub)

--- a/deploy/k8s/twitch-ingress.yaml
+++ b/deploy/k8s/twitch-ingress.yaml
@@ -229,6 +229,14 @@ spec:
               value: "16000"
             # One atomic JetStream commit per scheduler-local cohort. The 1ms
             # tail bound avoids adding visible latency when traffic is quiet.
+            # Lane publishes carry no Nats-Msg-Id: EventSub websockets never
+            # redeliver, and the 2026-07-13 live A/B measured the broker's
+            # per-message dedup insert at ~27% of single-stream ingest capacity
+            # (86k/s with, 117k/s without). Without the header an ambiguous ack
+            # timeout drops instead of retrying (at-most-once); definite
+            # failures still retry. Applies to premium + standard identically.
+            - name: INGRESS_PUBLISH_DEDUP
+              value: "off"
             - name: INGRESS_PUBLISH_BATCH_SIZE
               value: "128"
             - name: INGRESS_PUBLISH_BATCH_WAIT_MS

--- a/pkg/bus/atomic_batch.go
+++ b/pkg/bus/atomic_batch.go
@@ -1,0 +1,290 @@
+package bus
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/bytedance/sonic"
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nuid"
+	"go.uber.org/zap"
+
+	"ItsBagelBot/pkg/env"
+)
+
+// ADR-050 atomic batch publishing (NATS 2.14): a cohort is written as one
+// batch and the broker answers with a single commit PubAck instead of one
+// PubAck per message. That removes the dominant per-event cost of the async
+// publish path — the reply-subject routing and ack message for every event —
+// while keeping per-message Nats-Msg-Id deduplication (supported inside
+// batches since 2.12.1; a batch containing a duplicate id is rejected whole).
+//
+// The mode is selected by NATS_PUBLISH_WIRE=atomic and defaults to the
+// per-message PubAck wire, so it ships dark and is enabled per service once
+// the live dedup measurements decide the standard/premium lane policy.
+//
+// Failure handling leans on atomicity + dedup: an errored or unacknowledged
+// batch either stored nothing (abandoned) or everything (commit ack lost).
+// The fallback re-publishes the cohort per message with its Nats-Msg-Id, so
+// the broker stores the missing events or folds every duplicate — no
+// double-store in either case. The fallback happens off the send loop, so a
+// rare broker-rejected cohort may interleave with later cohorts; per-message
+// dedup keeps that safe.
+
+const (
+	batchIDHdr     = "Nats-Batch-Id"
+	batchSeqHdr    = "Nats-Batch-Sequence"
+	batchCommitHdr = "Nats-Batch-Commit"
+)
+
+// wireMode selects how a publish cohort reaches the broker.
+type wireMode int
+
+const (
+	// wireSingle publishes every message with its own PubAck (nats.go async).
+	wireSingle wireMode = iota
+	// wireAtomic publishes a cohort as one ADR-050 atomic batch.
+	wireAtomic
+)
+
+func publishWireMode() wireMode {
+	if env.Get("NATS_PUBLISH_WIRE", "single") == "atomic" {
+		return wireAtomic
+	}
+	return wireSingle
+}
+
+// atomicBatchMax is the server's per-batch message ceiling (ADR-050). The
+// cohort collector caps batches at defaultPublishBatchSize, far below it; this
+// guard only protects against a future batch-size bump past the protocol.
+const atomicBatchMax = 1000
+
+var errAtomicAckTimeout = errors.New("bus: atomic batch commit ack timeout")
+
+// atomicSender owns one connection's reply inbox for batch acknowledgements.
+// Sends happen serially from each stream's active-object worker; several
+// workers on the same connection share the sender, so registration is locked.
+type atomicSender struct {
+	nc     *nats.Conn
+	prefix string
+	sub    *nats.Subscription
+
+	mu    sync.Mutex
+	waits map[string]chan *nats.Msg
+}
+
+func newAtomicSender(nc *nats.Conn) (*atomicSender, error) {
+	s := &atomicSender{
+		nc:     nc,
+		prefix: nats.NewInbox() + ".",
+		waits:  make(map[string]chan *nats.Msg),
+	}
+	sub, err := nc.Subscribe(s.prefix+">", s.route)
+	if err != nil {
+		return nil, fmt.Errorf("bus: subscribe atomic batch inbox: %w", err)
+	}
+	s.sub = sub
+	return s, nil
+}
+
+// route delivers broker replies to the cohort awaiting them. Reply subjects
+// are <prefix>s.<id> for the batch-opening message (zero-byte on success,
+// error JSON otherwise) and <prefix>c.<id> for the commit PubAck.
+func (s *atomicSender) route(msg *nats.Msg) {
+	token, ok := strings.CutPrefix(msg.Subject, s.prefix)
+	if !ok {
+		return
+	}
+	kind, id, ok := strings.Cut(token, ".")
+	if !ok {
+		return
+	}
+	if kind == "s" && len(msg.Data) == 0 {
+		return // successful batch open; only the commit ack resolves the cohort
+	}
+	s.mu.Lock()
+	ch := s.waits[id]
+	s.mu.Unlock()
+	if ch == nil {
+		return
+	}
+	select {
+	case ch <- msg:
+	default:
+	}
+}
+
+type atomicCohort struct {
+	id string
+	ch chan *nats.Msg
+	n  int
+}
+
+func (s *atomicSender) begin(id string) chan *nats.Msg {
+	// Two slots: a batch-open error and the commit reply can both arrive.
+	ch := make(chan *nats.Msg, 2)
+	s.mu.Lock()
+	s.waits[id] = ch
+	s.mu.Unlock()
+	return ch
+}
+
+func (s *atomicSender) end(id string) {
+	s.mu.Lock()
+	delete(s.waits, id)
+	s.mu.Unlock()
+}
+
+// send writes one cohort as an atomic batch, preserving the caller's wire
+// order. The first message carries a reply so a rejected batch open surfaces
+// immediately; intermediate messages travel unacknowledged; the final message
+// commits the batch and receives the single PubAck.
+func (s *atomicSender) send(batch []publishRequest) (atomicCohort, error) {
+	if len(batch) > atomicBatchMax {
+		return atomicCohort{}, fmt.Errorf("bus: cohort of %d exceeds the %d-message atomic batch limit", len(batch), atomicBatchMax)
+	}
+	id := nuid.Next()
+	cohort := atomicCohort{id: id, ch: s.begin(id), n: len(batch)}
+	frameBatch(s.prefix, batch, id)
+	for _, req := range batch {
+		if err := s.nc.PublishMsg(req.msg); err != nil {
+			s.end(id)
+			return atomicCohort{}, fmt.Errorf("bus: atomic batch publish %s: %w", req.msg.Subject, err)
+		}
+	}
+	return cohort, nil
+}
+
+// frameBatch stamps ADR-050 batch framing onto a cohort: the opening message
+// carries a reply for immediate rejection errors, intermediates travel
+// unacknowledged, and the final message commits the batch.
+func frameBatch(prefix string, batch []publishRequest, id string) {
+	for i, req := range batch {
+		msg := req.msg
+		msg.Header.Set(batchIDHdr, id)
+		msg.Header.Set(batchSeqHdr, strconv.Itoa(i+1))
+		switch i {
+		case 0:
+			msg.Reply = prefix + "s." + id
+		case len(batch) - 1:
+			msg.Header.Set(batchCommitHdr, "1")
+			msg.Reply = prefix + "c." + id
+		default:
+			msg.Reply = ""
+		}
+	}
+}
+
+// await blocks until the cohort's commit PubAck, a broker error reply, or the
+// timeout. The commit ack must account for every message in the batch.
+func (s *atomicSender) await(cohort atomicCohort, timeout time.Duration) error {
+	defer s.end(cohort.id)
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case msg := <-cohort.ch:
+		return checkBatchAck(msg.Data, cohort)
+	case <-timer.C:
+		return errAtomicAckTimeout
+	}
+}
+
+// batchPubAck is the ADR-050 commit acknowledgement. nats.go v1.52 does not
+// yet expose the batch fields on its PubAck, so they are decoded here.
+type batchPubAck struct {
+	Stream    string          `json:"stream"`
+	Sequence  uint64          `json:"seq"`
+	Duplicate bool            `json:"duplicate"`
+	BatchID   string          `json:"batch"`
+	Count     int             `json:"count"`
+	Error     *batchAckAPIErr `json:"error"`
+}
+
+type batchAckAPIErr struct {
+	Code        int    `json:"code"`
+	ErrCode     int    `json:"err_code"`
+	Description string `json:"description"`
+}
+
+func (e *batchAckAPIErr) Error() string {
+	return fmt.Sprintf("bus: atomic batch rejected (%d/%d): %s", e.Code, e.ErrCode, e.Description)
+}
+
+func checkBatchAck(data []byte, cohort atomicCohort) error {
+	var ack batchPubAck
+	if err := sonic.ConfigFastest.Unmarshal(data, &ack); err != nil {
+		return fmt.Errorf("bus: undecodable atomic batch ack: %w", err)
+	}
+	if ack.Error != nil {
+		return ack.Error
+	}
+	if ack.Sequence == 0 {
+		return errors.New("bus: atomic batch ack carries no stream sequence")
+	}
+	if ack.BatchID != cohort.id || ack.Count != cohort.n {
+		return fmt.Errorf("bus: atomic batch ack mismatch: batch %q count %d, want %q count %d",
+			ack.BatchID, ack.Count, cohort.id, cohort.n)
+	}
+	return nil
+}
+
+// stripBatchHeaders reverts a request staged for an atomic batch so it can be
+// re-published individually: leftover batch headers would make the broker
+// treat it as part of an unknown batch, and the stale reply subject must not
+// leak into nats.go's own async reply management.
+func stripBatchHeaders(batch []publishRequest) {
+	for _, req := range batch {
+		req.msg.Header.Del(batchIDHdr)
+		req.msg.Header.Del(batchSeqHdr)
+		req.msg.Header.Del(batchCommitHdr)
+		req.msg.Reply = ""
+	}
+}
+
+// publishAtomic drives one cohort over the atomic wire: batch send from the
+// worker's serial loop, commit await in the bounded overlap goroutine, and a
+// dedup-protected per-message fallback if the batch is rejected, abandoned,
+// or its ack lost.
+func (w *publishBatchWorker) publishAtomic(batch []publishRequest) {
+	w.slots <- struct{}{}
+	cohort, err := w.owner.sender.send(batch)
+	if err != nil {
+		w.acks.Add(1)
+		go func() {
+			defer w.acks.Done()
+			defer func() { <-w.slots }()
+			w.fallbackIndividually(batch, err)
+		}()
+		return
+	}
+	w.acks.Add(1)
+	go func() {
+		defer w.acks.Done()
+		defer func() { <-w.slots }()
+		if err := w.owner.sender.await(cohort, defaultPublishAckWait); err != nil {
+			w.fallbackIndividually(batch, err)
+			return
+		}
+		w.finish(batch, nil)
+	}()
+}
+
+// fallbackIndividually re-drives a failed atomic cohort message by message.
+// Every request kept its Nats-Msg-Id, so whichever half-state the batch left
+// behind converges: an abandoned batch stores everything exactly once, a
+// committed batch whose ack was lost folds every message as a duplicate.
+func (w *publishBatchWorker) fallbackIndividually(batch []publishRequest, cause error) {
+	w.owner.log.Warn("atomic batch failed; re-publishing cohort individually",
+		zap.Int("messages", len(batch)), zap.Error(cause))
+	stripBatchHeaders(batch)
+	futures, err := w.startAsync(batch)
+	if err != nil {
+		w.finish(batch, err)
+		return
+	}
+	w.finish(batch, w.awaitAsync(futures))
+}

--- a/pkg/bus/atomic_batch_test.go
+++ b/pkg/bus/atomic_batch_test.go
@@ -22,39 +22,53 @@ func TestPublishWireModeDefaultsToSingle(t *testing.T) {
 	}
 }
 
-func TestAtomicSendStagesBatchFraming(t *testing.T) {
-	sender := &atomicSender{prefix: "_INBOX.test.", waits: make(map[string]chan *nats.Msg)}
+// framedBatch stages a 3-message cohort and frames it exactly as send does,
+// without a live connection.
+func framedBatch() []publishRequest {
 	batch := stagedBatch(3)
+	frameBatch("_INBOX.test.", batch, "B1")
+	return batch
+}
 
-	// Frame exactly as send does, without a live connection.
-	cohort := atomicCohort{id: "B1", ch: sender.begin("B1"), n: len(batch)}
-	frameBatch(sender.prefix, batch, cohort.id)
+func TestFrameBatchStampsHeadersAndReplies(t *testing.T) {
+	batch := framedBatch()
 
 	first, mid, last := batch[0].msg, batch[1].msg, batch[2].msg
-	for i, msg := range []*nats.Msg{first, mid, last} {
-		if msg.Header.Get(batchIDHdr) != "B1" {
+	for i, want := range []struct {
+		msg    *nats.Msg
+		seq    string
+		commit string
+		reply  string
+	}{
+		{first, "1", "", "_INBOX.test.s.B1"},
+		{mid, "2", "", ""},
+		{last, "3", "1", "_INBOX.test.c.B1"},
+	} {
+		if want.msg.Header.Get(batchIDHdr) != "B1" {
 			t.Fatalf("message %d lost its batch id", i)
 		}
+		if got := want.msg.Header.Get(batchSeqHdr); got != want.seq {
+			t.Fatalf("message %d sequence %q, want %q", i, got, want.seq)
+		}
+		if got := want.msg.Header.Get(batchCommitHdr); got != want.commit {
+			t.Fatalf("message %d commit header %q, want %q", i, got, want.commit)
+		}
+		if want.msg.Reply != want.reply {
+			t.Fatalf("message %d reply %q, want %q", i, want.msg.Reply, want.reply)
+		}
 	}
-	if first.Header.Get(batchSeqHdr) != "1" || mid.Header.Get(batchSeqHdr) != "2" || last.Header.Get(batchSeqHdr) != "3" {
-		t.Fatal("batch sequence numbering is wrong")
-	}
-	if first.Reply != "_INBOX.test.s.B1" {
-		t.Fatalf("batch-opening message must carry the start reply, got %q", first.Reply)
-	}
-	if mid.Reply != "" || mid.Header.Get(batchCommitHdr) != "" {
-		t.Fatal("intermediate message must travel without reply or commit header")
-	}
-	if last.Header.Get(batchCommitHdr) != "1" || last.Reply != "_INBOX.test.c.B1" {
-		t.Fatal("final message must commit the batch and carry the commit reply")
-	}
+}
 
+func TestStripBatchHeadersRevertsFramingKeepsDedup(t *testing.T) {
+	batch := framedBatch()
 	stripBatchHeaders(batch)
+
 	for i, req := range batch {
-		if req.msg.Reply != "" ||
+		framed := req.msg.Reply != "" ||
 			req.msg.Header.Get(batchIDHdr) != "" ||
 			req.msg.Header.Get(batchSeqHdr) != "" ||
-			req.msg.Header.Get(batchCommitHdr) != "" {
+			req.msg.Header.Get(batchCommitHdr) != ""
+		if framed {
 			t.Fatalf("message %d kept batch framing after strip", i)
 		}
 		if req.msg.Header.Get(nats.MsgIdHdr) == "" {

--- a/pkg/bus/atomic_batch_test.go
+++ b/pkg/bus/atomic_batch_test.go
@@ -1,0 +1,132 @@
+package bus
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/nats-io/nats.go"
+)
+
+func TestPublishWireModeDefaultsToSingle(t *testing.T) {
+	t.Setenv("NATS_PUBLISH_WIRE", "")
+	if publishWireMode() != wireSingle {
+		t.Fatal("unset NATS_PUBLISH_WIRE must select the per-message PubAck wire")
+	}
+	t.Setenv("NATS_PUBLISH_WIRE", "nonsense")
+	if publishWireMode() != wireSingle {
+		t.Fatal("unknown NATS_PUBLISH_WIRE must select the per-message PubAck wire")
+	}
+	t.Setenv("NATS_PUBLISH_WIRE", "atomic")
+	if publishWireMode() != wireAtomic {
+		t.Fatal("NATS_PUBLISH_WIRE=atomic must select the atomic batch wire")
+	}
+}
+
+func TestAtomicSendStagesBatchFraming(t *testing.T) {
+	sender := &atomicSender{prefix: "_INBOX.test.", waits: make(map[string]chan *nats.Msg)}
+	batch := stagedBatch(3)
+
+	// Frame exactly as send does, without a live connection.
+	cohort := atomicCohort{id: "B1", ch: sender.begin("B1"), n: len(batch)}
+	frameBatch(sender.prefix, batch, cohort.id)
+
+	first, mid, last := batch[0].msg, batch[1].msg, batch[2].msg
+	for i, msg := range []*nats.Msg{first, mid, last} {
+		if msg.Header.Get(batchIDHdr) != "B1" {
+			t.Fatalf("message %d lost its batch id", i)
+		}
+	}
+	if first.Header.Get(batchSeqHdr) != "1" || mid.Header.Get(batchSeqHdr) != "2" || last.Header.Get(batchSeqHdr) != "3" {
+		t.Fatal("batch sequence numbering is wrong")
+	}
+	if first.Reply != "_INBOX.test.s.B1" {
+		t.Fatalf("batch-opening message must carry the start reply, got %q", first.Reply)
+	}
+	if mid.Reply != "" || mid.Header.Get(batchCommitHdr) != "" {
+		t.Fatal("intermediate message must travel without reply or commit header")
+	}
+	if last.Header.Get(batchCommitHdr) != "1" || last.Reply != "_INBOX.test.c.B1" {
+		t.Fatal("final message must commit the batch and carry the commit reply")
+	}
+
+	stripBatchHeaders(batch)
+	for i, req := range batch {
+		if req.msg.Reply != "" ||
+			req.msg.Header.Get(batchIDHdr) != "" ||
+			req.msg.Header.Get(batchSeqHdr) != "" ||
+			req.msg.Header.Get(batchCommitHdr) != "" {
+			t.Fatalf("message %d kept batch framing after strip", i)
+		}
+		if req.msg.Header.Get(nats.MsgIdHdr) == "" {
+			t.Fatalf("message %d lost its dedup id during strip", i)
+		}
+	}
+}
+
+func itoa(n int) string {
+	return string(rune('0' + n))
+}
+
+func stagedBatch(n int) []publishRequest {
+	batch := make([]publishRequest, 0, n)
+	for i := 0; i < n; i++ {
+		msg := nats.NewMsg("data.test.batch")
+		msg.Header.Set(nats.MsgIdHdr, "id-"+itoa(i+1))
+		batch = append(batch, publishRequest{msg: msg, msgID: "id-" + itoa(i+1)})
+	}
+	return batch
+}
+
+func TestAtomicRouteFiltersStartAcks(t *testing.T) {
+	sender := &atomicSender{prefix: "_INBOX.test.", waits: make(map[string]chan *nats.Msg)}
+	ch := sender.begin("B1")
+	defer sender.end("B1")
+
+	// Zero-byte start ack: success signal only, must not resolve the cohort.
+	sender.route(&nats.Msg{Subject: "_INBOX.test.s.B1"})
+	select {
+	case <-ch:
+		t.Fatal("zero-byte start ack must be filtered")
+	default:
+	}
+
+	// A start error must reach the waiter.
+	sender.route(&nats.Msg{Subject: "_INBOX.test.s.B1", Data: []byte(`{"error":{"code":400,"err_code":10174,"description":"batch publish not enabled"}}`)})
+	select {
+	case msg := <-ch:
+		err := checkBatchAck(msg.Data, atomicCohort{id: "B1", n: 2})
+		var apiErr *batchAckAPIErr
+		if !errors.As(err, &apiErr) || apiErr.ErrCode != 10174 {
+			t.Fatalf("start error did not surface as a batch API error: %v", err)
+		}
+	default:
+		t.Fatal("start error was not routed to the cohort")
+	}
+
+	// Replies for unknown cohorts and foreign subjects are dropped silently.
+	sender.route(&nats.Msg{Subject: "_INBOX.test.c.UNKNOWN", Data: []byte(`{}`)})
+	sender.route(&nats.Msg{Subject: "other.subject", Data: []byte(`{}`)})
+}
+
+func TestCheckBatchAck(t *testing.T) {
+	cohort := atomicCohort{id: "B1", n: 3}
+
+	if err := checkBatchAck([]byte(`{"stream":"BAGEL_DATA","seq":42,"batch":"B1","count":3}`), cohort); err != nil {
+		t.Fatalf("valid commit ack rejected: %v", err)
+	}
+	if err := checkBatchAck([]byte(`{"error":{"code":400,"err_code":10201,"description":"duplicate message id"}}`), cohort); err == nil {
+		t.Fatal("error ack must fail the cohort")
+	}
+	if err := checkBatchAck([]byte(`{"stream":"BAGEL_DATA","seq":42,"batch":"OTHER","count":3}`), cohort); err == nil {
+		t.Fatal("commit ack for a different batch must fail the cohort")
+	}
+	if err := checkBatchAck([]byte(`{"stream":"BAGEL_DATA","seq":42,"batch":"B1","count":2}`), cohort); err == nil {
+		t.Fatal("commit ack covering fewer messages must fail the cohort")
+	}
+	if err := checkBatchAck([]byte(`{}`), cohort); err == nil {
+		t.Fatal("ack without a stream sequence must fail the cohort")
+	}
+	if err := checkBatchAck([]byte(`not json`), cohort); err == nil {
+		t.Fatal("undecodable ack must fail the cohort")
+	}
+}

--- a/pkg/bus/batch_publisher.go
+++ b/pkg/bus/batch_publisher.go
@@ -59,6 +59,12 @@ type batchPublisher struct {
 	js  nats.JetStreamContext
 	log *zap.Logger
 
+	// wire selects the cohort protocol (per-message PubAcks or ADR-050 atomic
+	// batches); sender is the connection's shared batch-ack inbox, present only
+	// on the atomic wire.
+	wire   wireMode
+	sender *atomicSender
+
 	mu       sync.RWMutex
 	workerMu sync.Mutex
 	closed   bool
@@ -123,8 +129,9 @@ func newPublisherPoolForStream(url, fixedStream string, log *zap.Logger) (Publis
 		poolSize = 32
 	}
 	pool := &publisherPool{members: make([]*batchPublisher, 0, poolSize), router: hashStreamRouter{}, fixedStream: fixedStream}
+	wire := publishWireMode()
 	for i := 0; i < poolSize; i++ {
-		member, err := newBatchPublisherConnection(url, i, log)
+		member, err := newBatchPublisherConnection(url, i, wire, log)
 		if err != nil {
 			_ = pool.Close()
 			return nil, err
@@ -134,8 +141,8 @@ func newPublisherPoolForStream(url, fixedStream string, log *zap.Logger) (Publis
 	return pool, nil
 }
 
-func newBatchPublisherConnection(url string, index int, log *zap.Logger) (*batchPublisher, error) {
-	nc, err := nats.Connect(busURL(url), busOptions(fmt.Sprintf("batch-publisher-%d", index))...)
+func newBatchPublisherConnection(url string, index int, wire wireMode, log *zap.Logger) (*batchPublisher, error) {
+	nc, err := nats.Connect(busPublishURL(url), busOptions(fmt.Sprintf("batch-publisher-%d", index))...)
 	if err != nil {
 		return nil, fmt.Errorf("bus: connect batch publisher: %w", err)
 	}
@@ -144,11 +151,20 @@ func newBatchPublisherConnection(url string, index int, log *zap.Logger) (*batch
 		nc.Close()
 		return nil, fmt.Errorf("bus: jetstream batch publisher: %w", err)
 	}
-	return &batchPublisher{
-		nc: nc, js: js, log: log,
+	publisher := &batchPublisher{
+		nc: nc, js: js, log: log, wire: wire,
 		workers: make(map[string]*publishBatchWorker),
 		changed: make(chan struct{}),
-	}, nil
+	}
+	if wire == wireAtomic {
+		sender, err := newAtomicSender(nc)
+		if err != nil {
+			nc.Close()
+			return nil, err
+		}
+		publisher.sender = sender
+	}
+	return publisher, nil
 }
 
 func (p *publisherPool) PublishOwned(ctx context.Context, topic string, payload []byte) error {
@@ -433,6 +449,12 @@ func stopAndDrainTimer(timer *time.Timer) {
 }
 
 func (w *publishBatchWorker) publish(batch []publishRequest) {
+	// A single-message cohort gains nothing from batch framing; ADR-050 also
+	// shapes a lone commit as an ordinary PubAck, so the plain wire is simpler.
+	if w.owner.wire == wireAtomic && len(batch) > 1 {
+		w.publishAtomic(batch)
+		return
+	}
 	w.slots <- struct{}{}
 	futures, err := w.startAsync(batch)
 	if err != nil {

--- a/pkg/bus/batch_publisher_integration_test.go
+++ b/pkg/bus/batch_publisher_integration_test.go
@@ -2,6 +2,7 @@ package bus
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"sync"
 	"testing"
@@ -21,6 +22,68 @@ func TestBatchPublisherIntegration(t *testing.T) {
 	publishIntegrationMessages(t, pub, messages)
 	flushIntegrationPublisher(t, pub, 5*time.Second)
 	assertIntegrationStream(t, url, messages)
+}
+
+// TestAtomicBatchPublisherIntegration exercises the ADR-050 atomic wire
+// end-to-end: cohorts must land whole with one commit PubAck each.
+func TestAtomicBatchPublisherIntegration(t *testing.T) {
+	t.Setenv("NATS_PUBLISH_WIRE", "atomic")
+	url, pub := openIntegrationPublisher(t)
+	defer closeIntegrationPublisher(t, url, pub)
+	const messages = 64
+	publishIntegrationMessages(t, pub, messages)
+	flushIntegrationPublisher(t, pub, 5*time.Second)
+	assertIntegrationStream(t, url, messages)
+}
+
+// TestAtomicBatchDedupIntegration proves the safety property the fallback
+// relies on: a cohort whose ids were already stored must not store twice.
+// The broker rejects an atomic batch containing already-seen Nats-Msg-Ids
+// (err 10201), the publisher falls back to per-message publishes, and the
+// dedup window folds every one of them.
+func TestAtomicBatchDedupIntegration(t *testing.T) {
+	t.Setenv("NATS_PUBLISH_WIRE", "atomic")
+	url, pub := openIntegrationPublisher(t)
+	defer closeIntegrationPublisher(t, url, pub)
+
+	const messages = 8
+	publishIdentifiedIntegrationMessages(t, pub, messages)
+	flushIntegrationPublisher(t, pub, 5*time.Second)
+	assertIntegrationStream(t, url, messages)
+
+	// Same ids again: whichever path the broker takes (batch rejection +
+	// individual fallback, or batch-level dedup), the stream must not grow
+	// and the publisher must report success.
+	publishIdentifiedIntegrationMessages(t, pub, messages)
+	flushIntegrationPublisher(t, pub, 5*time.Second)
+	assertIntegrationStream(t, url, messages)
+}
+
+func publishIdentifiedIntegrationMessages(t *testing.T, pub Publisher, messages int) {
+	t.Helper()
+	start := make(chan struct{})
+	errs := make(chan error, messages)
+	var wg sync.WaitGroup
+	for i := 0; i < messages; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			errs <- PublishConfirmed(context.Background(), pub, Publication{
+				Subject: "data.test.batch",
+				ID:      fmt.Sprintf("atomic-dedup-%d", i),
+				Payload: []byte(`{"n":1}`),
+			})
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
 }
 
 func publishIntegrationMessages(t *testing.T, pub Publisher, messages int) {
@@ -127,6 +190,7 @@ func openIntegrationPublisher(tb testing.TB) (string, Publisher) {
 	tb.Setenv("NATS_JS_DOMAIN", "hub")
 	tb.Setenv("NATS_LEAF_URL", "")
 	tb.Setenv("NATS_HUB_URL", "")
+	tb.Setenv("NATS_HUB_PUBLISH_URL", "")
 	if err := EnsureStreams(context.Background(), url, DataStreams, zap.NewNop()); err != nil {
 		tb.Fatal(err)
 	}

--- a/pkg/bus/batch_publisher_integration_test.go
+++ b/pkg/bus/batch_publisher_integration_test.go
@@ -61,32 +61,25 @@ func TestAtomicBatchDedupIntegration(t *testing.T) {
 
 func publishIdentifiedIntegrationMessages(t *testing.T, pub Publisher, messages int) {
 	t.Helper()
-	start := make(chan struct{})
-	errs := make(chan error, messages)
-	var wg sync.WaitGroup
-	for i := 0; i < messages; i++ {
-		wg.Add(1)
-		go func(i int) {
-			defer wg.Done()
-			<-start
-			errs <- PublishConfirmed(context.Background(), pub, Publication{
-				Subject: "data.test.batch",
-				ID:      fmt.Sprintf("atomic-dedup-%d", i),
-				Payload: []byte(`{"n":1}`),
-			})
-		}(i)
-	}
-	close(start)
-	wg.Wait()
-	close(errs)
-	for err := range errs {
-		if err != nil {
-			t.Fatal(err)
-		}
-	}
+	publishConcurrently(t, messages, func(i int) error {
+		return PublishConfirmed(context.Background(), pub, Publication{
+			Subject: "data.test.batch",
+			ID:      fmt.Sprintf("atomic-dedup-%d", i),
+			Payload: []byte(`{"n":1}`),
+		})
+	})
 }
 
 func publishIntegrationMessages(t *testing.T, pub Publisher, messages int) {
+	t.Helper()
+	publishConcurrently(t, messages, func(i int) error {
+		return PublishJSON(context.Background(), pub, "data.test.batch", map[string]int{"n": i})
+	})
+}
+
+// publishConcurrently releases `messages` simultaneous publishes so cohort
+// assembly is exercised, then fails on the first publish error.
+func publishConcurrently(t *testing.T, messages int, publish func(i int) error) {
 	t.Helper()
 	start := make(chan struct{})
 	errs := make(chan error, messages)
@@ -96,7 +89,7 @@ func publishIntegrationMessages(t *testing.T, pub Publisher, messages int) {
 		go func(i int) {
 			defer wg.Done()
 			<-start
-			errs <- PublishJSON(context.Background(), pub, "data.test.batch", map[string]int{"n": i})
+			errs <- publish(i)
 		}(i)
 	}
 	close(start)

--- a/pkg/bus/connect.go
+++ b/pkg/bus/connect.go
@@ -165,3 +165,19 @@ func busURL(url string) string {
 	}
 	return serverList(url)
 }
+
+// busPublishURL resolves the endpoint for the asynchronous publisher pool. The
+// R1 firehose streams are placement-pinned to specific hub ordinals, so a
+// publisher dialed into a non-leader member pays an intra-hub route hop on
+// every message and its PubAck. NATS_HUB_PUBLISH_URL points the pool straight
+// at the ordinal leading the streams this service publishes (per-pod headless
+// DNS; the hub cert carries those SANs). A service whose consume and publish
+// streams lead on different ordinals sets both variables. Consumers and the
+// stream guardian stay on busURL — the JetStream API is routed cluster-wide,
+// and consumer deliveries follow their own stream's leader.
+func busPublishURL(url string) string {
+	if publish := env.Get("NATS_HUB_PUBLISH_URL", ""); publish != "" {
+		return publish
+	}
+	return busURL(url)
+}

--- a/pkg/bus/provision.go
+++ b/pkg/bus/provision.go
@@ -160,11 +160,13 @@ var DataStreams = []StreamSpec{
 		// lane makes a flooded lane wrap itself while the other lanes keep their
 		// retention (and stays within the 1 GiB stream cap).
 		MaxMsgsPer: 400_000,
-		// Ingress publishes carry Nats-Msg-Id (derived from Twitch's message id)
-		// so publish retries and Twitch's own EventSub redeliveries collapse at
-		// the broker. Both happen within seconds; 10s covers them while bounding
-		// the broker's dedup-id state on the firehose — at 200k/s a 30s window
-		// would track ~6M ids, a 10s window ~2M.
+		// The dedup window only applies to messages that carry a Nats-Msg-Id.
+		// Production ingress runs INGRESS_PUBLISH_DEDUP=off (the per-message
+		// dedup insert measured ~27% of single-stream ingest capacity, and
+		// EventSub websockets never redeliver), so lane events are unindexed
+		// and this window costs nothing for them. It stays at 10s to bound
+		// dedup state for any id-carrying publisher on these subjects — at
+		// 200k/s a 30s window would track ~6M ids, a 10s window ~2M.
 		Duplicates:   10 * time.Second,
 		BatchPublish: true,
 	},

--- a/pkg/bus/testdata/nats-2.14.conf
+++ b/pkg/bus/testdata/nats-2.14.conf
@@ -4,6 +4,9 @@ server_name: "pkg-bus-integration"
 jetstream {
   store_dir: $NATS_TEST_STORE
   domain: "hub"
-  max_mem: 1GB
+  # TWITCH_INGRESS alone reserves 1 GiB of memory storage; leave headroom so
+  # another suite's small memory stream on the same broker cannot fail fleet
+  # provisioning with "insufficient memory resources".
+  max_mem: 2GB
   max_file: 1GB
 }


### PR DESCRIPTION
## What

Three hot-path changes against the serialized per-stream ingest ceiling (rated 86k/s on 2026-07-12; leader at 1.77/4 cores with 163k PubAcks in flight, so ack work is the cap, not CPU or window):

### 1. Leader-direct dialing (config + one helper)
Stream-plane clients dial the hub ordinal that leads their placement-pinned R1 streams via per-pod headless DNS (already hub cert SANs), skipping the intra-hub route hop the PreferSameNode `nats` Service adds from non-leader members:
- twitch-ingress firehose (`NATS_HUB_HOST`) and sesame consumers (`NATS_HUB_URL`) -> nats-0 (TWITCH_INGRESS)
- sesame publisher pool (new `NATS_HUB_PUBLISH_URL`, read by `busPublishURL` in pkg/bus) + outgress + projector -> nats-1 (TWITCH_OUTGRESS / BAGEL_DATA)

No availability change: an R1 placement-pinned stream is down with its peer regardless of which member the client dialed.

### 2. ADR-050 atomic batch publish wire (dark, default off)
`NATS_PUBLISH_WIRE=atomic` (Go pkg/bus) / `INGRESS_PUBLISH_WIRE=atomic` (Elixir ingress) publish a cohort as one atomic batch: one commit PubAck per 128 events instead of 128. Rejected/abandoned/unacked batches fall back per message; atomicity means the broker stored nothing or everything, so the fallback stores exactly once or folds entirely. In-flight batches capped per shard under the broker's 50-per-stream limit. Verified against nats:2.14.3 in both stacks, including replayed-cohort no-double-store. Stays off until a live A/B decides.

### 3. Lane dedup off (measured, then decided)
New harness mode `-msg-id=false` / `MSG_ID=off` isolates the dedup cost. Live A/B on the production hub (four interleaved 3M-message runs, quiet window, zero errors):

| Mode | Aggregate |
|---|---|
| Nats-Msg-Id on | 83,671 / 86,735 per s |
| Nats-Msg-Id off | 117,343 / 117,721 per s |

The per-message dedup-index insert costs ~27% of single-stream ingest capacity. EventSub websockets never redeliver, so the header only folded the publisher's own ack-timeout retries. `INGRESS_PUBLISH_DEDUP=off` (prod) strips ids at admission; ack timeouts now drop instead of re-publishing (at-most-once on ambiguity, a re-publish could double-store), definite failures still retry, expired unprotected atomic batches drop whole. Premium and standard identical; lanes differ only in priority and reserved quota. sesame unaffected (output replay ids derive from the EventID payload field; TWITCH_OUTGRESS output dedup still folds duplicate sends).

## Expected capacity
Rated ~117k/s single stream (was 86k); 75% operating target ~88k/s (was 64.5k).

## Verification
- Full Go build + pkg/bus suite; ingress 121/121
- Go + Elixir integration suites against a real nats:2.14.3 broker (atomic wire, dedup fold, replay no-double-store)
- Live fleet A/B above, hub logs clean, no slow consumers, zero service restarts

## Rollback
Dedup: flip `INGRESS_PUBLISH_DEDUP` back on (env only). Leader pins: revert env values to `nats`. Batch wire: already off.