### PR TITLE
feat(eventsub): handle authorization revocation end to end

### DIFF
--- a/app/ingress/lib/ingress/shard_session.ex
+++ b/app/ingress/lib/ingress/shard_session.ex
@@ -513,6 +513,22 @@ defmodule Ingress.ShardSession do
     end
   end
 
+  # user.authorization.grant / user.authorization.revoke are client-scoped
+  # subscriptions (condition keys on our client id, not a broadcaster), so they
+  # bypass the lane pipeline: no broadcaster admission applies and their only
+  # consumer is outgress, which reconciles the channel's enrollment state. The
+  # binary-prefix match keeps the hot chat path untouched.
+  defp handle_twitch(
+         _which,
+         "notification",
+         %{"subscription" => %{"type" => "user.authorization." <> action}} = payload,
+         _meta,
+         state
+       ) do
+    publish_authz(action, payload["event"] || %{})
+    {:noreply, state |> count_notification() |> pet_watchdog()}
+  end
+
   defp handle_twitch(_which, "notification", payload, meta, state) do
     Ingress.Dispatcher.dispatch(payload, %{
       shard_id: state.shard_id,
@@ -524,8 +540,24 @@ defmodule Ingress.ShardSession do
     {:noreply, state |> count_notification() |> pet_watchdog()}
   end
 
+  # Twitch revoked one subscription (authorization_revoked, user_removed,
+  # version_removed, ...). Publish it on the authz status subject so outgress
+  # can flip the channel's enrollment state; the surviving subscriptions are
+  # deliberately left alone (stream.online keeps working without any user
+  # grant, and it is the beacon that lets the bot tell the streamer to
+  # reconnect on their next go-live).
   defp handle_twitch(_which, "revocation", payload, _meta, state) do
-    Logger.warning("subscription revoked: #{inspect(payload["subscription"])}")
+    sub = payload["subscription"] || %{}
+    Logger.warning("subscription revoked: #{inspect(sub)}")
+    Metrics.count("Shard/Revocations")
+
+    Nats.publish("twitch.ingress.status.authz.subrevoked", %{
+      broadcaster_id: revoked_broadcaster(sub),
+      type: sub["type"],
+      status: sub["status"],
+      at: DateTime.utc_now()
+    })
+
     {:noreply, pet_watchdog(state)}
   end
 
@@ -546,6 +578,36 @@ defmodule Ingress.ShardSession do
   end
 
   def permanent_bind_error?(_reason), do: false
+
+  # Announce an authorization change for our client id. "grant" fires when a
+  # user (re)consents through the dashboard OAuth flow; "revoke" when Twitch
+  # invalidates the authorization (the user disconnected the app or changed
+  # their password). Outgress owns the reaction: revoke marks the channel's
+  # enrollment revoked, grant re-enrolls the missing subscriptions.
+  defp publish_authz(action, event) when action in ["grant", "revoke"] do
+    Metrics.count("Shard/Authz/#{action}")
+    outcome = if action == "grant", do: "granted", else: "revoked"
+
+    Nats.publish("twitch.ingress.status.authz.#{outcome}", %{
+      user_id: event["user_id"],
+      user_login: event["user_login"],
+      at: DateTime.utc_now()
+    })
+  end
+
+  defp publish_authz(action, _event) do
+    Logger.debug("unhandled user.authorization action #{action}")
+  end
+
+  # The condition names the owning channel differently per subscription type:
+  # broadcaster_user_id for channel.* types, to_broadcaster_user_id for raid,
+  # user_id for the client-scoped user.* types.
+  defp revoked_broadcaster(sub) do
+    condition = sub["condition"] || %{}
+
+    condition["broadcaster_user_id"] || condition["to_broadcaster_user_id"] ||
+      condition["user_id"]
+  end
 
   # Announce that this shard (re)established its binding: "fresh" after a
   # full connect + Helix bind, "moved" after a session_reconnect handshake

--- a/app/outgress/internal/channels/registry.go
+++ b/app/outgress/internal/channels/registry.go
@@ -343,6 +343,19 @@ func (r *Registry) EnrollCooldownActive(ctx context.Context, broadcasterID strin
 	return n > 0, nil
 }
 
+// reauthBeaconPrefix throttles the go-live "please reconnect" chat line for a
+// revoked channel.
+const reauthBeaconPrefix = "outgress:reauth:beacon:"
+
+// ArmReauthBeacon claims the right to send one reauth chat beacon for the
+// broadcaster within ttl. SET NX makes the claim atomic across replicas and
+// across a stream being restarted several times in a row: the first caller
+// wins, everyone else skips. Fails closed (false, err) on a Valkey error so
+// an outage cannot spam a streamer's chat.
+func (r *Registry) ArmReauthBeacon(ctx context.Context, broadcasterID string, ttl time.Duration) (bool, error) {
+	return r.acquireLock(ctx, reauthBeaconPrefix+broadcasterID, "1", ttl)
+}
+
 // AcquireEnrollLock tries to set a Valkey NX key as a distributed lock.
 // Returns true if this caller owns the lock, false if another replica holds it.
 func (r *Registry) AcquireEnrollLock(ctx context.Context, broadcasterID, owner string, ttl time.Duration) (bool, error) {

--- a/app/outgress/internal/config/config.go
+++ b/app/outgress/internal/config/config.go
@@ -81,6 +81,21 @@ type Config struct {
 	// projector's NATS_SUBJECT_LANE_STREAM.
 	StreamLaneSubject string
 
+	// Authz*Subject are the ingress status subjects carrying the authorization
+	// lifecycle: a user re-consented (granted), a user's authorization died
+	// (revoked), or Twitch revoked one concrete subscription (subrevoked).
+	// Outgress binds a durable consumer per subject to reconcile channel
+	// enrollment state.
+	AuthzGrantedSubject    string
+	AuthzRevokedSubject    string
+	AuthzSubRevokedSubject string
+
+	// NotifySendSubject is the notifications service direct-send verb the
+	// reauth nudge goes through; UsersStateSubject is the users service verb
+	// the streamer's locale is read from.
+	NotifySendSubject string
+	UsersStateSubject string
+
 	RateRegion          string
 	LeaseEpoch          time.Duration
 	LeaseGuard          time.Duration
@@ -92,36 +107,41 @@ type Config struct {
 func Load() *Config {
 	natsURL := env.Get("NATS_URL", "nats://127.0.0.1:4222")
 	return &Config{
-		NATSURL:               natsURL,
-		NATSRPCURL:            env.Get("NATS_RPC_URL", natsURL),
-		PremiumSubject:        env.Get("NATS_OUTGRESS_PREMIUM_SUBJECT", "twitch.outgress.premium"),
-		StandardSubject:       env.Get("NATS_OUTGRESS_STANDARD_SUBJECT", "twitch.outgress.standard"),
-		SystemSubject:         env.Get("NATS_OUTGRESS_SYSTEM_SUBJECT", "twitch.outgress.system"),
-		RPCPrefix:             env.Get("NATS_OUTGRESS_RPC_PREFIX", "bagel.rpc.outgress"),
-		ValkeyAddr:            env.Get("VALKEY_ADDR", "127.0.0.1:6379"),
-		ValkeyPassword:        env.Get("VALKEY_PASSWORD", ""),
-		TwitchClientID:        env.MustGet("TWITCH_CLIENT_ID"),
-		TwitchClientSecret:    env.MustGet("TWITCH_CLIENT_SECRET"),
-		TwitchConduitID:       env.Get("TWITCH_CONDUIT_ID", ""),
-		ConduitSubject:        env.Get("NATS_CONDUIT_SUBJECT", "bagel.rpc.ingress.conduit.get"),
-		TwitchBotUserID:       env.Get("TWITCH_BOT_USER_ID", ""),
-		TwitchBotRefreshToken: env.Get("TWITCH_BOT_REFRESH_TOKEN", ""),
-		TokensSubjectPrefix:   env.Get("NATS_INTERNAL_TOKENS_SUBJECT_PREFIX", "bagel.rpc.internal.tokens"),
-		CacheInvalidatePrefix: env.Get("NATS_CACHE_INVALIDATION_PREFIX", "bagel.cache.invalidate"),
-		LiveTTL:               env.GetDuration("WORKER_LIVE_TTL", 12*time.Hour),
-		StreamLaneSubject:     env.Get("NATS_SUBJECT_LANE_STREAM", "twitch.ingress.event.stream"),
-		MinRoutines:           env.GetInt("OUTGRESS_MIN_ROUTINES", 2),
-		MaxRoutines:           env.GetInt("OUTGRESS_MAX_ROUTINES", 8),
-		MaxConsumers:          env.GetInt("OUTGRESS_MAX_CONSUMERS", 3),
-		ScaleUpAfter:          env.GetDuration("OUTGRESS_SCALE_UP_AFTER", 5*time.Second),
-		ScaleDownAfter:        env.GetDuration("OUTGRESS_SCALE_DOWN_AFTER", 30*time.Second),
-		PremiumReserve:        env.GetInt("OUTGRESS_PREMIUM_RESERVE_PERCENT", 25),
-		SystemWorkers:         env.GetInt("OUTGRESS_SYSTEM_WORKERS", 2),
-		RateRegion:            env.Get("OUTGRESS_REGION", "local"),
-		LeaseEpoch:            env.GetDuration("OUTGRESS_LEASE_EPOCH", 30*time.Second),
-		LeaseGuard:            env.GetDuration("OUTGRESS_LEASE_GUARD", 250*time.Millisecond),
-		LeaseMinMembers:       env.GetInt("OUTGRESS_LEASE_MIN_MEMBERS", 1),
-		LeaseReplicas:         env.GetInt("OUTGRESS_LEASE_REPLICAS", 0),
-		LeaseReplicaTimeout:   env.GetDuration("OUTGRESS_LEASE_REPLICA_TIMEOUT", 2*time.Second),
+		NATSURL:                natsURL,
+		NATSRPCURL:             env.Get("NATS_RPC_URL", natsURL),
+		PremiumSubject:         env.Get("NATS_OUTGRESS_PREMIUM_SUBJECT", "twitch.outgress.premium"),
+		StandardSubject:        env.Get("NATS_OUTGRESS_STANDARD_SUBJECT", "twitch.outgress.standard"),
+		SystemSubject:          env.Get("NATS_OUTGRESS_SYSTEM_SUBJECT", "twitch.outgress.system"),
+		RPCPrefix:              env.Get("NATS_OUTGRESS_RPC_PREFIX", "bagel.rpc.outgress"),
+		ValkeyAddr:             env.Get("VALKEY_ADDR", "127.0.0.1:6379"),
+		ValkeyPassword:         env.Get("VALKEY_PASSWORD", ""),
+		TwitchClientID:         env.MustGet("TWITCH_CLIENT_ID"),
+		TwitchClientSecret:     env.MustGet("TWITCH_CLIENT_SECRET"),
+		TwitchConduitID:        env.Get("TWITCH_CONDUIT_ID", ""),
+		ConduitSubject:         env.Get("NATS_CONDUIT_SUBJECT", "bagel.rpc.ingress.conduit.get"),
+		TwitchBotUserID:        env.Get("TWITCH_BOT_USER_ID", ""),
+		TwitchBotRefreshToken:  env.Get("TWITCH_BOT_REFRESH_TOKEN", ""),
+		TokensSubjectPrefix:    env.Get("NATS_INTERNAL_TOKENS_SUBJECT_PREFIX", "bagel.rpc.internal.tokens"),
+		CacheInvalidatePrefix:  env.Get("NATS_CACHE_INVALIDATION_PREFIX", "bagel.cache.invalidate"),
+		LiveTTL:                env.GetDuration("WORKER_LIVE_TTL", 12*time.Hour),
+		StreamLaneSubject:      env.Get("NATS_SUBJECT_LANE_STREAM", "twitch.ingress.event.stream"),
+		AuthzGrantedSubject:    env.Get("NATS_SUBJECT_AUTHZ_GRANTED", "twitch.ingress.status.authz.granted"),
+		AuthzRevokedSubject:    env.Get("NATS_SUBJECT_AUTHZ_REVOKED", "twitch.ingress.status.authz.revoked"),
+		AuthzSubRevokedSubject: env.Get("NATS_SUBJECT_AUTHZ_SUBREVOKED", "twitch.ingress.status.authz.subrevoked"),
+		NotifySendSubject:      env.Get("NATS_NOTIFY_SEND_SUBJECT", "bagel.rpc.admin.notifications.send"),
+		UsersStateSubject:      env.Get("NATS_USERS_STATE_SUBJECT", "bagel.rpc.dashboard.state_get"),
+		MinRoutines:            env.GetInt("OUTGRESS_MIN_ROUTINES", 2),
+		MaxRoutines:            env.GetInt("OUTGRESS_MAX_ROUTINES", 8),
+		MaxConsumers:           env.GetInt("OUTGRESS_MAX_CONSUMERS", 3),
+		ScaleUpAfter:           env.GetDuration("OUTGRESS_SCALE_UP_AFTER", 5*time.Second),
+		ScaleDownAfter:         env.GetDuration("OUTGRESS_SCALE_DOWN_AFTER", 30*time.Second),
+		PremiumReserve:         env.GetInt("OUTGRESS_PREMIUM_RESERVE_PERCENT", 25),
+		SystemWorkers:          env.GetInt("OUTGRESS_SYSTEM_WORKERS", 2),
+		RateRegion:             env.Get("OUTGRESS_REGION", "local"),
+		LeaseEpoch:             env.GetDuration("OUTGRESS_LEASE_EPOCH", 30*time.Second),
+		LeaseGuard:             env.GetDuration("OUTGRESS_LEASE_GUARD", 250*time.Millisecond),
+		LeaseMinMembers:        env.GetInt("OUTGRESS_LEASE_MIN_MEMBERS", 1),
+		LeaseReplicas:          env.GetInt("OUTGRESS_LEASE_REPLICAS", 0),
+		LeaseReplicaTimeout:    env.GetDuration("OUTGRESS_LEASE_REPLICA_TIMEOUT", 2*time.Second),
 	}
 }

--- a/app/outgress/internal/twitch/client.go
+++ b/app/outgress/internal/twitch/client.go
@@ -66,6 +66,10 @@ func NewClient(clientID string, app, user *Source, broadcasters *BroadcasterToke
 	}
 }
 
+// ClientID exposes the app's client id for condition fields that key on it
+// (the client-scoped user.authorization.* subscriptions).
+func (c *Client) ClientID() string { return c.clientID }
+
 // Warmup mints the app token and establishes a reusable Twitch connection
 // before queue consumers become ready. The read-only request is deliberately
 // tiny; its response is drained so HTTP/1.1 transports can reuse the socket.

--- a/app/outgress/internal/twitch/eventsub.go
+++ b/app/outgress/internal/twitch/eventsub.go
@@ -75,6 +75,19 @@ func ChannelOptionalSubscriptions(broadcasterID string) []SubSpec {
 	}
 }
 
+// ClientSubscriptions lists the client-scoped subscriptions the conduit
+// carries exactly once (not per channel): user.authorization.grant and
+// user.authorization.revoke, keyed on our client id and authorized by the app
+// token alone. They are how Twitch tells us a broadcaster's consent appeared
+// or died, which drives the revoked enrollment state and the re-enroll that
+// follows a re-consent. Ensured idempotently at worker startup.
+func ClientSubscriptions(clientID string) []SubSpec {
+	return []SubSpec{
+		{"user.authorization.grant", "1", map[string]string{"client_id": clientID}},
+		{"user.authorization.revoke", "1", map[string]string{"client_id": clientID}},
+	}
+}
+
 // CreateEventSub creates one subscription on the Conduit under the app
 // token. An already-existing subscription (409) is success, so re-running a
 // partially applied job converges instead of failing.
@@ -184,4 +197,3 @@ func statusError(res *http.Response, op string) error {
 	body, _ := io.ReadAll(io.LimitReader(res.Body, 2048))
 	return &StatusError{Status: res.StatusCode, Op: op, Body: string(body)}
 }
-

--- a/app/outgress/internal/worker/authz.go
+++ b/app/outgress/internal/worker/authz.go
@@ -234,22 +234,39 @@ func (w *Worker) EnsureClientEventSubs(ctx context.Context) {
 		return
 	}
 
-	for attempt := 1; ; attempt++ {
-		if err := w.createClientEventSubs(ctx, clientID); err == nil {
-			w.log.Info("user.authorization eventsubs ensured on conduit")
+	for attempt := 1; ctx.Err() == nil; attempt++ {
+		if w.tryCreateClientEventSubs(ctx, clientID, attempt) {
 			return
-		} else if ctx.Err() != nil {
-			return
-		} else {
-			w.log.Warn("ensuring user.authorization eventsubs failed, will retry",
-				zap.Int("attempt", attempt), zap.Error(err))
 		}
+		if !sleepCtx(ctx, backoffDelay(attempt)) {
+			return
+		}
+	}
+}
 
-		select {
-		case <-ctx.Done():
-			return
-		case <-time.After(backoffDelay(attempt)):
-		}
+// tryCreateClientEventSubs runs one create pass and reports whether the
+// subscriptions are in place; a failure is logged for the retry loop unless
+// the context already ended (shutdown is not an error worth a warning).
+func (w *Worker) tryCreateClientEventSubs(ctx context.Context, clientID string, attempt int) bool {
+	err := w.createClientEventSubs(ctx, clientID)
+	if err == nil {
+		w.log.Info("user.authorization eventsubs ensured on conduit")
+		return true
+	}
+	if ctx.Err() == nil {
+		w.log.Warn("ensuring user.authorization eventsubs failed, will retry",
+			zap.Int("attempt", attempt), zap.Error(err))
+	}
+	return false
+}
+
+// sleepCtx pauses for d, reporting false when ctx ended first.
+func sleepCtx(ctx context.Context, d time.Duration) bool {
+	select {
+	case <-ctx.Done():
+		return false
+	case <-time.After(d):
+		return true
 	}
 }
 

--- a/app/outgress/internal/worker/authz.go
+++ b/app/outgress/internal/worker/authz.go
@@ -68,7 +68,10 @@ func (w *Worker) HandleAuthzGranted(msg *bus.Message) error {
 	if err != nil {
 		return err // transient registry read: nak for paced redelivery
 	}
-	if !found || !ch.Enabled || !reenrollableSubState(ch.SubState) {
+	if !found || !ch.Enabled {
+		return nil
+	}
+	if !reenrollableSubState(ch.SubState) {
 		return nil
 	}
 
@@ -95,7 +98,11 @@ func (w *Worker) HandleAuthzGranted(msg *bus.Message) error {
 // creates converge through 409s at worst). Only a healthy "ok" (or an
 // unenrolled channel) skips.
 func reenrollableSubState(state string) bool {
-	return state == subStateRevoked || state == subStateFailing || state == subStatePending
+	switch state {
+	case subStateRevoked, subStateFailing, subStatePending:
+		return true
+	}
+	return false
 }
 
 // HandleAuthzRevoked marks a channel revoked when Twitch reports the

--- a/app/outgress/internal/worker/authz.go
+++ b/app/outgress/internal/worker/authz.go
@@ -1,0 +1,274 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"ItsBagelBot/app/outgress/internal/twitch"
+	"ItsBagelBot/pkg/bus"
+
+	"github.com/bytedance/sonic"
+
+	"go.uber.org/zap"
+)
+
+// errBotAuthRevoked names the fleet-level failure where the bot account's own
+// authorization died; it exists so New Relic groups these apart from
+// per-channel noise.
+var errBotAuthRevoked = errors.New("bot account authorization revoked")
+
+// Authorization lifecycle events off the ingress status subjects. Ingress
+// publishes them when Twitch reports an authorization change for our client:
+//
+//   - authz.granted: a user (re)consented through the OAuth flow
+//     (user.authorization.grant).
+//   - authz.revoked: a user's authorization died (user.authorization.revoke):
+//     they disconnected the app or changed their password.
+//   - authz.subrevoked: Twitch revoked one concrete subscription, with the
+//     status naming why (authorization_revoked, user_removed,
+//     version_removed, ...).
+//
+// The policy encoded here, deliberately: a revocation only MARKS the channel
+// (sub_state "revoked") and notifies the streamer. It never deletes the
+// subscriptions Twitch left alive: stream.online/offline survive without any
+// user grant, and go-live is the beacon that reaches the streamer in chat.
+// Re-enrollment happens exactly when Twitch says the consent is back (the
+// grant event), not on our own login flow's schedule.
+
+// authzUser is the wire payload of authz.granted / authz.revoked.
+type authzUser struct {
+	UserID    string `json:"user_id"`
+	UserLogin string `json:"user_login"`
+}
+
+// authzSubRevoked is the wire payload of authz.subrevoked.
+type authzSubRevoked struct {
+	BroadcasterID string `json:"broadcaster_id"`
+	Type          string `json:"type"`
+	Status        string `json:"status"`
+}
+
+// HandleAuthzGranted re-enrolls a channel whose consent just came back. Only
+// a channel the registry knows, still enabled, and currently marked revoked
+// or failing gets the enroll: a first-time consent has no registry entry yet
+// (the dashboard enable owns that path), and a healthy channel needs nothing.
+// The enable path is create-only (409-idempotent), so the surviving unscoped
+// subscriptions are never dropped and recreated.
+func (w *Worker) HandleAuthzGranted(msg *bus.Message) error {
+	ctx := msg.Context()
+
+	var ev authzUser
+	if err := sonic.Unmarshal(msg.Payload, &ev); err != nil || ev.UserID == "" {
+		w.log.Error("dropping malformed authz.granted event", zap.Error(err))
+		return nil
+	}
+
+	ch, found, err := w.registry.Get(ctx, ev.UserID)
+	if err != nil {
+		return err // transient registry read: nak for paced redelivery
+	}
+	if !found || !ch.Enabled || !reenrollableSubState(ch.SubState) {
+		return nil
+	}
+
+	w.log.Info("authorization granted, re-enrolling eventsubs",
+		zap.String("broadcaster_id", ev.UserID),
+		zap.String("user_login", ev.UserLogin),
+		zap.String("prior_sub_state", ch.SubState))
+
+	conduitID, err := w.conduit.Get(ctx)
+	if err != nil {
+		return err
+	}
+	// Leave the revoked guard: the enable path skips revoked channels, so the
+	// state steps to pending first. enableEventSubs acks failures into the
+	// persisted state itself, so this handler never loops on a bad channel.
+	_ = w.registry.SetSubState(ctx, ev.UserID, subStatePending, "")
+	return w.enableEventSubs(ctx, enrollment{broadcasterID: ev.UserID, conduitID: conduitID})
+}
+
+// reenrollableSubState reports whether a grant event should trigger a fresh
+// enroll. Revoked is the designed case; failing rides along because a consent
+// refresh is exactly what a consent-shaped failure needs; pending keeps a
+// nakked grant retryable after this handler already stepped the state (the
+// creates converge through 409s at worst). Only a healthy "ok" (or an
+// unenrolled channel) skips.
+func reenrollableSubState(state string) bool {
+	return state == subStateRevoked || state == subStateFailing || state == subStatePending
+}
+
+// HandleAuthzRevoked marks a channel revoked when Twitch reports the
+// broadcaster's authorization died. No Twitch calls: the scoped subscriptions
+// are already gone server-side, and the survivors are kept as the go-live
+// beacon.
+func (w *Worker) HandleAuthzRevoked(msg *bus.Message) error {
+	ctx := msg.Context()
+
+	var ev authzUser
+	if err := sonic.Unmarshal(msg.Payload, &ev); err != nil || ev.UserID == "" {
+		w.log.Error("dropping malformed authz.revoked event", zap.Error(err))
+		return nil
+	}
+
+	if ev.UserID == w.botID {
+		// The bot account's own grant died: every channel's chat is affected
+		// and no per-channel state captures that. Scream for the operator.
+		w.log.Error("BOT ACCOUNT authorization revoked, chat send and chat reads will fail until the bot re-authorizes",
+			zap.String("bot_id", w.botID))
+		noticeError(ctx, errBotAuthRevoked)
+		return nil
+	}
+
+	return w.markAuthorizationRevoked(ctx, ev.UserID, "authorization_revoked")
+}
+
+// HandleAuthzSubRevoked folds a single-subscription revocation into the
+// channel state. Consent-shaped statuses mark the channel revoked; anything
+// else (version_removed, notification_failures_exceeded) is a bot-side fault
+// and marks it failing so the operator sees it.
+func (w *Worker) HandleAuthzSubRevoked(msg *bus.Message) error {
+	ctx := msg.Context()
+
+	var ev authzSubRevoked
+	if err := sonic.Unmarshal(msg.Payload, &ev); err != nil || ev.BroadcasterID == "" {
+		w.log.Error("dropping malformed authz.subrevoked event", zap.Error(err))
+		return nil
+	}
+
+	if ev.BroadcasterID == w.botID {
+		// The bot appears as condition.user_id on every channel's chat sub;
+		// a per-channel state write would target the wrong entity.
+		w.log.Error("subscription carrying the bot's own authorization revoked",
+			zap.String("type", ev.Type), zap.String("status", ev.Status))
+		return nil
+	}
+
+	if !consentRevokedStatus(ev.Status) {
+		return w.markSubDropped(ctx, ev)
+	}
+	return w.markAuthorizationRevoked(ctx, ev.BroadcasterID, ev.Status+": "+ev.Type)
+}
+
+// consentRevokedStatus reports whether a revocation status means the
+// broadcaster's consent is gone (as opposed to a bot-side subscription
+// fault).
+func consentRevokedStatus(status string) bool {
+	return status == "authorization_revoked" || status == "user_removed"
+}
+
+// markAuthorizationRevoked flips one channel to the revoked state and
+// notifies the streamer, exactly once per outage: repeat events (Twitch sends
+// one revocation per subscription) see the state already revoked and stop.
+func (w *Worker) markAuthorizationRevoked(ctx context.Context, broadcasterID, reason string) error {
+	ch, found, err := w.registry.Get(ctx, broadcasterID)
+	if err != nil {
+		return err // transient registry read: nak for paced redelivery
+	}
+	if !found || ch.SubState == subStateRevoked {
+		return nil
+	}
+
+	if err := w.registry.SetSubState(ctx, broadcasterID, subStateRevoked, reason); err != nil {
+		return err
+	}
+	w.log.Warn("broadcaster authorization revoked, channel marked for reconnect",
+		zap.String("broadcaster_id", broadcasterID),
+		zap.String("reason", reason))
+
+	w.notifyReauthNeeded(ctx, broadcasterID)
+	return nil
+}
+
+// markSubDropped records a non-consent revocation (version_removed,
+// notification_failures_exceeded) as a failing enrollment so the dashboard
+// offers the restart that re-creates it.
+func (w *Worker) markSubDropped(ctx context.Context, ev authzSubRevoked) error {
+	ch, found, err := w.registry.Get(ctx, ev.BroadcasterID)
+	if err != nil {
+		return err
+	}
+	// A channel already flagged revoked keeps that stronger state: it also
+	// explains the dropped subscription, and the reconnect CTA would fail
+	// until the broadcaster re-consents anyway.
+	if !found || ch.SubState == subStateRevoked {
+		return nil
+	}
+
+	if err := w.registry.SetSubState(ctx, ev.BroadcasterID, subStateFailing, ev.Status+": "+ev.Type); err != nil {
+		return err
+	}
+	w.log.Error("eventsub subscription revoked for a bot-side fault",
+		zap.String("broadcaster_id", ev.BroadcasterID),
+		zap.String("type", ev.Type),
+		zap.String("status", ev.Status))
+	return nil
+}
+
+// notifyReauthNeeded fans the revocation out to the streamer-facing channels
+// (dashboard bell notification). Best-effort: state is already persisted, and
+// the go-live chat beacon still fires later regardless.
+func (w *Worker) notifyReauthNeeded(ctx context.Context, broadcasterID string) {
+	if w.reauth == nil {
+		return
+	}
+	w.reauth.NotifyRevoked(ctx, broadcasterID)
+}
+
+// EnsureClientEventSubs creates the client-scoped authorization subscriptions
+// on the conduit (409-idempotent), retrying with backoff until they exist or
+// ctx ends. Runs once per boot in the background: without these, revocations
+// and re-grants only surface through per-subscription revocation messages and
+// enroll failures.
+func (w *Worker) EnsureClientEventSubs(ctx context.Context) {
+	clientID := w.twitch.ClientID()
+	if clientID == "" {
+		w.log.Warn("client id not configured, skipping user.authorization subscriptions")
+		return
+	}
+
+	for attempt := 1; ; attempt++ {
+		if err := w.createClientEventSubs(ctx, clientID); err == nil {
+			w.log.Info("user.authorization eventsubs ensured on conduit")
+			return
+		} else if ctx.Err() != nil {
+			return
+		} else {
+			w.log.Warn("ensuring user.authorization eventsubs failed, will retry",
+				zap.Int("attempt", attempt), zap.Error(err))
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(backoffDelay(attempt)):
+		}
+	}
+}
+
+func (w *Worker) createClientEventSubs(ctx context.Context, clientID string) error {
+	conduitID, err := w.conduit.Get(ctx)
+	if err != nil {
+		return err
+	}
+	for _, spec := range twitch.ClientSubscriptions(clientID) {
+		if err := w.takeSystemHelix(ctx); err != nil {
+			return err
+		}
+		if err := w.twitch.CreateEventSub(ctx, spec, conduitID); err != nil {
+			w.conduit.Invalidate()
+			return err
+		}
+	}
+	return nil
+}
+
+// backoffDelay grows linearly to a one-minute ceiling; boot-time conduit
+// resolution is the only expected transient here.
+func backoffDelay(attempt int) time.Duration {
+	d := time.Duration(attempt) * 5 * time.Second
+	if d > time.Minute {
+		return time.Minute
+	}
+	return d
+}

--- a/app/outgress/internal/worker/eventsub.go
+++ b/app/outgress/internal/worker/eventsub.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"ItsBagelBot/app/outgress/internal/twitch"
@@ -23,6 +24,21 @@ import (
 // touching Twitch. Repair paths are unaffected: the skip requires sub_state
 // "ok", so a failing, pending, or cleared channel always gets its enroll.
 const enrollCooldownTTL = 2 * time.Minute
+
+// Enrollment states persisted in the channel registry (sub_state). The
+// console's connection model mirrors these exact strings.
+const (
+	subStateOK      = "ok"
+	subStatePending = "pending"
+	subStateFailing = "failing"
+	// subStateRevoked means Twitch revoked the broadcaster's authorization
+	// (app disconnected or password changed). Scoped subscriptions are gone
+	// and cannot be re-created until the broadcaster re-consents; surviving
+	// unscoped subscriptions (stream.online/offline, raid, channel.update,
+	// chat) are deliberately kept alive. Cleared by the authorization-grant
+	// re-enroll or an explicit disconnect.
+	subStateRevoked = "revoked"
+)
 
 // enrollment identifies one channel's EventSub enrollment on our conduit: the
 // broadcaster whose subscriptions are managed and the conduit they route to.
@@ -120,6 +136,25 @@ func (w *Worker) underEnrollLock(ctx context.Context, op string, e enrollment, f
 	return fn()
 }
 
+// skipRevokedEnroll acknowledges an enable/reconnect for a channel whose
+// authorization Twitch revoked. Re-creating the scoped subscriptions cannot
+// succeed until the broadcaster re-consents, and reconnect's drop phase would
+// delete the surviving unscoped subscriptions (stream.online above all, the
+// beacon that lets the bot ask the streamer to reconnect on go-live). So the
+// job is absorbed: no drop, no create, no state change. The revoked state is
+// cleared only by the user.authorization.grant path (which re-enrolls) or by
+// an explicit disconnect. Fails open on a read error: wrongly skipping a real
+// repair is worse than wrongly spending budget.
+func (w *Worker) skipRevokedEnroll(ctx context.Context, e enrollment, op string) bool {
+	ch, found, err := w.registry.Get(ctx, e.broadcasterID)
+	if err != nil || !found || ch.SubState != subStateRevoked {
+		return false
+	}
+	w.log.Info(op+" skipped: authorization revoked, waiting for the broadcaster to reconnect",
+		zap.String("broadcaster_id", e.broadcasterID))
+	return true
+}
+
 // skipFreshEnroll acknowledges a redundant enroll: the channel completed a
 // full enroll inside the cooldown window and the registry still reports it
 // healthy, so re-running would only spend Helix budget re-creating (409) what
@@ -143,13 +178,13 @@ func (w *Worker) skipFreshEnroll(ctx context.Context, e enrollment, op string) b
 // redundantEnroll trusts the cooldown only while the registry still reports
 // the enrollment healthy; any other state means there is real work to do.
 func redundantEnroll(ch manage.Channel, found bool) bool {
-	return found && ch.SubState == "ok"
+	return found && ch.SubState == subStateOK
 }
 
 // recordEnrollSuccess persists the healthy outcome and arms the cooldown that
 // lets an immediately repeated enable/reconnect be skipped.
 func (w *Worker) recordEnrollSuccess(ctx context.Context, e enrollment) {
-	_ = w.registry.SetSubState(ctx, e.broadcasterID, "ok", "")
+	_ = w.registry.SetSubState(ctx, e.broadcasterID, subStateOK, "")
 	_ = w.registry.ArmEnrollCooldown(ctx, e.broadcasterID, enrollCooldownTTL)
 }
 
@@ -185,10 +220,10 @@ func retryTransient(ctx context.Context, fn func() error) error {
 // with a persisted "failing" state surfaces the problem to the dashboard instead.
 func (w *Worker) enableEventSubs(ctx context.Context, e enrollment) error {
 	return w.underEnrollLock(ctx, "enable", e, func() error {
-		if w.skipFreshEnroll(ctx, e, "enable") {
+		if w.skipFreshEnroll(ctx, e, "enable") || w.skipRevokedEnroll(ctx, e, "enable") {
 			return nil
 		}
-		_ = w.registry.SetSubState(ctx, e.broadcasterID, "pending", "")
+		_ = w.registry.SetSubState(ctx, e.broadcasterID, subStatePending, "")
 
 		err := retryTransient(ctx, func() error {
 			return w.createAllEventSubs(ctx, e)
@@ -203,12 +238,30 @@ func (w *Worker) enableEventSubs(ctx context.Context, e enrollment) error {
 			return nil
 		}
 
-		_ = w.registry.SetSubState(ctx, e.broadcasterID, "failing", err.Error())
-		w.log.Error("enable: eventsubs not fully accepted, marked failing",
+		w.recordEnrollFailure(ctx, e, "enable", err)
+		return nil // ack: the failing/revoked state is surfaced for the operator
+	})
+}
+
+// recordEnrollFailure persists why an enroll could not complete. A create
+// rejected for missing authorization means Twitch revoked the broadcaster's
+// consent: that is the revoked state (user action required, retrying is
+// pointless), and the streamer is notified. Everything else stays failing
+// (bot-side, the restart path applies).
+func (w *Worker) recordEnrollFailure(ctx context.Context, e enrollment, op string, err error) {
+	if isAuthRevoked(err) {
+		_ = w.registry.SetSubState(ctx, e.broadcasterID, subStateRevoked, err.Error())
+		w.log.Warn(op+": twitch reports the broadcaster authorization revoked",
 			zap.String("broadcaster_id", e.broadcasterID),
 			zap.Error(err))
-		return nil // ack: failing state is surfaced for the operator
-	})
+		w.notifyReauthNeeded(ctx, e.broadcasterID)
+		return
+	}
+
+	_ = w.registry.SetSubState(ctx, e.broadcasterID, subStateFailing, err.Error())
+	w.log.Error(op+": eventsubs not fully accepted, marked failing",
+		zap.String("broadcaster_id", e.broadcasterID),
+		zap.Error(err))
 }
 
 // disableChannel deletes all of a channel's eventsub subscriptions with the same
@@ -229,7 +282,7 @@ func (w *Worker) disableChannel(ctx context.Context, e enrollment) error {
 			return nil
 		}
 
-		_ = w.registry.SetSubState(ctx, e.broadcasterID, "failing", err.Error())
+		_ = w.registry.SetSubState(ctx, e.broadcasterID, subStateFailing, err.Error())
 		w.log.Error("disable: eventsubs not fully removed, marked failing",
 			zap.String("broadcaster_id", e.broadcasterID),
 			zap.Error(err))
@@ -244,10 +297,10 @@ func (w *Worker) disableChannel(ctx context.Context, e enrollment) error {
 // polling Twitch.
 func (w *Worker) reconnectEventSubs(ctx context.Context, e enrollment) error {
 	return w.underEnrollLock(ctx, "reconnect", e, func() error {
-		if w.skipFreshEnroll(ctx, e, "reconnect") {
+		if w.skipFreshEnroll(ctx, e, "reconnect") || w.skipRevokedEnroll(ctx, e, "reconnect") {
 			return nil
 		}
-		_ = w.registry.SetSubState(ctx, e.broadcasterID, "pending", "")
+		_ = w.registry.SetSubState(ctx, e.broadcasterID, subStatePending, "")
 
 		// Best-effort drop: if listing/deleting fails we still try to recreate;
 		// 409 idempotency on create means the end state converges either way.
@@ -270,7 +323,14 @@ func (w *Worker) reconnectEventSubs(ctx context.Context, e enrollment) error {
 			return nil
 		}
 
-		_ = w.registry.SetSubState(ctx, e.broadcasterID, "failing", err.Error())
+		if isAuthRevoked(err) {
+			// Redelivery cannot restore consent; ack with the revoked state so
+			// the grant path (or the streamer) takes it from here.
+			w.recordEnrollFailure(ctx, e, "reconnect", err)
+			return nil
+		}
+
+		_ = w.registry.SetSubState(ctx, e.broadcasterID, subStateFailing, err.Error())
 		w.log.Error("reconnect: eventsubs not fully accepted, retrying",
 			zap.String("broadcaster_id", e.broadcasterID),
 			zap.Error(err))
@@ -441,4 +501,17 @@ func isPermanent(err error) bool {
 			se.Status != http.StatusUnauthorized
 	}
 	return false
+}
+
+// isAuthRevoked reports whether err is Twitch rejecting a mandatory
+// subscription create because the broadcaster's consent is gone (the user
+// disconnected the app or changed their password). Twitch answers 403 with
+// this exact message; other 403s (a non-affiliate's channel-points sub) never
+// reach this check because optional creates are tolerated upstream.
+func isAuthRevoked(err error) bool {
+	var se *twitch.StatusError
+	if !errors.As(err, &se) || se.Status != http.StatusForbidden {
+		return false
+	}
+	return strings.Contains(se.Body, "subscription missing proper authorization")
 }

--- a/app/outgress/internal/worker/eventsub.go
+++ b/app/outgress/internal/worker/eventsub.go
@@ -147,7 +147,10 @@ func (w *Worker) underEnrollLock(ctx context.Context, op string, e enrollment, f
 // repair is worse than wrongly spending budget.
 func (w *Worker) skipRevokedEnroll(ctx context.Context, e enrollment, op string) bool {
 	ch, found, err := w.registry.Get(ctx, e.broadcasterID)
-	if err != nil || !found || ch.SubState != subStateRevoked {
+	if err != nil || !found {
+		return false
+	}
+	if ch.SubState != subStateRevoked {
 		return false
 	}
 	w.log.Info(op+" skipped: authorization revoked, waiting for the broadcaster to reconnect",

--- a/app/outgress/internal/worker/reauth.go
+++ b/app/outgress/internal/worker/reauth.go
@@ -1,0 +1,134 @@
+package worker
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	notificationsrpc "ItsBagelBot/internal/domain/rpc/notifications"
+	usersrpc "ItsBagelBot/internal/domain/rpc/users"
+	"ItsBagelBot/pkg/bus"
+
+	"github.com/nats-io/nats.go"
+
+	"go.uber.org/zap"
+)
+
+// dashboardURL is where a streamer re-consents; baked into the reauth copy.
+const dashboardURL = "https://dashboard.itsbagelbot.com"
+
+// reauthCopy is one locale's reauth wording: the dashboard bell notification
+// (title + body) and the go-live chat beacon line.
+type reauthCopy struct {
+	title string
+	body  string
+	chat  string
+}
+
+// reauthMessages carries every supported locale, keyed by the users service's
+// locale codes. English is the fallback for unknown codes, mirroring the
+// console's translate() fallback.
+var reauthMessages = map[string]reauthCopy{
+	"en": {
+		title: "Bot lost access to your channel",
+		body: "Twitch revoked the bot's authorization for your channel (this happens after a password change or if the app was disconnected). " +
+			"Chat replies and alerts are paused. Log in at " + dashboardURL + " and reconnect your Twitch account to bring the bot back.",
+		chat: "The bot lost its Twitch authorization for this channel (password change or app disconnect). " +
+			"Log in at " + dashboardURL + " to reconnect it.",
+	},
+	"fr": {
+		title: "Le bot a perdu l'accès à votre chaîne",
+		body: "Twitch a révoqué l'autorisation du bot pour votre chaîne (cela arrive après un changement de mot de passe ou si l'application a été déconnectée). " +
+			"Les réponses et alertes sont en pause. Connectez-vous sur " + dashboardURL + " et reconnectez votre compte Twitch pour rétablir le bot.",
+		chat: "Le bot a perdu son autorisation Twitch pour cette chaîne (changement de mot de passe ou déconnexion de l'application). " +
+			"Connectez-vous sur " + dashboardURL + " pour le reconnecter.",
+	},
+}
+
+// ReauthNotifier tells a streamer their consent died and how to fix it, in
+// their dashboard language. It rides outgress's RPC connection: the locale
+// comes from the users service (state_get) and the bell notification goes
+// through the notifications admin send verb, the same one the gift
+// notification uses.
+type ReauthNotifier struct {
+	nc           *nats.Conn
+	sendSubject  string // notifications admin send verb
+	stateSubject string // users dashboard state_get verb (locale source)
+	botID        string // numeric actor id the notifications service requires
+	log          *zap.Logger
+}
+
+func NewReauthNotifier(nc *nats.Conn, sendSubject, stateSubject, botID string, log *zap.Logger) *ReauthNotifier {
+	return &ReauthNotifier{
+		nc:           nc,
+		sendSubject:  sendSubject,
+		stateSubject: stateSubject,
+		botID:        botID,
+		log:          log,
+	}
+}
+
+// NotifyRevoked sends the dashboard bell notification. Best-effort: the
+// revoked registry state is already persisted by the caller and the console
+// surfaces it on its own; a lost notification loses only the nudge. The
+// request id folds the repeated per-subscription revocations of one outage
+// into a single row per day.
+func (r *ReauthNotifier) NotifyRevoked(ctx context.Context, broadcasterID string) {
+	if _, err := strconv.ParseUint(r.botID, 10, 64); err != nil {
+		r.log.Warn("reauth notification skipped: bot id not numeric, no actor to send as",
+			zap.String("broadcaster_id", broadcasterID))
+		return
+	}
+
+	copyFor := r.localizedCopy(ctx, broadcasterID)
+	day := time.Now().UTC().Format("2006-01-02")
+
+	reply, err := bus.RequestJSONTimeout[notificationsrpc.SendReply](ctx, r.nc, r.sendSubject,
+		notificationsrpc.SendRequest{
+			Scope:        "direct",
+			TargetUserID: broadcasterID,
+			Title:        copyFor.title,
+			Body:         copyFor.body,
+			Level:        "warning",
+			ActorID:      r.botID,
+			ActorLogin:   "system",
+			RequestID:    "authz-revoked-" + broadcasterID + "-" + day,
+		}, 5*time.Second)
+
+	switch {
+	case err != nil:
+		r.log.Warn("reauth notification send failed",
+			zap.String("broadcaster_id", broadcasterID), zap.Error(err))
+	case reply.Error != "":
+		r.log.Warn("reauth notification rejected",
+			zap.String("broadcaster_id", broadcasterID), zap.String("error", reply.Error))
+	default:
+		r.log.Info("reauth notification sent", zap.String("broadcaster_id", broadcasterID))
+	}
+}
+
+// ChatBeacon returns the localized go-live chat line asking the streamer to
+// reconnect.
+func (r *ReauthNotifier) ChatBeacon(ctx context.Context, broadcasterID string) string {
+	return r.localizedCopy(ctx, broadcasterID).chat
+}
+
+// localizedCopy resolves the broadcaster's dashboard locale, falling back to
+// English on any failure or unknown code.
+func (r *ReauthNotifier) localizedCopy(ctx context.Context, broadcasterID string) reauthCopy {
+	locale := "en"
+
+	reply, err := bus.RequestJSONTimeout[usersrpc.StateGetReply](ctx, r.nc, r.stateSubject,
+		usersrpc.StateGetRequest{BroadcasterUserID: broadcasterID}, 3*time.Second)
+	if err != nil {
+		r.log.Debug("locale lookup failed, defaulting to en",
+			zap.String("broadcaster_id", broadcasterID), zap.Error(err))
+	} else if reply.Locale != "" {
+		locale = reply.Locale
+	}
+
+	if c, ok := reauthMessages[locale]; ok {
+		return c
+	}
+	return reauthMessages["en"]
+}

--- a/app/outgress/internal/worker/reauth.go
+++ b/app/outgress/internal/worker/reauth.go
@@ -45,27 +45,29 @@ var reauthMessages = map[string]reauthCopy{
 	},
 }
 
+// ReauthConfig carries the NATS wiring for the reauth messaging: the
+// notifications admin send verb, the users state_get verb the locale comes
+// from, and the bot's numeric user id (the actor the notifications service
+// requires).
+type ReauthConfig struct {
+	SendSubject  string
+	StateSubject string
+	BotID        string
+}
+
 // ReauthNotifier tells a streamer their consent died and how to fix it, in
 // their dashboard language. It rides outgress's RPC connection: the locale
 // comes from the users service (state_get) and the bell notification goes
 // through the notifications admin send verb, the same one the gift
 // notification uses.
 type ReauthNotifier struct {
-	nc           *nats.Conn
-	sendSubject  string // notifications admin send verb
-	stateSubject string // users dashboard state_get verb (locale source)
-	botID        string // numeric actor id the notifications service requires
-	log          *zap.Logger
+	nc  *nats.Conn
+	cfg ReauthConfig
+	log *zap.Logger
 }
 
-func NewReauthNotifier(nc *nats.Conn, sendSubject, stateSubject, botID string, log *zap.Logger) *ReauthNotifier {
-	return &ReauthNotifier{
-		nc:           nc,
-		sendSubject:  sendSubject,
-		stateSubject: stateSubject,
-		botID:        botID,
-		log:          log,
-	}
+func NewReauthNotifier(nc *nats.Conn, cfg ReauthConfig, log *zap.Logger) *ReauthNotifier {
+	return &ReauthNotifier{nc: nc, cfg: cfg, log: log}
 }
 
 // NotifyRevoked sends the dashboard bell notification. Best-effort: the
@@ -74,7 +76,7 @@ func NewReauthNotifier(nc *nats.Conn, sendSubject, stateSubject, botID string, l
 // request id folds the repeated per-subscription revocations of one outage
 // into a single row per day.
 func (r *ReauthNotifier) NotifyRevoked(ctx context.Context, broadcasterID string) {
-	if _, err := strconv.ParseUint(r.botID, 10, 64); err != nil {
+	if _, err := strconv.ParseUint(r.cfg.BotID, 10, 64); err != nil {
 		r.log.Warn("reauth notification skipped: bot id not numeric, no actor to send as",
 			zap.String("broadcaster_id", broadcasterID))
 		return
@@ -83,14 +85,14 @@ func (r *ReauthNotifier) NotifyRevoked(ctx context.Context, broadcasterID string
 	copyFor := r.localizedCopy(ctx, broadcasterID)
 	day := time.Now().UTC().Format("2006-01-02")
 
-	reply, err := bus.RequestJSONTimeout[notificationsrpc.SendReply](ctx, r.nc, r.sendSubject,
+	reply, err := bus.RequestJSONTimeout[notificationsrpc.SendReply](ctx, r.nc, r.cfg.SendSubject,
 		notificationsrpc.SendRequest{
 			Scope:        "direct",
 			TargetUserID: broadcasterID,
 			Title:        copyFor.title,
 			Body:         copyFor.body,
 			Level:        "warning",
-			ActorID:      r.botID,
+			ActorID:      r.cfg.BotID,
 			ActorLogin:   "system",
 			RequestID:    "authz-revoked-" + broadcasterID + "-" + day,
 		}, 5*time.Second)
@@ -118,7 +120,7 @@ func (r *ReauthNotifier) ChatBeacon(ctx context.Context, broadcasterID string) s
 func (r *ReauthNotifier) localizedCopy(ctx context.Context, broadcasterID string) reauthCopy {
 	locale := "en"
 
-	reply, err := bus.RequestJSONTimeout[usersrpc.StateGetReply](ctx, r.nc, r.stateSubject,
+	reply, err := bus.RequestJSONTimeout[usersrpc.StateGetReply](ctx, r.nc, r.cfg.StateSubject,
 		usersrpc.StateGetRequest{BroadcasterUserID: broadcasterID}, 3*time.Second)
 	if err != nil {
 		r.log.Debug("locale lookup failed, defaulting to en",

--- a/app/outgress/internal/worker/streamstatus.go
+++ b/app/outgress/internal/worker/streamstatus.go
@@ -2,11 +2,15 @@ package worker
 
 import (
 	"context"
+	"errors"
 	"strconv"
+	"time"
 
 	eventtwitch "ItsBagelBot/internal/domain/event/twitch"
 	"ItsBagelBot/internal/domain/outgress"
 	"ItsBagelBot/pkg/bus"
+
+	"github.com/bytedance/sonic"
 
 	"go.uber.org/zap"
 )
@@ -131,8 +135,70 @@ func (w *Worker) HandleStreamEvent(msg *bus.Message) error {
 	broadcasterID := strconv.FormatUint(status.BroadcasterID, 10)
 
 	w.scheduleModStatus(broadcasterID, "")
+	w.reauthBeaconOnLive(msg.Context(), broadcasterID)
 
 	w.log.Debug("mod status refresh scheduled on go-live",
 		zap.String("broadcaster_id", broadcasterID))
 	return nil
 }
+
+// reauthBeaconTTL spaces the go-live reconnect nudge: one chat line per
+// channel per window, however many times the stream restarts.
+const reauthBeaconTTL = 12 * time.Hour
+
+// reauthBeaconOnLive asks the streamer to reconnect, in their own chat, when
+// they go live on a channel whose authorization Twitch revoked. stream.online
+// survives a revocation (it needs no user grant) and chat send runs on the
+// app token backed by the bot's own user:bot grant plus its moderator seat,
+// so this path stays alive exactly when everything scoped is dead. That makes
+// go-live the one reliable moment the bot can still reach the streamer where
+// they are looking. Best-effort at every step; the beacon must never disturb
+// the go-live pipeline.
+func (w *Worker) reauthBeaconOnLive(ctx context.Context, broadcasterID string) {
+	if w.reauth == nil {
+		return
+	}
+	ch, found, err := w.registry.Get(ctx, broadcasterID)
+	if err != nil || !found || ch.SubState != subStateRevoked {
+		return
+	}
+
+	armed, err := w.registry.ArmReauthBeacon(ctx, broadcasterID, reauthBeaconTTL)
+	if err != nil || !armed {
+		return
+	}
+
+	if err := w.sendReauthChat(ctx, broadcasterID); err != nil {
+		w.log.Warn("reauth chat beacon failed",
+			zap.String("broadcaster_id", broadcasterID), zap.Error(err))
+		return
+	}
+	w.log.Info("reauth chat beacon sent", zap.String("broadcaster_id", broadcasterID))
+}
+
+// sendReauthChat pushes the localized reconnect line through the ordinary
+// chat send path (type route defaults + bot sender injection + per-channel
+// chat rate bucket), exactly as if a lane job carried it.
+func (w *Worker) sendReauthChat(ctx context.Context, broadcasterID string) error {
+	body, err := sonic.Marshal(struct {
+		BroadcasterID string `json:"broadcaster_id"`
+		Message       string `json:"message"`
+	}{broadcasterID, w.reauth.ChatBeacon(ctx, broadcasterID)})
+	if err != nil {
+		return err
+	}
+
+	payload := outgress.Message{
+		Type:          outgress.TypeChat,
+		BroadcasterID: broadcasterID,
+		Payload:       body,
+	}
+	if !w.resolveHelixRoute(&payload) {
+		return errReauthChatRoute
+	}
+	return w.processChat(ctx, payload)
+}
+
+// errReauthChatRoute only fires if the chat type route table loses its "chat"
+// entry, which would be a programming error.
+var errReauthChatRoute = errors.New("reauth beacon: chat route unresolved")

--- a/app/outgress/internal/worker/streamstatus.go
+++ b/app/outgress/internal/worker/streamstatus.go
@@ -159,7 +159,10 @@ func (w *Worker) reauthBeaconOnLive(ctx context.Context, broadcasterID string) {
 		return
 	}
 	ch, found, err := w.registry.Get(ctx, broadcasterID)
-	if err != nil || !found || ch.SubState != subStateRevoked {
+	if err != nil || !found {
+		return
+	}
+	if ch.SubState != subStateRevoked {
 		return
 	}
 

--- a/app/outgress/internal/worker/worker.go
+++ b/app/outgress/internal/worker/worker.go
@@ -83,6 +83,11 @@ type Worker struct {
 	// live writes the result of a Twitch live re-check back into the projection.
 	// Only the system lane sets it (via SetLiveWriter); nil elsewhere.
 	live *LiveWriter
+	// reauth tells a streamer their Twitch consent died (dashboard bell + the
+	// go-live chat beacon copy). Only the system lane sets it (via
+	// SetReauthNotifier); nil elsewhere and in tests, where every call site
+	// degrades to a no-op.
+	reauth *ReauthNotifier
 }
 
 // Config wires one lane worker's collaborators.
@@ -127,6 +132,10 @@ func New(cfg Config) *Worker {
 func (w *Worker) SetLiveWriter(lw *LiveWriter) { w.live = lw }
 
 func (w *Worker) SetModVerifier(v *ModVerifier) { w.modVerifier = v }
+
+// SetReauthNotifier attaches the streamer-facing reauth messaging, used by
+// the system lane worker that consumes the authorization lifecycle events.
+func (w *Worker) SetReauthNotifier(r *ReauthNotifier) { w.reauth = r }
 
 // Login->id resolutions (shoutout targets) are a small, fleet-shared keyspace,
 // so wiring builds one bounded cache and injects it into every lane worker

--- a/app/outgress/main.go
+++ b/app/outgress/main.go
@@ -132,8 +132,19 @@ func main() {
 	})
 	d.startSystemLane(ctx, systemSub, system)
 
+	// Authorization lifecycle: streamer-facing messaging attaches before any
+	// consumer that can call it (the stream lane's go-live beacon and the
+	// authz consumers below), then the client-scoped user.authorization.*
+	// subscriptions that feed them are ensured in the background.
+	system.SetReauthNotifier(worker.NewReauthNotifier(
+		nc, cfg.NotifySendSubject, cfg.UsersStateSubject, cfg.TwitchBotUserID, log.Named("reauth")))
+
 	closeStreamLane := d.startStreamLane(ctx, system)
 	defer closeStreamLane()
+
+	closeAuthzLane := d.startAuthzLane(ctx, system)
+	defer closeAuthzLane()
+	go system.EnsureClientEventSubs(ctx)
 
 	fatalIf(log, rpc.SubscribeManage(nc, registry, tw, cfg.RPCPrefix, "outgress-rpc", nrApp, log.Named("rpc")),
 		"failed to subscribe management rpc")
@@ -405,6 +416,30 @@ func (d *deps) startStreamLane(ctx context.Context, system *worker.Worker) func(
 		"failed to consume stream lane")
 
 	return func() { _ = streamSub.Close() }
+}
+
+// startAuthzLane binds one durable consumer per authorization lifecycle
+// subject (granted / revoked / subrevoked) under outgress's service group, on
+// the same TWITCH_INGRESS stream as the stream lane. Ingress publishes these
+// when Twitch reports an authorization change; the system worker reconciles
+// the channel's enrollment state (mark revoked, re-enroll on grant). Distinct
+// literal subjects keep each handler's intent typed instead of re-dispatching
+// on a wildcard.
+func (d *deps) startAuthzLane(ctx context.Context, system *worker.Worker) func() {
+	authzSub, err := bus.NewSubscriber(d.cfg.NATSURL, serviceName, d.log)
+	fatalIf(d.log, err, "failed to connect authz subscriber")
+
+	lanes := map[string]func(*bus.Message) error{
+		d.cfg.AuthzGrantedSubject:    system.HandleAuthzGranted,
+		d.cfg.AuthzRevokedSubject:    system.HandleAuthzRevoked,
+		d.cfg.AuthzSubRevokedSubject: system.HandleAuthzSubRevoked,
+	}
+	for subject, handle := range lanes {
+		fatalIf(d.log, bus.Consume(ctx, d.nrApp, authzSub, subject, handle, d.log),
+			"failed to consume authz subject "+subject)
+	}
+
+	return func() { _ = authzSub.Close() }
 }
 
 func (d *deps) logReady(tw *twitch.Client) {

--- a/app/outgress/main.go
+++ b/app/outgress/main.go
@@ -136,8 +136,11 @@ func main() {
 	// consumer that can call it (the stream lane's go-live beacon and the
 	// authz consumers below), then the client-scoped user.authorization.*
 	// subscriptions that feed them are ensured in the background.
-	system.SetReauthNotifier(worker.NewReauthNotifier(
-		nc, cfg.NotifySendSubject, cfg.UsersStateSubject, cfg.TwitchBotUserID, log.Named("reauth")))
+	system.SetReauthNotifier(worker.NewReauthNotifier(nc, worker.ReauthConfig{
+		SendSubject:  cfg.NotifySendSubject,
+		StateSubject: cfg.UsersStateSubject,
+		BotID:        cfg.TwitchBotUserID,
+	}, log.Named("reauth")))
 
 	closeStreamLane := d.startStreamLane(ctx, system)
 	defer closeStreamLane()

--- a/console/admin/src/lib/server/services.ts
+++ b/console/admin/src/lib/server/services.ts
@@ -386,7 +386,8 @@ export async function channelSubState(broadcasterId: string): Promise<ChannelSub
     const c = r.channel;
     if (!r.found || !c) return { state: 'unknown', error: '', checkedAt: null };
     const s = (c.sub_state || '') as string;
-    const state = (s === 'ok' || s === 'pending' || s === 'failing' || s === 'revoked') ? s : 'unknown';
+    const known = ['ok', 'pending', 'failing', 'revoked'];
+    const state = known.includes(s) ? (s as ChannelSubState['state']) : 'unknown';
     return { state, error: c.sub_error || '', checkedAt: c.sub_checked_at || null };
   } catch {
     return { state: 'unknown', error: '', checkedAt: null };

--- a/console/admin/src/lib/server/services.ts
+++ b/console/admin/src/lib/server/services.ts
@@ -368,7 +368,7 @@ export async function publishUserEventSub(userId: string, enabled: boolean): Pro
 }
 
 export type ChannelSubState = {
-  state: 'ok' | 'pending' | 'failing' | 'unknown';
+  state: 'ok' | 'pending' | 'failing' | 'revoked' | 'unknown';
   error: string;
   checkedAt: string | null;
 };
@@ -386,7 +386,7 @@ export async function channelSubState(broadcasterId: string): Promise<ChannelSub
     const c = r.channel;
     if (!r.found || !c) return { state: 'unknown', error: '', checkedAt: null };
     const s = (c.sub_state || '') as string;
-    const state = (s === 'ok' || s === 'pending' || s === 'failing') ? s : 'unknown';
+    const state = (s === 'ok' || s === 'pending' || s === 'failing' || s === 'revoked') ? s : 'unknown';
     return { state, error: c.sub_error || '', checkedAt: c.sub_checked_at || null };
   } catch {
     return { state: 'unknown', error: '', checkedAt: null };

--- a/console/admin/src/routes/(admin)/users/+page.svelte
+++ b/console/admin/src/routes/(admin)/users/+page.svelte
@@ -431,13 +431,17 @@
     });
   }
 
-  const subTone = $derived(
-    subState?.state === 'ok'
-      ? 'green'
-      : subState?.state === 'failing' || subState?.state === 'revoked'
-        ? 'err'
-        : 'warn'
-  );
+  const subTone = $derived.by(() => {
+    switch (subState?.state) {
+      case 'ok':
+        return 'green';
+      case 'failing':
+      case 'revoked':
+        return 'err';
+      default:
+        return 'warn';
+    }
+  });
 
   function onKey(e: KeyboardEvent) {
     if (e.key === 'Escape' && selectedId) closeInspector();

--- a/console/admin/src/routes/(admin)/users/+page.svelte
+++ b/console/admin/src/routes/(admin)/users/+page.svelte
@@ -432,7 +432,11 @@
   }
 
   const subTone = $derived(
-    subState?.state === 'ok' ? 'green' : subState?.state === 'failing' ? 'err' : 'warn'
+    subState?.state === 'ok'
+      ? 'green'
+      : subState?.state === 'failing' || subState?.state === 'revoked'
+        ? 'err'
+        : 'warn'
   );
 
   function onKey(e: KeyboardEvent) {

--- a/console/dashboard/src/lib/components/overview/BotStatusPanel.svelte
+++ b/console/dashboard/src/lib/components/overview/BotStatusPanel.svelte
@@ -55,6 +55,8 @@
         return t('overview.connecting');
       case 'degraded':
         return t('overview.reconnectNeeded');
+      case 'reauth_required':
+        return t('overview.twitchAccessLost');
       case 'sub_unknown':
         return t('overview.connectedIdle');
       case 'unavailable':
@@ -72,6 +74,8 @@
         return t('overview.allGood');
       case 'degraded':
         return t('overview.issueSubs');
+      case 'reauth_required':
+        return t('overview.issueReauth');
       case 'sub_unknown':
         return t('overview.issueIdle');
       case 'disabled':
@@ -138,7 +142,10 @@
           <Button variant="primary" icon="power" type="submit" class="ov-cta">{t('overview.enable')}</Button>
         </form>
       {:else if ui.showConnect}
-        <ButtonLink href="/settings" variant="primary" icon="power" class="ov-cta">{t('overview.issueNoAuthCta')}</ButtonLink>
+        <!-- reauth_required: the grant died server-side, only a fresh Twitch
+             consent restores it, so the one action offered is the reconnect. -->
+        <ButtonLink href="/settings" variant="primary" icon="power" class="ov-cta"
+          >{kind === 'reauth_required' ? t('common.reconnect') : t('overview.issueNoAuthCta')}</ButtonLink>
       {:else if ui.canRetry}
         <ButtonLink href="/" variant="ghost" icon="activity" class="ov-cta">{t('overview.retry')}</ButtonLink>
       {/if}

--- a/console/dashboard/src/lib/components/overview/status.ts
+++ b/console/dashboard/src/lib/components/overview/status.ts
@@ -8,14 +8,15 @@ import type { ConnKind } from '@bagel/shared';
 
 export type StatusTone = 'success' | 'warning' | 'error' | 'neutral';
 
-// Map main's ConnKind to a tone. `online` is the only success; `degraded` is the
-// only error (connected but not serving chat); a down core read is neutral; every
-// mid-flight or not-connected state warns.
+// Map main's ConnKind to a tone. `online` is the only success; `degraded` and
+// `reauth_required` are errors (the bot is not serving chat and needs help); a
+// down core read is neutral; every mid-flight or not-connected state warns.
 export function statusTone(kind: ConnKind): StatusTone {
   switch (kind) {
     case 'online':
       return 'success';
     case 'degraded':
+    case 'reauth_required':
       return 'error';
     case 'unavailable':
       return 'neutral';

--- a/console/dashboard/src/lib/server/services.ts
+++ b/console/dashboard/src/lib/server/services.ts
@@ -242,7 +242,7 @@ export async function publishEventSubEnsureOptional(broadcasterId: string): Prom
 }
 
 export type ChannelSubState = {
-  state: 'ok' | 'pending' | 'failing' | 'unenrolled' | 'unknown';
+  state: 'ok' | 'pending' | 'failing' | 'revoked' | 'unenrolled' | 'unknown';
   error: string;
   checkedAt: string | null;
 };
@@ -251,8 +251,11 @@ function unknownSubState(): ChannelSubState {
   return { state: 'unknown', error: '', checkedAt: null };
 }
 
-function isKnownSubState(s: string): s is 'ok' | 'pending' | 'failing' {
-  return s === 'ok' || s === 'pending' || s === 'failing';
+// 'revoked' must stay a known state: folding it into 'unenrolled' would let
+// the home page's self-heal publish enables against a channel outgress
+// deliberately refuses to enroll until the broadcaster re-consents.
+function isKnownSubState(s: string): s is 'ok' | 'pending' | 'failing' | 'revoked' {
+  return s === 'ok' || s === 'pending' || s === 'failing' || s === 'revoked';
 }
 
 // Read the persisted EventSub enroll state for a channel. Two distinct

--- a/console/dashboard/src/lib/server/services.ts
+++ b/console/dashboard/src/lib/server/services.ts
@@ -254,8 +254,10 @@ function unknownSubState(): ChannelSubState {
 // 'revoked' must stay a known state: folding it into 'unenrolled' would let
 // the home page's self-heal publish enables against a channel outgress
 // deliberately refuses to enroll until the broadcaster re-consents.
-function isKnownSubState(s: string): s is 'ok' | 'pending' | 'failing' | 'revoked' {
-  return s === 'ok' || s === 'pending' || s === 'failing' || s === 'revoked';
+const KNOWN_SUB_STATES = ['ok', 'pending', 'failing', 'revoked'] as const;
+
+function isKnownSubState(s: string): s is (typeof KNOWN_SUB_STATES)[number] {
+  return (KNOWN_SUB_STATES as readonly string[]).includes(s);
 }
 
 // Read the persisted EventSub enroll state for a channel. Two distinct

--- a/console/shared/lib/connection-state.test.ts
+++ b/console/shared/lib/connection-state.test.ts
@@ -14,8 +14,8 @@ describe('connectionUiState', () => {
 		expect(connectionUiState(base).live).toBe(true);
 	});
 
-	test('pending / unenrolled / failing / unknown never read as online', () => {
-		const notOnline: SubState[] = ['pending', 'unenrolled', 'failing', 'unknown'];
+	test('pending / unenrolled / failing / revoked / unknown never read as online', () => {
+		const notOnline: SubState[] = ['pending', 'unenrolled', 'failing', 'revoked', 'unknown'];
 		for (const sub of notOnline) {
 			const r = connectionUiState({ ...base, sub });
 			expect(r.kind).not.toBe('online');
@@ -28,6 +28,15 @@ describe('connectionUiState', () => {
 		expect(connectionUiState({ ...base, sub: 'unenrolled' }).kind).toBe('connecting');
 		expect(connectionUiState({ ...base, sub: 'failing' }).kind).toBe('degraded');
 		expect(connectionUiState({ ...base, sub: 'unknown' }).kind).toBe('sub_unknown');
+	});
+
+	test('revoked → reauth_required (reconnect via settings, no enable, no retry)', () => {
+		const r = connectionUiState({ ...base, sub: 'revoked' });
+		expect(r.kind).toBe('reauth_required');
+		expect(r.showConnect).toBe(true);
+		expect(r.showEnable).toBe(false);
+		expect(r.canRetry).toBe(false);
+		expect(r.live).toBe(false);
 	});
 
 	test('a down core read is unavailable, not a definite state', () => {
@@ -55,7 +64,7 @@ describe('connectionUiState', () => {
 	});
 
 	test('enable is never offered while a channel is active or in flight', () => {
-		for (const sub of ['ok', 'pending', 'unenrolled', 'failing', 'unknown'] as SubState[]) {
+		for (const sub of ['ok', 'pending', 'unenrolled', 'failing', 'revoked', 'unknown'] as SubState[]) {
 			expect(connectionUiState({ ...base, sub }).showEnable).toBe(false);
 		}
 	});
@@ -63,7 +72,7 @@ describe('connectionUiState', () => {
 	test('every signal permutation resolves to exactly one kind', () => {
 		const grants: (boolean | 'unknown')[] = [true, false, 'unknown'];
 		const actives: (boolean | 'unknown')[] = [true, false, 'unknown'];
-		const subs: SubState[] = ['ok', 'pending', 'failing', 'unenrolled', 'unknown'];
+		const subs: SubState[] = ['ok', 'pending', 'failing', 'revoked', 'unenrolled', 'unknown'];
 		for (const grant of grants)
 			for (const active of actives)
 				for (const sub of subs) {

--- a/console/shared/lib/connection-state.ts
+++ b/console/shared/lib/connection-state.ts
@@ -75,14 +75,19 @@ function activeKind(sub: SubState): ConnKind {
   }
 }
 
+// Per-kind action sets. Membership lists keep each ConnUi flag a single
+// readable predicate instead of a growing boolean chain.
+const MANAGEABLE: readonly ConnKind[] = ['online', 'degraded', 'sub_unknown', 'connecting'];
+const CONNECTABLE: readonly ConnKind[] = ['auth_required', 'reauth_required'];
+const RETRYABLE: readonly ConnKind[] = ['unavailable', 'sub_unknown'];
+
 function ui(kind: ConnKind): ConnUi {
   return {
     kind,
     live: kind === 'online',
-    canManage:
-      kind === 'online' || kind === 'degraded' || kind === 'sub_unknown' || kind === 'connecting',
+    canManage: MANAGEABLE.includes(kind),
     showEnable: kind === 'disabled',
-    showConnect: kind === 'auth_required' || kind === 'reauth_required',
-    canRetry: kind === 'unavailable' || kind === 'sub_unknown'
+    showConnect: CONNECTABLE.includes(kind),
+    canRetry: RETRYABLE.includes(kind)
   };
 }

--- a/console/shared/lib/connection-state.ts
+++ b/console/shared/lib/connection-state.ts
@@ -11,7 +11,7 @@
 // matrix. String-literal types mirror ChannelSubState['state'] and AccountStatus
 // in dashboard $lib/server/services.ts (kept in sync by hand, both closed sets).
 
-export type SubState = 'ok' | 'pending' | 'failing' | 'unenrolled' | 'unknown';
+export type SubState = 'ok' | 'pending' | 'failing' | 'revoked' | 'unenrolled' | 'unknown';
 export type PlanStatus = 'free' | 'paid' | 'vip';
 
 // A read that failed (RPC down / timeout) surfaces as 'unknown', never a silent
@@ -27,6 +27,7 @@ export type ConnSignals = {
 export type ConnKind =
   | 'unavailable' // a core read (grant or active) is down — we cannot tell
   | 'auth_required' // no Twitch grant on file
+  | 'reauth_required' // Twitch revoked the grant (password change / app disconnect); user must re-consent
   | 'disabled' // grant present but the channel is inactive (disconnected)
   | 'connecting' // active, enroll in flight (pending / just-published)
   | 'online' // active + enroll ok — the ONLY truthful "online"
@@ -61,6 +62,11 @@ function activeKind(sub: SubState): ConnKind {
       return 'online';
     case 'failing':
       return 'degraded';
+    // Twitch revoked the broadcaster's authorization. Restart cannot fix it
+    // (outgress skips enrolls for revoked channels on purpose); only a fresh
+    // Twitch consent can, so the UI routes to reconnect instead of retry.
+    case 'revoked':
+      return 'reauth_required';
     case 'pending':
     case 'unenrolled':
       return 'connecting';
@@ -76,7 +82,7 @@ function ui(kind: ConnKind): ConnUi {
     canManage:
       kind === 'online' || kind === 'degraded' || kind === 'sub_unknown' || kind === 'connecting',
     showEnable: kind === 'disabled',
-    showConnect: kind === 'auth_required',
+    showConnect: kind === 'auth_required' || kind === 'reauth_required',
     canRetry: kind === 'unavailable' || kind === 'sub_unknown'
   };
 }

--- a/console/shared/lib/i18n/en.ts
+++ b/console/shared/lib/i18n/en.ts
@@ -127,6 +127,9 @@ export const en = {
     connectedIdle: 'Connected · idle',
     notConnected: 'Not connected',
     reconnectNeeded: 'Reconnect needed',
+    twitchAccessLost: 'Twitch access lost',
+    issueReauth:
+      'Twitch revoked the bot’s access to your channel. This happens after a password change or if the app was disconnected on Twitch. Reconnect your Twitch account to bring the bot back.',
     reconnecting: 'Reconnecting…',
     connecting: 'Connecting…',
     unavailable: 'Connection status unavailable',

--- a/console/shared/lib/i18n/fr.ts
+++ b/console/shared/lib/i18n/fr.ts
@@ -126,6 +126,9 @@ export const fr = {
     connectedIdle: 'Connecté · inactif',
     notConnected: 'Non connecté',
     reconnectNeeded: 'Reconnexion nécessaire',
+    twitchAccessLost: 'Accès Twitch perdu',
+    issueReauth:
+      'Twitch a révoqué l’accès du bot à votre chaîne. Cela arrive après un changement de mot de passe ou si l’application a été déconnectée sur Twitch. Reconnectez votre compte Twitch pour rétablir le bot.',
     reconnecting: 'Reconnexion…',
     connecting: 'Connexion…',
     unavailable: 'État de connexion indisponible',

--- a/deploy/k8s/nats-auth.conf
+++ b/deploy/k8s/nats-auth.conf
@@ -267,7 +267,11 @@ accounts: {
               "$JS.ACK.*.*.TWITCH_INGRESS.>"
             ]
           }
-          subscribe: { allow: ["twitch.outgress.>", "twitch.ingress.event.stream", "_INBOX.>"] }
+          # twitch.ingress.status.authz.* carries the authorization lifecycle
+          # (user.authorization.grant/revoke + per-subscription revocations);
+          # outgress binds durable consumers there to reconcile enrollment
+          # state (mark revoked, re-enroll on grant).
+          subscribe: { allow: ["twitch.outgress.>", "twitch.ingress.event.stream", "twitch.ingress.status.authz.>", "_INBOX.>"] }
         }
       },
       {
@@ -438,6 +442,11 @@ accounts: {
     imports: [
       { service: { account: "USERS_RPC",          subject: "bagel.rpc.internal.tokens.>" } }
       { service: { account: "TWITCH_INGRESS_RPC",  subject: "bagel.rpc.ingress.conduit.get" } }
+      # Reauth nudge when Twitch revokes a broadcaster's authorization: the
+      # locale read localizes the copy, the notifications send delivers the
+      # dashboard bell entry (same verb the transactions gift notice uses).
+      { service: { account: "USERS_RPC",          subject: "bagel.rpc.dashboard.state_get" } }
+      { service: { account: "NOTIFICATIONS_RPC",  subject: "bagel.rpc.admin.notifications.send" } }
     ]
   }
 

--- a/deploy/k8s/nats_auth_acceptance_test.go
+++ b/deploy/k8s/nats_auth_acceptance_test.go
@@ -117,6 +117,10 @@ func (h *acceptanceHarness) assertAllowedBindings(t *testing.T) {
 		{serviceIdentity{"outgress_bus"}, "authz_outgress", "twitch.outgress.premium"},
 		{serviceIdentity{"outgress_bus"}, "authz_outgress", "twitch.outgress.system"},
 		{serviceIdentity{"outgress_bus"}, "authz_outgress", "twitch.ingress.event.stream"},
+		// Authorization lifecycle consumers (revocation marking + grant re-enroll).
+		{serviceIdentity{"outgress_bus"}, "authz_outgress", "twitch.ingress.status.authz.granted"},
+		{serviceIdentity{"outgress_bus"}, "authz_outgress", "twitch.ingress.status.authz.revoked"},
+		{serviceIdentity{"outgress_bus"}, "authz_outgress", "twitch.ingress.status.authz.subrevoked"},
 	}
 	for _, binding := range bindings {
 		binding := binding

--- a/internal/domain/rpc/users/users.go
+++ b/internal/domain/rpc/users/users.go
@@ -208,6 +208,22 @@ type LocaleSetRequest struct {
 	Locale            string `json:"locale"`
 }
 
+// StateGetRequest is the payload for the dashboard state_get verb.
+type StateGetRequest struct {
+	BroadcasterUserID string `json:"broadcaster_user_id"`
+}
+
+// StateGetReply is the subset of the state_get reply Go callers consume
+// (outgress reads the locale to localize streamer-facing reauth copy). The
+// verb returns more fields; unknown ones are ignored on decode.
+type StateGetReply struct {
+	Active    bool   `json:"active"`
+	Status    string `json:"status"`
+	Onboarded bool   `json:"onboarded"`
+	Locale    string `json:"locale"`
+	Error     string `json:"error,omitempty"`
+}
+
 // OnboardedSetRequest is the payload for the dashboard onboarded_set verb.
 type OnboardedSetRequest struct {
 	BroadcasterUserID string `json:"broadcaster_user_id"`


### PR DESCRIPTION
## Why

Twitch revokes a broadcaster's authorization on password change or app disconnect (both arrive as `authorization_revoked`). Ingress only logged the revocation notice, so scoped subscriptions silently died while the dashboard kept reporting Online: `sub_state` was only ever written by enroll jobs, and `grant_has` counts dead token rows. That is exactly the greenwhaleshark incident (2026-07-17): channel dark, dashboard green, restart clicks looping 403 "subscription missing proper authorization" until re-consent.

## What

- **ingress**: publish `user.authorization.grant/revoke` and per-subscription revocations on `twitch.ingress.status.authz.*` instead of dropping them.
- **outgress**: new `revoked` enrollment state. A revocation only marks the channel; the surviving unscoped subscriptions (stream.online/offline, raid, channel.update, chat) are never dropped. Re-enroll runs only when Twitch reports the grant back (`user.authorization.grant` on the conduit, ensured at boot), create-only with no drop phase. Enable/reconnect skip revoked channels, and the 403 auth error is classified as revoked and acked instead of retry-looping.
- **streamer messaging**, localized EN/FR from the account locale: go-live chat beacon in the streamer's own chat (stream.online and chat send both survive a revocation, so go-live is the one reliable moment to reach them), 12h cooldown; plus a dashboard bell notification, deduped per day.
- **console**: `revoked` maps to a new `reauth_required` state (error tone, single Reconnect CTA). Keeping `revoked` a known sub state stops the home page self-heal from spamming enables against a channel outgress refuses to enroll.
- **nats ACLs**: outgress subscribes the authz subjects and imports `bagel.rpc.dashboard.state_get` + `bagel.rpc.admin.notifications.send` (same pattern as the transactions gift notice). No new accounts.

## Testing

- Go build/vet/tests (outgress, domain), Elixir 142 tests, bun connection-state matrix incl. revoked, svelte-check clean on both consoles.
- Dashboard revoked panel verified live in EN and FR.