### PR TITLE
chore(net): cluster-wide network tune + CoreDNS re-home

### DIFF
--- a/deploy/infra/cluster/coredns.yaml
+++ b/deploy/infra/cluster/coredns.yaml
@@ -1,0 +1,225 @@
+# Cluster DNS. Replaces the k3s-packaged coredns addon (skipped via
+# coredns.yaml.skip on the node2 server since the 2026-06-30 DNS-stall fix,
+# when the stock 1-replica Deployment was hand-converted to a DaemonSet).
+# This file brings that hand-applied state under Flux ownership with two
+# deliberate changes (2026-07-15 network-tune):
+#
+#   1. CoreDNS no longer runs on node1: required nodeAffinity keeps the
+#      DaemonSet on node2/node3/worker1 only. node1 is the infra/frontend
+#      node; the hot path is anti-affinitied off it, so every hot-path pod
+#      now has a node-local resolver.
+#   2. kube-dns gets trafficDistribution: PreferSameNode (same mechanism as
+#      the nats Service): queries from node2/node3/worker1 never cross the
+#      tailnet; node1 pods fall back to the nearest remote replica.
+#
+# The ConfigMap deliberately declares ONLY the Corefile key. NodeHosts is
+# owned and continuously updated by the k3s node-hosts controller; omitting
+# it here keeps server-side apply from fighting over that key. Apply this
+# file with SSA (Flux does; for manual use: kubectl apply --server-side).
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: coredns
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:coredns
+  labels:
+    kubernetes.io/bootstrapping: rbac-defaults
+rules:
+  - apiGroups: [""]
+    resources: [endpoints, services, pods, namespaces]
+    verbs: [list, watch]
+  - apiGroups: [discovery.k8s.io]
+    resources: [endpointslices]
+    verbs: [list, watch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:coredns
+  labels:
+    kubernetes.io/bootstrapping: rbac-defaults
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:coredns
+subjects:
+  - kind: ServiceAccount
+    name: coredns
+    namespace: kube-system
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns
+  namespace: kube-system
+data:
+  Corefile: |
+    .:53 {
+        errors
+        health
+        ready
+        kubernetes cluster.local in-addr.arpa ip6.arpa {
+          pods insecure
+          fallthrough in-addr.arpa ip6.arpa
+        }
+        hosts /etc/coredns/NodeHosts {
+          ttl 60
+          reload 15s
+          fallthrough
+        }
+        prometheus :9153
+        cache 30 {
+          success 9984 30
+          denial 9984 5
+          prefetch 5 60s 10%
+          serve_stale 3600s immediate
+        }
+        loop
+        reload
+        loadbalance
+        import /etc/coredns/custom/*.override
+        # Forward external names to routable anycast resolvers instead of
+        # /etc/resolv.conf: node1's host upstream is an OCI link-local address
+        # (169.254.169.254) that CoreDNS cannot reach from the pod network, which
+        # stalled fresh lookups on that node.
+        forward . 1.1.1.1 8.8.8.8 9.9.9.9 {
+          policy sequential
+          max_concurrent 1000
+        }
+    }
+    import /etc/coredns/custom/*.server
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: coredns
+  namespace: kube-system
+  labels:
+    k8s-app: kube-dns
+    kubernetes.io/name: CoreDNS
+spec:
+  revisionHistoryLimit: 0
+  selector:
+    matchLabels:
+      k8s-app: kube-dns
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        k8s-app: kube-dns
+    spec:
+      serviceAccountName: coredns
+      priorityClassName: system-cluster-critical
+      # DNS lives on the hot nodes only; node1 pods use a remote replica via
+      # the PreferSameNode fallback on the kube-dns Service.
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: NotIn
+                    values: [node1]
+      nodeSelector:
+        kubernetes.io/os: linux
+      dnsPolicy: Default
+      tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+        # worker1 carries the worker-pool taint; DNS must still run there.
+        - key: itsbagelbot.dev/pool
+          operator: Equal
+          value: worker-pool
+          effect: NoSchedule
+      containers:
+        - name: coredns
+          image: rancher/mirrored-coredns-coredns:1.14.3
+          imagePullPolicy: IfNotPresent
+          args: ["-conf", "/etc/coredns/Corefile"]
+          ports:
+            - {containerPort: 53, name: dns, protocol: UDP}
+            - {containerPort: 53, name: dns-tcp, protocol: TCP}
+            - {containerPort: 9153, name: metrics, protocol: TCP}
+          resources:
+            requests: {cpu: 100m, memory: 70Mi}
+            limits: {memory: 170Mi}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              add: [NET_BIND_SERVICE]
+              drop: [all]
+            readOnlyRootFilesystem: true
+          livenessProbe:
+            httpGet: {path: /health, port: 8080, scheme: HTTP}
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet: {path: /ready, port: 8181, scheme: HTTP}
+            periodSeconds: 2
+            successThreshold: 1
+            failureThreshold: 3
+          volumeMounts:
+            - {name: config-volume, mountPath: /etc/coredns, readOnly: true}
+            - {name: custom-config-volume, mountPath: /etc/coredns/custom, readOnly: true}
+      volumes:
+        - name: config-volume
+          configMap:
+            name: coredns
+            items:
+              - {key: Corefile, path: Corefile}
+              - {key: NodeHosts, path: NodeHosts}
+        - name: custom-config-volume
+          configMap:
+            name: coredns-custom
+            optional: true
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-dns
+  namespace: kube-system
+  annotations:
+    prometheus.io/port: "9153"
+    prometheus.io/scrape: "true"
+  labels:
+    k8s-app: kube-dns
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: CoreDNS
+spec:
+  type: ClusterIP
+  clusterIP: 10.43.0.10
+  ipFamilyPolicy: SingleStack
+  # Resolve against the node-local CoreDNS when one exists (node2/node3/
+  # worker1); node1 falls back to a remote replica automatically.
+  trafficDistribution: PreferSameNode
+  selector:
+    k8s-app: kube-dns
+  ports:
+    - {name: dns, port: 53, protocol: UDP, targetPort: 53}
+    - {name: dns-tcp, port: 53, protocol: TCP, targetPort: 53}
+    - {name: metrics, port: 9153, protocol: TCP, targetPort: 9153}
+---
+# Drains/rolls may take one replica at a time, never two.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: coredns
+  namespace: kube-system
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      k8s-app: kube-dns

--- a/deploy/infra/cluster/kustomization.yaml
+++ b/deploy/infra/cluster/kustomization.yaml
@@ -8,6 +8,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - cloudflared.yaml
+  # coredns replaces the skipped k3s addon (coredns.yaml.skip on node2);
+  # DaemonSet on node2/node3/worker1 + PreferSameNode kube-dns.
+  - coredns.yaml
   - newrelic-dopplersecrets.yaml
   - newrelic-logging.yaml
   - traefik-config.yaml

--- a/deploy/k8s/network-tune/2026-07-15-baseline.md
+++ b/deploy/k8s/network-tune/2026-07-15-baseline.md
@@ -1,0 +1,66 @@
+# Cluster network baseline — 2026-07-15 (before tuning)
+
+Measured before any change from the tailscale + cluster-network tuning plan.
+All cross-node traffic rides flannel VXLAN over tailscale0 (wireguard-go).
+
+## Topology facts
+
+- flannel backend `vxlan` on all four nodes; MTU chain: tailscale0 1280 →
+  flannel.1/cni0/pods 1230.
+- Every tailscale peer pair is **direct** (no DERP). node3↔node2 negotiates
+  IPv6 underlay.
+- tailscale 1.98.8 on node1/node2/node3; **1.98.4 on worker1** (drift).
+- BBR + fq already active on all nodes. `rmem_max`/`wmem_max` = 4 MiB
+  (below the ~7.5 MiB wireguard-go asks for). `netdev_max_backlog` 16384 on
+  node1, 1000 elsewhere.
+- worker1 has **no ethernet interface**; its only link is wifi
+  (2x2 80 MHz VHT, tx phy 650 Mbps, signal -51 dBm). The 3 gbps fiber plan
+  sits behind that air gap.
+- No socket-buffer clamp warnings and no GSO/GRO complaints in tailscaled
+  journals on any node.
+
+## Underlay path-MTU probes (ping -M do, payload+28 = wire bytes)
+
+| Path | 1460 wire | 1500 wire | Underlay RTT |
+|---|---|---|---|
+| node3 → node2 | — | pass | 0.4 ms (same metro) |
+| node1 → node2 | pass | pass | 1.7 ms |
+| node1 → node3 | pass | pass | 1.9 ms |
+| worker1 → node3 | pass | fail (PPPoE ~1492) | ~4 ms |
+| inbound to worker1 | n/a — NAT drops inbound ICMP | | |
+| inbound to node1 | n/a — OCI filters ICMP | | |
+
+Conclusion: wire ≤ 1460 is safe on every measurable path → tailscale0 MTU
+1350 (wire ≈ 1430) has margin everywhere. tailscale's own PMTUD already
+reported `mtu=1360` healthy in magicsock logs.
+
+## tailscale ping RTT matrix (tailnet, 3-ping best)
+
+| From \ To | node1 | node2 | node3 | worker1 |
+|---|---|---|---|---|
+| node1 | — | 2 ms | 2 ms | 6 ms |
+| node2 | 3 ms | — | 1 ms | 4 ms |
+| node3 | 2 ms | 1 ms | — | 4 ms |
+| worker1 | 5 ms | 5 ms | 6 ms | — |
+
+## iperf3 TCP over tailscale0 (5 s, single stream, iperf 3.17.1)
+
+| Src → Dst | Throughput | Retransmits |
+|---|---:|---:|
+| node1 → node2 | 1195 Mbps | 439 |
+| node1 → node3 | 1215 Mbps | 553 |
+| node1 → worker1 | 265 Mbps | 479 |
+| node2 → node1 | 1094 Mbps | 177 |
+| node2 → node3 | 1169 Mbps | 282 |
+| node2 → worker1 | 270 Mbps | 743 |
+| node3 → node1 | 1200 Mbps | 634 |
+| node3 → node2 | 926 Mbps | 501 |
+| node3 → worker1 | 267 Mbps | 798 |
+| worker1 → node1 | 267 Mbps | 782 |
+| worker1 → node2 | 264 Mbps | 952 |
+| worker1 → node3 | 270 Mbps | 921 |
+
+Read: DC↔DC pairs sustain ~0.9–1.2 Gbps through wireguard-go at MTU 1280.
+Every worker1 path is pinned at ~265 Mbps with 2–4× the retransmits — the
+wifi link is the ceiling and the loss source, not tailscale and not the WAN.
+A wired uplink for worker1 is the single biggest lever on that node.

--- a/deploy/k8s/network-tune/2026-07-15-results.md
+++ b/deploy/k8s/network-tune/2026-07-15-results.md
@@ -1,0 +1,85 @@
+# Cluster network tune — 2026-07-15 results
+
+Companion to `2026-07-15-baseline.md`. All four phases landed the same day.
+
+## What changed
+
+1. **Socket buffers + sysctl parity** (`90-bagelbot-net.conf`, all nodes):
+   `rmem_max`/`wmem_max` 4 → 16 MiB, `netdev_max_backlog` 16384 everywhere,
+   `tcp_mtu_probing=1`. After the tailscaled restarts, wireguard-go's UDP
+   sockets sit at 14.6 MB actual (`rb14680064`) instead of clamping at 8.4 MB.
+2. **worker1 tailscale** 1.98.4 → 1.98.9.
+3. **MTU raise**: `TS_DEBUG_MTU=1350` systemd override on tailscaled
+   (`tailscaled-10-mtu.conf`), all nodes. tailscale0 1280 → 1350, flannel/cni0
+   1230 → 1300 after k3s(-agent) restarts. Full-size 1350-byte DF pings pass
+   between every node pair. Existing pods keep 1230 veths until they roll.
+4. **CoreDNS re-homed** (`deploy/infra/cluster/coredns.yaml`, Flux-owned):
+   DaemonSet now excludes node1 (one replica each on node2/node3/worker1),
+   kube-dns Service gained `trafficDistribution: PreferSameNode`, PDB
+   minAvailable 2. The k3s packaged addon stays skipped (`coredns.yaml.skip`
+   on node2 since 2026-06-30); NodeHosts stays k3s-managed (SSA, ConfigMap
+   declares only Corefile).
+
+## Incident during rollout — read before restarting tailscaled
+
+Restarting tailscaled recreated tailscale0 and on **node1 and node3** left
+flannel VXLAN stranded: host↔host traffic fine, cross-node **pod** traffic
+blackholed (node2/worker1 were unaffected — trigger not fully understood).
+On node3 this cut nats-0 off (`JetStream is still recovering meta layer`,
+firehose unavailable ~6 min); on node1 it silently broke every cross-node DNS
+query because both CoreDNS replicas still lived there. **Heal = restart
+k3s/k3s-agent on the affected node.** Rule: after any tailscaled restart,
+curl a pod IP on that node from another node before moving on. (Phase 4
+removes the DNS half of this failure mode for good.)
+
+## After numbers
+
+### DNS to 10.43.0.10 (5 UDP queries, ms)
+
+| Node | Before (both replicas on node1) | After |
+|---|---|---|
+| node2 | cross-node, drop-prone (5 s stall incidents) | 0.23–0.39 |
+| node3 | cross-node, drop-prone | 0.17–0.5 |
+| worker1 | cross-node, drop-prone | 0.08–0.24 |
+| node1 | node-local | 2.8–8.5 (remote fallback, acceptable) |
+
+Hot-path nodes now resolve in sub-millisecond node-local hops; the tailnet
+UDP DNS failure mode is gone by construction.
+
+### iperf3 TCP over tailscale0 (5 s single stream)
+
+| Path | Before | After |
+|---|---:|---:|
+| node1 → node3 | 1215 Mbps | 1334 Mbps |
+| node3 → node1 | 1200 Mbps | 1219 Mbps |
+| node1 → node2 | 1195 Mbps | 1171 Mbps |
+| node2 → node3 | 1169 Mbps | 1186 Mbps |
+| node3 → node2 | 926 Mbps | 979 Mbps |
+| worker1 ↔ any | 264–270 Mbps | 266–274 Mbps |
+
+DC↔DC: flat to +10% on a single flow (single-stream is cwnd/loss-bound; the
+MTU and buffer changes mostly buy fewer packets per byte and burst-loss
+headroom rather than single-flow ceiling). worker1 is pinned at ~270 Mbps in
+every direction by its wifi link (2x2 80 MHz, ~650 Mbps phy) with 2–4× the
+retransmits of wired paths. **A wired uplink is the only fix and remains the
+single biggest lever for that node** — hardware decision, user's call.
+
+### NATS acceptance (3M sustained, production shape, msg-id on)
+
+| Run | Acked | Errors | Aggregate rate |
+|---|---:|---:|---:|
+| 2026-07-12 rating (pre-tune) | 3,000,000 | 0 | 86,017/s |
+| 2026-07-15 post-tune | 3,000,000 | 0 | ~86,050/s |
+
+Unchanged, as expected: the 86k/s cap is the broker's serialized per-stream
+ingest, not the network. The network tune buys burst robustness and latency
+(DNS, PubAck jitter, fewer pps); raising the ingest cap itself is the parked
+NATS-broker track (atomic batch wire, already provisioned server-side).
+
+## Node-side state mirrored in this directory
+
+- `90-bagelbot-net.conf` → `/etc/sysctl.d/90-bagelbot-net.conf` (all nodes)
+- `tailscaled-10-mtu.conf` → `/etc/systemd/system/tailscaled.service.d/10-mtu.conf` (all nodes)
+
+Both must be restored on any node rebuild (same lesson as the untracked k3s
+GOMEMLIMIT on node2).

--- a/deploy/k8s/network-tune/90-bagelbot-net.conf
+++ b/deploy/k8s/network-tune/90-bagelbot-net.conf
@@ -1,0 +1,18 @@
+# Cluster-wide network tuning — lives at /etc/sysctl.d/90-bagelbot-net.conf
+# on every node (node1, node2, node3, worker1). This repo copy is the source
+# of truth for node rebuilds (same lesson as the k3s GOMEMLIMIT drift).
+#
+# rmem/wmem: wireguard-go (tailscaled) requests ~7.5 MiB socket buffers; the
+# EL10 default cap of 4 MiB silently clamped them, which fed cross-node UDP
+# burst drops (the 5s DNS stall incident). 16 MiB gives headroom for the
+# tailscale socket and the flannel VXLAN socket alike.
+net.core.rmem_max = 16777216
+net.core.wmem_max = 16777216
+
+# Per-CPU ingress queue for bursts; matches what node1 already ran, brings
+# node2/node3/worker1 up from the 1000 default.
+net.core.netdev_max_backlog = 16384
+
+# Packetization-layer PMTU probing: insurance against any silent MTU
+# blackhole once tailscale0 runs above the 1280 floor (TS_DEBUG_MTU=1350).
+net.ipv4.tcp_mtu_probing = 1

--- a/deploy/k8s/network-tune/tailscaled-10-mtu.conf
+++ b/deploy/k8s/network-tune/tailscaled-10-mtu.conf
@@ -1,0 +1,15 @@
+# Lives at /etc/systemd/system/tailscaled.service.d/10-mtu.conf on every node
+# (node1, node2, node3, worker1). Repo copy is the rebuild source of truth.
+#
+# Raises tailscale0 from the 1280 default to 1350 (wire ≈ 1430 with wireguard
+# overhead). Verified 2026-07-15: every inter-node underlay path passes ≥1460
+# wire (worker1 PPPoE ~1492 is the tightest; DC↔DC pass full 1500). flannel
+# re-derives 1300 for flannel.1/cni0/pods on the next k3s (agent) restart.
+# net.ipv4.tcp_mtu_probing=1 (90-bagelbot-net.conf) is the blackhole backstop.
+#
+# Rollback: delete this file, daemon-reload, restart tailscaled + k3s(-agent).
+# CAUTION: after any tailscaled restart, verify cross-node POD traffic per
+# node (curl a pod IP from another node). 2026-07-15: node1 and node3 kept
+# host-level connectivity but stranded flannel VXLAN until k3s-agent restart.
+[Service]
+Environment=TS_DEBUG_MTU=1350


### PR DESCRIPTION
## What

- **Sysctl parity + socket buffers** (all nodes, mirrored in `deploy/k8s/network-tune/90-bagelbot-net.conf`): rmem/wmem 16MiB (wireguard-go was clamped at 8.4MB), netdev_max_backlog 16384, tcp_mtu_probing=1.
- **MTU raise**: tailscale0 1280→1350 via tailscaled systemd override (mirrored as `tailscaled-10-mtu.conf`); flannel/cni0/pods 1230→1300. Every underlay path probed ≥1460 wire first; full-size DF pings pass on all pairs.
- **CoreDNS re-home** (`deploy/infra/cluster/coredns.yaml`, new Flux-owned manifest): DaemonSet excludes node1, one replica each on node2/node3/worker1, kube-dns Service gains `trafficDistribution: PreferSameNode`, PDB minAvailable 2. ConfigMap declares only Corefile so the k3s node-hosts controller keeps NodeHosts (SSA). k3s packaged addon stays skipped (coredns.yaml.skip on node2).
- Baseline + results docs in `deploy/k8s/network-tune/`.

## Live state

Everything here is already applied to the cluster (2026-07-15) and verified: hot-node DNS 0.08–0.5ms, EndpointSlice forNodes hints active, NATS 3M acceptance 86,050/s zero errors. Merging brings the coredns manifest under the Flux `cluster` Kustomization (prune:true) so GitOps owns it and nothing reverts it.

## Verification

- `kubectl kustomize deploy/infra/cluster` builds clean.
- Post-merge: Flux `cluster` Kustomization reconciles, coredns objects gain Flux inventory labels, DaemonSet stays 3/3 with no pod roll (template unchanged from live).