### PR TITLE
fix(deploy): right-size production resources

### DIFF
--- a/deploy/flux/clusters/production/flux-system/kustomization.yaml
+++ b/deploy/flux/clusters/production/flux-system/kustomization.yaml
@@ -40,8 +40,10 @@ patches:
           containers:
             - name: manager
               resources:
+                requests:
+                  memory: 320Mi
                 limits:
-                  memory: 384Mi
+                  memory: 512Mi
 - patch: |-
     apiVersion: apps/v1
     kind: Deployment
@@ -54,5 +56,7 @@ patches:
           containers:
             - name: manager
               resources:
+                requests:
+                  memory: 96Mi
                 limits:
                   memory: 256Mi

--- a/deploy/flux/clusters/production/newrelic.yaml
+++ b/deploy/flux/clusters/production/newrelic.yaml
@@ -225,6 +225,9 @@ spec:
     # =======================================================================
     kube-state-metrics:
       enabled: true
+      resources:
+        requests: {cpu: 10m, memory: 128Mi}
+        limits: {cpu: 200m, memory: 256Mi}
 
     # =======================================================================
     # newrelic-prometheus-agent
@@ -239,6 +242,10 @@ spec:
       enabled: true
       cluster: bagelbot
       lowDataMode: true
+      resources:
+        prometheus:
+          requests: {cpu: 10m, memory: 192Mi}
+          limits: {cpu: 500m, memory: 384Mi}
       customSecretName: nri-bundle-newrelic-prometheus-agent-license
       customSecretLicenseKey: licenseKey
       config:

--- a/deploy/infra/cert-manager/release.yaml
+++ b/deploy/infra/cert-manager/release.yaml
@@ -80,11 +80,11 @@ spec:
     # Trimmed for this small fleet, same as keda/newrelic. Re-widen if the
     # controller/webhook/cainjector is throttled or OOMKilled in practice.
     resources:
-      requests: {cpu: 25m, memory: 64Mi}
+      requests: {cpu: 25m, memory: 128Mi}
       limits: {cpu: 250m, memory: 256Mi}
     webhook:
       resources:
-        requests: {cpu: 10m, memory: 32Mi}
+        requests: {cpu: 10m, memory: 96Mi}
         limits: {cpu: 200m, memory: 128Mi}
     cainjector:
       resources:

--- a/deploy/infra/cluster/coredns.yaml
+++ b/deploy/infra/cluster/coredns.yaml
@@ -151,8 +151,9 @@ spec:
             - {containerPort: 53, name: dns-tcp, protocol: TCP}
             - {containerPort: 9153, name: metrics, protocol: TCP}
           resources:
-            requests: {cpu: 100m, memory: 70Mi}
-            limits: {memory: 170Mi}
+            # The node-local caches on node2/node3 hold about 100Mi steadily.
+            requests: {cpu: 100m, memory: 128Mi}
+            limits: {memory: 256Mi}
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/deploy/infra/cluster/metrics-server.yaml
+++ b/deploy/infra/cluster/metrics-server.yaml
@@ -150,8 +150,11 @@ spec:
             periodSeconds: 10
           resources:
             requests:
-              cpu: 100m
-              memory: 200Mi
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              cpu: 250m
+              memory: 256Mi
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/deploy/infra/cluster/traefik-config.yaml
+++ b/deploy/infra/cluster/traefik-config.yaml
@@ -43,7 +43,8 @@ spec:
     resources:
       requests:
         cpu: 100m
-        memory: 64Mi
+        # The per-node ingress proxies sit at 174-190Mi in steady state.
+        memory: 192Mi
       limits:
         cpu: 1000m
         memory: 256Mi

--- a/deploy/infra/keda/release.yaml
+++ b/deploy/infra/keda/release.yaml
@@ -72,15 +72,16 @@ spec:
     cleanupOnFail: true
   values:
     watchNamespace: "" # all namespaces; only production uses it today, but the fleet is single-tenant
-    operator:
-      resources:
+    # KEDA 2.20 reads component sizing from the top-level resources map.
+    # Putting resources under operator/metricsServer/webhooks is accepted as
+    # unused YAML and silently falls back to 100m/100Mi + 1CPU/1000Mi defaults.
+    resources:
+      operator:
         requests: {cpu: 50m, memory: 64Mi}
         limits: {cpu: 500m, memory: 256Mi}
-    metricsServer:
-      resources:
+      metricServer:
         requests: {cpu: 50m, memory: 64Mi}
         limits: {cpu: 500m, memory: 256Mi}
-    webhooks:
-      resources:
+      webhooks:
         requests: {cpu: 25m, memory: 32Mi}
         limits: {cpu: 250m, memory: 128Mi}

--- a/deploy/infra/tailscale/proxies.yaml
+++ b/deploy/infra/tailscale/proxies.yaml
@@ -32,10 +32,11 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 32Mi
+            # The management-plane proxy settles between 45Mi and 105Mi.
+            memory: 128Mi
           limits:
             cpu: 500m
-            memory: 128Mi
+            memory: 256Mi
 ---
 apiVersion: tailscale.com/v1alpha1
 kind: ProxyGroup

--- a/deploy/infra/valkey/statefulset.yaml
+++ b/deploy/infra/valkey/statefulset.yaml
@@ -432,10 +432,11 @@ spec:
           timeoutSeconds: 3
         resources:
           limits:
-            cpu: 100m
+            cpu: 250m
             memory: 64Mi
           requests:
-            cpu: 10m
+            # TLS health checks use 25-40m steadily on every replica.
+            cpu: 50m
             memory: 32Mi
         securityContext:
           allowPrivilegeEscalation: false

--- a/deploy/k8s/console-admin.yaml
+++ b/deploy/k8s/console-admin.yaml
@@ -253,10 +253,10 @@ spec:
           resources:
             requests:
               cpu: 25m
-              memory: 96Mi
+              memory: 128Mi
             limits:
               cpu: 500m
-              memory: 192Mi
+              memory: 256Mi
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/deploy/k8s/console-dashboard.yaml
+++ b/deploy/k8s/console-dashboard.yaml
@@ -234,7 +234,7 @@ spec:
           resources:
             requests:
               cpu: 25m
-              memory: 96Mi
+              memory: 128Mi
             limits:
               cpu: "1"
               memory: 256Mi

--- a/deploy/k8s/nats.yaml
+++ b/deploy/k8s/nats.yaml
@@ -111,11 +111,12 @@ spec:
           resources:
             # R1 memory-backed ingress needs enough headroom above JetStream's
             # 4GB max_mem for dedup indexes, connections and the Go runtime.
-            # node2/node3 each have 6 cores and worker1 has 8. Live usage before
-            # this bump was 9%/17%/9%; a 2-core request fits every node while a
-            # 4-core ceiling lets whichever R1 member owns TWITCH_INGRESS absorb
-            # batch commits without CPU throttling. Memory remains unchanged.
-            requests: {cpu: "2", memory: 2Gi}
+            # node2/node3 each have 6 cores and worker1 has 8. Sustained load
+            # has peaked around 1.77 cores on the R1 leader. Reserve 1.5 cores
+            # on every member so quorum placement does not strand half a node,
+            # while the 4-core ceiling still lets the active leader burst.
+            # Memory stays at 2Gi because one member can own all R1 streams.
+            requests: {cpu: 1500m, memory: 2Gi}
             limits: {cpu: "4", memory: 6Gi}
           securityContext:
             allowPrivilegeEscalation: false

--- a/deploy/k8s/twitch-ingress.yaml
+++ b/deploy/k8s/twitch-ingress.yaml
@@ -219,7 +219,8 @@ spec:
                 +S 2:2 +SDcpu 2:2 +SDio 2 +sbwt short +sbwtdcpu none +sbwtdio none -kernel inet_dist_listen_min 9100 -kernel inet_dist_listen_max 9110
           resources:
             requests:
-              cpu: 150m
+              # Live steady state is 195-240m across all three node-local pods.
+              cpu: 250m
               memory: 256Mi
             limits:
               cpu: "2"


### PR DESCRIPTION
## Summary
- right-size NATS and ingress CPU requests against measured production utilization while preserving burst ceilings
- fix KEDA 2.20 resource values so the chart no longer ignores our intended sizing
- add honest requests/limits for observed infrastructure and monitoring memory usage
- remove a stale terminal Flux pod from production

## Validation
- go test -race ./...
- kubectl kustomize deploy/k8s
- kubectl kustomize deploy/infra/{keda,cluster,tailscale,valkey}
- kubectl kustomize deploy/flux/clusters/production/flux-system
- flux build kustomization cert-manager --path deploy/infra/cert-manager
- Helm-rendered KEDA 2.20.1 and New Relic 6.0.36 resource values verified
