### PR TITLE
feat(deploy): bring falco under flux with rule-noise exceptions

### DIFF
--- a/deploy/flux/clusters/production/falco-RUNBOOK.md
+++ b/deploy/flux/clusters/production/falco-RUNBOOK.md
@@ -1,0 +1,200 @@
+# Falco: cutover to a Flux HelmRelease
+
+Migrating falco from its current **orphaned** state (installed out-of-band, no
+helm release secret in ns `falco`) to the Flux-managed `HelmRelease` in
+`deploy/flux/clusters/production/falco.yaml`. Same class of migration as
+`newrelic-RUNBOOK.md`; this one is much smaller (one DaemonSet, two ConfigMaps,
+one Service, one ServiceAccount, plus dead falcosidekick leftovers).
+
+This runbook is **not executed automatically**. Do the steps in order.
+
+---
+
+## 0. Ground truth (verified 2026-07-17)
+
+- `helm list -n falco` is empty and there is **no `sh.helm.release.v1.falco.*`
+  secret**, so helm owns nothing; the live objects are kubectl-owned orphans
+  carrying `helm.sh/chart=falco-8.0.3` labels.
+- Chart pinned in the HelmRelease is **falco 8.0.3** (app 0.43.1), matching
+  every live label and both live images (falco:0.43.1, falcoctl:0.12.2).
+- Values in falco.yaml reproduce the live install exactly: a
+  `helm template --version 8.0.3` render with those values diffs clean against
+  the live DaemonSet and both ConfigMaps except for (a) API-server-defaulted
+  fields, (b) the new customRules ConfigMap/mount, (c) the dead
+  `http_output.url` falcosidekick remnant we intentionally drop.
+- The customRules file was validated inside a live falco pod against the
+  live-loaded ruleset: `falco -V /etc/falco/falco_rules.yaml -V <file>` ->
+  zero errors, zero warnings.
+- Live orphan inventory in ns `falco`:
+  - `daemonset/falco`, `configmap/falco`, `configmap/falco-falcoctl`,
+    `service/falco-metrics`, `serviceaccount/falco` — all re-rendered by the
+    new release (same names).
+  - falcosidekick leftovers from an old experiment (sidekick is NOT enabled in
+    the new release and these will NOT come back): `serviceaccount/falco-falcosidekick`,
+    `serviceaccount/falco-falcosidekick-ui`, `role/falco-falcosidekick`,
+    `role/falco-falcosidekick-ui`, `rolebinding/falco-falcosidekick`,
+    `rolebinding/falco-falcosidekick-ui`.
+  - `secret/newrelic-key-secret` (an NR license key for the dead sidekick
+    output; nothing consumes it).
+- **No cluster-scoped falco objects exist** (no ClusterRole/ClusterRoleBinding),
+  and the new render creates none. With `driver.kind=modern_ebpf` the chart
+  also skips the falco Role/RoleBinding and the driver-loader init container,
+  so the rendered object set is exactly: SA, 3 ConfigMaps (falco,
+  falco-falcoctl, falco-rules), Service falco-metrics, DaemonSet.
+
+---
+
+## THE KEY RISK and the decision
+
+Identical to the nri-bundle cutover: helm refuses to take over objects it did
+not create (`... exists and cannot be imported into the current release:
+invalid ownership metadata ...`).
+
+**Decision: pre-delete the orphans and let helm install fresh** (option (a)
+from newrelic-RUNBOOK.md, for the same reasons). Falco is a detection-only
+sensor; nothing at runtime depends on it. A 1-2 minute gap in syscall
+monitoring while the DaemonSet is recreated is acceptable, and there is no
+state to preserve (rules/plugins live in emptyDirs re-pulled by falcoctl at
+pod start).
+
+Failure mode if the ordering slips: if helm-controller tries to install while
+the orphans still exist, the install just errors and the live orphaned falco
+keeps running untouched. Delete the orphans and let the install remediation
+(retries: 3) or a manual `flux reconcile` pick it up. Nothing breaks; you only
+lose tidiness.
+
+---
+
+## Pre-flight (read-only)
+
+```sh
+CTX=k8s-operator.tail451e6d.ts.net
+
+# 1. Still no helm release to clash with.
+helm --kube-context $CTX list -n falco                       # expect: empty
+kubectl --context $CTX -n falco get secret | grep sh.helm.release  # expect: none
+
+# 2. Snapshot everything we are about to delete (rollback safety net).
+kubectl --context $CTX -n falco get ds,svc,cm,sa,role,rolebinding -o yaml \
+  > /tmp/falco-pre-cutover.yaml
+
+# 3. Confirm there really are no cluster-scoped falco objects.
+kubectl --context $CTX get clusterrole,clusterrolebinding -o name | grep -i falco
+# expect: no output
+```
+
+---
+
+## Cutover
+
+### Step 1 - Land the repo change (merge to main)
+
+Merge the branch carrying `deploy/flux/clusters/production/falco.yaml` and this
+runbook. **Suspend the HelmRelease the moment Flux creates it**, so the delete
+in Step 2 happens before helm-controller's first install attempt:
+
+```sh
+flux --context $CTX reconcile kustomization flux-system --with-source  # pull the merge
+flux --context $CTX suspend helmrelease falco -n falco
+# The falcosecurity HelmRepository can reconcile freely; only the install waits.
+```
+
+(If helm-controller wins the race anyway, see "Failure mode" above — no harm.)
+
+### Step 2 - Delete the orphaned objects
+
+```sh
+# The release-rendered orphans (recreated by helm in Step 3):
+kubectl --context $CTX -n falco delete \
+  daemonset/falco configmap/falco configmap/falco-falcoctl \
+  service/falco-metrics serviceaccount/falco
+
+# The dead falcosidekick leftovers (NOT recreated; sidekick stays disabled):
+kubectl --context $CTX -n falco delete \
+  serviceaccount/falco-falcosidekick serviceaccount/falco-falcosidekick-ui \
+  role/falco-falcosidekick role/falco-falcosidekick-ui \
+  rolebinding/falco-falcosidekick rolebinding/falco-falcosidekick-ui
+
+# KEEP: the namespace itself.
+# OPTIONAL cleanup: secret/newrelic-key-secret holds an NR license key nothing
+# consumes anymore (the key also lives in Doppler). Safe to delete; not
+# required for the cutover.
+```
+
+### Step 3 - Resume Flux; let helm-controller install fresh
+
+```sh
+flux --context $CTX resume helmrelease falco -n falco
+flux --context $CTX reconcile helmrelease falco -n falco --with-source
+```
+
+---
+
+## Post-cutover verification
+
+```sh
+# 1. Release exists and is Flux-owned now.
+helm --kube-context $CTX list -n falco                    # falco: deployed
+flux --context $CTX get helmrelease -n falco              # Ready=True
+kubectl --context $CTX -n falco get secret | grep sh.helm.release  # present
+
+# 2. DaemonSet back to 4/4 (node1, node2, node3, worker1 — the worker-pool
+#    toleration must keep worker1 covered).
+kubectl --context $CTX -n falco get ds,pods -o wide
+
+# 3. The exceptions file is mounted and LOADED (this is the whole point).
+kubectl --context $CTX -n falco get cm falco-rules \
+  -o jsonpath='{.data.bagelbot-exceptions\.yaml}' | head -5
+kubectl --context $CTX -n falco logs ds/falco -c falco | grep -i 'rules.d\|Loading rules'
+#   expect a "Loading rules from ... rules.d/bagelbot-exceptions.yaml" line and
+#   NO rule-loading errors/warnings.
+
+# 4. The three FP families go quiet. Immediately:
+kubectl --context $CTX -n falco logs ds/falco -c falco --since=15m \
+  | grep -c 'Contact K8S API Server'        # expect 0 (was hundreds/hour)
+#    And over the next day in New Relic: falco volume drops from ~6.5k/day to
+#    roughly zero (only real signal remains).
+
+# 5. The sensor still detects (canary: read a sensitive file from a container
+#    that is NOT allowlisted — the falco pod itself works and always exists;
+#    the open() is the trigger, the content does not matter):
+kubectl --context $CTX -n falco exec ds/falco -c falco -- cat /etc/shadow >/dev/null
+kubectl --context $CTX -n falco logs ds/falco -c falco --since=2m | grep 'sensitive file'
+#   expect one "Sensitive file opened for reading by non-trusted program" event.
+```
+
+---
+
+## Rollback
+
+```sh
+flux --context $CTX suspend helmrelease falco -n falco
+helm --kube-context $CTX uninstall falco -n falco    # if a release got created
+kubectl --context $CTX -n falco apply -f /tmp/falco-pre-cutover.yaml
+```
+
+The snapshot restores the exact pre-cutover orphaned state (including the
+sidekick leftovers). Revert the falco.yaml commit if abandoning entirely,
+otherwise Flux will retry the install on the next reconcile.
+
+---
+
+## What changed vs the orphaned install (behavior)
+
+1. **customRules** (`bagelbot-exceptions.yaml`, ConfigMap `falco-rules`,
+   loaded from /etc/falco/rules.d): allowlists for the three stock-rule FP
+   families (~6.5k events/day): systemd-userwork//etc/shadow +
+   systemd-executor//etc/pam.d for "Read sensitive file untrusted";
+   infra-namespace + nats-selfheal pod-prefix allowlist for "Contact K8S API
+   Server From Container" (rule stays enabled); alpine/k8s acceptance-test
+   pods (nats-live-acceptance / valkey-live-acceptance / wg-latency) for
+   "Drop and execute new binary in container" and "Redirect STDOUT/STDIN to
+   Network Connection in Container". Details and rationale live as comments in
+   falco.yaml.
+2. `falco.http_output.url` no longer points at the dead falco-falcosidekick
+   Service (http_output was and stays disabled; the URL was inert).
+3. The falcosidekick leftover SAs/Roles/RoleBindings are gone.
+4. Everything else renders byte-identical to live (chart 8.0.3, modern_ebpf,
+   json_output, metrics + falco-metrics Service, trimmed resources, infra-low
+   priority class, worker-pool toleration, default falcoctl artifact config:
+   falco-rules:5 + container plugin, follow every 168h).

--- a/deploy/flux/clusters/production/falco.yaml
+++ b/deploy/flux/clusters/production/falco.yaml
@@ -1,0 +1,207 @@
+# Falco, brought under Flux (HelmRelease) from an out-of-band install.
+# `helm list -n falco` is empty: the live DaemonSet/ConfigMaps/Service/SA carry
+# helm.sh/chart labels but no helm release secret exists, i.e. they are
+# kubectl-owned orphans (same situation newrelic.yaml started from).
+#
+# CHART VERSION
+# -------------
+# falco 8.0.3 (app 0.43.1). Verified against every live label
+# (helm.sh/chart=falco-8.0.3, app.kubernetes.io/version=0.43.1) and the live
+# images falco:0.43.1 / falcoctl:0.12.2, which are exactly what 8.0.3 pins.
+#
+# VALUES = LIVE RECONSTRUCTION (verified 2026-07-17 by rendering
+# `helm template falco falcosecurity/falco --version 8.0.3` with these values
+# and diffing against the live DaemonSet + falco/falco-falcoctl ConfigMaps;
+# the only remaining deltas are API-server-defaulted fields and the customRules
+# additions):
+#   - driver.kind modern_ebpf: live engine.kind. Also what makes the chart skip
+#     the falco-driver-loader init container AND the configmap Role/RoleBinding,
+#     both absent live.
+#   - falco.json_output true: the fluent-bit -> New Relic pipeline
+#     (deploy/infra/cluster/newrelic-logging.yaml, level_extract.lua) matches
+#     falco events on rule/priority/output_fields markers in the JSON line.
+#   - metrics.enabled true: renders the falco-metrics Service and flips
+#     webserver.prometheus_metrics_enabled, both live. The prometheus.io pod
+#     annotations are the podAnnotations below.
+#   - resources trimmed way below chart defaults (node1 is a 2-core host),
+#     infra-low priority class, and the itsbagelbot.dev/pool=worker-pool
+#     toleration so the DaemonSet lands on worker1 too (4/4 nodes).
+#   - falcoctl config needs ZERO overrides: rules artifact falco-rules:5,
+#     container plugin 0.6.3 and follow every 168h are all 8.0.3 defaults
+#     (live falcoctl.yaml diffs empty against the default render).
+#   - Intentionally NOT carried over: falco.http_output.url pointing at the
+#     long-gone falco-falcosidekick Service. http_output is disabled, the URL
+#     was inert cruft from the era when falcosidekick was installed (its
+#     leftover SAs/Roles get deleted in the cutover, see the RUNBOOK).
+#
+# CUSTOM RULES (the reason this exists: ~6,500 events/day to New Relic, nearly
+# all false positives from the stock ruleset)
+# ---------------------------------------------------------------------------
+# Three FP families, each tuned via the customization stub upstream ships for
+# exactly this purpose ((never_true) macros / empty lists + `override:`).
+# The rules land in ConfigMap falco-rules, mounted at /etc/falco/rules.d which
+# loads AFTER falco_rules.yaml, so the overrides re-define the stock stubs.
+# Macro/list names AND the whole file were validated 2026-07-17 with
+# `falco -V /etc/falco/falco_rules.yaml -V <this file>` inside a live falco
+# pod (falco 0.43.1, rules artifact falco-rules:5): zero errors, zero warnings.
+#
+# MIGRATION / CUTOVER RUNBOOK: deploy/flux/clusters/production/falco-RUNBOOK.md.
+# Same orphaned-release problem newrelic-RUNBOOK.md documents: helm-controller
+# WILL fail with "exists and cannot be imported into the current release"
+# until the kubectl-owned orphans are deleted. Read it before letting Flux
+# reconcile this the first time.
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: falcosecurity
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://falcosecurity.github.io/charts
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: falco
+  namespace: falco
+spec:
+  interval: 1h
+  timeout: 10m
+  releaseName: falco # MUST stay "falco" so rendered names (falco, falco-falcoctl,
+                     # falco-metrics, falco-rules) match the orphaned install and
+                     # the fluent-bit falco-forwarding match keeps working.
+  chart:
+    spec:
+      chart: falco
+      version: 8.0.3 # exact pin; matches every live helm.sh/chart label
+      sourceRef:
+        kind: HelmRepository
+        name: falcosecurity
+        namespace: flux-system
+      interval: 1h
+  install:
+    # Namespace falco already exists (created out-of-band); helm must not own it.
+    createNamespace: false
+    crds: Skip # chart ships no CRDs
+    remediation:
+      retries: 3
+  upgrade:
+    crds: Skip
+    remediation:
+      retries: 3
+      remediateLastFailure: true
+    cleanupOnFail: true
+  values:
+    driver:
+      kind: modern_ebpf
+
+    falco:
+      json_output: true
+
+    # Renders the falco-metrics Service and enables the prometheus endpoint on
+    # the webserver (port 8765), matching live.
+    metrics:
+      enabled: true
+
+    podAnnotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "8765"
+      prometheus.io/path: /metrics
+
+    podPriorityClassName: infra-low
+
+    # Chart default only tolerates control-plane taints; the extra entry keeps
+    # falco on worker1 (tainted itsbagelbot.dev/pool=worker-pool).
+    tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+      - effect: NoSchedule
+        key: itsbagelbot.dev/pool
+        operator: Equal
+        value: worker-pool
+
+    # Far below chart defaults (100m/512Mi -> 1000m/1024Mi); live-proven for
+    # this fleet and node1 is 2-core.
+    resources:
+      requests:
+        cpu: 10m
+        memory: 128Mi
+      limits:
+        cpu: 200m
+        memory: 256Mi
+
+    falcoctl:
+      artifact:
+        follow:
+          resources:
+            requests:
+              cpu: 5m
+              memory: 16Mi
+            limits:
+              cpu: 25m
+              memory: 32Mi
+
+    customRules:
+      bagelbot-exceptions.yaml: |-
+        # Local tuning of the stock falco-rules ruleset (falcoctl artifact
+        # falco-rules:5). Loaded from /etc/falco/rules.d AFTER
+        # /etc/falco/falco_rules.yaml, so the `override:` markers below
+        # re-define the (never_true) customization stubs and empty allowlist
+        # lists upstream ships for exactly this purpose.
+
+        # --- 1. "Read sensitive file untrusted" family (~690/day FPs) --------
+        # EL10/systemd-257 hosts: systemd-userdbd workers legitimately read
+        # /etc/shadow for NSS/userdb lookups, and systemd-executor (the
+        # systemd 254+ unit spawner) reads /etc/pam.d/* during PAM session
+        # setup for user@N.service (triggered by e.g. oracle-cloud-agent sudo
+        # probes). Known upstream falcosecurity/rules FP family. Scoped to the
+        # exact host executable paths AND the exact files they touch, so any
+        # other sensitive-file read by these binaries still alerts.
+        - macro: user_known_read_sensitive_files_activities
+          condition: >
+            ((proc.exepath = /usr/lib/systemd/systemd-userwork and fd.name = /etc/shadow)
+             or (proc.exepath = /usr/lib/systemd/systemd-executor and fd.directory = /etc/pam.d))
+          override:
+            condition: replace
+
+        # --- 2. "Contact K8S API Server From Container" (~5,800/day FPs) -----
+        # Kept ENABLED with an allowlist (not disabled) so unexpected API-server
+        # access from app workloads still alerts. Every legitimate API client
+        # lives in an infra namespace (flux controllers, keda, cert-manager +
+        # trust-manager, tailscale operator + proxies, nri-kubernetes;
+        # kube-system/coredns is already excluded by the stock k8s_containers
+        # macro), except the nats-selfheal CronJob in ns production, which is
+        # matched by pod-name prefix, NOT namespace-wide. Residual trickle:
+        # connects raced during pod startup can miss k8s metadata enrichment
+        # (k8s.ns.name=<NA>) and still alert; rare, accepted.
+        - macro: user_known_contact_k8s_api_server_activities
+          condition: >
+            (k8s.ns.name in (flux-system, keda, cert-manager, tailscale, newrelic)
+             or (k8s.ns.name = production and k8s.pod.name startswith "nats-selfheal-"))
+          override:
+            condition: replace
+
+        # --- 3. Acceptance-test pods (drop-and-execute + stdio redirect) -----
+        # nats-live-acceptance / valkey-live-acceptance / wg-latency test pods
+        # run image alpine/k8s and get freshly built binaries kubectl-cp'd in
+        # and executed (deploy/k8s/nats-live-acceptance/*.sh): textbook trigger
+        # for "Drop and execute new binary in container" and "Redirect
+        # STDOUT/STDIN to Network Connection in Container". The container
+        # plugin reports container.image.repository WITH the registry prefix
+        # (verified live), so both forms are listed.
+        - list: known_drop_and_execute_containers
+          items: [alpine/k8s, docker.io/alpine/k8s]
+          override:
+            items: append
+
+        - macro: user_known_stand_streams_redirect_activities
+          condition: >
+            (container.image.repository in (alpine/k8s, docker.io/alpine/k8s)
+             or k8s.pod.name startswith "nats-live-acceptance"
+             or k8s.pod.name startswith "valkey-live-acceptance"
+             or k8s.pod.name startswith "wg-latency")
+          override:
+            condition: replace


### PR DESCRIPTION
Falco was installed out-of-band: `helm list -n falco` is empty and no falco manifests exist in the repo (only the fluent-bit forwarding config mentions it). It emits ~6,500 events/day to New Relic, nearly all false positives from stock rules.

This brings it under Flux as a HelmRelease (same pattern as `newrelic.yaml`) and tunes the three FP families.

## Chart version

Pinned **falco 8.0.3** (app 0.43.1) — matches every live label (`helm.sh/chart=falco-8.0.3`, `app.kubernetes.io/version=0.43.1`) and both live images (`falco:0.43.1`, `falcoctl:0.12.2`).

## Values = live reconstruction

Verified by rendering `helm template falco falcosecurity/falco --version 8.0.3` with these values and diffing against the live DaemonSet + `falco`/`falco-falcoctl` ConfigMaps. Only remaining deltas: API-server-defaulted fields, the new customRules ConfigMap/mount, and one intentional drop (`falco.http_output.url` pointed at the long-gone `falco-falcosidekick` Service; `http_output` is disabled, so the URL was inert cruft).

Notable findings baked into the comments:
- falcoctl config needs **zero** overrides — `falco-rules:5`, container plugin 0.6.3, follow every 168h are all 8.0.3 defaults (live `falcoctl.yaml` diffs empty against the default render).
- `driver.kind: modern_ebpf` is what makes the chart skip the driver-loader init container **and** the configmap Role/RoleBinding — both absent live.

## Custom rules (the point)

Three FP families, each tuned via the customization stub upstream ships for exactly this purpose (`(never_true)` macros / empty lists + `override:`). Rules land in ConfigMap `falco-rules`, mounted at `/etc/falco/rules.d` which loads *after* `falco_rules.yaml`.

1. **Read sensitive file untrusted** (~690/day): allowlist `systemd-userwork` reading `/etc/shadow` and `systemd-executor` reading `/etc/pam.d/*`. Scoped to the exact host exepaths **and** the exact files, so any other sensitive-file read by those binaries still alerts.
2. **Contact K8S API Server From Container** (~5,800/day): rule stays **enabled** with an allowlist rather than being disabled or downgraded, so unexpected API access from app workloads still alerts. Infra namespaces (`flux-system, keda, cert-manager, tailscale, newrelic`) plus the `nats-selfheal-` CronJob matched by **pod-name prefix**, not namespace-wide — it lives in ns `production`, so a namespace allowlist there would gut the rule. `kube-system`/coredns is already excluded by the stock `k8s_containers` macro.
3. **Drop and execute new binary** / **Redirect STDOUT/STDIN**: our acceptance-test pods (`nats-live-acceptance`, `valkey-live-acceptance`, `wg-latency`) run image `alpine/k8s` and get freshly built binaries `kubectl cp`'d in and executed. The container plugin reports `container.image.repository` **with** the registry prefix (verified in live event JSON), so both forms are listed.

## Validation

The customRules file was validated **inside a live falco pod** against the actually-loaded ruleset:

```
falco -V /etc/falco/falco_rules.yaml -V <file>
```

falco 0.43.1, rules artifact `falco-rules:5` → zero errors, zero warnings, `schema_valid: true` for both files. All four upstream stubs confirmed present as `(never_true)` / empty list.

## Cutover

**Not automatic.** `deploy/flux/clusters/production/falco-RUNBOOK.md` documents the same orphaned-release problem `newrelic-RUNBOOK.md` covers: helm-controller will fail with *"exists and cannot be imported into the current release"* until the kubectl-owned orphans are deleted.

Flow: merge → `flux suspend helmrelease falco` → delete orphans (DaemonSet, 2 ConfigMaps, Service, SA, plus 6 dead falcosidekick SA/Role/RoleBinding leftovers) → resume. If helm-controller wins the race anyway the install just errors and the live orphaned falco keeps running untouched — no breakage, only untidiness.

Post-cutover checks include a canary (`cat /etc/shadow` in the falco pod, which is *not* allowlisted) to prove the sensor still fires after the exceptions land.