### PR TITLE
feat(nats): isolate R3 benchmark control lane

### DIFF
--- a/deploy/k8s/nats-auth.conf
+++ b/deploy/k8s/nats-auth.conf
@@ -321,12 +321,19 @@ accounts: {
               "$JS.API.STREAM.MSG.GET.KV_admin_lanes",
               "$JS.API.DIRECT.GET.KV_admin_lanes",
               "$JS.API.DIRECT.GET.KV_admin_lanes.>",
+              # The live capacity harness is restricted to one fixed stream.
+              # Keep these exact subjects: a wildcard here could mutate a
+              # production stream instead of the isolated benchmark lane.
+              "$JS.API.STREAM.CREATE.R3_SHADOW_BENCH",
+              "$JS.API.STREAM.DELETE.R3_SHADOW_BENCH",
+              "$JS.API.STREAM.LEADER.STEPDOWN.R3_SHADOW_BENCH",
               "$KV.admin_lanes.>"
             ]
           }
           subscribe: {
             allow: [
               "twitch.ingress.status.>",
+              "$JS.EVENT.ADVISORY.STREAM.LEADER_ELECTED.R3_SHADOW_BENCH",
               "_INBOX.>"
             ]
           }

--- a/deploy/k8s/nats_auth_test.go
+++ b/deploy/k8s/nats_auth_test.go
@@ -13,6 +13,7 @@ const jetStreamAPI = "$JS.API."
 
 var busUserPattern = regexp.MustCompile(`(?m)^[ \t]*user: "([a-z_]+_bus)"`)
 var jsSubjectPattern = regexp.MustCompile(`"(\$JS[^"]+)"`)
+var streamMutationPattern = regexp.MustCompile(`^\$JS\.API\.STREAM\.(CREATE|UPDATE|DELETE|LEADER\.STEPDOWN)\.`)
 
 // TestServiceBusJetStreamPermissionsAreExact is the regression gate for the
 // BUS-account blast radius. A broad $JS.> grant, an extra stream, or a newly
@@ -57,6 +58,35 @@ func TestServiceBusJetStreamPermissionsAreExact(t *testing.T) {
 				t.Fatalf("JetStream grants differ (-want +got):\nwant %v\n got %v", want, got)
 			}
 		})
+	}
+}
+
+// TestAdminBenchmarkStreamPermissionsAreExact keeps the production capacity
+// runner confined to its disposable stream. The admin retains its existing KV
+// ownership, but may not gain wildcard mutation access to the BUS account.
+func TestAdminBenchmarkStreamPermissionsAreExact(t *testing.T) {
+	config := sourceFile{name: "nats-auth.conf"}.read(t)
+	block, ok := (authConfig{body: config}).busUserBlocks(t)["admin_bus"]
+	if !ok {
+		t.Fatal("missing admin_bus authorization block")
+	}
+
+	var got []string
+	for _, subject := range block.jetStreamSubjects() {
+		if streamMutationPattern.MatchString(subject) || strings.Contains(subject, "R3_SHADOW_BENCH") {
+			got = append(got, subject)
+		}
+	}
+	want := []string{
+		"$JS.API.STREAM.CREATE.KV_admin_lanes",
+		"$JS.API.STREAM.CREATE.R3_SHADOW_BENCH",
+		"$JS.API.STREAM.DELETE.R3_SHADOW_BENCH",
+		"$JS.API.STREAM.LEADER.STEPDOWN.R3_SHADOW_BENCH",
+		"$JS.API.STREAM.UPDATE.KV_admin_lanes",
+		"$JS.EVENT.ADVISORY.STREAM.LEADER_ELECTED.R3_SHADOW_BENCH",
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("admin stream mutation grants differ (-want +got):\nwant %v\n got %v", want, got)
 	}
 }
 


### PR DESCRIPTION
## What changed

- grant `admin_bus` create, delete, and leader-stepdown access to the single fixed `R3_SHADOW_BENCH` stream
- grant the matching exact leader-election advisory subscription
- add a regression test that rejects broader BUS stream-mutation permissions

## Why

The production capacity runner needs a short-lived control identity for its isolated R3 stream. The previous runbook described that identity, but the live authorization model did not grant it. Reusing the existing Doppler-managed admin BUS credential with exact subjects avoids a new broker credential and prevents the harness from mutating production streams.

The NATS config reloader applies this additive ACL without restarting the brokers or application workloads.

## Validation

- `go test ./deploy/k8s`
- `go vet ./...`
- `kubectl kustomize deploy/k8s`
- NATS 2.14.3 config parse validation

`go test ./...` is currently blocked by the unrelated UTC-midnight fixture bug in `TestAdminEnrollmentBucketsPerDay`; that deterministic correction is being published separately.
