### PR TITLE
feat(nats): route publishers through local hubs

### DIFF
--- a/deploy/k8s/commands.yaml
+++ b/deploy/k8s/commands.yaml
@@ -104,6 +104,8 @@ spec:
               value: nats://nats-leaf:4222
             - name: NATS_HUB_URL
               value: nats://nats:4222
+            - name: NATS_HUB_PUBLISH_URL
+              value: nats://nats:4222
             # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS server
             # TLS cert now that NATS is out of the Linkerd mesh; read as RootCAs by
             # pkg/bus (Go services) and the console nats lib (TS).

--- a/deploy/k8s/modules.yaml
+++ b/deploy/k8s/modules.yaml
@@ -104,6 +104,8 @@ spec:
               value: nats://nats-leaf:4222
             - name: NATS_HUB_URL
               value: nats://nats:4222
+            - name: NATS_HUB_PUBLISH_URL
+              value: nats://nats:4222
             # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS server
             # TLS cert now that NATS is out of the Linkerd mesh; read as RootCAs by
             # pkg/bus (Go services) and the console nats lib (TS).

--- a/deploy/k8s/nats_publish_locality_test.go
+++ b/deploy/k8s/nats_publish_locality_test.go
@@ -1,0 +1,40 @@
+package k8s
+
+import (
+	"regexp"
+	"testing"
+)
+
+func TestJetStreamPublishersUseNodeLocalHubService(t *testing.T) {
+	publishers := []struct {
+		manifest string
+		variable string
+		value    string
+	}{
+		{"twitch-ingress.yaml", "NATS_HUB_HOST", "nats"},
+		{"commands.yaml", "NATS_HUB_PUBLISH_URL", "nats://nats:4222"},
+		{"modules.yaml", "NATS_HUB_PUBLISH_URL", "nats://nats:4222"},
+		{"projector.yaml", "NATS_HUB_PUBLISH_URL", "nats://nats:4222"},
+		{"sesame.yaml", "NATS_HUB_PUBLISH_URL", "tls://nats:4222"},
+		{"users.yaml", "NATS_HUB_PUBLISH_URL", "nats://nats:4222"},
+	}
+
+	for _, publisher := range publishers {
+		t.Run(publisher.manifest, func(t *testing.T) {
+			manifest := sourceFile{name: publisher.manifest}.read(t)
+			pattern := regexp.MustCompile(`(?m)^\s*- name: ` + regexp.QuoteMeta(publisher.variable) +
+				`\n\s+value: ` + regexp.QuoteMeta(publisher.value) + `$`)
+			if !pattern.MatchString(manifest) {
+				t.Fatalf("%s must set %s=%s", publisher.manifest, publisher.variable, publisher.value)
+			}
+		})
+	}
+}
+
+func TestHubServicePrefersSameNode(t *testing.T) {
+	manifest := sourceFile{name: "nats.yaml"}.read(t)
+	service := regexp.MustCompile(`(?s)kind: Service\nmetadata:.*?\n  name: nats\n.*?trafficDistribution: PreferSameNode`).FindString(manifest)
+	if service == "" {
+		t.Fatal("nats Service must retain trafficDistribution: PreferSameNode")
+	}
+}

--- a/deploy/k8s/projector.yaml
+++ b/deploy/k8s/projector.yaml
@@ -98,14 +98,16 @@ spec:
             # (NATS_HUB_URL) so stream traffic never pays a leaf forwarding hop;
             # the RPC + cache plane (NATS_RPC_URL / NATS_LEAF_URL) stays on the
             # node-local leaf. NATS_URL is the local-dev fallback only.
-            # BAGEL_DATA (both the folds it consumes and the events it
-            # publishes) is placement-pinned to nats-1 (pkg/bus/provision.go);
-            # dialing that ordinal directly skips the intra-hub route hop the
-            # PreferSameNode `nats` Service would add from a non-leader member.
+            # BAGEL_DATA folds remain pinned to nats-1. The independent publisher
+            # pool uses the PreferSameNode hub Service so its TLS/socket/batch
+            # work is distributed across the three brokers before NATS routes
+            # each commit to the stream leader.
             - name: NATS_URL
               value: nats://nats-leaf:4222
             - name: NATS_HUB_URL
               value: nats://nats-1.nats-headless.production.svc.cluster.local:4222
+            - name: NATS_HUB_PUBLISH_URL
+              value: nats://nats:4222
             # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS server
             # TLS cert now that NATS is out of the Linkerd mesh; read as RootCAs by
             # pkg/bus (Go services) and the console nats lib (TS).

--- a/deploy/k8s/sesame.yaml
+++ b/deploy/k8s/sesame.yaml
@@ -131,19 +131,17 @@ spec:
             # PubAcks through it adds a cross-leaf round trip and stalls large
             # windows.
             #
-            # The two JetStream planes dial the ordinal that leads their streams
-            # (R1 placement pins from pkg/bus/provision.go), skipping the
-            # intra-hub route hop the PreferSameNode `nats` Service would add on
-            # a non-leader member: consumers (NATS_HUB_URL) sit with
-            # TWITCH_INGRESS on nats-0, the publisher pool
-            # (NATS_HUB_PUBLISH_URL) with TWITCH_OUTGRESS + BAGEL_DATA on
-            # nats-1. Both per-pod headless names are hub cert SANs.
+            # Consumers remain pinned beside TWITCH_INGRESS on nats-0. Publishers
+            # use the PreferSameNode `nats` Service: the R3 qualification measured
+            # ~75k/s node-local vs ~60.6k/s when every client dialed the leader.
+            # The stream leader still performs the RAFT commit, while client TLS,
+            # socket and batch work is spread over all three hub members.
             - name: NATS_URL
               value: tls://nats:4222
             - name: NATS_HUB_URL
               value: tls://nats-0.nats-headless.production.svc.cluster.local:4222
             - name: NATS_HUB_PUBLISH_URL
-              value: tls://nats-1.nats-headless.production.svc.cluster.local:4222
+              value: tls://nats:4222
             # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS server
             # TLS cert now that NATS is out of the Linkerd mesh; read as RootCAs by
             # pkg/bus (Go services) and the console nats lib (TS).

--- a/deploy/k8s/twitch-ingress.yaml
+++ b/deploy/k8s/twitch-ingress.yaml
@@ -145,19 +145,17 @@ spec:
             - name: NATS_HOST
               value: nats
             # The RPC plane (:gnat) stays on the node-local leaf. The BUS firehose
-            # plane (:gnat_bus) connects DIRECT to the hub member leading
-            # TWITCH_INGRESS (placement-pinned to nats-0 by the stream contract):
-            # the leaf runs no JetStream, and the PreferSameNode `nats` Service
-            # would land pods on a non-leader member, paying an intra-hub route
-            # hop per publish and PubAck. The per-pod headless name is a hub cert
-            # SAN, follows the pod across nodes, and loses no availability — an
-            # R1 stream is down with its pinned peer no matter which member the
-            # client dialed. A hub roll re-pins the BUS connection (Gnat
-            # reconnect); the RPC path is unaffected.
+            # plane (:gnat_bus) uses the `nats` Service, whose PreferSameNode
+            # routing lands each ingress publisher on the hub member beside it.
+            # Production R3 qualification measured ~75k/s through this route vs
+            # ~60.6k/s when every publisher dialed the stream leader directly:
+            # distributing client TLS/socket/batch work outweighs the NATS route
+            # hop to the RAFT leader. The leaf remains RPC-only and never carries
+            # JetStream traffic.
             - name: NATS_LEAF_HOST
               value: nats-leaf
             - name: NATS_HUB_HOST
-              value: nats-0.nats-headless.production.svc.cluster.local
+              value: nats
             # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS server
             # TLS cert now that NATS is out of the Linkerd mesh; decoded to ssl_opts
             # cacerts in config/runtime.exs. Both :gnat (leaf) and :gnat_bus (hub)

--- a/deploy/k8s/users.yaml
+++ b/deploy/k8s/users.yaml
@@ -116,6 +116,8 @@ spec:
               value: nats://nats-leaf:4222
             - name: NATS_HUB_URL
               value: nats://nats:4222
+            - name: NATS_HUB_PUBLISH_URL
+              value: nats://nats:4222
             # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS server
             # TLS cert now that NATS is out of the Linkerd mesh; read as RootCAs by
             # pkg/bus (Go services) and the console nats lib (TS).

--- a/pkg/bus/connect.go
+++ b/pkg/bus/connect.go
@@ -166,15 +166,12 @@ func busURL(url string) string {
 	return serverList(url)
 }
 
-// busPublishURL resolves the endpoint for the asynchronous publisher pool. The
-// R1 firehose streams are placement-pinned to specific hub ordinals, so a
-// publisher dialed into a non-leader member pays an intra-hub route hop on
-// every message and its PubAck. NATS_HUB_PUBLISH_URL points the pool straight
-// at the ordinal leading the streams this service publishes (per-pod headless
-// DNS; the hub cert carries those SANs). A service whose consume and publish
-// streams lead on different ordinals sets both variables. Consumers and the
-// stream guardian stay on busURL — the JetStream API is routed cluster-wide,
-// and consumer deliveries follow their own stream's leader.
+// busPublishURL resolves the endpoint for the asynchronous publisher pool.
+// Production sets NATS_HUB_PUBLISH_URL to the PreferSameNode hub Service: each
+// pod performs client TLS/socket/batch work on its local NATS member, then NATS
+// routes the commit to the stream's RAFT leader. Consumers may still pin
+// NATS_HUB_URL to the member leading their stream, so publish and consume
+// locality remain independent. Local development falls back to busURL.
 func busPublishURL(url string) string {
 	if publish := env.Get("NATS_HUB_PUBLISH_URL", ""); publish != "" {
 		return publish

--- a/pkg/bus/connect_test.go
+++ b/pkg/bus/connect_test.go
@@ -32,6 +32,15 @@ func TestBusURLFallsBackWhenNoHub(t *testing.T) {
 	}
 }
 
+func TestBusPublishURLPrefersNodeLocalOverride(t *testing.T) {
+	t.Setenv("NATS_HUB_URL", "nats://nats-1.nats-headless:4222")
+	t.Setenv("NATS_HUB_PUBLISH_URL", "nats://nats:4222")
+
+	if got := busPublishURL("ignored"); got != "nats://nats:4222" {
+		t.Fatalf("busPublishURL = %q, want node-local hub Service", got)
+	}
+}
+
 // RPC stays leaf-only even once NATS_HUB_URL is set. The leaf Service handles
 // cross-node failover, while the hub is reserved for streams.
 func TestRPCServerListStaysOnLeaf(t *testing.T) {


### PR DESCRIPTION
## What changed

- route the Elixir ingress BUS publisher pool through the `nats` Service
- route every Go shared-bus publisher pool through `NATS_HUB_PUBLISH_URL=nats:4222`
- retain pinned consumer endpoints and RPC-only node-local leaves
- add regression tests for publisher locality and `PreferSameNode`

## Why

Production R3 qualification measured approximately 75k events/s with node-local hub connections versus 60.6k events/s when every publisher connected directly to the stream leader. Distributing TLS, socket, and batch handling across the hub members increases throughput while NATS still routes commits to the RAFT leader.

## Production impact

This changes publisher connection placement only. It does not change stream replicas, subjects, retention, credentials, or the RPC leaf topology. The hot stream remains R1.

## Validation

- `go test ./...`
- `kubectl kustomize deploy/k8s`
- server-side Kubernetes dry-run of the rendered production manifests
- live `nats` Service has `trafficDistribution: PreferSameNode` and one hub endpoint on node2, node3, and worker1
