### PR TITLE
fix(dashboard): inspector save crashed cloning $state proxy drafts

### DIFF
--- a/console/shared/lib/inspector-machine.test.ts
+++ b/console/shared/lib/inspector-machine.test.ts
@@ -152,4 +152,14 @@ describe('inspector-machine', () => {
 		const s: InspectorState<Cmd> = openClean('a', A);
 		expect(requestSave(s, 'r')).toBe(s);
 	});
+
+	test('requestSave snapshots a proxied draft (structuredClone rejects proxies)', () => {
+		// At runtime the draft arrives wrapped in a Svelte 5 $state proxy, which
+		// structuredClone throws DataCloneError on; the clone must fall back.
+		let s = openClean('a', A);
+		s = edit(s, new Proxy({ ...A, response: 'changed' }, {}));
+		s = requestSave(s, 'req-p');
+		expect(s.status).toBe('saving');
+		expect(s.submitted?.snapshot).toEqual({ ...A, response: 'changed' });
+	});
 });

--- a/console/shared/lib/inspector-machine.ts
+++ b/console/shared/lib/inspector-machine.ts
@@ -40,8 +40,19 @@ export type SaveOutcome<T> =
   | { type: 'error' }
   | { type: 'conflict'; committed?: T };
 
-const clone = <T>(v: T): T =>
-  typeof structuredClone === 'function' ? structuredClone(v) : (JSON.parse(JSON.stringify(v)) as T);
+// Drafts are plain JSON data, but at runtime they arrive wrapped in Svelte 5
+// $state proxies, which structuredClone rejects (DataCloneError: a Proxy has no
+// clonable internal slots). Fall back to JSON cloning for those.
+const clone = <T>(v: T): T => {
+  if (typeof structuredClone === 'function') {
+    try {
+      return structuredClone(v);
+    } catch {
+      // proxied state — clone via JSON below
+    }
+  }
+  return JSON.parse(JSON.stringify(v)) as T;
+};
 
 // Default dirtiness check: deep-equal by JSON. Drafts here are plain data;
 // unknown params so a possibly-null draft compares without generic friction.


### PR DESCRIPTION
## Problem
Timers page (and any future inspector-framework page): New timer / Save did nothing. No toast, no network request, no visible error.

## Root cause
`inspector-machine.ts` `clone()` used `structuredClone` on the draft. At runtime the draft is wrapped in a Svelte 5 `$state` deep proxy (the reactive wrapper holds the machine state in `$state`), and `structuredClone` throws `DataCloneError` on proxies. `requestSave` rejected inside SvelteKit's `enhance` submit handler after `preventDefault` but before the fetch, so the submit died silently.

## Fix
`clone()` tries `structuredClone`, falls back to JSON cloning when it throws (drafts are plain JSON data per the machine's contract). Regression test saves a `Proxy`-wrapped draft.

## Verification
- Before: clicking Create timer produced zero network traffic; unhandled rejection stack pointed at `clone → requestSave → beginSave → saveSubmit`.
- After: `POST /timers?/create → 200`, editor closes on success, toast shown.
- `bun test` in console/shared: 78 pass, 0 fail.
- Generic `/modules/[id]` patch path unaffected (direct fetch, no clone): verified `POST /modules/time?/patch → 200`.