### PR TITLE
Calibrate ingress autoscaling to measured WebSocket capacity

### DIFF
--- a/app/ingress/README.md
+++ b/app/ingress/README.md
@@ -56,12 +56,13 @@ to standard.
 | `TWITCH_CLIENT_ID` / `TWITCH_CLIENT_SECRET` | App credentials for Helix.                             | (required)                                    |
 | `TWITCH_CONDUIT_ID`                 | Conduit to own; empty: reuse first existing or create.         | (empty)                                       |
 | `TWITCH_CONDUIT_SHARD_COUNT`        | Desired shard count.                                           | `2`                                           |
-| `TWITCH_CONDUIT_MAX_SHARDS`         | Hard ceiling for manual and automatic shard counts.            | `20`                                          |
+| `TWITCH_CONDUIT_MAX_SHARDS`         | Hard ceiling for manual and automatic shard counts.            | `11`                                          |
 | `INGRESS_CAPACITY_POD_RATED_EPS`    | Measured cached-path capacity per live ingress pod.             | `140000`                                      |
-| `INGRESS_CAPACITY_NATS_RATED_EPS`   | Live-cluster direct-hub PubAck capacity shared by the fleet.     | `86000`                                       |
-| `INGRESS_CAPACITY_WEBSOCKET_RATED_EPS` | Rated read/decode capacity per conduit WebSocket.            | `12500`                                       |
+| `INGRESS_CAPACITY_NATS_RATED_EPS`   | Live-cluster direct-hub PubAck capacity shared by the fleet.     | `123000`                                      |
+| `INGRESS_CAPACITY_WEBSOCKET_RATED_EPS` | Rated read/decode capacity per conduit WebSocket.            | `16000`                                       |
 | `INGRESS_CAPACITY_TARGET_UTILIZATION_PCT` | Autoscale and dashboard operating target.                  | `75`                                          |
-| `INGRESS_PUBLISH_BATCH_SIZE`          | Scheduler-local atomic JetStream cohort size.                  | `128`                                         |
+| `INGRESS_PUBLISH_BATCH_SIZE`          | Scheduler-local JetStream publish cohort size.                 | `128`                                         |
+| `INGRESS_PUBLISH_SEND_CONCURRENCY`    | Persistent Gnat send lanes per publisher connection.           | `22`                                          |
 | `INGRESS_PUBLISH_BATCH_WAIT_MS`       | Maximum wait for a partially full publish cohort.               | `1`                                           |
 | `TWITCH_EVENTSUB_WSS_URL`           | EventSub WebSocket endpoint.                                   | `wss://eventsub.wss.twitch.tv/ws?...`         |
 | `TWITCH_SPECIAL_USER_IDS`           | Comma-separated chatter IDs that always go premium.            | (empty)                                       |
@@ -113,6 +114,12 @@ MIX_ENV=test mix run bench/hot_path.exs
 MIX_ENV=test mix run bench/nats_publisher.exs
 MIX_ENV=test mix run bench/end_to_end.exs
 ```
+
+The isolated TLS WebSocket benchmark exercises a real shard through dispatcher
+handoff without Twitch or NATS. Run it across the three production ingress
+nodes with `bench/websocket_shard_cluster.sh`; the latest measurements and
+capacity decision are recorded in
+[`bench/2026-07-15-websocket-shard-results.md`](bench/2026-07-15-websocket-shard-results.md).
 
 The release builds on OTP 27 and uses its native `:json` codec for Twitch frame
 decoding and NATS event encoding. Control-plane RPCs retain Jason where protocol

--- a/app/ingress/bench/2026-07-15-websocket-shard-results.md
+++ b/app/ingress/bench/2026-07-15-websocket-shard-results.md
@@ -1,0 +1,39 @@
+# WebSocket shard capacity — 2026-07-15
+
+The benchmark exercised a real `Ingress.ShardSession` over TLS 1.3 with
+Twitch-shaped 1,338-byte `channel.chat.message` notifications. It included
+Mint WebSocket framing, the shard GenServer mailbox, native OTP JSON decoding,
+broadcaster extraction, rolling load accounting, and dispatcher handoff. The
+downstream handler was a counter, so neither NATS nor pipeline processing was
+part of this capacity measurement.
+
+Each temporary pod used the production VM shape (`+S 2:2`, two-CPU limit), 512
+dispatcher workers, a 25,000-event warm-up, and 500,000 measured events. Three
+samples ran on every eligible ingress node.
+
+| Node | Sample 1 | Sample 2 | Sample 3 | Slowest |
+|---|---:|---:|---:|---:|
+| node2 | 19,485/s | 19,041/s | 18,979/s | 18,979/s |
+| node3 | 17,516/s | 17,815/s | 17,813/s | **17,516/s** |
+| worker1 | 35,809/s | 35,689/s | 35,494/s | 35,494/s |
+
+All nine samples dispatched all 500,000 events, ended with zero pending work,
+and kept the shard mailbox at three messages or fewer.
+
+## Capacity decision
+
+- Per-WebSocket rated capacity: **16,000 events/s**, rounded below the slowest
+  observed production-node result.
+- Autoscale target at 75%: **12,000 events/s per shard**.
+- Shared NATS sustained ceiling: **123,000 events/s**.
+- Maximum useful automatic shard count: `ceil(123,000 / 12,000)` = **11**.
+
+At the 12,000/s scale point, the slowest tested node retains about 31% headroom
+to measured shard saturation. The benchmark runner removes every temporary pod
+and never connects to Twitch or NATS.
+
+Re-run all nodes from the repository root:
+
+```sh
+app/ingress/bench/websocket_shard_cluster.sh
+```

--- a/app/ingress/bench/websocket_shard.exs
+++ b/app/ingress/bench/websocket_shard.exs
@@ -1,0 +1,432 @@
+# Benchmarks one real Ingress.ShardSession from a local Twitch-shaped
+# WebSocket through dispatcher handoff. NATS and the downstream event pipeline
+# are deliberately replaced by a counter so this measures the per-shard
+# socket/read/decode/admit ceiling, not broker throughput.
+#
+# Run with the production scheduler shape:
+#   export ERL_FLAGS='+S 2:2 +SDcpu 2:2 +SDio 2 +sbwt short +sbwtdcpu none +sbwtdio none'
+#   MIX_ENV=test mix run --no-start bench/websocket_shard.exs
+
+defmodule Ingress.WebsocketShardBench.Server do
+  @websocket_guid "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+
+  def start(parent, opts \\ []) do
+    transport = if Keyword.get(opts, :tls, false), do: :ssl, else: :gen_tcp
+    {:ok, listener} = listen(transport, opts)
+    {:ok, {_address, port}} = sockname(transport, listener)
+    pid = spawn_link(fn -> accept(transport, listener, parent) end)
+    {pid, port}
+  end
+
+  defp listen(:gen_tcp, _opts) do
+    :gen_tcp.listen(0, [
+      :binary,
+      packet: :raw,
+      active: false,
+      reuseaddr: true,
+      nodelay: true,
+      ip: {127, 0, 0, 1}
+    ])
+  end
+
+  defp listen(:ssl, opts) do
+    :ssl.listen(0, [
+      :binary,
+      packet: :raw,
+      active: false,
+      reuseaddr: true,
+      nodelay: true,
+      ip: {127, 0, 0, 1},
+      versions: [:"tlsv1.3"],
+      certfile: Keyword.fetch!(opts, :certfile),
+      keyfile: Keyword.fetch!(opts, :keyfile)
+    ])
+  end
+
+  defp accept(transport, listener, parent) do
+    {:ok, socket} = accept_socket(transport, listener)
+    :ok = close(transport, listener)
+    request = receive_headers(transport, socket, "")
+    key = request |> header("sec-websocket-key") |> String.trim()
+    accept = :crypto.hash(:sha, key <> @websocket_guid) |> Base.encode64()
+
+    :ok =
+      send_data(transport, socket, [
+        "HTTP/1.1 101 Switching Protocols\r\n",
+        "upgrade: websocket\r\n",
+        "connection: Upgrade\r\n",
+        "sec-websocket-accept: ",
+        accept,
+        "\r\n\r\n"
+      ])
+
+    send(parent, {:websocket_server_ready, self()})
+    command_loop(transport, socket, parent)
+  end
+
+  defp accept_socket(:gen_tcp, listener), do: :gen_tcp.accept(listener)
+
+  defp accept_socket(:ssl, listener) do
+    with {:ok, socket} <- :ssl.transport_accept(listener, 5_000),
+         {:ok, socket} <- :ssl.handshake(socket, 5_000) do
+      {:ok, socket}
+    end
+  end
+
+  defp sockname(:gen_tcp, socket), do: :inet.sockname(socket)
+  defp sockname(:ssl, socket), do: :ssl.sockname(socket)
+
+  defp receive_headers(transport, socket, acc) do
+    case :binary.match(acc, "\r\n\r\n") do
+      :nomatch ->
+        {:ok, chunk} = recv(transport, socket, 0, 5_000)
+        receive_headers(transport, socket, acc <> chunk)
+
+      {_offset, _length} ->
+        acc
+    end
+  end
+
+  defp header(request, name) do
+    prefix = String.downcase(name) <> ":"
+
+    request
+    |> String.split("\r\n")
+    |> Enum.find_value(fn line ->
+      downcased = String.downcase(line)
+
+      if String.starts_with?(downcased, prefix),
+        do: binary_part(line, byte_size(prefix), byte_size(line) - byte_size(prefix))
+    end)
+    |> case do
+      nil -> raise "missing #{name} in websocket upgrade"
+      value -> value
+    end
+  end
+
+  defp command_loop(transport, socket, parent) do
+    receive do
+      {:send_frames, ref, frame, count, batch_size} ->
+        started = System.monotonic_time(:microsecond)
+        result = send_frames(transport, socket, frame, count, batch_size)
+        duration_us = System.monotonic_time(:microsecond) - started
+        send(parent, {:websocket_server_sent, ref, result, duration_us})
+        command_loop(transport, socket, parent)
+
+      :stop ->
+        close(transport, socket)
+        :ok
+    end
+  end
+
+  defp send_frames(_transport, _socket, _frame, 0, _batch_size), do: :ok
+
+  defp send_frames(transport, socket, frame, remaining, batch_size) do
+    batch_count = min(remaining, batch_size)
+
+    case send_data(transport, socket, List.duplicate(frame, batch_count)) do
+      :ok -> send_frames(transport, socket, frame, remaining - batch_count, batch_size)
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp recv(:gen_tcp, socket, length, timeout), do: :gen_tcp.recv(socket, length, timeout)
+  defp recv(:ssl, socket, length, timeout), do: :ssl.recv(socket, length, timeout)
+  defp send_data(:gen_tcp, socket, data), do: :gen_tcp.send(socket, data)
+  defp send_data(:ssl, socket, data), do: :ssl.send(socket, data)
+  defp close(:gen_tcp, socket), do: :gen_tcp.close(socket)
+  defp close(:ssl, socket), do: :ssl.close(socket)
+end
+
+defmodule Ingress.WebsocketShardBench do
+  alias Ingress.{Dispatcher, ShardSession}
+  alias Ingress.WebsocketShardBench.Server
+
+  def run do
+    {:ok, _} = Application.ensure_all_started(:mint_web_socket)
+    {:ok, _} = Application.ensure_all_started(:new_relic_agent)
+
+    events = env_integer("INGRESS_WS_BENCH_EVENTS", 500_000)
+    warmup = env_integer("INGRESS_WS_BENCH_WARMUP", 25_000)
+    batch_size = env_integer("INGRESS_WS_BENCH_BATCH_SIZE", 64)
+    workers = env_integer("INGRESS_WS_BENCH_WORKERS", 512)
+    tls? = System.get_env("INGRESS_WS_BENCH_TLS", "false") == "true"
+    cafile = System.get_env("INGRESS_WS_BENCH_CAFILE")
+    certfile = System.get_env("INGRESS_WS_BENCH_CERTFILE")
+    keyfile = System.get_env("INGRESS_WS_BENCH_KEYFILE")
+    completed = :atomics.new(1, signed: false)
+    handler = fn _payload, _meta -> :atomics.add(completed, 1, 1) end
+
+    {:ok, metrics} = Ingress.Metrics.start_link(flush_ms: 60_000)
+
+    {:ok, dispatcher_supervisor} =
+      Ingress.Dispatcher.Supervisor.start_link(
+        max_running: workers,
+        max_queue: events + warmup,
+        max_per_broadcaster: events + warmup,
+        completion_batch_size: 4,
+        completion_flush_ms: 25,
+        handler: handler
+      )
+
+    wait_workers(workers)
+    parent = self()
+    server_opts = if tls?, do: [tls: true, certfile: certfile, keyfile: keyfile], else: []
+    {server, port} = Server.start(parent, server_opts)
+    scheme = if tls?, do: "wss", else: "ws"
+    Application.put_env(:ingress, :eventsub_url, "#{scheme}://127.0.0.1:#{port}/ws")
+    ws_connect_opts = if tls?, do: [transport_opts: [cacertfile: cafile]], else: []
+
+    {:ok, shard} =
+      ShardSession.start_link(
+        shard_id: 0,
+        conduit_id: "websocket-benchmark",
+        rescue?: true,
+        ws_connect_opts: ws_connect_opts
+      )
+
+    receive do
+      {:websocket_server_ready, ^server} -> :ok
+    after
+      5_000 -> raise "websocket server handshake timed out"
+    end
+
+    wait_upgraded(shard)
+    cancel_welcome_deadline(shard)
+
+    payload = notification_payload()
+    frame = websocket_text_frame(payload)
+
+    {_warmup_us, warmup_stats} =
+      drive(server, shard, completed, frame, warmup, batch_size, warmup)
+
+    wait_dispatcher_drained()
+    reductions_before = process_reductions(shard)
+    memory_before = process_memory(shard)
+
+    {duration_us, stats} =
+      drive(server, shard, completed, frame, events, batch_size, warmup + events)
+
+    wait_dispatcher_drained()
+    reductions = process_reductions(shard) - reductions_before
+    memory_delta = process_memory(shard) - memory_before
+    status = ShardSession.status(shard)
+    sender_duration_us = receive_sender_duration(stats.ref)
+
+    result = %{
+      events: events,
+      warmup_events: warmup,
+      payload_bytes: byte_size(payload),
+      websocket_frame_bytes: byte_size(frame),
+      socket_batch_frames: batch_size,
+      workers: workers,
+      schedulers: System.schedulers_online(),
+      dirty_cpu_schedulers: :erlang.system_info(:dirty_cpu_schedulers),
+      tls: tls?,
+      receiver_events_per_second: round(events * 1_000_000 / duration_us),
+      sender_events_per_second: round(events * 1_000_000 / sender_duration_us),
+      duration_ms: Float.round(duration_us / 1_000, 3),
+      sender_duration_ms: Float.round(sender_duration_us / 1_000, 3),
+      shard_load_window_count: status.load,
+      dispatcher_completed: :atomics.get(completed, 1) - warmup,
+      dispatcher_pending: Dispatcher.admitted_count(),
+      shard_max_mailbox: stats.max_mailbox,
+      warmup_max_mailbox: warmup_stats.max_mailbox,
+      max_run_queue: stats.max_run_queue,
+      shard_reductions_per_event: Float.round(reductions / events, 2),
+      shard_memory_delta_bytes: memory_delta
+    }
+
+    IO.puts("WEBSOCKET_SHARD_RESULT=" <> Jason.encode!(result))
+
+    send(server, :stop)
+    GenServer.stop(shard)
+    Supervisor.stop(dispatcher_supervisor)
+    GenServer.stop(metrics)
+  end
+
+  defp drive(server, shard, completed, frame, count, batch_size, completed_target) do
+    ref = make_ref()
+    started = System.monotonic_time(:microsecond)
+    send(server, {:send_frames, ref, frame, count, batch_size})
+
+    stats =
+      wait_completed(
+        completed,
+        completed_target,
+        shard,
+        System.monotonic_time(:millisecond) + 120_000,
+        %{ref: ref, max_mailbox: 0, max_run_queue: 0}
+      )
+
+    {System.monotonic_time(:microsecond) - started, stats}
+  end
+
+  defp wait_completed(completed, target, shard, deadline, stats) do
+    mailbox = process_info_value(shard, :message_queue_len)
+    run_queue = :erlang.statistics(:run_queue)
+
+    stats = %{
+      stats
+      | max_mailbox: max(stats.max_mailbox, mailbox),
+        max_run_queue: max(stats.max_run_queue, run_queue)
+    }
+
+    cond do
+      :atomics.get(completed, 1) >= target ->
+        stats
+
+      System.monotonic_time(:millisecond) >= deadline ->
+        raise "shard benchmark timed out at #{:atomics.get(completed, 1)}/#{target} events"
+
+      not Process.alive?(shard) ->
+        raise "shard exited during benchmark"
+
+      true ->
+        Process.sleep(1)
+        wait_completed(completed, target, shard, deadline, stats)
+    end
+  end
+
+  defp receive_sender_duration(ref) do
+    receive do
+      {:websocket_server_sent, ^ref, :ok, duration_us} ->
+        duration_us
+
+      {:websocket_server_sent, ^ref, {:error, reason}, _duration_us} ->
+        raise "websocket sender failed: #{inspect(reason)}"
+    after
+      5_000 -> raise "websocket sender result timed out"
+    end
+  end
+
+  defp wait_workers(expected) do
+    wait_until(fn ->
+      Dispatcher.worker_names(Dispatcher)
+      |> Tuple.to_list()
+      |> Enum.count(&(Process.whereis(&1) != nil))
+      |> Kernel.==(expected)
+    end)
+  end
+
+  defp wait_upgraded(shard) do
+    wait_until(fn ->
+      case :sys.get_state(shard) do
+        %{primary: %{websocket: websocket}} when not is_nil(websocket) -> true
+        _ -> false
+      end
+    end)
+  end
+
+  defp cancel_welcome_deadline(shard) do
+    :sys.replace_state(shard, fn state ->
+      if state.welcome_timer, do: Process.cancel_timer(state.welcome_timer)
+      %{state | welcome_timer: nil}
+    end)
+  end
+
+  defp wait_dispatcher_drained do
+    wait_until(fn -> Dispatcher.admitted_count() == 0 end, 30_000)
+  end
+
+  defp wait_until(fun, timeout_ms \\ 10_000) do
+    deadline = System.monotonic_time(:millisecond) + timeout_ms
+    do_wait_until(fun, deadline, timeout_ms)
+  end
+
+  defp do_wait_until(fun, deadline, timeout_ms) do
+    cond do
+      fun.() ->
+        :ok
+
+      System.monotonic_time(:millisecond) >= deadline ->
+        raise "condition not met within #{timeout_ms}ms"
+
+      true ->
+        Process.sleep(2)
+        do_wait_until(fun, deadline, timeout_ms)
+    end
+  end
+
+  defp websocket_text_frame(payload) do
+    size = byte_size(payload)
+
+    cond do
+      size <= 125 -> <<0x81, size, payload::binary>>
+      size <= 65_535 -> <<0x81, 126, size::16, payload::binary>>
+      true -> <<0x81, 127, size::64, payload::binary>>
+    end
+  end
+
+  defp notification_payload do
+    Ingress.JSON.encode(%{
+      "metadata" => %{
+        "message_id" => "01JZWEBSOCKETBENCHMARK000001",
+        "message_type" => "notification",
+        "message_timestamp" => "2026-07-15T12:00:00.000000000Z",
+        "subscription_type" => "channel.chat.message",
+        "subscription_version" => "1"
+      },
+      "payload" => %{
+        "subscription" => %{
+          "id" => "benchmark-subscription",
+          "status" => "enabled",
+          "type" => "channel.chat.message",
+          "version" => "1",
+          "condition" => %{"broadcaster_user_id" => "123456"},
+          "transport" => %{"method" => "websocket", "session_id" => "benchmark-session"},
+          "created_at" => "2026-07-15T12:00:00.000000000Z",
+          "cost" => 0
+        },
+        "event" => %{
+          "broadcaster_user_id" => "123456",
+          "broadcaster_user_login" => "benchmark_channel",
+          "broadcaster_user_name" => "Benchmark Channel",
+          "chatter_user_id" => "654321",
+          "chatter_user_login" => "benchmark_chatter",
+          "chatter_user_name" => "Benchmark Chatter",
+          "message_id" => "benchmark-message",
+          "message" => %{
+            "text" => "A representative Twitch chat message for the ingress WebSocket benchmark",
+            "fragments" => [
+              %{
+                "type" => "text",
+                "text" =>
+                  "A representative Twitch chat message for the ingress WebSocket benchmark",
+                "cheermote" => nil,
+                "emote" => nil,
+                "mention" => nil
+              }
+            ]
+          },
+          "color" => "#52B788",
+          "badges" => [%{"set_id" => "subscriber", "id" => "12", "info" => "12"}],
+          "message_type" => "text",
+          "cheer" => nil,
+          "reply" => nil,
+          "channel_points_custom_reward_id" => nil,
+          "source_broadcaster_user_id" => nil,
+          "source_broadcaster_user_login" => nil,
+          "source_broadcaster_user_name" => nil,
+          "source_message_id" => nil,
+          "source_badges" => nil
+        }
+      }
+    })
+    |> IO.iodata_to_binary()
+  end
+
+  defp process_reductions(pid), do: process_info_value(pid, :reductions)
+  defp process_memory(pid), do: process_info_value(pid, :memory)
+
+  defp process_info_value(pid, key) do
+    {^key, value} = Process.info(pid, key)
+    value
+  end
+
+  defp env_integer(name, default) do
+    name |> System.get_env(Integer.to_string(default)) |> String.to_integer()
+  end
+end
+
+Ingress.WebsocketShardBench.run()

--- a/app/ingress/bench/websocket_shard.exs
+++ b/app/ingress/bench/websocket_shard.exs
@@ -108,7 +108,14 @@ defmodule Ingress.WebsocketShardBench.Server do
     receive do
       {:send_frames, ref, frame, count, batch_size} ->
         started = System.monotonic_time(:microsecond)
-        result = send_frames(transport, socket, frame, count, batch_size)
+
+        result =
+          send_frames(transport, socket, %{
+            frame: frame,
+            remaining: count,
+            batch_size: batch_size
+          })
+
         duration_us = System.monotonic_time(:microsecond) - started
         send(parent, {:websocket_server_sent, ref, result, duration_us})
         command_loop(transport, socket, parent)
@@ -119,13 +126,14 @@ defmodule Ingress.WebsocketShardBench.Server do
     end
   end
 
-  defp send_frames(_transport, _socket, _frame, 0, _batch_size), do: :ok
+  defp send_frames(_transport, _socket, %{remaining: 0}), do: :ok
 
-  defp send_frames(transport, socket, frame, remaining, batch_size) do
+  defp send_frames(transport, socket, %{frame: frame} = request) do
+    %{remaining: remaining, batch_size: batch_size} = request
     batch_count = min(remaining, batch_size)
 
     case send_data(transport, socket, List.duplicate(frame, batch_count)) do
-      :ok -> send_frames(transport, socket, frame, remaining - batch_count, batch_size)
+      :ok -> send_frames(transport, socket, %{request | remaining: remaining - batch_count})
       {:error, _reason} = error -> error
     end
   end
@@ -143,39 +151,81 @@ defmodule Ingress.WebsocketShardBench do
   alias Ingress.WebsocketShardBench.Server
 
   def run do
+    context = start_benchmark(load_config())
+
+    try do
+      result = measure(context)
+      IO.puts("WEBSOCKET_SHARD_RESULT=" <> Jason.encode!(result))
+    after
+      stop_benchmark(context)
+    end
+  end
+
+  defp load_config do
+    %{
+      events: env_integer("INGRESS_WS_BENCH_EVENTS", 500_000),
+      warmup: env_integer("INGRESS_WS_BENCH_WARMUP", 25_000),
+      batch_size: env_integer("INGRESS_WS_BENCH_BATCH_SIZE", 64),
+      workers: env_integer("INGRESS_WS_BENCH_WORKERS", 512),
+      tls?: System.get_env("INGRESS_WS_BENCH_TLS", "false") == "true",
+      cafile: System.get_env("INGRESS_WS_BENCH_CAFILE"),
+      certfile: System.get_env("INGRESS_WS_BENCH_CERTFILE"),
+      keyfile: System.get_env("INGRESS_WS_BENCH_KEYFILE")
+    }
+  end
+
+  defp start_benchmark(config) do
     {:ok, _} = Application.ensure_all_started(:mint_web_socket)
     {:ok, _} = Application.ensure_all_started(:new_relic_agent)
-
-    events = env_integer("INGRESS_WS_BENCH_EVENTS", 500_000)
-    warmup = env_integer("INGRESS_WS_BENCH_WARMUP", 25_000)
-    batch_size = env_integer("INGRESS_WS_BENCH_BATCH_SIZE", 64)
-    workers = env_integer("INGRESS_WS_BENCH_WORKERS", 512)
-    tls? = System.get_env("INGRESS_WS_BENCH_TLS", "false") == "true"
-    cafile = System.get_env("INGRESS_WS_BENCH_CAFILE")
-    certfile = System.get_env("INGRESS_WS_BENCH_CERTFILE")
-    keyfile = System.get_env("INGRESS_WS_BENCH_KEYFILE")
     completed = :atomics.new(1, signed: false)
-    handler = fn _payload, _meta -> :atomics.add(completed, 1, 1) end
-
     {:ok, metrics} = Ingress.Metrics.start_link(flush_ms: 60_000)
+    dispatcher_supervisor = start_dispatcher(config, completed)
+    wait_workers(config.workers)
+    server = start_server(config)
+    shard = start_shard(config)
+    await_websocket(server, shard)
+
+    %{
+      config: config,
+      completed: completed,
+      metrics: metrics,
+      dispatcher_supervisor: dispatcher_supervisor,
+      server: server,
+      shard: shard
+    }
+  end
+
+  defp start_dispatcher(config, completed) do
+    handler = fn _payload, _meta -> :atomics.add(completed, 1, 1) end
 
     {:ok, dispatcher_supervisor} =
       Ingress.Dispatcher.Supervisor.start_link(
-        max_running: workers,
-        max_queue: events + warmup,
-        max_per_broadcaster: events + warmup,
+        max_running: config.workers,
+        max_queue: config.events + config.warmup,
+        max_per_broadcaster: config.events + config.warmup,
         completion_batch_size: 4,
         completion_flush_ms: 25,
         handler: handler
       )
 
-    wait_workers(workers)
-    parent = self()
-    server_opts = if tls?, do: [tls: true, certfile: certfile, keyfile: keyfile], else: []
-    {server, port} = Server.start(parent, server_opts)
-    scheme = if tls?, do: "wss", else: "ws"
+    dispatcher_supervisor
+  end
+
+  defp start_server(config) do
+    server_opts =
+      if config.tls?,
+        do: [tls: true, certfile: config.certfile, keyfile: config.keyfile],
+        else: []
+
+    {server, port} = Server.start(self(), server_opts)
+    scheme = if config.tls?, do: "wss", else: "ws"
     Application.put_env(:ingress, :eventsub_url, "#{scheme}://127.0.0.1:#{port}/ws")
-    ws_connect_opts = if tls?, do: [transport_opts: [cacertfile: cafile]], else: []
+
+    server
+  end
+
+  defp start_shard(config) do
+    ws_connect_opts = if config.tls?, do: [transport_opts: [cacertfile: config.cafile]], else: []
 
     {:ok, shard} =
       ShardSession.start_link(
@@ -185,6 +235,10 @@ defmodule Ingress.WebsocketShardBench do
         ws_connect_opts: ws_connect_opts
       )
 
+    shard
+  end
+
+  defp await_websocket(server, shard) do
     receive do
       {:websocket_server_ready, ^server} -> :ok
     after
@@ -193,76 +247,106 @@ defmodule Ingress.WebsocketShardBench do
 
     wait_upgraded(shard)
     cancel_welcome_deadline(shard)
+  end
 
+  defp measure(context) do
     payload = notification_payload()
     frame = websocket_text_frame(payload)
+    context = Map.merge(context, %{payload: payload, frame: frame})
+    warmup_stats = run_warmup(context)
+    measured = run_measurement(context)
+
+    build_result(context, warmup_stats, measured)
+  end
+
+  defp run_warmup(context) do
+    %{config: config} = context
 
     {_warmup_us, warmup_stats} =
-      drive(server, shard, completed, frame, warmup, batch_size, warmup)
+      drive(context, config.warmup, config.warmup)
 
     wait_dispatcher_drained()
-    reductions_before = process_reductions(shard)
-    memory_before = process_memory(shard)
+
+    warmup_stats
+  end
+
+  defp run_measurement(context) do
+    %{config: config, shard: shard} = context
+    before = %{reductions: process_reductions(shard), memory: process_memory(shard)}
 
     {duration_us, stats} =
-      drive(server, shard, completed, frame, events, batch_size, warmup + events)
+      drive(context, config.events, config.warmup + config.events)
 
     wait_dispatcher_drained()
-    reductions = process_reductions(shard) - reductions_before
-    memory_delta = process_memory(shard) - memory_before
-    status = ShardSession.status(shard)
-    sender_duration_us = receive_sender_duration(stats.ref)
 
-    result = %{
-      events: events,
-      warmup_events: warmup,
+    %{
+      duration_us: duration_us,
+      sender_duration_us: receive_sender_duration(stats.ref),
+      stats: stats,
+      status: ShardSession.status(shard),
+      reductions: process_reductions(shard) - before.reductions,
+      memory_delta: process_memory(shard) - before.memory
+    }
+  end
+
+  defp build_result(context, warmup_stats, measured) do
+    %{completed: completed, config: config, frame: frame, payload: payload} = context
+    %{duration_us: duration_us, sender_duration_us: sender_duration_us, stats: stats} = measured
+
+    %{
+      events: config.events,
+      warmup_events: config.warmup,
       payload_bytes: byte_size(payload),
       websocket_frame_bytes: byte_size(frame),
-      socket_batch_frames: batch_size,
-      workers: workers,
+      socket_batch_frames: config.batch_size,
+      workers: config.workers,
       schedulers: System.schedulers_online(),
       dirty_cpu_schedulers: :erlang.system_info(:dirty_cpu_schedulers),
-      tls: tls?,
-      receiver_events_per_second: round(events * 1_000_000 / duration_us),
-      sender_events_per_second: round(events * 1_000_000 / sender_duration_us),
+      tls: config.tls?,
+      receiver_events_per_second: round(config.events * 1_000_000 / duration_us),
+      sender_events_per_second: round(config.events * 1_000_000 / sender_duration_us),
       duration_ms: Float.round(duration_us / 1_000, 3),
       sender_duration_ms: Float.round(sender_duration_us / 1_000, 3),
-      shard_load_window_count: status.load,
-      dispatcher_completed: :atomics.get(completed, 1) - warmup,
+      shard_load_window_count: measured.status.load,
+      dispatcher_completed: :atomics.get(completed, 1) - config.warmup,
       dispatcher_pending: Dispatcher.admitted_count(),
       shard_max_mailbox: stats.max_mailbox,
       warmup_max_mailbox: warmup_stats.max_mailbox,
       max_run_queue: stats.max_run_queue,
-      shard_reductions_per_event: Float.round(reductions / events, 2),
-      shard_memory_delta_bytes: memory_delta
+      shard_reductions_per_event: Float.round(measured.reductions / config.events, 2),
+      shard_memory_delta_bytes: measured.memory_delta
     }
-
-    IO.puts("WEBSOCKET_SHARD_RESULT=" <> Jason.encode!(result))
-
-    send(server, :stop)
-    GenServer.stop(shard)
-    Supervisor.stop(dispatcher_supervisor)
-    GenServer.stop(metrics)
   end
 
-  defp drive(server, shard, completed, frame, count, batch_size, completed_target) do
+  defp stop_benchmark(context) do
+    send(context.server, :stop)
+    GenServer.stop(context.shard)
+    Supervisor.stop(context.dispatcher_supervisor)
+    GenServer.stop(context.metrics)
+  end
+
+  defp drive(context, count, completed_target) do
+    %{completed: completed, config: config, frame: frame, server: server, shard: shard} = context
     ref = make_ref()
     started = System.monotonic_time(:microsecond)
-    send(server, {:send_frames, ref, frame, count, batch_size})
+    send(server, {:send_frames, ref, frame, count, config.batch_size})
 
     stats =
-      wait_completed(
-        completed,
-        completed_target,
-        shard,
-        System.monotonic_time(:millisecond) + 120_000,
-        %{ref: ref, max_mailbox: 0, max_run_queue: 0}
-      )
+      wait_completed(%{
+        completed: completed,
+        target: completed_target,
+        shard: shard,
+        deadline: System.monotonic_time(:millisecond) + 120_000,
+        stats: %{ref: ref, max_mailbox: 0, max_run_queue: 0}
+      })
 
     {System.monotonic_time(:microsecond) - started, stats}
   end
 
-  defp wait_completed(completed, target, shard, deadline, stats) do
+  defp wait_completed(state) do
+    %{completed: completed, deadline: deadline, shard: shard, stats: stats, target: target} =
+      state
+
     mailbox = process_info_value(shard, :message_queue_len)
     run_queue = :erlang.statistics(:run_queue)
 
@@ -284,7 +368,7 @@ defmodule Ingress.WebsocketShardBench do
 
       true ->
         Process.sleep(1)
-        wait_completed(completed, target, shard, deadline, stats)
+        wait_completed(%{state | stats: stats})
     end
   end
 

--- a/app/ingress/bench/websocket_shard_cluster.sh
+++ b/app/ingress/bench/websocket_shard_cluster.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Runs the WebSocket-only shard benchmark on each production ingress node in a
+# temporary, CPU-limited pod. It publishes nothing to NATS and never connects
+# to Twitch; the benchmark pod hosts its own Twitch-shaped WebSocket endpoint.
+set -euo pipefail
+
+namespace=${NAMESPACE:-production}
+image=${BENCH_IMAGE:-docker.io/library/elixir:1.17-otp-27}
+events=${EVENTS:-500000}
+warmup=${WARMUP:-25000}
+samples=${SAMPLES:-3}
+nodes_string=${NODES:-"node2 node3 worker1"}
+run_id=$(date -u +%Y%m%d%H%M%S)
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+ingress_dir=$(cd "$script_dir/.." && pwd)
+pods=()
+
+read -r -a nodes <<<"$nodes_string"
+
+cleanup() {
+  if ((${#pods[@]} > 0)); then
+    kubectl -n "$namespace" delete pod "${pods[@]}" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT INT TERM
+
+create_pod() {
+  local pod=$1 node=$2
+  local manifest
+
+  manifest=$(jq -nc \
+    --arg pod "$pod" \
+    --arg node "$node" \
+    --arg image "$image" \
+    --arg run "$run_id" \
+    '{
+      apiVersion:"v1",
+      kind:"Pod",
+      metadata:{
+        name:$pod,
+        labels:{app:"ingress-websocket-bench",run:$run}
+      },
+      spec:{
+        nodeName:$node,
+        enableServiceLinks:false,
+        restartPolicy:"Never",
+        containers:[{
+          name:"bench",
+          image:$image,
+          command:["sleep","1800"],
+          resources:{
+            requests:{cpu:"500m",memory:"512Mi"},
+            limits:{cpu:"2",memory:"1Gi"}
+          },
+          securityContext:{
+            allowPrivilegeEscalation:false,
+            capabilities:{drop:["ALL"]}
+          }
+        }]
+      }
+    }')
+
+  jq -e . <<<"$manifest" | kubectl -n "$namespace" create -f - >/dev/null
+  kubectl -n "$namespace" wait --for=condition=Ready "pod/$pod" --timeout=180s >/dev/null
+}
+
+copy_source() {
+  local pod=$1
+
+  kubectl -n "$namespace" exec "$pod" -- mkdir -p /bench/lib /bench/config /bench/bench
+  kubectl -n "$namespace" cp --no-preserve "$ingress_dir/mix.exs" "$pod:/bench/mix.exs"
+  kubectl -n "$namespace" cp --no-preserve "$ingress_dir/mix.lock" "$pod:/bench/mix.lock"
+  kubectl -n "$namespace" cp --no-preserve "$ingress_dir/lib/." "$pod:/bench/lib"
+  kubectl -n "$namespace" cp --no-preserve "$ingress_dir/config/." "$pod:/bench/config"
+  kubectl -n "$namespace" cp --no-preserve "$script_dir/websocket_shard.exs" "$pod:/bench/bench/websocket_shard.exs"
+}
+
+prepare() {
+  local pod=$1
+
+  kubectl -n "$namespace" exec "$pod" -- sh -c \
+    "openssl req -x509 -newkey rsa:2048 -nodes -days 1 \
+      -keyout /tmp/ingress-ws-bench-ca.key -out /tmp/ingress-ws-bench-ca.crt \
+      -subj /CN=ingress-ws-bench-ca -addext basicConstraints=critical,CA:TRUE >/dev/null 2>&1 && \
+     openssl req -new -newkey rsa:2048 -nodes \
+      -keyout /tmp/ingress-ws-bench.key -out /tmp/ingress-ws-bench.csr \
+      -subj /CN=127.0.0.1 -addext subjectAltName=IP:127.0.0.1 >/dev/null 2>&1 && \
+     openssl x509 -req -in /tmp/ingress-ws-bench.csr \
+      -CA /tmp/ingress-ws-bench-ca.crt -CAkey /tmp/ingress-ws-bench-ca.key \
+      -CAcreateserial -days 1 -copy_extensions copy \
+      -out /tmp/ingress-ws-bench.crt >/dev/null 2>&1"
+
+  kubectl -n "$namespace" exec "$pod" -- env MIX_ENV=test sh -c \
+    'cd /bench && mix local.hex --force && mix local.rebar --force && mix deps.get && mix deps.compile'
+}
+
+run_sample() {
+  local pod=$1 node=$2 sample=$3
+
+  echo "websocket shard benchmark node=$node sample=$sample/$samples"
+  kubectl -n "$namespace" exec "$pod" -- env \
+    'ERL_FLAGS=+S 2:2 +SDcpu 2:2 +SDio 2 +sbwt short +sbwtdcpu none +sbwtdio none' \
+    MIX_ENV=test \
+    INGRESS_WS_BENCH_TLS=true \
+    INGRESS_WS_BENCH_CAFILE=/tmp/ingress-ws-bench-ca.crt \
+    INGRESS_WS_BENCH_CERTFILE=/tmp/ingress-ws-bench.crt \
+    INGRESS_WS_BENCH_KEYFILE=/tmp/ingress-ws-bench.key \
+    INGRESS_WS_BENCH_EVENTS="$events" \
+    INGRESS_WS_BENCH_WARMUP="$warmup" \
+    sh -c 'cd /bench && mix run --no-start bench/websocket_shard.exs'
+}
+
+for node in "${nodes[@]}"; do
+  pod="ingress-ws-bench-${node}-${run_id}"
+  pods+=("$pod")
+  create_pod "$pod" "$node"
+  copy_source "$pod"
+  prepare "$pod"
+
+  for sample in $(seq 1 "$samples"); do
+    run_sample "$pod" "$node" "$sample"
+  done
+
+  kubectl -n "$namespace" delete pod "$pod" --wait=true >/dev/null
+done

--- a/app/ingress/config/runtime.exs
+++ b/app/ingress/config/runtime.exs
@@ -84,7 +84,8 @@ config :ingress,
   # Side-effect-free admin latency probe shared by every RPC-serving service.
   rpc_health_subject: System.get_env("NATS_RPC_HEALTH_SUBJECT", "bagel.rpc.health.ingress"),
   # Hard ceiling applied to both manual targets and the autoscaler estimate.
-  max_shards: String.to_integer(System.get_env("TWITCH_CONDUIT_MAX_SHARDS", "20")),
+  # 123k NATS ceiling / 12k per-shard operating target = 11 useful shards.
+  max_shards: String.to_integer(System.get_env("TWITCH_CONDUIT_MAX_SHARDS", "11")),
   # Capacity values are reported to the admin console and drive shard scaling.
   # The pod rating is the rounded-down production-shaped full-path benchmark;
   # the websocket rating is kept separate because adding a conduit shard adds
@@ -97,8 +98,10 @@ config :ingress,
   # effective fleet throughput.
   capacity_nats_rated_eps:
     String.to_integer(System.get_env("INGRESS_CAPACITY_NATS_RATED_EPS", "123000")),
+  # Rounded below the slowest production-node TLS 1.3 shard benchmark
+  # (17,516/s); the 75% operating target therefore scales at 12,000/s.
   capacity_websocket_rated_eps:
-    String.to_integer(System.get_env("INGRESS_CAPACITY_WEBSOCKET_RATED_EPS", "12500")),
+    String.to_integer(System.get_env("INGRESS_CAPACITY_WEBSOCKET_RATED_EPS", "16000")),
   capacity_target_utilization_pct:
     String.to_integer(System.get_env("INGRESS_CAPACITY_TARGET_UTILIZATION_PCT", "75")),
   # NATS RPC endpoint exposed by the Go service that owns broadcaster data.

--- a/app/ingress/lib/ingress/admin_rpc.ex
+++ b/app/ingress/lib/ingress/admin_rpc.ex
@@ -78,6 +78,7 @@ defmodule Ingress.AdminRpc do
       desired_count: desired,
       target: scaler.target,
       min_shards: scaler.min_shards,
+      max_shards: scaler.max_shards,
       autoscale: scaler.autoscale,
       max_load: scaler.max_load,
       max_load_shard_id: scaler.max_load_shard_id,

--- a/app/ingress/lib/ingress/capacity.ex
+++ b/app/ingress/lib/ingress/capacity.ex
@@ -22,7 +22,11 @@ defmodule Ingress.Capacity do
   # dialing live. Up from 86,000 — the per-message dedup insert was ~27% of the
   # single stream's serialized ingest capacity.
   @default_nats_rated_eps 123_000
-  @default_websocket_rated_eps 12_500
+  # Rounded down from the slowest 2026-07-15 production-node TLS 1.3 shard
+  # saturation sample (17,516/s on node3). Nine 500k-event samples exercised
+  # Mint framing, native JSON decode, load accounting and dispatcher handoff;
+  # every sample completed without backlog and with a shard mailbox <= 3.
+  @default_websocket_rated_eps 16_000
   @default_target_utilization_pct 75
 
   def load_window_seconds, do: @load_window_seconds
@@ -54,6 +58,18 @@ defmodule Ingress.Capacity do
   def websocket_target_eps, do: at_target(websocket_rated_eps())
 
   @doc """
+  Highest useful WebSocket shard count at the shared NATS ceiling.
+
+  Each socket is budgeted at the 75% operating target. Once their combined
+  target capacity covers NATS' maximum sustained rate, another shard cannot
+  increase end-to-end throughput.
+  """
+  def websocket_autoscale_max_shards do
+    per_shard = max(websocket_target_eps(), 1)
+    max(div(nats_rated_eps() + per_shard - 1, per_shard), 1)
+  end
+
+  @doc """
   Capacity metadata for the admin wire snapshot.
 
   Fleet capacity grows with live BEAM nodes (one ingress pod per node name),
@@ -81,7 +97,8 @@ defmodule Ingress.Capacity do
       effective_target_eps: effective_target,
       bottleneck: if(nats_rated_eps() <= fleet_rated, do: "nats", else: "ingress_compute"),
       websocket_rated_eps: websocket_rated_eps(),
-      websocket_target_eps: websocket_target_eps()
+      websocket_target_eps: websocket_target_eps(),
+      websocket_autoscale_max_shards: websocket_autoscale_max_shards()
     }
   end
 

--- a/app/ingress/lib/ingress/config.ex
+++ b/app/ingress/lib/ingress/config.ex
@@ -79,7 +79,7 @@ defmodule Ingress.Config do
 
   # Hard ceiling on shard count; the autoscaler and manual target are both
   # clamped to this value so a runaway load spike cannot blow the conduit cap.
-  def max_shards, do: Application.get_env(:ingress, :max_shards, 20)
+  def max_shards, do: Application.get_env(:ingress, :max_shards, 11)
 
   def broadcaster_status_subject,
     do: Application.fetch_env!(:ingress, :broadcaster_status_subject)

--- a/app/ingress/lib/ingress/shard_scaler.ex
+++ b/app/ingress/lib/ingress/shard_scaler.ex
@@ -27,9 +27,10 @@ defmodule Ingress.ShardScaler do
     * needed < target for consecutive ticks → drain one shard
     * otherwise                             → hold
 
-  The effective desired count is always `clamp(target, min_shards, max_shards)`.
-  Decisions run every `@autoscale_interval_ms`. Ratings, utilization, and
-  tick counts live in `Ingress.ShardScaler.Policy`.
+  The effective desired count is always clamped to the node floor and the
+  lower of the operator limit or NATS-limited useful WebSocket count. Decisions
+  run every `@autoscale_interval_ms`. Ratings, utilization, and tick counts
+  live in `Ingress.ShardScaler.Policy`.
   """
 
   use GenServer
@@ -157,6 +158,7 @@ defmodule Ingress.ShardScaler do
        target: state.target,
        autoscale: state.autoscale,
        min_shards: min_s,
+       max_shards: effective_max_shards(state.autoscale, min_s),
        desired: compute_desired(state),
        load: load,
        max_load: max_load,
@@ -214,8 +216,15 @@ defmodule Ingress.ShardScaler do
   end
 
   defp compute_desired(state) do
-    clamp(state.target, min_shards(), Config.max_shards())
+    min_s = min_shards()
+    clamp(state.target, min_s, effective_max_shards(state.autoscale, min_s))
   end
+
+  defp effective_max_shards(true, min_s) do
+    max(min_s, Ingress.ShardScaler.Policy.autoscale_max_shards(Config.max_shards()))
+  end
+
+  defp effective_max_shards(false, _min_s), do: Config.max_shards()
 
   defp evaluate_autoscale(state) do
     sample = sample_shards(state)
@@ -224,10 +233,12 @@ defmodule Ingress.ShardScaler do
 
     min_s = min_shards()
 
+    current_target = compute_desired(state)
+
     {new_target, ticks, action} =
       Ingress.ShardScaler.Policy.evaluate(
         sample,
-        state.target,
+        current_target,
         state.ticks,
         min_s,
         Config.max_shards()
@@ -236,12 +247,12 @@ defmodule Ingress.ShardScaler do
     case action do
       :up ->
         Logger.info(
-          "shard_scaler: autoscale up load=#{sample.aggregate_load}/window → target #{state.target} → #{new_target}"
+          "shard_scaler: autoscale up load=#{sample.aggregate_load}/window → target #{current_target} → #{new_target}"
         )
 
       :down ->
         Logger.info(
-          "shard_scaler: autoscale down load=#{sample.aggregate_load}/window → target #{state.target} → #{new_target}"
+          "shard_scaler: autoscale down load=#{sample.aggregate_load}/window → target #{current_target} → #{new_target}"
         )
 
       :hold ->
@@ -334,6 +345,7 @@ defmodule Ingress.ShardScaler do
       target: Config.conduit_shard_count(),
       autoscale: false,
       min_shards: min_shards(),
+      max_shards: Config.max_shards(),
       desired: Config.conduit_shard_count(),
       load: 0,
       max_load: 0,

--- a/app/ingress/lib/ingress/shard_scaler/policy.ex
+++ b/app/ingress/lib/ingress/shard_scaler/policy.ex
@@ -12,9 +12,9 @@ defmodule Ingress.ShardScaler.Policy do
 
   A shard's per-event work is deliberately thin: JSON-decode the frame and
   enqueue into `Ingress.Dispatcher` (filtering, re-encode, and NATS publish
-  happen in the dispatcher's worker pool). The socket rating is 12,500 ev/s
+  happen in the dispatcher's worker pool). The socket rating is 16,000 ev/s
   and the scaler does not add another shard until the current sockets would
-  exceed the 75% target (9,375 ev/s each). This keeps sockets dense instead of
+  exceed the 75% target (12,000 ev/s each). This keeps sockets dense instead of
   opening giant WebSockets for breadcrumb traffic.
 
   Hysteresis state is a `%{low: n, high: n}` map of consecutive ticks spent
@@ -34,7 +34,9 @@ defmodule Ingress.ShardScaler.Policy do
 
   Both values and the 75% target come from `Ingress.Capacity`, which is also
   serialized into the admin snapshot. The scaler and dashboard therefore use
-  the same limits without duplicating constants.
+  the same limits without duplicating constants. Automatic scaling stops once
+  the sockets' combined target capacity covers the shared NATS ceiling; more
+  sockets beyond that point cannot add end-to-end throughput.
   """
 
   alias Ingress.Capacity
@@ -59,6 +61,13 @@ defmodule Ingress.ShardScaler.Policy do
   def scale_down_ticks, do: @scale_down_ticks
   def concentration_ratio, do: @concentration_ratio
   def concentration_min_pct, do: @concentration_min_pct
+
+  @doc """
+  Autoscale ceiling after applying the operator limit and shared NATS capacity.
+  """
+  def autoscale_max_shards(configured_max) do
+    min(configured_max, Capacity.websocket_autoscale_max_shards())
+  end
 
   @doc """
   Events per window one shard is rated for (100% utilization).
@@ -161,7 +170,8 @@ defmodule Ingress.ShardScaler.Policy do
       # Unresponsive shards contribute no load to the sample, but Twitch only
       # routes to healthy shards, so the responsive aggregate is the real
       # traffic — no extrapolation needed on the way up.
-      needed = clamp(shards_needed(sample.aggregate_load), min_shards, max_shards)
+      effective_max = max(min_shards, autoscale_max_shards(max_shards))
+      needed = clamp(shards_needed(sample.aggregate_load), min_shards, effective_max)
 
       cond do
         needed > current_target ->

--- a/app/ingress/lib/ingress/shard_session.ex
+++ b/app/ingress/lib/ingress/shard_session.ex
@@ -65,6 +65,9 @@ defmodule Ingress.ShardSession do
             last_frame_system_ms: nil,
             # duplicate-shard takeover in flight: %{winner:, monitor:, timer:}
             takeover: nil,
+            # Optional Mint connection options used by the isolated WebSocket
+            # benchmark for its temporary CA. Production leaves this empty.
+            ws_connect_opts: [],
             # Aggregate counter for notification load.
             load_counter: Ingress.LoadCounter.new()
 
@@ -107,7 +110,8 @@ defmodule Ingress.ShardSession do
 
     state = %__MODULE__{
       shard_id: shard_id,
-      conduit_id: Keyword.fetch!(opts, :conduit_id)
+      conduit_id: Keyword.fetch!(opts, :conduit_id),
+      ws_connect_opts: Keyword.get(opts, :ws_connect_opts, [])
     }
 
     {:ok, state, {:continue, :connect}}
@@ -498,7 +502,7 @@ defmodule Ingress.ShardSession do
     if state.pending, do: WS.close(state.pending)
     cancel(state.handshake_timer)
 
-    case url && WS.connect(url) do
+    case url && WS.connect(url, state.ws_connect_opts) do
       {:ok, pending} ->
         timer = Process.send_after(self(), :handshake_deadline, @handshake_deadline_ms)
         {:noreply, pet_watchdog(%{state | pending: pending, handshake_timer: timer})}
@@ -587,7 +591,7 @@ defmodule Ingress.ShardSession do
   # --- connect / reconnect ---------------------------------------------------
 
   defp connect(state) do
-    case WS.connect(Config.eventsub_url()) do
+    case WS.connect(Config.eventsub_url(), state.ws_connect_opts) do
       {:ok, ws} ->
         timer = Process.send_after(self(), :welcome_deadline, @welcome_deadline_ms)
         %{state | primary: ws, welcome_timer: timer}

--- a/app/ingress/lib/ingress/ws.ex
+++ b/app/ingress/lib/ingress/ws.ex
@@ -22,15 +22,19 @@ defmodule Ingress.WS do
           | {:frame, Mint.WebSocket.frame()}
           | {:closed, term()}
 
-  @spec connect(String.t()) :: {:ok, t()} | {:error, term()}
-  def connect(url) do
+  @spec connect(String.t(), keyword()) :: {:ok, t()} | {:error, term()}
+  def connect(url, opts \\ []) do
     uri = URI.parse(url)
     {scheme, ws_scheme, default_port} = schemes(uri.scheme)
     port = uri.port || default_port
     path = (uri.path || "/") <> if(uri.query, do: "?" <> uri.query, else: "")
+    transport_opts = Keyword.get(opts, :transport_opts, [])
 
     with {:ok, conn} <-
-           Mint.HTTP.connect(scheme, uri.host, port, protocols: [:http1], transport_opts: []),
+           Mint.HTTP.connect(scheme, uri.host, port,
+             protocols: [:http1],
+             transport_opts: transport_opts
+           ),
          {:ok, conn, ref} <- Mint.WebSocket.upgrade(ws_scheme, conn, path, []) do
       {:ok, %__MODULE__{conn: conn, ref: ref}}
     else

--- a/app/ingress/test/capacity_test.exs
+++ b/app/ingress/test/capacity_test.exs
@@ -8,8 +8,9 @@ defmodule Ingress.CapacityTest do
     assert Capacity.pod_target_eps() == 105_000
     assert Capacity.nats_rated_eps() == 123_000
     assert Capacity.nats_target_eps() == 92_250
-    assert Capacity.websocket_rated_eps() == 12_500
-    assert Capacity.websocket_target_eps() == 9_375
+    assert Capacity.websocket_rated_eps() == 16_000
+    assert Capacity.websocket_target_eps() == 12_000
+    assert Capacity.websocket_autoscale_max_shards() == 11
     assert Capacity.target_utilization_pct() == 75
   end
 
@@ -23,7 +24,8 @@ defmodule Ingress.CapacityTest do
              effective_target_eps: 92_250,
              bottleneck: "nats",
              pod_rated_eps: 140_000,
-             websocket_rated_eps: 12_500
+             websocket_rated_eps: 16_000,
+             websocket_autoscale_max_shards: 11
            } = Capacity.snapshot(5)
   end
 end

--- a/app/ingress/test/shard_scaler_policy_test.exs
+++ b/app/ingress/test/shard_scaler_policy_test.exs
@@ -21,9 +21,10 @@ defmodule Ingress.ShardScaler.PolicyTest do
 
   describe "capacity model" do
     test "uses the measured socket rating and keeps a 25% burst cushion" do
-      assert Policy.shard_rated_eps() == 12_500
+      assert Policy.shard_rated_eps() == 16_000
       assert Policy.target_utilization_pct() == 75
       assert Policy.budget_per_window() == div(Policy.rated_per_window() * 75, 100)
+      assert Policy.autoscale_max_shards(@max) == 11
     end
 
     test "shards_needed sizes from aggregate at target utilization" do
@@ -95,9 +96,14 @@ defmodule Ingress.ShardScaler.PolicyTest do
       assert {4, %{high: 1, low: 0}, :hold} = Policy.evaluate(high, 4, ticks, @min, @max)
     end
 
-    test "needed count clamps at max_shards" do
+    test "needed count clamps at the NATS-limited useful shard count" do
       s = sample(Policy.budget_per_window() * 50)
-      assert {@max, _, :up} = Policy.evaluate(s, 4, Policy.reset_ticks(), @min, @max)
+      assert {11, _, :up} = Policy.evaluate(s, 4, Policy.reset_ticks(), @min, @max)
+    end
+
+    test "operator max remains authoritative below the NATS-limited ceiling" do
+      s = sample(Policy.budget_per_window() * 50)
+      assert {8, _, :up} = Policy.evaluate(s, 4, Policy.reset_ticks(), @min, 8)
     end
   end
 
@@ -199,7 +205,7 @@ defmodule Ingress.ShardScaler.PolicyTest do
     end
 
     test "above both the ratio and the absolute floor is concentrated" do
-      assert Policy.concentrated?(%{responsive_count: 4, avg_load: 1_000, max_load: 150_000})
+      assert Policy.concentrated?(%{responsive_count: 4, avg_load: 1_000, max_load: 200_000})
     end
 
     test "a single responsive shard is never concentrated, regardless of ratio" do

--- a/console/admin/src/lib/server/sample.ts
+++ b/console/admin/src/lib/server/sample.ts
@@ -27,6 +27,7 @@ export const sampleSnapshot: ShardSnapshot = {
   desired_count: 4,
   target: 4,
   min_shards: 2,
+  max_shards: 11,
   autoscale: false,
   capacity: {
     benchmark: 'cached_chat_full_path_in_vm_puback',
@@ -43,8 +44,9 @@ export const sampleSnapshot: ShardSnapshot = {
     effective_rated_eps: 123_000,
     effective_target_eps: 92_250,
     bottleneck: 'nats',
-    websocket_rated_eps: 12_500,
-    websocket_target_eps: 9_375
+    websocket_rated_eps: 16_000,
+    websocket_target_eps: 12_000,
+    websocket_autoscale_max_shards: 11
   }
 };
 

--- a/console/admin/src/lib/throughput.ts
+++ b/console/admin/src/lib/throughput.ts
@@ -1,7 +1,7 @@
 import type { IngressCapacity, ShardSnapshot } from '@bagel/shared';
 
 const FALLBACK_POD_RATED_EPS = 140_000;
-const FALLBACK_WEBSOCKET_RATED_EPS = 12_500;
+const FALLBACK_WEBSOCKET_RATED_EPS = 16_000;
 const FALLBACK_NATS_RATED_EPS = 123_000;
 const FALLBACK_TARGET_PCT = 75;
 const FALLBACK_WINDOW_SECONDS = 60;
@@ -39,7 +39,8 @@ export function resolveCapacity(snapshot: ShardSnapshot): IngressCapacity {
     effective_target_eps: Math.min(fleetTarget, natsTarget),
     bottleneck: FALLBACK_NATS_RATED_EPS <= fleetRated ? 'nats' : 'ingress_compute',
     websocket_rated_eps: FALLBACK_WEBSOCKET_RATED_EPS,
-    websocket_target_eps: websocketTarget
+    websocket_target_eps: websocketTarget,
+    websocket_autoscale_max_shards: Math.ceil(FALLBACK_NATS_RATED_EPS / websocketTarget)
   };
 }
 

--- a/console/admin/src/routes/(admin)/shards/+page.svelte
+++ b/console/admin/src/routes/(admin)/shards/+page.svelte
@@ -93,6 +93,7 @@
   const cm = $derived(snap?.conduit_manager);
   const capacity = $derived(snap ? resolveCapacity(snap) : null);
   const minShards = $derived(snap?.min_shards ?? 1);
+  const maxShards = $derived(snap?.max_shards ?? capacity?.websocket_autoscale_max_shards ?? 11);
   const autoscaleOn = $derived(snap?.autoscale ?? false);
 
   // Scale stepper: tracks user edits; resets when the authoritative base moves.
@@ -279,6 +280,7 @@
         <div class="ctrl-stat"><span class="ctrl-label">desired</span><span class="ctrl-val">{snap.desired_count ?? '—'}</span></div>
         <div class="ctrl-stat"><span class="ctrl-label">target</span><span class="ctrl-val">{snap.target ?? '—'}</span></div>
         <div class="ctrl-stat"><span class="ctrl-label">min</span><span class="ctrl-val">{snap.min_shards ?? '—'}</span></div>
+        <div class="ctrl-stat"><span class="ctrl-label">max</span><span class="ctrl-val">{maxShards}</span></div>
       </div>
 
       <!-- Manual scale: input stays submittable while autoscale is on (visually
@@ -297,6 +299,7 @@
             name="count"
             class="step-input"
             min={minShards}
+            max={maxShards}
             value={scaleCount}
             oninput={(e) => {
               const v = parseInt((e.target as HTMLInputElement).value, 10);
@@ -304,7 +307,7 @@
             }}
             aria-label="shard count"
           />
-          <button type="button" class="step-btn" aria-label="increase shard count" onclick={() => scaleOffset++}>+</button>
+          <button type="button" class="step-btn" aria-label="increase shard count" disabled={scaleCount >= maxShards} onclick={() => scaleOffset++}>+</button>
         </div>
         <button type="submit" class="btn-apply" disabled={autoscaleOn || busy}>Apply</button>
         {#if autoscaleOn}<span class="ctrl-hint">disable autoscale to set manually</span>{/if}

--- a/console/admin/test/throughput.test.ts
+++ b/console/admin/test/throughput.test.ts
@@ -33,7 +33,8 @@ describe('throughput capacity', () => {
     expect(capacity.effective_rated_eps).toBe(123_000);
     expect(capacity.effective_target_eps).toBe(92_250);
     expect(capacity.bottleneck).toBe('nats');
-    expect(capacity.websocket_target_eps).toBe(9_375);
+    expect(capacity.websocket_target_eps).toBe(12_000);
+    expect(capacity.websocket_autoscale_max_shards).toBe(11);
     expect(capacity.target_utilization_pct).toBe(75);
   });
 
@@ -49,11 +50,11 @@ describe('throughput capacity', () => {
 
   test('percentage and bar share the same rated denominator', () => {
     const rate = eventsPerSecond(420_000, 60);
-    const utilization = utilizationPct(rate, 12_500);
+    const utilization = utilizationPct(rate, 16_000);
 
     expect(rate).toBe(7_000);
-    expect(utilization).toBeCloseTo(56);
-    expect(barWidth(utilization)).toBe(56);
+    expect(utilization).toBeCloseTo(43.75);
+    expect(barWidth(utilization)).toBe(44);
   });
 
   test('75% is the scale target, with warning beginning at 60%', () => {

--- a/console/shared/lib/types.ts
+++ b/console/shared/lib/types.ts
@@ -186,6 +186,7 @@ export interface ShardSnapshot {
   desired_count: number;
   target: number;
   min_shards: number;
+  max_shards?: number;
   autoscale: boolean;
   max_load?: number;
   max_load_shard_id?: number | null;
@@ -211,6 +212,7 @@ export interface IngressCapacity {
   bottleneck: 'nats' | 'ingress_compute';
   websocket_rated_eps: number;
   websocket_target_eps: number;
+  websocket_autoscale_max_shards: number;
 }
 
 export interface NavLink {


### PR DESCRIPTION
## What\n- Add a production-shaped TLS WebSocket benchmark for the actual Twitch shard session path.\n- Rate each shard at 16,000 events/s and scale at 75% sustained use (12,000 events/s).\n- Cap autoscaling at 11 shards so the 123,000 events/s NATS ceiling remains the system-wide maximum.\n- Surface the effective shard maximum in the admin API and console.\n\n## Why\nThe deployment now runs three ingress pods, one per eligible node. Autoscaling should follow measured Twitch WebSocket capacity rather than treating NATS throughput as per-shard capacity.\n\nThe slowest measured node sustained 17,516 events/s across the real ShardSession decode and dispatch path with no backlog. The 16,000 events/s rating preserves margin, and the 12,000 events/s target triggers scale-out at 75% utilization.\n\n## Impact\n- Baseline remains 3 ingress pods with one pod per node (merged in #411).\n- Scale-out starts after two consecutive 30-second samples at or above 12,000 events/s per shard.\n- Immediate pressure handling remains in place above the 16,000 events/s rated capacity.\n- Maximum shard count is 11: ceil(123,000 / 12,000).\n\n## Checks\n- Ingress: 140 tests, 0 failures\n- Admin throughput tests: 4 passed\n- Svelte check: 0 errors, 0 warnings\n- Kubernetes manifest client dry-run passed\n- WebSocket benchmark: 9 samples across node2, node3, and worker1; no pending dispatcher work