### PR TITLE
Speed up ingress NATS publishing and enforce 1/1/1 placement

### DIFF
--- a/app/ingress/config/runtime.exs
+++ b/app/ingress/config/runtime.exs
@@ -141,6 +141,11 @@ config :ingress,
   publish_max_pending: String.to_integer(System.get_env("INGRESS_PUBLISH_MAX_PENDING", "16384")),
   publish_batch_size: String.to_integer(System.get_env("INGRESS_PUBLISH_BATCH_SIZE", "128")),
   publish_batch_wait_ms: String.to_integer(System.get_env("INGRESS_PUBLISH_BATCH_WAIT_MS", "1")),
+  # Gnat coalesces up to eleven concurrent pub calls into one socket write.
+  # Keep two write windows queued so the connection stays fed while the first
+  # callers are being replied to, without creating one task/process per event.
+  publish_send_concurrency:
+    String.to_integer(System.get_env("INGRESS_PUBLISH_SEND_CONCURRENCY", "22")),
   # Cohort wire: "single" (per-event PubAck, default) or "atomic" (one ADR-050
   # batch commit ack per cohort; NATS 2.14). Anything unrecognized stays single.
   publish_wire:

--- a/app/ingress/lib/ingress/config.ex
+++ b/app/ingress/lib/ingress/config.ex
@@ -171,6 +171,12 @@ defmodule Ingress.Config do
   def publish_batch_wait_ms,
     do: Application.get_env(:ingress, :publish_batch_wait_ms, 1)
 
+  # Persistent send lanes feeding one Gnat connection. Gnat currently
+  # coalesces the active call plus ten queued calls into one socket write; two
+  # windows keep its mailbox fed between replies.
+  def publish_send_concurrency,
+    do: Application.get_env(:ingress, :publish_send_concurrency, 22) |> max(1) |> min(32)
+
   # Wire protocol for one flushed cohort. :single publishes every event with
   # its own JetStream PubAck (the long-standing path). :atomic writes the
   # cohort as one ADR-050 atomic batch (NATS 2.14): a single commit PubAck

--- a/app/ingress/lib/ingress/nats/cohort_sender.ex
+++ b/app/ingress/lib/ingress/nats/cohort_sender.ex
@@ -1,0 +1,88 @@
+defmodule Ingress.Nats.CohortSender do
+  @moduledoc """
+  Fixed send-lane pool for one ingress publisher connection.
+
+  `Gnat` can coalesce concurrent `pub/4` calls into one socket write, but a
+  cohort collector calling it serially never gives that coalescer more than
+  one command. This pool keeps a small set of persistent processes and fans a
+  flushed cohort across them. The public Gnat API remains the only wire
+  implementation; this module only supplies the concurrency it is designed to
+  combine.
+
+  The pool is used for ordinary per-message publishes. Atomic batches retain
+  their single ordered sender because their sequence headers must reach NATS
+  in order.
+  """
+
+  @type token :: term()
+  @type request :: {token(), String.t(), iodata(), keyword()}
+  @type result :: {token(), :ok | {:error, term()}}
+
+  @spec start(pos_integer()) :: [pid()]
+  def start(size) when is_integer(size) and size > 0 do
+    for _ <- 1..size, do: spawn_link(&worker/0)
+  end
+
+  @spec publish([pid()], GenServer.server(), [request()]) :: [result()]
+  def publish(_workers, _connection, []), do: []
+
+  def publish(workers, connection, requests) do
+    assignments = assign(requests, workers)
+    reference = make_ref()
+
+    Enum.each(assignments, fn {worker, lane} ->
+      send(worker, {:publish, self(), reference, connection, lane})
+    end)
+
+    collect(reference, length(assignments), [])
+  end
+
+  @spec stop([pid()]) :: :ok
+  def stop(workers) do
+    Enum.each(workers, &send(&1, :stop))
+    :ok
+  end
+
+  defp assign(requests, workers) do
+    lane_count = min(length(requests), length(workers))
+
+    requests
+    |> Enum.with_index()
+    |> Enum.reduce(%{}, fn {request, index}, lanes ->
+      Map.update(lanes, rem(index, lane_count), [request], &[request | &1])
+    end)
+    |> Enum.sort_by(&elem(&1, 0))
+    |> Enum.map(fn {index, lane} -> {Enum.at(workers, index), Enum.reverse(lane)} end)
+  end
+
+  defp collect(_reference, 0, results), do: results
+
+  defp collect(reference, remaining, results) do
+    receive do
+      {:published, ^reference, lane_results} ->
+        collect(reference, remaining - 1, lane_results ++ results)
+    end
+  end
+
+  defp worker do
+    receive do
+      {:publish, owner, reference, connection, requests} ->
+        results =
+          Enum.map(requests, fn {token, subject, payload, opts} ->
+            {token, safe_publish(connection, subject, payload, opts)}
+          end)
+
+        send(owner, {:published, reference, results})
+        worker()
+
+      :stop ->
+        :ok
+    end
+  end
+
+  defp safe_publish(connection, subject, payload, opts) do
+    Gnat.pub(connection, subject, payload, opts)
+  catch
+    :exit, _reason -> {:error, :not_connected}
+  end
+end

--- a/app/ingress/lib/ingress/nats/publisher.ex
+++ b/app/ingress/lib/ingress/nats/publisher.ex
@@ -31,6 +31,7 @@ defmodule Ingress.Nats.Publisher do
   require Logger
 
   alias Ingress.{Config, Metrics, Nats}
+  alias Ingress.Nats.CohortSender
 
   @idx_pending 1
   @idx_next_id 2
@@ -170,6 +171,7 @@ defmodule Ingress.Nats.Publisher do
       max_attempts: Config.publish_attempts(),
       batch_size: Config.publish_batch_size(),
       batch_wait_ms: Config.publish_batch_wait_ms(),
+      senders: CohortSender.start(Config.publish_send_concurrency()),
       wire: Config.publish_wire(),
       batch_inflight_cap: Config.publish_batch_inflight(),
       queue: [],
@@ -298,29 +300,31 @@ defmodule Ingress.Nats.Publisher do
   defp atomic_batch?(_state, _entries), do: false
 
   defp send_individual_entries(entries, state) do
-    Enum.each(entries, fn {subject, json, dedup_id, from} ->
-      id = :atomics.add_get(state.counter, @idx_next_id, 1)
-      :ets.insert(state.table, {id, :single, subject, json, dedup_id, 1, now_ms()})
+    requests = Enum.map(entries, &stage_single(&1, state))
 
-      case pub(
-             state.conn,
-             subject,
-             json,
-             single_reply_subject(state.prefix, id),
-             dedup_headers(dedup_id)
-           ) do
-        :ok ->
-          reply_entry(from, :ok)
-
-        {:error, reason} ->
-          :ets.delete(state.table, id)
-          :atomics.sub(state.counter, @idx_pending, 1)
-          :atomics.add(state.counter, @idx_failed, 1)
-          reply_entry(from, {:error, reason})
-      end
-    end)
+    state.senders
+    |> CohortSender.publish(state.conn, requests)
+    |> Enum.each(&finish_single_send(&1, state))
 
     state
+  end
+
+  defp stage_single({subject, json, dedup_id, from}, state) do
+    id = :atomics.add_get(state.counter, @idx_next_id, 1)
+    :ets.insert(state.table, {id, :single, subject, json, dedup_id, 1, now_ms()})
+
+    token = {id, from}
+    opts = [reply_to: single_reply_subject(state.prefix, id), headers: dedup_headers(dedup_id)]
+    {token, subject, json, opts}
+  end
+
+  defp finish_single_send({{_id, from}, :ok}, _state), do: reply_entry(from, :ok)
+
+  defp finish_single_send({{id, from}, {:error, reason}}, state) do
+    :ets.delete(state.table, id)
+    :atomics.sub(state.counter, @idx_pending, 1)
+    :atomics.add(state.counter, @idx_failed, 1)
+    reply_entry(from, {:error, reason})
   end
 
   ## Atomic batch wire (ADR-050)
@@ -596,6 +600,7 @@ defmodule Ingress.Nats.Publisher do
   @impl true
   def terminate(_reason, state) do
     :persistent_term.erase({__MODULE__, :ctx, state.index})
+    CohortSender.stop(state.senders)
     :ok
   end
 

--- a/app/ingress/lib/ingress/nats/publisher_pool.ex
+++ b/app/ingress/lib/ingress/nats/publisher_pool.ex
@@ -4,8 +4,11 @@ defmodule Ingress.Nats.PublisherPool do
   independent BUS connections, each paired with one
   `Ingress.Nats.Publisher` cohort collector.
 
-  Every `Gnat.pub` is serialized by one connection process, so the pool spreads
-  writes and ordinary per-message PubAck collection across online schedulers.
+  Every Gnat connection still owns and serializes its socket. Each publisher
+  feeds that connection through a bounded `CohortSender` lane pool, allowing
+  Gnat to coalesce concurrent public `pub/4` calls into fewer socket writes;
+  the outer pool spreads those writes and ordinary per-message PubAck
+  collection across online schedulers.
 
   The pool records the shard count in `:persistent_term` before any collector
   starts, so `Ingress.Nats.Publisher.enqueue/3` — invoked from dispatcher and

--- a/app/ingress/test/nats_cohort_sender_test.exs
+++ b/app/ingress/test/nats_cohort_sender_test.exs
@@ -1,0 +1,53 @@
+defmodule Ingress.Nats.CohortSenderTest do
+  use ExUnit.Case, async: true
+
+  alias Ingress.Nats.CohortSender
+
+  defmodule BarrierGnat do
+    use GenServer
+
+    def start_link(opts), do: GenServer.start_link(__MODULE__, opts)
+
+    @impl true
+    def init(opts) do
+      {:ok,
+       %{
+         expected: Keyword.fetch!(opts, :expected),
+         owner: Keyword.fetch!(opts, :owner),
+         calls: []
+       }}
+    end
+
+    @impl true
+    def handle_call({:pub, _subject, _payload, _opts}, from, state) do
+      calls = [from | state.calls]
+
+      if length(calls) == state.expected do
+        Enum.each(calls, &GenServer.reply(&1, :ok))
+        send(state.owner, {:coalesced, length(calls)})
+        {:noreply, %{state | calls: []}}
+      else
+        {:noreply, %{state | calls: calls}}
+      end
+    end
+  end
+
+  test "fans one cohort into simultaneous public Gnat calls" do
+    {:ok, connection} = start_supervised({BarrierGnat, expected: 3, owner: self()})
+    senders = CohortSender.start(3)
+    on_exit(fn -> CohortSender.stop(senders) end)
+
+    requests =
+      for id <- 1..3 do
+        {id, "twitch.ingress.event.standard", "{}", reply_to: "_INBOX.#{id}"}
+      end
+
+    assert CohortSender.publish(senders, connection, requests) |> Enum.sort() == [
+             {1, :ok},
+             {2, :ok},
+             {3, :ok}
+           ]
+
+    assert_received {:coalesced, 3}
+  end
+end

--- a/deploy/k8s/twitch-ingress.yaml
+++ b/deploy/k8s/twitch-ingress.yaml
@@ -45,7 +45,7 @@ metadata:
   annotations:
     secrets.doppler.com/reload: "true"
 spec:
-  replicas: 5 # node1 excluded via hot-path anti-affinity; target shape node3=2, worker1=2, node2=1 (see affinity)
+  replicas: 3 # one per eligible hot-path node: node2, node3, worker1
   revisionHistoryLimit: 3
   # On SIGTERM each pod hands its conduit shards off make-before-break
   # (Ingress.Drain): the successor binds on a peer before the local socket
@@ -97,21 +97,7 @@ spec:
           tolerationSeconds: 60
       # node1 (2-core ARM) is reserved for stateful/frontend + infra; keep ingress
       # off it via nodeAffinity. Eligible nodes are node2/node3/worker1, and the
-      # spread is SOFT (ScheduleAnyway): a worker1 outage (home node) must not
-      # strand ingress with a hard maxSkew it cannot satisfy on fewer nodes.
-      # Baseline shape: node3=2, worker1=2, node2=1. node2 already carries the
-      # control plane + valkey master, so the doubles belong on the big-CPU
-      # pair (node3 6c, worker1 8c) and node2 keeps the single. The soft skew
-      # allows any 2/2/1 split; the two graded preferences below pick WHICH
-      # nodes take the doubles (node3 first, worker1 second, node2 never
-      # preferred). Soft only — a node outage re-packs onto the survivors.
-      #
-      # Weights are deliberately LOW: a skew >= 1 must outscore them so the
-      # spread still wins against pile-ups. Weight 100 proved to overpower the
-      # spread during a maxSurge=0 roll (old pods still count in the skew),
-      # piling 3 replicas onto node3 and none on node2. Empty-node resource
-      # scoring can still stack with these during bulk scheduling; if the shape
-      # drifts, deleting the surplus pod once re-lands it correctly.
+      # three replicas are spread one per eligible node in steady state.
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -120,31 +106,16 @@ spec:
                   - key: kubernetes.io/hostname
                     operator: NotIn
                     values: [node1]
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 25
-              preference:
-                matchExpressions:
-                  - key: kubernetes.io/hostname
-                    operator: In
-                    values: [node3]
-            - weight: 20
-              preference:
-                matchExpressions:
-                  - key: kubernetes.io/hostname
-                    operator: In
-                    values: [worker1]
       topologySpreadConstraints:
         # matchLabelKeys scopes the skew to the CURRENT ReplicaSet: during a
         # maxSurge=0 roll the outgoing pods no longer count, so every rollout
         # re-spreads one-per-node instead of piling onto whichever node freed
-        # capacity first (bit the ingress on 2026-07-10: 3/0/1). Soft constraint
-        # stays soft, so a node outage never wedges scheduling; the KEDA floor
-        # (>= one per hot-path node) plus the ReplicaSet downscaler's
-        # remove-co-located-duplicates-first ranking keep steady state at
-        # >= 1 per node.
+        # capacity first (bit the ingress on 2026-07-10: 3/0/1). With three
+        # replicas and three eligible nodes, maxSkew=1 plus DoNotSchedule makes
+        # the steady-state placement exactly 1/1/1.
         - maxSkew: 1
           topologyKey: kubernetes.io/hostname
-          whenUnsatisfiable: ScheduleAnyway
+          whenUnsatisfiable: DoNotSchedule
           matchLabelKeys: [pod-template-hash]
           labelSelector:
             matchLabels:
@@ -247,7 +218,7 @@ spec:
             # `none` across repeated direct-dispatch runs, while dirty
             # schedulers stay at `none` because ingress does no sustained dirty
             # NIF work. More than two schedulers only creates cgroup contention
-            # on this five-replica deployment.
+            # on this three-replica deployment.
             - name: ERL_FLAGS
               # Range, not a single port: probe/remote-shell hidden nodes
               # need their own listen port besides the main VM's.


### PR DESCRIPTION
## What changed

- feed each scheduler-local Gnat connection through a bounded persistent sender pool
- use 22 lanes so Gnat keeps two 11-call socket-write coalescing windows queued
- retain the public `Gnat.pub/4` API and leave ordered atomic batches unchanged
- add a concurrency regression test that requires simultaneous public Gnat calls
- reduce ingress to three replicas and enforce one pod on each of node2, node3, and worker1

## Root cause

Ingress assembled 128-event cohorts but published them with synchronous `Gnat.pub/4` calls in a serial `Enum.each`. Gnat can coalesce the active publish plus ten queued concurrent calls into one socket write, but the serial caller never populated that queue, so every event paid a Publisher GenServer round-trip and a separate Gnat call/write path.

## Impact

On the same two-CPU production-shaped worker1 probe, the sustained 500,000-message result improved from 38,260/s to 54,960/s (+43.6%), with all messages stored and zero pending publishes. The initial paired A/B reached 56,618/s (+48.0%).

## Validation

- `mix test`: 139 tests, 0 failures
- targeted formatter checks pass
- `git diff --check` passes
- Kubernetes manifest server-side dry run passes
- live isolated NATS streams stored every attempted publish
- no NATS warnings, slow consumers, queue-limit events, or leftover benchmark resources
