### PR TITLE
fix(console): keep EventSub enrollment in step with serving state

### DIFF
--- a/console/admin/src/lib/server/services.ts
+++ b/console/admin/src/lib/server/services.ts
@@ -360,6 +360,13 @@ export async function restartUserEventSub(userId: string): Promise<void> {
   invalidateUser(userId);
 }
 
+// Enqueue the EventSub on/off job that keeps a channel's Twitch enrollment in
+// step with its active flag: enabled=true (re)creates the subscriptions,
+// false deletes them. Same lane the dashboard's connect/disconnect uses.
+export async function publishUserEventSub(userId: string, enabled: boolean): Promise<void> {
+  await publish(SUB.outgress, { type: 'eventsub', broadcaster_id: userId, payload: { enabled } });
+}
+
 export type ChannelSubState = {
   state: 'ok' | 'pending' | 'failing' | 'unknown';
   error: string;

--- a/console/admin/src/routes/(admin)/users/+page.server.ts
+++ b/console/admin/src/routes/(admin)/users/+page.server.ts
@@ -16,6 +16,7 @@ import {
   tokenClear,
   tokenStatus,
   restartUserEventSub,
+  publishUserEventSub,
   channelSubState,
   auditAppend,
   type AdminUserWire,
@@ -323,7 +324,19 @@ export const actions: Actions = {
     demoNotice: DEMO ? 'active set (demo)' : '',
     notice: (user) => `active=${user?.is_active}`,
     detail: (f) => String(formActive(f)),
-    run: (userId, f) => userSetActive(userId, formActive(f))
+    // The flag and the Twitch EventSub enrollment move together, mirroring the
+    // dashboard's connect/disconnect. Ordered so no failure mode leaves an
+    // inactive user with live subscriptions: activating flips the flag before
+    // enrolling, deactivating unenrolls before flipping the flag.
+    run: async (userId, f) => {
+      if (formActive(f)) {
+        const user = await userSetActive(userId, true);
+        await publishUserEventSub(userId, true);
+        return user;
+      }
+      await publishUserEventSub(userId, false);
+      return userSetActive(userId, false);
+    }
   }),
 
   // Creator code carries its own length validation and demo-lookup shaping, so

--- a/console/admin/src/routes/(admin)/users/+page.server.ts
+++ b/console/admin/src/routes/(admin)/users/+page.server.ts
@@ -261,17 +261,25 @@ function formActive(f: FormData): boolean {
 // leaves a non-served user with live subscriptions; verbs that may resume
 // serving enroll afterwards, and only when the refreshed row is actually
 // served again (active and not banned).
-async function unenrollThen<T>(userId: string, mutate: () => Promise<T>): Promise<T> {
-  await publishUserEventSub(userId, false);
-  return mutate();
+type EnrollmentSyncedMutation<T> = {
+  userId: string;
+  sync: 'unenroll-first' | 'enroll-after';
+  mutate: () => Promise<T>;
+};
+
+function served(user: AdminUserWire | null): boolean {
+  return user !== null && user.is_active && !user.banned;
 }
 
-async function enrollAfter(
-  userId: string,
-  mutate: () => Promise<AdminUserWire>
-): Promise<AdminUserWire> {
-  const user = await mutate();
-  if (user.is_active && !user.banned) await publishUserEventSub(userId, true);
+async function withEnrollmentSync<T extends AdminUserWire | null>(
+  m: EnrollmentSyncedMutation<T>
+): Promise<T> {
+  if (m.sync === 'unenroll-first') {
+    await publishUserEventSub(m.userId, false);
+    return m.mutate();
+  }
+  const user = await m.mutate();
+  if (served(user)) await publishUserEventSub(m.userId, true);
   return user;
 }
 
@@ -344,10 +352,14 @@ export const actions: Actions = {
     demoNotice: DEMO ? 'active set (demo)' : '',
     notice: (user) => `active=${user?.is_active}`,
     detail: (f) => String(formActive(f)),
-    run: (userId, f) =>
-      formActive(f)
-        ? enrollAfter(userId, () => userSetActive(userId, true))
-        : unenrollThen(userId, () => userSetActive(userId, false))
+    run: (userId, f) => {
+      const active = formActive(f);
+      return withEnrollmentSync({
+        userId,
+        sync: active ? 'enroll-after' : 'unenroll-first',
+        mutate: () => userSetActive(userId, active)
+      });
+    }
   }),
 
   // Creator code carries its own length validation and demo-lookup shaping, so
@@ -389,14 +401,16 @@ export const actions: Actions = {
     name: 'ban',
     demoNotice: DEMO ? 'user banned (demo)' : '',
     notice: () => 'user banned',
-    run: (userId) => unenrollThen(userId, () => userBan(userId))
+    run: (userId) =>
+      withEnrollmentSync({ userId, sync: 'unenroll-first', mutate: () => userBan(userId) })
   }),
 
   unban: userAction({
     name: 'unban',
     demoNotice: DEMO ? 'user unbanned (demo)' : '',
     notice: () => 'user unbanned',
-    run: (userId) => enrollAfter(userId, () => userUnban(userId))
+    run: (userId) =>
+      withEnrollmentSync({ userId, sync: 'enroll-after', mutate: () => userUnban(userId) })
   }),
 
   restart: async ({ request, locals }) => {
@@ -470,9 +484,13 @@ export const actions: Actions = {
     demoNotice: DEMO ? 'user deleted (demo only, no real data removed)' : '',
     notice: () => 'user deleted',
     run: (userId) =>
-      unenrollThen(userId, async () => {
-        await userDelete(userId);
-        return null;
+      withEnrollmentSync({
+        userId,
+        sync: 'unenroll-first',
+        mutate: async () => {
+          await userDelete(userId);
+          return null;
+        }
       })
   })
 };

--- a/console/admin/src/routes/(admin)/users/+page.server.ts
+++ b/console/admin/src/routes/(admin)/users/+page.server.ts
@@ -255,6 +255,26 @@ function formActive(f: FormData): boolean {
   return String(f.get('active') ?? '').trim() === 'true';
 }
 
+// Serving state and Twitch EventSub enrollment move together, mirroring the
+// dashboard's connect/disconnect. Every verb that stops serving a user
+// (deactivate, ban, delete) unenrolls before its mutation, so no failure mode
+// leaves a non-served user with live subscriptions; verbs that may resume
+// serving enroll afterwards, and only when the refreshed row is actually
+// served again (active and not banned).
+async function unenrollThen<T>(userId: string, mutate: () => Promise<T>): Promise<T> {
+  await publishUserEventSub(userId, false);
+  return mutate();
+}
+
+async function enrollAfter(
+  userId: string,
+  mutate: () => Promise<AdminUserWire>
+): Promise<AdminUserWire> {
+  const user = await mutate();
+  if (user.is_active && !user.banned) await publishUserEventSub(userId, true);
+  return user;
+}
+
 export const actions: Actions = {
   lookup: async ({ request, locals }) => {
     if (!(await requireAdmin(locals.session))) return fail(403, { error: 'forbidden' });
@@ -324,19 +344,10 @@ export const actions: Actions = {
     demoNotice: DEMO ? 'active set (demo)' : '',
     notice: (user) => `active=${user?.is_active}`,
     detail: (f) => String(formActive(f)),
-    // The flag and the Twitch EventSub enrollment move together, mirroring the
-    // dashboard's connect/disconnect. Ordered so no failure mode leaves an
-    // inactive user with live subscriptions: activating flips the flag before
-    // enrolling, deactivating unenrolls before flipping the flag.
-    run: async (userId, f) => {
-      if (formActive(f)) {
-        const user = await userSetActive(userId, true);
-        await publishUserEventSub(userId, true);
-        return user;
-      }
-      await publishUserEventSub(userId, false);
-      return userSetActive(userId, false);
-    }
+    run: (userId, f) =>
+      formActive(f)
+        ? enrollAfter(userId, () => userSetActive(userId, true))
+        : unenrollThen(userId, () => userSetActive(userId, false))
   }),
 
   // Creator code carries its own length validation and demo-lookup shaping, so
@@ -378,14 +389,14 @@ export const actions: Actions = {
     name: 'ban',
     demoNotice: DEMO ? 'user banned (demo)' : '',
     notice: () => 'user banned',
-    run: (userId) => userBan(userId)
+    run: (userId) => unenrollThen(userId, () => userBan(userId))
   }),
 
   unban: userAction({
     name: 'unban',
     demoNotice: DEMO ? 'user unbanned (demo)' : '',
     notice: () => 'user unbanned',
-    run: (userId) => userUnban(userId)
+    run: (userId) => enrollAfter(userId, () => userUnban(userId))
   }),
 
   restart: async ({ request, locals }) => {
@@ -458,9 +469,10 @@ export const actions: Actions = {
     name: 'delete',
     demoNotice: DEMO ? 'user deleted (demo only, no real data removed)' : '',
     notice: () => 'user deleted',
-    run: async (userId) => {
-      await userDelete(userId);
-      return null;
-    }
+    run: (userId) =>
+      unenrollThen(userId, async () => {
+        await userDelete(userId);
+        return null;
+      })
   })
 };

--- a/console/dashboard/src/routes/(app)/settings/+page.server.ts
+++ b/console/dashboard/src/routes/(app)/settings/+page.server.ts
@@ -8,6 +8,7 @@ import {
   delegationOptOut,
   delegationRevoke,
   deleteSelf,
+  publishEventSub,
   auditDashboardImpersonation,
   notificationsForUser,
   notificationMarkRead,
@@ -139,6 +140,10 @@ export const actions: Actions = {
     if (s.delegate_of) return fail(403, { error: 'Not allowed.' });
 
     try {
+      // Unenroll before the row goes away (same ordering as disconnect): if
+      // either step fails the account still exists and can retry, so no
+      // failure mode leaves a deleted account with live EventSub subs.
+      await publishEventSub(s.user_id, false);
       await deleteSelf(s.user_id);
       auditDashboardImpersonation(s, 'account:delete');
     } catch {


### PR DESCRIPTION
## Problem

Deactivating a user in the admin console only flipped the users-service flag; the channel's Twitch EventSub subscriptions stayed live on the conduit. Confirmed in prod on 2026-07-16: a deactivation at 00:53Z left 10 subscriptions up for 3.5h until a manual dashboard disconnect removed them. Admin ban/delete and the dashboard's self-serve account deletion had the same gap.

## Fix

Every verb that changes whether a user is served now moves the EventSub enrollment with it, using the same outgress job lane the dashboard's connect/disconnect already uses.

**Admin console** — one shared helper pair, no per-verb duplication:
- `unenrollThen` (deactivate, ban, delete): publishes the disable job **before** the user mutation, so no failure mode leaves a non-served user with live subscriptions.
- `enrollAfter` (activate, unban): mutates first, enrolls after, and only when the refreshed row is actually served again (active and not banned) — unban now restores events for an active user, and activating a still-banned user no longer enrolls pointlessly.

**Dashboard** — account self-delete publishes the disable job before `delete_self`, matching disconnect's ordering.

Failure ordering rationale: creates are 409-idempotent and deletes 404-idempotent on the outgress side, so any half-completed action converges on retry, and the dashboard's self-heal re-enrolls an active-but-unenrolled channel on next load.

## Verification

- `bun run check`: 0 errors in both consoles; admin tests 14/14.
- Post-deploy: deactivate/ban a test user, expect `eventsub subscriptions removed` in outgress logs within seconds (verified the dashboard path produces exactly this in prod).