### PR TITLE
feat(console): confirm composed commands in a modal

### DIFF
--- a/console/dashboard/src/routes/(app)/commands/+page.svelte
+++ b/console/dashboard/src/routes/(app)/commands/+page.svelte
@@ -17,6 +17,8 @@
     normName,
     getI18n,
     builtinDef,
+    validateCommand,
+    PERM_LABELS,
     PERMS,
     COMMAND_NAME_MAX,
     COOLDOWN_MAX,
@@ -28,6 +30,7 @@
   import CommandRow from '$lib/components/commands/CommandRow.svelte';
   import CommandEditor from '$lib/components/commands/CommandEditor.svelte';
   import BuiltinInspector from '$lib/components/commands/BuiltinInspector.svelte';
+  import ChatPreview from '$lib/components/commands/ChatPreview.svelte';
   import { loadDraft, clearDraft, hasDraft, type CommandDraft } from '$lib/components/commands/drafts';
 
   let { data } = $props();
@@ -280,13 +283,20 @@
     guarded(doOpenNew);
   }
 
-  // --- Deep-link prefill (marketing command builder) --------------------------
+  // --- Deep-link compose (marketing command builder) ---------------------------
   // The public command builder links here as /commands?compose=1&name=…&response=…
-  // so a visitor's finished command lands pre-filled in the "new" editor and they
-  // only review and press Create. The path (with query) survives the login
-  // round-trip via safeNextPath, same as /billing?subscribe=1. Runs once on
-  // mount; the params are then stripped so a refresh can't re-open a stale
-  // draft over newer work.
+  // A valid draft opens a confirmation modal (summary + the same chat rehearsal
+  // as the editor) and one press creates the command — no inspector round-trip.
+  // A draft the validator rejects falls back to the pre-filled editor so the
+  // visitor can fix it. The path (with query) survives the login round-trip via
+  // safeNextPath, same as /billing?subscribe=1. Runs once on mount; the params
+  // are then stripped so a refresh can't re-run a stale compose.
+  let composeDraft = $state<CommandDraft | null>(null);
+  let composeBusy = $state(false);
+  const composeReplaces = $derived(
+    composeDraft !== null && items.some((c) => c.name === composeDraft!.name)
+  );
+
   onMount(() => {
     const url = new URL(window.location.href);
     if (url.searchParams.get('compose') !== '1') return;
@@ -295,7 +305,7 @@
     const cooldown = Math.floor(Number(url.searchParams.get('cooldown')) || 0);
     const aliases = (url.searchParams.get('aliases') ?? '').split(',').map(normName).filter(Boolean);
 
-    editorDraft = {
+    const draft: CommandDraft = {
       ...blankDraft(),
       name: normName(url.searchParams.get('name') ?? '').slice(0, COMMAND_NAME_MAX),
       // The Go validator caps aliases at 25; drop the excess instead of failing.
@@ -305,9 +315,23 @@
       perm: (PERMS as readonly string[]).includes(perm) ? (perm as Perm) : 'everyone',
       cooldown: Math.min(Math.max(cooldown, 0), COOLDOWN_MAX)
     };
-    serverErrors = null;
-    expanded = NEW;
-    editorGen++;
+
+    const problems = validateCommand({
+      name: draft.name,
+      aliases: draft.aliases,
+      response: draft.response,
+      cooldown: draft.cooldown,
+      allowedUserId: ''
+    });
+    if (Object.keys(problems).length === 0) {
+      composeDraft = draft;
+    } else {
+      // Broken deep link: hand it to the editor with the fields to fix.
+      serverErrors = problems;
+      editorDraft = draft;
+      expanded = NEW;
+      editorGen++;
+    }
 
     for (const key of ['compose', 'name', 'response', 'perm', 'cooldown', 'aliases', 'lang']) {
       url.searchParams.delete(key);
@@ -316,6 +340,45 @@
     // onMount runs, and a same-tick replaceState is dropped.
     setTimeout(() => replaceState(url, {}), 0);
   });
+
+  function composeCancel() {
+    if (composeBusy) return;
+    composeDraft = null;
+  }
+
+  async function composeConfirm() {
+    const d = composeDraft;
+    if (!d || composeBusy) return;
+    composeBusy = true;
+    const payload = await postAction(
+      'save',
+      formDataFor({
+        name: d.name,
+        aliases: d.aliases,
+        response: d.response,
+        is_active: true,
+        stream_online_only: false,
+        perm: d.perm,
+        cooldown: d.cooldown,
+        allowed_user_id: ''
+      })
+    );
+    composeBusy = false;
+    composeDraft = null;
+    if (payload?.ok) {
+      applyResult(payload); // reconciles the row and toasts created/updated
+      return;
+    }
+    if (payload?.errors) {
+      // The server disagreed: open the editor with the draft + its complaints.
+      serverErrors = payload.errors;
+      editorDraft = d;
+      expanded = NEW;
+      editorGen++;
+      return;
+    }
+    toast('err', payload?.error ?? t('commands.toastSaveFailed'));
+  }
   function openEdit(c: CommandView) {
     if (expanded === c.name) {
       closeEditor();
@@ -675,6 +738,28 @@
 </section>
 
 <ConfirmDialog
+  open={composeDraft !== null}
+  title={t('commands.composeTitle', { name: composeDraft?.name ?? '' })}
+  body={composeReplaces ? t('commands.composeReplace', { name: composeDraft?.name ?? '' }) : undefined}
+  confirmLabel={composeReplaces ? t('commandEditor.saveChanges') : t('commandEditor.create')}
+  cancelLabel={t('common.cancel')}
+  busy={composeBusy}
+  onConfirm={composeConfirm}
+  onCancel={composeCancel}
+>
+  {#if composeDraft}
+    <div class="compose-meta">
+      <span>{PERM_LABELS[composeDraft.perm]}</span>
+      <span>{t('commandRow.cooldown')} {composeDraft.cooldown}s</span>
+      {#if composeDraft.aliases.length}
+        <span>{t('commandRow.also', { aliases: composeDraft.aliases.map((a) => '!' + a).join(' ') })}</span>
+      {/if}
+    </div>
+    <ChatPreview name={composeDraft.name} response={composeDraft.response} />
+  {/if}
+</ConfirmDialog>
+
+<ConfirmDialog
   open={discardOpen}
   title={t('commands.discardTitle')}
   body={t('commands.discardBody')}
@@ -688,6 +773,17 @@
 <svelte:window onkeydown={onKey} />
 
 <style>
+  .compose-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px 14px;
+    margin-bottom: 4px;
+    font-family: var(--bb-font-mono);
+    font-size: 11px;
+    letter-spacing: 0.04em;
+    color: var(--bb-muted);
+  }
+
   .toolbar-search { width: 220px; }
 
   .keys {

--- a/console/dashboard/src/routes/(app)/commands/+page.svelte
+++ b/console/dashboard/src/routes/(app)/commands/+page.svelte
@@ -17,6 +17,7 @@
     normName,
     getI18n,
     builtinDef,
+    BUILTIN_NAMES,
     validateCommand,
     PERM_LABELS,
     PERMS,
@@ -294,7 +295,7 @@
   let composeDraft = $state<CommandDraft | null>(null);
   let composeBusy = $state(false);
   const composeReplaces = $derived(
-    composeDraft !== null && items.some((c) => c.name === composeDraft!.name)
+    composeDraft !== null && items.some((c) => !c.builtin && c.name === composeDraft!.name)
   );
 
   onMount(() => {
@@ -323,6 +324,9 @@
       cooldown: draft.cooldown,
       allowedUserId: ''
     });
+    if (BUILTIN_NAMES.has(draft.name)) {
+      problems.name = t('commands.errBuiltinName');
+    }
     if (Object.keys(problems).length === 0) {
       composeDraft = draft;
     } else {
@@ -350,34 +354,46 @@
     const d = composeDraft;
     if (!d || composeBusy) return;
     composeBusy = true;
-    const payload = await postAction(
-      'save',
-      formDataFor({
-        name: d.name,
-        aliases: d.aliases,
-        response: d.response,
-        is_active: true,
-        stream_online_only: false,
-        perm: d.perm,
-        cooldown: d.cooldown,
-        allowed_user_id: ''
-      })
-    );
+    const replacing = composeReplaces;
+    const view: CommandView = {
+      name: d.name,
+      aliases: d.aliases,
+      response: d.response,
+      is_active: true,
+      stream_online_only: false,
+      perm: d.perm,
+      cooldown: d.cooldown,
+      allowed_user_id: ''
+    };
+    const body = formDataFor(view);
+    if (replacing) {
+      // The modal warned "replace" — save as an edit so the server reports
+      // (and audits) an update, not a create.
+      body.set('edit', '1');
+      body.set('original_name', d.name);
+    }
+    setStatus(d.name, 'saving');
+    const payload = await postAction('save', body);
     composeBusy = false;
     composeDraft = null;
     if (payload?.ok) {
       applyResult(payload); // reconciles the row and toasts created/updated
+      // The write can land while the read-back fails (empty commands[]);
+      // reconcile from the draft so the toasted command is actually visible.
+      if (!items.some((c) => c.name === d.name)) {
+        items = [...items, view];
+      }
+      ackSaved(d.name);
       return;
     }
-    if (payload?.errors) {
-      // The server disagreed: open the editor with the draft + its complaints.
-      serverErrors = payload.errors;
-      editorDraft = d;
-      expanded = NEW;
-      editorGen++;
-      return;
-    }
-    toast('err', payload?.error ?? t('commands.toastSaveFailed'));
+    flagError(d.name);
+    // Never drop the composed work: reopen it in the editor, with the
+    // server's field complaints when it sent any.
+    serverErrors = payload?.errors ?? null;
+    editorDraft = d;
+    expanded = NEW;
+    editorGen++;
+    if (!payload?.errors) toast('err', payload?.error ?? t('commands.toastSaveFailed'));
   }
   function openEdit(c: CommandView) {
     if (expanded === c.name) {
@@ -614,6 +630,7 @@
   // Escape is owned by the InspectorSurface (it yields to the discard dialog);
   // the page only handles the search / new shortcuts.
   function onKey(e: KeyboardEvent) {
+    if (composeDraft !== null || discardOpen) return;
     if (isTyping(e) || e.metaKey || e.ctrlKey || e.altKey) return;
     if (e.key === '/') {
       e.preventDefault();

--- a/console/shared/lib/i18n/en.ts
+++ b/console/shared/lib/i18n/en.ts
@@ -349,6 +349,7 @@ export const en = {
     inspector: 'Inspector',
     closeEditor: 'Close editor',
     inspectorIdle: 'Select a command to edit it here, or start a new one.',
+    errBuiltinName: 'That name belongs to a built-in command. Pick another.',
     composeTitle: 'Add !{name} to your channel?',
     composeReplace: 'You already have !{name}. Creating this will replace its response and settings.',
     toastCreated: 'Command !{name} created.',

--- a/console/shared/lib/i18n/en.ts
+++ b/console/shared/lib/i18n/en.ts
@@ -349,6 +349,8 @@ export const en = {
     inspector: 'Inspector',
     closeEditor: 'Close editor',
     inspectorIdle: 'Select a command to edit it here, or start a new one.',
+    composeTitle: 'Add !{name} to your channel?',
+    composeReplace: 'You already have !{name}. Creating this will replace its response and settings.',
     toastCreated: 'Command !{name} created.',
     toastUpdated: 'Command !{name} updated.',
     toastDeleted: 'Command !{name} deleted.',

--- a/console/shared/lib/i18n/fr.ts
+++ b/console/shared/lib/i18n/fr.ts
@@ -348,6 +348,7 @@ export const fr = {
     inspector: 'Inspecteur',
     closeEditor: 'Fermer l\'éditeur',
     inspectorIdle: 'Sélectionnez une commande à modifier ici, ou créez-en une nouvelle.',
+    errBuiltinName: 'Ce nom appartient à une commande intégrée. Choisissez-en un autre.',
     composeTitle: 'Ajouter !{name} à votre chaîne?',
     composeReplace: 'Vous avez déjà !{name}. Cette création remplacera sa réponse et ses réglages.',
     toastCreated: 'Commande !{name} créée.',

--- a/console/shared/lib/i18n/fr.ts
+++ b/console/shared/lib/i18n/fr.ts
@@ -348,6 +348,8 @@ export const fr = {
     inspector: 'Inspecteur',
     closeEditor: 'Fermer l\'éditeur',
     inspectorIdle: 'Sélectionnez une commande à modifier ici, ou créez-en une nouvelle.',
+    composeTitle: 'Ajouter !{name} à votre chaîne?',
+    composeReplace: 'Vous avez déjà !{name}. Cette création remplacera sa réponse et ses réglages.',
     toastCreated: 'Commande !{name} créée.',
     toastUpdated: 'Commande !{name} mise à jour.',
     toastDeleted: 'Commande !{name} supprimée.',

--- a/web/src/components/builder/CommandBuilder.astro
+++ b/web/src/components/builder/CommandBuilder.astro
@@ -3,8 +3,9 @@
  * CommandBuilder — the interactive command workbench. Non-technical streamers
  * compose a command (or a module reply) by clicking variables instead of
  * memorizing syntax, watch a live chat rehearsal, then either send the result
- * straight into the dashboard's command editor (deep link, pre-filled) or
- * copy it as a !cmd chat line / template.
+ * to the dashboard (deep link; a confirmation modal creates it, falling back
+ * to the pre-filled editor only when the draft fails validation) or copy it
+ * as a !cmd chat line / template.
  *
  * Layout is deliberately two zones: one compose card (essentials on top,
  * access/cooldown/aliases folded into "More options") and a slim aside with

--- a/web/src/i18n/builder.ts
+++ b/web/src/i18n/builder.ts
@@ -449,7 +449,7 @@ const UI = {
   responseLabel: { en: 'Bot response', fr: 'Réponse du bot' },
   recipesLabel: { en: 'Quick starts', fr: 'Départs rapides' },
   moreOptions: { en: 'More options: access, cooldown, alternate names', fr: "Plus d'options: accès, délai, autres noms" },
-  sendHelp: { en: 'Review it in the editor that opens, press Create, done.', fr: "Relisez-la dans l'éditeur qui s'ouvre, appuyez sur Créer, c'est fait." },
+  sendHelp: { en: 'Review the summary that opens, press Create, done.', fr: "Relisez le récapitulatif qui s'ouvre, appuyez sur Créer, c'est fait." },
   step3Title: { en: 'Make it dynamic', fr: 'Rendez-la dynamique' },
   step3Sub: { en: 'Click a variable to insert it at your cursor. Only variables that work here are shown.', fr: 'Cliquez une variable pour l’insérer au curseur. Seules les variables qui fonctionnent ici sont montrées.' },
   bracesSummary: { en: 'What do the braces mean?', fr: 'Que signifient les accolades?' },

--- a/web/src/pages/fr/guides/commands.astro
+++ b/web/src/pages/fr/guides/commands.astro
@@ -242,8 +242,8 @@ const sections = [
                 Tout ce guide est intégré au
                 <a href="/fr/command-builder">constructeur de commandes</a>: choisissez les variables
                 dans une liste expliquée au lieu de les mémoriser, regardez une répétition de chat en
-                direct pendant que vous tapez, et quand tout sonne juste, envoyez la commande dans
-                l'éditeur de votre tableau de bord en un clic. C'est le chemin le plus court entre
+                direct pendant que vous tapez, et quand tout sonne juste, envoyez la commande à votre
+                tableau de bord, où une confirmation la crée en un clic. C'est le chemin le plus court entre
                 l'idée et la commande qui fonctionne.
             </p>
             <p class="gtip">

--- a/web/src/pages/guides/commands.astro
+++ b/web/src/pages/guides/commands.astro
@@ -238,7 +238,7 @@ const sections = [
                 Everything in this guide is baked into the
                 <a href="/command-builder">command builder</a>: pick variables from a labeled list
                 instead of memorizing them, watch a live chat rehearsal as you type, and when it reads
-                right, send it straight into your dashboard's editor with one click. It is the fastest
+                right, send it straight to your dashboard, where one press confirms and creates it. It is the fastest
                 way to go from idea to working command.
             </p>
             <p class="gtip">


### PR DESCRIPTION
## What

The marketing builder's `/commands?compose=1&…` deep link now lands in a **confirmation modal** instead of the docked inspector: command summary (access, cooldown, aliases) + the editor's own chat rehearsal, and one press creates the command.

- **Replace-aware**: composing over an existing custom command warns it will be replaced, relabels the action *Save changes*, and saves as an edit so the server reports and audits an update
- **Resilient**: a rejected draft falls back to the pre-filled editor with inline errors (never drops the visitor's work); an empty read-back still shows the created row; the row gets the standard save pulse
- **Guarded**: built-in command names are rejected up front with a localized complaint (no hidden shadows); page shortcuts (`n`, `/`) stay quiet while a dialog is open
- Web copy that still promised "the pre-filled editor" now describes the modal (EN + FR)

## Verification

- svelte-check clean; Astro build green; Playwright 17 passing (1 pre-existing WebGL timing flake)
- Every branch exercised live in DEMO mode: create, replace (→ "updated" toast), cancel, invalid draft → editor fallback, built-in name rejection, shortcut suppression
- Reviewed by two parallel subagents (modal correctness + builder↔console contract); all 10 findings fixed