### PR TITLE
fix(nats,sesame): feed counter ACL import, valkey total view, natural bot-name matching

### DIFF
--- a/app/modules/rpc/personality.go
+++ b/app/modules/rpc/personality.go
@@ -26,9 +26,10 @@ type PersonalityWiring struct {
 }
 
 // SubscribePersonality answers the personality verbs under w.Prefix. There is
-// one: feed, the permanent global feed-counter bump. It rides the same
-// MODULES_RPC account export as the quote verbs, so no ACL change is needed
-// for sesame to call it.
+// one: feed, the permanent global feed-counter bump. It rides the MODULES_RPC
+// account export like the quote verbs, but sesame's WORKER_RPC imports are
+// scoped per subtree, so the verb needs its own import line in nats-auth.conf
+// (a bare export is not enough for the request to cross accounts).
 func SubscribePersonality(w PersonalityWiring) error {
 	handler := func(ctx context.Context, _ modulesrpc.FeedBumpRequest) modulesrpc.FeedBumpReply {
 		total, err := w.Repo.FeedBump(ctx)

--- a/app/sesame/engine/personality_valkey.go
+++ b/app/sesame/engine/personality_valkey.go
@@ -19,9 +19,10 @@ const personalityTTL = 12 * time.Hour
 //
 //   - a monotonic per-channel fact cursor (personality:fact:<id>, no TTL) so
 //     the fun-fact list plays in order instead of repeating at random;
-//   - the today half of the global feed counter (personality:feed:global,
-//     TTL window); the permanent half is the modules service's DB row,
-//     reached through the injected FeedTotalBumper;
+//   - both halves of the global feed counter: the today window
+//     (personality:feed:global, TTL) and a live view of the lifetime total
+//     (personality:feed:total, no TTL) that is seeded from and persisted to
+//     the modules service's DB row through the injected FeedTotalBumper;
 //   - a per-stream mood (personality:mood:<id>), first roll wins.
 //
 // Fact and mood are best-effort (the module falls back to stateless randomness
@@ -48,19 +49,24 @@ func (s *ValkeyPersonality) FactCursor(ctx context.Context, broadcasterID uint64
 	return s.client.Do(ctx, s.client.B().Incr().Key(key).Build()).AsInt64()
 }
 
-// feedKey is the today half of the fleet-wide feed counter: one bagel, fed by
+// feedTodayKey is the today half of the fleet-wide feed counter: one bagel, fed by
 // every channel at once.
-const feedKey = "personality:feed:global"
+const feedTodayKey = "personality:feed:global"
 
-// Feed records one feeding on both counters and returns them: the permanent DB
-// total first (authoritative, never resets), then the valkey today window. An
-// error on either side errors the whole call; the module then stays silent
-// instead of reporting half a readout.
+// feedTotalKey is the valkey live view of the permanent feed total. The DB row
+// in the modules service stays the source of truth; this key exists so the
+// reply path never waits on an RPC once the view is warm.
+const feedTotalKey = "personality:feed:total"
+
+// Feed records one feeding on both counters and returns them: the lifetime
+// total from the valkey live view (DB-seeded, persisted behind the reply) and
+// the valkey today window. An error on either side errors the whole call; the
+// module then stays silent instead of reporting half a readout.
 func (s *ValkeyPersonality) Feed(ctx context.Context) (FeedCounts, error) {
 	if s.total == nil {
 		return FeedCounts{}, errors.New("personality: no feed total backend")
 	}
-	total, err := s.total.FeedBump(ctx)
+	total, err := s.feedTotal(ctx)
 	if err != nil {
 		return FeedCounts{}, err
 	}
@@ -71,17 +77,55 @@ func (s *ValkeyPersonality) Feed(ctx context.Context) (FeedCounts, error) {
 	return FeedCounts{Today: today, Total: total}, nil
 }
 
+// feedTotal serves the lifetime total from the valkey view. A warm view
+// answers locally and lets the DB bump ride behind the reply; a cold view
+// (INCR landed on a fresh key after a flush or failover) seeds itself from the
+// synchronous RPC bump, which also counts this feeding. Two pods racing a cold
+// key can briefly answer a low number; the seed's SET snaps the view back to
+// the DB total, so drift self-heals at every cold start.
+func (s *ValkeyPersonality) feedTotal(ctx context.Context) (uint64, error) {
+	n, err := s.client.Do(ctx, s.client.B().Incr().Key(feedTotalKey).Build()).AsInt64()
+	if err != nil {
+		return 0, err
+	}
+	if n > 1 {
+		s.bumpBehind()
+		return uint64(n), nil
+	}
+	dbTotal, err := s.total.FeedBump(ctx)
+	if err != nil {
+		return 0, err
+	}
+	if err := s.client.Do(ctx, s.client.B().Set().Key(feedTotalKey).Value(strconv.FormatUint(dbTotal, 10)).Build()).Error(); err != nil {
+		s.log.Warn("personality: feed total seed failed", zap.Error(err))
+	}
+	return dbTotal, nil
+}
+
+// bumpBehind persists one feeding to the modules service off the reply path,
+// mirroring ValkeyReputation.Bump: a failure only lets the DB lag the view
+// until the next cold seed reconciles them.
+func (s *ValkeyPersonality) bumpBehind() {
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if _, err := s.total.FeedBump(ctx); err != nil {
+			s.log.Debug("personality: feed write-behind failed", zap.Error(err))
+		}
+	}()
+}
+
 // feedToday bumps and returns the today window. The first feed of the window
 // claims the TTL; later feeds leave it in place so the count reads as "today",
 // not a sliding forever-window.
 func (s *ValkeyPersonality) feedToday(ctx context.Context) (uint64, error) {
-	n, err := s.client.Do(ctx, s.client.B().Incr().Key(feedKey).Build()).AsInt64()
+	n, err := s.client.Do(ctx, s.client.B().Incr().Key(feedTodayKey).Build()).AsInt64()
 	if err != nil {
 		return 0, err
 	}
 	if n == 1 {
 		seconds := int64(personalityTTL.Seconds())
-		if err := s.client.Do(ctx, s.client.B().Expire().Key(feedKey).Seconds(seconds).Build()).Error(); err != nil {
+		if err := s.client.Do(ctx, s.client.B().Expire().Key(feedTodayKey).Seconds(seconds).Build()).Error(); err != nil {
 			s.log.Warn("personality: feed expire failed", zap.Error(err))
 		}
 	}

--- a/app/sesame/modules/personality.go
+++ b/app/sesame/modules/personality.go
@@ -45,32 +45,60 @@ type personalityReply func(ctx context.Context, d engine.Deps, c *module.Context
 
 // reaction is one row of the personality table: the phrases that trip it, the
 // per-channel cooldown that keeps it charming instead of spammy, an optional
-// 1-in-N chance gate for ambient reactions, and the reply renderer.
+// 1-in-N chance gate for ambient reactions, and the reply renderer. matchRaw
+// rows match against the raw lowercased message instead of the normalized one
+// (needed for the 🥯 emoji, which normalization would strip).
 type reaction struct {
 	name     string
 	phrases  []string
 	cooldown time.Duration
 	oneIn    int
+	matchRaw bool
 	reply    personalityReply
 }
 
+// botNames are every way chat addresses the bot, bare "bagel" included; a
+// directed reaction ("good {name}", "feed the {name}") accepts any of them.
+// botHandles is the strict subset that unambiguously means the bot itself,
+// used by the mention→fact row so a lone "bagel" (the food) never triggers it.
+var (
+	botNames   = []string{"bagel", "bagelbot", "bagel bot", "itsbagelbot", "its bagel bot"}
+	botHandles = []string{"bagelbot", "bagel bot", "itsbagelbot", "its bagel bot"}
+)
+
+// withNames expands "{name}" in each pattern across the given name list, so a
+// reaction declares its shape once ("feed the {name}") and every way of
+// addressing the bot comes along naturally.
+func withNames(names []string, patterns ...string) []string {
+	out := make([]string, 0, len(patterns)*len(names))
+	for _, p := range patterns {
+		for _, n := range names {
+			out = append(out, strings.ReplaceAll(p, "{name}", n))
+		}
+	}
+	return out
+}
+
 // personalityReactions is scanned in order and the first match wins, so the
-// specific interactions sit above the generic mention→fact row: "good bagel
-// bot" lands on praise, not on a fun fact. Phrases are lowercase; matching is
-// word-boundary via containsWord.
+// specific interactions sit above the generic mention→fact row: "good night
+// @itsbagelbot" lands on the goodnight, "good bagel bot" on praise, and only
+// an undirected mention falls through to a fun fact. gn sits above good so an
+// explicit goodnight always beats a praise phrase sharing the line. Phrases
+// are lowercase; matching is word-boundary via containsWord on normalized
+// text (see normalizeChat), except the raw-text emoji row.
 var personalityReactions = []reaction{
-	{name: "good", phrases: []string{"good bagel", "good bot", "good bagelbot"}, cooldown: 15 * time.Second, reply: packReply(personalityGoodPack)},
-	{name: "bad", phrases: []string{"bad bagel", "bad bot", "bad bagelbot"}, cooldown: 15 * time.Second, reply: packReply(personalityBadPack)},
-	{name: "thanks", phrases: []string{"thank you bagel", "thanks bagel", "ty bagel", "merci bagel"}, cooldown: 15 * time.Second, reply: packReply(personalityThanksPack)},
-	{name: "toast", phrases: []string{"toast the bagel", "toast bagel"}, cooldown: 30 * time.Second, reply: toastReply},
-	{name: "pet", phrases: []string{"pet the bagel", "pet bagel", "pets the bagel", "hug the bagel", "hug bagel", "hugs the bagel", "bagel hug"}, cooldown: 30 * time.Second, reply: packReply(personalityAffectionPack)},
-	{name: "feed", phrases: []string{"feed the bagel", "feed bagel", "feeds the bagel"}, cooldown: 30 * time.Second, reply: feedReply},
-	{name: "boop", phrases: []string{"boop the bagel", "boop bagel", "boops the bagel"}, cooldown: 30 * time.Second, reply: packReply(personalityBoopPack)},
-	{name: "gn", phrases: []string{"gn bagel", "goodnight bagel", "good night bagel", "bonne nuit bagel"}, cooldown: 60 * time.Second, reply: packReply(personalityGnPack)},
-	{name: "mood", phrases: []string{"bagel mood", "mood of the bagel"}, cooldown: 60 * time.Second, reply: moodReply},
-	{name: "emoji", phrases: []string{"🥯"}, cooldown: 90 * time.Second, oneIn: 12, reply: packReply(personalityEmojiPack)},
-	{name: "fact", phrases: []string{"@itsbagelbot", "itsbagelbot", "bagelbot", "bagel bot", "bagel fact"}, cooldown: 10 * time.Second, reply: factReply},
-	{name: "give", phrases: []string{"give me a bagel", "I want a bagel", "gimme bagel", "gimme a bagel"}, cooldown: 30 * time.Second, reply: packReply(personalityGiveBagel)},
+	{name: "gn", phrases: withNames(botNames, "gn {name}", "goodnight {name}", "good night {name}", "night {name}", "bonne nuit {name}"), cooldown: 60 * time.Second, reply: packReply(personalityGnPack)},
+	{name: "good", phrases: append(withNames(botNames, "good {name}"), "good bot"), cooldown: 15 * time.Second, reply: packReply(personalityGoodPack)},
+	{name: "bad", phrases: append(withNames(botNames, "bad {name}"), "bad bot"), cooldown: 15 * time.Second, reply: packReply(personalityBadPack)},
+	{name: "thanks", phrases: withNames(botNames, "thank you {name}", "thanks {name}", "ty {name}", "merci {name}"), cooldown: 15 * time.Second, reply: packReply(personalityThanksPack)},
+	{name: "toast", phrases: withNames(botNames, "toast the {name}", "toast {name}"), cooldown: 30 * time.Second, reply: toastReply},
+	{name: "pet", phrases: withNames(botNames, "pet the {name}", "pet {name}", "pets the {name}", "hug the {name}", "hug {name}", "hugs the {name}", "{name} hug"), cooldown: 30 * time.Second, reply: packReply(personalityAffectionPack)},
+	{name: "feed", phrases: withNames(botNames, "feed the {name}", "feed {name}", "feeds the {name}"), cooldown: 30 * time.Second, reply: feedReply},
+	{name: "boop", phrases: withNames(botNames, "boop the {name}", "boop {name}", "boops the {name}"), cooldown: 30 * time.Second, reply: packReply(personalityBoopPack)},
+	{name: "mood", phrases: withNames(botNames, "{name} mood", "mood of the {name}"), cooldown: 60 * time.Second, reply: moodReply},
+	{name: "give", phrases: []string{"give me a bagel", "i want a bagel", "gimme bagel", "gimme a bagel"}, cooldown: 30 * time.Second, reply: packReply(personalityGiveBagel)},
+	{name: "emoji", phrases: []string{"🥯"}, cooldown: 90 * time.Second, oneIn: 12, matchRaw: true, reply: packReply(personalityEmojiPack)},
+	{name: "fact", phrases: append(withNames(botHandles, "{name}"), "bagel fact", "bagel facts"), cooldown: 10 * time.Second, reply: factReply},
 }
 
 // personalityOnChat is the chat handler: screen the line, find the first
@@ -99,16 +127,45 @@ func personalityOnChat(d engine.Deps) module.EventHandler {
 }
 
 // matchReaction returns the first reaction one of whose phrases occurs in the
-// lowercased message at word boundaries.
-func matchReaction(text string) (reaction, bool) {
+// message at word boundaries. Most rows match the normalized text so "gn,
+// @ItsBagelBot!!" reads as "gn itsbagelbot"; raw rows see the lowercased
+// original.
+func matchReaction(raw string) (reaction, bool) {
+	norm := normalizeChat(raw)
 	for _, r := range personalityReactions {
-		for _, p := range r.phrases {
-			if containsWord(text, p) {
-				return r, true
-			}
+		text := norm
+		if r.matchRaw {
+			text = raw
+		}
+		if matchesAny(text, r.phrases) {
+			return r, true
 		}
 	}
 	return reaction{}, false
+}
+
+// matchesAny reports whether any phrase occurs in text at word boundaries.
+func matchesAny(text string, phrases []string) bool {
+	for _, p := range phrases {
+		if containsWord(text, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// normalizeChat flattens an already-lowercased chat line for phrase matching:
+// every non-alphanumeric rune (punctuation, "@", emotes) becomes a space and
+// runs of spaces collapse. "good night, @itsbagelbot!!" → "good night
+// itsbagelbot", so phrases stay plain words and chat punctuates freely.
+func normalizeChat(s string) string {
+	mapped := strings.Map(func(r rune) rune {
+		if isWordRune(r) {
+			return r
+		}
+		return ' '
+	}, s)
+	return strings.Join(strings.Fields(mapped), " ")
 }
 
 // personalityAllowed runs the reaction's chance gate, then claims its

--- a/app/sesame/modules/personality_test.go
+++ b/app/sesame/modules/personality_test.go
@@ -222,8 +222,63 @@ func TestPersonalityEmojiChanceGate(t *testing.T) {
 
 func TestPersonalitySpecificReactionBeatsMentionFact(t *testing.T) {
 	pinPersonalityRand(t)
+	h := personalityHandler(t, engine.Deps{})
+	for text, want := range map[string]string{
+		"good bagel bot":                 personalityGoodPack[0],
+		"Good night @ItsBagelBot":        personalityGnPack[0],
+		"gn, @ItsBagelBot!!":             personalityGnPack[0],
+		"bonne nuit itsbagelbot":         personalityGnPack[0],
+		"thanks itsbagelbot":             personalityThanksPack[0],
+		"you are a good bagelbot":        personalityGoodPack[0],
+		"bad @ItsBagelBot. very bad bot": personalityBadPack[0],
+	} {
+		var col collector
+		require.NoError(t, h(context.Background(), personalityCtx(text), col.emit))
+		require.Len(t, col.out, 1, text)
+		assert.Equal(t, expandFor(want), col.out[0].Text, text)
+	}
+}
+
+// expandFor renders a pack line the way packReply would for the test chatter.
+func expandFor(line string) string {
+	return module.ExpandString(line, func(key string) (string, bool) {
+		if key == "user" {
+			return "Bob", true
+		}
+		return module.ParseDynamic(key)
+	})
+}
+
+func TestPersonalityNameVariantsReachDirectedReactions(t *testing.T) {
+	pinPersonalityRand(t)
+	d := engine.Deps{Personality: &fakePersonality{feed: engine.FeedCounts{Today: 2, Total: 7}}}
+	h := personalityHandler(t, d)
+	for _, text := range []string{"feed the bagelbot", "feed itsbagelbot", "feed the bagel bot", "feed @ItsBagelBot"} {
+		var col collector
+		require.NoError(t, h(context.Background(), personalityCtx(text), col.emit))
+		require.Len(t, col.out, 1, text)
+		assert.Equal(t, fmt.Sprintf(personalityFeedCountPack[0], 2, 7), col.out[0].Text, text)
+	}
+}
+
+func TestPersonalityBareMentionStillFacts(t *testing.T) {
+	pinPersonalityRand(t)
+	store := &fakePersonality{cursor: 1}
+	h := personalityHandler(t, engine.Deps{Personality: store})
+	for _, text := range []string{"@ItsBagelBot", "yo bagelbot", "its bagel bot is here"} {
+		var col collector
+		require.NoError(t, h(context.Background(), personalityCtx(text), col.emit))
+		require.Len(t, col.out, 1, text)
+		assert.Equal(t, personalityFacts[0], col.out[0].Text, text)
+	}
+
 	var col collector
-	require.NoError(t, personalityHandler(t, engine.Deps{})(context.Background(), personalityCtx("good bagel bot"), col.emit))
-	require.Len(t, col.out, 1)
-	assert.Equal(t, personalityGoodPack[0], col.out[0].Text, "praise must win over the generic mention fact")
+	require.NoError(t, h(context.Background(), personalityCtx("I love a warm bagel"), col.emit))
+	assert.Empty(t, col.out, "bare 'bagel' (the food) must not trigger the fact row")
+}
+
+func TestPersonalityNormalizeChat(t *testing.T) {
+	assert.Equal(t, "good night itsbagelbot", normalizeChat("good night, @itsbagelbot!!"))
+	assert.Equal(t, "gn bagel", normalizeChat("gn   bagel 🥯"))
+	assert.Equal(t, "", normalizeChat("!?@"))
 }

--- a/deploy/k8s/nats-auth.conf
+++ b/deploy/k8s/nats-auth.conf
@@ -509,6 +509,10 @@ accounts: {
       # service's quote verbs. Scoped to the quote subtree, not the whole
       # modules CRUD surface (which owns module toggles/config).
       { service: { account: "MODULES_RPC", subject: "bagel.rpc.modules.quote.>" } }
+      # Personality feed counter: the built-in personality module persists the
+      # global "feed the bagel" tally through the modules service. Scoped to
+      # the one verb, same rationale as the quote subtree above.
+      { service: { account: "MODULES_RPC", subject: "bagel.rpc.modules.personality.feed" } }
       { service: { account: "PROJECTOR_RPC", subject: "bagel.rpc.projector.dashboard.commands.get" } }
       { service: { account: "PROJECTOR_RPC", subject: "bagel.rpc.projector.dashboard.modules.get" } }
       { service: { account: "PROJECTOR_RPC", subject: "bagel.rpc.broadcaster.live.get" } }


### PR DESCRIPTION
## What

Three follow-ups to #423 (personality module):

- **ACL fix (the "feed the bagel" silence):** WORKER_RPC imports from MODULES_RPC are scoped per subtree (`quote.>`), so `bagel.rpc.modules.personality.feed` never crossed accounts; the 2s RPC timeout silenced the reply. Adds the one-verb import. Conf is Flux + config-reloader, hot ACL reload on merge, no broker restart, no new creds.
- **Feed caching:** lifetime total now lives in a valkey view (`personality:feed:total`). Warm feeds answer from valkey and persist to the modules DB behind the reply (fire-and-forget); a cold key seeds from the synchronous bump. DB stays source of truth; drift self-heals at every cold seed.
- **Natural addressing:** reactions declare shapes once (`feed the {name}`) and expand across bagel / bagelbot / bagel bot / itsbagelbot / its bagel bot. Matching runs on normalized text (punctuation and @ stripped), gn sits above good, so "Good night @ItsBagelBot!!" lands on the goodnight, never the fun fact. Fact row keeps a strict handle list so bare "bagel" (the food) stays silent.

## Notes

- Corrects the stale "no ACL change needed" comment from #423 (export ≠ import).
- ACL takes effect on merge; feed starts working even before the new sesame image rolls.