### PR TITLE
fix(dashboard): delegate module pages bounced to /commands

### DIFF
--- a/console/dashboard/src/lib/server/guard.ts
+++ b/console/dashboard/src/lib/server/guard.ts
@@ -15,6 +15,7 @@
 // dynamic-env proxy there deadlocks server.init (exit 13). process.env carries
 // the same runtime value.
 import { redirect, type RequestEvent } from '@sveltejs/kit';
+import { MODULE_CATALOG, moduleDelegateSections } from '@bagel/shared';
 import { COOKIE, type Session } from '$lib/server/session';
 import { accountState, delegationAccess, isBanned } from '$lib/server/services';
 import { RpcError } from '@bagel/shared/server/nats';
@@ -30,6 +31,23 @@ function isPublic(pathname: string): boolean {
 
 function wipe(event: RequestEvent): void {
   event.cookies.delete(COOKIE, { path: '/', secure: event.url.protocol === 'https:' });
+}
+
+// delegateAllowedPaths lists the (app) path prefixes a delegate may open: each
+// granted section's own page, plus every bespoke module page whose catalog def
+// is opened by one of those grants (moduleDelegateSections — the same source
+// the per-page gates and the tile grid read, so the three can never drift and
+// a new module page needs no edit here). Counters is loyalty's companion page
+// without a tile of its own, so it rides the modules grant explicitly.
+function delegateAllowedPaths(sections: readonly string[]): string[] {
+  const allowed = sections.map((sec) => `/${sec}`);
+  for (const def of MODULE_CATALOG) {
+    if (def.href && moduleDelegateSections(def).some((sec) => sections.includes(sec))) {
+      allowed.push(def.href);
+    }
+  }
+  if (sections.includes('modules')) allowed.push('/counters');
+  return allowed;
 }
 
 // guardSession validates an already-opened session against authoritative
@@ -79,11 +97,7 @@ export async function guardSession(event: RequestEvent, s: Session): Promise<Ses
     // Section scope for everything under (app) — pages AND their actions
     // (the per-page gates remain as defense in depth).
     if (event.route.id?.startsWith('/(app)')) {
-      const allowed = (s.sections ?? []).map((sec) => `/${sec}`);
-      // Timers has no standalone scope: the commands grant covers /timers too.
-      if (s.sections?.includes('commands')) allowed.push('/timers');
-      // Loyalty and its counters ride the modules grant (same as their gates).
-      if (s.sections?.includes('modules')) allowed.push('/loyalty', '/counters');
+      const allowed = delegateAllowedPaths(s.sections ?? []);
       const ok = allowed.some((p) => event.url.pathname === p || event.url.pathname.startsWith(p + '/'));
       if (!ok) throw redirect(303, allowed[0] ?? '/delegate/exit');
     }

--- a/console/dashboard/src/lib/server/module-gate.ts
+++ b/console/dashboard/src/lib/server/module-gate.ts
@@ -5,16 +5,22 @@
 // and a new bespoke page needs no bespoke gate. This stays as defense in depth
 // under the guard: pages call it from load AND every action.
 import { redirect } from '@sveltejs/kit';
-import { moduleDef, moduleDelegateSections } from '@bagel/shared';
+import { moduleDef, moduleDelegateSections, type ModuleDef } from '@bagel/shared';
 import type { Session } from '$lib/server/session';
 
-// gateModulePage throws unless the session may open the module's page: owners
-// and normal logins always pass; a delegate needs one of the def's sections.
-export function gateModulePage(session: Session | null | undefined, moduleId: string): void {
-  if (!session?.delegate_of) return;
-  const def = moduleDef(moduleId);
+// delegateCanOpen reports whether the session may open a module's page.
+// Owners and normal logins always may, as may anyone for a module without a
+// bespoke page (its generic /modules/[id] page rides the modules grant); a
+// delegate needs one of the def's sections. Also drives the tile grid, which
+// hides modules a delegate cannot open.
+export function delegateCanOpen(def: ModuleDef, session: Session | null | undefined): boolean {
+  if (!session?.delegate_of || !def.href) return true;
   const sections = session.sections ?? [];
-  if (!def || !moduleDelegateSections(def).some((sec) => sections.includes(sec))) {
-    throw redirect(302, '/');
-  }
+  return moduleDelegateSections(def).some((sec) => sections.includes(sec));
+}
+
+// gateModulePage throws unless the session may open the module's page.
+export function gateModulePage(session: Session | null | undefined, moduleId: string): void {
+  const def = moduleDef(moduleId);
+  if (!def || !delegateCanOpen(def, session)) throw redirect(302, '/');
 }

--- a/console/dashboard/src/lib/server/module-gate.ts
+++ b/console/dashboard/src/lib/server/module-gate.ts
@@ -1,0 +1,20 @@
+// Delegate gate for the bespoke module pages (quotes, timers, govee, ...).
+// Which delegation grants open a page comes from the module catalog
+// (moduleDelegateSections), the same source guard.ts uses for route scoping —
+// one place to declare it, so the route guard and the page gates can't drift
+// and a new bespoke page needs no bespoke gate. This stays as defense in depth
+// under the guard: pages call it from load AND every action.
+import { redirect } from '@sveltejs/kit';
+import { moduleDef, moduleDelegateSections } from '@bagel/shared';
+import type { Session } from '$lib/server/session';
+
+// gateModulePage throws unless the session may open the module's page: owners
+// and normal logins always pass; a delegate needs one of the def's sections.
+export function gateModulePage(session: Session | null | undefined, moduleId: string): void {
+  if (!session?.delegate_of) return;
+  const def = moduleDef(moduleId);
+  const sections = session.sections ?? [];
+  if (!def || !moduleDelegateSections(def).some((sec) => sections.includes(sec))) {
+    throw redirect(302, '/');
+  }
+}

--- a/console/dashboard/src/routes/(app)/channelpoints/+page.server.ts
+++ b/console/dashboard/src/routes/(app)/channelpoints/+page.server.ts
@@ -10,19 +10,19 @@ import {
   type RewardResult
 } from '$lib/server/channelpoints-store';
 import { auditDashboardImpersonation } from '$lib/server/services';
+import { gateModulePage } from '$lib/server/module-gate';
 import type { Session } from '$lib/server/session';
 import { env } from '$env/dynamic/private';
-import { fail, redirect } from '@sveltejs/kit';
+import { fail } from '@sveltejs/kit';
 
 function effectiveId(session: Session | null | undefined): string {
   return session?.delegate_of ?? session?.user_id ?? 'demo';
 }
 
-// A delegate needs the 'channelpoints' section; a normal login always may.
+// Delegate scope comes from the channelpoints catalog def (its own grant, not
+// the blanket 'modules' one — see module-gate.ts).
 function gate(session: Session | null | undefined): void {
-  if (session?.delegate_of && !(session.sections ?? []).includes('channelpoints')) {
-    throw redirect(302, '/');
-  }
+  gateModulePage(session, 'channelpoints');
 }
 
 // Demo rewards so the tab renders without a live backend.

--- a/console/dashboard/src/routes/(app)/counters/+page.server.ts
+++ b/console/dashboard/src/routes/(app)/counters/+page.server.ts
@@ -3,20 +3,19 @@ import type { CounterDef, CounterEntryView, CounterScope } from '@bagel/shared';
 import { COUNTER_SCOPES } from '@bagel/shared';
 import { listCounters, createCounter, setCounter, deleteCounter, counterEntries } from '$lib/server/loyalty-store';
 import { auditDashboardImpersonation } from '$lib/server/services';
+import { gateModulePage } from '$lib/server/module-gate';
 import type { Session } from '$lib/server/session';
 import { env } from '$env/dynamic/private';
-import { fail, redirect } from '@sveltejs/kit';
+import { fail } from '@sveltejs/kit';
 
 function effectiveId(session: Session | null | undefined): string {
   return session?.delegate_of ?? session?.user_id ?? 'demo';
 }
 
-// A delegate needs the 'modules' section; a normal login always may. Counters
-// belong to the loyalty module even though they live on their own page.
+// Counters belong to the loyalty module even though they live on their own
+// page, so they share loyalty's delegate scope (see module-gate.ts).
 function gate(session: Session | null | undefined): void {
-  if (session?.delegate_of && !(session.sections ?? []).includes('modules')) {
-    throw redirect(302, '/');
-  }
+  gateModulePage(session, 'loyalty');
 }
 
 function demoCounters(): CounterDef[] {

--- a/console/dashboard/src/routes/(app)/govee/+page.server.ts
+++ b/console/dashboard/src/routes/(app)/govee/+page.server.ts
@@ -10,20 +10,18 @@ import {
   type RewardDraft
 } from '$lib/server/govee-store';
 import { auditDashboardImpersonation } from '$lib/server/services';
+import { gateModulePage } from '$lib/server/module-gate';
 import type { Session } from '$lib/server/session';
 import { env } from '$env/dynamic/private';
-import { fail, redirect } from '@sveltejs/kit';
+import { fail } from '@sveltejs/kit';
 
 function effectiveId(session: Session | null | undefined): string {
   return session?.delegate_of ?? session?.user_id ?? 'demo';
 }
 
-// A delegate needs the 'modules' section; a normal login always may. Govee is a
-// module, so it rides the same grant as the modules page.
+// Delegate scope comes from the govee catalog def (see module-gate.ts).
 function gate(session: Session | null | undefined): void {
-  if (session?.delegate_of && !(session.sections ?? []).includes('modules')) {
-    throw redirect(302, '/');
-  }
+  gateModulePage(session, 'govee');
 }
 
 function demoView(): GoveeView {

--- a/console/dashboard/src/routes/(app)/loyalty/+page.server.ts
+++ b/console/dashboard/src/routes/(app)/loyalty/+page.server.ts
@@ -3,20 +3,18 @@ import type { LoyaltyConfig, LoyaltyStanding } from '@bagel/shared';
 import { blankLoyaltyConfig } from '@bagel/shared';
 import { readLoyalty, writeLoyalty, topStandings } from '$lib/server/loyalty-store';
 import { auditDashboardImpersonation } from '$lib/server/services';
+import { gateModulePage } from '$lib/server/module-gate';
 import type { Session } from '$lib/server/session';
 import { env } from '$env/dynamic/private';
-import { fail, redirect } from '@sveltejs/kit';
+import { fail } from '@sveltejs/kit';
 
 function effectiveId(session: Session | null | undefined): string {
   return session?.delegate_of ?? session?.user_id ?? 'demo';
 }
 
-// A delegate needs the 'modules' section; a normal login always may. Loyalty is
-// a module even though it lives on its own page.
+// Delegate scope comes from the loyalty catalog def (see module-gate.ts).
 function gate(session: Session | null | undefined): void {
-  if (session?.delegate_of && !(session.sections ?? []).includes('modules')) {
-    throw redirect(302, '/');
-  }
+  gateModulePage(session, 'loyalty');
 }
 
 function demoStandings(): LoyaltyStanding[] {

--- a/console/dashboard/src/routes/(app)/modules/+page.server.ts
+++ b/console/dashboard/src/routes/(app)/modules/+page.server.ts
@@ -1,8 +1,9 @@
 import type { Actions, PageServerLoad } from './$types';
-import type { ModuleDef, ModuleState } from '@bagel/shared';
-import { MODULE_CATALOG, moduleDef, moduleDelegateSections } from '@bagel/shared';
+import type { ModuleState } from '@bagel/shared';
+import { MODULE_CATALOG, moduleDef } from '@bagel/shared';
 import { listModules, upsertModule, type ModuleView } from '$lib/server/commands-store';
 import { auditDashboardImpersonation } from '$lib/server/services';
+import { delegateCanOpen } from '$lib/server/module-gate';
 import type { Session } from '$lib/server/session';
 import { env } from '$env/dynamic/private';
 import { fail, redirect } from '@sveltejs/kit';
@@ -29,20 +30,13 @@ function asConfig(raw: unknown): Record<string, string> {
   return out;
 }
 
-// A delegate's grid drops tiles their grant cannot open (a bespoke page whose
-// delegateSections the session lacks, e.g. Channel Points without that grant) —
-// such a tile would only bounce off the route guard. Owners see everything.
-function openable(def: ModuleDef, session: Session | null | undefined): boolean {
-  if (!session?.delegate_of || !def.href) return true;
-  const secs = session.sections ?? [];
-  return moduleDelegateSections(def).some((sec) => secs.includes(sec));
-}
-
 // Merge the catalog (the modules we expose) with the broadcaster's stored rows.
-// Modules absent from the catalog (system, bagel, ...) are never surfaced.
+// Modules absent from the catalog (system, bagel, ...) are never surfaced, and
+// a delegate's grid drops tiles their grant cannot open (delegateCanOpen) —
+// such a tile would only bounce off the route guard. Owners see everything.
 function merge(rows: ModuleView[], session: Session | null | undefined): ModuleState[] {
   const byName = new Map(rows.map((r) => [r.name, r]));
-  return MODULE_CATALOG.filter((def) => !def.hidden && openable(def, session)).map((def) => {
+  return MODULE_CATALOG.filter((def) => !def.hidden && delegateCanOpen(def, session)).map((def) => {
     const row = byName.get(def.id);
     return {
       def,

--- a/console/dashboard/src/routes/(app)/modules/+page.server.ts
+++ b/console/dashboard/src/routes/(app)/modules/+page.server.ts
@@ -1,6 +1,6 @@
 import type { Actions, PageServerLoad } from './$types';
-import type { ModuleState } from '@bagel/shared';
-import { MODULE_CATALOG, moduleDef } from '@bagel/shared';
+import type { ModuleDef, ModuleState } from '@bagel/shared';
+import { MODULE_CATALOG, moduleDef, moduleDelegateSections } from '@bagel/shared';
 import { listModules, upsertModule, type ModuleView } from '$lib/server/commands-store';
 import { auditDashboardImpersonation } from '$lib/server/services';
 import type { Session } from '$lib/server/session';
@@ -29,11 +29,20 @@ function asConfig(raw: unknown): Record<string, string> {
   return out;
 }
 
+// A delegate's grid drops tiles their grant cannot open (a bespoke page whose
+// delegateSections the session lacks, e.g. Channel Points without that grant) —
+// such a tile would only bounce off the route guard. Owners see everything.
+function openable(def: ModuleDef, session: Session | null | undefined): boolean {
+  if (!session?.delegate_of || !def.href) return true;
+  const secs = session.sections ?? [];
+  return moduleDelegateSections(def).some((sec) => secs.includes(sec));
+}
+
 // Merge the catalog (the modules we expose) with the broadcaster's stored rows.
 // Modules absent from the catalog (system, bagel, ...) are never surfaced.
-function merge(rows: ModuleView[]): ModuleState[] {
+function merge(rows: ModuleView[], session: Session | null | undefined): ModuleState[] {
   const byName = new Map(rows.map((r) => [r.name, r]));
-  return MODULE_CATALOG.filter((def) => !def.hidden).map((def) => {
+  return MODULE_CATALOG.filter((def) => !def.hidden && openable(def, session)).map((def) => {
     const row = byName.get(def.id);
     return {
       def,
@@ -48,11 +57,11 @@ function merge(rows: ModuleView[]): ModuleState[] {
 export const load: PageServerLoad = async ({ locals }) => {
   gateModules(locals.session);
   const uid = effectiveId(locals.session);
-  if (env.DEMO === '1') return { modules: merge([]) };
+  if (env.DEMO === '1') return { modules: merge([], locals.session) };
   try {
-    return { modules: merge(await listModules(uid)) };
+    return { modules: merge(await listModules(uid), locals.session) };
   } catch {
-    return { modules: merge([]), degraded: true };
+    return { modules: merge([], locals.session), degraded: true };
   }
 };
 

--- a/console/dashboard/src/routes/(app)/quotes/+page.server.ts
+++ b/console/dashboard/src/routes/(app)/quotes/+page.server.ts
@@ -8,9 +8,10 @@ import {
   type QuoteView
 } from '$lib/server/quotes-store';
 import { auditDashboardImpersonation } from '$lib/server/services';
+import { gateModulePage } from '$lib/server/module-gate';
 import type { Session } from '$lib/server/session';
 import { env } from '$env/dynamic/private';
-import { fail, redirect } from '@sveltejs/kit';
+import { fail } from '@sveltejs/kit';
 
 // The longest quote the modules service will store (repository.QuoteTextMaxLen).
 const QUOTE_MAX = 450;
@@ -30,12 +31,9 @@ function effectiveId(session: Session | null | undefined): string {
   return session?.delegate_of ?? session?.user_id ?? 'demo';
 }
 
-// Quotes rides under the 'commands' scope, like timers — no standalone grant.
+// Delegate scope comes from the quotes catalog def (see module-gate.ts).
 function gate(session: Session | null | undefined): void {
-  const secs = session?.sections ?? [];
-  if (session?.delegate_of && !secs.includes('commands') && !secs.includes('quotes')) {
-    throw redirect(302, '/');
-  }
+  gateModulePage(session, 'quotes');
 }
 
 // actingLogin is the login stamped as a quote's added_by (audit only): the

--- a/console/dashboard/src/routes/(app)/timers/+page.server.ts
+++ b/console/dashboard/src/routes/(app)/timers/+page.server.ts
@@ -10,21 +10,18 @@ import {
   type TimerResult
 } from '$lib/server/timers-store';
 import { auditDashboardImpersonation } from '$lib/server/services';
+import { gateModulePage } from '$lib/server/module-gate';
 import type { Session } from '$lib/server/session';
 import { env } from '$env/dynamic/private';
-import { fail, redirect } from '@sveltejs/kit';
+import { fail } from '@sveltejs/kit';
 
 function effectiveId(session: Session | null | undefined): string {
   return session?.delegate_of ?? session?.user_id ?? 'demo';
 }
 
-// Timers rides under the 'commands' scope (no standalone timers grant). Legacy
-// links minted with a bare 'timers' section still pass. A normal login always may.
+// Delegate scope comes from the timers catalog def (see module-gate.ts).
 function gate(session: Session | null | undefined): void {
-  const secs = session?.sections ?? [];
-  if (session?.delegate_of && !secs.includes('commands') && !secs.includes('timers')) {
-    throw redirect(302, '/');
-  }
+  gateModulePage(session, 'timers');
 }
 
 // Demo timers so the tab renders without a live backend.

--- a/console/shared/lib/types.ts
+++ b/console/shared/lib/types.ts
@@ -348,6 +348,18 @@ export interface ModuleDef {
   // instead of the generic /modules/[id] reply page (govee's device + reward
   // setup). Absent for the ordinary reply-configured modules.
   href?: string;
+  // delegateSections names the delegation grants that open the bespoke href
+  // page for a delegate. Defaults to ['modules'] (the tile lives on /modules),
+  // so it only needs setting when a page has its own grant (channel points) or
+  // additionally rides another one (timers/quotes under 'commands'). Read via
+  // moduleDelegateSections; the route guard, the per-page gates and the tile
+  // grid all derive from it, so a new bespoke page never touches those.
+  delegateSections?: readonly string[];
+}
+
+// moduleDelegateSections resolves a def's delegation scope (see the field doc).
+export function moduleDelegateSections(def: ModuleDef): readonly string[] {
+  return def.delegateSections ?? ['modules'];
 }
 
 // A module's current state as shown on the dashboard: catalog metadata merged
@@ -449,6 +461,9 @@ export const MODULE_CATALOG: readonly ModuleDef[] = [
     category: 'Chat Tools',
     defaultEnabled: false,
     href: '/channelpoints',
+    // Channel Points is its own delegation grant (see SECTIONS in the settings
+    // page), not part of the blanket 'modules' one.
+    delegateSections: ['channelpoints'],
     replies: []
   },
   {
@@ -461,6 +476,10 @@ export const MODULE_CATALOG: readonly ModuleDef[] = [
     category: 'Chat Tools',
     defaultEnabled: false,
     href: '/timers',
+    // Timers has no standalone grant: the 'commands' grant has always covered
+    // it too (see the settings page SECTIONS comment). 'timers' keeps legacy
+    // grants minted with a bare timers section working.
+    delegateSections: ['modules', 'commands', 'timers'],
     replies: []
   },
   {
@@ -1091,6 +1110,8 @@ export const MODULE_CATALOG: readonly ModuleDef[] = [
     // Bespoke page: the quote book (list + add/remove) plus the enable and
     // save-permission settings live on /quotes, not the generic reply page.
     href: '/quotes',
+    // Like timers, the quote book also rides the 'commands' grant.
+    delegateSections: ['modules', 'commands'],
     replies: [],
     commands: [
       { trigger: '!quote', summary: 'Post a random saved quote (also !quotes).' },


### PR DESCRIPTION
## Problem
On a delegate board, clicking some module tiles (Quotes, Govee) redirected to /commands instead of the module's settings page. The route guard hand-listed the paths a delegate may open and never learned /quotes or /govee, and the per-page gates each kept their own copy of the scope rules, which had already drifted from the guard.

## Fix
Make the module catalog the single source of truth for delegate scoping:

- `ModuleDef.delegateSections` declares which delegation grants open a bespoke module page (default `['modules']`, since the tile lives on /modules). Channel Points keeps its own grant; timers and quotes also ride `commands` as before.
- The route guard derives its allowed-path list from the catalog (`delegateAllowedPaths`), replacing the hand-written list.
- A shared `gateModulePage` helper replaces the six per-page gate copies, reading the same catalog field, so the guard and the gates can never drift.
- The delegate's module grid hides tiles their grant cannot open (previously the Channel Points tile would render and then bounce).

A future module with a bespoke page is covered by adding its catalog def; no guard or gate edits needed.

## Verification
- `svelte-check`: dashboard and admin, 0 errors
- `bun test shared`: 77 pass
- Scope resolution exercised against the real catalog: `modules` grant opens /modules /timers /loyalty /quotes /govee /counters; `commands` opens /commands /timers /quotes; `channelpoints` stays its own grant.