### PR TITLE
Keep hot RPC responders node-local

### DIFF
--- a/deploy/k8s/commands.yaml
+++ b/deploy/k8s/commands.yaml
@@ -21,7 +21,7 @@ metadata:
   annotations:
     secrets.doppler.com/reload: "true"
 spec:
-  replicas: 3 # one per node; 3 schedulable nodes incl worker1 (tolerates worker-pool); node3 decommissioned
+  replicas: 3 # one per hot-path node: node2, node3, worker1
   revisionHistoryLimit: 3
   minReadySeconds: 10
   strategy:
@@ -60,14 +60,30 @@ spec:
           operator: Exists
           effect: NoExecute
           tolerationSeconds: 60
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: NotIn
+                    values: [node1]
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  app: commands
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: kubernetes.io/hostname
-          whenUnsatisfiable: ScheduleAnyway
+          whenUnsatisfiable: DoNotSchedule
+          matchLabelKeys: [pod-template-hash]
           labelSelector:
             matchLabels:
               app: commands
-      # DaemonSet placement keeps one commands pod per schedulable node.
+      # Required pod anti-affinity prevents old and new ReplicaSets from ever
+      # stacking two commands pods on one hot-path node.
       securityContext:
         runAsNonRoot: true
         runAsUser: 65532

--- a/deploy/k8s/gateway.yaml
+++ b/deploy/k8s/gateway.yaml
@@ -34,9 +34,9 @@ metadata:
   annotations:
     secrets.doppler.com/reload: "true"
 spec:
-  # Stateless and cache-backed: two replicas queue-group the RPC subjects. Not
-  # per-node — the working set is one HTTP client and a Valkey connection.
-  replicas: 2
+  # Stateless and cache-backed: keep one local RPC responder beside Sesame on
+  # each hot-path node; the working set is one HTTP client and Valkey connection.
+  replicas: 3
   revisionHistoryLimit: 3
   minReadySeconds: 10
   strategy:
@@ -75,10 +75,25 @@ spec:
           operator: Exists
           effect: NoExecute
           tolerationSeconds: 60
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: NotIn
+                    values: [node1]
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  app: gateway
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: kubernetes.io/hostname
-          whenUnsatisfiable: ScheduleAnyway
+          whenUnsatisfiable: DoNotSchedule
+          matchLabelKeys: [pod-template-hash]
           labelSelector:
             matchLabels:
               app: gateway

--- a/deploy/k8s/loyalty.yaml
+++ b/deploy/k8s/loyalty.yaml
@@ -21,10 +21,9 @@ metadata:
   annotations:
     secrets.doppler.com/reload: "true"
 spec:
-  # Two replicas suffice: the hot writes are queue-group event folds with
-  # in-memory accumulators, and losing one instance costs at most one flush
-  # window of loss-tolerant deltas.
-  replicas: 2
+  # Keep one local loyalty RPC responder beside Sesame on every hot-path node.
+  # Event folds remain queue-grouped across the three replicas.
+  replicas: 3
   revisionHistoryLimit: 3
   minReadySeconds: 10
   strategy:
@@ -63,10 +62,25 @@ spec:
           operator: Exists
           effect: NoExecute
           tolerationSeconds: 60
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: NotIn
+                    values: [node1]
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  app: loyalty
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: kubernetes.io/hostname
-          whenUnsatisfiable: ScheduleAnyway
+          whenUnsatisfiable: DoNotSchedule
+          matchLabelKeys: [pod-template-hash]
           labelSelector:
             matchLabels:
               app: loyalty

--- a/deploy/k8s/modules.yaml
+++ b/deploy/k8s/modules.yaml
@@ -21,7 +21,7 @@ metadata:
   annotations:
     secrets.doppler.com/reload: "true"
 spec:
-  replicas: 3 # one per node; 3 schedulable nodes incl worker1 (tolerates worker-pool); node3 decommissioned
+  replicas: 3 # one per hot-path node: node2, node3, worker1
   revisionHistoryLimit: 3
   minReadySeconds: 10
   strategy:
@@ -60,14 +60,30 @@ spec:
           operator: Exists
           effect: NoExecute
           tolerationSeconds: 60
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: NotIn
+                    values: [node1]
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  app: modules
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: kubernetes.io/hostname
-          whenUnsatisfiable: ScheduleAnyway
+          whenUnsatisfiable: DoNotSchedule
+          matchLabelKeys: [pod-template-hash]
           labelSelector:
             matchLabels:
               app: modules
-      # DaemonSet placement keeps one modules pod per schedulable node.
+      # Required pod anti-affinity prevents old and new ReplicaSets from ever
+      # stacking two modules pods on one hot-path node.
       securityContext:
         runAsNonRoot: true
         runAsUser: 65532

--- a/deploy/k8s/projector.yaml
+++ b/deploy/k8s/projector.yaml
@@ -21,7 +21,7 @@ metadata:
   annotations:
     secrets.doppler.com/reload: "true"
 spec:
-  replicas: 3 # one per node; 3 schedulable nodes incl worker1 (tolerates worker-pool); node3 decommissioned
+  replicas: 3 # one per hot-path node: node2, node3, worker1
   revisionHistoryLimit: 3
   minReadySeconds: 10
   strategy:
@@ -58,14 +58,30 @@ spec:
           operator: Exists
           effect: NoExecute
           tolerationSeconds: 60
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: NotIn
+                    values: [node1]
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  app: projector
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: kubernetes.io/hostname
-          whenUnsatisfiable: ScheduleAnyway
+          whenUnsatisfiable: DoNotSchedule
+          matchLabelKeys: [pod-template-hash]
           labelSelector:
             matchLabels:
               app: projector
-      # DaemonSet placement keeps one projector pod per schedulable node.
+      # Required pod anti-affinity prevents old and new ReplicaSets from ever
+      # stacking two projector pods on one hot-path node.
       securityContext:
         runAsNonRoot: true
         runAsUser: 65532

--- a/deploy/k8s/users.yaml
+++ b/deploy/k8s/users.yaml
@@ -21,7 +21,7 @@ metadata:
   annotations:
     secrets.doppler.com/reload: "true"
 spec:
-  replicas: 3 # one per node; 3 schedulable nodes incl worker1 (tolerates worker-pool); node3 decommissioned
+  replicas: 3 # one per hot-path node: node2, node3, worker1
   revisionHistoryLimit: 3
   minReadySeconds: 10
   strategy:
@@ -60,14 +60,33 @@ spec:
           operator: Exists
           effect: NoExecute
           tolerationSeconds: 60
+      # Keep RPC responders beside Sesame on the three hot-path nodes. Node1
+      # remains available for stateful/frontend/infra work, but never satisfies
+      # this Deployment's scheduling domain.
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: NotIn
+                    values: [node1]
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  app: users
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: kubernetes.io/hostname
-          whenUnsatisfiable: ScheduleAnyway
+          whenUnsatisfiable: DoNotSchedule
+          matchLabelKeys: [pod-template-hash]
           labelSelector:
             matchLabels:
               app: users
-      # DaemonSet placement keeps one users pod per schedulable node.
+      # Three replicas + three eligible nodes + required pod anti-affinity yields
+      # exactly one users pod per hot-path node, including during rolls.
       # Resolve external hosts (Twitch OAuth token refresh) without the cluster
       # search-domain fan-out (ndots:1) and serialize A/AAAA to dodge the
       # conntrack race; cap any DNS stall well under a few seconds.


### PR DESCRIPTION
## What changed

- restrict users, commands, modules, projector, gateway, and loyalty to node2/node3/worker1
- require same-service pod anti-affinity by hostname so old and new ReplicaSets cannot stack on one node
- make topology spreading hard and revision-scoped
- scale gateway and loyalty to three replicas for one local responder per hot-path node

## Why

Sesame runs on node2/node3/worker1, but node3 had no local users, commands, modules, or projector responder. Those requests unnecessarily crossed the NATS leaf mesh. This makes the hot RPC plane node-local while preserving direct leaf routing as failover.

## Validation

- server-side dry-run passed for all six manifests
- invariant checks confirm three replicas, node1 exclusion, required pod anti-affinity, and hard hostname spread
- node2/node3/worker1 are Ready and schedulable; worker1's taint is tolerated
- requested-resource headroom remains sufficient on all three nodes
