### PR TITLE
fix(ingress): self-healing conduit shards + race-free rollouts

### DIFF
--- a/app/ingress/lib/ingress/application.ex
+++ b/app/ingress/lib/ingress/application.ex
@@ -59,6 +59,17 @@ defmodule Ingress.Application do
     Supervisor.start_link(children, strategy: :one_for_one, name: Ingress.Supervisor)
   end
 
+  # Runs on SIGTERM before the supervision tree stops: hand every local
+  # shard off to a surviving node (make-before-break — the successor binds
+  # before the local socket closes), so a rolling deploy never drops a
+  # slot's events. Unplanned deaths skip this; the ConduitManager health
+  # pass is the floor there.
+  @impl true
+  def prep_stop(state) do
+    if Application.get_env(:ingress, :server, true), do: Ingress.Drain.run()
+    state
+  end
+
   @impl true
   def stop(_state) do
     Config.uninstall_hot_path()
@@ -74,7 +85,13 @@ defmodule Ingress.Application do
          name: Ingress.ShardSupervisor,
          strategy: :one_for_one,
          members: :auto,
-         process_redistribution: :active,
+         # :passive — processes move only when their node dies, never to
+         # rebalance on a join. :active moved shards stop-then-start on
+         # every membership change, a 2-5s event gap per moved shard on
+         # every scale-up and a second mover racing the drain handoff
+         # (Ingress.Drain) during rollouts. Balance comes from deterministic
+         # round-robin placement at start time instead.
+         process_redistribution: :passive,
          # Round-robin shards across nodes (3/2 on a two-node fleet) instead
          # of the default hash ring, which clusters them (4/1 observed).
          distribution_strategy: Ingress.ShardDistribution

--- a/app/ingress/lib/ingress/bootstrapper.ex
+++ b/app/ingress/lib/ingress/bootstrapper.ex
@@ -8,39 +8,103 @@ defmodule Ingress.Bootstrapper do
 
   Horde's registry guarantees at most one instance of each; this loop
   guarantees at least one, even right after boot when cluster membership is
-  still syncing, or after the node that hosted them disappears. ShardScaler
-  is ensured first so ConduitManager finds it ready when its first reconcile
-  runs.
+  still syncing, or after the node that hosted them disappears.
+
+  "Registered" is not "alive": a registration can wedge on a pid whose node
+  died uncleanly, and `start_child` then answers `:already_started` forever
+  while nothing runs — with ConduitManager down, no shard healing runs
+  anywhere. So an `:already_started` singleton is probed for process
+  liveness (not a mailbox call, so a singleton busy in a long reconcile is
+  never mistaken for dead); one that stays unreachable across consecutive
+  ticks is terminated through the supervisor and restarted by a following
+  tick. Two ticks of misses, not one, so a transient netsplit blip is not
+  answered with a replacement.
+
+  ShardScaler is ensured first so ConduitManager finds it ready when its
+  first reconcile runs. This process is plainly supervised per node and
+  shares no cluster state, so it cannot wedge cluster-wide itself.
   """
 
   use GenServer
   require Logger
 
   @interval_ms 10_000
+  @probe_timeout_ms 5_000
+  @max_probe_misses 2
 
   def start_link(opts), do: GenServer.start_link(__MODULE__, opts, name: __MODULE__)
 
   @impl true
   def init(_opts) do
     send(self(), :ensure)
-    {:ok, %{}}
+    {:ok, %{misses: %{}}}
   end
 
   @impl true
   def handle_info(:ensure, state) do
-    ensure_singleton(Ingress.ShardScaler, "shard scaler")
-    ensure_singleton(Ingress.ConduitManager, "conduit manager")
+    misses = state.misses
+    misses = ensure_singleton(Ingress.ShardScaler, "shard scaler", misses)
+    misses = ensure_singleton(Ingress.ConduitManager, "conduit manager", misses)
 
     Process.send_after(self(), :ensure, @interval_ms)
-    {:noreply, state}
+    {:noreply, %{state | misses: misses}}
   end
 
-  defp ensure_singleton(module, label) do
+  defp ensure_singleton(module, label, misses) do
     case Horde.DynamicSupervisor.start_child(Ingress.ShardSupervisor, module) do
-      {:ok, _pid} -> Logger.info("#{label} started on #{node()}")
-      {:error, {:already_started, _pid}} -> :ok
-      :ignore -> :ok
-      {:error, reason} -> Logger.debug("#{label} not started: #{inspect(reason)}")
+      {:ok, _pid} ->
+        Logger.info("#{label} started on #{node()}")
+        Map.delete(misses, module)
+
+      {:error, {:already_started, pid}} ->
+        check_responsive(module, label, pid, misses)
+
+      :ignore ->
+        misses
+
+      {:error, reason} ->
+        Logger.debug("#{label} not started: #{inspect(reason)}")
+        misses
+    end
+  end
+
+  defp check_responsive(module, label, pid, misses) do
+    case probe(pid) do
+      :ok -> Map.delete(misses, module)
+      :unreachable -> record_miss(module, label, pid, misses)
+    end
+  end
+
+  defp probe(pid) when node(pid) == node() do
+    if Process.alive?(pid), do: :ok, else: :unreachable
+  end
+
+  defp probe(pid) do
+    case :rpc.call(node(pid), Process, :alive?, [pid], @probe_timeout_ms) do
+      true -> :ok
+      _ -> :unreachable
+    end
+  end
+
+  defp record_miss(module, label, pid, misses) do
+    seen = Map.get(misses, module, 0) + 1
+
+    if seen >= @max_probe_misses do
+      Logger.warning("#{label} registered but not alive (#{seen} probes); replacing")
+      replace_singleton(label, pid)
+      Map.delete(misses, module)
+    else
+      Logger.warning("#{label} liveness probe failed (#{seen})")
+      Map.put(misses, module, seen)
+    end
+  end
+
+  # Terminate only; the next :ensure tick performs the start. No immediate
+  # restart here, so a replace loop cannot run hotter than the tick interval.
+  defp replace_singleton(label, pid) do
+    case Horde.DynamicSupervisor.terminate_child(Ingress.ShardSupervisor, pid) do
+      :ok -> :ok
+      {:error, reason} -> Logger.warning("#{label} terminate failed: #{inspect(reason)}")
     end
   end
 end

--- a/app/ingress/lib/ingress/conduit_manager.ex
+++ b/app/ingress/lib/ingress/conduit_manager.ex
@@ -9,9 +9,13 @@ defmodule Ingress.ConduitManager do
   `Ingress.ShardScaler`), then converges the running `Ingress.ShardSession`
   processes to match — starting missing shards and stopping excess ones.
 
-  Reconciliation repeats periodically to heal local shards whose supervisor
-  gave up. Twitch is updated only when the internally-owned desired shard count
-  changes; stable reconciliation ticks never spend Helix quota.
+  Reconciliation repeats periodically. Each tick reads Twitch's per-shard
+  snapshot once and uses it twice: to gate shard starts (never start into a
+  slot Twitch says is being served — that is how rolling deploys used to
+  spawn duplicate copies) and to heal any slot Twitch reports unhealthy
+  (dead binding, wedged session, blocked replacement — see the rescue
+  section below). Conduit writes still happen only when the desired shard
+  count changes.
   """
 
   use GenServer
@@ -92,8 +96,9 @@ defmodule Ingress.ConduitManager do
         adopt_then_converge(state, scaler)
 
       {:ok, desired, _scaler} ->
-        applied = converge_shards(state.conduit_id, desired, state.applied_shard_count)
-        state = run_health_pass(%{state | applied_shard_count: applied}, desired)
+        snapshot = shard_snapshot(state.conduit_id)
+        applied = converge_shards(state.conduit_id, desired, state.applied_shard_count, snapshot)
+        state = run_health_pass(%{state | applied_shard_count: applied}, desired, snapshot)
         Process.send_after(self(), :reconcile, @reconcile_interval_ms)
         state
 
@@ -147,11 +152,24 @@ defmodule Ingress.ConduitManager do
   #      slots for them; stopping is safe because :transient restart means a
   #      deliberate shutdown will not restart the session).
   #   3. Start any missing sessions for shard IDs 0..(desired-1).
-  defp converge_shards(conduit_id, desired, applied) when desired > 0 do
+  # Twitch's per-shard snapshot backing both the duplicate-start gate and the
+  # health pass; fetched once per tick.
+  defp shard_snapshot(conduit_id) do
+    case Api.get_shards(conduit_id) do
+      {:ok, shards} ->
+        {:ok, shards}
+
+      {:error, reason} ->
+        Logger.warning("shard snapshot failed: #{inspect(reason)}")
+        :error
+    end
+  end
+
+  defp converge_shards(conduit_id, desired, applied, snapshot) when desired > 0 do
     applied = maybe_resize_conduit(conduit_id, desired, applied)
 
     stop_excess_shards(desired)
-    start_missing_shards(conduit_id, desired)
+    start_missing_shards(conduit_id, desired, snapshot)
     applied
   end
 
@@ -219,9 +237,18 @@ defmodule Ingress.ConduitManager do
     end
   end
 
-  defp start_missing_shards(conduit_id, desired) do
-    for shard_id <- 0..(desired - 1), do: start_shard(conduit_id, shard_id)
+  # A shard is only started when Twitch does not report its slot enabled: an
+  # enabled slot has a live serving socket somewhere even if the registry
+  # shows a hole (registry state lags membership changes during a rolling
+  # deploy — starting into the hole is how duplicate copies used to spawn
+  # and race the serving one). Without a snapshot, fall back to starting
+  # every slot; the registry still deduplicates the common case.
+  defp start_missing_shards(conduit_id, desired, snapshot) do
+    for shard_id <- startable_ids(snapshot, desired), do: start_shard(conduit_id, shard_id)
   end
+
+  defp startable_ids({:ok, shards}, desired), do: ShardHealth.startable_ids(shards, desired)
+  defp startable_ids(:error, desired), do: Enum.to_list(0..(desired - 1))
 
   # :started only when a fresh session actually spawned. :already_started is
   # normal during converge (the shard runs), but right after a terminate it
@@ -253,19 +280,16 @@ defmodule Ingress.ConduitManager do
   # receiving keepalives after the binding moved or died with another copy).
   # So reconciliation asks Twitch for its per-shard view and repairs every
   # slot it reports unhealthy. Decisions live in `Ingress.ShardHealth`.
-  defp run_health_pass(state, desired) do
-    case Api.get_shards(state.conduit_id) do
-      {:ok, shards} ->
-        unhealthy = ShardHealth.unhealthy_ids(shards, desired)
-        {counts, rescues} = heal_all(state, unhealthy)
-        rescues = reap_rescues(unhealthy, rescues)
-        %{state | unhealthy_counts: counts, rescues: rescues}
-
-      {:error, reason} ->
-        Logger.warning("shard health poll failed: #{inspect(reason)}")
-        state
-    end
+  defp run_health_pass(state, desired, {:ok, shards}) do
+    unhealthy = ShardHealth.unhealthy_ids(shards, desired)
+    {counts, rescues} = heal_all(state, unhealthy)
+    rescues = reap_rescues(unhealthy, rescues)
+    %{state | unhealthy_counts: counts, rescues: rescues}
   end
+
+  # No snapshot, no verdicts: carry the counts unchanged rather than treating
+  # a Helix hiccup as five healthy shards.
+  defp run_health_pass(state, _desired, :error), do: state
 
   # Heals every Twitch-unhealthy shard, threading the consecutive-unhealthy
   # counts and the rescue table. Shards Twitch reports healthy drop out of the

--- a/app/ingress/lib/ingress/conduit_manager.ex
+++ b/app/ingress/lib/ingress/conduit_manager.ex
@@ -293,34 +293,35 @@ defmodule Ingress.ConduitManager do
 
   # Heals every Twitch-unhealthy shard, threading the consecutive-unhealthy
   # counts and the rescue table. Shards Twitch reports healthy drop out of the
-  # counts map, so a heal that works resets the escalation clock.
+  # counts map, so a heal that works resets the escalation clock. A slot is
+  # `{conduit_id, shard_id}` throughout the heal path.
   defp heal_all(state, unhealthy) do
     Enum.reduce(unhealthy, {%{}, state.rescues}, fn shard_id, {counts, rescues} ->
       seen = Map.get(state.unhealthy_counts, shard_id, 0) + 1
-      {count, rescues} = heal_shard(state.conduit_id, shard_id, seen, rescues)
+      {count, rescues} = heal_shard({state.conduit_id, shard_id}, seen, rescues)
       {Map.put(counts, shard_id, count), rescues}
     end)
   end
 
-  defp heal_shard(conduit_id, shard_id, seen, rescues) do
+  defp heal_shard({_conduit_id, shard_id} = slot, seen, rescues) do
     case Horde.Registry.lookup(Ingress.Registry, {:shard, shard_id}) do
-      [] -> heal_unregistered(conduit_id, shard_id, seen, rescues)
-      [{pid, _}] -> heal_registered(conduit_id, shard_id, pid, seen, rescues)
+      [] -> heal_unregistered(slot, seen, rescues)
+      [{pid, _}] -> heal_registered(slot, pid, seen, rescues)
     end
   end
 
   # Nothing registered: normally this tick's start_missing_shards pass covers
   # it. If the shard is still unhealthy after that had its chance, starting is
   # blocked (supervisor wedge, placement failure) — bring up a rescue.
-  defp heal_unregistered(conduit_id, shard_id, seen, rescues) do
+  defp heal_unregistered(slot, seen, rescues) do
     if ShardHealth.escalate?(seen) do
-      ensure_rescue(conduit_id, shard_id, seen, rescues)
+      ensure_rescue(slot, seen, rescues)
     else
       {seen, rescues}
     end
   end
 
-  defp heal_registered(conduit_id, shard_id, pid, seen, rescues) do
+  defp heal_registered({_conduit_id, shard_id} = slot, pid, seen, rescues) do
     case ShardHealth.heal_action(probe_shard(pid), seen) do
       :skip ->
         {seen, rescues}
@@ -332,7 +333,7 @@ defmodule Ingress.ConduitManager do
         {seen, rescues}
 
       :restart ->
-        restart_registered(conduit_id, shard_id, pid, seen, rescues)
+        restart_registered(slot, pid, seen, rescues)
     end
   end
 
@@ -340,17 +341,17 @@ defmodule Ingress.ConduitManager do
   # gets the full backstop window before it can be judged wedged. A blocked
   # restart (the registration or supervision is wedged on a pid nothing can
   # remove) escalates to a rescue session, which needs no name at all.
-  defp restart_registered(conduit_id, shard_id, pid, seen, rescues) do
+  defp restart_registered({_conduit_id, shard_id} = slot, pid, seen, rescues) do
     Logger.warning("shard #{shard_id} unhealthy on Twitch (#{seen} ticks); replacing session")
     Metrics.count("Conduit/ShardRestarts")
 
-    case restart_shard(conduit_id, shard_id, pid) do
+    case restart_shard(slot, pid) do
       :started -> {0, rescues}
-      :blocked -> ensure_rescue(conduit_id, shard_id, seen, rescues)
+      :blocked -> ensure_rescue(slot, seen, rescues)
     end
   end
 
-  defp restart_shard(conduit_id, shard_id, pid) do
+  defp restart_shard({conduit_id, shard_id}, pid) do
     case Horde.DynamicSupervisor.terminate_child(Ingress.ShardSupervisor, pid) do
       :ok -> :ok
       {:error, :not_found} -> stop_orphan_shard(shard_id, pid)
@@ -376,14 +377,14 @@ defmodule Ingress.ConduitManager do
   # says. Once Twitch reports the slot healthy and a live named session holds
   # a binding, the named session re-asserts and the rescue is stopped.
 
-  defp ensure_rescue(conduit_id, shard_id, seen, rescues) do
+  defp ensure_rescue({_conduit_id, shard_id} = slot, seen, rescues) do
     case Map.get(rescues, shard_id) do
-      nil -> {seen, spawn_rescue(conduit_id, shard_id, seen, rescues)}
-      {pid, spawned_seen} -> heal_rescue(conduit_id, shard_id, pid, seen, spawned_seen, rescues)
+      nil -> {seen, spawn_rescue(slot, seen, rescues)}
+      entry -> heal_rescue(slot, entry, seen, rescues)
     end
   end
 
-  defp spawn_rescue(conduit_id, shard_id, seen, rescues) do
+  defp spawn_rescue({conduit_id, shard_id}, seen, rescues) do
     Logger.warning("shard #{shard_id} cannot be replaced in place; starting rescue session")
     Metrics.count("Conduit/ShardRescues")
 
@@ -410,7 +411,7 @@ defmodule Ingress.ConduitManager do
   # A rescue is judged by the same rules as a named session, on its own clock
   # (ticks since it was spawned): give it the settle window, force a re-bind
   # if it claims a binding Twitch says is dead, replace it if it stays stuck.
-  defp heal_rescue(conduit_id, shard_id, pid, seen, spawned_seen, rescues) do
+  defp heal_rescue({_conduit_id, shard_id} = slot, {pid, spawned_seen}, seen, rescues) do
     case ShardHealth.heal_action(probe_shard(pid), seen - spawned_seen) do
       :skip ->
         {seen, rescues}
@@ -421,7 +422,7 @@ defmodule Ingress.ConduitManager do
 
       :restart ->
         stop_rescue(shard_id, pid)
-        {seen, spawn_rescue(conduit_id, shard_id, seen, Map.delete(rescues, shard_id))}
+        {seen, spawn_rescue(slot, seen, Map.delete(rescues, shard_id))}
     end
   end
 

--- a/app/ingress/lib/ingress/conduit_manager.ex
+++ b/app/ingress/lib/ingress/conduit_manager.ex
@@ -17,7 +17,10 @@ defmodule Ingress.ConduitManager do
   use GenServer
   require Logger
 
+  alias Ingress.Metrics
+  alias Ingress.ShardHealth
   alias Ingress.ShardScaler
+  alias Ingress.ShardSession
   alias Ingress.Twitch.Api
 
   @reconcile_interval_ms 30_000
@@ -33,7 +36,8 @@ defmodule Ingress.ConduitManager do
 
   @impl true
   def init(_) do
-    {:ok, %{conduit_id: nil, applied_shard_count: nil, adopted_scaler: nil},
+    {:ok,
+     %{conduit_id: nil, applied_shard_count: nil, adopted_scaler: nil, unhealthy_counts: %{}},
      {:continue, :reconcile}}
   end
 
@@ -80,8 +84,9 @@ defmodule Ingress.ConduitManager do
 
       {:ok, desired, _scaler} ->
         applied = converge_shards(state.conduit_id, desired, state.applied_shard_count)
+        counts = heal_unhealthy_shards(state.conduit_id, desired, state.unhealthy_counts)
         Process.send_after(self(), :reconcile, @reconcile_interval_ms)
-        %{state | applied_shard_count: applied}
+        %{state | applied_shard_count: applied, unhealthy_counts: counts}
 
       :error ->
         hold_convergence(state, "shard scaler unreachable")
@@ -206,15 +211,93 @@ defmodule Ingress.ConduitManager do
   end
 
   defp start_missing_shards(conduit_id, desired) do
-    for shard_id <- 0..(desired - 1) do
-      spec = {Ingress.ShardSession, shard_id: shard_id, conduit_id: conduit_id}
+    for shard_id <- 0..(desired - 1), do: start_shard(conduit_id, shard_id)
+  end
 
-      case Horde.DynamicSupervisor.start_child(Ingress.ShardSupervisor, spec) do
-        {:ok, _pid} -> Logger.info("started shard #{shard_id}")
-        {:error, {:already_started, _pid}} -> :ok
-        :ignore -> :ok
-        {:error, reason} -> Logger.warning("shard #{shard_id} start failed: #{inspect(reason)}")
-      end
+  defp start_shard(conduit_id, shard_id) do
+    spec = {Ingress.ShardSession, shard_id: shard_id, conduit_id: conduit_id}
+
+    case Horde.DynamicSupervisor.start_child(Ingress.ShardSupervisor, spec) do
+      {:ok, _pid} -> Logger.info("started shard #{shard_id}")
+      {:error, {:already_started, _pid}} -> :ok
+      :ignore -> :ok
+      {:error, reason} -> Logger.warning("shard #{shard_id} start failed: #{inspect(reason)}")
     end
+  end
+
+  # Twitch silently drops events routed to a shard slot whose transport is not
+  # enabled — a conduit never rebalances a subscription to a healthy shard —
+  # and a slot can die without any local process noticing (its socket keeps
+  # receiving keepalives after the binding moved or died with another copy).
+  # So reconciliation asks Twitch for its per-shard view and repairs every
+  # slot it reports unhealthy. Decisions live in `Ingress.ShardHealth`.
+  #
+  # Returns the consecutive-unhealthy-tick count per shard id, carried in the
+  # manager state so persistent unhealth escalates to a restart. Shards Twitch
+  # reports healthy drop out of the map.
+  defp heal_unhealthy_shards(conduit_id, desired, counts) do
+    case Api.get_shards(conduit_id) do
+      {:ok, shards} ->
+        shards
+        |> ShardHealth.unhealthy_ids(desired)
+        |> Map.new(fn shard_id ->
+          seen = Map.get(counts, shard_id, 0) + 1
+          {shard_id, heal_shard(conduit_id, shard_id, seen)}
+        end)
+
+      {:error, reason} ->
+        Logger.warning("shard health poll failed: #{inspect(reason)}")
+        counts
+    end
+  end
+
+  defp heal_shard(conduit_id, shard_id, seen) do
+    case Horde.Registry.lookup(Ingress.Registry, {:shard, shard_id}) do
+      # Nothing registered: this tick's start_missing_shards pass (or the next
+      # one) starts the shard; healing has nothing to act on yet.
+      [] ->
+        seen
+
+      [{pid, _}] ->
+        action = ShardHealth.heal_action(probe_shard(pid), seen)
+        apply_heal(action, conduit_id, shard_id, pid, seen)
+    end
+  end
+
+  # A restart resets the observation count: the replacement session gets the
+  # full backstop window before it can be judged wedged.
+  defp apply_heal(:restart, conduit_id, shard_id, pid, seen) do
+    Logger.warning(
+      "shard #{shard_id} unhealthy on Twitch (#{seen} ticks); replacing local session"
+    )
+
+    Metrics.count("Conduit/ShardRestarts")
+    restart_shard(conduit_id, shard_id, pid)
+    0
+  end
+
+  defp apply_heal(:force_rebind, _conduit_id, shard_id, pid, seen) do
+    Logger.warning("shard #{shard_id} unhealthy on Twitch but bound locally; forcing re-bind")
+    Metrics.count("Conduit/ShardRebinds")
+    GenServer.cast(pid, :force_rebind)
+    seen
+  end
+
+  defp apply_heal(:skip, _conduit_id, _shard_id, _pid, seen), do: seen
+
+  defp probe_shard(pid) do
+    ShardSession.status(pid)
+  catch
+    :exit, _ -> :unreachable
+  end
+
+  defp restart_shard(conduit_id, shard_id, pid) do
+    case Horde.DynamicSupervisor.terminate_child(Ingress.ShardSupervisor, pid) do
+      :ok -> :ok
+      {:error, :not_found} -> stop_orphan_shard(shard_id, pid)
+      {:error, reason} -> Logger.warning("stop shard #{shard_id} failed: #{inspect(reason)}")
+    end
+
+    start_shard(conduit_id, shard_id)
   end
 end

--- a/app/ingress/lib/ingress/conduit_manager.ex
+++ b/app/ingress/lib/ingress/conduit_manager.ex
@@ -23,7 +23,9 @@ defmodule Ingress.ConduitManager do
   alias Ingress.ShardSession
   alias Ingress.Twitch.Api
 
-  @reconcile_interval_ms 30_000
+  # Also the shard-health poll cadence: worst-case blackhole detection is one
+  # interval, and escalation to a replacement/rescue is two.
+  @reconcile_interval_ms 15_000
   @retry_interval_ms 5_000
   # How long a direct stop of an unsupervised (orphan) shard may take.
   @orphan_stop_timeout_ms 5_000
@@ -37,8 +39,15 @@ defmodule Ingress.ConduitManager do
   @impl true
   def init(_) do
     {:ok,
-     %{conduit_id: nil, applied_shard_count: nil, adopted_scaler: nil, unhealthy_counts: %{}},
-     {:continue, :reconcile}}
+     %{
+       conduit_id: nil,
+       applied_shard_count: nil,
+       adopted_scaler: nil,
+       # shard_id => consecutive reconcile ticks observed unhealthy on Twitch
+       unhealthy_counts: %{},
+       # shard_id => {rescue pid, seen count when the rescue was spawned}
+       rescues: %{}
+     }, {:continue, :reconcile}}
   end
 
   @impl true
@@ -84,9 +93,9 @@ defmodule Ingress.ConduitManager do
 
       {:ok, desired, _scaler} ->
         applied = converge_shards(state.conduit_id, desired, state.applied_shard_count)
-        counts = heal_unhealthy_shards(state.conduit_id, desired, state.unhealthy_counts)
+        state = run_health_pass(%{state | applied_shard_count: applied}, desired)
         Process.send_after(self(), :reconcile, @reconcile_interval_ms)
-        %{state | applied_shard_count: applied, unhealthy_counts: counts}
+        state
 
       :error ->
         hold_convergence(state, "shard scaler unreachable")
@@ -214,14 +223,27 @@ defmodule Ingress.ConduitManager do
     for shard_id <- 0..(desired - 1), do: start_shard(conduit_id, shard_id)
   end
 
+  # :started only when a fresh session actually spawned. :already_started is
+  # normal during converge (the shard runs), but right after a terminate it
+  # means the registration is wedged on a pid nothing can remove — callers on
+  # the restart path treat :blocked as the cue to escalate to a rescue.
   defp start_shard(conduit_id, shard_id) do
     spec = {Ingress.ShardSession, shard_id: shard_id, conduit_id: conduit_id}
 
     case Horde.DynamicSupervisor.start_child(Ingress.ShardSupervisor, spec) do
-      {:ok, _pid} -> Logger.info("started shard #{shard_id}")
-      {:error, {:already_started, _pid}} -> :ok
-      :ignore -> :ok
-      {:error, reason} -> Logger.warning("shard #{shard_id} start failed: #{inspect(reason)}")
+      {:ok, _pid} ->
+        Logger.info("started shard #{shard_id}")
+        :started
+
+      {:error, {:already_started, _pid}} ->
+        :blocked
+
+      :ignore ->
+        :blocked
+
+      {:error, reason} ->
+        Logger.warning("shard #{shard_id} start failed: #{inspect(reason)}")
+        :blocked
     end
   end
 
@@ -231,64 +253,77 @@ defmodule Ingress.ConduitManager do
   # receiving keepalives after the binding moved or died with another copy).
   # So reconciliation asks Twitch for its per-shard view and repairs every
   # slot it reports unhealthy. Decisions live in `Ingress.ShardHealth`.
-  #
-  # Returns the consecutive-unhealthy-tick count per shard id, carried in the
-  # manager state so persistent unhealth escalates to a restart. Shards Twitch
-  # reports healthy drop out of the map.
-  defp heal_unhealthy_shards(conduit_id, desired, counts) do
-    case Api.get_shards(conduit_id) do
+  defp run_health_pass(state, desired) do
+    case Api.get_shards(state.conduit_id) do
       {:ok, shards} ->
-        shards
-        |> ShardHealth.unhealthy_ids(desired)
-        |> Map.new(fn shard_id ->
-          seen = Map.get(counts, shard_id, 0) + 1
-          {shard_id, heal_shard(conduit_id, shard_id, seen)}
-        end)
+        unhealthy = ShardHealth.unhealthy_ids(shards, desired)
+        {counts, rescues} = heal_all(state, unhealthy)
+        rescues = reap_rescues(unhealthy, rescues)
+        %{state | unhealthy_counts: counts, rescues: rescues}
 
       {:error, reason} ->
         Logger.warning("shard health poll failed: #{inspect(reason)}")
-        counts
+        state
     end
   end
 
-  defp heal_shard(conduit_id, shard_id, seen) do
+  # Heals every Twitch-unhealthy shard, threading the consecutive-unhealthy
+  # counts and the rescue table. Shards Twitch reports healthy drop out of the
+  # counts map, so a heal that works resets the escalation clock.
+  defp heal_all(state, unhealthy) do
+    Enum.reduce(unhealthy, {%{}, state.rescues}, fn shard_id, {counts, rescues} ->
+      seen = Map.get(state.unhealthy_counts, shard_id, 0) + 1
+      {count, rescues} = heal_shard(state.conduit_id, shard_id, seen, rescues)
+      {Map.put(counts, shard_id, count), rescues}
+    end)
+  end
+
+  defp heal_shard(conduit_id, shard_id, seen, rescues) do
     case Horde.Registry.lookup(Ingress.Registry, {:shard, shard_id}) do
-      # Nothing registered: this tick's start_missing_shards pass (or the next
-      # one) starts the shard; healing has nothing to act on yet.
-      [] ->
-        seen
-
-      [{pid, _}] ->
-        action = ShardHealth.heal_action(probe_shard(pid), seen)
-        apply_heal(action, conduit_id, shard_id, pid, seen)
+      [] -> heal_unregistered(conduit_id, shard_id, seen, rescues)
+      [{pid, _}] -> heal_registered(conduit_id, shard_id, pid, seen, rescues)
     end
   end
 
-  # A restart resets the observation count: the replacement session gets the
-  # full backstop window before it can be judged wedged.
-  defp apply_heal(:restart, conduit_id, shard_id, pid, seen) do
-    Logger.warning(
-      "shard #{shard_id} unhealthy on Twitch (#{seen} ticks); replacing local session"
-    )
+  # Nothing registered: normally this tick's start_missing_shards pass covers
+  # it. If the shard is still unhealthy after that had its chance, starting is
+  # blocked (supervisor wedge, placement failure) — bring up a rescue.
+  defp heal_unregistered(conduit_id, shard_id, seen, rescues) do
+    if ShardHealth.escalate?(seen) do
+      ensure_rescue(conduit_id, shard_id, seen, rescues)
+    else
+      {seen, rescues}
+    end
+  end
 
+  defp heal_registered(conduit_id, shard_id, pid, seen, rescues) do
+    case ShardHealth.heal_action(probe_shard(pid), seen) do
+      :skip ->
+        {seen, rescues}
+
+      :force_rebind ->
+        Logger.warning("shard #{shard_id} unhealthy on Twitch but bound locally; forcing re-bind")
+        Metrics.count("Conduit/ShardRebinds")
+        GenServer.cast(pid, :force_rebind)
+        {seen, rescues}
+
+      :restart ->
+        restart_registered(conduit_id, shard_id, pid, seen, rescues)
+    end
+  end
+
+  # A successful restart resets the observation count: the replacement session
+  # gets the full backstop window before it can be judged wedged. A blocked
+  # restart (the registration or supervision is wedged on a pid nothing can
+  # remove) escalates to a rescue session, which needs no name at all.
+  defp restart_registered(conduit_id, shard_id, pid, seen, rescues) do
+    Logger.warning("shard #{shard_id} unhealthy on Twitch (#{seen} ticks); replacing session")
     Metrics.count("Conduit/ShardRestarts")
-    restart_shard(conduit_id, shard_id, pid)
-    0
-  end
 
-  defp apply_heal(:force_rebind, _conduit_id, shard_id, pid, seen) do
-    Logger.warning("shard #{shard_id} unhealthy on Twitch but bound locally; forcing re-bind")
-    Metrics.count("Conduit/ShardRebinds")
-    GenServer.cast(pid, :force_rebind)
-    seen
-  end
-
-  defp apply_heal(:skip, _conduit_id, _shard_id, _pid, seen), do: seen
-
-  defp probe_shard(pid) do
-    ShardSession.status(pid)
-  catch
-    :exit, _ -> :unreachable
+    case restart_shard(conduit_id, shard_id, pid) do
+      :started -> {0, rescues}
+      :blocked -> ensure_rescue(conduit_id, shard_id, seen, rescues)
+    end
   end
 
   defp restart_shard(conduit_id, shard_id, pid) do
@@ -299,5 +334,114 @@ defmodule Ingress.ConduitManager do
     end
 
     start_shard(conduit_id, shard_id)
+  end
+
+  defp probe_shard(pid) do
+    ShardSession.status(pid)
+  catch
+    :exit, _ -> :unreachable
+  end
+
+  # --- rescue sessions --------------------------------------------------------
+  #
+  # Last line of defense: when a shard slot stays dead on Twitch and the named
+  # session cannot even be replaced (Horde registration or supervision wedged
+  # on a dead pid), an unnamed session is started instead. It binds the shard
+  # on Twitch — the binding PATCH, not the registry, decides who receives
+  # events — so the slot serves again no matter what the cluster metadata
+  # says. Once Twitch reports the slot healthy and a live named session holds
+  # a binding, the named session re-asserts and the rescue is stopped.
+
+  defp ensure_rescue(conduit_id, shard_id, seen, rescues) do
+    case Map.get(rescues, shard_id) do
+      nil -> {seen, spawn_rescue(conduit_id, shard_id, seen, rescues)}
+      {pid, spawned_seen} -> heal_rescue(conduit_id, shard_id, pid, seen, spawned_seen, rescues)
+    end
+  end
+
+  defp spawn_rescue(conduit_id, shard_id, seen, rescues) do
+    Logger.warning("shard #{shard_id} cannot be replaced in place; starting rescue session")
+    Metrics.count("Conduit/ShardRescues")
+
+    spec = %{
+      id: {:rescue, shard_id},
+      start:
+        {Ingress.ShardSession, :start_link,
+         [[shard_id: shard_id, conduit_id: conduit_id, rescue?: true]]},
+      # :temporary — a crashed rescue is not restarted blindly; the next
+      # health pass decides whether one is still needed.
+      restart: :temporary
+    }
+
+    case Horde.DynamicSupervisor.start_child(Ingress.ShardSupervisor, spec) do
+      {:ok, pid} ->
+        Map.put(rescues, shard_id, {pid, seen})
+
+      other ->
+        Logger.warning("rescue for shard #{shard_id} failed to start: #{inspect(other)}")
+        rescues
+    end
+  end
+
+  # A rescue is judged by the same rules as a named session, on its own clock
+  # (ticks since it was spawned): give it the settle window, force a re-bind
+  # if it claims a binding Twitch says is dead, replace it if it stays stuck.
+  defp heal_rescue(conduit_id, shard_id, pid, seen, spawned_seen, rescues) do
+    case ShardHealth.heal_action(probe_shard(pid), seen - spawned_seen) do
+      :skip ->
+        {seen, rescues}
+
+      :force_rebind ->
+        GenServer.cast(pid, :force_rebind)
+        {seen, rescues}
+
+      :restart ->
+        stop_rescue(shard_id, pid)
+        {seen, spawn_rescue(conduit_id, shard_id, seen, Map.delete(rescues, shard_id))}
+    end
+  end
+
+  # Twitch reports a rescued slot healthy again: hand it back to the named
+  # session when one is alive and bound (re-assert makes Twitch's routing
+  # follow it before the rescue socket closes). While no named session
+  # serves, the rescue IS the shard; keep it.
+  defp reap_rescues(unhealthy, rescues) do
+    Enum.reduce(rescues, %{}, fn {shard_id, entry}, acc ->
+      if shard_id in unhealthy do
+        Map.put(acc, shard_id, entry)
+      else
+        maybe_release_rescue(shard_id, entry, acc)
+      end
+    end)
+  end
+
+  defp maybe_release_rescue(shard_id, {pid, _spawned_seen} = entry, acc) do
+    case named_session_serving(shard_id) do
+      {:ok, named} ->
+        GenServer.cast(named, :reassert_binding)
+        stop_rescue(shard_id, pid)
+        acc
+
+      :not_serving ->
+        Map.put(acc, shard_id, entry)
+    end
+  end
+
+  defp named_session_serving(shard_id) do
+    with [{pid, _}] <- Horde.Registry.lookup(Ingress.Registry, {:shard, shard_id}),
+         %{bound: true} <- probe_shard(pid) do
+      {:ok, pid}
+    else
+      _ -> :not_serving
+    end
+  end
+
+  defp stop_rescue(shard_id, pid) do
+    Logger.info("stopping rescue session for shard #{shard_id}")
+
+    case Horde.DynamicSupervisor.terminate_child(Ingress.ShardSupervisor, pid) do
+      :ok -> :ok
+      {:error, _} -> stop_orphan_shard(shard_id, pid)
+    end
   end
 end

--- a/app/ingress/lib/ingress/drain.ex
+++ b/app/ingress/lib/ingress/drain.ex
@@ -1,0 +1,190 @@
+defmodule Ingress.Drain do
+  @moduledoc """
+  Make-before-break shard handoff for planned shutdown.
+
+  `Ingress.Application.prep_stop/1` calls `run/0` on SIGTERM, before the
+  supervision tree stops. For every shard session running on this node:
+
+    1. Release its cluster registration (`:release_name`) — the socket keeps
+       serving, but the name is free for a successor.
+    2. Start a successor session on a surviving node. The `{:draining, node}`
+       marker registered here keeps `Ingress.ShardDistribution` from placing
+       it back on this node.
+    3. Wait for the successor to bind. The Conduit routes each event to
+       whichever session bound last, so the slot switches to the successor
+       the moment its PATCH lands — no gap, no drop.
+    4. Stop the local session; its socket is now an idle superseded one.
+
+  Handoffs run concurrently and are deadline-bounded so the whole drain fits
+  inside the pod's termination grace period. Every failure path degrades to
+  "keep serving until the tree stops", and the ConduitManager health pass is
+  the floor for anything a drain could not hand off — including rescue
+  sessions (unnamed, never handed off) and unplanned deaths (crash, OOM,
+  node loss), which never run this path at all.
+  """
+
+  require Logger
+
+  alias Ingress.{Config, Metrics, ShardSession}
+
+  # Budget per shard for the successor to connect, welcome and bind. The
+  # whole drain must fit inside terminationGracePeriodSeconds minus the
+  # preStop sleep; handoffs run concurrently so this is also ~the total.
+  @handoff_deadline_ms 12_000
+  @poll_interval_ms 300
+  @call_timeout_ms 2_000
+
+  def run do
+    marker = mark_draining()
+
+    local_shards()
+    |> Task.async_stream(&hand_off/1,
+      timeout: @handoff_deadline_ms + 5_000,
+      on_timeout: :kill_task,
+      ordered: false
+    )
+    |> Stream.run()
+
+    release_marker(marker)
+    :ok
+  rescue
+    error ->
+      Logger.error("drain failed: #{Exception.message(error)}; shutting down without handoff")
+      :ok
+  end
+
+  # The marker must outlive each registering call, so it lives in a helper
+  # process that survives until the drain finishes; its registration (and the
+  # draining flag with it) dies with the pod at the latest.
+  defp mark_draining do
+    caller = self()
+
+    pid =
+      spawn(fn ->
+        Horde.Registry.register(Ingress.Registry, {:draining, node()}, nil)
+        send(caller, {:marked, self()})
+
+        receive do
+          :release -> :ok
+        end
+      end)
+
+    receive do
+      {:marked, ^pid} -> pid
+    after
+      @call_timeout_ms -> pid
+    end
+  end
+
+  defp release_marker(pid), do: send(pid, :release)
+
+  defp local_shards do
+    Horde.Registry.select(Ingress.Registry, [
+      {{{:shard, :"$1"}, :"$2", :_}, [], [{{:"$1", :"$2"}}]}
+    ])
+    |> Enum.filter(fn {_shard_id, pid} -> node(pid) == node() end)
+  end
+
+  defp hand_off({shard_id, pid}) do
+    Logger.info("draining shard #{shard_id}")
+    Metrics.count("Drain/Handoffs")
+    release_name(pid)
+
+    case start_successor(shard_id) do
+      {:ok, successor} ->
+        await_bound(successor, deadline())
+        stop_session(pid)
+
+      :error ->
+        # No successor possible (no peers, start failed): keep serving until
+        # the tree stops — every second counts — and let the health pass
+        # re-establish the slot after this pod is gone.
+        Logger.warning("shard #{shard_id}: no successor; serving until shutdown")
+        Metrics.count("Drain/HandoffFailures")
+    end
+  end
+
+  defp release_name(pid) do
+    GenServer.call(pid, :release_name, @call_timeout_ms)
+  catch
+    :exit, _ -> :ok
+  end
+
+  # Placement is Horde's (drain-aware via the marker), but the start call
+  # must run on a surviving node: a start_child issued here could not place
+  # the child anywhere once this node's supervisor begins stopping. If the
+  # marker has not replicated yet and placement lands back on this dying
+  # node, tear that copy down and try again — one round of the registry's
+  # sync interval is enough for the marker to arrive.
+  defp start_successor(shard_id), do: start_successor(shard_id, 2)
+
+  defp start_successor(shard_id, 0) do
+    Logger.warning("successor for shard #{shard_id} kept landing on the draining node")
+    :error
+  end
+
+  defp start_successor(shard_id, attempts) do
+    spec = {ShardSession, shard_id: shard_id, conduit_id: Config.twitch_conduit_id()}
+
+    case remote_start(spec) do
+      {:ok, pid} when node(pid) != node() ->
+        {:ok, pid}
+
+      {:ok, pid} ->
+        Horde.DynamicSupervisor.terminate_child(Ingress.ShardSupervisor, pid)
+        Process.sleep(500)
+        start_successor(shard_id, attempts - 1)
+
+      other ->
+        Logger.warning("successor for shard #{shard_id} did not start: #{inspect(other)}")
+        :error
+    end
+  end
+
+  defp remote_start(spec) do
+    case Node.list() do
+      [] ->
+        {:error, :no_peers}
+
+      [target | _] ->
+        case :rpc.call(target, Horde.DynamicSupervisor, :start_child, [
+               Ingress.ShardSupervisor,
+               spec
+             ]) do
+          {:ok, pid} when is_pid(pid) -> {:ok, pid}
+          {:error, {:already_started, pid}} -> {:ok, pid}
+          other -> other
+        end
+    end
+  end
+
+  defp deadline, do: System.monotonic_time(:millisecond) + @handoff_deadline_ms
+
+  defp await_bound(pid, deadline) do
+    cond do
+      bound?(pid) ->
+        :ok
+
+      System.monotonic_time(:millisecond) >= deadline ->
+        # Close anyway: the successor keeps trying on its own, and the
+        # health pass repairs the slot if it never manages to bind.
+        :timeout
+
+      true ->
+        Process.sleep(@poll_interval_ms)
+        await_bound(pid, deadline)
+    end
+  end
+
+  defp bound?(pid) do
+    match?(%{bound: true}, ShardSession.status(pid))
+  catch
+    :exit, _ -> false
+  end
+
+  defp stop_session(pid) do
+    GenServer.stop(pid, :normal, @call_timeout_ms)
+  catch
+    :exit, _ -> :ok
+  end
+end

--- a/app/ingress/lib/ingress/shard_distribution.ex
+++ b/app/ingress/lib/ingress/shard_distribution.ex
@@ -5,19 +5,25 @@ defmodule Ingress.ShardDistribution do
   Conduit on two nodes always splits 3/2 instead of wherever the default
   hash ring happens to land (4/1 in practice).
 
-  Placement is deterministic given the same membership, which matters for
-  `process_redistribution: :active`: after a node joins or leaves, Horde
-  re-evaluates `choose_node/2` and moves exactly the shards whose target
-  changed, restoring balance with the minimum number of session teardowns.
+  Placement is deterministic given the same membership, so restarts and
+  scale-ups land in a balanced shape without any rebalancing moves.
 
-  Anything that is not a shard session (the ConduitManager singleton) falls
-  back to `Horde.UniformDistribution`.
+  Nodes carrying a `{:draining, node}` marker (registered by `Ingress.Drain`
+  during a planned shutdown) are excluded from every placement — a handoff
+  successor placed back on the dying pod would die seconds later. A marker
+  whose owner is no longer a visible cluster member is ignored, so a stale
+  entry can never fence a node out permanently.
+
+  Anything that is not a shard session (the singletons, rescue sessions)
+  falls back to `Horde.UniformDistribution` over the same filtered members.
   """
 
   @behaviour Horde.DistributionStrategy
 
   @impl true
   def choose_node(child_spec, members) do
+    members = Enum.reject(members, &draining?/1)
+
     case shard_id(child_spec) do
       nil ->
         Horde.UniformDistribution.choose_node(child_spec, members)
@@ -35,6 +41,17 @@ defmodule Ingress.ShardDistribution do
 
   @impl true
   def has_quorum?(_members), do: true
+
+  defp draining?(%{name: {_sup, node}}) do
+    case Horde.Registry.lookup(Ingress.Registry, {:draining, node}) do
+      [{pid, _}] -> node(pid) in [node() | Node.list()]
+      [] -> false
+    end
+  rescue
+    # Registry not running (placement asked before the tree is up): no
+    # markers can exist either.
+    ArgumentError -> false
+  end
 
   defp shard_id(%{start: {Ingress.ShardSession, :start_link, [opts]}}) when is_list(opts),
     do: Keyword.get(opts, :shard_id)

--- a/app/ingress/lib/ingress/shard_health.ex
+++ b/app/ingress/lib/ingress/shard_health.ex
@@ -18,8 +18,11 @@ defmodule Ingress.ShardHealth do
   # A shard observed unhealthy this many consecutive reconcile ticks gets its
   # local session replaced outright, whatever state the session claims. This
   # is the backstop for sessions wedged in a state their own machinery never
-  # leaves (a takeover that never completes, a lost reconnect timer).
-  @max_unhealthy_observations 6
+  # leaves (a takeover that never completes, a lost reconnect timer). Two
+  # ticks: one tick of unhealth is the normal shadow of an in-flight
+  # reconnect (a healthy rebind lands well inside one tick interval); two
+  # consecutive ticks means nobody is fixing it.
+  @max_unhealthy_observations 2
 
   @doc """
   Shard ids (below `desired`) whose Twitch-side transport is not enabled.
@@ -56,6 +59,13 @@ defmodule Ingress.ShardHealth do
   def heal_action(%{bound: true, bound_at: bound_at}, _seen, now) do
     if settled?(bound_at, now), do: :force_rebind, else: :skip
   end
+
+  @doc """
+  True once `seen` consecutive unhealthy observations exhaust the session's
+  chance to heal itself; callers escalate (replace the session, or bring up
+  a rescue when no session can even be started).
+  """
+  def escalate?(seen), do: seen >= @max_unhealthy_observations
 
   defp settled?(%DateTime{} = bound_at, now),
     do: DateTime.diff(now, bound_at, :millisecond) >= @rebind_grace_ms

--- a/app/ingress/lib/ingress/shard_health.ex
+++ b/app/ingress/lib/ingress/shard_health.ex
@@ -67,6 +67,26 @@ defmodule Ingress.ShardHealth do
   """
   def escalate?(seen), do: seen >= @max_unhealthy_observations
 
+  @doc """
+  Shard ids in `0..desired-1` safe to start a session for, given Twitch's
+  snapshot. A slot whose transport is `"enabled"` is served by a live socket
+  somewhere right now — starting another session for it creates a duplicate
+  that races the serving copy (the registry lags cluster membership changes
+  during a rolling deploy, so an empty registry slot does not mean an
+  unserved shard). Slots missing from the snapshot (fresh conduit,
+  just-resized) or in any non-enabled state are startable; a dead socket
+  flips off `"enabled"` within Twitch's own keepalive window.
+  """
+  def startable_ids(shards, desired) when is_list(shards) do
+    enabled =
+      for %{"id" => id, "status" => "enabled"} <- shards,
+          {int_id, ""} <- [Integer.parse(to_string(id))],
+          into: MapSet.new(),
+          do: int_id
+
+    Enum.reject(0..(desired - 1), &(&1 in enabled))
+  end
+
   defp settled?(%DateTime{} = bound_at, now),
     do: DateTime.diff(now, bound_at, :millisecond) >= @rebind_grace_ms
 

--- a/app/ingress/lib/ingress/shard_health.ex
+++ b/app/ingress/lib/ingress/shard_health.ex
@@ -1,0 +1,64 @@
+defmodule Ingress.ShardHealth do
+  @moduledoc """
+  Pure decision logic for conduit shard self-healing.
+
+  Twitch is the source of truth for whether a shard slot receives events: a
+  conduit hash-routes each subscription to a fixed shard and never rebalances
+  it to a healthy one, so a slot whose transport is not `"enabled"` drops its
+  notifications silently while every local process reports healthy. The
+  reconciler polls Twitch's per-shard status and repairs any slot that stays
+  unhealthy. This module holds the decisions; `Ingress.ConduitManager`
+  executes them.
+  """
+
+  # A shard bound more recently than this is still settling: Twitch's status
+  # read may predate the bind, so healing would tear down a healthy socket.
+  @rebind_grace_ms 60_000
+
+  # A shard observed unhealthy this many consecutive reconcile ticks gets its
+  # local session replaced outright, whatever state the session claims. This
+  # is the backstop for sessions wedged in a state their own machinery never
+  # leaves (a takeover that never completes, a lost reconnect timer).
+  @max_unhealthy_observations 6
+
+  @doc """
+  Shard ids (below `desired`) whose Twitch-side transport is not enabled.
+  Slots at or above `desired` are scale-down leftovers the converge pass
+  already stops; they are not health problems.
+  """
+  def unhealthy_ids(shards, desired) when is_list(shards) do
+    for %{"id" => id, "status" => status} <- shards,
+        {int_id, ""} <- [Integer.parse(to_string(id))],
+        int_id < desired and status != "enabled",
+        do: int_id
+  end
+
+  @doc """
+  What to do about one Twitch-unhealthy shard, given the local session probe
+  and how many consecutive reconcile ticks (`seen`) the shard has now been
+  observed unhealthy.
+
+    * `:restart` — no live process answers for the shard, or it has stayed
+      unhealthy past the observation backstop; replace it.
+    * `:force_rebind` — a session claims a settled binding Twitch says is
+      dead (its socket may still receive keepalives after the binding moved
+      or died, so the session cannot notice on its own); tear the socket
+      down and bind a fresh session.
+    * `:skip` — the session is mid-connect/bind; its own machinery heals.
+  """
+  def heal_action(probe, seen, now \\ DateTime.utc_now())
+  def heal_action(:unreachable, _seen, _now), do: :restart
+
+  def heal_action(_probe, seen, _now) when seen >= @max_unhealthy_observations, do: :restart
+
+  def heal_action(%{bound: false}, _seen, _now), do: :skip
+
+  def heal_action(%{bound: true, bound_at: bound_at}, _seen, now) do
+    if settled?(bound_at, now), do: :force_rebind, else: :skip
+  end
+
+  defp settled?(%DateTime{} = bound_at, now),
+    do: DateTime.diff(now, bound_at, :millisecond) >= @rebind_grace_ms
+
+  defp settled?(_bound_at, _now), do: true
+end

--- a/app/ingress/lib/ingress/shard_session.ex
+++ b/app/ingress/lib/ingress/shard_session.ex
@@ -68,9 +68,18 @@ defmodule Ingress.ShardSession do
             # Aggregate counter for notification load.
             load_counter: Ingress.LoadCounter.new()
 
+  # A rescue session (started by the reconciler when the named shard cannot
+  # be replaced — its registration or supervision is wedged on a dead pid)
+  # runs unnamed: it skips cluster-wide registration entirely, so no wedge
+  # can block it, and duplicate-shard resolution never signals it. It serves
+  # by binding the shard on Twitch, exactly like a named session, and the
+  # reconciler stops it once a named session is serving again.
   def start_link(opts) do
-    shard_id = Keyword.fetch!(opts, :shard_id)
-    GenServer.start_link(__MODULE__, opts, name: via(shard_id))
+    if Keyword.get(opts, :rescue?, false) do
+      GenServer.start_link(__MODULE__, opts)
+    else
+      GenServer.start_link(__MODULE__, opts, name: via(Keyword.fetch!(opts, :shard_id)))
+    end
   end
 
   def via(shard_id), do: {:via, Horde.Registry, {Ingress.Registry, {:shard, shard_id}}}
@@ -94,6 +103,7 @@ defmodule Ingress.ShardSession do
     Process.flag(:trap_exit, true)
     shard_id = Keyword.fetch!(opts, :shard_id)
     Logger.metadata(shard_id: shard_id)
+    if Keyword.get(opts, :rescue?, false), do: Logger.metadata(rescue: true)
 
     state = %__MODULE__{
       shard_id: shard_id,

--- a/app/ingress/lib/ingress/shard_session.ex
+++ b/app/ingress/lib/ingress/shard_session.ex
@@ -125,6 +125,18 @@ defmodule Ingress.ShardSession do
     {:reply, status_map(state, load), state}
   end
 
+  # Planned-shutdown handoff (`Ingress.Drain`): give up the cluster-wide
+  # registration but keep the socket serving. The successor the drain starts
+  # takes the name without a conflict, binds, and only then is this copy
+  # stopped — the slot never goes dark. Unregistering also means no
+  # name-conflict signal can reach us afterwards, so nothing can order this
+  # copy to stand down while it is the one still serving.
+  @impl true
+  def handle_call(:release_name, _from, state) do
+    Horde.Registry.unregister(Ingress.Registry, {:shard, state.shard_id})
+    {:reply, :ok, state}
+  end
+
   # The other copy of this shard is bound but lost the registry merge; it is
   # taking the registration over and asks us to stand down. If we bound
   # concurrently (race between the merge and this message), keep serving:

--- a/app/ingress/lib/ingress/shard_session.ex
+++ b/app/ingress/lib/ingress/shard_session.ex
@@ -118,10 +118,27 @@ defmodule Ingress.ShardSession do
   # The other copy of this shard is bound but lost the registry merge; it is
   # taking the registration over and asks us to stand down. If we bound
   # concurrently (race between the merge and this message), keep serving:
-  # the requester's takeover deadline makes it yield instead.
+  # the requester's takeover deadline makes it yield instead. Re-assert the
+  # binding, since the requester may have bound after us.
   @impl true
-  def handle_cast(:stand_down_duplicate, %{bound?: true} = state), do: {:noreply, state}
+  def handle_cast(:stand_down_duplicate, %{bound?: true} = state), do: reassert_binding(state)
   def handle_cast(:stand_down_duplicate, state), do: {:stop, :normal, stand_down(state)}
+
+  # A duplicate-shard resolution just closed the other copy's socket. Twitch
+  # routes a shard's events to whichever session bound it last — possibly the
+  # copy that stood down — so the survivor re-binds its own session to pull
+  # the routing back. The PATCH is idempotent when we already own the binding.
+  def handle_cast(:reassert_binding, state), do: reassert_binding(state)
+
+  # Reconciler-ordered repair: Twitch reports this shard's transport dead even
+  # though we believe we are bound. Our socket may still be receiving
+  # keepalives (Twitch keeps superseded sockets alive), so the watchdog cannot
+  # notice; only a full fresh reconnect — new session, new Helix bind — heals.
+  def handle_cast(:force_rebind, state) do
+    Logger.warning("re-bind forced by reconciler; reconnecting with a fresh session")
+    Metrics.count("Shard/ForcedRebinds")
+    {:noreply, reconnect(state)}
+  end
 
   defp status_map(state, load) do
     last_frame_at =
@@ -232,6 +249,10 @@ defmodule Ingress.ShardSession do
           "duplicate shard resolved: copy on #{winner_status.node} is bound; standing down"
         )
 
+        # If we bound after the winner (rolling deploys race exactly this
+        # way), Twitch is routing to the socket we are about to close. The
+        # winner re-asserts its binding so the routing follows the survivor.
+        GenServer.cast(winner, :reassert_binding)
         {:stop, :normal, stand_down(state)}
 
       state.bound? ->
@@ -588,12 +609,41 @@ defmodule Ingress.ShardSession do
     case Horde.Registry.register(Ingress.Registry, {:shard, state.shard_id}, nil) do
       {:ok, _} ->
         Logger.info("duplicate shard resolved: registration reclaimed, we keep serving")
-        {:noreply, state}
+        # The loser may have bound after us before it exited; make Twitch's
+        # routing follow the copy that actually survived.
+        reassert_binding(state)
 
       {:error, {:already_registered, _pid}} ->
         # A third copy raced us to the name (fresh start by the reconciler).
         Logger.warning("duplicate shard: registration reclaimed by another copy; standing down")
         {:stop, :normal, stand_down(state)}
+    end
+  end
+
+  # Re-bind our current session to the shard. Twitch's conduit routes to the
+  # last session bound, so this is how a surviving copy pulls the routing back
+  # after a duplicate resolution. No-op unless we hold a bound session.
+  defp reassert_binding(%{bound?: true, session_id: session_id} = state)
+       when session_id != nil do
+    case Api.assign_shard(state.conduit_id, state.shard_id, session_id) do
+      :ok ->
+        Logger.info("shard binding re-asserted, session #{session_id}")
+        {:noreply, state}
+
+      {:error, reason} ->
+        reassert_failed(state, reason)
+    end
+  end
+
+  defp reassert_binding(state), do: {:noreply, state}
+
+  defp reassert_failed(state, reason) do
+    if permanent_bind_error?(reason) do
+      Logger.warning("binding re-assert rejected as permanent: #{inspect(reason)}; stopping")
+      {:stop, :normal, stand_down(state)}
+    else
+      Logger.warning("binding re-assert failed: #{inspect(reason)}; reconnecting")
+      {:noreply, reconnect(state)}
     end
   end
 

--- a/app/ingress/lib/ingress/twitch/api.ex
+++ b/app/ingress/lib/ingress/twitch/api.ex
@@ -87,6 +87,30 @@ defmodule Ingress.Twitch.Api do
   end
 
   @doc """
+  Lists the conduit's shards with Twitch's per-shard transport status. This is
+  Twitch's view of which shard slots actually receive events; a slot that is
+  not `"enabled"` gets its notifications dropped silently.
+  """
+  @spec get_shards(String.t()) :: {:ok, [map()]} | {:error, term()}
+  def get_shards(conduit_id), do: get_shards_page(conduit_id, nil, [])
+
+  defp get_shards_page(conduit_id, cursor, acc) do
+    path = "/eventsub/conduits/shards?conduit_id=" <> conduit_id <> cursor_param(cursor)
+
+    with {:ok, body} <- request(:get, path, nil) do
+      shards = acc ++ (body["data"] || [])
+
+      case get_in(body, ["pagination", "cursor"]) do
+        cursor when cursor in [nil, ""] -> {:ok, shards}
+        next -> get_shards_page(conduit_id, next, shards)
+      end
+    end
+  end
+
+  defp cursor_param(nil), do: ""
+  defp cursor_param(cursor), do: "&after=" <> URI.encode_www_form(cursor)
+
+  @doc """
   Binds a WebSocket `session_id` to `shard_id` on the conduit. This is the call
   a shard session makes after receiving `session_welcome` on a fresh socket.
   """

--- a/app/ingress/test/shard_health_test.exs
+++ b/app/ingress/test/shard_health_test.exs
@@ -85,4 +85,32 @@ defmodule Ingress.ShardHealthTest do
       assert ShardHealth.escalate?(3)
     end
   end
+
+  describe "startable_ids/2" do
+    test "never starts into a slot Twitch says is served" do
+      shards = [
+        shard(0, "enabled"),
+        shard(1, "websocket_disconnected"),
+        shard(2, "enabled")
+      ]
+
+      assert ShardHealth.startable_ids(shards, 5) == [1, 3, 4]
+    end
+
+    test "a fresh or just-resized conduit reports no shards; all startable" do
+      assert ShardHealth.startable_ids([], 3) == [0, 1, 2]
+    end
+
+    test "enabled slots beyond desired do not mask startable ones" do
+      shards = [shard(0, "enabled"), shard(5, "enabled")]
+
+      assert ShardHealth.startable_ids(shards, 3) == [1, 2]
+    end
+
+    test "malformed entries are ignored" do
+      shards = [%{"id" => "zero", "status" => "enabled"}, %{}]
+
+      assert ShardHealth.startable_ids(shards, 2) == [0, 1]
+    end
+  end
 end

--- a/app/ingress/test/shard_health_test.exs
+++ b/app/ingress/test/shard_health_test.exs
@@ -1,0 +1,77 @@
+defmodule Ingress.ShardHealthTest do
+  use ExUnit.Case, async: true
+
+  alias Ingress.ShardHealth
+
+  @now ~U[2026-07-13 12:00:00Z]
+
+  defp shard(id, status), do: %{"id" => to_string(id), "status" => status}
+
+  describe "unhealthy_ids/2" do
+    test "picks shards whose transport is not enabled" do
+      shards = [
+        shard(0, "websocket_disconnected"),
+        shard(1, "enabled"),
+        shard(2, "websocket_failed_ping_pong"),
+        shard(3, "enabled"),
+        shard(4, "enabled")
+      ]
+
+      assert ShardHealth.unhealthy_ids(shards, 5) == [0, 2]
+    end
+
+    test "ignores slots at or above the desired count (scale-down leftovers)" do
+      shards = [shard(4, "websocket_disconnected"), shard(5, "websocket_disconnected")]
+
+      assert ShardHealth.unhealthy_ids(shards, 5) == [4]
+    end
+
+    test "ignores malformed entries" do
+      shards = [%{"id" => "not-a-number", "status" => "websocket_disconnected"}, %{}]
+
+      assert ShardHealth.unhealthy_ids(shards, 5) == []
+    end
+
+    test "all healthy yields no work" do
+      shards = for id <- 0..4, do: shard(id, "enabled")
+
+      assert ShardHealth.unhealthy_ids(shards, 5) == []
+    end
+  end
+
+  describe "heal_action/3" do
+    test "unreachable session is restarted" do
+      assert ShardHealth.heal_action(:unreachable, 1, @now) == :restart
+    end
+
+    test "session bound long ago but dead on Twitch is force-rebound" do
+      probe = %{bound: true, bound_at: ~U[2026-07-13 11:00:00Z]}
+
+      assert ShardHealth.heal_action(probe, 1, @now) == :force_rebind
+    end
+
+    test "session bound within the grace window is left settling" do
+      probe = %{bound: true, bound_at: ~U[2026-07-13 11:59:30Z]}
+
+      assert ShardHealth.heal_action(probe, 1, @now) == :skip
+    end
+
+    test "session with no bind timestamp counts as settled" do
+      probe = %{bound: true, bound_at: nil}
+
+      assert ShardHealth.heal_action(probe, 1, @now) == :force_rebind
+    end
+
+    test "unbound session is healing itself" do
+      assert ShardHealth.heal_action(%{bound: false}, 1, @now) == :skip
+    end
+
+    test "persistent unhealth escalates to a restart whatever the session claims" do
+      recently_bound = %{bound: true, bound_at: @now}
+
+      assert ShardHealth.heal_action(%{bound: false}, 6, @now) == :restart
+      assert ShardHealth.heal_action(recently_bound, 6, @now) == :restart
+      assert ShardHealth.heal_action(%{bound: false}, 5, @now) == :skip
+    end
+  end
+end

--- a/app/ingress/test/shard_health_test.exs
+++ b/app/ingress/test/shard_health_test.exs
@@ -69,9 +69,20 @@ defmodule Ingress.ShardHealthTest do
     test "persistent unhealth escalates to a restart whatever the session claims" do
       recently_bound = %{bound: true, bound_at: @now}
 
-      assert ShardHealth.heal_action(%{bound: false}, 6, @now) == :restart
-      assert ShardHealth.heal_action(recently_bound, 6, @now) == :restart
-      assert ShardHealth.heal_action(%{bound: false}, 5, @now) == :skip
+      assert ShardHealth.heal_action(%{bound: false}, 2, @now) == :restart
+      assert ShardHealth.heal_action(recently_bound, 2, @now) == :restart
+      assert ShardHealth.heal_action(%{bound: false}, 1, @now) == :skip
+    end
+  end
+
+  describe "escalate?/1" do
+    test "one unhealthy tick is the shadow of an in-flight reconnect" do
+      refute ShardHealth.escalate?(1)
+    end
+
+    test "two consecutive unhealthy ticks exhaust self-healing" do
+      assert ShardHealth.escalate?(2)
+      assert ShardHealth.escalate?(3)
     end
   end
 end

--- a/deploy/k8s/twitch-ingress.yaml
+++ b/deploy/k8s/twitch-ingress.yaml
@@ -47,13 +47,14 @@ metadata:
 spec:
   replicas: 5 # node1 excluded via hot-path anti-affinity; target shape node3=2, worker1=2, node2=1 (see affinity)
   revisionHistoryLimit: 3
-  # Each pod death forces its EventSub conduit shards to rebind on a peer (new
-  # websocket session + transport update), and Twitch drops a shard's events
-  # until the rebind lands. Hold each replacement pod Ready for a full minute
-  # before killing the next old pod so the Horde registry converges and the
-  # displaced shards re-bind between swaps — the 2026-07-10 mid-stream incident
-  # was pods cycling within a minute of each other, stacking shard gaps and
-  # registry races ("registry pick unreachable") into a ~5 min chat outage.
+  # On SIGTERM each pod hands its conduit shards off make-before-break
+  # (Ingress.Drain): the successor binds on a peer before the local socket
+  # closes, so a rollout drops no events. Still hold each replacement pod
+  # Ready for a full minute before killing the next old pod: the Horde
+  # registry converges between swaps, keeping one drain in flight at a time
+  # — the 2026-07-10 mid-stream incident was pods cycling within a minute of
+  # each other, stacking registry races ("registry pick unreachable") into a
+  # ~5 min chat outage.
   minReadySeconds: 60
   strategy:
     type: RollingUpdate
@@ -265,8 +266,11 @@ spec:
           lifecycle:
             preStop:
               exec:
-                # Grace period for Linkerd and kube-proxy to drain this endpoint
-                # before SIGTERM fires. Horde redistributes shards during this window.
+                # Delay SIGTERM so cluster membership settles before the BEAM
+                # starts its shard drain (Ingress.Drain runs in prep_stop on
+                # SIGTERM: successor binds on a peer, then the local socket
+                # closes). Drain (~12s worst case) + this sleep must stay
+                # inside terminationGracePeriodSeconds.
                 command: ["/bin/sh", "-c", "sleep 10"]
           livenessProbe:
             exec:


### PR DESCRIPTION
## Problem

2026-07-13 outage: a rolling deploy raced duplicate shard copies. Twitch routes a conduit shard's events to whichever websocket session bound last; duplicate resolution picked its survivor from Horde registry state instead. The surviving copy held a binding Twitch no longer routed to, its socket kept receiving keepalives (so every local check stayed green), and shards 0+2 silently dropped all events for 90+ minutes — conduits never rebalance a subscription to a healthy shard, and nothing observed Twitch's per-shard status.

## Fixes

**Binding re-assert (session layer).** Every duplicate-resolution path now ends with the survivor re-PATCHing its session, so Twitch's routing follows the surviving copy regardless of who bound last.

**Self-healing reconciler.** Each 15s tick reads Twitch's per-shard snapshot once and repairs any slot not `enabled`: session claiming a settled bind → forced fresh re-bind; unreachable/wedged session → replaced; 2 consecutive unhealthy ticks → replaced whatever it claims. Decisions in the pure `Ingress.ShardHealth` module, tested.

**Rescue sessions.** If a replacement is blocked (registration/supervision wedged on a pid nothing can remove), an unnamed session starts instead — the binding PATCH, not the registry, decides who receives events. Reaped once a named session serves again.

**Singleton liveness.** Bootstrapper probes `:already_started` singletons for process liveness (rpc, not a mailbox call); two missed probes replace them. A wedged ConduitManager registration previously disabled all healing fleet-wide.

**Race-free rollouts (make-before-break drain).** On SIGTERM, `Ingress.Drain` hands each local shard off before the socket closes: release name → start successor on a peer (`{:draining, node}` markers steer placement away from dying nodes) → successor binds (slot switches at that PATCH, zero gap) → local copy stops. Shard starts are gated on Twitch's snapshot so a registry hole during a deploy can no longer spawn duplicate copies. `process_redistribution` goes `:passive`: no more stop-then-start shard moves on membership joins.

## Worst-case recovery

| Event | Before | After |
|---|---|---|
| Rolling deploy | 2-5s gap per shard + race risk | zero-gap handoff |
| Dead binding, session thinks bound | forever (manual) | ~20s |
| Wedged session / blocked replace | forever (manual) | ~30-35s (replace / rescue) |
| ConduitManager dead | forever (no healing anywhere) | ~30s |

137 tests green, `--warnings-as-errors` clean.