### PR TITLE
chore(infra): track k3s server memory guard, retire inotify band-aid

### DIFF
--- a/deploy/ansible/k3s-server-tuning.yml
+++ b/deploy/ansible/k3s-server-tuning.yml
@@ -1,0 +1,55 @@
+---
+# Pin the k3s server's Go runtime memory guard.
+#
+#   doppler run -- ansible-playbook -i inventory.cluster.ini k3s-server-tuning.yml
+#
+# node2 is the SINGLE k3s server (sqlite/kine — no HA, see the control-plane
+# migration notes). Its Go heap is capped with GOMEMLIMIT + GOGC, delivered via
+# the stock unit's `EnvironmentFile=-/etc/systemd/system/k3s.service.env` hook.
+# Without it the apiserver heap coasts upward on a 12GB box that also hosts
+# pods, and a single-server control plane has no peer to absorb an OOM.
+#
+# WHY THIS FILE EXISTS: the values were live-but-untracked, and have already
+# been lost once (node2 rebuilt 2026-07-02, env file re-created by hand
+# 2026-07-06). Untracked node-local state is exactly what let the retired
+# flannel-watchdog keep restarting this control plane unnoticed for ~23h
+# (see cluster-network-wireguard.yml) — a migration cannot clean up, and a
+# rebuild cannot restore, what the repo does not know exists.
+#
+# Verified live 2026-07-17: /proc/<k3s-pid>/environ carries both vars and
+# k3s-server RSS sits at ~1.4G against GOMEMLIMIT=1300MiB (heap held at the
+# limit + normal Go runtime overhead), so the guard is doing its job.
+#
+# NOTE: `systemctl show k3s -p Environment` renders EMPTY here and does NOT
+# mean the tuning is missing — it only prints `Environment=` directives, never
+# EnvironmentFile contents. Check /proc/<pid>/environ instead.
+- name: Pin the k3s server Go runtime memory guard
+  hosts: k3s_server
+  become: true
+  gather_facts: false
+  vars:
+    k3s_gomemlimit: 1300MiB
+    k3s_gogc: "75"
+  tasks:
+    - name: Install the k3s server Go runtime environment file
+      ansible.builtin.copy:
+        dest: /etc/systemd/system/k3s.service.env
+        owner: root
+        group: root
+        mode: "0644"
+        content: |
+          GOMEMLIMIT={{ k3s_gomemlimit }}
+          GOGC={{ k3s_gogc }}
+      register: k3s_server_env
+
+    # Deliberately NO automatic restart. Applying a changed value requires an
+    # explicit, human-timed `systemctl restart k3s`: this is the only control
+    # plane, and nothing automated should ever bounce it. That principle is the
+    # whole lesson of the flannel-watchdog incident.
+    - name: Report that a restart is required to apply a change
+      ansible.builtin.debug:
+        msg: >-
+          k3s.service.env changed on {{ inventory_hostname }}. Run
+          `sudo systemctl restart k3s` during a maintenance window to apply it.
+          Not restarted automatically: this is the single control plane.
+      when: k3s_server_env is changed

--- a/deploy/ansible/roles/base/tasks/main.yml
+++ b/deploy/ansible/roles/base/tasks/main.yml
@@ -81,6 +81,39 @@
     mode: "0644"
   notify: reload sysctl
 
+# --- Retire the superseded inotify band-aid ----------------------------------
+# node1 carried an untracked `inotify-heal` timer (every 5 min) that doubled
+# fs.inotify.max_user_instances whenever usage hit 80% and rewrote its own
+# /etc/sysctl.d/99-inotify.conf. It predates this role, which now pins 8192
+# permanently (64x the kernel default) — so the healer never fires and is dead
+# weight. Worse, its file pinned 512 and only lost the race because
+# "99-inotify" sorts before "99-kubernetes-tuning": drop this role's file and
+# the fleet would silently downgrade to 512. Removed live 2026-07-17 (it had
+# not fired in 7 days; node1 sat at 99 instances against the 8192 ceiling).
+- name: Remove the superseded inotify-heal band-aid
+  ansible.builtin.systemd:
+    name: inotify-heal.timer
+    state: stopped
+    enabled: false
+  failed_when: false
+
+- name: Remove the superseded inotify-heal files
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - /etc/systemd/system/inotify-heal.timer
+    - /etc/systemd/system/inotify-heal.service
+    - /usr/local/bin/inotify-heal.sh
+    - /etc/sysctl.d/99-inotify.conf
+  register: inotify_heal_removed
+  notify: reload sysctl
+
+- name: Reload systemd after removing inotify-heal
+  ansible.builtin.systemd:
+    daemon_reload: true
+  when: inotify_heal_removed is changed
+
 - name: NATS RPC latency sysctl tuning
   ansible.builtin.copy:
     src: 99-nats-rpc.conf


### PR DESCRIPTION
Follow-up to #440. Both changes address **untracked node-local state** — the same drift class that let the flannel-watchdog restart the control plane unnoticed for ~23h. A migration can't clean up, and a rebuild can't restore, what the repo doesn't know exists.

## 1. Track the k3s server memory guard (`k3s-server-tuning.yml`)

**Correction first:** node2's `GOMEMLIMIT` is **not** missing — I previously reported it was, based on `systemctl show k3s -p Environment` rendering empty. That command only prints `Environment=` directives and **never** shows `EnvironmentFile=` contents. `/proc/<k3s-pid>/environ` confirms both vars are live, and k3s-server RSS sits at ~1.4G against `GOMEMLIMIT=1300MiB` (heap held at the limit + normal Go overhead). The guard works. That gotcha is now documented in the playbook header so nobody repeats it.

The real problem is that it's **untracked**, and has already been lost once: node2 was rebuilt 2026-07-02 and the env file is dated 2026-07-06 — re-created by hand, four days later.

This playbook pins `GOMEMLIMIT=1300MiB` / `GOGC=75` via the stock unit's `EnvironmentFile=-/etc/systemd/system/k3s.service.env` hook. It renders **byte-identical** to the live file (27 bytes, mode 644, verified with `od -c`), so applying it is a guaranteed no-op — it only captures reality in git.

It deliberately has **no restart handler**. Applying a changed value needs an explicit, human-timed `systemctl restart k3s`. This is the only control plane, and nothing automated should ever bounce it — that's the whole lesson of #440.

## 2. Retire the inotify band-aid (`base` role)

node1 carried an untracked `inotify-heal` timer (every 5 min) that doubled `fs.inotify.max_user_instances` at 80% usage and rewrote its own `/etc/sysctl.d/99-inotify.conf`.

It's superseded: the `base` role already pins **8192** (64× the kernel default), so the healer never fires — 0 firings in 7 days, node1 sitting at 99 instances against the 8192 ceiling.

It's also a latent trap: its file pinned **512**, and only lost the sysctl race because `99-inotify` sorts before `99-kubernetes-tuning`. Drop this role's file and the fleet would silently downgrade to 512, at which point the healer would start doubling from there. Removed live and now ensured absent.

## Also cleaned live (no repo change — none of it was tracked)

| Removed | Why |
|---|---|
| `kube-system/fix-kubelet-cert` Job | Stale 16d one-off; privileged `nsenter` doing `rm client-kubelet.crt && systemctl restart k3s-agent`. Completed, untracked, a loaded gun. |
| falcosidekick SA/Role/RoleBinding ×6 | Sidekick doesn't exist and the release renders none. |
| `falco/newrelic-key-secret` | License for the nonexistent sidekick; nothing referenced it, key is Doppler-synced in ns `newrelic`. |
| node2 `coredns.yaml.bak*` ×2 | June leftovers in the k3s auto-apply dir. |

**Deliberately kept:** `coredns.yaml.skip` is **load-bearing** — k3s rewrites `coredns.yaml` on every start, and without that marker it would apply its packaged CoreDNS over the Flux-owned DaemonSet. Also kept `wait-for-tailscale0` + the `After=tailscaled` ordering (node-ip is a tailnet address, so k3s genuinely needs it), `fleet-cni-trust`, and `tailscale-udp-gro`.

## Fleet state

Only stock OS timers remain fleet-wide (`fwupd`, `raid-check`, `plocate`, vendor agents). No custom unit can restart k3s any more. node2's control plane has been stable since 11:37 UTC, straight through the 12:07 restart that was previously guaranteed.

Single control plane retained as requested. Its remaining gap is **DR, not stability**: sqlite/kine (110MB `state.db`, 59G free) has no automatic snapshots — k3s only auto-snapshots etcd. The one file in `db/backups/` is a one-off `pre-wireguard-native` migration dump. Flagged, not actioned.