### PR TITLE
fix(console): JetStream INFO probe, feed TLS, fully async admin loads

### DIFF
--- a/console/admin/src/lib/server/feed.ts
+++ b/console/admin/src/lib/server/feed.ts
@@ -8,8 +8,10 @@ import { enableLeafFailback } from '@bagel/shared/server/nats';
 let conn: NatsConnection | null = null;
 let dialing: Promise<NatsConnection> | null = null;
 
+// The status stream lives on the hub (like the shared client's bus role);
+// NATS_URL is the local-dev fallback only.
 function url(): string {
-  return process.env.NATS_URL ?? 'nats://127.0.0.1:4222';
+  return process.env.NATS_HUB_URL ?? process.env.NATS_URL ?? 'nats://127.0.0.1:4222';
 }
 
 async function get(): Promise<NatsConnection> {
@@ -25,6 +27,11 @@ async function get(): Promise<NatsConnection> {
   if (process.env.NATS_USER) opts.user = process.env.NATS_USER;
   if (process.env.NATS_PASSWORD) opts.pass = process.env.NATS_PASSWORD;
   if (process.env.NATS_TOKEN) opts.token = process.env.NATS_TOKEN;
+  // Verify the server's TLS cert against the fleet CA, exactly like the shared
+  // client: without it Node rejects the NATS-native TLS handshake ("unable to
+  // verify the first certificate") and the feed never connects. No CA (local
+  // dev against a plaintext server) keeps the connection plaintext.
+  if (process.env.NATS_CA_PEM) opts.tls = { ca: process.env.NATS_CA_PEM };
 
   dialing = connect(opts)
     .then((c) => {

--- a/console/admin/src/routes/(admin)/+layout.svelte
+++ b/console/admin/src/routes/(admin)/+layout.svelte
@@ -27,8 +27,6 @@
     data.role === 'owner' ? 'Owner' : data.role === 'admin' ? 'Admin' : 'Moderator'
   );
 
-  // Notifications (compose + history) has NO nav entry: the topbar bell is the
-  // only way in.
   const groups = $derived([
     {
       label: 'Operate',
@@ -43,7 +41,8 @@
       label: 'Accounts',
       items: [
         { href: '/users', icon: 'users', label: 'Users', active: crumb === 'Users' },
-        { href: '/analytics', icon: 'activity', label: 'Analytics', active: crumb === 'Analytics' }
+        { href: '/analytics', icon: 'activity', label: 'Analytics', active: crumb === 'Analytics' },
+        { href: '/notifications', icon: 'bell', label: 'Notifications', active: crumb === 'Notifications' }
       ]
     },
     ...(isManager
@@ -69,6 +68,7 @@
     { href: '/events', icon: 'pulse', label: 'Events', active: crumb === 'Events' },
     { href: '/users', icon: 'users', label: 'Users', active: crumb === 'Users' },
     { href: '/analytics', icon: 'activity', label: 'Analytics', active: crumb === 'Analytics' },
+    { href: '/notifications', icon: 'bell', label: 'Notifs', active: crumb === 'Notifications' },
     ...(isManager
       ? [
           { href: '/staff', icon: 'moderation', label: 'Staff', active: crumb === 'Staff' },

--- a/console/admin/src/routes/(admin)/notifications/+page.server.ts
+++ b/console/admin/src/routes/(admin)/notifications/+page.server.ts
@@ -22,7 +22,16 @@ function parsePage(raw: string | null): number {
   return Math.min(Math.max(Math.trunc(page), 1), NOTIFICATIONS_MAX_PAGES);
 }
 
-function demoPage(page: number) {
+export type HistoryBundle = {
+  notifications: NotificationWire[];
+  page: number;
+  pageSize: number;
+  maxPages: number;
+  hasMore: boolean;
+  degraded: boolean;
+};
+
+function demoPage(page: number): HistoryBundle {
   return {
     notifications: sampleNotifications,
     page,
@@ -33,11 +42,7 @@ function demoPage(page: number) {
   };
 }
 
-export const load: PageServerLoad = async ({ url }) => {
-  const page = parsePage(url.searchParams.get('page'));
-
-  if (isDemo()) return demoPage(page);
-
+async function loadHistory(page: number): Promise<HistoryBundle> {
   try {
     const result = await notificationsList(page);
     return {
@@ -50,7 +55,7 @@ export const load: PageServerLoad = async ({ url }) => {
     };
   } catch {
     return {
-      notifications: [] as NotificationWire[],
+      notifications: [],
       page,
       pageSize: NOTIFICATIONS_PAGE_SIZE,
       maxPages: NOTIFICATIONS_MAX_PAGES,
@@ -58,6 +63,16 @@ export const load: PageServerLoad = async ({ url }) => {
       degraded: true
     };
   }
+}
+
+// Streamed: compose renders immediately; the sent history hydrates when the
+// notifications RPC lands.
+export const load: PageServerLoad = ({ url }) => {
+  const page = parsePage(url.searchParams.get('page'));
+  const history: Promise<HistoryBundle> = isDemo()
+    ? Promise.resolve(demoPage(page))
+    : loadHistory(page);
+  return { history };
 };
 
 type SendForm = {

--- a/console/admin/src/routes/(admin)/notifications/+page.svelte
+++ b/console/admin/src/routes/(admin)/notifications/+page.svelte
@@ -1,26 +1,34 @@
 <script lang="ts">
   import { enhance } from '$app/forms';
   import type { SubmitFunction } from '@sveltejs/kit';
-  import { Icon, PageHead, Card, CardHead, Button, EmptyState, ConfirmDialog, RadioGroup, toast } from '@bagel/shared';
+  import { Icon, PageHead, Card, CardHead, Button, EmptyState, ConfirmDialog, RadioGroup, Skeleton, toast } from '@bagel/shared';
   import type { NotificationWire } from '$lib/server/services';
   let { data, form } = $props();
 
-  // Local copy so a retract can apply optimistically and roll back on failure.
-  // svelte-ignore state_referenced_locally
-  let notifications = $state<NotificationWire[]>((data.notifications ?? []) as NotificationWire[]);
-  // Plain variable on purpose: it only marks which `data` seeded local state,
-  // so it must compare by raw identity (a $state proxy never equals `data`).
-  // svelte-ignore state_referenced_locally
-  let seed = data;
+  // Streamed history -> local state, so a retract can apply optimistically
+  // and roll back on failure.
+  let notifications = $state<NotificationWire[]>([]);
+  let historyLoaded = $state(false);
+  let degraded = $state(false);
+  let page = $state(1);
+  let maxPages = $state(25);
+  let hasMore = $state(false);
   $effect(() => {
-    if (data !== seed) {
-      seed = data;
-      notifications = (data.notifications ?? []) as NotificationWire[];
-    }
+    let alive = true;
+    historyLoaded = false;
+    data.history.then((h) => {
+      if (!alive) return;
+      notifications = h.notifications;
+      degraded = h.degraded;
+      page = h.page;
+      maxPages = h.maxPages;
+      hasMore = h.hasMore;
+      historyLoaded = true;
+    });
+    return () => {
+      alive = false;
+    };
   });
-  const page = $derived(Number(data.page ?? 1));
-  const maxPages = $derived(Number(data.maxPages ?? 25));
-  const hasMore = $derived(Boolean(data.hasMore));
 
   let scope = $state<'broadcast' | 'direct'>('broadcast');
   let level = $state('info');
@@ -136,7 +144,13 @@
 
   <Card class="notif-card">
     <CardHead title="Sent" />
-    {#if notifications.length === 0}
+    {#if !historyLoaded}
+      <div class="row-skeletons">
+        {#each [0, 1, 2] as i (i)}<Skeleton variant="block" height="72px" />{/each}
+      </div>
+    {:else if degraded}
+      <EmptyState icon="bell" title="History unavailable" body="The notifications service is unreachable; sent messages are not shown." />
+    {:else if notifications.length === 0}
       <EmptyState icon="bell" title="No notifications yet" body="Notifications you send appear here." />
     {:else}
       <div class="list">
@@ -194,6 +208,7 @@
   :global(.notif-card) { margin-top: 18px; }
 
   .compose { display: flex; flex-direction: column; gap: 14px; }
+  .row-skeletons { display: flex; flex-direction: column; gap: 10px; }
   .row { display: flex; gap: 14px; flex-wrap: wrap; }
   .row.two > label { flex: 1; min-width: 180px; }
 

--- a/console/admin/src/routes/(admin)/staff/+page.server.ts
+++ b/console/admin/src/routes/(admin)/staff/+page.server.ts
@@ -13,6 +13,8 @@ const sampleStaff: AdminAcct[] = [
   { id: 222222222, login: 'a_mod', display_name: 'A Mod', role: 'moderator', active: true, added_by: 804932984, created_at: new Date(Date.now() - 86400_000 * 2).toISOString() }
 ];
 
+export type RosterBundle = { staff: AdminAcct[]; degraded: boolean };
+
 export const load: PageServerLoad = async ({ parent }) => {
   const layout = await parent();
   const admin: AdminIdentity = {
@@ -24,19 +26,15 @@ export const load: PageServerLoad = async ({ parent }) => {
   // Staff roster is managers-only; moderators get bounced to the overview.
   if (!isManager(admin.role)) throw redirect(302, '/');
 
-  if (isDemo()) {
-    return { staff: sampleStaff, me: admin, degraded: false };
-  }
-  // Roster only — a member's action history is lazy-loaded from /staff/history
-  // when their drawer opens, so this page never ships the whole audit log.
-  let staff: AdminAcct[] = [];
-  let degraded = false;
-  try {
-    staff = await adminListAccts();
-  } catch {
-    degraded = true;
-  }
-  return { staff, me: admin, degraded };
+  // Streamed: the shell renders immediately; the roster hydrates when the RPC
+  // lands. A member's action history stays lazy-loaded from /staff/history.
+  const roster: Promise<RosterBundle> = isDemo()
+    ? Promise.resolve({ staff: sampleStaff, degraded: false })
+    : adminListAccts()
+        .then((staff) => ({ staff, degraded: false }))
+        .catch(() => ({ staff: [], degraded: true }));
+
+  return { roster, me: admin };
 };
 
 function audit(admin: AdminIdentity, action: string, target: string, detail: string, ok: boolean, error?: string): void {

--- a/console/admin/src/routes/(admin)/staff/+page.svelte
+++ b/console/admin/src/routes/(admin)/staff/+page.svelte
@@ -11,25 +11,30 @@
     EmptyState,
     ConfirmDialog,
     Scroller,
+    Skeleton,
     toast
   } from '@bagel/shared';
   import type { AdminAcct, AdminRole, AuditEntry } from '$lib/server/services';
 
   let { data } = $props();
 
-  // Roster is small; the load ships it resolved. Mutations reconcile against
-  // the authoritative roster echoed by the users service (never a local guess).
-  // svelte-ignore state_referenced_locally
-  let staff = $state<AdminAcct[]>(data.staff ?? []);
-  // Plain variable on purpose: it only marks which `data` seeded local state,
-  // so it must compare by raw identity (a $state proxy never equals `data`).
-  // svelte-ignore state_referenced_locally
-  let seed = data;
+  // Streamed roster -> local state, so mutations can reconcile against the
+  // authoritative roster echoed by the users service (never a local guess).
+  let staff = $state<AdminAcct[]>([]);
+  let rosterLoaded = $state(false);
+  let degraded = $state(false);
   $effect(() => {
-    if (data !== seed) {
-      seed = data;
-      staff = data.staff ?? [];
-    }
+    let alive = true;
+    rosterLoaded = false;
+    data.roster.then((r) => {
+      if (!alive) return;
+      staff = r.staff;
+      degraded = r.degraded;
+      rosterLoaded = true;
+    });
+    return () => {
+      alive = false;
+    };
   });
 
   const me = $derived(data.me);
@@ -145,13 +150,17 @@
     Staff <em>roster</em>
   </PageHead>
 
-  {#if data.degraded}
-    <AlertBanner>Roster service unreachable; the list below may be stale.</AlertBanner>
+  {#if degraded}
+    <AlertBanner>Roster service unreachable; nothing below is live.</AlertBanner>
   {/if}
 
   <PageToolbar>
     {#snippet lead()}
-      <span class="roster-count">{roster.length} member{roster.length === 1 ? '' : 's'}</span>
+      {#if rosterLoaded}
+        <span class="roster-count">{roster.length} member{roster.length === 1 ? '' : 's'}</span>
+      {:else}
+        <Skeleton variant="pill" width="110px" />
+      {/if}
     {/snippet}
     {#snippet trail()}
       <Button variant="primary" icon="plus" onclick={() => (addOpen = !addOpen)}>Add member</Button>
@@ -192,7 +201,11 @@
 
   <div class="deck">
     <DeckList>
-      {#if roster.length}
+      {#if !rosterLoaded}
+        <div class="row-skeletons">
+          {#each [0, 1, 2] as i (i)}<Skeleton variant="block" height="60px" />{/each}
+        </div>
+      {:else if roster.length}
         <ul class="list" aria-label="Staff">
           {#each roster as member (member.id)}
             <li class="staff-row">
@@ -336,6 +349,7 @@
   .roster-count { font-family: var(--bb-font-body); font-size: 12.5px; color: var(--bb-muted); }
 
   .add-card { margin-bottom: 16px; }
+  .row-skeletons { display: flex; flex-direction: column; gap: 8px; padding: 12px; }
   .add-form { display: grid; grid-template-columns: repeat(4, 1fr) auto; gap: 12px; align-items: end; }
   .add-form label {
     display: flex; flex-direction: column; gap: 6px;

--- a/console/shared/lib/server/nats.ts
+++ b/console/shared/lib/server/nats.ts
@@ -8,7 +8,8 @@ import {
   type ConnectionOptions,
   type NatsConnection,
   type JetStreamClient,
-  type JetStreamManager
+  type JetStreamManager,
+  type JetStreamManagerOptions
 } from 'nats';
 
 const jc = JSONCodec();
@@ -200,15 +201,23 @@ async function get(role: Role): Promise<NatsConnection> {
 let jsClient: JetStreamClient | null = null;
 let jsManager: JetStreamManager | null = null;
 
+// checkAPI:false is load-bearing: the enablement probe publishes the
+// domain-LESS `$JS.API.INFO`, which the per-account allow lists deliberately
+// do not grant (only `$JS.hub.API.>` subjects are). With the probe on, manager
+// creation times out on a permission violation and every JetStream view
+// (lanes, KV aliases) reports TIMEOUT. The option rides the client opts so KV
+// views inherit it when they derive their own manager.
+const JS_OPTS: JetStreamManagerOptions = { domain: 'hub', checkAPI: false };
+
 export async function js(): Promise<JetStreamClient> {
   const nc = await get('bus');
-  if (!jsClient) jsClient = nc.jetstream({ domain: 'hub' });
+  if (!jsClient) jsClient = nc.jetstream(JS_OPTS);
   return jsClient;
 }
 
 export async function jsm(): Promise<JetStreamManager> {
   const nc = await get('bus');
-  if (!jsManager) jsManager = await nc.jetstreamManager({ domain: 'hub' });
+  if (!jsManager) jsManager = await nc.jetstreamManager(JS_OPTS);
   return jsManager;
 }
 


### PR DESCRIPTION
## What

Three production issues in the admin console plus the last blocking loads.

- **Lanes "TIMEOUT"**: nats.js's JetStream enablement probe publishes the domain-less `$JS.API.INFO`, which the per-account allow lists deliberately don't grant (`admin_bus` only has `$JS.hub.API.>`). Manager creation timed out on a permission violation (visible as violation spam in the hub log every sampler tick), so lane telemetry and the KV alias store never answered. JetStream clients are now created with `checkAPI: false`; all real calls already use the permitted hub-prefixed subjects, and KV views inherit the option.
- **Events "unable to verify the first certificate"**: the status-feed connection never got the NATS-native-TLS treatment. It now dials the hub with the same fleet-CA options (`NATS_CA_PEM`) the working bus connection uses.
- **Async loads**: Staff and Notifications were the last pages blocking SSR on a NATS round trip; both stream now (instant shell + skeletons).
- **Nav**: Notifications page listed under Accounts (was reachable only via the bell).

## Testing
- svelte-check clean on both console apps.
- Demo browser pass: notifications nav entry + streamed history, staff skeleton→roster, compose intact.
- NATS fixes verified against the hub server logs (violation signature) and the nats.js source path for `checkAPI`; not reproducible locally (no TLS hub in dev).