### PR TITLE
Fix admin NATS telemetry and RPC diagnostics

### DIFF
--- a/app/commands/main.go
+++ b/app/commands/main.go
@@ -191,6 +191,9 @@ func main() {
 	if err := rpc.SubscribeDashboard(nc, repo, commandsPrefix, "commands-rpc", nrApp, log); err != nil {
 		log.Fatal("failed to subscribe dashboard rpc", zap.Error(err))
 	}
+	if err := bus.SubscribeRPCHealth(nc, serviceName, "commands-rpc"); err != nil {
+		log.Fatal("failed to subscribe rpc health", zap.Error(err))
+	}
 
 	health.Serve(env.Get("LISTEN_ADDR", ":8080"), nc.IsConnected)
 

--- a/app/gateway/main.go
+++ b/app/gateway/main.go
@@ -89,6 +89,9 @@ func main() {
 	if err := engine.Serve(nc, cfg.SubjectPrefix, queueGroup, active, nrApp, log); err != nil {
 		log.Fatal("failed to subscribe provider endpoints", zap.Error(err))
 	}
+	if err := bus.SubscribeRPCHealth(nc, serviceName, queueGroup); err != nil {
+		log.Fatal("failed to subscribe rpc health", zap.Error(err))
+	}
 
 	health.Serve(cfg.ListenAddr, nc.IsConnected)
 

--- a/app/gateway/main.go
+++ b/app/gateway/main.go
@@ -28,6 +28,7 @@ import (
 	"ItsBagelBot/pkg/ratelimit"
 	pkg_valkey "ItsBagelBot/pkg/valkey"
 
+	"github.com/nats-io/nats.go"
 	"go.uber.org/zap"
 )
 
@@ -89,9 +90,7 @@ func main() {
 	if err := engine.Serve(nc, cfg.SubjectPrefix, queueGroup, active, nrApp, log); err != nil {
 		log.Fatal("failed to subscribe provider endpoints", zap.Error(err))
 	}
-	if err := bus.SubscribeRPCHealth(nc, serviceName, queueGroup); err != nil {
-		log.Fatal("failed to subscribe rpc health", zap.Error(err))
-	}
+	subscribeRPCHealth(nc, queueGroup, log)
 
 	health.Serve(cfg.ListenAddr, nc.IsConnected)
 
@@ -107,4 +106,10 @@ func main() {
 	<-ctx.Done()
 
 	log.Info("gateway shutting down")
+}
+
+func subscribeRPCHealth(nc *nats.Conn, queueGroup string, log *zap.Logger) {
+	if err := bus.SubscribeRPCHealth(nc, serviceName, queueGroup); err != nil {
+		log.Fatal("failed to subscribe rpc health", zap.Error(err))
+	}
 }

--- a/app/ingress/config/runtime.exs
+++ b/app/ingress/config/runtime.exs
@@ -81,6 +81,8 @@ config :ingress,
     System.get_env("NATS_AUTOSCALE_SUBJECT", "twitch.ingress.admin.shards.autoscale"),
   # Live conduit id query: body {}, replies {"conduit_id": "<uuid>"} or {"error": "..."}.
   conduit_subject: System.get_env("NATS_CONDUIT_SUBJECT", "bagel.rpc.ingress.conduit.get"),
+  # Side-effect-free admin latency probe shared by every RPC-serving service.
+  rpc_health_subject: System.get_env("NATS_RPC_HEALTH_SUBJECT", "bagel.rpc.health.ingress"),
   # Hard ceiling applied to both manual targets and the autoscaler estimate.
   max_shards: String.to_integer(System.get_env("TWITCH_CONDUIT_MAX_SHARDS", "20")),
   # Capacity values are reported to the admin console and drive shard scaling.

--- a/app/ingress/lib/ingress/application.ex
+++ b/app/ingress/lib/ingress/application.ex
@@ -34,6 +34,7 @@ defmodule Ingress.Application do
       `Ingress.ScaleRpc` (manual shard count).
     * `Gnat.ConsumerSupervisor` (autoscale) - request-reply control endpoint
       for `Ingress.AutoscaleRpc` (load-based autoscaler toggle).
+    * `Gnat.ConsumerSupervisor` (health) - side-effect-free RPC latency probe.
     * `Ingress.Bootstrapper` - ensures the cluster-singleton ShardScaler and
       ConduitManager run.
   """
@@ -140,6 +141,10 @@ defmodule Ingress.Application do
       ),
       # Live conduit id: body {}, replies {"conduit_id": "<uuid>"}.
       consumer_child(:conduit_consumer, Ingress.ConduitRpc, Config.conduit_subject(),
+        queue_group: @admin_queue
+      ),
+      # Side-effect-free fleet RPC latency probe.
+      consumer_child(:health_consumer, Ingress.HealthRpc, Config.rpc_health_subject(),
         queue_group: @admin_queue
       ),
       Ingress.Bootstrapper

--- a/app/ingress/lib/ingress/config.ex
+++ b/app/ingress/lib/ingress/config.ex
@@ -74,6 +74,9 @@ defmodule Ingress.Config do
   # Subject for live conduit id query: body {}, replies {"conduit_id": "<uuid>"}.
   def conduit_subject, do: Application.fetch_env!(:ingress, :conduit_subject)
 
+  # Side-effect-free admin RPC latency probe.
+  def rpc_health_subject, do: Application.fetch_env!(:ingress, :rpc_health_subject)
+
   # Hard ceiling on shard count; the autoscaler and manual target are both
   # clamped to this value so a runaway load spike cannot blow the conduit cap.
   def max_shards, do: Application.get_env(:ingress, :max_shards, 20)

--- a/app/ingress/lib/ingress/health_rpc.ex
+++ b/app/ingress/lib/ingress/health_rpc.ex
@@ -1,0 +1,21 @@
+defmodule Ingress.HealthRpc do
+  @moduledoc """
+  Side-effect-free NATS request/reply endpoint used by the admin RPC latency
+  panel. A reply proves the ingress RPC connection, account route and consumer
+  dispatcher are live without asking the shard registry for a full snapshot.
+  """
+
+  use Gnat.Server
+  require Logger
+
+  @impl true
+  def request(%{body: _body}) do
+    {:reply, ~s({"service":"ingress","ok":true})}
+  end
+
+  @impl true
+  def error(_message, error) do
+    Logger.error("health rpc error: #{inspect(error)}")
+    :ok
+  end
+end

--- a/app/ingress/test/health_rpc_test.exs
+++ b/app/ingress/test/health_rpc_test.exs
@@ -1,0 +1,8 @@
+defmodule Ingress.HealthRpcTest do
+  use ExUnit.Case, async: true
+
+  test "returns the standard side-effect-free health envelope" do
+    assert {:reply, body} = Ingress.HealthRpc.request(%{body: "{}"})
+    assert Jason.decode!(body) == %{"service" => "ingress", "ok" => true}
+  end
+end

--- a/app/loyalty/main.go
+++ b/app/loyalty/main.go
@@ -167,6 +167,9 @@ func main() {
 	if err := rpc.Subscribe(nc, repo, loyaltyPrefix, "loyalty-rpc", nrApp, log); err != nil {
 		log.Fatal("failed to subscribe loyalty rpc", zap.Error(err))
 	}
+	if err := bus.SubscribeRPCHealth(nc, serviceName, "loyalty-rpc"); err != nil {
+		log.Fatal("failed to subscribe rpc health", zap.Error(err))
+	}
 
 	health.Serve(env.Get("LISTEN_ADDR", ":8080"), nc.IsConnected)
 

--- a/app/modules/main.go
+++ b/app/modules/main.go
@@ -84,10 +84,7 @@ func main() {
 
 	quotes := repository.NewQuotes(client, log)
 
-	nc, err := bus.Connect(rpcURL, serviceName)
-	if err != nil {
-		log.Fatal("failed to connect to nats", zap.Error(err))
-	}
+	nc := connectRPC(rpcURL, log)
 	defer nc.Close()
 
 	// Broadcast subscription: every instance must drop its cached view when
@@ -175,8 +172,6 @@ func main() {
 	}); err != nil {
 		log.Fatal("failed to subscribe quotes rpc", zap.Error(err))
 	}
-	subscribeRPCHealth(nc, log)
-
 	health.Serve(env.Get("LISTEN_ADDR", ":8080"), nc.IsConnected)
 
 	log.Info("modules service ready", zap.String("projection_subject", projectionSubject))
@@ -186,8 +181,13 @@ func main() {
 	log.Info("modules service shutting down")
 }
 
-func subscribeRPCHealth(nc *nats.Conn, log *zap.Logger) {
+func connectRPC(url string, log *zap.Logger) *nats.Conn {
+	nc, err := bus.Connect(url, serviceName)
+	if err != nil {
+		log.Fatal("failed to connect to nats", zap.Error(err))
+	}
 	if err := bus.SubscribeRPCHealth(nc, serviceName, "modules-rpc"); err != nil {
 		log.Fatal("failed to subscribe rpc health", zap.Error(err))
 	}
+	return nc
 }

--- a/app/modules/main.go
+++ b/app/modules/main.go
@@ -174,6 +174,9 @@ func main() {
 	}); err != nil {
 		log.Fatal("failed to subscribe quotes rpc", zap.Error(err))
 	}
+	if err := bus.SubscribeRPCHealth(nc, serviceName, "modules-rpc"); err != nil {
+		log.Fatal("failed to subscribe rpc health", zap.Error(err))
+	}
 
 	health.Serve(env.Get("LISTEN_ADDR", ":8080"), nc.IsConnected)
 

--- a/app/modules/main.go
+++ b/app/modules/main.go
@@ -24,6 +24,7 @@ import (
 	"ItsBagelBot/pkg/monitor"
 
 	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/nats-io/nats.go"
 
 	"go.uber.org/zap"
 )
@@ -174,9 +175,7 @@ func main() {
 	}); err != nil {
 		log.Fatal("failed to subscribe quotes rpc", zap.Error(err))
 	}
-	if err := bus.SubscribeRPCHealth(nc, serviceName, "modules-rpc"); err != nil {
-		log.Fatal("failed to subscribe rpc health", zap.Error(err))
-	}
+	subscribeRPCHealth(nc, log)
 
 	health.Serve(env.Get("LISTEN_ADDR", ":8080"), nc.IsConnected)
 
@@ -185,4 +184,10 @@ func main() {
 	<-ctx.Done()
 
 	log.Info("modules service shutting down")
+}
+
+func subscribeRPCHealth(nc *nats.Conn, log *zap.Logger) {
+	if err := bus.SubscribeRPCHealth(nc, serviceName, "modules-rpc"); err != nil {
+		log.Fatal("failed to subscribe rpc health", zap.Error(err))
+	}
 }

--- a/app/notifications/main.go
+++ b/app/notifications/main.go
@@ -125,6 +125,9 @@ func main() {
 	if err := rpc.SubscribeMaintenance(nc, repo, cleanupSubject, queueGroup, nrApp, log); err != nil {
 		log.Fatal("failed to subscribe maintenance rpc", zap.Error(err))
 	}
+	if err := bus.SubscribeRPCHealth(nc, serviceName, queueGroup); err != nil {
+		log.Fatal("failed to subscribe rpc health", zap.Error(err))
+	}
 
 	health.Serve(env.Get("LISTEN_ADDR", ":8080"), nc.IsConnected)
 

--- a/app/notifications/main.go
+++ b/app/notifications/main.go
@@ -20,6 +20,7 @@ import (
 	"ItsBagelBot/pkg/logger"
 	"ItsBagelBot/pkg/monitor"
 
+	"github.com/nats-io/nats.go"
 	"go.uber.org/zap"
 )
 
@@ -125,9 +126,7 @@ func main() {
 	if err := rpc.SubscribeMaintenance(nc, repo, cleanupSubject, queueGroup, nrApp, log); err != nil {
 		log.Fatal("failed to subscribe maintenance rpc", zap.Error(err))
 	}
-	if err := bus.SubscribeRPCHealth(nc, serviceName, queueGroup); err != nil {
-		log.Fatal("failed to subscribe rpc health", zap.Error(err))
-	}
+	subscribeRPCHealth(nc, queueGroup, log)
 
 	health.Serve(env.Get("LISTEN_ADDR", ":8080"), nc.IsConnected)
 
@@ -139,4 +138,10 @@ func main() {
 	<-ctx.Done()
 
 	log.Info("notifications service shutting down")
+}
+
+func subscribeRPCHealth(nc *nats.Conn, queueGroup string, log *zap.Logger) {
+	if err := bus.SubscribeRPCHealth(nc, serviceName, queueGroup); err != nil {
+		log.Fatal("failed to subscribe rpc health", zap.Error(err))
+	}
 }

--- a/app/notifications/main.go
+++ b/app/notifications/main.go
@@ -74,10 +74,7 @@ func main() {
 	natsURL := env.Get("NATS_URL", "nats://127.0.0.1:4222")
 	rpcURL := bus.RPCURL(natsURL)
 
-	nc, err := bus.Connect(rpcURL, serviceName)
-	if err != nil {
-		log.Fatal("failed to connect to nats", zap.Error(err))
-	}
+	nc := connectRPC(rpcURL, log)
 	defer nc.Close()
 
 	repo := repository.New(client)
@@ -126,8 +123,6 @@ func main() {
 	if err := rpc.SubscribeMaintenance(nc, repo, cleanupSubject, queueGroup, nrApp, log); err != nil {
 		log.Fatal("failed to subscribe maintenance rpc", zap.Error(err))
 	}
-	subscribeRPCHealth(nc, queueGroup, log)
-
 	health.Serve(env.Get("LISTEN_ADDR", ":8080"), nc.IsConnected)
 
 	log.Info("notifications service ready",
@@ -140,8 +135,13 @@ func main() {
 	log.Info("notifications service shutting down")
 }
 
-func subscribeRPCHealth(nc *nats.Conn, queueGroup string, log *zap.Logger) {
-	if err := bus.SubscribeRPCHealth(nc, serviceName, queueGroup); err != nil {
+func connectRPC(url string, log *zap.Logger) *nats.Conn {
+	nc, err := bus.Connect(url, serviceName)
+	if err != nil {
+		log.Fatal("failed to connect to nats", zap.Error(err))
+	}
+	if err := bus.SubscribeRPCHealth(nc, serviceName, "notifications-rpc"); err != nil {
 		log.Fatal("failed to subscribe rpc health", zap.Error(err))
 	}
+	return nc
 }

--- a/app/outgress/main.go
+++ b/app/outgress/main.go
@@ -150,6 +150,7 @@ func main() {
 	if err := rpc.SubscribeChatters(nc, tw, cfg.TwitchBotUserID, cfg.RPCPrefix, "outgress-rpc", nrApp, log.Named("rpc")); err != nil {
 		log.Fatal("failed to subscribe chatters rpc", zap.Error(err))
 	}
+	fatalIf(log, bus.SubscribeRPCHealth(nc, serviceName, "outgress-rpc"), "failed to subscribe rpc health")
 
 	health.Serve(env.Get("LISTEN_ADDR", ":8080"), nc.IsConnected)
 

--- a/app/projector/main.go
+++ b/app/projector/main.go
@@ -120,6 +120,7 @@ func main() {
 	subscribeRPCs(rpcRuntime{
 		nc: nc, store: valkeyStore, pub: pub, hydrator: hydrator, nrApp: nrApp, log: log,
 	}, topics)
+	fatalIf(log, bus.SubscribeRPCHealth(nc, serviceName, "projector-rpc"), "failed to subscribe rpc health")
 
 	health.Serve(env.Get("LISTEN_ADDR", ":8080"), nc.IsConnected)
 

--- a/app/sesame/main.go
+++ b/app/sesame/main.go
@@ -99,6 +99,9 @@ func main() {
 	if err != nil {
 		log.Fatal("failed to start consumer", zap.Error(err))
 	}
+	if err := bus.SubscribeRPCHealth(nc, serviceName, "sesame-rpc"); err != nil {
+		log.Fatal("failed to subscribe rpc health", zap.Error(err))
+	}
 
 	health.Serve(cfg.ListenAddr, nc.IsConnected)
 	logReady(cfg, deps.Special.Len(), log)

--- a/app/transactions/main.go
+++ b/app/transactions/main.go
@@ -70,12 +70,8 @@ func main() {
 
 	// RPC-plane connection (TRANSACTIONS_RPC account): answers the checkout
 	// basket verb and issues the recipient-lookup / gift-notification requests.
-	nc, err := bus.Connect(bus.RPCURL(natsURL), serviceName)
-	if err != nil {
-		log.Fatal("failed to connect rpc nats", zap.Error(err))
-	}
+	nc := connectRPC(natsURL, log)
 	defer nc.Close()
-	subscribeRPCHealth(nc, log)
 
 	// Checkout RPC (dashboard -> basket_create). Optional: without the Tebex
 	// Headless credentials the service stays webhook-only, exactly as before.
@@ -159,10 +155,15 @@ func main() {
 	serveHTTP(ctx, httpServer, log)
 }
 
-func subscribeRPCHealth(nc *nats.Conn, log *zap.Logger) {
+func connectRPC(natsURL string, log *zap.Logger) *nats.Conn {
+	nc, err := bus.Connect(bus.RPCURL(natsURL), serviceName)
+	if err != nil {
+		log.Fatal("failed to connect rpc nats", zap.Error(err))
+	}
 	if err := bus.SubscribeRPCHealth(nc, serviceName, "transactions-rpc"); err != nil {
 		log.Fatal("failed to subscribe rpc health", zap.Error(err))
 	}
+	return nc
 }
 
 // serveHTTP runs the server until ctx is cancelled or the listener fails,

--- a/app/transactions/main.go
+++ b/app/transactions/main.go
@@ -24,6 +24,7 @@ import (
 	"ItsBagelBot/pkg/logger"
 	"ItsBagelBot/pkg/monitor"
 
+	"github.com/nats-io/nats.go"
 	"go.uber.org/zap"
 )
 
@@ -74,9 +75,7 @@ func main() {
 		log.Fatal("failed to connect rpc nats", zap.Error(err))
 	}
 	defer nc.Close()
-	if err := bus.SubscribeRPCHealth(nc, serviceName, "transactions-rpc"); err != nil {
-		log.Fatal("failed to subscribe rpc health", zap.Error(err))
-	}
+	subscribeRPCHealth(nc, log)
 
 	// Checkout RPC (dashboard -> basket_create). Optional: without the Tebex
 	// Headless credentials the service stays webhook-only, exactly as before.
@@ -158,6 +157,12 @@ func main() {
 	)
 
 	serveHTTP(ctx, httpServer, log)
+}
+
+func subscribeRPCHealth(nc *nats.Conn, log *zap.Logger) {
+	if err := bus.SubscribeRPCHealth(nc, serviceName, "transactions-rpc"); err != nil {
+		log.Fatal("failed to subscribe rpc health", zap.Error(err))
+	}
 }
 
 // serveHTTP runs the server until ctx is cancelled or the listener fails,

--- a/app/transactions/main.go
+++ b/app/transactions/main.go
@@ -74,6 +74,9 @@ func main() {
 		log.Fatal("failed to connect rpc nats", zap.Error(err))
 	}
 	defer nc.Close()
+	if err := bus.SubscribeRPCHealth(nc, serviceName, "transactions-rpc"); err != nil {
+		log.Fatal("failed to subscribe rpc health", zap.Error(err))
+	}
 
 	// Checkout RPC (dashboard -> basket_create). Optional: without the Tebex
 	// Headless credentials the service stays webhook-only, exactly as before.

--- a/app/users/main.go
+++ b/app/users/main.go
@@ -71,6 +71,7 @@ func main() {
 
 	wiring := rpc.Wiring{NC: nc, Repo: repo, App: nrApp, Queue: "users-rpc", Log: log}
 	subjects := subscribeRPCs(ctx, wiring, client, log)
+	fatalIf(log, bus.SubscribeRPCHealth(nc, serviceName, "users-rpc"), "failed to subscribe rpc health")
 
 	health.Serve(env.Get("LISTEN_ADDR", ":8080"), nc.IsConnected)
 	subjects.logReady(log)

--- a/console/admin/src/lib/server/feed.ts
+++ b/console/admin/src/lib/server/feed.ts
@@ -3,7 +3,6 @@
 // request/reply client so a long-lived subscription never interferes with the
 // short-lived RPC requests (and vice versa).
 import { connect, type ConnectionOptions, type NatsConnection, type Subscription } from 'nats';
-import { enableLeafFailback } from '@bagel/shared/server/nats';
 
 let conn: NatsConnection | null = null;
 let dialing: Promise<NatsConnection> | null = null;
@@ -22,7 +21,9 @@ async function get(): Promise<NatsConnection> {
     name: (process.env.NATS_CLIENT_NAME ?? 'console') + '-feed',
     maxReconnectAttempts: -1,
     reconnectTimeWait: 500,
-    pingInterval: 20_000
+    pingInterval: 20_000,
+    ignoreAuthErrorAbort: true,
+    timeout: 3_000
   };
   if (process.env.NATS_USER) opts.user = process.env.NATS_USER;
   if (process.env.NATS_PASSWORD) opts.pass = process.env.NATS_PASSWORD;
@@ -36,7 +37,6 @@ async function get(): Promise<NatsConnection> {
   dialing = connect(opts)
     .then((c) => {
       conn = c;
-      enableLeafFailback(c);
       return c;
     })
     .finally(() => {

--- a/console/admin/src/lib/server/sample.ts
+++ b/console/admin/src/lib/server/sample.ts
@@ -73,9 +73,16 @@ export const sampleUsers: AdminUserWire[] = [
 
 export const sampleHealth: ServiceHealth[] = [
   { id: 'users', label: 'Users', ok: true, ms: 4 },
+  { id: 'commands', label: 'Commands', ok: true, ms: 6 },
+  { id: 'modules', label: 'Modules', ok: true, ms: 7 },
+  { id: 'loyalty', label: 'Loyalty', ok: true, ms: 9 },
+  { id: 'projector', label: 'Projector', ok: true, ms: 5 },
+  { id: 'sesame', label: 'Sesame', ok: true, ms: 8 },
+  { id: 'gateway', label: 'Gateway', ok: true, ms: 12 },
   { id: 'ingress', label: 'Ingress', ok: true, ms: 11 },
   { id: 'outgress', label: 'Outgress', ok: true, ms: 7 },
-  { id: 'notifications', label: 'Notifications', ok: false, ms: 2000, error: 'timeout' }
+  { id: 'transactions', label: 'Transactions', ok: true, ms: 10 },
+  { id: 'notifications', label: 'Notifications', ok: false, ms: 1500, error: 'timeout' }
 ];
 
 export const sampleAudit: AuditEntry[] = [

--- a/console/admin/src/lib/server/services.ts
+++ b/console/admin/src/lib/server/services.ts
@@ -25,7 +25,8 @@ const SUB = {
   audit: process.env.NATS_ADMIN_AUDIT_SUBJECT_PREFIX ?? 'bagel.rpc.admin.user.audit',
   outgress: process.env.NATS_OUTGRESS_SYSTEM_SUBJECT ?? 'twitch.outgress.system',
   outgressRpc: process.env.NATS_OUTGRESS_RPC_PREFIX ?? 'bagel.rpc.outgress',
-  notifications: process.env.NATS_ADMIN_NOTIFICATIONS_SUBJECT_PREFIX ?? 'bagel.rpc.admin.notifications'
+  notifications: process.env.NATS_ADMIN_NOTIFICATIONS_SUBJECT_PREFIX ?? 'bagel.rpc.admin.notifications',
+  health: process.env.NATS_RPC_HEALTH_PREFIX ?? 'bagel.rpc.health'
 };
 
 export const STATUS_PREFIX = SUB.status;
@@ -386,9 +387,10 @@ export async function channelSubState(broadcasterId: string): Promise<ChannelSub
 }
 
 // ── Service health ───────────────────────────────────────────────────────────
-// Latency probes over the RPC surfaces the admin NATS account may reach. Each
-// probe is a real request (no cache) so the number is the round trip an
-// operator action would actually pay.
+// Latency probes over every service RPC account the admin may reach. Each
+// service exposes the same side-effect-free no-op responder, so the number is
+// the transport/account/subscriber round trip rather than database or external
+// API work and a sample can never mutate production state.
 
 export interface ServiceHealth {
   id: string;
@@ -398,7 +400,7 @@ export interface ServiceHealth {
   error?: string;
 }
 
-const HEALTH_TIMEOUT_MS = 2000;
+const HEALTH_TIMEOUT_MS = 1500;
 
 interface HealthProbe {
   id: string;
@@ -408,17 +410,24 @@ interface HealthProbe {
 }
 
 const HEALTH_PROBES: HealthProbe[] = [
-  { id: 'users', label: 'Users', subject: `${SUB.user}.stats`, payload: {} },
-  { id: 'ingress', label: 'Ingress', subject: SUB.shards, payload: {} },
-  { id: 'outgress', label: 'Outgress', subject: `${SUB.outgressRpc}.channel.get`, payload: { broadcaster_id: '1' } },
-  { id: 'notifications', label: 'Notifications', subject: `${SUB.notifications}.list`, payload: { page: 1, limit: 1 } }
+  { id: 'users', label: 'Users', subject: `${SUB.health}.users`, payload: {} },
+  { id: 'commands', label: 'Commands', subject: `${SUB.health}.commands`, payload: {} },
+  { id: 'modules', label: 'Modules', subject: `${SUB.health}.modules`, payload: {} },
+  { id: 'loyalty', label: 'Loyalty', subject: `${SUB.health}.loyalty`, payload: {} },
+  { id: 'projector', label: 'Projector', subject: `${SUB.health}.projector`, payload: {} },
+  { id: 'sesame', label: 'Sesame', subject: `${SUB.health}.sesame`, payload: {} },
+  { id: 'gateway', label: 'Gateway', subject: `${SUB.health}.gateway`, payload: {} },
+  { id: 'ingress', label: 'Ingress', subject: `${SUB.health}.ingress`, payload: {} },
+  { id: 'outgress', label: 'Outgress', subject: `${SUB.health}.outgress`, payload: {} },
+  { id: 'transactions', label: 'Transactions', subject: `${SUB.health}.transactions`, payload: {} },
+  { id: 'notifications', label: 'Notifications', subject: `${SUB.health}.notifications`, payload: {} }
 ];
 
 async function probeOnce(probe: HealthProbe): Promise<ServiceHealth> {
   const started = performance.now();
   const failure = await rpc(probe.subject, probe.payload, HEALTH_TIMEOUT_MS).then(
     () => undefined,
-    (e: Error) => e.message || 'unreachable'
+    (e: unknown) => e instanceof Error ? (e.message || 'unreachable') : String(e || 'unreachable')
   );
   return {
     id: probe.id,

--- a/console/admin/src/routes/(admin)/+layout.svelte
+++ b/console/admin/src/routes/(admin)/+layout.svelte
@@ -11,7 +11,7 @@
     ['/analytics', 'Analytics'],
     ['/shards', 'Shards'],
     ['/lanes', 'Lanes'],
-    ['/events', 'Events'],
+    ['/events', 'Ingress feed'],
     ['/users', 'Users'],
     ['/notifications', 'Notifications'],
     ['/staff', 'Staff'],
@@ -34,7 +34,7 @@
         { href: '/', icon: 'overview', label: 'Overview', active: crumb === 'Overview' },
         { href: '/shards', icon: 'server', label: 'Shards', active: crumb === 'Shards' },
         { href: '/lanes', icon: 'lanes', label: 'Lanes', active: crumb === 'Lanes' },
-        { href: '/events', icon: 'pulse', label: 'Events', active: crumb === 'Events' }
+        { href: '/events', icon: 'pulse', label: 'Ingress feed', active: crumb === 'Ingress feed' }
       ]
     },
     {
@@ -65,7 +65,7 @@
     { href: '/', icon: 'overview', label: 'Overview', active: crumb === 'Overview' },
     { href: '/shards', icon: 'server', label: 'Shards', active: crumb === 'Shards' },
     { href: '/lanes', icon: 'lanes', label: 'Lanes', active: crumb === 'Lanes' },
-    { href: '/events', icon: 'pulse', label: 'Events', active: crumb === 'Events' },
+    { href: '/events', icon: 'pulse', label: 'Ingress', active: crumb === 'Ingress feed' },
     { href: '/users', icon: 'users', label: 'Users', active: crumb === 'Users' },
     { href: '/analytics', icon: 'activity', label: 'Analytics', active: crumb === 'Analytics' },
     { href: '/notifications', icon: 'bell', label: 'Notifs', active: crumb === 'Notifications' },

--- a/console/admin/src/routes/(admin)/+page.server.ts
+++ b/console/admin/src/routes/(admin)/+page.server.ts
@@ -4,13 +4,11 @@ import {
   userEnrollment,
   tokenStatus,
   auditList,
-  serviceHealth,
   type EnrollmentWire,
-  type AuditEntry,
-  type ServiceHealth
+  type AuditEntry
 } from '$lib/server/services';
 import { isDemo, isManager } from '$lib/server/access';
-import { sampleAudit, sampleEnrollment, sampleHealth, sampleSnapshot } from '$lib/server/sample';
+import { sampleAudit, sampleEnrollment, sampleSnapshot } from '$lib/server/sample';
 import { env } from '$env/dynamic/private';
 import type { ShardSnapshot } from '@bagel/shared';
 
@@ -21,7 +19,6 @@ export type Overview = {
   snapshot: ShardSnapshot;
   botPresent: boolean;
   recentAudit: AuditEntry[];
-  health: ServiceHealth[];
   degraded: boolean;
 };
 
@@ -29,8 +26,9 @@ export type Overview = {
 // page waits one round trip instead of four. Every read falls back so the page
 // keeps rendering when a responder is down; a failed *critical* read flips the
 // degraded flag — the banner says so, the page never pretends the fallback is
-// live. Health probe failures are the health panel's own signal, not a
-// degraded page.
+// live. Fleet-wide RPC timing belongs to Analytics and is deliberately absent
+// here, so a diagnostic timeout can never hold the operational overview on
+// skeletons.
 async function loadOverview(withAudit: boolean): Promise<Overview> {
   let degraded = false;
   const orFallback = <T>(load: Promise<T>, fallback: T, critical = true): Promise<T> =>
@@ -40,15 +38,14 @@ async function loadOverview(withAudit: boolean): Promise<Overview> {
     });
 
   const botId = env.ADMIN_BOT_USER_ID ?? '';
-  const [enrollment, snapshot, token, recentAudit, health] = await Promise.all([
+  const [enrollment, snapshot, token, recentAudit] = await Promise.all([
     orFallback(userEnrollment(), sampleEnrollment),
     orFallback(shardSnapshot(), sampleSnapshot),
     orFallback(botId ? tokenStatus(botId) : Promise.resolve({ present: false }), { present: false }),
-    orFallback(withAudit ? auditList(AUDIT_PEEK) : Promise.resolve([]), []),
-    orFallback(serviceHealth(), [], false)
+    orFallback(withAudit ? auditList(AUDIT_PEEK) : Promise.resolve([]), [])
   ]);
 
-  return { enrollment, snapshot, botPresent: token.present, recentAudit, health, degraded };
+  return { enrollment, snapshot, botPresent: token.present, recentAudit, degraded };
 }
 
 export const load: PageServerLoad = async ({ parent }) => {
@@ -64,7 +61,6 @@ export const load: PageServerLoad = async ({ parent }) => {
         snapshot: sampleSnapshot,
         botPresent: true,
         recentAudit: withAudit ? sampleAudit : [],
-        health: sampleHealth,
         degraded: false
       })
     : loadOverview(withAudit);

--- a/console/admin/src/routes/(admin)/+page.svelte
+++ b/console/admin/src/routes/(admin)/+page.svelte
@@ -3,28 +3,9 @@
   import { Icon, StatTile, PageHead, CardHead, Card, Button, Skeleton, AlertBanner } from '@bagel/shared';
   import type { ShardSnapshot } from '@bagel/shared';
   import EnrollmentChart from '$lib/components/EnrollmentChart.svelte';
-  import type { AuditEntry, ServiceHealth } from '$lib/server/services';
+  import type { AuditEntry } from '$lib/server/services';
 
   let { data } = $props();
-
-  // Health repolls every 30s so a recovering service turns green live; until
-  // the first poll lands the card shows the load-time probes.
-  let liveHealth = $state<ServiceHealth[] | null>(null);
-  async function pollHealth() {
-    if (typeof document !== 'undefined' && document.hidden) return;
-    try {
-      const res = await fetch('/health');
-      if (!res.ok) return;
-      const body = (await res.json()) as { health?: ServiceHealth[] };
-      if (body.health) liveHealth = body.health;
-    } catch {
-      /* transient; keep last known */
-    }
-  }
-  onMount(() => {
-    const timer = setInterval(pollHealth, 30_000);
-    return () => clearInterval(timer);
-  });
 
   // Absolute URL of the bot-authorization route. The operator opens it in the
   // browser signed into the bot account; that browser gets the state cookie and
@@ -216,27 +197,6 @@
       </Card>
     </div>
 
-    {@const health = liveHealth ?? o.health}
-    <div class="card health-card">
-      <div class="card-head">
-        <h3>Service health</h3>
-        <span class="more">round-trip over NATS RPC · refreshes every 30s</span>
-      </div>
-      {#if health.length === 0}
-        <p class="audit-empty">Health probes unavailable.</p>
-      {:else}
-        <div class="health-grid">
-          {#each health as h (h.id)}
-            <div class="health-cell" class:down={!h.ok}>
-              <span class="health-dot {h.ok ? '' : 'err'}"></span>
-              <span class="health-name">{h.label}</span>
-              <span class="health-ms">{h.ok ? `${h.ms} ms` : (h.error?.includes('timeout') ? 'timeout' : 'down')}</span>
-            </div>
-          {/each}
-        </div>
-      {/if}
-    </div>
-
     {#if data.isManager}
       <div class="card audit-card">
         <div class="card-head">
@@ -273,27 +233,6 @@
 
   .audit-card { margin-top: var(--row-gap); }
 
-  .health-card { margin-top: var(--row-gap); }
-  .health-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-    gap: 10px;
-  }
-  .health-cell {
-    display: flex; align-items: center; gap: 10px;
-    padding: 12px 14px;
-    border: 1px solid var(--rule); border-radius: 8px;
-    background: rgba(240, 236, 228, 0.02);
-  }
-  .health-cell.down { border-color: rgba(176, 90, 70, 0.35); background: rgba(176, 90, 70, 0.05); }
-  .health-dot {
-    width: 8px; height: 8px; border-radius: 50%; flex: none;
-    background: var(--bb-green-glow); box-shadow: 0 0 8px var(--bb-green-glow);
-  }
-  .health-dot.err { background: #cf8a78; box-shadow: 0 0 8px rgba(176, 90, 70, 0.6); }
-  .health-name { font-family: var(--bb-font-body); font-weight: 600; font-size: 13px; color: var(--bb-white); }
-  .health-ms { margin-left: auto; font-family: var(--bb-font-mono); font-size: 11.5px; color: var(--bb-muted); }
-  .health-cell.down .health-ms { color: #cf8a78; }
   .audit-empty { font-family: var(--bb-font-body); font-size: 13px; color: var(--bb-muted); margin: 0; }
   .audit-err {
     font-family: var(--bb-font-mono); font-size: 10.5px; color: #cf8a78;

--- a/console/admin/src/routes/(admin)/analytics/+page.server.ts
+++ b/console/admin/src/routes/(admin)/analytics/+page.server.ts
@@ -1,7 +1,12 @@
 import type { PageServerLoad } from './$types';
-import { userEnrollment, type EnrollmentWire } from '$lib/server/services';
+import {
+  serviceHealth,
+  userEnrollment,
+  type EnrollmentWire,
+  type ServiceHealth
+} from '$lib/server/services';
 import { isDemo } from '$lib/server/access';
-import { demoEnrollment, sampleEnrollment } from '$lib/server/sample';
+import { demoEnrollment, sampleEnrollment, sampleHealth } from '$lib/server/sample';
 
 // Window sizes the page offers; the users service clamps to 90 anyway.
 const WINDOWS = new Set([7, 30, 90]);
@@ -23,5 +28,12 @@ export const load: PageServerLoad = ({ url }) => {
         .then((enrollment) => ({ enrollment, degraded: false }))
         .catch(() => ({ enrollment: sampleEnrollment, degraded: true }));
 
-  return { bundle, days };
+  // RPC timing is diagnostic data, not an analytics-page dependency. Stream it
+  // independently so a missing responder can only hold its own cells until the
+  // probe timeout; enrollment still renders as soon as the users read lands.
+  const health: Promise<ServiceHealth[]> = isDemo()
+    ? Promise.resolve(sampleHealth)
+    : serviceHealth();
+
+  return { bundle, health, days };
 };

--- a/console/admin/src/routes/(admin)/analytics/+page.svelte
+++ b/console/admin/src/routes/(admin)/analytics/+page.svelte
@@ -1,10 +1,32 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
+  import { onMount } from 'svelte';
   import { PageHead, PageToolbar, AlertBanner, Skeleton } from '@bagel/shared';
   import EnrollmentChart from '$lib/components/EnrollmentChart.svelte';
+  import type { ServiceHealth } from '$lib/server/services';
   import type { AnalyticsBundle } from './+page.server';
 
   let { data } = $props();
+
+  // A fresh uncached no-op request to every RPC service every 30 seconds makes
+  // recovery visible without turning the Analytics page itself into a poller
+  // while the tab is hidden.
+  let liveHealth = $state<ServiceHealth[] | null>(null);
+  async function pollHealth() {
+    if (typeof document !== 'undefined' && document.hidden) return;
+    try {
+      const res = await fetch('/health');
+      if (!res.ok) return;
+      const body = (await res.json()) as { health?: ServiceHealth[] };
+      if (body.health) liveHealth = body.health;
+    } catch {
+      /* transient: retain the last completed sample */
+    }
+  }
+  onMount(() => {
+    const timer = setInterval(pollHealth, 30_000);
+    return () => clearInterval(timer);
+  });
 
   let bundle = $state<AnalyticsBundle | null>(null);
   $effect(() => {
@@ -89,7 +111,7 @@
 </script>
 
 <section class="screen active">
-  <PageHead eyebrow="Analytics" description="Signups, base composition, and growth patterns from the users service.">
+  <PageHead eyebrow="Analytics" description="Growth patterns and live NATS RPC round-trip timing across the fleet.">
     Growth <em>analytics</em>
   </PageHead>
 
@@ -111,6 +133,45 @@
       </div>
     {/snippet}
   </PageToolbar>
+
+  <div class="card rpc-card">
+    <div class="card-head">
+      <h3>RPC round-trip latency</h3>
+      <span class="more">uncached no-op over NATS · refreshes every 30s</span>
+    </div>
+    <p class="rpc-note">
+      Measures the full admin → local leaf → service → reply path. A timeout means the route or responder is unavailable.
+    </p>
+    {#await data.health}
+      <div class="health-grid">
+        {#each Array.from({ length: 11 }) as _, i (i)}
+          <Skeleton variant="block" height="42px" />
+        {/each}
+      </div>
+    {:then initialHealth}
+      {@const health = liveHealth ?? initialHealth}
+      {#if health.length === 0}
+        <p class="rpc-empty">RPC probes unavailable.</p>
+      {:else}
+        <div class="health-grid">
+          {#each health as h (h.id)}
+            <div
+              class="health-cell"
+              class:slow={h.ok && h.ms >= 250}
+              class:down={!h.ok}
+              title={h.error ?? `${h.ms} ms round trip`}
+            >
+              <span class="health-dot" class:warn={h.ok && h.ms >= 250} class:err={!h.ok}></span>
+              <span class="health-name">{h.label}</span>
+              <span class="health-ms">
+                {h.ok ? `${h.ms} ms` : (h.error?.includes('timeout') ? 'timeout' : 'down')}
+              </span>
+            </div>
+          {/each}
+        </div>
+      {/if}
+    {/await}
+  </div>
 
   {#if bundle === null}
     <div class="loading-stack">
@@ -213,6 +274,35 @@
 
 <style>
   .loading-stack { display: flex; flex-direction: column; gap: 14px; }
+  .rpc-card { margin-bottom: var(--row-gap); }
+  .rpc-note, .rpc-empty {
+    margin: -2px 0 14px;
+    font-family: var(--bb-font-body); font-size: 12.5px; color: var(--bb-muted);
+  }
+  .rpc-empty { margin-bottom: 0; }
+  .health-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 10px;
+  }
+  .health-cell {
+    display: flex; align-items: center; gap: 10px;
+    padding: 12px 14px;
+    border: 1px solid var(--rule); border-radius: 8px;
+    background: rgba(240, 236, 228, 0.02);
+  }
+  .health-cell.slow { border-color: rgba(202, 167, 106, 0.35); background: rgba(202, 167, 106, 0.05); }
+  .health-cell.down { border-color: rgba(176, 90, 70, 0.35); background: rgba(176, 90, 70, 0.05); }
+  .health-dot {
+    width: 8px; height: 8px; border-radius: 50%; flex: none;
+    background: var(--bb-green-glow); box-shadow: 0 0 8px var(--bb-green-glow);
+  }
+  .health-dot.warn { background: var(--bb-tan-light); box-shadow: 0 0 8px rgba(202, 167, 106, 0.6); }
+  .health-dot.err { background: #cf8a78; box-shadow: 0 0 8px rgba(176, 90, 70, 0.6); }
+  .health-name { font-family: var(--bb-font-body); font-weight: 600; font-size: 13px; color: var(--bb-white); }
+  .health-ms { margin-left: auto; font-family: var(--bb-font-mono); font-size: 11.5px; color: var(--bb-muted); }
+  .health-cell.slow .health-ms { color: var(--bb-tan-light); }
+  .health-cell.down .health-ms { color: #cf8a78; }
   .seg { display: flex; gap: 6px; flex-wrap: wrap; }
   .chip {
     font-family: var(--bb-font-mono); font-size: 11px; letter-spacing: 0.06em;

--- a/console/admin/src/routes/(admin)/events/+page.svelte
+++ b/console/admin/src/routes/(admin)/events/+page.svelte
@@ -92,10 +92,10 @@
 
 <section class="screen active">
   <PageHead
-    eyebrow="Ingress status"
-    description="Shard up/down, binding, and status messages streamed straight off the fleet bus."
+    eyebrow="Ingress lifecycle"
+    description="A live, non-persistent view of shard connections, Conduit bindings, and disconnect reasons. Only transitions after this page opens appear here; chat and EventSub payloads do not."
   >
-    Live <em>events</em>
+    Shard <em>lifecycle feed</em>
   </PageHead>
 
   <PageToolbar>
@@ -104,7 +104,7 @@
     {/snippet}
     {#snippet trail()}
       <div class="toolbar-search">
-        <SearchInput bind:value={search} placeholder="Filter subject or payload…" />
+        <SearchInput bind:value={search} placeholder="Filter lifecycle message…" />
       </div>
       <Button variant="ghost" onclick={togglePause}>
         {paused ? `Resume${missedWhilePaused ? ` (+${missedWhilePaused})` : ''}` : 'Pause'}
@@ -114,7 +114,7 @@
   </PageToolbar>
 
   <Card>
-    <CardHead title="Feed">
+    <CardHead title="twitch.ingress.status.>">
       {#snippet action()}
         <span class="feed-meta">
           <span class="count up">{upCount} up</span>
@@ -132,8 +132,8 @@
         {#if events.length === 0}
           <EmptyState
             icon="pulse"
-            title={conn === 'live' ? 'Quiet so far' : connLabel}
-            body="Shard up/down and binding messages appear here the moment the ingress publishes them."
+            title={conn === 'live' ? 'No lifecycle changes yet' : connLabel}
+            body="A healthy steady-state fleet is quiet. New shard up, bound, and down transitions appear here; this is not stored event history."
           />
         {:else}
           <EmptyState icon="search" title="No events match the filter" />

--- a/console/admin/src/routes/(admin)/events/stream/+server.ts
+++ b/console/admin/src/routes/(admin)/events/stream/+server.ts
@@ -10,10 +10,10 @@ function sse(event: string, data: unknown): Uint8Array {
   return enc.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
 }
 
-// SSE bridge from the ingress status subjects. Mirrors the old admin /events:
-// a wildcard subscription under `${prefix}.>` forwarded as named events, with a
-// heartbeat so proxies do not idle the connection out. Under DEMO=1 the broker
-// may be absent, so it emits a synthetic feed instead of failing.
+// SSE bridge from the ingress shard-lifecycle status subjects. This is a live,
+// non-persistent wildcard subscription under `${prefix}.>` — not the Twitch
+// EventSub payload stream. Heartbeats keep proxies from idling it out. Under
+// DEMO=1 the broker may be absent, so it emits a synthetic feed instead.
 export const GET: RequestHandler = async ({ locals }) => {
   if (!(await requireAdmin(locals.session))) throw error(403, 'forbidden');
 

--- a/console/admin/src/routes/(admin)/health/+server.ts
+++ b/console/admin/src/routes/(admin)/health/+server.ts
@@ -4,7 +4,7 @@ import { requireAdmin, isDemo } from '$lib/server/access';
 import { serviceHealth } from '$lib/server/services';
 import { sampleHealth } from '$lib/server/sample';
 
-// Live poll target for the Overview health card: fresh RPC probes per call,
+// Live poll target for the Analytics RPC timing panel: fresh probes per call,
 // so a recovering service turns green without a page reload.
 export const GET: RequestHandler = async ({ locals }) => {
   if (!(await requireAdmin(locals.session))) throw error(403, 'forbidden');

--- a/console/shared/lib/server/nats-failback.test.ts
+++ b/console/shared/lib/server/nats-failback.test.ts
@@ -6,7 +6,7 @@ mock.module('newrelic', () => ({
     recordMetric: () => {}
   }
 }));
-const { localLeafReady } = await import('./nats');
+const { hubJetStreamOptions, localLeafReady } = await import('./nats');
 
 const server = Bun.serve({
   port: 0,
@@ -26,5 +26,15 @@ describe('local leaf failback probe', () => {
   test('rejects non-200 and unreachable endpoints', async () => {
     expect(await localLeafReady(`${server.url}missing`, 500)).toBe(false);
     expect(await localLeafReady('http://127.0.0.1:1/healthz', 25)).toBe(false);
+  });
+});
+
+describe('direct-hub JetStream options', () => {
+  test('uses the API prefix authorized on the hub account', () => {
+    expect(hubJetStreamOptions()).toEqual({ apiPrefix: '$JS.API', checkAPI: false });
+  });
+
+  test('returns a fresh object for client normalization', () => {
+    expect(hubJetStreamOptions()).not.toBe(hubJetStreamOptions());
   });
 });

--- a/console/shared/lib/server/nats.ts
+++ b/console/shared/lib/server/nats.ts
@@ -152,6 +152,10 @@ function options(role: Role): ConnectionOptions {
     name: `${process.env.NATS_CLIENT_NAME ?? 'console'}-${role}`,
     maxReconnectAttempts: -1,
     reconnectTimeWait: 500,
+    // Broker auth/config and Doppler-driven app restarts can briefly land out
+    // of order during a rollout. Keep reconnecting through that window instead
+    // of permanently closing after the client's default two auth failures.
+    ignoreAuthErrorAbort: true,
     pingInterval: 20_000,
     // Bound the initial dial so a cold/unreachable NATS fails fast (and re-dials
     // on the next request) instead of hanging SSR to the 20s default and surfacing
@@ -189,6 +193,13 @@ async function get(role: Role): Promise<NatsConnection> {
       // dead connection in the pool.
       if (c.isClosed()) throw new Error('nats connection closed during dial');
       pool.conn = c;
+      // JetStream wrappers retain the connection they were created from. If a
+      // fully closed BUS connection is replaced (as opposed to reconnecting in
+      // place), force lane/KV callers to derive fresh wrappers from this one.
+      if (role === 'bus') {
+        jsClient = null;
+        jsManager = null;
+      }
       if (role === 'rpc') enableLeafFailback(c);
       return c;
     })
@@ -201,23 +212,25 @@ async function get(role: Role): Promise<NatsConnection> {
 let jsClient: JetStreamClient | null = null;
 let jsManager: JetStreamManager | null = null;
 
-// checkAPI:false is load-bearing: the enablement probe publishes the
-// domain-LESS `$JS.API.INFO`, which the per-account allow lists deliberately
-// do not grant (only `$JS.hub.API.>` subjects are). With the probe on, manager
-// creation times out on a permission violation and every JetStream view
-// (lanes, KV aliases) reports TIMEOUT. The option rides the client opts so KV
-// views inherit it when they derive their own manager.
-const JS_OPTS: JetStreamManagerOptions = { domain: 'hub', checkAPI: false };
+// BUS connects directly to the hub, so its JetStream API is the standard
+// $JS.API prefix. Using domain:'hub' here makes the client generate a domain
+// alias that the server remaps before account permission checks; the admin
+// account then sees a denied $JS.API request and every lane view times out.
+// Skip the extra enablement probe and return a fresh options object because the
+// NATS client normalizes/mutates JetStream options internally.
+export function hubJetStreamOptions(): JetStreamManagerOptions {
+  return { apiPrefix: '$JS.API', checkAPI: false };
+}
 
 export async function js(): Promise<JetStreamClient> {
   const nc = await get('bus');
-  if (!jsClient) jsClient = nc.jetstream(JS_OPTS);
+  if (!jsClient) jsClient = nc.jetstream(hubJetStreamOptions());
   return jsClient;
 }
 
 export async function jsm(): Promise<JetStreamManager> {
   const nc = await get('bus');
-  if (!jsManager) jsManager = await nc.jetstreamManager(JS_OPTS);
+  if (!jsManager) jsManager = await nc.jetstreamManager(hubJetStreamOptions());
   return jsManager;
 }
 
@@ -300,6 +313,8 @@ export async function closeNats(): Promise<void> {
     if (pool.conn && !pool.conn.isClosed()) await pool.conn.drain();
     pool.conn = null;
   }
+  jsClient = null;
+  jsManager = null;
 }
 
 /**

--- a/deploy/k8s/nats-auth.conf
+++ b/deploy/k8s/nats-auth.conf
@@ -27,8 +27,8 @@
 # Each runtime holds two connections: a BUS connection (NATS_USER/PASSWORD) for
 # JetStream goes directly to the TLS hub, and a per-service-account connection
 # (NATS_RPC_USER/PASSWORD) for RPC + cache stays on the node-local leaf tier.
-# JetStream clients target domain "hub" and are granted broad $JS.> access;
-# leaves run no JetStream and have no link to the hub.
+# JetStream clients connect directly to the hub and use its standard $JS.API
+# prefix; leaves run no JetStream and have no link to the hub.
 #
 # Service exports answer only requests they received (the account-level
 # equivalent of the old allow_responses:true). Cache-invalidation is modelled as
@@ -169,8 +169,9 @@ accounts: {
       {
         # admin: operator tool; enqueues per-user EventSub restarts on the
         # outgress system lane, requests reprojections, watches the ingress
-        # status stream, and reads JetStream stream/consumer state (read-only)
-        # for the lane telemetry view in the hub domain.
+        # status stream, and reads JetStream stream/consumer state for lane
+        # telemetry. This connection is already direct-to-hub, so JetStream
+        # authorization sees the standard $JS.API prefix (not $JS.hub.API).
         user: "admin_bus"
         password: $NATS_BCRYPT_ADMIN_BUS
         permissions: {
@@ -178,21 +179,22 @@ accounts: {
             allow: [
               "twitch.outgress.system",
               "data.reproject.request",
-              "$JS.hub.API.INFO",
-              "$JS.hub.API.STREAM.NAMES",
-              "$JS.hub.API.STREAM.LIST",
-              "$JS.hub.API.STREAM.INFO.>",
-              "$JS.hub.API.CONSUMER.NAMES.>",
-              "$JS.hub.API.CONSUMER.LIST.>",
-              "$JS.hub.API.CONSUMER.INFO.>",
-              "$JS.hub.API.CONSUMER.CREATE.>",
-              "$JS.hub.API.CONSUMER.DURABLE.CREATE.>",
-              "$JS.hub.API.CONSUMER.DELETE.>",
-              "$JS.hub.API.STREAM.CREATE.KV_admin_lanes",
-              "$JS.hub.API.STREAM.UPDATE.KV_admin_lanes",
-              "$JS.hub.API.STREAM.MSG.GET.KV_admin_lanes",
-              "$JS.hub.API.DIRECT.GET.KV_admin_lanes",
-              "$JS.hub.API.DIRECT.GET.KV_admin_lanes.>",
+              "$JS.API.INFO",
+              "$JS.API.STREAM.NAMES",
+              "$JS.API.STREAM.LIST",
+              "$JS.API.STREAM.INFO.>",
+              "$JS.API.CONSUMER.NAMES.>",
+              "$JS.API.CONSUMER.LIST.>",
+              "$JS.API.CONSUMER.INFO.>",
+              "$JS.API.CONSUMER.CREATE.>",
+              "$JS.API.CONSUMER.DURABLE.CREATE.>",
+              "$JS.API.CONSUMER.DELETE.>",
+              "$JS.API.CONSUMER.MSG.NEXT.>",
+              "$JS.API.STREAM.CREATE.KV_admin_lanes",
+              "$JS.API.STREAM.UPDATE.KV_admin_lanes",
+              "$JS.API.STREAM.MSG.GET.KV_admin_lanes",
+              "$JS.API.DIRECT.GET.KV_admin_lanes",
+              "$JS.API.DIRECT.GET.KV_admin_lanes.>",
               "$KV.admin_lanes.>"
             ]
           }
@@ -213,6 +215,7 @@ accounts: {
   USERS_RPC: {
     users: [ { user: "users_rpc", password: $NATS_BCRYPT_USERS_RPC } ]
     exports: [
+      { service: "bagel.rpc.health.users" }
       { service: "bagel.rpc.dashboard.>" }
       { service: "bagel.rpc.admin.user.>" }
       { service: "bagel.rpc.delegation.>" }
@@ -234,6 +237,7 @@ accounts: {
   COMMANDS_RPC: {
     users: [ { user: "commands_rpc", password: $NATS_BCRYPT_COMMANDS_RPC } ]
     exports: [
+      { service: "bagel.rpc.health.commands" }
       { service: "bagel.rpc.commands.>" }
       { service: "bagel.rpc.internal.projection.commands.get" }
     ]
@@ -245,6 +249,7 @@ accounts: {
   MODULES_RPC: {
     users: [ { user: "modules_rpc", password: $NATS_BCRYPT_MODULES_RPC } ]
     exports: [
+      { service: "bagel.rpc.health.modules" }
       { service: "bagel.rpc.modules.>" }
       { service: "bagel.rpc.internal.projection.modules.get" }
       # Decrypted per-broadcaster Govee API key; import-gated to GATEWAY_RPC
@@ -260,6 +265,7 @@ accounts: {
   LOYALTY_RPC: {
     users: [ { user: "loyalty_rpc", password: $NATS_BCRYPT_LOYALTY_RPC } ]
     exports: [
+      { service: "bagel.rpc.health.loyalty" }
       { service: "bagel.rpc.loyalty.>" }
     ]
   }
@@ -270,6 +276,7 @@ accounts: {
   PROJECTOR_RPC: {
     users: [ { user: "projector_rpc", password: $NATS_BCRYPT_PROJECTOR_RPC } ]
     exports: [
+      { service: "bagel.rpc.health.projector" }
       { service: "bagel.rpc.projector.dashboard.>" }
       { service: "bagel.rpc.broadcaster.status.get" }
       { service: "bagel.rpc.broadcaster.live.get" }
@@ -292,6 +299,7 @@ accounts: {
   OUTGRESS_RPC: {
     users: [ { user: "outgress_rpc", password: $NATS_BCRYPT_OUTGRESS_RPC } ]
     exports: [
+      { service: "bagel.rpc.health.outgress" }
       { service: "bagel.rpc.outgress.>" }
     ]
     imports: [
@@ -307,6 +315,7 @@ accounts: {
   TRANSACTIONS_RPC: {
     users: [ { user: "transactions_rpc", password: $NATS_BCRYPT_TRANSACTIONS_RPC } ]
     exports: [
+      { service: "bagel.rpc.health.transactions" }
       { service: "bagel.rpc.transactions.>" }
     ]
     imports: [
@@ -323,6 +332,7 @@ accounts: {
   NOTIFICATIONS_RPC: {
     users: [ { user: "notifications_rpc", password: $NATS_BCRYPT_NOTIFICATIONS_RPC } ]
     exports: [
+      { service: "bagel.rpc.health.notifications" }
       { service: "bagel.rpc.notifications.>" }
       { service: "bagel.rpc.admin.notifications.>" }
       { stream: "bagel.cache.invalidate.notifications" }
@@ -339,6 +349,7 @@ accounts: {
   GATEWAY_RPC: {
     users: [ { user: "gateway_rpc", password: $NATS_BCRYPT_GATEWAY_RPC } ]
     exports: [
+      { service: "bagel.rpc.health.gateway" }
       { service: "bagel.rpc.gateway.>" }
     ]
     imports: [
@@ -355,6 +366,9 @@ accounts: {
   # (status, grant, locale, commands, modules, live).
   WORKER_RPC: {
     users: [ { user: "worker_rpc", password: $NATS_BCRYPT_WORKER_RPC } ]
+    exports: [
+      { service: "bagel.rpc.health.sesame" }
+    ]
     imports: [
       { service: { account: "USERS_RPC",    subject: "bagel.rpc.internal.projection.users.get" } }
       { service: { account: "COMMANDS_RPC", subject: "bagel.rpc.commands.>" } }
@@ -426,6 +440,17 @@ accounts: {
   ADMIN_RPC: {
     users: [ { user: "admin_rpc", password: $NATS_BCRYPT_ADMIN_RPC } ]
     imports: [
+      { service: { account: "USERS_RPC",          subject: "bagel.rpc.health.users" } }
+      { service: { account: "COMMANDS_RPC",       subject: "bagel.rpc.health.commands" } }
+      { service: { account: "MODULES_RPC",        subject: "bagel.rpc.health.modules" } }
+      { service: { account: "LOYALTY_RPC",        subject: "bagel.rpc.health.loyalty" } }
+      { service: { account: "PROJECTOR_RPC",      subject: "bagel.rpc.health.projector" } }
+      { service: { account: "OUTGRESS_RPC",       subject: "bagel.rpc.health.outgress" } }
+      { service: { account: "TRANSACTIONS_RPC",   subject: "bagel.rpc.health.transactions" } }
+      { service: { account: "NOTIFICATIONS_RPC",  subject: "bagel.rpc.health.notifications" } }
+      { service: { account: "GATEWAY_RPC",        subject: "bagel.rpc.health.gateway" } }
+      { service: { account: "WORKER_RPC",         subject: "bagel.rpc.health.sesame" } }
+      { service: { account: "TWITCH_INGRESS_RPC", subject: "bagel.rpc.health.ingress" } }
       { service: { account: "USERS_RPC",          subject: "bagel.rpc.admin.user.>" } }
       { service: { account: "OUTGRESS_RPC",       subject: "bagel.rpc.outgress.channel.get" } }
       { service: { account: "TWITCH_INGRESS_RPC", subject: "twitch.ingress.admin.shards.>" } }
@@ -441,6 +466,7 @@ accounts: {
   TWITCH_INGRESS_RPC: {
     users: [ { user: "twitch_ingress_rpc", password: $NATS_BCRYPT_TWITCH_INGRESS_RPC } ]
     exports: [
+      { service: "bagel.rpc.health.ingress" }
       { service: "twitch.ingress.admin.shards.>" }
       { service: "bagel.rpc.ingress.conduit.get" }
     ]

--- a/pkg/bus/health_rpc.go
+++ b/pkg/bus/health_rpc.go
@@ -1,0 +1,54 @@
+package bus
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/nats-io/nats.go"
+)
+
+// RPCHealthPrefix is a fleet-wide, side-effect-free request/reply surface used
+// by the admin Analytics page. Keeping it separate from business RPCs means a
+// latency sample never reads a database, calls Twitch, or mutates state.
+const RPCHealthPrefix = "bagel.rpc.health"
+
+// RPCHealthReply is intentionally tiny: the useful measurement is the NATS
+// round trip at the caller, while the body confirms which service answered.
+type RPCHealthReply struct {
+	Service string `json:"service"`
+	OK      bool   `json:"ok"`
+}
+
+func RPCHealthSubject(service string) string {
+	return RPCHealthPrefix + "." + service
+}
+
+// SubscribeRPCHealth registers one queue-balanced no-op responder for a
+// service. It uses the service's existing RPC connection, so a successful
+// response covers the same leaf route, account import/export, connection and
+// subscriber dispatch path as its real RPC handlers.
+func SubscribeRPCHealth(nc *nats.Conn, service, queueGroup string) error {
+	if service == "" || strings.ContainsAny(service, ".*> \t\r\n") {
+		return fmt.Errorf("invalid rpc health service token %q", service)
+	}
+	if queueGroup == "" {
+		return fmt.Errorf("rpc health queue group is required")
+	}
+
+	reply, err := json.Marshal(RPCHealthReply{Service: service, OK: true})
+	if err != nil {
+		return fmt.Errorf("marshal rpc health reply: %w", err)
+	}
+
+	subject := RPCHealthSubject(service)
+	if _, err := nc.QueueSubscribe(subject, queueGroup, func(msg *nats.Msg) {
+		_ = msg.Respond(reply)
+	}); err != nil {
+		return fmt.Errorf("subscribe %s: %w", subject, err)
+	}
+	if err := nc.Flush(); err != nil {
+		return fmt.Errorf("flush subscription %s: %w", subject, err)
+	}
+	return nil
+}

--- a/pkg/bus/health_rpc_test.go
+++ b/pkg/bus/health_rpc_test.go
@@ -1,0 +1,20 @@
+package bus
+
+import "testing"
+
+func TestRPCHealthSubject(t *testing.T) {
+	if got := RPCHealthSubject("projector"); got != "bagel.rpc.health.projector" {
+		t.Fatalf("RPCHealthSubject() = %q", got)
+	}
+}
+
+func TestSubscribeRPCHealthRejectsInvalidTokensBeforeDial(t *testing.T) {
+	for _, service := range []string{"", "two.tokens", "wildcard.*", "has space"} {
+		if err := SubscribeRPCHealth(nil, service, "health"); err == nil {
+			t.Fatalf("SubscribeRPCHealth accepted invalid service %q", service)
+		}
+	}
+	if err := SubscribeRPCHealth(nil, "users", ""); err == nil {
+		t.Fatal("SubscribeRPCHealth accepted an empty queue group")
+	}
+}


### PR DESCRIPTION
## Summary

- remove fleet-wide diagnostic probes from the Overview render path and move them to Analytics
- add side-effect-free health RPC responders across eleven service accounts
- repair direct-hub JetStream permissions and lane telemetry API routing
- harden admin NATS reconnection and remove invalid leaf failback from the ingress feed
- clarify that the Events route is a live, non-persistent ingress shard lifecycle feed

## Verification

- go test ./...
- 138 ingress tests pass
- 80 shared console tests pass
- admin production build succeeds
- Svelte check reports zero errors and warnings
- modified NATS configuration validates with the production NATS binary