### PR TITLE
fix(infra): retire the VXLAN-era flannel watchdog

### DIFF
--- a/deploy/ansible/cluster-network-wireguard.yml
+++ b/deploy/ansible/cluster-network-wireguard.yml
@@ -127,6 +127,52 @@
         immediate: true
         state: disabled
 
+    # --- Retire the VXLAN-era flannel watchdog ------------------------------
+    # A hand-installed (never repo-tracked) /usr/local/sbin/flannel-watchdog +
+    # timer greps for `flannel.1` every 2 min and runs `systemctl restart
+    # k3s(-agent)` when it is missing, rate-limited to once per 30 min. It was
+    # added 2026-07-01 for the tailscale-era boot race where flannel VXLAN was
+    # stranded if tailscale0 flapped.
+    #
+    # wireguard-native names the interface `flannel-wg`, so `flannel.1` is gone
+    # BY DESIGN and the watchdog's fault condition can never clear again. This
+    # migration therefore turned it into a permanent 30-minute restart loop the
+    # moment it activated (first firing 2026-07-16 12:58, found 2026-07-17):
+    #   * server  -> 46 control-plane restarts/day (API 503s, dropped watches)
+    #   * worker1 -> 46 kubelet restarts/day (pod churn)
+    #   * node1   -> 46 crash-loops/day of its demoted-but-still-present
+    #                k3s.service, because the watchdog picks UNIT=k3s whenever
+    #                k3s.service merely EXISTS, agent or not.
+    # node3 never had the watchdog and rode the migration without a restart,
+    # which is the proof it is not load-bearing.
+    #
+    # Do NOT "fix" this by repointing it at flannel-wg: the race it guarded
+    # cannot recur now that pod traffic is off tailscale0 entirely, and the
+    # k3s(-agent) units already block on ExecStartPre=wait-for-tailscale0.
+    # Restarting a single-server control plane on a timer is not a safety net.
+    - name: Stop the obsolete VXLAN-era flannel watchdog
+      ansible.builtin.systemd:
+        name: flannel-watchdog.timer
+        state: stopped
+        enabled: false
+      failed_when: false
+
+    - name: Remove the obsolete VXLAN-era flannel watchdog
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - /etc/systemd/system/flannel-watchdog.timer
+        - /etc/systemd/system/flannel-watchdog.service
+        - /usr/local/sbin/flannel-watchdog
+        - /run/flannel-watchdog.last
+      register: watchdog_removed
+
+    - name: Reload systemd after removing the flannel watchdog
+      ansible.builtin.systemd:
+        daemon_reload: true
+      when: watchdog_removed is changed
+
 - name: Activate native WireGuard on the K3s server
   hosts: k3s_server
   become: true


### PR DESCRIPTION
## What happened

`flannel-watchdog` is a hand-installed script (**never repo-tracked** — it exists nowhere in git, only on the nodes) that greps for `flannel.1` every 2 minutes and runs `systemctl restart k3s(-agent)` when it's missing, rate-limited to once per 30 min. It was added 2026-07-01 for the tailscale-era boot race where flannel's VXLAN interface was stranded if tailscale0 flapped.

`wireguard-native` names the interface **`flannel-wg`**. So `flannel.1` is gone **by design**, and the watchdog's fault condition can never clear again.

**This migration turned it into a permanent 30-minute restart loop the moment it activated.** First firing 2026-07-16 12:58 — the exact hour of the cutover. It ran for ~23 hours before being found:

| Node | Impact |
|---|---|
| node2 (server) | **46 control-plane restarts/day** — API 503s, dropped watches |
| worker1 | **46 kubelet restarts/day** — pod churn |
| node1 | 46 crash-loops/day of its demoted-but-still-present `k3s.service` |
| node3 | **0** — never had the watchdog |

node1's case is a second bug in the same script: it selects `UNIT=k3s` whenever `k3s.service` merely *exists*, agent or not. node1 was demoted from control-plane but kept a stale `k3s.service`, so the watchdog kept resurrecting a server that fails 100% of the time with `critical configuration value mismatch between servers`. That's the crash-looping unit noted after the demotion — the watchdog was the mechanism restarting it.

**node3 is the control**: no watchdog, `flannel-wg` present, `flannel.1` absent, and it rode the migration without a single restart. That's the proof the watchdog is not load-bearing.

## Why remove rather than repoint at flannel-wg

- The race it guarded **cannot recur**: pod traffic no longer rides tailscale0 at all (that was the entire point of this migration).
- The `k3s`/`k3s-agent` units already block on `ExecStartPre=/usr/local/sbin/wait-for-tailscale0`, which is the correct, ordered guard.
- Restarting a **single-server** control plane on a timer is not a safety net. A missing data-plane interface should alert a human, not bounce the API server.

## What this PR does

Adds the cleanup to the idempotent `hosts: cluster` staging play, beside the existing "Close obsolete public VXLAN transport" task — this migration is what orphaned the watchdog, so this is where retiring it belongs. Already removed live on all nodes; this makes it reproducible so a re-run or rebuild can't resurrect it.

Validated with `ansible-playbook --syntax-check`. (First draft used `notify: reload systemd`, which would have been a hard error — this playbook has no `handlers:` section — so it uses an explicit `daemon_reload` task guarded by `register`/`when: is changed`, matching the file's existing inline pattern.)

## Live state after the fix

All 4 nodes: `flannel-watchdog` units and files **gone**, `flannel-wg` present, k3s/k3s-agent active, all Ready. node1's stale `k3s.service` stopped and **masked** so it can never start again (its agent, the real unit, is untouched and has been up since Jul 16).

## Follow-ups not in this PR

- **node2's `GOMEMLIMIT`/`GOGC` env is gone** (`Environment=` is empty, `MemoryMax=infinity`, unit at ~3.5G). Documented as 1300MiB/GOGC=75 but node-local and untracked — same drift class as this watchdog.
- **Single-server control plane** is the deeper fragility this exposed; 3 servers with embedded etcd would make one restart a non-event.