### PR TITLE
fix(console): describe trigger rule editor in module catalog

### DIFF
--- a/console/shared/lib/types.ts
+++ b/console/shared/lib/types.ts
@@ -501,16 +501,17 @@ export const MODULE_CATALOG: readonly ModuleDef[] = [
     label: 'Trigger Words',
     tagline: 'Auto-reply when a word shows up in chat — no "!" needed.',
     description:
-      'Give the bot a list of words or phrases and the line to post when it sees one in ordinary chat — no command prefix required. Write one rule per line as "phrase => response". Prefix the phrase with contains:, exact: or prefix: to change how it matches (the default matches the whole word, so "hi" will not fire inside "this"). Responses support {user}, {random} and {choice:a,b,c}. The first matching rule wins, so one message gets at most one reply.',
+      'Give the bot a list of words or phrases and the line to post when it sees one in ordinary chat — no command prefix required. Each rule pairs a phrase with a response: pick how the phrase matches (whole word, contains, exact message or starts with — the default matches the whole word, so "hi" will not fire inside "this"), write the reply, and switch individual rules on or off without deleting them. Responses support {user}, {random} and {choice:a,b,c}. The first matching rule wins, so one message gets at most one reply.',
     icon: 'caps',
     category: 'Chat Tools',
     defaultEnabled: false,
     // Trigger rules are a free-form list of phrase→response pairs the author grows,
     // so the module page renders them as add/removable ReplyRows with a bespoke
-    // rule inspector (see the def.id === 'triggers' branch in the module page).
-    // The whole list is persisted as one "rules" string the sesame module parses
-    // line by line (a disabled rule is stored as a "#" comment, which the parser
-    // skips). See app/sesame/modules/triggers.go.
+    // rule inspector (TriggerRuleEditor: phrase, match mode, response, per-rule
+    // enabled switch). The whole list is persisted as one "rules" string holding
+    // a JSON array of structured rules; the sesame module also still parses the
+    // legacy "phrase => response" line format for configs saved before the
+    // migration. See app/sesame/modules/triggers.go.
     replies: []
   },
   {


### PR DESCRIPTION
## Summary
- Rewrite the `triggers` MODULE_CATALOG description in `console/shared/lib/types.ts`: it still taught the legacy `phrase => response` line syntax, but the dashboard edits rules through the structured per-rule editor (phrase, match-mode picker, response editor, per-rule enabled switch) persisted as a JSON array.
- Keep the whole-word `"hi" won't fire inside "this"` example, the `{user}`/`{random}`/`{choice:a,b,c}` tokens, and the first-match-wins rule.
- Fix the stale storage comment below the entry: rules persist as a JSON array of structured rules; the line format is only a legacy parse fallback in `app/sesame/modules/triggers.go`.

FR catalog: not applicable — MODULE_CATALOG descriptions are not localized (fr.ts covers UI keys only; the page renders `def.description` directly).

## Testing
- `bun run check` (svelte-check) in `console/dashboard`: 1130 files, 0 errors.