### PR TITLE
feat(sesame): localize built-in command system output (en/fr)

### DIFF
--- a/app/sesame/i18n/i18n.go
+++ b/app/sesame/i18n/i18n.go
@@ -69,6 +69,34 @@ var catalog = map[string]map[string]string{
 		"loyalty.counter.list.empty":  "No counters yet. Create one with !counter create <name>.",
 		"loyalty.counter.not_found":   "@{user} counter {counter} was not found.",
 		"loyalty.counter.err":         "@{user} that didn't work, please try again.",
+
+		"lookup.not_user":         "@%s is not a Twitch user.",
+		"followage.unavailable":   "Followage is unavailable right now.",
+		"followage.broadcaster":   "@%s is the broadcaster.",
+		"followage.not_following": "@%s is not following this channel.",
+		"followage.followed":      "@%s has followed for %s.",
+		"accountage.unavailable":  "Account age is unavailable right now.",
+		"accountage.age":          "@%s's account is %s old.",
+
+		"time.less_than_minute": "less than a minute",
+		"time.year":             "year",
+		"time.years":            "years",
+		"time.month":            "month",
+		"time.months":           "months",
+		"time.day":              "day",
+		"time.days":             "days",
+		"time.hour":             "hour",
+		"time.hours":            "hours",
+		"time.minute":           "minute",
+		"time.minutes":          "minutes",
+
+		"external.retry": "still looking that up, try again in a moment",
+
+		"mcsr.session.started": "session tracking just started (%s elo), ask again after a match!",
+		"mcsr.unrated":         "unrated",
+
+		"fortnite.shop.empty": "empty today",
+		"fortnite.shop.more":  "+%d more",
 	},
 	"fr": {
 		"ping":         "Pong ! ItsBagelBot est actif depuis %s",
@@ -126,6 +154,34 @@ var catalog = map[string]map[string]string{
 		"loyalty.counter.list.empty":  "Aucun compteur pour le moment. Créez-en un avec !counter create <nom>.",
 		"loyalty.counter.not_found":   "@{user} le compteur {counter} n'a pas été trouvé.",
 		"loyalty.counter.err":         "@{user} ça n'a pas fonctionné, veuillez réessayer.",
+
+		"lookup.not_user":         "@%s n'est pas un utilisateur Twitch.",
+		"followage.unavailable":   "Le suivi n'est pas disponible pour le moment.",
+		"followage.broadcaster":   "@%s est le diffuseur.",
+		"followage.not_following": "@%s ne suit pas cette chaîne.",
+		"followage.followed":      "@%s suit la chaîne depuis %s.",
+		"accountage.unavailable":  "L'âge du compte n'est pas disponible pour le moment.",
+		"accountage.age":          "Le compte de @%s existe depuis %s.",
+
+		"time.less_than_minute": "moins d'une minute",
+		"time.year":             "an",
+		"time.years":            "ans",
+		"time.month":            "mois",
+		"time.months":           "mois",
+		"time.day":              "jour",
+		"time.days":             "jours",
+		"time.hour":             "heure",
+		"time.hours":            "heures",
+		"time.minute":           "minute",
+		"time.minutes":          "minutes",
+
+		"external.retry": "recherche en cours, réessayez dans un instant",
+
+		"mcsr.session.started": "le suivi de session vient de démarrer (%s elo), redemandez après une partie !",
+		"mcsr.unrated":         "non classé",
+
+		"fortnite.shop.empty": "vide aujourd'hui",
+		"fortnite.shop.more":  "+%d de plus",
 	},
 }
 

--- a/app/sesame/modules/external.go
+++ b/app/sesame/modules/external.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"strings"
 
+	"ItsBagelBot/app/sesame/i18n"
 	"ItsBagelBot/app/sesame/module"
 	"ItsBagelBot/internal/domain/outgress"
 	"ItsBagelBot/pkg/bus"
@@ -57,7 +58,7 @@ func chatReplyError(c *module.Context, emit module.Emit, account string, err err
 	emit(&module.Output{
 		Type:          outgress.TypeChat,
 		BroadcasterID: c.Env.BroadcasterUserID,
-		Text:          account + ": still looking that up, try again in a moment",
+		Text:          account + ": " + i18n.T(c.Locale, "external.retry"),
 	})
 	return false
 }

--- a/app/sesame/modules/followage.go
+++ b/app/sesame/modules/followage.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"ItsBagelBot/app/sesame/engine"
+	"ItsBagelBot/app/sesame/i18n"
 	"ItsBagelBot/app/sesame/module"
 	"ItsBagelBot/internal/domain/outgress"
 
@@ -35,17 +36,17 @@ func Followage(d engine.Deps) module.Module {
 	followage := func(ctx context.Context, c *module.Context, target lookupTarget) string {
 		bid := c.Env.BroadcasterUserID
 		return lookupCall[engine.FollowageResult]{
-			log: log, logKey: followageModuleName, unavailable: "Followage is unavailable right now.",
+			log: log, logKey: followageModuleName, unavailable: i18n.T(c.Locale, "followage.unavailable"),
 			read:   readIf(d.Followage != nil, func() (engine.FollowageResult, error) { return d.Followage.Lookup(ctx, bid, target.id, target.login) }),
-			format: func(res engine.FollowageResult) string { return formatFollowageResult(target.name, bid, res) },
+			format: func(res engine.FollowageResult) string { return formatFollowageResult(c.Locale, target.name, bid, res) },
 		}.run()
 	}
 
-	accountAge := func(ctx context.Context, _ *module.Context, target lookupTarget) string {
+	accountAge := func(ctx context.Context, c *module.Context, target lookupTarget) string {
 		return lookupCall[engine.AccountAgeResult]{
-			log: log, logKey: accountAgeModuleName, unavailable: "Account age is unavailable right now.",
+			log: log, logKey: accountAgeModuleName, unavailable: i18n.T(c.Locale, "accountage.unavailable"),
 			read:   readIf(d.AccountAge != nil, func() (engine.AccountAgeResult, error) { return d.AccountAge.Lookup(ctx, target.id, target.login) }),
-			format: func(res engine.AccountAgeResult) string { return formatAccountAgeResult(target.name, res) },
+			format: func(res engine.AccountAgeResult) string { return formatAccountAgeResult(c.Locale, target.name, res) },
 		}.run()
 	}
 
@@ -129,48 +130,49 @@ func emitLookup(c *module.Context, text string, emit module.Emit) {
 	emit(&module.Output{Type: outgress.TypeChat, BroadcasterID: c.Env.BroadcasterUserID, Text: text})
 }
 
-func formatFollowageResult(targetName, broadcasterID string, result engine.FollowageResult) string {
+func formatFollowageResult(locale, targetName, broadcasterID string, result engine.FollowageResult) string {
 	if !result.UserFound {
-		return fmt.Sprintf("@%s is not a Twitch user.", targetName)
+		return fmt.Sprintf(i18n.T(locale, "lookup.not_user"), targetName)
 	}
 	if result.TargetID == broadcasterID {
-		return fmt.Sprintf("@%s is the broadcaster.", targetName)
+		return fmt.Sprintf(i18n.T(locale, "followage.broadcaster"), targetName)
 	}
 	if !result.Following {
-		return fmt.Sprintf("@%s is not following this channel.", targetName)
+		return fmt.Sprintf(i18n.T(locale, "followage.not_following"), targetName)
 	}
-	return fmt.Sprintf("@%s has followed for %s.", targetName, humanizeDuration(time.Since(result.FollowedAt)))
+	return fmt.Sprintf(i18n.T(locale, "followage.followed"), targetName, humanizeDuration(locale, time.Since(result.FollowedAt)))
 }
 
-func formatAccountAgeResult(targetName string, result engine.AccountAgeResult) string {
+func formatAccountAgeResult(locale, targetName string, result engine.AccountAgeResult) string {
 	if !result.UserFound {
-		return fmt.Sprintf("@%s is not a Twitch user.", targetName)
+		return fmt.Sprintf(i18n.T(locale, "lookup.not_user"), targetName)
 	}
-	return fmt.Sprintf("@%s's account is %s old.", targetName, humanizeDuration(time.Since(result.CreatedAt)))
+	return fmt.Sprintf(i18n.T(locale, "accountage.age"), targetName, humanizeDuration(locale, time.Since(result.CreatedAt)))
 }
 
 // humanizeDuration renders a span as the two largest non-zero units (e.g.
-// "2 years, 3 months"), used by both !followage and !accountage.
-func humanizeDuration(d time.Duration) string {
+// "2 years, 3 months"), used by both !followage and !accountage. Unit names are
+// localized; a plural count reads the "<unit>s" key ("time.year" -> "time.years").
+func humanizeDuration(locale string, d time.Duration) string {
 	if d < 0 {
 		d = 0
 	}
 	minutes := int64(d / time.Minute)
 	if minutes < 1 {
-		return "less than a minute"
+		return i18n.T(locale, "time.less_than_minute")
 	}
 	units := []struct {
 		minutes int64
-		name    string
-	}{{365 * 24 * 60, "year"}, {30 * 24 * 60, "month"}, {24 * 60, "day"}, {60, "hour"}, {1, "minute"}}
+		key     string
+	}{{365 * 24 * 60, "time.year"}, {30 * 24 * 60, "time.month"}, {24 * 60, "time.day"}, {60, "time.hour"}, {1, "time.minute"}}
 	parts := make([]string, 0, 2)
 	for _, unit := range units {
 		if n := minutes / unit.minutes; n > 0 {
-			name := unit.name
+			key := unit.key
 			if n != 1 {
-				name += "s"
+				key += "s"
 			}
-			parts = append(parts, fmt.Sprintf("%d %s", n, name))
+			parts = append(parts, fmt.Sprintf("%d %s", n, i18n.T(locale, key)))
 			minutes %= unit.minutes
 			if len(parts) == 2 {
 				break

--- a/app/sesame/modules/followage.go
+++ b/app/sesame/modules/followage.go
@@ -37,16 +37,25 @@ func Followage(d engine.Deps) module.Module {
 		bid := c.Env.BroadcasterUserID
 		return lookupCall[engine.FollowageResult]{
 			log: log, logKey: followageModuleName, unavailable: i18n.T(c.Locale, "followage.unavailable"),
-			read:   readIf(d.Followage != nil, func() (engine.FollowageResult, error) { return d.Followage.Lookup(ctx, bid, target.id, target.login) }),
-			format: func(res engine.FollowageResult) string { return formatFollowageResult(c.Locale, target.name, bid, res) },
+			read: readIf(d.Followage != nil, func() (engine.FollowageResult, error) { return d.Followage.Lookup(ctx, bid, target.id, target.login) }),
+			// The broadcaster case is resolved here, where bid is in scope.
+			format: func(res engine.FollowageResult) string {
+				r := lookupReply{locale: c.Locale, targetName: target.name}
+				if res.UserFound && res.TargetID == bid {
+					return r.broadcaster()
+				}
+				return r.followage(res)
+			},
 		}.run()
 	}
 
 	accountAge := func(ctx context.Context, c *module.Context, target lookupTarget) string {
 		return lookupCall[engine.AccountAgeResult]{
 			log: log, logKey: accountAgeModuleName, unavailable: i18n.T(c.Locale, "accountage.unavailable"),
-			read:   readIf(d.AccountAge != nil, func() (engine.AccountAgeResult, error) { return d.AccountAge.Lookup(ctx, target.id, target.login) }),
-			format: func(res engine.AccountAgeResult) string { return formatAccountAgeResult(c.Locale, target.name, res) },
+			read: readIf(d.AccountAge != nil, func() (engine.AccountAgeResult, error) { return d.AccountAge.Lookup(ctx, target.id, target.login) }),
+			format: func(res engine.AccountAgeResult) string {
+				return lookupReply{locale: c.Locale, targetName: target.name}.accountAge(res)
+			},
 		}.run()
 	}
 
@@ -130,24 +139,36 @@ func emitLookup(c *module.Context, text string, emit module.Emit) {
 	emit(&module.Output{Type: outgress.TypeChat, BroadcasterID: c.Env.BroadcasterUserID, Text: text})
 }
 
-func formatFollowageResult(locale, targetName, broadcasterID string, result engine.FollowageResult) string {
-	if !result.UserFound {
-		return fmt.Sprintf(i18n.T(locale, "lookup.not_user"), targetName)
-	}
-	if result.TargetID == broadcasterID {
-		return fmt.Sprintf(i18n.T(locale, "followage.broadcaster"), targetName)
-	}
-	if !result.Following {
-		return fmt.Sprintf(i18n.T(locale, "followage.not_following"), targetName)
-	}
-	return fmt.Sprintf(i18n.T(locale, "followage.followed"), targetName, humanizeDuration(locale, time.Since(result.FollowedAt)))
+// lookupReply renders a viewer-lookup command's chat text in the broadcaster
+// locale. Bundling the locale and resolved target name onto the receiver keeps
+// the per-result formatters off a string-heavy argument list.
+type lookupReply struct {
+	locale     string
+	targetName string
 }
 
-func formatAccountAgeResult(locale, targetName string, result engine.AccountAgeResult) string {
+// broadcaster is the reply when the looked-up user is the broadcaster.
+func (r lookupReply) broadcaster() string {
+	return fmt.Sprintf(i18n.T(r.locale, "followage.broadcaster"), r.targetName)
+}
+
+// followage renders the !followage result (broadcaster case handled upstream).
+func (r lookupReply) followage(result engine.FollowageResult) string {
 	if !result.UserFound {
-		return fmt.Sprintf(i18n.T(locale, "lookup.not_user"), targetName)
+		return fmt.Sprintf(i18n.T(r.locale, "lookup.not_user"), r.targetName)
 	}
-	return fmt.Sprintf(i18n.T(locale, "accountage.age"), targetName, humanizeDuration(locale, time.Since(result.CreatedAt)))
+	if !result.Following {
+		return fmt.Sprintf(i18n.T(r.locale, "followage.not_following"), r.targetName)
+	}
+	return fmt.Sprintf(i18n.T(r.locale, "followage.followed"), r.targetName, humanizeDuration(r.locale, time.Since(result.FollowedAt)))
+}
+
+// accountAge renders the !accountage result.
+func (r lookupReply) accountAge(result engine.AccountAgeResult) string {
+	if !result.UserFound {
+		return fmt.Sprintf(i18n.T(r.locale, "lookup.not_user"), r.targetName)
+	}
+	return fmt.Sprintf(i18n.T(r.locale, "accountage.age"), r.targetName, humanizeDuration(r.locale, time.Since(result.CreatedAt)))
 }
 
 // humanizeDuration renders a span as the two largest non-zero units (e.g.

--- a/app/sesame/modules/followage_test.go
+++ b/app/sesame/modules/followage_test.go
@@ -129,7 +129,7 @@ func TestBuiltinToggleSuppressesCommand(t *testing.T) {
 }
 
 func TestHumanizeDuration(t *testing.T) {
-	assert.Equal(t, "2 years, 3 months", humanizeDuration((2*365+3*30+4)*24*time.Hour))
+	assert.Equal(t, "2 years, 3 months", humanizeDuration("en", (2*365+3*30+4)*24*time.Hour))
 }
 
 type fakeAccountAge struct {

--- a/app/sesame/modules/fortnite.go
+++ b/app/sesame/modules/fortnite.go
@@ -2,11 +2,13 @@ package modules
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
 
 	"ItsBagelBot/app/sesame/engine"
+	"ItsBagelBot/app/sesame/i18n"
 	"ItsBagelBot/app/sesame/module"
 	"ItsBagelBot/internal/domain/outgress"
 	gatewayrpc "ItsBagelBot/internal/domain/rpc/gateway"
@@ -211,7 +213,7 @@ func fortniteStoreRun(d engine.Deps) module.RunFunc {
 			case "count":
 				return strconv.Itoa(reply.Count), true
 			case "items":
-				return formatShopEntries(reply.Entries), true
+				return formatShopEntries(c.Locale, reply.Entries), true
 			}
 			return module.ParseDynamic(key)
 		})
@@ -223,9 +225,9 @@ func fortniteStoreRun(d engine.Deps) module.RunFunc {
 // formatShopEntries renders the shop offers as "Name (price), ..." within the
 // chat budget; whatever does not fit collapses into "+N more". Prices are
 // V-Bucks; a zero price (a free or bugged offer) renders name-only.
-func formatShopEntries(entries []gatewayrpc.FortniteShopEntry) string {
+func formatShopEntries(locale string, entries []gatewayrpc.FortniteShopEntry) string {
 	if len(entries) == 0 {
-		return "empty today"
+		return i18n.T(locale, "fortnite.shop.empty")
 	}
 	var b strings.Builder
 	shown := 0
@@ -244,7 +246,7 @@ func formatShopEntries(entries []gatewayrpc.FortniteShopEntry) string {
 		shown++
 	}
 	if rest := len(entries) - shown; rest > 0 {
-		b.WriteString(" +" + strconv.Itoa(rest) + " more")
+		b.WriteString(" " + fmt.Sprintf(i18n.T(locale, "fortnite.shop.more"), rest))
 	}
 	return b.String()
 }

--- a/app/sesame/modules/fortnite_test.go
+++ b/app/sesame/modules/fortnite_test.go
@@ -186,7 +186,7 @@ func TestStoreDefaultTemplate(t *testing.T) {
 }
 
 func TestFormatShopEntriesBudget(t *testing.T) {
-	assert.Equal(t, "empty today", formatShopEntries(nil))
+	assert.Equal(t, "empty today", formatShopEntries("en", nil))
 
 	// A long shop truncates within the budget and reports the remainder.
 	var entries []gatewayrpc.FortniteShopEntry
@@ -195,14 +195,14 @@ func TestFormatShopEntriesBudget(t *testing.T) {
 			Name: "Some Cosmetic Item " + strconv.Itoa(i), Price: 1200,
 		})
 	}
-	got := formatShopEntries(entries)
+	got := formatShopEntries("en", entries)
 	assert.LessOrEqual(t, len(got), fortniteShopBudget+len(" +99 more"))
 	assert.Contains(t, got, " more")
 	assert.True(t, strings.HasPrefix(got, "Some Cosmetic Item 0 (1200), "))
 
 	// The first entry always renders, even when it alone blows the budget.
 	huge := gatewayrpc.FortniteShopEntry{Name: strings.Repeat("x", fortniteShopBudget+50), Price: 100}
-	got = formatShopEntries([]gatewayrpc.FortniteShopEntry{huge, {Name: "Next", Price: 1}})
+	got = formatShopEntries("en", []gatewayrpc.FortniteShopEntry{huge, {Name: "Next", Price: 1}})
 	assert.True(t, strings.HasPrefix(got, huge.Name))
 	assert.Contains(t, got, "+1 more")
 }

--- a/app/sesame/modules/mcsr.go
+++ b/app/sesame/modules/mcsr.go
@@ -2,13 +2,15 @@ package modules
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"time"
 
 	"ItsBagelBot/app/sesame/engine"
+	"ItsBagelBot/app/sesame/i18n"
 	"ItsBagelBot/app/sesame/module"
-	gatewayrpc "ItsBagelBot/internal/domain/rpc/gateway"
 	"ItsBagelBot/internal/domain/outgress"
+	gatewayrpc "ItsBagelBot/internal/domain/rpc/gateway"
 
 	"go.uber.org/zap"
 )
@@ -119,7 +121,7 @@ func mcsrEloRun(d engine.Deps) module.RunFunc {
 			case "player":
 				return reply.Nickname, true
 			case "elo":
-				return mcsrElo(reply.Elo), true
+				return mcsrElo(c.Locale, reply.Elo), true
 			case "rank":
 				return mcsrRank(reply.Rank), true
 			case "wins":
@@ -169,7 +171,7 @@ func mcsrSessionRun(d engine.Deps) module.RunFunc {
 			emit(&module.Output{
 				Type:          outgress.TypeChat,
 				BroadcasterID: c.Env.BroadcasterUserID,
-				Text:          reply.Nickname + ": session tracking just started (" + mcsrElo(reply.Elo) + " elo), ask again after a match!",
+				Text:          reply.Nickname + ": " + fmt.Sprintf(i18n.T(c.Locale, "mcsr.session.started"), mcsrElo(c.Locale, reply.Elo)),
 			})
 			return nil
 		}
@@ -180,7 +182,7 @@ func mcsrSessionRun(d engine.Deps) module.RunFunc {
 			case "player":
 				return reply.Nickname, true
 			case "elo":
-				return mcsrElo(reply.Elo), true
+				return mcsrElo(c.Locale, reply.Elo), true
 			case "elochange":
 				return signed(reply.EloChange), true
 			case "wins":
@@ -199,9 +201,9 @@ func mcsrSessionRun(d engine.Deps) module.RunFunc {
 }
 
 // mcsrElo renders an elo value, naming the unrated sentinel.
-func mcsrElo(elo int) string {
+func mcsrElo(locale string, elo int) string {
 	if elo < 0 {
-		return "unrated"
+		return i18n.T(locale, "mcsr.unrated")
 	}
 	return strconv.Itoa(elo)
 }


### PR DESCRIPTION
## What

Extends the sesame i18n catalog to the command modules that still emitted raw English, so built-in **system** chat answers in the broadcaster's console locale (same mechanism as `cmd`/`queue`/`loyalty`).

| Module | Localized system strings |
|---|---|
| followage/accountage | unavailable, not-a-user, is-broadcaster, not-following, followed-for, account-age, humanized durations (locale-aware units + "less than a minute") |
| external (shared) | gateway retry line used by fortnite/mcsr/urchin |
| mcsr | "session tracking just started", `unrated` sentinel |
| fortnite | shop "empty today", "+N more" |

`+23` catalog keys, each in `en` and `fr`.

## Scope

Per the i18n package contract, only built-in **system** output is localized. Broadcaster-customizable `{token}` default templates (fortnite/mcsr/urchin/alerts/shoutout/govee), urchin's upstream cheater taxonomy, and clip (reply text is outgress-side) are intentionally left as-is.

## Safety

- Locale threads from `module.Context.Locale`.
- English catalog values are **byte-identical** to the previous literals, so existing string assertions stay green; only direct helper call-sites (`humanizeDuration`, `formatShopEntries`) gained the `locale` arg.
- `en`/`fr` key sets verified symmetric; French rendered at runtime with no format-verb mismatches.
- Full `./app/sesame/...` suite passes; gofmt + vet clean.