### PR TITLE
feat(fortnite): add !fn session stream-delta command

### DIFF
--- a/app/gateway/internal/providers/fortnite/fortnite.go
+++ b/app/gateway/internal/providers/fortnite/fortnite.go
@@ -51,6 +51,9 @@ const (
 	// shopTTL: the shop rotates once a day (00:00 UTC), so a 15-minute lag on
 	// rotation day is invisible against a 24h cycle.
 	shopTTL = 15 * time.Minute
+	// sessionSnapshotTTL outlives any plausible single stream; Twitch caps
+	// broadcasts at 48h.
+	sessionSnapshotTTL = 49 * time.Hour
 
 	httpTimeout    = 10 * time.Second
 	handlerTimeout = 15 * time.Second
@@ -146,7 +149,11 @@ func (p *Provider) Endpoints() []provider.Endpoint {
 		{Name: "shop", Timeout: handlerTimeout, Handle: p.shopEndpoint},
 	}
 	if p.keyed {
-		eps = append(eps, provider.Endpoint{Name: "stats", Timeout: handlerTimeout, Handle: p.statsEndpoint})
+		eps = append(eps,
+			provider.Endpoint{Name: "stats", Timeout: handlerTimeout, Handle: p.statsEndpoint},
+			provider.Endpoint{Name: "session_start", Timeout: handlerTimeout, Handle: p.sessionStart},
+			provider.Endpoint{Name: "session", Timeout: handlerTimeout, Handle: p.session},
+		)
 	}
 	return eps
 }
@@ -388,6 +395,129 @@ func (p *Provider) fetchStats(ctx context.Context, q statsQuery, isPremium bool)
 		Duo:     modes[1].reply(),
 		Squad:   modes[2].reply(),
 	}, nil
+}
+
+// --- session -------------------------------------------------------------------
+
+// snapshot is the stream-start standing stored per channel: the lifetime
+// overall counters the session delta is diffed against. Session always tracks
+// lifetime, never the season window — a season rollover mid-stream would
+// corrupt a delta taken across it.
+type snapshot struct {
+	Account string `json:"account"`
+	Player  string `json:"player"`
+	Wins    int64  `json:"wins"`
+	Matches int64  `json:"matches"`
+	Kills   int64  `json:"kills"`
+	AtUnix  int64  `json:"at_unix"`
+}
+
+func snapshotKey(channelID string) string { return core.Key("fortnite", "session", channelID) }
+
+// cachedLifetimeStats reads a player's live lifetime stats behind the shared
+// staleness budget. It is keyed apart from the byte-flow !fnstats path (that
+// path stores pre-marshaled wire bytes, not the envelope core.Cached needs),
+// so repeated !fn session calls within the window cost one upstream hit.
+func (p *Provider) cachedLifetimeStats(ctx context.Context, account string, isPremium bool) (gatewayrpc.FortniteStatsReply, error) {
+	key := core.Key(p.Name(), "session-live", strings.ToLower(strings.TrimSpace(account)))
+	return core.Cached(ctx, p.cache, key, statsTTL, negativeTTL, func(ctx context.Context) (gatewayrpc.FortniteStatsReply, error) {
+		return p.fetchStats(ctx, statsQuery{account: account, window: "lifetime"}, isPremium)
+	})
+}
+
+// writeSnapshot stores the channel's stream-start standing under the snapshot
+// key for sessionSnapshotTTL.
+func (p *Provider) writeSnapshot(ctx context.Context, channelID, account string, stats gatewayrpc.FortniteStatsReply) error {
+	return p.cache.SetJSON(ctx, snapshotKey(channelID), snapshot{
+		Account: strings.ToLower(account),
+		Player:  stats.Player,
+		Wins:    stats.Overall.Wins,
+		Matches: stats.Overall.Matches,
+		Kills:   stats.Overall.Kills,
+		AtUnix:  time.Now().Unix(),
+	}, sessionSnapshotTTL)
+}
+
+// sessionError maps an upstream failure to a friendly reply message, logging
+// (as op) the infrastructure failures the friendly mapper does not name.
+func (p *Provider) sessionError(op, account string, err error) string {
+	if msg, _ := core.FriendlyUpstream(err); msg != "" {
+		return msg
+	}
+	p.log.Warn("fortnite "+op+" fetch failed", zap.String("account", account), zap.Error(err))
+	return "stats lookup failed"
+}
+
+// sessionStart snapshots the player's live lifetime standing for the channel.
+// It fetches fresh (not through cachedLifetimeStats): the snapshot is the
+// session baseline, so it must not predate the stream by a stale cache window.
+func (p *Provider) sessionStart(ctx context.Context, req gatewayrpc.Request) any {
+	account := strings.TrimSpace(req.Account)
+	if account == "" || req.ChannelID == "" {
+		return gatewayrpc.FortniteSnapshotReply{Error: "missing account or channel"}
+	}
+	if msg := epicOnly(req.AccountType); msg != "" {
+		return gatewayrpc.FortniteSnapshotReply{Player: account, Error: msg}
+	}
+	stats, err := p.fetchStats(ctx, statsQuery{account: account, window: "lifetime"}, req.IsPremium)
+	if err != nil {
+		return gatewayrpc.FortniteSnapshotReply{Player: account, Error: p.sessionError("snapshot", account, err)}
+	}
+	if err := p.writeSnapshot(ctx, req.ChannelID, account, stats); err != nil {
+		p.log.Warn("fortnite snapshot write failed", zap.String("channel_id", req.ChannelID), zap.Error(err))
+		return gatewayrpc.FortniteSnapshotReply{Player: stats.Player, Error: "snapshot store failed"}
+	}
+	return gatewayrpc.FortniteSnapshotReply{Player: stats.Player}
+}
+
+// session answers the delta since the channel's stream-start snapshot. Without
+// a usable snapshot (none stored, or it tracks a different account) it takes
+// one now and reports HasSnapshot=false so the caller can say "tracking from
+// now".
+func (p *Provider) session(ctx context.Context, req gatewayrpc.Request) any {
+	account := strings.TrimSpace(req.Account)
+	if account == "" || req.ChannelID == "" {
+		return gatewayrpc.FortniteSessionReply{Error: "missing account or channel"}
+	}
+	if msg := epicOnly(req.AccountType); msg != "" {
+		return gatewayrpc.FortniteSessionReply{Player: account, Error: msg}
+	}
+	live, err := p.cachedLifetimeStats(ctx, account, req.IsPremium)
+	if err != nil {
+		return gatewayrpc.FortniteSessionReply{Player: account, Error: p.sessionError("session", account, err)}
+	}
+
+	var snap snapshot
+	ok, err := p.cache.GetJSON(ctx, snapshotKey(req.ChannelID), &snap)
+	if err != nil {
+		p.log.Warn("fortnite snapshot read failed", zap.String("channel_id", req.ChannelID), zap.Error(err))
+	}
+	if !ok || snap.Account != strings.ToLower(account) {
+		if werr := p.writeSnapshot(ctx, req.ChannelID, account, live); werr != nil {
+			p.log.Warn("fortnite snapshot write failed", zap.String("channel_id", req.ChannelID), zap.Error(werr))
+		}
+		return gatewayrpc.FortniteSessionReply{Player: live.Player, HasSnapshot: false, SinceUnix: time.Now().Unix()}
+	}
+
+	// Lifetime counters only grow, but clamp defensively so an upstream
+	// correction can never render a negative "this stream" line. modeAgg.reply
+	// derives K/D and win rate exactly as the stats path does.
+	delta := modeAgg{
+		wins:    max(0, live.Overall.Wins-snap.Wins),
+		matches: max(0, live.Overall.Matches-snap.Matches),
+		kills:   max(0, live.Overall.Kills-snap.Kills),
+	}
+	ms := delta.reply()
+	return gatewayrpc.FortniteSessionReply{
+		Player:      live.Player,
+		Wins:        ms.Wins,
+		Matches:     ms.Matches,
+		Kills:       ms.Kills,
+		KD:          ms.KD,
+		WinRate:     ms.WinRate,
+		SinceUnix:   snap.AtUnix,
+		HasSnapshot: true,
+	}
 }
 
 // --- item shop -------------------------------------------------------------------

--- a/app/gateway/internal/providers/fortnite/fortnite_test.go
+++ b/app/gateway/internal/providers/fortnite/fortnite_test.go
@@ -96,9 +96,30 @@ func asReply[T any](t *testing.T, res any) T {
 
 // asStats / asShop are the endpoint-typed instantiations the tests read with.
 var (
-	asStats = asReply[gatewayrpc.FortniteStatsReply]
-	asShop  = asReply[gatewayrpc.FortniteShopReply]
+	asStats    = asReply[gatewayrpc.FortniteStatsReply]
+	asShop     = asReply[gatewayrpc.FortniteShopReply]
+	asSnapshot = asReply[gatewayrpc.FortniteSnapshotReply]
+	asSession  = asReply[gatewayrpc.FortniteSessionReply]
 )
+
+// mutableStatsUpstream is statsUpstream with a stats body the test can change
+// between calls (to simulate games played between the snapshot and the session
+// read); it serves lifetime only, so the season endpoint is never touched.
+func mutableStatsUpstream(t *testing.T, account string, body *string, reqs *[]*http.Request) http.Handler {
+	t.Helper()
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*reqs = append(*reqs, r.Clone(context.Background()))
+		switch {
+		case strings.EqualFold(r.URL.Path, "/api/v1/account/displayName/"+account):
+			_, _ = w.Write([]byte(`{"id":"deadbeef","displayName":"` + account + `"}`))
+		case r.URL.Path == "/api/v2/stats/deadbeef":
+			_, _ = w.Write([]byte(*body))
+		default:
+			t.Errorf("unexpected stats-upstream path %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+}
 
 // statsUpstream fakes api-fortnite.com: the display-name lookup answers
 // account, the stats path answers body, the season endpoint answers a fixed
@@ -309,6 +330,97 @@ func TestStatsMissingAccount(t *testing.T) {
 	assert.Equal(t, "missing account", reply.Error)
 }
 
+// A stream-start snapshot records the baseline; after games are played the
+// session endpoint reports the lifetime delta with K/D and win rate derived
+// over the session's own games.
+func TestSessionStartThenDelta(t *testing.T) {
+	body := syntheticBlob // overall wins=20, matches=150, kills=450
+	var reqs []*http.Request
+	p := newTestProvider(t, mutableStatsUpstream(t, "Ninja", &body, &reqs), noUpstream(t, "shop"), nil)
+
+	snap := asSnapshot(t, handle(t, p, "session_start")(context.Background(),
+		gatewayrpc.Request{Account: "Ninja", ChannelID: "42"}))
+	require.Empty(t, snap.Error)
+	assert.Equal(t, "Ninja", snap.Player)
+
+	// Games played: overall climbs +5 wins, +20 matches, +150 kills.
+	body = `{"accountId":"deadbeef","stats":{
+		"br_placetop1_keyboardmouse_m0_playlist_defaultsolo": 25,
+		"br_matchesplayed_keyboardmouse_m0_playlist_defaultsolo": 170,
+		"br_kills_keyboardmouse_m0_playlist_defaultsolo": 600
+	}}`
+
+	sess := asSession(t, handle(t, p, "session")(context.Background(),
+		gatewayrpc.Request{Account: "Ninja", ChannelID: "42"}))
+	require.Empty(t, sess.Error)
+	assert.True(t, sess.HasSnapshot)
+	assert.Equal(t, "Ninja", sess.Player)
+	assert.Equal(t, int64(5), sess.Wins)
+	assert.Equal(t, int64(20), sess.Matches)
+	assert.Equal(t, int64(150), sess.Kills)
+	// deaths = 20 - 5 = 15; K/D = 150/15 = 10; win rate = 5*100/20 = 25.
+	assert.InDelta(t, 10.0, sess.KD, 1e-9)
+	assert.InDelta(t, 25.0, sess.WinRate, 1e-9)
+	assert.Positive(t, sess.SinceUnix)
+}
+
+// Without a snapshot (module enabled mid-stream) the first session call starts
+// tracking and says so; the snapshot it writes gives the next call a baseline.
+func TestSessionNoSnapshotStartsTracking(t *testing.T) {
+	body := syntheticBlob
+	var reqs []*http.Request
+	p := newTestProvider(t, mutableStatsUpstream(t, "Ninja", &body, &reqs), noUpstream(t, "shop"), nil)
+	h := handle(t, p, "session")
+
+	sess := asSession(t, h(context.Background(), gatewayrpc.Request{Account: "Ninja", ChannelID: "77"}))
+	require.Empty(t, sess.Error)
+	assert.False(t, sess.HasSnapshot)
+	assert.Equal(t, "Ninja", sess.Player)
+
+	// The baseline now exists: a follow-up reports a zero delta, not "tracking".
+	sess = asSession(t, h(context.Background(), gatewayrpc.Request{Account: "Ninja", ChannelID: "77"}))
+	assert.True(t, sess.HasSnapshot)
+	assert.Zero(t, sess.Wins)
+	assert.Zero(t, sess.Matches)
+	assert.Zero(t, sess.Kills)
+}
+
+// A snapshot keyed to a different account is not diffed against: the endpoint
+// re-snapshots for the new account instead of reporting a bogus delta.
+func TestSessionAccountMismatchResnapshots(t *testing.T) {
+	body := syntheticBlob
+	var reqs []*http.Request
+	p := newTestProvider(t, mutableStatsUpstream(t, "Ninja", &body, &reqs), noUpstream(t, "shop"), nil)
+
+	// Seed a snapshot for a different account on this channel.
+	require.NoError(t, p.writeSnapshot(context.Background(), "42", "someoneelse", gatewayrpc.FortniteStatsReply{Player: "SomeoneElse"}))
+
+	sess := asSession(t, handle(t, p, "session")(context.Background(),
+		gatewayrpc.Request{Account: "Ninja", ChannelID: "42"}))
+	require.Empty(t, sess.Error)
+	assert.False(t, sess.HasSnapshot, "a foreign-account snapshot must not be diffed against")
+}
+
+func TestSessionMissingArgs(t *testing.T) {
+	p := newTestProvider(t, noUpstream(t, "stats"), noUpstream(t, "shop"), nil)
+	assert.Equal(t, "missing account or channel",
+		asSnapshot(t, handle(t, p, "session_start")(context.Background(), gatewayrpc.Request{Account: "Ninja"})).Error)
+	assert.Equal(t, "missing account or channel",
+		asSession(t, handle(t, p, "session")(context.Background(), gatewayrpc.Request{ChannelID: "1"})).Error)
+}
+
+// Platform lookups the free plan cannot do answer a friendly error on the
+// session endpoints too, with no upstream call.
+func TestSessionPlatformNotSupported(t *testing.T) {
+	p := newTestProvider(t, noUpstream(t, "stats"), noUpstream(t, "shop"), nil)
+	assert.Equal(t, "only Epic display names are supported right now",
+		asSnapshot(t, handle(t, p, "session_start")(context.Background(),
+			gatewayrpc.Request{Account: "Ninja", ChannelID: "42", AccountType: "psn"})).Error)
+	assert.Equal(t, "only Epic display names are supported right now",
+		asSession(t, handle(t, p, "session")(context.Background(),
+			gatewayrpc.Request{Account: "Ninja", ChannelID: "42", AccountType: "xbl"})).Error)
+}
+
 const shopBody = `{
 	"status": 200,
 	"data": {
@@ -368,14 +480,14 @@ func TestKeylessServesShopOnly(t *testing.T) {
 	assert.Equal(t, 3, reply.Count)
 }
 
-func TestKeyedServesBothEndpoints(t *testing.T) {
+func TestKeyedServesAllEndpoints(t *testing.T) {
 	p := New(Config{APIKey: "k"},
 		provider.Deps{Cache: core.NewCache(newMemStore()), Log: zap.NewNop()})
 	names := make([]string, 0, len(p.Endpoints()))
 	for _, ep := range p.Endpoints() {
 		names = append(names, ep.Name)
 	}
-	assert.ElementsMatch(t, []string{"shop", "stats"}, names)
+	assert.ElementsMatch(t, []string{"shop", "stats", "session_start", "session"}, names)
 }
 
 func TestOddRateLimitDoesNotPanic(t *testing.T) {

--- a/app/sesame/modules/fortnite.go
+++ b/app/sesame/modules/fortnite.go
@@ -10,6 +10,8 @@ import (
 	"ItsBagelBot/app/sesame/module"
 	"ItsBagelBot/internal/domain/outgress"
 	gatewayrpc "ItsBagelBot/internal/domain/rpc/gateway"
+
+	"go.uber.org/zap"
 )
 
 // fortniteModuleName is the ModuleView key; the console MODULE_CATALOG entry
@@ -20,12 +22,16 @@ const fortniteModuleName = "fortnite"
 // upstream replies, so this only shields chat from command spam, not the API.
 const fortniteCooldown = 10 * time.Second
 
+// fortniteSnapshotTimeout bounds the fire-and-forget stream-start snapshot call.
+const fortniteSnapshotTimeout = 10 * time.Second
+
 // Default reply templates. The broadcaster customizes them per command on the
 // module page; blank falls back to these.
 const (
-	defaultFortniteStatsTemplate  = "{player} all time: {wins} wins in {matches} matches · {winrate}% WR · {kills} kills · {kd} K/D · solo {solowins}W / duo {duowins}W / squad {squadwins}W"
-	defaultFortniteSeasonTemplate = "{player} this season: {wins} wins in {matches} matches · {winrate}% WR · {kills} kills · {kd} K/D · solo {solowins}W / duo {duowins}W / squad {squadwins}W"
-	defaultFortniteStoreTemplate  = "Item Shop {date}: {items}"
+	defaultFortniteStatsTemplate   = "{player} all time: {wins} wins in {matches} matches · {winrate}% WR · {kills} kills · {kd} K/D · solo {solowins}W / duo {duowins}W / squad {squadwins}W"
+	defaultFortniteSeasonTemplate  = "{player} this season: {wins} wins in {matches} matches · {winrate}% WR · {kills} kills · {kd} K/D · solo {solowins}W / duo {duowins}W / squad {squadwins}W"
+	defaultFortniteSessionTemplate = "{player} this stream: {wins} wins in {matches} matches · {winrate}% WR · {kills} kills · {kd} K/D"
+	defaultFortniteStoreTemplate   = "Item Shop {date}: {items}"
 )
 
 // fortniteShopBudget caps the rendered {items} list so the chat line stays
@@ -43,12 +49,14 @@ type fortniteConfig struct {
 	Account     string `json:"account"`
 	AccountType string `json:"accountType"`
 
-	StatsEnabled  string `json:"statsEnabled"`
-	StatsMessage  string `json:"statsMessage"`
-	SeasonEnabled string `json:"seasonEnabled"`
-	SeasonMessage string `json:"seasonMessage"`
-	StoreEnabled  string `json:"storeEnabled"`
-	StoreMessage  string `json:"storeMessage"`
+	StatsEnabled   string `json:"statsEnabled"`
+	StatsMessage   string `json:"statsMessage"`
+	SeasonEnabled  string `json:"seasonEnabled"`
+	SeasonMessage  string `json:"seasonMessage"`
+	SessionEnabled string `json:"sessionEnabled"`
+	SessionMessage string `json:"sessionMessage"`
+	StoreEnabled   string `json:"storeEnabled"`
+	StoreMessage   string `json:"storeMessage"`
 }
 
 // Fortnite owns the Fortnite chat commands backed by the gateway service. It
@@ -61,10 +69,13 @@ type fortniteConfig struct {
 //
 //	!fn [player]         all-time Battle Royale stats (also !fn stats, !fnstats)
 //	!fn season [player]  the current season's stats (also !fnseason)
+//	!fn session          wins/kills/K/D since the stream started (also !fnsession)
 //	!fn store            the current item-shop rotation (also !fnstore)
 //
 // All stats replies carry the solo/duo/squad breakdown; the gateway resolves
-// the season window itself.
+// the season window itself. The session baseline is snapshotted when
+// stream.online arrives — the gateway stores the linked account's standing
+// keyed by this channel — so "this stream" is exactly the live session.
 func Fortnite(d engine.Deps) module.Module {
 	statsRun := fortniteStatsRun(d, fortniteStatsCommand{
 		window:   "lifetime",
@@ -78,25 +89,72 @@ func Fortnite(d engine.Deps) module.Module {
 		message:  func(c fortniteConfig) string { return c.SeasonMessage },
 		fallback: defaultFortniteSeasonTemplate,
 	})
+	sessionRun := fortniteSessionRun(d)
 	storeRun := fortniteStoreRun(d)
 
 	m := module.NewModule(fortniteModuleName, module.KindOptIn)
 	m.Command("fn").Everyone().Cooldown(fortniteCooldown).
-		Run(fortniteDispatchRun(statsRun, seasonRun, storeRun))
+		Run(fortniteDispatchRun(statsRun, seasonRun, sessionRun, storeRun))
 	m.Command("fnstats").Everyone().Cooldown(fortniteCooldown).Aliases("fortnitestats").
 		Run(statsRun)
 	m.Command("fnseason").Everyone().Cooldown(fortniteCooldown).
 		Run(seasonRun)
+	m.Command("fnsession").Everyone().Cooldown(fortniteCooldown).
+		Run(sessionRun)
 	m.Command("fnstore").Everyone().Cooldown(fortniteCooldown).Aliases("itemshop", "fnshop").
 		Run(storeRun)
+
+	// Snapshot the linked account's standing the moment the stream goes online,
+	// so !fn session has a baseline. Gated on the session toggle: no point
+	// spending the tight daily stats budget for a command the broadcaster
+	// turned off.
+	m.On("stream.online", fortniteSnapshotOnline(d))
 	return m.Build()
 }
 
+// fortniteSnapshotOnline snapshots the linked account's lifetime standing when
+// the stream goes online. The pipeline only runs this when the module is
+// enabled and wires the module config in. Fire and forget on a Background
+// context (the consumer ctx is acked and may cancel the moment the handler
+// returns), mirroring the mcsr module's write discipline.
+func fortniteSnapshotOnline(d engine.Deps) module.EventHandler {
+	log := d.Log
+	if log == nil {
+		log = zap.NewNop()
+	}
+	return func(_ context.Context, c *module.Context, _ module.Emit) error {
+		if d.Gateway == nil {
+			return nil
+		}
+		var cfg fortniteConfig
+		_ = c.Decode(&cfg)
+		if !alertOn(cfg.SessionEnabled) {
+			return nil
+		}
+		account := resolveAccount(accountSources{Linked: cfg.Account, BroadcasterLogin: c.Env.BroadcasterUserLogin})
+		channelID := strconv.FormatUint(c.BroadcasterID, 10)
+		go func() {
+			wctx, cancel := context.WithTimeout(context.Background(), fortniteSnapshotTimeout)
+			defer cancel()
+			req := gatewayrpc.Request{Account: account, AccountType: cfg.AccountType, ChannelID: channelID, IsPremium: c.Regress.IsPremium()}
+			var reply gatewayrpc.FortniteSnapshotReply
+			if err := d.Gateway.Call(wctx, "fortnite", "session_start", req, &reply); err != nil {
+				log.Warn("fortnite: stream-start snapshot failed",
+					zap.String("channel_id", channelID), zap.String("account", account), zap.Error(err))
+				return
+			}
+			log.Debug("fortnite: stream-start snapshot stored",
+				zap.String("channel_id", channelID), zap.String("player", reply.Player))
+		}()
+		return nil
+	}
+}
+
 // fortniteDispatchRun routes !fn's first argument word onto the subcommand
-// runners: "stats"/"season"/"store" (and "shop") select one explicitly, and
-// anything else — nothing, or a player name — is an all-time stats lookup, so
-// "!fn Ninja" reads naturally.
-func fortniteDispatchRun(statsRun, seasonRun, storeRun module.RunFunc) module.RunFunc {
+// runners: "stats"/"season"/"session"/"store" (and "shop") select one
+// explicitly, and anything else — nothing, or a player name — is an all-time
+// stats lookup, so "!fn Ninja" reads naturally.
+func fortniteDispatchRun(statsRun, seasonRun, sessionRun, storeRun module.RunFunc) module.RunFunc {
 	return func(ctx context.Context, c *module.Context, args string, emit module.Emit) error {
 		sub, rest, _ := strings.Cut(strings.TrimSpace(args), " ")
 		switch strings.ToLower(sub) {
@@ -104,6 +162,8 @@ func fortniteDispatchRun(statsRun, seasonRun, storeRun module.RunFunc) module.Ru
 			return statsRun(ctx, c, rest, emit)
 		case "season":
 			return seasonRun(ctx, c, rest, emit)
+		case "session":
+			return sessionRun(ctx, c, rest, emit)
 		case "store", "shop":
 			return storeRun(ctx, c, rest, emit)
 		default:
@@ -177,6 +237,68 @@ func fortniteStatsRun(d engine.Deps, cmd fortniteStatsCommand) module.RunFunc {
 		msg := module.ExpandString(orDefault(cmd.message(cfg), cmd.fallback), func(key string) (string, bool) {
 			if field, ok := tokens[key]; ok {
 				return field(&reply), true
+			}
+			return module.ParseDynamic(key)
+		})
+		emit(&module.Output{Type: outgress.TypeChat, BroadcasterID: c.Env.BroadcasterUserID, Text: msg})
+		return nil
+	}
+}
+
+// fortniteSessionRun answers !fn session / !fnsession with the delta since the
+// stream-start snapshot. Template tokens: {player} {wins} {matches} {kills}
+// {kd} {winrate}. Like the mcsr session command it always targets the linked
+// account, never a typed argument: the baseline is stored per channel and keyed
+// to the linked account, so honoring an arbitrary player would clobber the
+// streamer's stream-start baseline. Without a baseline (module enabled
+// mid-stream) the gateway starts tracking now and the reply says so instead of
+// faking a zero delta.
+func fortniteSessionRun(d engine.Deps) module.RunFunc {
+	return func(ctx context.Context, c *module.Context, _ string, emit module.Emit) error {
+		var cfg fortniteConfig
+		_ = c.Decode(&cfg)
+		if !alertOn(cfg.SessionEnabled) || d.Gateway == nil {
+			return nil
+		}
+
+		account := resolveAccount(accountSources{Linked: cfg.Account, BroadcasterLogin: c.Env.BroadcasterUserLogin})
+		req := gatewayrpc.Request{
+			Account:     account,
+			AccountType: cfg.AccountType,
+			ChannelID:   strconv.FormatUint(c.BroadcasterID, 10),
+			IsPremium:   c.Regress.IsPremium(),
+		}
+		var reply gatewayrpc.FortniteSessionReply
+		if err := d.Gateway.Call(ctx, "fortnite", "session", req, &reply); err != nil {
+			if chatReplyError(c, emit, account, err) {
+				return nil
+			}
+			return err
+		}
+
+		if !reply.HasSnapshot {
+			emit(&module.Output{
+				Type:          outgress.TypeChat,
+				BroadcasterID: c.Env.BroadcasterUserID,
+				Text:          reply.Player + ": session tracking just started, come back after a few games!",
+			})
+			return nil
+		}
+
+		msg := module.ExpandString(orDefault(cfg.SessionMessage, defaultFortniteSessionTemplate), func(key string) (string, bool) {
+			switch key {
+			case "player":
+				return reply.Player, true
+			case "wins":
+				return i64(reply.Wins), true
+			case "matches":
+				return i64(reply.Matches), true
+			case "kills":
+				return i64(reply.Kills), true
+			case "kd":
+				return trimScore(reply.KD), true
+			case "winrate":
+				return trimScore(reply.WinRate), true
 			}
 			return module.ParseDynamic(key)
 		})

--- a/app/sesame/modules/fortnite_test.go
+++ b/app/sesame/modules/fortnite_test.go
@@ -5,9 +5,11 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"ItsBagelBot/app/sesame/engine"
 	"ItsBagelBot/app/sesame/module"
+	"ItsBagelBot/internal/domain/event/lane"
 	"ItsBagelBot/internal/domain/outgress"
 	gatewayrpc "ItsBagelBot/internal/domain/rpc/gateway"
 	"ItsBagelBot/pkg/bus"
@@ -100,6 +102,7 @@ func TestFortniteDisabledStaysSilent(t *testing.T) {
 		{"fn", `{"statsEnabled":"off"}`},
 		{"fnstats", `{"statsEnabled":"off"}`},
 		{"fnseason", `{"seasonEnabled":"off"}`},
+		{"fnsession", `{"sessionEnabled":"off"}`},
 		{"fnstore", `{"storeEnabled":"off"}`},
 	}
 	for _, tc := range cases {
@@ -133,6 +136,7 @@ func TestFnDispatch(t *testing.T) {
 		{"player arg is stats", "@SomePlayer extra", "stats", "lifetime", "SomePlayer", fortniteStatsReply()},
 		{"season subcommand", "season", "stats", "season", "streamer", seasonReply},
 		{"season with player", "season OtherGuy", "stats", "season", "OtherGuy", seasonReply},
+		{"session subcommand", "session", "session", "", "", gatewayrpc.FortniteSessionReply{Player: "Ninja", HasSnapshot: true}},
 		{"store subcommand", "store", "shop", "", "", gatewayrpc.FortniteShopReply{Date: "2026-07-10"}},
 		{"shop alias, any case", "SHOP", "shop", "", "", gatewayrpc.FortniteShopReply{Date: "2026-07-10"}},
 	}
@@ -163,6 +167,112 @@ func TestFnstatsReplyErrorChats(t *testing.T) {
 	require.NoError(t, cmd.Run(context.Background(), urchinCtx(""), "Ghosty", col.emit))
 	require.Len(t, col.out, 1)
 	assert.Equal(t, "Ghosty: player not found", col.out[0].Text)
+}
+
+func TestFnSessionDefaultTemplate(t *testing.T) {
+	gw := &fakeGateway{replies: map[string]any{
+		"fortnite.session": gatewayrpc.FortniteSessionReply{
+			Player: "Ninja", Wins: 3, Matches: 12, Kills: 48, KD: 5.33, WinRate: 25.0, HasSnapshot: true,
+		},
+	}}
+	cmd := fortniteCmd(t, gw, "fnsession")
+
+	var col collector
+	require.NoError(t, cmd.Run(context.Background(), urchinCtx(`{"account":"Ninja"}`), "", col.emit))
+	require.Len(t, col.out, 1)
+	assert.Equal(t, "Ninja this stream: 3 wins in 12 matches · 25% WR · 48 kills · 5.33 K/D", col.out[0].Text)
+
+	// The session request is scoped to this channel and its linked account.
+	call := gw.lastCall(t)
+	assert.Equal(t, "session", call.endpoint)
+	assert.Equal(t, "2", call.req.ChannelID)
+	assert.Equal(t, "Ninja", call.req.Account)
+}
+
+// !fn session ignores a typed player argument so a viewer cannot retarget (and
+// clobber) the streamer's per-channel baseline; it always uses the linked
+// account.
+func TestFnSessionIgnoresArgument(t *testing.T) {
+	gw := &fakeGateway{replies: map[string]any{
+		"fortnite.session": gatewayrpc.FortniteSessionReply{Player: "Ninja", HasSnapshot: true},
+	}}
+	cmd := fortniteCmd(t, gw, "fnsession")
+
+	var col collector
+	require.NoError(t, cmd.Run(context.Background(), urchinCtx(`{"account":"Ninja"}`), "SomeoneElse", col.emit))
+	assert.Equal(t, "Ninja", gw.lastCall(t).req.Account)
+}
+
+func TestFnSessionWithoutSnapshot(t *testing.T) {
+	gw := &fakeGateway{replies: map[string]any{
+		"fortnite.session": gatewayrpc.FortniteSessionReply{Player: "Ninja", HasSnapshot: false},
+	}}
+	cmd := fortniteCmd(t, gw, "fnsession")
+
+	var col collector
+	require.NoError(t, cmd.Run(context.Background(), urchinCtx(""), "", col.emit))
+	require.Len(t, col.out, 1)
+	assert.Contains(t, col.out[0].Text, "session tracking just started")
+}
+
+// stream.online snapshots the linked account so !fn session has a baseline. The
+// call is fire-and-forget on its own goroutine.
+func TestFnStreamOnlineSnapshots(t *testing.T) {
+	done := make(chan struct{})
+	gw := &fakeGateway{
+		replies: map[string]any{"fortnite.session_start": gatewayrpc.FortniteSnapshotReply{Player: "Ninja"}},
+		done:    done,
+	}
+	m := Fortnite(engine.Deps{Gateway: gw, Log: zap.NewNop()})
+	h := m.Events["stream.online"]
+	require.NotNil(t, h, "fortnite must handle stream.online")
+
+	c := &module.Context{
+		Env: lane.Envelope{
+			Type:                 "stream.online",
+			BroadcasterUserID:    "2",
+			BroadcasterUserLogin: "streamer",
+		},
+		BroadcasterID: 2,
+		Log:           zap.NewNop(),
+		Config:        []byte(`{"account":"Ninja","accountType":"epic"}`),
+	}
+	var col collector
+	require.NoError(t, h(context.Background(), c, col.emit))
+	assert.Empty(t, col.out, "snapshot handler must not chat")
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("stream.online never called the gateway")
+	}
+	call := gw.lastCall(t)
+	assert.Equal(t, "fortnite", call.provider)
+	assert.Equal(t, "session_start", call.endpoint)
+	assert.Equal(t, "Ninja", call.req.Account)
+	assert.Equal(t, "epic", call.req.AccountType)
+	assert.Equal(t, "2", call.req.ChannelID)
+}
+
+// With the session command toggled off, stream.online must not spend the daily
+// stats budget on a snapshot: the handler returns before spawning the call.
+func TestFnStreamOnlineSkipsWhenSessionOff(t *testing.T) {
+	gw := &fakeGateway{}
+	m := Fortnite(engine.Deps{Gateway: gw, Log: zap.NewNop()})
+	h := m.Events["stream.online"]
+	require.NotNil(t, h)
+
+	c := &module.Context{
+		Env:           lane.Envelope{Type: "stream.online", BroadcasterUserID: "2", BroadcasterUserLogin: "streamer"},
+		BroadcasterID: 2,
+		Log:           zap.NewNop(),
+		Config:        []byte(`{"account":"Ninja","sessionEnabled":"off"}`),
+	}
+	var col collector
+	require.NoError(t, h(context.Background(), c, col.emit))
+	gw.mu.Lock()
+	assert.Empty(t, gw.calls)
+	gw.mu.Unlock()
 }
 
 func TestStoreDefaultTemplate(t *testing.T) {

--- a/console/shared/lib/types.ts
+++ b/console/shared/lib/types.ts
@@ -422,6 +422,19 @@ const FN_STATS_SAMPLES: Record<string, string> = {
   squadkd: '4.1'
 };
 
+// Token palette + preview samples for !fn session: deltas since the
+// stream-start snapshot (no per-mode breakdown, no window — always this
+// stream, always the linked account).
+const FN_SESSION_TOKENS = ['player', 'wins', 'matches', 'kills', 'kd', 'winrate'];
+const FN_SESSION_SAMPLES: Record<string, string> = {
+  player: 'Ninja',
+  wins: '3',
+  matches: '12',
+  kills: '48',
+  kd: '5.33',
+  winrate: '25.0'
+};
+
 export const MODULE_CATALOG: readonly ModuleDef[] = [
   // Chat Tools: the bot's viewer-facing chat features, surfaced first. Channel
   // Points and Timers own bespoke pages (opened via href); Trigger Words uses
@@ -827,7 +840,7 @@ export const MODULE_CATALOG: readonly ModuleDef[] = [
     label: 'Fortnite Stats',
     tagline: 'Fortnite BR stats and the daily item shop in chat.',
     description:
-      'One command, three looks: !fn shows a player\'s all-time wins, matches, kills, K/D and win rate with a solo/duo/squad breakdown; !fn season shows the same for the current season (the bot tracks season rollovers automatically); !fn store lists what is in today\'s item shop. The squashed forms !fnstats, !fnseason and !fnstore work too. Link your Epic display name below. Viewers can also name any player, e.g. "!fn Ninja". PlayStation and Xbox name lookups are not supported yet.',
+      'One command, four looks: !fn shows a player\'s all-time wins, matches, kills, K/D and win rate with a solo/duo/squad breakdown; !fn season shows the same for the current season (the bot tracks season rollovers automatically); !fn session shows wins, kills and K/D since the stream started, snapshotting your standing the moment you go live; !fn store lists what is in today\'s item shop. The squashed forms !fnstats, !fnseason, !fnsession and !fnstore work too. Link your Epic display name below. Viewers can also name any player, e.g. "!fn Ninja"; !fn session always tracks your linked account. PlayStation and Xbox name lookups are not supported yet.',
     icon: 'gamepad',
     category: 'Games',
     defaultEnabled: false,
@@ -874,6 +887,19 @@ export const MODULE_CATALOG: readonly ModuleDef[] = [
           squadmatches: '5',
           squadkd: '21.5'
         }
+      },
+      {
+        key: 'session',
+        label: '!fn session',
+        tagline: 'Wins, kills and K/D since the stream started (also !fnsession).',
+        event: '!fn session',
+        command: 'fn session',
+        enableKey: 'sessionEnabled',
+        messageKey: 'sessionMessage',
+        defaultMessage:
+          '{player} this stream: {wins} wins in {matches} matches · {winrate}% WR · {kills} kills · {kd} K/D',
+        tokens: FN_SESSION_TOKENS,
+        previewSamples: FN_SESSION_SAMPLES
       },
       {
         key: 'store',

--- a/internal/domain/rpc/gateway/gateway.go
+++ b/internal/domain/rpc/gateway/gateway.go
@@ -211,6 +211,33 @@ type FortniteShopReply struct {
 	Error   string              `json:"error,omitempty"`
 }
 
+// FortniteSnapshotReply is the answer to fortnite.session_start: acknowledges
+// the stream-start snapshot the session delta is later computed against.
+type FortniteSnapshotReply struct {
+	Player string `json:"player"`
+	Error  string `json:"error,omitempty"`
+}
+
+// FortniteSessionReply is the answer to fortnite.session (sesame's !fn
+// session): the change in a player's Battle Royale stats since the
+// stream-start snapshot for this channel. Wins/Matches/Kills are deltas over
+// the live session; KD and WinRate are derived from those session games alone.
+//
+// HasSnapshot is false when no snapshot existed for the channel (the module
+// was enabled mid-stream, or the gateway lost it); the gateway then takes one,
+// so the next call has a baseline.
+type FortniteSessionReply struct {
+	Player      string  `json:"player"`
+	Wins        int64   `json:"wins"`
+	Matches     int64   `json:"matches"`
+	Kills       int64   `json:"kills"`
+	KD          float64 `json:"kd"`
+	WinRate     float64 `json:"win_rate"`
+	SinceUnix   int64   `json:"since_unix"`
+	HasSnapshot bool    `json:"has_snapshot"`
+	Error       string  `json:"error,omitempty"`
+}
+
 // --- govee (smart-light control over the broadcaster's own key) -------------
 
 // GoveeDevice is one controllable device on a broadcaster's Govee account, as


### PR DESCRIPTION
## What

Adds `!fn session` (and the squashed `!fnsession`) — Fortnite stats since the stream started, the same pattern as MCSR's `!session`.

**Flow:** stream goes online → snapshot the linked account's lifetime BR stats keyed by channel → `!fn session` diffs live stats against that baseline → chats the delta.

## Changes

- **RPC** (`internal/domain/rpc/gateway`): `FortniteSnapshotReply` (session_start ack) + `FortniteSessionReply` (delta: wins/matches/kills/kd/winrate, `HasSnapshot`).
- **Gateway provider**: new `session_start` + `session` endpoints (keyed-only, alongside `stats`). Snapshot stored per channel (49h TTL); session diffs cached live lifetime stats against it, deriving K/D and win rate over the session's own games via the existing `modeAgg.reply()`. No snapshot (module enabled mid-stream) → starts tracking and says so. Always the **lifetime** window — a season rollover mid-stream would corrupt a delta taken across it.
- **Sesame module**: `!fn session` subcommand + `!fnsession` trigger + `stream.online` snapshot handler. The snapshot is **gated on the session toggle** (the daily stats budget is tight, so don't spend it for a disabled command — stricter than mcsr). Always tracks the linked account, ignores a typed arg so a viewer can't clobber the streamer's baseline.
- **Dashboard** (`console/shared/lib/types.ts`): session reply entry + tokens/samples. The module page renders `replies` generically, so the toggle and template editor appear automatically.

Default template: `{player} this stream: {wins} wins in {matches} matches · {winrate}% WR · {kills} kills · {kd} K/D`

## Tests

Both sides covered and green: delta math (+5W/+20M/+150K → 10.0 K/D, 25% WR), no-snapshot tracking, account-mismatch re-snapshot, platform guard, toggle-off, fire-and-forget `stream.online`.

## Deploy

No new secrets, no ACL change (`bagel.rpc.gateway.>` wildcard already covers the new subjects; endpoints auto-subscribe). Ship gateway + sesame images. Uses the existing fortnite stats key (same as `!fnstats`).