### PR TITLE
refactor(gateway): builder-pattern provider authoring

### DIFF
--- a/app/gateway/internal/core/buckets.go
+++ b/app/gateway/internal/core/buckets.go
@@ -53,6 +53,14 @@ func NewBuckets(key string, capacity, windowSeconds float64) Buckets {
 	}
 }
 
+// WithKey returns a copy of b spending the same derived specs under a
+// different limiter key, for per-caller budgets (govee: one bucket per
+// broadcaster) without re-deriving the specs on every request.
+func (b Buckets) WithKey(key string) Buckets {
+	b.key = key
+	return b
+}
+
 // Enforce consumes one request from the budget. Standard requests must pass
 // both their restricted bucket AND the general bucket in one atomic script (a
 // denial consumes neither); premium requests consume only the general bucket,

--- a/app/gateway/internal/core/cache.go
+++ b/app/gateway/internal/core/cache.go
@@ -165,7 +165,7 @@ func Cached[T any](ctx context.Context, c *Cache, key string, ttl, negativeTTL t
 		if b, merr := sonic.Marshal(env); merr == nil {
 			_ = c.store.Set(ctx, key, b, cacheTTL)
 		}
-		
+
 		if env.Error != nil {
 			return v, env.Error
 		}

--- a/app/gateway/internal/provider/builder.go
+++ b/app/gateway/internal/provider/builder.go
@@ -111,7 +111,7 @@ func (b *Builder) validateTerminal(s *endpointSpec) error {
 	case s.handle == nil && s.flow == nil:
 		return fmt.Errorf("endpoint %q has no terminal (chain .Handle or .Cached(...).Fetch to finish it)", s.name)
 	case s.flow != nil:
-		return s.flow.validate(s.name, b.deps)
+		return s.flow.validate(b.deps, endpointRef{provider: b.name, endpoint: s.name})
 	}
 	return nil
 }
@@ -122,7 +122,7 @@ func (s *endpointSpec) handler(b *Builder) HandlerFunc {
 	if s.handle != nil {
 		return s.handle
 	}
-	return s.flow.handler(b.deps, b.name, s.name)
+	return s.flow.handler(b.deps, endpointRef{provider: b.name, endpoint: s.name})
 }
 
 // EndpointBuilder chains a single endpoint's settings. Handle is the terminal

--- a/app/gateway/internal/provider/builder.go
+++ b/app/gateway/internal/provider/builder.go
@@ -1,0 +1,164 @@
+package provider
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+// Builder is the fluent authoring surface for one provider, the gateway's twin
+// of sesame's module.Builder. A provider's New creates a Builder with
+// NewProvider, declares its endpoints, then calls Build to get the immutable
+// Provider the engine serves:
+//
+//	b := provider.NewProvider("mcsr", d)
+//	b.Endpoint("user").Timeout(15 * time.Second).Handle(p.user)
+//	b.Endpoint("session").Timeout(15 * time.Second).Handle(p.session)
+//	return b.Build()
+//
+// Byte-flow endpoints (the cached fetch-and-shape skeleton every stats
+// provider shares) chain Cached instead of Handle; see FlowBuilder.
+//
+// The Builder holds *endpointSpec pointers while it is being assembled so the
+// chained setters mutate in place; Build copies them into the immutable
+// Provider. A Builder is single-use and not safe for concurrent use.
+type Builder struct {
+	name string
+	deps Deps
+	eps  []*endpointSpec
+}
+
+// endpointSpec is one endpoint under assembly: exactly one of handle (a
+// bespoke handler) or flow (a declared byte-flow) finishes it.
+type endpointSpec struct {
+	name    string
+	timeout time.Duration
+	handle  HandlerFunc
+	flow    *flowSpec
+}
+
+// NewProvider starts a provider of the given name. Unlike sesame's module
+// package, Deps rides in here: cached flow endpoints need the shared cache and
+// logger when Build assembles their handlers. Bespoke Handle endpoints still
+// capture their services by closure, exactly like sesame modules.
+func NewProvider(name string, d Deps) *Builder {
+	d.Log = d.Logger()
+	return &Builder{name: name, deps: d}
+}
+
+// Endpoint starts one RPC verb, returning an EndpointBuilder to chain its
+// timeout and terminal. The endpoint is not complete until Handle or a
+// Cached flow's Fetch is called; an unfinished endpoint is reported by Build.
+func (b *Builder) Endpoint(name string) *EndpointBuilder {
+	s := &endpointSpec{name: name}
+	b.eps = append(b.eps, s)
+	return &EndpointBuilder{s: s}
+}
+
+// Build validates the assembled provider and returns its immutable form. It
+// panics on a programmer error (empty or duplicate endpoint name, an endpoint
+// with no terminal, an unfinished flow): these are startup misconfigurations,
+// not runtime data, so failing loud at boot is the right behavior. Use
+// Validate to check without panicking.
+func (b *Builder) Build() Provider {
+	if err := b.Validate(); err != nil {
+		panic("gateway/provider: " + err.Error())
+	}
+	eps := make([]Endpoint, len(b.eps))
+	for i, s := range b.eps {
+		eps[i] = Endpoint{Name: s.name, Timeout: s.timeout, Handle: s.handler(b)}
+	}
+	return built{name: b.name, endpoints: eps}
+}
+
+// Validate reports the first problem with the assembled provider, or nil when
+// it is well formed. Build calls it and panics on a non-nil result; tests can
+// call it directly.
+func (b *Builder) Validate() error {
+	if b.name == "" {
+		return errors.New("provider must have a non-empty name")
+	}
+	if len(b.eps) == 0 {
+		return fmt.Errorf("provider %q declares no endpoints", b.name)
+	}
+	claimed := make(map[string]struct{}, len(b.eps))
+	for _, s := range b.eps {
+		if err := b.validateEndpoint(claimed, s); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateEndpoint checks one endpoint's name uniqueness and its terminal.
+func (b *Builder) validateEndpoint(claimed map[string]struct{}, s *endpointSpec) error {
+	if s.name == "" {
+		return fmt.Errorf("provider %q has an endpoint with an empty name", b.name)
+	}
+	if _, dup := claimed[s.name]; dup {
+		return fmt.Errorf("provider %q declares endpoint %q twice", b.name, s.name)
+	}
+	claimed[s.name] = struct{}{}
+	return b.validateTerminal(s)
+}
+
+// validateTerminal enforces that exactly one terminal finished the endpoint
+// and, for a flow, that the flow itself is complete.
+func (b *Builder) validateTerminal(s *endpointSpec) error {
+	switch {
+	case s.handle != nil && s.flow != nil:
+		return fmt.Errorf("endpoint %q chains both Handle and Cached", s.name)
+	case s.handle == nil && s.flow == nil:
+		return fmt.Errorf("endpoint %q has no terminal (chain .Handle or .Cached(...).Fetch to finish it)", s.name)
+	case s.flow != nil:
+		return s.flow.validate(s.name, b.deps)
+	}
+	return nil
+}
+
+// handler resolves the endpoint's HandlerFunc: the bespoke Handle, or the one
+// its declared flow assembles.
+func (s *endpointSpec) handler(b *Builder) HandlerFunc {
+	if s.handle != nil {
+		return s.handle
+	}
+	return s.flow.handler(b.deps, b.name, s.name)
+}
+
+// EndpointBuilder chains a single endpoint's settings. Handle is the terminal
+// that finishes a bespoke endpoint; Cached opens the byte-flow chain whose own
+// terminal is Fetch.
+type EndpointBuilder struct {
+	s *endpointSpec
+}
+
+// Timeout bounds one handler run; zero (the default) means the bus default.
+func (e *EndpointBuilder) Timeout(d time.Duration) *EndpointBuilder {
+	e.s.timeout = d
+	return e
+}
+
+// Handle sets the endpoint's bespoke handler and finishes it. It is terminal:
+// it returns nothing so a declaration cannot accidentally continue past it.
+func (e *EndpointBuilder) Handle(fn HandlerFunc) {
+	e.s.handle = fn
+}
+
+// Cached declares the endpoint as a byte-flow: successes cache for ttl,
+// negatively cacheable friendly failures (player not found) for negativeTTL.
+// The returned FlowBuilder chains the flow's identity, reply shaping and
+// terminal Fetch.
+func (e *EndpointBuilder) Cached(ttl, negativeTTL time.Duration) *FlowBuilder {
+	f := &flowSpec{ttl: ttl, negativeTTL: negativeTTL, id: Account}
+	e.s.flow = f
+	return &FlowBuilder{f: f}
+}
+
+// built is the immutable Provider Build returns.
+type built struct {
+	name      string
+	endpoints []Endpoint
+}
+
+func (p built) Name() string          { return p.name }
+func (p built) Endpoints() []Endpoint { return p.endpoints }

--- a/app/gateway/internal/provider/builder_test.go
+++ b/app/gateway/internal/provider/builder_test.go
@@ -1,0 +1,242 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"ItsBagelBot/app/gateway/internal/core"
+	gatewayrpc "ItsBagelBot/internal/domain/rpc/gateway"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// memStore is an in-memory core.Store for tests.
+type memStore struct {
+	mu sync.Mutex
+	m  map[string][]byte
+}
+
+func newMemStore() *memStore { return &memStore{m: map[string][]byte{}} }
+
+func (s *memStore) Get(_ context.Context, key string) ([]byte, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	b, ok := s.m[key]
+	return b, ok, nil
+}
+func (s *memStore) Set(_ context.Context, key string, val []byte, _ time.Duration) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	// Copy: the Store contract says val may come from a pooled buffer the
+	// caller recycles as soon as Set returns.
+	s.m[key] = append([]byte(nil), val...)
+	return nil
+}
+func (s *memStore) Del(_ context.Context, key string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.m, key)
+	return nil
+}
+
+func testDeps() Deps {
+	return Deps{Cache: core.NewCache(newMemStore())}
+}
+
+// testReply is a minimal typed reply for flow tests.
+type testReply struct {
+	Player string `json:"player"`
+	Value  int    `json:"value"`
+	Error  string `json:"error,omitempty"`
+}
+
+func testErrReply(id, msg string) any { return testReply{Player: id, Error: msg} }
+
+func decode(t *testing.T, res any) testReply {
+	t.Helper()
+	if v, ok := res.(testReply); ok {
+		return v
+	}
+	raw, ok := res.(json.RawMessage)
+	require.True(t, ok, "unexpected handler result type %T", res)
+	var v testReply
+	require.NoError(t, json.Unmarshal(raw, &v))
+	return v
+}
+
+func TestBuildIndexesEndpointsInOrder(t *testing.T) {
+	b := NewProvider("demo", testDeps())
+	b.Endpoint("one").Timeout(3 * time.Second).Handle(func(context.Context, gatewayrpc.Request) any { return "1" })
+	b.Endpoint("two").Handle(func(context.Context, gatewayrpc.Request) any { return "2" })
+	p := b.Build()
+
+	assert.Equal(t, "demo", p.Name())
+	require.Len(t, p.Endpoints(), 2)
+	assert.Equal(t, "one", p.Endpoints()[0].Name)
+	assert.Equal(t, 3*time.Second, p.Endpoints()[0].Timeout)
+	assert.Equal(t, "two", p.Endpoints()[1].Name)
+	assert.Equal(t, "1", p.Endpoints()[0].Handle(context.Background(), gatewayrpc.Request{}))
+}
+
+func TestValidateRejectsMisassembly(t *testing.T) {
+	handler := func(context.Context, gatewayrpc.Request) any { return nil }
+
+	t.Run("empty provider name", func(t *testing.T) {
+		b := NewProvider("", testDeps())
+		b.Endpoint("x").Handle(handler)
+		assert.ErrorContains(t, b.Validate(), "non-empty name")
+	})
+	t.Run("no endpoints", func(t *testing.T) {
+		assert.ErrorContains(t, NewProvider("demo", testDeps()).Validate(), "no endpoints")
+	})
+	t.Run("empty endpoint name", func(t *testing.T) {
+		b := NewProvider("demo", testDeps())
+		b.Endpoint("").Handle(handler)
+		assert.ErrorContains(t, b.Validate(), "empty name")
+	})
+	t.Run("duplicate endpoint", func(t *testing.T) {
+		b := NewProvider("demo", testDeps())
+		b.Endpoint("x").Handle(handler)
+		b.Endpoint("x").Handle(handler)
+		assert.ErrorContains(t, b.Validate(), "twice")
+	})
+	t.Run("no terminal", func(t *testing.T) {
+		b := NewProvider("demo", testDeps())
+		b.Endpoint("x")
+		assert.ErrorContains(t, b.Validate(), "no terminal")
+	})
+	t.Run("flow without Fetch", func(t *testing.T) {
+		b := NewProvider("demo", testDeps())
+		b.Endpoint("x").Cached(time.Minute, time.Minute).Reply(testErrReply)
+		assert.ErrorContains(t, b.Validate(), "no Fetch")
+	})
+	t.Run("flow without Reply", func(t *testing.T) {
+		b := NewProvider("demo", testDeps())
+		b.Endpoint("x").Cached(time.Minute, time.Minute).
+			Fetch(func(context.Context, gatewayrpc.Request, ID) (any, error) { return nil, nil })
+		assert.ErrorContains(t, b.Validate(), "no Reply")
+	})
+	t.Run("flow without cache", func(t *testing.T) {
+		b := NewProvider("demo", Deps{})
+		b.Endpoint("x").Cached(time.Minute, time.Minute).Reply(testErrReply).
+			Fetch(func(context.Context, gatewayrpc.Request, ID) (any, error) { return nil, nil })
+		assert.ErrorContains(t, b.Validate(), "Deps.Cache is nil")
+	})
+}
+
+func TestBuildPanicsOnProgrammerError(t *testing.T) {
+	b := NewProvider("demo", testDeps())
+	b.Endpoint("x")
+	assert.Panics(t, func() { b.Build() })
+}
+
+// A flow endpoint runs the full skeleton: identity validation, cached fetch,
+// and raw-bytes hits.
+func TestFlowServesAndCaches(t *testing.T) {
+	fetches := 0
+	b := NewProvider("demo", testDeps())
+	b.Endpoint("stats").
+		Cached(time.Minute, time.Minute).
+		Reply(testErrReply).
+		Fallback("stats lookup failed").
+		Fetch(func(_ context.Context, _ gatewayrpc.Request, id ID) (any, error) {
+			fetches++
+			return testReply{Player: id.Display, Value: 7}, nil
+		})
+	h := b.Build().Endpoints()[0].Handle
+
+	first := decode(t, h(context.Background(), gatewayrpc.Request{Account: "Techno"}))
+	require.Empty(t, first.Error)
+	assert.Equal(t, "Techno", first.Player)
+	assert.Equal(t, 7, first.Value)
+
+	// Case-insensitive hit: served from the cache as raw wire bytes.
+	res := h(context.Background(), gatewayrpc.Request{Account: "techno"})
+	_, isRaw := res.(json.RawMessage)
+	assert.True(t, isRaw, "cache hit must answer stored wire bytes")
+	assert.Equal(t, 1, fetches)
+}
+
+func TestFlowRejectsMissingIdentity(t *testing.T) {
+	b := NewProvider("demo", testDeps())
+	b.Endpoint("stats").
+		Cached(time.Minute, time.Minute).
+		Reply(testErrReply).
+		Fetch(func(context.Context, gatewayrpc.Request, ID) (any, error) {
+			t.Error("no fetch expected")
+			return nil, nil
+		})
+	h := b.Build().Endpoints()[0].Handle
+
+	reply := decode(t, h(context.Background(), gatewayrpc.Request{}))
+	assert.Equal(t, "missing account", reply.Error)
+}
+
+// A friendly upstream failure (404) answers through the Reply shaper and
+// negative-caches; an infrastructure failure answers the Fallback message.
+func TestFlowErrorShaping(t *testing.T) {
+	t.Run("friendly upstream", func(t *testing.T) {
+		fetches := 0
+		b := NewProvider("demo", testDeps())
+		b.Endpoint("stats").
+			Cached(time.Minute, time.Minute).
+			Reply(testErrReply).
+			Fetch(func(context.Context, gatewayrpc.Request, ID) (any, error) {
+				fetches++
+				return nil, &core.UpstreamError{Status: 404, Message: "player not found"}
+			})
+		h := b.Build().Endpoints()[0].Handle
+
+		reply := decode(t, h(context.Background(), gatewayrpc.Request{Account: "ghost"}))
+		assert.Equal(t, "player not found", reply.Error)
+		assert.Equal(t, "ghost", reply.Player)
+
+		reply = decode(t, h(context.Background(), gatewayrpc.Request{Account: "ghost"}))
+		assert.Equal(t, "player not found", reply.Error)
+		assert.Equal(t, 1, fetches, "the miss must be served from the negative cache")
+	})
+	t.Run("infrastructure fallback", func(t *testing.T) {
+		b := NewProvider("demo", testDeps())
+		b.Endpoint("stats").
+			Cached(time.Minute, time.Minute).
+			Reply(testErrReply).
+			Fallback("stats lookup failed").
+			Fetch(func(context.Context, gatewayrpc.Request, ID) (any, error) {
+				return nil, errors.New("upstream unreachable")
+			})
+		h := b.Build().Endpoints()[0].Handle
+
+		reply := decode(t, h(context.Background(), gatewayrpc.Request{Account: "Techno"}))
+		assert.Equal(t, "stats lookup failed", reply.Error)
+		assert.Equal(t, "Techno", reply.Player)
+	})
+}
+
+func TestIDExtractors(t *testing.T) {
+	t.Run("Account", func(t *testing.T) {
+		id, reject := Account(gatewayrpc.Request{Account: "  Techno "})
+		require.Empty(t, reject)
+		assert.Equal(t, ID{Display: "Techno", Key: "techno"}, id)
+
+		_, reject = Account(gatewayrpc.Request{})
+		assert.Equal(t, "missing account", reject)
+	})
+	t.Run("Channel", func(t *testing.T) {
+		id, reject := Channel(gatewayrpc.Request{ChannelID: " 42 "})
+		require.Empty(t, reject)
+		assert.Equal(t, ID{Display: "42", Key: "42"}, id)
+
+		_, reject = Channel(gatewayrpc.Request{})
+		assert.Equal(t, "missing channel", reject)
+	})
+	t.Run("StaticID", func(t *testing.T) {
+		id, reject := StaticID("current")(gatewayrpc.Request{Account: "ignored"})
+		require.Empty(t, reject)
+		assert.Equal(t, ID{Key: "current"}, id)
+	})
+}

--- a/app/gateway/internal/provider/flow.go
+++ b/app/gateway/internal/provider/flow.go
@@ -109,17 +109,24 @@ func (fb *FlowBuilder) Fetch(fn FetchFunc) {
 	fb.f.fetch = fn
 }
 
+// endpointRef identifies one declared endpoint (its provider and endpoint
+// subject tokens) for cache keys, validation messages and failure logs.
+type endpointRef struct {
+	provider string
+	endpoint string
+}
+
 // validate reports the first problem with the declared flow, or nil.
-func (f *flowSpec) validate(endpoint string, d Deps) error {
+func (f *flowSpec) validate(d Deps, ref endpointRef) error {
 	switch {
 	case f.reply == nil:
-		return fmt.Errorf("endpoint %q flow has no Reply shaper", endpoint)
+		return fmt.Errorf("endpoint %q flow has no Reply shaper", ref.endpoint)
 	case f.fetch == nil:
-		return fmt.Errorf("endpoint %q flow has no Fetch (chain .Fetch to finish it)", endpoint)
+		return fmt.Errorf("endpoint %q flow has no Fetch (chain .Fetch to finish it)", ref.endpoint)
 	case f.ttl <= 0:
-		return fmt.Errorf("endpoint %q flow has a non-positive TTL", endpoint)
+		return fmt.Errorf("endpoint %q flow has a non-positive TTL", ref.endpoint)
 	case d.Cache == nil:
-		return fmt.Errorf("endpoint %q is cached but Deps.Cache is nil", endpoint)
+		return fmt.Errorf("endpoint %q is cached but Deps.Cache is nil", ref.endpoint)
 	}
 	return nil
 }
@@ -128,7 +135,7 @@ func (f *flowSpec) validate(endpoint string, d Deps) error {
 // bytes untouched (json.RawMessage passes through the engine verbatim); a miss
 // runs fetch through core.BuildReply so successes and friendly failures are
 // shaped and marshaled exactly once.
-func (f *flowSpec) handler(d Deps, providerName, endpointName string) HandlerFunc {
+func (f *flowSpec) handler(d Deps, ref endpointRef) HandlerFunc {
 	cache, log := d.Cache, d.Log
 	fallback := f.fallback
 	if fallback == "" {
@@ -139,7 +146,7 @@ func (f *flowSpec) handler(d Deps, providerName, endpointName string) HandlerFun
 		if reject != "" {
 			return f.reply(id.Display, reject)
 		}
-		b, err := core.CachedBytes(ctx, cache, core.Key(providerName, endpointName, id.Key),
+		b, err := core.CachedBytes(ctx, cache, core.Key(ref.provider, ref.endpoint, id.Key),
 			func(ctx context.Context) ([]byte, time.Duration, error) {
 				return core.BuildReply(ctx, f.ttl, f.negativeTTL,
 					func(ctx context.Context) (any, error) { return f.fetch(ctx, req, id) },
@@ -148,8 +155,8 @@ func (f *flowSpec) handler(d Deps, providerName, endpointName string) HandlerFun
 			})
 		if err != nil {
 			log.Warn("gateway fetch failed",
-				zap.String("provider", providerName),
-				zap.String("endpoint", endpointName),
+				zap.String("provider", ref.provider),
+				zap.String("endpoint", ref.endpoint),
 				zap.String("id", id.Display),
 				zap.Error(err))
 			return f.reply(id.Display, fallback)

--- a/app/gateway/internal/provider/flow.go
+++ b/app/gateway/internal/provider/flow.go
@@ -1,0 +1,159 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"ItsBagelBot/app/gateway/internal/core"
+	gatewayrpc "ItsBagelBot/internal/domain/rpc/gateway"
+
+	"go.uber.org/zap"
+)
+
+// ID is one validated request identity a flow feeds its Fetch and Reply
+// shaper. Display is echoed in replies exactly as the caller typed it; Key
+// discriminates cache entries (normalized, so "Player" and "player" share one
+// entry).
+type ID struct {
+	Display string
+	Key     string
+}
+
+// IDFunc extracts and validates a flow's identity from the request. A
+// non-empty reject message answers immediately with the endpoint's error reply
+// (no cache read, no upstream call); Display may still be set so the reply
+// echoes the input.
+type IDFunc func(req gatewayrpc.Request) (id ID, reject string)
+
+// Account is the default IDFunc: the trimmed Request.Account, cache-keyed
+// case-insensitively.
+func Account(req gatewayrpc.Request) (ID, string) {
+	a := strings.TrimSpace(req.Account)
+	if a == "" {
+		return ID{}, "missing account"
+	}
+	return ID{Display: a, Key: strings.ToLower(a)}, ""
+}
+
+// Channel identifies the flow by the trimmed Request.ChannelID.
+func Channel(req gatewayrpc.Request) (ID, string) {
+	c := strings.TrimSpace(req.ChannelID)
+	if c == "" {
+		return ID{}, "missing channel"
+	}
+	return ID{Display: c, Key: c}, ""
+}
+
+// StaticID identifies every request identically, for endpoints whose reply
+// carries no request state (the fortnite item shop).
+func StaticID(key string) IDFunc {
+	return func(gatewayrpc.Request) (ID, string) { return ID{Key: key}, "" }
+}
+
+// FetchFunc produces one endpoint's typed success reply for a validated
+// identity. Upstream failures return typed errors (*core.UpstreamError) so the
+// flow maps them onto friendly reply errors; anything else propagates as an
+// infrastructure failure.
+type FetchFunc func(ctx context.Context, req gatewayrpc.Request, id ID) (any, error)
+
+// ReplyFunc shapes the endpoint's typed reply-with-Error for one identity and
+// message. The flow uses it for every failure it answers: a rejected identity,
+// a friendly upstream failure, and the infrastructure fallback.
+type ReplyFunc func(id, msg string) any
+
+// flowSpec is one declared byte-flow endpoint: the caching windows plus the
+// identity, reply shaping and fetch the FlowBuilder chained.
+type flowSpec struct {
+	ttl         time.Duration
+	negativeTTL time.Duration
+	id          IDFunc
+	reply       ReplyFunc
+	fallback    string
+	fetch       FetchFunc
+}
+
+// FlowBuilder chains one byte-flow endpoint, the skeleton every cached
+// endpoint used to hand-roll: validate the identity, read through the byte
+// cache (stale-while-revalidate), shape friendly upstream failures via the
+// Reply shaper, and answer infrastructure failures with the Fallback message
+// after logging. Fetch is the terminal that finishes the flow.
+type FlowBuilder struct {
+	f *flowSpec
+}
+
+// ID sets the flow's identity extractor; Account is the default.
+func (fb *FlowBuilder) ID(fn IDFunc) *FlowBuilder {
+	fb.f.id = fn
+	return fb
+}
+
+// Reply sets the shaper for every error reply the flow answers. Required.
+func (fb *FlowBuilder) Reply(fn ReplyFunc) *FlowBuilder {
+	fb.f.reply = fn
+	return fb
+}
+
+// Fallback sets the reply message for an infrastructure failure (upstream
+// unreachable, cache marshal); the default is "lookup failed".
+func (fb *FlowBuilder) Fallback(msg string) *FlowBuilder {
+	fb.f.fallback = msg
+	return fb
+}
+
+// Fetch sets the flow's success producer and finishes it. It is terminal: it
+// returns nothing so a declaration cannot accidentally continue past it.
+func (fb *FlowBuilder) Fetch(fn FetchFunc) {
+	fb.f.fetch = fn
+}
+
+// validate reports the first problem with the declared flow, or nil.
+func (f *flowSpec) validate(endpoint string, d Deps) error {
+	switch {
+	case f.reply == nil:
+		return fmt.Errorf("endpoint %q flow has no Reply shaper", endpoint)
+	case f.fetch == nil:
+		return fmt.Errorf("endpoint %q flow has no Fetch (chain .Fetch to finish it)", endpoint)
+	case f.ttl <= 0:
+		return fmt.Errorf("endpoint %q flow has a non-positive TTL", endpoint)
+	case d.Cache == nil:
+		return fmt.Errorf("endpoint %q is cached but Deps.Cache is nil", endpoint)
+	}
+	return nil
+}
+
+// handler assembles the endpoint's HandlerFunc. A hit answers the stored wire
+// bytes untouched (json.RawMessage passes through the engine verbatim); a miss
+// runs fetch through core.BuildReply so successes and friendly failures are
+// shaped and marshaled exactly once.
+func (f *flowSpec) handler(d Deps, providerName, endpointName string) HandlerFunc {
+	cache, log := d.Cache, d.Log
+	fallback := f.fallback
+	if fallback == "" {
+		fallback = "lookup failed"
+	}
+	return func(ctx context.Context, req gatewayrpc.Request) any {
+		id, reject := f.id(req)
+		if reject != "" {
+			return f.reply(id.Display, reject)
+		}
+		b, err := core.CachedBytes(ctx, cache, core.Key(providerName, endpointName, id.Key),
+			func(ctx context.Context) ([]byte, time.Duration, error) {
+				return core.BuildReply(ctx, f.ttl, f.negativeTTL,
+					func(ctx context.Context) (any, error) { return f.fetch(ctx, req, id) },
+					func(msg string) any { return f.reply(id.Display, msg) },
+				)
+			})
+		if err != nil {
+			log.Warn("gateway fetch failed",
+				zap.String("provider", providerName),
+				zap.String("endpoint", endpointName),
+				zap.String("id", id.Display),
+				zap.Error(err))
+			return f.reply(id.Display, fallback)
+		}
+		return json.RawMessage(b)
+	}
+}

--- a/app/gateway/internal/provider/provider.go
+++ b/app/gateway/internal/provider/provider.go
@@ -6,9 +6,12 @@
 // under internal/providers plus one line in providers.All — the same shape as
 // sesame's modules.All.
 //
-// Like sesame's module package, this one carries no runtime wiring: a provider
-// captures the services it needs (cache, limiter, HTTP clients) from Deps by
-// closure, so the authoring surface stays small and unit-testable on its own.
+// A provider is declared through the fluent Builder (see NewProvider), the
+// twin of sesame's module.Builder: endpoints chain their timeout and terminal
+// handler, and Build returns the immutable Provider the engine consumes.
+// Bespoke endpoints capture the services they need (limiter, HTTP clients) by
+// closure; the cached fetch-and-shape skeleton every stats endpoint shares is
+// declared once through the FlowBuilder instead of hand-rolled per endpoint.
 package provider
 
 import (
@@ -22,17 +25,21 @@ import (
 	"go.uber.org/zap"
 )
 
-// Endpoint is one RPC verb a provider answers. Handle returns the reply value
-// to marshal back; it must embed the conventional {"error": ""} envelope and
-// report user-facing failures (player not found) there rather than panicking
-// or returning nothing.
+// HandlerFunc answers one RPC request, returning the reply value to marshal
+// back. It must embed the conventional {"error": ""} envelope and report
+// user-facing failures (player not found) there rather than panicking or
+// returning nothing. Pre-marshaled bytes (json.RawMessage) pass to the wire
+// untouched.
+type HandlerFunc func(ctx context.Context, req gatewayrpc.Request) any
+
+// Endpoint is one RPC verb a provider answers.
 type Endpoint struct {
 	// Name is the last subject token ("daily", "user", "session_start", ...).
 	Name string
 	// Timeout bounds one handler run; zero means the bus default (5s).
 	Timeout time.Duration
 	// Handle answers one request.
-	Handle func(ctx context.Context, req gatewayrpc.Request) any
+	Handle HandlerFunc
 }
 
 // Provider is one external API system.
@@ -64,4 +71,13 @@ type Deps struct {
 	// nil disables that provider (providers.All skips it), the same degrade as a
 	// missing service API key.
 	GoveeKeys GoveeKeyResolver
+}
+
+// Logger returns Log, or a nop logger when it is unset, so providers and the
+// Builder never nil-check it themselves.
+func (d Deps) Logger() *zap.Logger {
+	if d.Log == nil {
+		return zap.NewNop()
+	}
+	return d.Log
 }

--- a/app/gateway/internal/providers/clashroyale/clashroyale.go
+++ b/app/gateway/internal/providers/clashroyale/clashroyale.go
@@ -6,7 +6,6 @@ package clashroyale
 
 import (
 	"context"
-	"encoding/json"
 	"math"
 	"net/url"
 	"strings"
@@ -16,7 +15,7 @@ import (
 	"ItsBagelBot/app/gateway/internal/provider"
 	gatewayrpc "ItsBagelBot/internal/domain/rpc/gateway"
 
-	"go.uber.org/zap"
+	"ItsBagelBot/pkg/ratelimit"
 )
 
 const (
@@ -40,17 +39,30 @@ type Config struct {
 	RateLimit float64
 }
 
-// Provider implements provider.Provider for the Clash Royale API.
-type Provider struct {
+// providerName is the subject token this provider answers under.
+const providerName = "clashroyale"
+
+// api holds the provider's runtime pieces; the declared endpoints capture it.
+type api struct {
 	http    *core.HTTPClient
 	cache   *core.Cache
-	log     *zap.Logger
-	deps    provider.Deps
+	limiter *ratelimit.Limiter
 	buckets core.Buckets
 }
 
-// New builds a Clash Royale provider.
-func New(cfg Config, d provider.Deps) *Provider {
+// New builds a Clash Royale provider: four byte-flow views over one shared
+// profile cache, so reading several views still costs one upstream request.
+func New(cfg Config, d provider.Deps) provider.Provider {
+	p := newAPI(cfg, d)
+	b := provider.NewProvider(providerName, d)
+	p.view(b, "stats", func(tag, msg string) any { return statsReply{Tag: tag, Error: msg} }, shapeStats)
+	p.view(b, "decks", func(tag, msg string) any { return decksReply{Tag: tag, Error: msg} }, shapeDecks)
+	p.view(b, "ranked", func(tag, msg string) any { return rankedReply{Tag: tag, Error: msg} }, shapeRanked)
+	p.view(b, "trophy_road", func(tag, msg string) any { return trophyRoadReply{Tag: tag, Error: msg} }, shapeTrophyRoad)
+	return b.Build()
+}
+
+func newAPI(cfg Config, d provider.Deps) *api {
 	base := strings.TrimSuffix(cfg.BaseURL, "/")
 	if base == "" {
 		base = defaultBaseURL
@@ -58,29 +70,47 @@ func New(cfg Config, d provider.Deps) *Provider {
 	if cfg.RateLimit <= 0 {
 		cfg.RateLimit = 600
 	}
-	log := d.Log
-	if log == nil {
-		log = zap.NewNop()
-	}
-	return &Provider{
+	return &api{
 		http: core.NewHTTPClient(base, map[string]string{
 			"Authorization": "Bearer " + cfg.APIKey,
 		}, httpTimeout),
 		cache:   d.Cache,
-		log:     log,
-		deps:    d,
+		limiter: d.Limiter,
 		buckets: core.NewBuckets("ratelimit:gateway:clashroyale", cfg.RateLimit, rateWindowSeconds),
 	}
 }
 
-func (p *Provider) Name() string { return "clashroyale" }
+// view declares one byte-flow endpoint that projects the shared player profile
+// through shape.
+func (p *api) view(b *provider.Builder, name string, errReply provider.ReplyFunc, shape func(playerProfile) any) {
+	b.Endpoint(name).Timeout(handlerTimeout).
+		Cached(profileTTL, negativeTTL).
+		ID(tagID).
+		Reply(errReply).
+		Fallback(name + " lookup failed").
+		Fetch(p.profileFetch(shape))
+}
 
-func (p *Provider) Endpoints() []provider.Endpoint {
-	return []provider.Endpoint{
-		{Name: "stats", Timeout: handlerTimeout, Handle: p.stats},
-		{Name: "decks", Timeout: handlerTimeout, Handle: p.decks},
-		{Name: "ranked", Timeout: handlerTimeout, Handle: p.ranked},
-		{Name: "trophy_road", Timeout: handlerTimeout, Handle: p.trophyRoad},
+// tagID validates and canonicalizes the player tag: the reply echoes the
+// canonical "#TAG" form once it parses, or the raw input on a validation
+// error.
+func tagID(req gatewayrpc.Request) (provider.ID, string) {
+	tag, msg := parsePlayerTag(req.Account)
+	if msg != "" {
+		return provider.ID{Display: strings.TrimSpace(req.Account)}, msg
+	}
+	return provider.ID{Display: tag.String(), Key: tag.cacheKey()}, ""
+}
+
+// profileFetch loads the shared profile and projects it through shape.
+func (p *api) profileFetch(shape func(playerProfile) any) provider.FetchFunc {
+	return func(ctx context.Context, req gatewayrpc.Request, id provider.ID) (any, error) {
+		tag, _ := parsePlayerTag(id.Display) // already validated by tagID
+		profile, err := p.profile(ctx, tag, req.IsPremium)
+		if err != nil {
+			return nil, err
+		}
+		return shape(profile), nil
 	}
 }
 
@@ -244,10 +274,10 @@ type trophyRoadReply struct {
 	Error        string `json:"error,omitempty"`
 }
 
-func (p *Provider) profile(ctx context.Context, tag playerTag, isPremium bool) (playerProfile, error) {
-	key := core.Key(p.Name(), "profile", tag.cacheKey())
+func (p *api) profile(ctx context.Context, tag playerTag, isPremium bool) (playerProfile, error) {
+	key := core.Key(providerName, "profile", tag.cacheKey())
 	return core.Cached(ctx, p.cache, key, profileTTL, negativeTTL, func(ctx context.Context) (playerProfile, error) {
-		if err := p.buckets.Enforce(ctx, p.deps.Limiter, isPremium); err != nil {
+		if err := p.buckets.Enforce(ctx, p.limiter, isPremium); err != nil {
 			return playerProfile{}, err
 		}
 		var profile playerProfile
@@ -262,83 +292,42 @@ func (p *Provider) profile(ctx context.Context, tag playerTag, isPremium bool) (
 	})
 }
 
-// endpoint centralizes tag validation, byte-flow caching, and friendly error
-// shaping. shape selects one public view from the shared profile.
-func (p *Provider) endpoint(endpoint string, errorReply func(string, string) any, shape func(playerProfile) any) func(context.Context, gatewayrpc.Request) any {
-	return func(ctx context.Context, req gatewayrpc.Request) any {
-		tag, validationError := parsePlayerTag(req.Account)
-		if validationError != "" {
-			return errorReply(strings.TrimSpace(req.Account), validationError)
-		}
-		key := core.Key(p.Name(), endpoint, tag.cacheKey())
-		b, err := core.CachedBytes(ctx, p.cache, key, func(ctx context.Context) ([]byte, time.Duration, error) {
-			return core.BuildReply(ctx, profileTTL, negativeTTL,
-				func(ctx context.Context) (any, error) {
-					profile, err := p.profile(ctx, tag, req.IsPremium)
-					if err != nil {
-						return nil, err
-					}
-					return shape(profile), nil
-				},
-				func(msg string) any { return errorReply(tag.String(), msg) },
-			)
-		})
-		if err != nil {
-			p.log.Warn("clash royale fetch failed", zap.String("endpoint", endpoint), zap.String("tag", tag.String()), zap.Error(err))
-			return errorReply(tag.String(), endpoint+" lookup failed")
-		}
-		return json.RawMessage(b)
+func shapeStats(profile playerProfile) any {
+	draws := profile.BattleCount - profile.Wins - profile.Losses
+	if draws < 0 {
+		draws = 0
+	}
+	winRate := 0.0
+	if profile.BattleCount > 0 {
+		winRate = float64(profile.Wins) * 100 / float64(profile.BattleCount)
+	}
+	return statsReply{
+		Player: profile.Name, Tag: profile.Tag, KingLevel: profile.ExpLevel,
+		ExperiencePoints: profile.ExpPoints, StarPoints: profile.StarPoints,
+		Wins: profile.Wins, Losses: profile.Losses, Draws: draws,
+		Battles: profile.BattleCount, WinRate: winRate,
+		ThreeCrownWins:    profile.ThreeCrownWins,
+		ChallengeCardsWon: profile.ChallengeCardsWon, ChallengeMaxWins: profile.ChallengeMaxWins,
+		TournamentCardsWon: profile.TournamentCardsWon, TournamentBattleCount: profile.TournamentBattleCount,
+		Donations: profile.Donations, DonationsReceived: profile.DonationsReceived,
+		TotalDonations: profile.TotalDonations, Clan: profile.Clan,
+		FavouriteCard: profile.CurrentFavouriteCard,
 	}
 }
 
-func (p *Provider) stats(ctx context.Context, req gatewayrpc.Request) any {
-	h := p.endpoint("stats",
-		func(tag, msg string) any { return statsReply{Tag: tag, Error: msg} },
-		func(profile playerProfile) any {
-			draws := profile.BattleCount - profile.Wins - profile.Losses
-			if draws < 0 {
-				draws = 0
-			}
-			winRate := 0.0
-			if profile.BattleCount > 0 {
-				winRate = float64(profile.Wins) * 100 / float64(profile.BattleCount)
-			}
-			return statsReply{
-				Player: profile.Name, Tag: profile.Tag, KingLevel: profile.ExpLevel,
-				ExperiencePoints: profile.ExpPoints, StarPoints: profile.StarPoints,
-				Wins: profile.Wins, Losses: profile.Losses, Draws: draws,
-				Battles: profile.BattleCount, WinRate: winRate,
-				ThreeCrownWins:    profile.ThreeCrownWins,
-				ChallengeCardsWon: profile.ChallengeCardsWon, ChallengeMaxWins: profile.ChallengeMaxWins,
-				TournamentCardsWon: profile.TournamentCardsWon, TournamentBattleCount: profile.TournamentBattleCount,
-				Donations: profile.Donations, DonationsReceived: profile.DonationsReceived,
-				TotalDonations: profile.TotalDonations, Clan: profile.Clan,
-				FavouriteCard: profile.CurrentFavouriteCard,
-			}
-		},
-	)
-	return h(ctx, req)
-}
-
-func (p *Provider) decks(ctx context.Context, req gatewayrpc.Request) any {
-	h := p.endpoint("decks",
-		func(tag, msg string) any { return decksReply{Tag: tag, Error: msg} },
-		func(profile playerProfile) any {
-			var total int
-			for _, c := range profile.CurrentDeck {
-				total += c.ElixirCost
-			}
-			average := 0.0
-			if len(profile.CurrentDeck) > 0 {
-				average = math.Round((float64(total)/float64(len(profile.CurrentDeck)))*100) / 100
-			}
-			return decksReply{
-				Player: profile.Name, Tag: profile.Tag, CurrentDeck: profile.CurrentDeck,
-				SupportCards: profile.CurrentDeckSupportCards, AverageElixir: average,
-			}
-		},
-	)
-	return h(ctx, req)
+func shapeDecks(profile playerProfile) any {
+	var total int
+	for _, c := range profile.CurrentDeck {
+		total += c.ElixirCost
+	}
+	average := 0.0
+	if len(profile.CurrentDeck) > 0 {
+		average = math.Round((float64(total)/float64(len(profile.CurrentDeck)))*100) / 100
+	}
+	return decksReply{
+		Player: profile.Name, Tag: profile.Tag, CurrentDeck: profile.CurrentDeck,
+		SupportCards: profile.CurrentDeckSupportCards, AverageElixir: average,
+	}
 }
 
 func hasRankedResult(r rankedResult) bool {
@@ -352,31 +341,19 @@ func preferRanked(primary, fallback rankedResult) rankedResult {
 	return fallback
 }
 
-func (p *Provider) ranked(ctx context.Context, req gatewayrpc.Request) any {
-	h := p.endpoint("ranked",
-		func(tag, msg string) any { return rankedReply{Tag: tag, Error: msg} },
-		func(profile playerProfile) any {
-			current := preferRanked(profile.CurrentPathOfLegendResult, profile.LeagueStatistics.Current)
-			previous := preferRanked(profile.LastPathOfLegendResult, profile.LeagueStatistics.Previous)
-			best := preferRanked(profile.BestPathOfLegendResult, profile.LeagueStatistics.Best)
-			return rankedReply{
-				Player: profile.Name, Tag: profile.Tag, Current: current, Previous: previous, Best: best,
-				Unranked: !hasRankedResult(current),
-			}
-		},
-	)
-	return h(ctx, req)
+func shapeRanked(profile playerProfile) any {
+	current := preferRanked(profile.CurrentPathOfLegendResult, profile.LeagueStatistics.Current)
+	previous := preferRanked(profile.LastPathOfLegendResult, profile.LeagueStatistics.Previous)
+	best := preferRanked(profile.BestPathOfLegendResult, profile.LeagueStatistics.Best)
+	return rankedReply{
+		Player: profile.Name, Tag: profile.Tag, Current: current, Previous: previous, Best: best,
+		Unranked: !hasRankedResult(current),
+	}
 }
 
-func (p *Provider) trophyRoad(ctx context.Context, req gatewayrpc.Request) any {
-	h := p.endpoint("trophy_road",
-		func(tag, msg string) any { return trophyRoadReply{Tag: tag, Error: msg} },
-		func(profile playerProfile) any {
-			return trophyRoadReply{
-				Player: profile.Name, Tag: profile.Tag, Trophies: profile.Trophies,
-				BestTrophies: profile.BestTrophies, Arena: profile.Arena,
-			}
-		},
-	)
-	return h(ctx, req)
+func shapeTrophyRoad(profile playerProfile) any {
+	return trophyRoadReply{
+		Player: profile.Name, Tag: profile.Tag, Trophies: profile.Trophies,
+		BestTrophies: profile.BestTrophies, Arena: profile.Arena,
+	}
 }

--- a/app/gateway/internal/providers/clashroyale/clashroyale_test.go
+++ b/app/gateway/internal/providers/clashroyale/clashroyale_test.go
@@ -46,7 +46,7 @@ func (s *memStore) Del(_ context.Context, key string) error {
 	return nil
 }
 
-func newTestProvider(t *testing.T, handler http.Handler) *Provider {
+func newTestProvider(t *testing.T, handler http.Handler) provider.Provider {
 	t.Helper()
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)
@@ -56,7 +56,7 @@ func newTestProvider(t *testing.T, handler http.Handler) *Provider {
 	})
 }
 
-func endpoint(t *testing.T, p *Provider, name string) func(context.Context, gatewayrpc.Request) any {
+func endpoint(t *testing.T, p provider.Provider, name string) func(context.Context, gatewayrpc.Request) any {
 	t.Helper()
 	for _, ep := range p.Endpoints() {
 		if ep.Name == name {

--- a/app/gateway/internal/providers/fortnite/fortnite.go
+++ b/app/gateway/internal/providers/fortnite/fortnite.go
@@ -23,7 +23,6 @@ package fortnite
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"net/url"
 	"regexp"
@@ -89,8 +88,11 @@ type Config struct {
 	SeasonStartUnix int64
 }
 
-// Provider implements provider.Provider for the fortnite systems.
-type Provider struct {
+// providerName is the subject token this provider answers under.
+const providerName = "fortnite"
+
+// api holds the provider's runtime pieces; the declared endpoints capture it.
+type api struct {
 	shop  *core.HTTPClient
 	stats *core.HTTPClient
 	cache *core.Cache
@@ -101,12 +103,39 @@ type Provider struct {
 	statsBucket core.Buckets
 	seasonStart int64
 	// keyed reports whether the stats key is configured; without it the stats
-	// endpoint is not served (shop-only mode).
+	// endpoints are not served (shop-only mode).
 	keyed bool
 }
 
-// New builds the fortnite provider.
-func New(cfg Config, d provider.Deps) *Provider {
+// New builds the fortnite provider. The shop endpoint always serves; the
+// keyed stats/session endpoints register only when the api-fortnite.com key is
+// configured, so shop-only mode simply never subscribes them.
+func New(cfg Config, d provider.Deps) provider.Provider {
+	return newAPI(cfg, d).build()
+}
+
+func (p *api) build() provider.Provider {
+	b := provider.NewProvider(providerName, p.deps)
+	b.Endpoint("shop").Timeout(handlerTimeout).
+		Cached(shopTTL, negativeTTL).
+		ID(provider.StaticID("current")).
+		Reply(shopErrReply).
+		Fallback("item shop lookup failed").
+		Fetch(p.shopFetch)
+	if p.keyed {
+		b.Endpoint("stats").Timeout(handlerTimeout).
+			Cached(statsTTL, negativeTTL).
+			ID(statsID).
+			Reply(statsErrReply).
+			Fallback("stats lookup failed").
+			Fetch(p.statsFetch)
+		b.Endpoint("session_start").Timeout(handlerTimeout).Handle(p.sessionStart)
+		b.Endpoint("session").Timeout(handlerTimeout).Handle(p.session)
+	}
+	return b.Build()
+}
+
+func newAPI(cfg Config, d provider.Deps) *api {
 	shopBase := strings.TrimSuffix(cfg.ShopBaseURL, "/")
 	if shopBase == "" {
 		shopBase = "https://fortnite-api.com"
@@ -121,19 +150,15 @@ func New(cfg Config, d provider.Deps) *Provider {
 	if cfg.StatsRateLimit <= 0 {
 		cfg.StatsRateLimit = 9000
 	}
-	log := d.Log
-	if log == nil {
-		log = zap.NewNop()
-	}
 	var statsHeaders map[string]string
 	if cfg.APIKey != "" {
 		statsHeaders = map[string]string{"x-api-key": cfg.APIKey}
 	}
-	return &Provider{
+	return &api{
 		shop:        core.NewHTTPClient(shopBase, nil, httpTimeout),
 		stats:       core.NewHTTPClient(statsBase, statsHeaders, httpTimeout),
 		cache:       d.Cache,
-		log:         log,
+		log:         d.Logger(),
 		deps:        d,
 		shopBucket:  core.NewBuckets("ratelimit:gateway:fortnite", cfg.ShopRateLimit, shopWindowSeconds),
 		statsBucket: core.NewBuckets("ratelimit:gateway:fortnite:stats", cfg.StatsRateLimit, statsWindowSeconds),
@@ -142,20 +167,9 @@ func New(cfg Config, d provider.Deps) *Provider {
 	}
 }
 
-func (p *Provider) Name() string { return "fortnite" }
-
-func (p *Provider) Endpoints() []provider.Endpoint {
-	eps := []provider.Endpoint{
-		{Name: "shop", Timeout: handlerTimeout, Handle: p.shopEndpoint},
-	}
-	if p.keyed {
-		eps = append(eps,
-			provider.Endpoint{Name: "stats", Timeout: handlerTimeout, Handle: p.statsEndpoint},
-			provider.Endpoint{Name: "session_start", Timeout: handlerTimeout, Handle: p.sessionStart},
-			provider.Endpoint{Name: "session", Timeout: handlerTimeout, Handle: p.session},
-		)
-	}
-	return eps
+func shopErrReply(_, msg string) any { return gatewayrpc.FortniteShopReply{Error: msg} }
+func statsErrReply(id, msg string) any {
+	return gatewayrpc.FortniteStatsReply{Player: id, Error: msg}
 }
 
 // normalizeWindow maps the dashboard's window setting onto the requested
@@ -177,11 +191,11 @@ type seasonResponse struct {
 // override when configured, otherwise the upstream's own current-season
 // begin date, cached an hour so a rollover is picked up automatically. 0
 // means no start could be resolved (the caller degrades to lifetime).
-func (p *Provider) seasonStartTime(ctx context.Context, isPremium bool) int64 {
+func (p *api) seasonStartTime(ctx context.Context, isPremium bool) int64 {
 	if p.seasonStart > 0 {
 		return p.seasonStart
 	}
-	key := core.Key(p.Name(), "season", "start")
+	key := core.Key(providerName, "season", "start")
 	start, err := core.Cached(ctx, p.cache, key, seasonTTL, negativeTTL, func(ctx context.Context) (int64, error) {
 		if err := p.statsBucket.Enforce(ctx, p.deps.Limiter, isPremium); err != nil {
 			return 0, err
@@ -231,8 +245,8 @@ func friendly404(err error, msg string) error {
 
 // resolveAccount turns a display name into the account ref via the stats
 // upstream, cached for a day. An unknown name 404s and negative-caches.
-func (p *Provider) resolveAccount(ctx context.Context, account string, isPremium bool) (accountRef, error) {
-	key := core.Key(p.Name(), "account", strings.ToLower(account))
+func (p *api) resolveAccount(ctx context.Context, account string, isPremium bool) (accountRef, error) {
+	key := core.Key(providerName, "account", strings.ToLower(account))
 	return core.Cached(ctx, p.cache, key, accountTTL, negativeTTL, func(ctx context.Context) (accountRef, error) {
 		if err := p.statsBucket.Enforce(ctx, p.deps.Limiter, isPremium); err != nil {
 			return accountRef{}, err
@@ -334,36 +348,30 @@ type statsQuery struct {
 	window  string
 }
 
-// statsEndpoint answers fortnite.stats (sesame's !fnstats) with the player's
-// aggregated Battle Royale stats over the requested window.
-func (p *Provider) statsEndpoint(ctx context.Context, req gatewayrpc.Request) any {
-	account := strings.TrimSpace(req.Account)
-	if account == "" {
-		return gatewayrpc.FortniteStatsReply{Error: "missing account"}
+// statsID validates the stats identity: an Epic display name, cache-keyed by
+// the requested window as well as the account so season and lifetime replies
+// never collide.
+func statsID(req gatewayrpc.Request) (provider.ID, string) {
+	a := strings.TrimSpace(req.Account)
+	if a == "" {
+		return provider.ID{}, "missing account"
 	}
 	if msg := epicOnly(req.AccountType); msg != "" {
-		return gatewayrpc.FortniteStatsReply{Player: account, Error: msg}
+		return provider.ID{Display: a}, msg
 	}
-	q := statsQuery{account: account, window: normalizeWindow(req.TimeWindow)}
+	return provider.ID{Display: a, Key: normalizeWindow(req.TimeWindow) + ":" + strings.ToLower(a)}, ""
+}
 
-	key := core.Key(p.Name(), "stats", q.window+":"+strings.ToLower(account))
-	b, err := core.CachedBytes(ctx, p.cache, key, func(ctx context.Context) ([]byte, time.Duration, error) {
-		return core.BuildReply(ctx, statsTTL, negativeTTL,
-			func(ctx context.Context) (any, error) { return p.fetchStats(ctx, q, req.IsPremium) },
-			func(msg string) any { return gatewayrpc.FortniteStatsReply{Player: account, Error: msg} },
-		)
-	})
-	if err != nil {
-		p.log.Warn("fortnite stats fetch failed", zap.String("account", account), zap.Error(err))
-		return gatewayrpc.FortniteStatsReply{Player: account, Error: "stats lookup failed"}
-	}
-	// Pre-marshaled wire bytes: the engine responds with these untouched.
-	return json.RawMessage(b)
+// statsFetch answers fortnite.stats (sesame's !fnstats) with the player's
+// aggregated Battle Royale stats over the requested window.
+func (p *api) statsFetch(ctx context.Context, req gatewayrpc.Request, id provider.ID) (any, error) {
+	q := statsQuery{account: id.Display, window: normalizeWindow(req.TimeWindow)}
+	return p.fetchStats(ctx, q, req.IsPremium)
 }
 
 // fetchStats resolves the account, spends the budget, pulls the raw counter
 // blob (window-filtered for season) and shapes the success reply.
-func (p *Provider) fetchStats(ctx context.Context, q statsQuery, isPremium bool) (gatewayrpc.FortniteStatsReply, error) {
+func (p *api) fetchStats(ctx context.Context, q statsQuery, isPremium bool) (gatewayrpc.FortniteStatsReply, error) {
 	ref, err := p.resolveAccount(ctx, q.account, isPremium)
 	if err != nil {
 		return gatewayrpc.FortniteStatsReply{}, err
@@ -418,8 +426,8 @@ func snapshotKey(channelID string) string { return core.Key("fortnite", "session
 // staleness budget. It is keyed apart from the byte-flow !fnstats path (that
 // path stores pre-marshaled wire bytes, not the envelope core.Cached needs),
 // so repeated !fn session calls within the window cost one upstream hit.
-func (p *Provider) cachedLifetimeStats(ctx context.Context, account string, isPremium bool) (gatewayrpc.FortniteStatsReply, error) {
-	key := core.Key(p.Name(), "session-live", strings.ToLower(strings.TrimSpace(account)))
+func (p *api) cachedLifetimeStats(ctx context.Context, account string, isPremium bool) (gatewayrpc.FortniteStatsReply, error) {
+	key := core.Key(providerName, "session-live", strings.ToLower(strings.TrimSpace(account)))
 	return core.Cached(ctx, p.cache, key, statsTTL, negativeTTL, func(ctx context.Context) (gatewayrpc.FortniteStatsReply, error) {
 		return p.fetchStats(ctx, statsQuery{account: account, window: "lifetime"}, isPremium)
 	})
@@ -427,7 +435,7 @@ func (p *Provider) cachedLifetimeStats(ctx context.Context, account string, isPr
 
 // writeSnapshot stores the channel's stream-start standing under the snapshot
 // key for sessionSnapshotTTL.
-func (p *Provider) writeSnapshot(ctx context.Context, channelID, account string, stats gatewayrpc.FortniteStatsReply) error {
+func (p *api) writeSnapshot(ctx context.Context, channelID, account string, stats gatewayrpc.FortniteStatsReply) error {
 	return p.cache.SetJSON(ctx, snapshotKey(channelID), snapshot{
 		Account: strings.ToLower(account),
 		Player:  stats.Player,
@@ -440,7 +448,7 @@ func (p *Provider) writeSnapshot(ctx context.Context, channelID, account string,
 
 // sessionError maps an upstream failure to a friendly reply message, logging
 // (as op) the infrastructure failures the friendly mapper does not name.
-func (p *Provider) sessionError(op, account string, err error) string {
+func (p *api) sessionError(op, account string, err error) string {
 	if msg, _ := core.FriendlyUpstream(err); msg != "" {
 		return msg
 	}
@@ -451,7 +459,7 @@ func (p *Provider) sessionError(op, account string, err error) string {
 // sessionStart snapshots the player's live lifetime standing for the channel.
 // It fetches fresh (not through cachedLifetimeStats): the snapshot is the
 // session baseline, so it must not predate the stream by a stale cache window.
-func (p *Provider) sessionStart(ctx context.Context, req gatewayrpc.Request) any {
+func (p *api) sessionStart(ctx context.Context, req gatewayrpc.Request) any {
 	account := strings.TrimSpace(req.Account)
 	if account == "" || req.ChannelID == "" {
 		return gatewayrpc.FortniteSnapshotReply{Error: "missing account or channel"}
@@ -473,7 +481,7 @@ func (p *Provider) sessionStart(ctx context.Context, req gatewayrpc.Request) any
 // loadSnapshot reads the channel's stream-start snapshot, reporting ok only
 // when one exists and tracks account — a snapshot keyed to a different account
 // must not be diffed against.
-func (p *Provider) loadSnapshot(ctx context.Context, channelID, account string) (snapshot, bool) {
+func (p *api) loadSnapshot(ctx context.Context, channelID, account string) (snapshot, bool) {
 	var snap snapshot
 	ok, err := p.cache.GetJSON(ctx, snapshotKey(channelID), &snap)
 	if err != nil {
@@ -484,7 +492,7 @@ func (p *Provider) loadSnapshot(ctx context.Context, channelID, account string) 
 
 // storeSnapshot writes the channel's baseline, logging the failure for callers
 // that cannot surface it (the session start-tracking path).
-func (p *Provider) storeSnapshot(ctx context.Context, channelID, account string, stats gatewayrpc.FortniteStatsReply) {
+func (p *api) storeSnapshot(ctx context.Context, channelID, account string, stats gatewayrpc.FortniteStatsReply) {
 	if err := p.writeSnapshot(ctx, channelID, account, stats); err != nil {
 		p.log.Warn("fortnite snapshot write failed", zap.String("channel_id", channelID), zap.Error(err))
 	}
@@ -517,7 +525,7 @@ func sessionDelta(live gatewayrpc.FortniteStatsReply, snap snapshot) gatewayrpc.
 // a usable snapshot (none stored, or it tracks a different account) it takes
 // one now and reports HasSnapshot=false so the caller can say "tracking from
 // now".
-func (p *Provider) session(ctx context.Context, req gatewayrpc.Request) any {
+func (p *api) session(ctx context.Context, req gatewayrpc.Request) any {
 	account := strings.TrimSpace(req.Account)
 	if account == "" || req.ChannelID == "" {
 		return gatewayrpc.FortniteSessionReply{Error: "missing account or channel"}
@@ -572,29 +580,13 @@ type shopResponse struct {
 	} `json:"data"`
 }
 
-// shopEndpoint answers fortnite.shop (sesame's !store) with the current
-// item-shop rotation. The shop is global, so the cache key carries no request
-// state.
-func (p *Provider) shopEndpoint(ctx context.Context, req gatewayrpc.Request) any {
-	key := core.Key(p.Name(), "shop", "current")
-	b, err := core.CachedBytes(ctx, p.cache, key, func(ctx context.Context) ([]byte, time.Duration, error) {
-		return core.BuildReply(ctx, shopTTL, negativeTTL,
-			func(ctx context.Context) (any, error) { return p.fetchShop(ctx, req.IsPremium) },
-			func(msg string) any { return gatewayrpc.FortniteShopReply{Error: msg} },
-		)
-	})
-	if err != nil {
-		p.log.Warn("fortnite shop fetch failed", zap.Error(err))
-		return gatewayrpc.FortniteShopReply{Error: "item shop lookup failed"}
-	}
-	return json.RawMessage(b)
-}
-
-// fetchShop spends the budget, queries /v2/shop and normalizes each offer to
-// name + final price. Offers with nothing displayable are dropped.
-func (p *Provider) fetchShop(ctx context.Context, isPremium bool) (gatewayrpc.FortniteShopReply, error) {
-	if err := p.shopBucket.Enforce(ctx, p.deps.Limiter, isPremium); err != nil {
-		return gatewayrpc.FortniteShopReply{}, err
+// shopFetch answers fortnite.shop (sesame's !store) with the current
+// item-shop rotation: it spends the budget, queries /v2/shop and normalizes
+// each offer to name + final price. Offers with nothing displayable are
+// dropped. The shop is global, so the flow's StaticID carries no request state.
+func (p *api) shopFetch(ctx context.Context, req gatewayrpc.Request, _ provider.ID) (any, error) {
+	if err := p.shopBucket.Enforce(ctx, p.deps.Limiter, req.IsPremium); err != nil {
+		return nil, err
 	}
 
 	var resp shopResponse

--- a/app/gateway/internal/providers/fortnite/fortnite_test.go
+++ b/app/gateway/internal/providers/fortnite/fortnite_test.go
@@ -50,8 +50,10 @@ func (s *memStore) Del(_ context.Context, key string) error {
 
 // newTestProvider wires the provider with BOTH upstreams faked: stats is the
 // api-fortnite.com double (account lookup + raw stats), shop the
-// fortnite-api.com double. extra tweaks the config before building.
-func newTestProvider(t *testing.T, stats, shop http.Handler, extra func(*Config)) *Provider {
+// fortnite-api.com double. extra tweaks the config before building. It returns
+// the inner api so tests can also seed provider-owned state (snapshots)
+// directly; endpoint handlers come from build() via handle.
+func newTestProvider(t *testing.T, stats, shop http.Handler, extra func(*Config)) *api {
 	t.Helper()
 	statsSrv := httptest.NewServer(stats)
 	t.Cleanup(statsSrv.Close)
@@ -61,7 +63,7 @@ func newTestProvider(t *testing.T, stats, shop http.Handler, extra func(*Config)
 	if extra != nil {
 		extra(&cfg)
 	}
-	return New(cfg, provider.Deps{Cache: core.NewCache(newMemStore()), Log: zap.NewNop()})
+	return newAPI(cfg, provider.Deps{Cache: core.NewCache(newMemStore()), Log: zap.NewNop()})
 }
 
 func noUpstream(t *testing.T, name string) http.Handler {
@@ -70,9 +72,9 @@ func noUpstream(t *testing.T, name string) http.Handler {
 	})
 }
 
-func handle(t *testing.T, p *Provider, name string) func(context.Context, gatewayrpc.Request) any {
+func handle(t *testing.T, p *api, name string) func(context.Context, gatewayrpc.Request) any {
 	t.Helper()
-	for _, ep := range p.Endpoints() {
+	for _, ep := range p.build().Endpoints() {
 		if ep.Name == name {
 			return ep.Handle
 		}
@@ -469,8 +471,9 @@ func TestKeylessServesShopOnly(t *testing.T) {
 		_, _ = w.Write([]byte(shopBody))
 	}), func(cfg *Config) { cfg.APIKey = "" })
 
-	names := make([]string, 0, len(p.Endpoints()))
-	for _, ep := range p.Endpoints() {
+	built := p.build()
+	names := make([]string, 0, len(built.Endpoints()))
+	for _, ep := range built.Endpoints() {
 		names = append(names, ep.Name)
 	}
 	assert.Equal(t, []string{"shop"}, names)

--- a/app/gateway/internal/providers/govee/govee.go
+++ b/app/gateway/internal/providers/govee/govee.go
@@ -22,6 +22,7 @@ import (
 	"ItsBagelBot/app/gateway/internal/core"
 	"ItsBagelBot/app/gateway/internal/provider"
 	gatewayrpc "ItsBagelBot/internal/domain/rpc/gateway"
+	"ItsBagelBot/pkg/ratelimit"
 
 	"github.com/google/uuid"
 	"go.uber.org/zap"
@@ -71,21 +72,38 @@ type Config struct {
 	RateLimit float64
 }
 
-// Provider implements provider.Provider for the Govee Developer API.
-type Provider struct {
-	http  *core.HTTPClient
-	cache *core.Cache
-	keys  provider.GoveeKeyResolver
-	log   *zap.Logger
+// providerName is the subject token this provider answers under.
+const providerName = "govee"
 
-	deps      provider.Deps
-	rateLimit float64
+// api holds the provider's runtime pieces; the declared endpoints capture it.
+// Both endpoints stay bespoke handlers: they resolve the broadcaster's key
+// before any cache or upstream work, which the shared byte-flow skeleton
+// deliberately does not model (a cached reply must never bypass the key
+// checks, and control caches nothing at all).
+type api struct {
+	http    *core.HTTPClient
+	cache   *core.Cache
+	keys    provider.GoveeKeyResolver
+	log     *zap.Logger
+	limiter *ratelimit.Limiter
+
+	// buckets is the per-broadcaster budget template: the derived specs are
+	// computed once here and re-keyed per caller (see enforceRate).
+	buckets core.Buckets
 }
 
 // New builds the govee provider. d.GoveeKeys must be non-nil (providers.All
 // skips the provider otherwise, since with no key resolver it can authenticate
 // nothing).
-func New(cfg Config, d provider.Deps) *Provider {
+func New(cfg Config, d provider.Deps) provider.Provider {
+	p := newAPI(cfg, d)
+	b := provider.NewProvider(providerName, d)
+	b.Endpoint("devices").Timeout(devicesTimeout).Handle(p.devices)
+	b.Endpoint("control").Timeout(controlTimeout).Handle(p.control)
+	return b.Build()
+}
+
+func newAPI(cfg Config, d provider.Deps) *api {
 	base := strings.TrimSuffix(cfg.BaseURL, "/")
 	if base == "" {
 		base = "https://openapi.api.govee.com"
@@ -93,35 +111,21 @@ func New(cfg Config, d provider.Deps) *Provider {
 	if cfg.RateLimit <= 0 {
 		cfg.RateLimit = defaultRateLimit
 	}
-	log := d.Log
-	if log == nil {
-		log = zap.NewNop()
-	}
-	return &Provider{
-		// No baked auth header: the key rides per request (see controlHeaders).
-		http:  core.NewHTTPClient(base, nil, httpTimeout),
-		cache: d.Cache,
-		keys:  d.GoveeKeys,
-		log:   log,
-
-		deps:      d,
-		rateLimit: cfg.RateLimit,
-	}
-}
-
-func (p *Provider) Name() string { return "govee" }
-
-func (p *Provider) Endpoints() []provider.Endpoint {
-	return []provider.Endpoint{
-		{Name: "devices", Timeout: devicesTimeout, Handle: p.devices},
-		{Name: "control", Timeout: controlTimeout, Handle: p.control},
+	return &api{
+		// No baked auth header: the key rides per request (see authHeader).
+		http:    core.NewHTTPClient(base, nil, httpTimeout),
+		cache:   d.Cache,
+		keys:    d.GoveeKeys,
+		log:     d.Logger(),
+		limiter: d.Limiter,
+		buckets: core.NewBuckets("ratelimit:gateway:govee", cfg.RateLimit, rateWindowSeconds),
 	}
 }
 
 // resolveKey pulls the broadcaster's decrypted key. An empty key (none on file)
 // is not an error here: it is a friendly "not set up" the handlers map to a
 // reply-level error.
-func (p *Provider) resolveKey(ctx context.Context, broadcasterID string) (string, error) {
+func (p *api) resolveKey(ctx context.Context, broadcasterID string) (string, error) {
 	if strings.TrimSpace(broadcasterID) == "" {
 		return "", nil
 	}
@@ -145,7 +149,7 @@ type deviceListResponse struct {
 	} `json:"data"`
 }
 
-func (p *Provider) devices(ctx context.Context, req gatewayrpc.Request) any {
+func (p *api) devices(ctx context.Context, req gatewayrpc.Request) any {
 	broadcaster := strings.TrimSpace(req.ChannelID)
 	if broadcaster == "" {
 		return gatewayrpc.GoveeDevicesReply{Error: "missing channel"}
@@ -159,7 +163,7 @@ func (p *Provider) devices(ctx context.Context, req gatewayrpc.Request) any {
 		return gatewayrpc.GoveeDevicesReply{Error: "no Govee API key on file"}
 	}
 
-	cacheKey := core.Key(p.Name(), "devices", broadcaster)
+	cacheKey := core.Key(providerName, "devices", broadcaster)
 	b, err := core.CachedBytes(ctx, p.cache, cacheKey, func(ctx context.Context) ([]byte, time.Duration, error) {
 		return core.BuildReply(ctx, devicesTTL, negativeTTL,
 			func(ctx context.Context) (any, error) {
@@ -232,7 +236,7 @@ type controlResponse struct {
 	Message string `json:"message"`
 }
 
-func (p *Provider) control(ctx context.Context, req gatewayrpc.Request) any {
+func (p *api) control(ctx context.Context, req gatewayrpc.Request) any {
 	if msg := validateControlInput(req); msg != "" {
 		return gatewayrpc.GoveeControlReply{Error: msg}
 	}
@@ -280,7 +284,7 @@ func validColorRGB(rgb int) bool {
 
 // controlKey resolves the broadcaster's key, returning ("", msg) with a
 // chat-safe reason when it cannot be used.
-func (p *Provider) controlKey(ctx context.Context, broadcaster string) (key, msg string) {
+func (p *api) controlKey(ctx context.Context, broadcaster string) (key, msg string) {
 	key, err := p.resolveKey(ctx, broadcaster)
 	if err != nil {
 		p.log.Warn("govee key resolve failed", zap.String("broadcaster", broadcaster), zap.Error(err))
@@ -293,10 +297,10 @@ func (p *Provider) controlKey(ctx context.Context, broadcaster string) (key, msg
 }
 
 // enforceRate spends one action from the broadcaster's own key budget. One
-// redemption is one action even though control costs two upstream calls.
-func (p *Provider) enforceRate(ctx context.Context, broadcaster string) error {
-	buckets := core.NewBuckets("ratelimit:gateway:govee:"+broadcaster, p.rateLimit, rateWindowSeconds)
-	return buckets.Enforce(ctx, p.deps.Limiter, true)
+// redemption is one action even though control costs two upstream calls. The
+// bucket specs come pre-derived from the template; only the key is per caller.
+func (p *api) enforceRate(ctx context.Context, broadcaster string) error {
+	return p.buckets.WithKey("ratelimit:gateway:govee:"+broadcaster).Enforce(ctx, p.limiter, true)
 }
 
 // controlStep is one capability set in a control sequence.

--- a/app/gateway/internal/providers/govee/govee_test.go
+++ b/app/gateway/internal/providers/govee/govee_test.go
@@ -54,7 +54,7 @@ type fakeKeys struct {
 
 func (f fakeKeys) Key(context.Context, string) (string, error) { return f.key, f.err }
 
-func newTestProvider(t *testing.T, keys provider.GoveeKeyResolver, handler http.Handler) *Provider {
+func newTestProvider(t *testing.T, keys provider.GoveeKeyResolver, handler http.Handler) provider.Provider {
 	t.Helper()
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)
@@ -62,7 +62,7 @@ func newTestProvider(t *testing.T, keys provider.GoveeKeyResolver, handler http.
 		provider.Deps{Cache: core.NewCache(newMemStore()), Log: zap.NewNop(), GoveeKeys: keys})
 }
 
-func endpoint(t *testing.T, p *Provider, name string) func(context.Context, gatewayrpc.Request) any {
+func endpoint(t *testing.T, p provider.Provider, name string) func(context.Context, gatewayrpc.Request) any {
 	t.Helper()
 	for _, ep := range p.Endpoints() {
 		if ep.Name == name {

--- a/app/gateway/internal/providers/hypixel/hypixel.go
+++ b/app/gateway/internal/providers/hypixel/hypixel.go
@@ -13,7 +13,6 @@ package hypixel
 
 import (
 	"context"
-	"encoding/json"
 	"net/url"
 	"strings"
 	"time"
@@ -22,7 +21,7 @@ import (
 	"ItsBagelBot/app/gateway/internal/provider"
 	gatewayrpc "ItsBagelBot/internal/domain/rpc/gateway"
 
-	"go.uber.org/zap"
+	"ItsBagelBot/pkg/ratelimit"
 )
 
 const (
@@ -49,19 +48,31 @@ type Config struct {
 	RateLimit     float64
 }
 
-// Provider implements provider.Provider for the Hypixel API.
-type Provider struct {
-	http   *core.HTTPClient
-	mojang *core.HTTPClient
-	cache  *core.Cache
-	log    *zap.Logger
+// providerName is the subject token this provider answers under.
+const providerName = "hypixel"
 
-	deps    provider.Deps
+// api holds the provider's runtime pieces; the declared endpoints capture it.
+type api struct {
+	http    *core.HTTPClient
+	mojang  *core.HTTPClient
+	cache   *core.Cache
+	limiter *ratelimit.Limiter
 	buckets core.Buckets
 }
 
-// New builds the hypixel provider.
-func New(cfg Config, d provider.Deps) *Provider {
+// New builds the hypixel provider: one byte-flow stats endpoint.
+func New(cfg Config, d provider.Deps) provider.Provider {
+	p := newAPI(cfg, d)
+	b := provider.NewProvider(providerName, d)
+	b.Endpoint("stats").Timeout(handlerTimeout).
+		Cached(statsTTL, negativeTTL).
+		Reply(statsErrReply).
+		Fallback("stats lookup failed").
+		Fetch(p.statsFetch)
+	return b.Build()
+}
+
+func newAPI(cfg Config, d provider.Deps) *api {
 	base := strings.TrimSuffix(cfg.BaseURL, "/")
 	if base == "" {
 		base = "https://api.hypixel.net"
@@ -73,26 +84,24 @@ func New(cfg Config, d provider.Deps) *Provider {
 	if cfg.RateLimit <= 0 {
 		cfg.RateLimit = 300
 	}
-	log := d.Log
-	if log == nil {
-		log = zap.NewNop()
-	}
-	return &Provider{
+	return &api{
 		http:    core.NewHTTPClient(base, map[string]string{"API-Key": cfg.APIKey}, httpTimeout),
 		mojang:  core.NewHTTPClient(mojangBase, nil, httpTimeout),
 		cache:   d.Cache,
-		log:     log,
-		deps:    d,
+		limiter: d.Limiter,
 		buckets: core.NewBuckets("ratelimit:gateway:hypixel", cfg.RateLimit, rateWindowSeconds),
 	}
 }
 
-func (p *Provider) Name() string { return "hypixel" }
+// statsErrReply shapes every stats error reply (missing account, friendly
+// upstream failure, infrastructure fallback).
+func statsErrReply(id, msg string) any {
+	return gatewayrpc.HypixelStatsReply{Player: id, Error: msg}
+}
 
-func (p *Provider) Endpoints() []provider.Endpoint {
-	return []provider.Endpoint{
-		{Name: "stats", Timeout: handlerTimeout, Handle: p.stats},
-	}
+// statsFetch adapts fetchStats to the flow's fetch signature.
+func (p *api) statsFetch(ctx context.Context, req gatewayrpc.Request, id provider.ID) (any, error) {
+	return p.fetchStats(ctx, id.Display, req.IsPremium)
 }
 
 // accountKey normalizes the player identifier for cache keys.
@@ -126,11 +135,11 @@ func looksLikeUUID(account string) bool {
 // resolveUUID turns a username into the canonical uuid via Mojang, cached for
 // a day. An unknown name is a 404 there already (204 on the legacy path is
 // also treated as missing by the empty-id check), so it negative-caches.
-func (p *Provider) resolveUUID(ctx context.Context, account string) (string, error) {
+func (p *api) resolveUUID(ctx context.Context, account string) (string, error) {
 	if looksLikeUUID(account) {
 		return strings.ReplaceAll(account, "-", ""), nil
 	}
-	key := core.Key(p.Name(), "uuid", accountKey(account))
+	key := core.Key(providerName, "uuid", accountKey(account))
 	return core.Cached(ctx, p.cache, key, uuidTTL, negativeTTL, func(ctx context.Context) (string, error) {
 		var profile mojangProfile
 		if err := p.mojang.GetJSON(ctx, "/users/profiles/minecraft/"+account, nil, &profile); err != nil {
@@ -166,36 +175,14 @@ type playerResponse struct {
 	} `json:"player"`
 }
 
-// stats answers hypixel.stats (sesame's !bwstats) with the player's lifetime
-// Bed Wars stats.
-func (p *Provider) stats(ctx context.Context, req gatewayrpc.Request) any {
-	account := strings.TrimSpace(req.Account)
-	if account == "" {
-		return gatewayrpc.HypixelStatsReply{Error: "missing account"}
-	}
-	key := core.Key(p.Name(), "stats", accountKey(account))
-	b, err := core.CachedBytes(ctx, p.cache, key, func(ctx context.Context) ([]byte, time.Duration, error) {
-		return core.BuildReply(ctx, statsTTL, negativeTTL,
-			func(ctx context.Context) (any, error) { return p.fetchStats(ctx, account, req.IsPremium) },
-			func(msg string) any { return gatewayrpc.HypixelStatsReply{Player: account, Error: msg} },
-		)
-	})
-	if err != nil {
-		p.log.Warn("hypixel stats fetch failed", zap.String("account", account), zap.Error(err))
-		return gatewayrpc.HypixelStatsReply{Player: account, Error: "stats lookup failed"}
-	}
-	// Pre-marshaled wire bytes: the engine responds with these untouched.
-	return json.RawMessage(b)
-}
-
 // fetchStats resolves the uuid, spends the Hypixel budget, and shapes the
 // success reply.
-func (p *Provider) fetchStats(ctx context.Context, account string, isPremium bool) (gatewayrpc.HypixelStatsReply, error) {
+func (p *api) fetchStats(ctx context.Context, account string, isPremium bool) (gatewayrpc.HypixelStatsReply, error) {
 	uuid, err := p.resolveUUID(ctx, account)
 	if err != nil {
 		return gatewayrpc.HypixelStatsReply{}, err
 	}
-	if err := p.buckets.Enforce(ctx, p.deps.Limiter, isPremium); err != nil {
+	if err := p.buckets.Enforce(ctx, p.limiter, isPremium); err != nil {
 		return gatewayrpc.HypixelStatsReply{}, err
 	}
 

--- a/app/gateway/internal/providers/hypixel/hypixel_test.go
+++ b/app/gateway/internal/providers/hypixel/hypixel_test.go
@@ -49,7 +49,7 @@ func (s *memStore) Del(_ context.Context, key string) error {
 
 // newTestProvider wires the provider with BOTH upstreams faked: mojang answers
 // the uuid resolve, hypixel answers /v2/player.
-func newTestProvider(t *testing.T, mojang, hypixel http.Handler) *Provider {
+func newTestProvider(t *testing.T, mojang, hypixel http.Handler) provider.Provider {
 	t.Helper()
 	mojangSrv := httptest.NewServer(mojang)
 	t.Cleanup(mojangSrv.Close)
@@ -59,7 +59,7 @@ func newTestProvider(t *testing.T, mojang, hypixel http.Handler) *Provider {
 		provider.Deps{Cache: core.NewCache(newMemStore()), Log: zap.NewNop()})
 }
 
-func statsHandle(t *testing.T, p *Provider) func(context.Context, gatewayrpc.Request) any {
+func statsHandle(t *testing.T, p provider.Provider) func(context.Context, gatewayrpc.Request) any {
 	t.Helper()
 	for _, ep := range p.Endpoints() {
 		if ep.Name == "stats" {

--- a/app/gateway/internal/providers/mcsr/mcsr.go
+++ b/app/gateway/internal/providers/mcsr/mcsr.go
@@ -18,6 +18,7 @@ import (
 	"ItsBagelBot/app/gateway/internal/core"
 	"ItsBagelBot/app/gateway/internal/provider"
 	gatewayrpc "ItsBagelBot/internal/domain/rpc/gateway"
+	"ItsBagelBot/pkg/ratelimit"
 
 	"go.uber.org/zap"
 )
@@ -42,21 +43,35 @@ type Config struct {
 	RateLimit float64
 }
 
-// Provider implements provider.Provider for the MCSR Ranked API.
-type Provider struct {
-	http  *core.HTTPClient
-	cache *core.Cache
-	log   *zap.Logger
-
-	deps    provider.Deps
-	buckets core.Buckets
-}
+// providerName is the subject token this provider answers under.
+const providerName = "mcsr"
 
 // rateWindowSeconds is the MCSR budget window (10 minutes: 500 requests).
 const rateWindowSeconds = 600.0
 
+// api holds the provider's runtime pieces; the declared endpoints capture it.
+// The endpoints stay bespoke handlers (not byte-flows): they answer typed
+// replies whose snapshot side effects and elo semantics do not fit the shared
+// cached-bytes skeleton.
+type api struct {
+	http    *core.HTTPClient
+	cache   *core.Cache
+	log     *zap.Logger
+	limiter *ratelimit.Limiter
+	buckets core.Buckets
+}
+
 // New builds the mcsr provider.
-func New(cfg Config, d provider.Deps) *Provider {
+func New(cfg Config, d provider.Deps) provider.Provider {
+	p := newAPI(cfg, d)
+	b := provider.NewProvider(providerName, d)
+	b.Endpoint("user").Timeout(handlerTimeout).Handle(p.user)
+	b.Endpoint("session_start").Timeout(handlerTimeout).Handle(p.sessionStart)
+	b.Endpoint("session").Timeout(handlerTimeout).Handle(p.session)
+	return b.Build()
+}
+
+func newAPI(cfg Config, d provider.Deps) *api {
 	base := strings.TrimSuffix(cfg.BaseURL, "/")
 	if base == "" {
 		base = "https://api.mcsrranked.com"
@@ -68,27 +83,12 @@ func New(cfg Config, d provider.Deps) *Provider {
 	if cfg.RateLimit <= 0 {
 		cfg.RateLimit = 500
 	}
-	log := d.Log
-	if log == nil {
-		log = zap.NewNop()
-	}
-	return &Provider{
-		http:  core.NewHTTPClient(base, headers, httpTimeout),
-		cache: d.Cache,
-		log:   log,
-
-		deps:    d,
+	return &api{
+		http:    core.NewHTTPClient(base, headers, httpTimeout),
+		cache:   d.Cache,
+		log:     d.Logger(),
+		limiter: d.Limiter,
 		buckets: core.NewBuckets("ratelimit:gateway:mcsr", cfg.RateLimit, rateWindowSeconds),
-	}
-}
-
-func (p *Provider) Name() string { return "mcsr" }
-
-func (p *Provider) Endpoints() []provider.Endpoint {
-	return []provider.Endpoint{
-		{Name: "user", Timeout: handlerTimeout, Handle: p.user},
-		{Name: "session_start", Timeout: handlerTimeout, Handle: p.sessionStart},
-		{Name: "session", Timeout: handlerTimeout, Handle: p.session},
 	}
 }
 
@@ -145,12 +145,12 @@ func friendlyError(err error) string {
 
 // enforceRateLimit consumes one request from the MCSR budget under the shared
 // premium/standard bucket discipline (see core.Buckets).
-func (p *Provider) enforceRateLimit(ctx context.Context, isPremium bool) error {
-	return p.buckets.Enforce(ctx, p.deps.Limiter, isPremium)
+func (p *api) enforceRateLimit(ctx context.Context, isPremium bool) error {
+	return p.buckets.Enforce(ctx, p.limiter, isPremium)
 }
 
 // fetchUser loads a player's live standing straight from the API.
-func (p *Provider) fetchUser(ctx context.Context, account string, isPremium bool) (gatewayrpc.McsrUserReply, error) {
+func (p *api) fetchUser(ctx context.Context, account string, isPremium bool) (gatewayrpc.McsrUserReply, error) {
 	if err := p.enforceRateLimit(ctx, isPremium); err != nil {
 		return gatewayrpc.McsrUserReply{}, err
 	}
@@ -192,8 +192,8 @@ func (p *Provider) fetchUser(ctx context.Context, account string, isPremium bool
 }
 
 // cachedUser is fetchUser behind the shared 60s cache.
-func (p *Provider) cachedUser(ctx context.Context, account string, isPremium bool) (gatewayrpc.McsrUserReply, error) {
-	key := core.Key(p.Name(), "user", strings.ToLower(strings.TrimSpace(account)))
+func (p *api) cachedUser(ctx context.Context, account string, isPremium bool) (gatewayrpc.McsrUserReply, error) {
+	key := core.Key(providerName, "user", strings.ToLower(strings.TrimSpace(account)))
 	return core.Cached(ctx, p.cache, key, userTTL, 5*time.Minute, func(ctx context.Context) (gatewayrpc.McsrUserReply, error) {
 		return p.fetchUser(ctx, account, isPremium)
 	})
@@ -201,7 +201,7 @@ func (p *Provider) cachedUser(ctx context.Context, account string, isPremium boo
 
 // --- endpoints ------------------------------------------------------------------
 
-func (p *Provider) user(ctx context.Context, req gatewayrpc.Request) any {
+func (p *api) user(ctx context.Context, req gatewayrpc.Request) any {
 	account := strings.TrimSpace(req.Account)
 	if account == "" {
 		return gatewayrpc.McsrUserReply{Error: "missing account"}
@@ -220,7 +220,7 @@ func (p *Provider) user(ctx context.Context, req gatewayrpc.Request) any {
 // sessionStart snapshots the player's live standing for the channel. It
 // fetches fresh (not through the 60s cache): the snapshot is the session
 // baseline, so it must not predate the stream by a stale cache window.
-func (p *Provider) sessionStart(ctx context.Context, req gatewayrpc.Request) any {
+func (p *api) sessionStart(ctx context.Context, req gatewayrpc.Request) any {
 	account := strings.TrimSpace(req.Account)
 	if account == "" || req.ChannelID == "" {
 		return gatewayrpc.McsrSnapshotReply{Error: "missing account or channel"}
@@ -240,7 +240,7 @@ func (p *Provider) sessionStart(ctx context.Context, req gatewayrpc.Request) any
 	return gatewayrpc.McsrSnapshotReply{Nickname: user.Nickname, Elo: user.Elo}
 }
 
-func (p *Provider) writeSnapshot(ctx context.Context, channelID, account string, user gatewayrpc.McsrUserReply) error {
+func (p *api) writeSnapshot(ctx context.Context, channelID, account string, user gatewayrpc.McsrUserReply) error {
 	return p.cache.SetJSON(ctx, snapshotKey(channelID), snapshot{
 		Account:  strings.ToLower(account),
 		Nickname: user.Nickname,
@@ -256,7 +256,7 @@ func (p *Provider) writeSnapshot(ctx context.Context, channelID, account string,
 // a usable snapshot (none stored, or it tracks a different account) it takes
 // one now and reports HasSnapshot=false so the caller can say "tracking from
 // now".
-func (p *Provider) session(ctx context.Context, req gatewayrpc.Request) any {
+func (p *api) session(ctx context.Context, req gatewayrpc.Request) any {
 	account := strings.TrimSpace(req.Account)
 	if account == "" || req.ChannelID == "" {
 		return gatewayrpc.McsrSessionReply{Error: "missing account or channel"}

--- a/app/gateway/internal/providers/mcsr/mcsr_test.go
+++ b/app/gateway/internal/providers/mcsr/mcsr_test.go
@@ -68,7 +68,7 @@ func userBody(elo int, wins, loses, played int) string {
 
 // newTestProvider serves handler as the MCSR API and returns the provider plus
 // its backing store (so tests can evict the 60s user cache to simulate time).
-func newTestProvider(t *testing.T, handler http.Handler) (*Provider, *memStore) {
+func newTestProvider(t *testing.T, handler http.Handler) (provider.Provider, *memStore) {
 	t.Helper()
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)
@@ -77,7 +77,7 @@ func newTestProvider(t *testing.T, handler http.Handler) (*Provider, *memStore) 
 		provider.Deps{Cache: core.NewCache(st), Log: zap.NewNop()}), st
 }
 
-func endpoint(t *testing.T, p *Provider, name string) func(context.Context, gatewayrpc.Request) any {
+func endpoint(t *testing.T, p provider.Provider, name string) func(context.Context, gatewayrpc.Request) any {
 	t.Helper()
 	for _, ep := range p.Endpoints() {
 		if ep.Name == name {

--- a/app/gateway/internal/providers/urchin/urchin.go
+++ b/app/gateway/internal/providers/urchin/urchin.go
@@ -22,7 +22,7 @@ import (
 	"ItsBagelBot/app/gateway/internal/provider"
 	gatewayrpc "ItsBagelBot/internal/domain/rpc/gateway"
 
-	"go.uber.org/zap"
+	"ItsBagelBot/pkg/ratelimit"
 )
 
 // Cache TTLs. Session deltas move while the player is online, so they stay
@@ -52,20 +52,45 @@ type Config struct {
 	RateLimit float64
 }
 
-// Provider implements provider.Provider for the Coral API.
-type Provider struct {
-	http  *core.HTTPClient
-	cache *core.Cache
-	key   string
-	log   *zap.Logger
+// providerName is the subject token this provider answers under.
+const providerName = "urchin"
 
-	deps    provider.Deps
+// api holds the provider's runtime pieces; the declared endpoints capture it.
+type api struct {
+	http    *core.HTTPClient
+	cache   *core.Cache
+	key     string
+	limiter *ratelimit.Limiter
 	buckets core.Buckets
 }
 
-// New builds the urchin provider. cfg.APIKey must be non-empty (providers.All
+// New builds the urchin provider: the three session-delta endpoints plus the
+// blacklist pair, all byte-flow. cfg.APIKey must be non-empty (providers.All
 // skips the provider entirely when it is not configured).
-func New(cfg Config, d provider.Deps) *Provider {
+func New(cfg Config, d provider.Deps) provider.Provider {
+	p := newAPI(cfg, d)
+	b := provider.NewProvider(providerName, d)
+	for _, period := range []string{"daily", "weekly", "monthly"} {
+		b.Endpoint(period).Timeout(handlerTimeout).
+			Cached(sessionTTL, negativeTTL).
+			Reply(sessionErrReply).
+			Fallback("stats lookup failed").
+			Fetch(p.sessionFetch(period))
+	}
+	b.Endpoint("sniper").Timeout(handlerTimeout).
+		Cached(sniperTTL, negativeTTL).
+		Reply(sniperErrReply).
+		Fallback("score lookup failed").
+		Fetch(p.sniperFetch)
+	b.Endpoint("tags").Timeout(handlerTimeout).
+		Cached(tagsTTL, negativeTTL).
+		Reply(tagsErrReply).
+		Fallback("tags lookup failed").
+		Fetch(p.tagsFetch)
+	return b.Build()
+}
+
+func newAPI(cfg Config, d provider.Deps) *api {
 	base := strings.TrimSuffix(cfg.BaseURL, "/")
 	if base == "" {
 		base = "https://api.urchin.gg"
@@ -73,32 +98,20 @@ func New(cfg Config, d provider.Deps) *Provider {
 	if cfg.RateLimit <= 0 {
 		cfg.RateLimit = 600
 	}
-	log := d.Log
-	if log == nil {
-		log = zap.NewNop()
-	}
-	return &Provider{
-		http:  core.NewHTTPClient(base, map[string]string{"X-API-Key": cfg.APIKey}, httpTimeout),
-		cache: d.Cache,
-		key:   cfg.APIKey,
-		log:   log,
-
-		deps:    d,
+	return &api{
+		http:    core.NewHTTPClient(base, map[string]string{"X-API-Key": cfg.APIKey}, httpTimeout),
+		cache:   d.Cache,
+		key:     cfg.APIKey,
+		limiter: d.Limiter,
 		buckets: core.NewBuckets("ratelimit:gateway:urchin", cfg.RateLimit, rateWindowSeconds),
 	}
 }
 
-func (p *Provider) Name() string { return "urchin" }
-
-func (p *Provider) Endpoints() []provider.Endpoint {
-	return []provider.Endpoint{
-		{Name: "daily", Timeout: handlerTimeout, Handle: p.session("daily")},
-		{Name: "weekly", Timeout: handlerTimeout, Handle: p.session("weekly")},
-		{Name: "monthly", Timeout: handlerTimeout, Handle: p.session("monthly")},
-		{Name: "sniper", Timeout: handlerTimeout, Handle: p.sniper},
-		{Name: "tags", Timeout: handlerTimeout, Handle: p.tags},
-	}
+func sessionErrReply(id, msg string) any {
+	return gatewayrpc.UrchinSessionReply{Player: id, Error: msg}
 }
+func sniperErrReply(id, msg string) any { return gatewayrpc.UrchinSniperReply{Player: id, Error: msg} }
+func tagsErrReply(id, msg string) any   { return gatewayrpc.UrchinTagsReply{Player: id, Error: msg} }
 
 // account is a Minecraft player identifier (a username or UUID; Coral resolves
 // usernames through Mojang) as supplied by the caller. It is a distinct type so
@@ -106,9 +119,6 @@ func (p *Provider) Endpoints() []provider.Endpoint {
 type account string
 
 func (a account) String() string { return string(a) }
-
-// empty reports whether the (trimmed) identifier is absent.
-func (a account) empty() bool { return strings.TrimSpace(string(a)) == "" }
 
 // cacheKey normalizes the identifier for cache keys so "Player" and "player"
 // share an entry.
@@ -155,33 +165,17 @@ func numDelta(raw json.RawMessage) int64 {
 	return int64(f)
 }
 
-func (p *Provider) session(period string) func(context.Context, gatewayrpc.Request) any {
-	return func(ctx context.Context, req gatewayrpc.Request) any {
-		acct := account(strings.TrimSpace(req.Account))
-		if acct.empty() {
-			return gatewayrpc.UrchinSessionReply{Error: "missing account"}
+// sessionFetch spends one Coral token and pulls the period's session delta.
+func (p *api) sessionFetch(period string) provider.FetchFunc {
+	return func(ctx context.Context, req gatewayrpc.Request, id provider.ID) (any, error) {
+		if err := p.buckets.Enforce(ctx, p.limiter, req.IsPremium); err != nil {
+			return nil, err
 		}
-		key := core.Key(p.Name(), period, acct.cacheKey())
-		b, err := core.CachedBytes(ctx, p.cache, key, func(ctx context.Context) ([]byte, time.Duration, error) {
-			return core.BuildReply(ctx, sessionTTL, negativeTTL,
-				func(ctx context.Context) (any, error) {
-					if err := p.buckets.Enforce(ctx, p.deps.Limiter, req.IsPremium); err != nil {
-						return nil, err
-					}
-					return p.fetchSession(ctx, period, acct)
-				},
-				func(msg string) any { return gatewayrpc.UrchinSessionReply{Player: acct.String(), Error: msg} },
-			)
-		})
-		if err != nil {
-			p.log.Warn("urchin session fetch failed", zap.String("period", period), zap.String("account", acct.String()), zap.Error(err))
-			return gatewayrpc.UrchinSessionReply{Player: acct.String(), Error: "stats lookup failed"}
-		}
-		return json.RawMessage(b)
+		return p.fetchSession(ctx, period, account(id.Display))
 	}
 }
 
-func (p *Provider) fetchSession(ctx context.Context, period string, acct account) (gatewayrpc.UrchinSessionReply, error) {
+func (p *api) fetchSession(ctx context.Context, period string, acct account) (gatewayrpc.UrchinSessionReply, error) {
 	var resp sessionResponse
 	q := url.Values{"player": {acct.String()}}
 	if err := p.http.GetJSON(ctx, "/v3/player/sessions/"+period, q, &resp); err != nil {
@@ -224,7 +218,7 @@ type tagsResponse struct {
 	} `json:"tags"`
 }
 
-func (p *Provider) fetchTags(ctx context.Context, acct account) (tagsResponse, error) {
+func (p *api) fetchTags(ctx context.Context, acct account) (tagsResponse, error) {
 	var resp tagsResponse
 	return resp, p.http.GetJSON(ctx, "/v3/player/tags", url.Values{"player": {acct.String()}}, &resp)
 }
@@ -235,46 +229,31 @@ func (p *Provider) fetchTags(ctx context.Context, acct account) (tagsResponse, e
 // two, and a missing player negative-caches once and satisfies both. It spends
 // one rate-limit token only on a real upstream fetch (the enforce lives inside
 // the cache's fill, so a hit costs nothing).
-func (p *Provider) playerTags(ctx context.Context, acct account, isPremium bool) (tagsResponse, error) {
-	key := core.Key(p.Name(), "playertags", acct.cacheKey())
+func (p *api) playerTags(ctx context.Context, acct account, isPremium bool) (tagsResponse, error) {
+	key := core.Key(providerName, "playertags", acct.cacheKey())
 	return core.Cached(ctx, p.cache, key, tagsTTL, negativeTTL, func(ctx context.Context) (tagsResponse, error) {
-		if err := p.buckets.Enforce(ctx, p.deps.Limiter, isPremium); err != nil {
+		if err := p.buckets.Enforce(ctx, p.limiter, isPremium); err != nil {
 			return tagsResponse{}, err
 		}
 		return p.fetchTags(ctx, acct)
 	})
 }
 
-func (p *Provider) tags(ctx context.Context, req gatewayrpc.Request) any {
-	acct := account(strings.TrimSpace(req.Account))
-	if acct.empty() {
-		return gatewayrpc.UrchinTagsReply{Error: "missing account"}
-	}
-	key := core.Key(p.Name(), "tags", acct.cacheKey())
-	b, err := core.CachedBytes(ctx, p.cache, key, func(ctx context.Context) ([]byte, time.Duration, error) {
-		return core.BuildReply(ctx, tagsTTL, negativeTTL,
-			func(ctx context.Context) (any, error) {
-				resp, err := p.playerTags(ctx, acct, req.IsPremium)
-				if err != nil {
-					return nil, err
-				}
-				out := gatewayrpc.UrchinTagsReply{
-					Player: displayOr(resp.DisplayName, acct.String()),
-					Tags:   make([]gatewayrpc.UrchinTag, 0, len(resp.Tags)),
-				}
-				for _, t := range resp.Tags {
-					out.Tags = append(out.Tags, gatewayrpc.UrchinTag{Type: t.TagType, Reason: t.Reason, AddedOn: t.AddedOn / 1000})
-				}
-				return out, nil
-			},
-			func(msg string) any { return gatewayrpc.UrchinTagsReply{Player: acct.String(), Error: msg} },
-		)
-	})
+// tagsFetch reads the shared tags cache and shapes the blacklist-tags reply.
+func (p *api) tagsFetch(ctx context.Context, req gatewayrpc.Request, id provider.ID) (any, error) {
+	acct := account(id.Display)
+	resp, err := p.playerTags(ctx, acct, req.IsPremium)
 	if err != nil {
-		p.log.Warn("urchin tags fetch failed", zap.String("account", acct.String()), zap.Error(err))
-		return gatewayrpc.UrchinTagsReply{Player: acct.String(), Error: "tags lookup failed"}
+		return nil, err
 	}
-	return json.RawMessage(b)
+	out := gatewayrpc.UrchinTagsReply{
+		Player: displayOr(resp.DisplayName, acct.String()),
+		Tags:   make([]gatewayrpc.UrchinTag, 0, len(resp.Tags)),
+	}
+	for _, t := range resp.Tags {
+		out.Tags = append(out.Tags, gatewayrpc.UrchinTag{Type: t.TagType, Reason: t.Reason, AddedOn: t.AddedOn / 1000})
+	}
+	return out, nil
 }
 
 // cubelifyResponse is the Coral CubelifyResponse subset the gateway reads.
@@ -291,7 +270,7 @@ type cubelifyResponse struct {
 // already have made instead of dialing Coral again. An empty uuid on a 200 is
 // shaped like a 404 so the downstream cubelify call is never made with a blank
 // id.
-func (p *Provider) resolveUUID(ctx context.Context, acct account, isPremium bool) (string, error) {
+func (p *api) resolveUUID(ctx context.Context, acct account, isPremium bool) (string, error) {
 	resp, err := p.playerTags(ctx, acct, isPremium)
 	if err != nil {
 		return "", err
@@ -302,45 +281,30 @@ func (p *Provider) resolveUUID(ctx context.Context, acct account, isPremium bool
 	return resp.UUID, nil
 }
 
-func (p *Provider) sniper(ctx context.Context, req gatewayrpc.Request) any {
-	acct := account(strings.TrimSpace(req.Account))
-	if acct.empty() {
-		return gatewayrpc.UrchinSniperReply{Error: "missing account"}
-	}
-	key := core.Key(p.Name(), "sniper", acct.cacheKey())
-	b, err := core.CachedBytes(ctx, p.cache, key, func(ctx context.Context) ([]byte, time.Duration, error) {
-		return core.BuildReply(ctx, sniperTTL, negativeTTL,
-			func(ctx context.Context) (any, error) {
-				uuid, err := p.resolveUUID(ctx, acct, req.IsPremium)
-				if err != nil {
-					return nil, err
-				}
-				if err := p.buckets.Enforce(ctx, p.deps.Limiter, req.IsPremium); err != nil {
-					return nil, err
-				}
-				// The cubelify endpoint authenticates via the key query parameter
-				// (it is built for the overlay); the client's X-API-Key header
-				// rides along too.
-				var resp cubelifyResponse
-				q := url.Values{"uuid": {uuid}, "key": {p.key}, "name": {acct.String()}}
-				if err := p.http.GetJSON(ctx, "/v3/cubelify", q, &resp); err != nil {
-					return nil, err
-				}
-				return gatewayrpc.UrchinSniperReply{
-					Player:   acct.String(),
-					Score:    resp.Score.Value,
-					Mode:     resp.Score.Mode,
-					TagCount: len(resp.Tags),
-				}, nil
-			},
-			func(msg string) any { return gatewayrpc.UrchinSniperReply{Player: acct.String(), Error: msg} },
-		)
-	})
+// sniperFetch resolves the uuid through the shared tags cache, spends one
+// Coral token, and pulls the cubelify sniper score.
+func (p *api) sniperFetch(ctx context.Context, req gatewayrpc.Request, id provider.ID) (any, error) {
+	acct := account(id.Display)
+	uuid, err := p.resolveUUID(ctx, acct, req.IsPremium)
 	if err != nil {
-		p.log.Warn("urchin sniper fetch failed", zap.String("account", acct.String()), zap.Error(err))
-		return gatewayrpc.UrchinSniperReply{Player: acct.String(), Error: "score lookup failed"}
+		return nil, err
 	}
-	return json.RawMessage(b)
+	if err := p.buckets.Enforce(ctx, p.limiter, req.IsPremium); err != nil {
+		return nil, err
+	}
+	// The cubelify endpoint authenticates via the key query parameter (it is
+	// built for the overlay); the client's X-API-Key header rides along too.
+	var resp cubelifyResponse
+	q := url.Values{"uuid": {uuid}, "key": {p.key}, "name": {acct.String()}}
+	if err := p.http.GetJSON(ctx, "/v3/cubelify", q, &resp); err != nil {
+		return nil, err
+	}
+	return gatewayrpc.UrchinSniperReply{
+		Player:   acct.String(),
+		Score:    resp.Score.Value,
+		Mode:     resp.Score.Mode,
+		TagCount: len(resp.Tags),
+	}, nil
 }
 
 // displayOr prefers the API's display name when present and non-empty.

--- a/app/gateway/internal/providers/urchin/urchin_test.go
+++ b/app/gateway/internal/providers/urchin/urchin_test.go
@@ -47,7 +47,7 @@ func (s *memStore) Del(_ context.Context, key string) error {
 	return nil
 }
 
-func newTestProvider(t *testing.T, handler http.Handler) *Provider {
+func newTestProvider(t *testing.T, handler http.Handler) provider.Provider {
 	t.Helper()
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)
@@ -55,7 +55,7 @@ func newTestProvider(t *testing.T, handler http.Handler) *Provider {
 		provider.Deps{Cache: core.NewCache(newMemStore()), Log: zap.NewNop()})
 }
 
-func endpoint(t *testing.T, p *Provider, name string) func(context.Context, gatewayrpc.Request) any {
+func endpoint(t *testing.T, p provider.Provider, name string) func(context.Context, gatewayrpc.Request) any {
 	t.Helper()
 	for _, ep := range p.Endpoints() {
 		if ep.Name == name {


### PR DESCRIPTION
## What

Rework the gateway's provider authoring surface into a fluent Builder, mirroring sesame's `module.Builder`:

- `provider.NewProvider(name, deps)` starts a provider; `.Endpoint(name).Timeout(d).Handle(fn)` declares a bespoke endpoint; `.Cached(ttl, negTTL).ID(...).Reply(...).Fallback(...).Fetch(fn)` declares a byte-flow endpoint. Both terminals return nothing so a declaration cannot continue past them.
- `Build()` validates the assembly (empty/duplicate endpoint names, missing terminal, unfinished flow, nil cache) and panics at boot on programmer error, exactly like sesame's module Build; `Validate()` checks without panicking.
- The new flow (provider/flow.go) declares once the skeleton every cached endpoint hand-rolled: identity validation, cache key, `CachedBytes` + `BuildReply`, structured failure logging, fallback reply, raw-bytes passthrough. Standard identity extractors `Account` / `Channel` / `StaticID`; fortnite and clashroyale plug custom ones.

All six providers migrated (urchin, hypixel, mcsr, fortnite, govee, clashroyale). Provider structs are now unexported; `New` returns `provider.Provider`. mcsr sessions and govee stay bespoke `.Handle` endpoints on purpose: their snapshot side effects and key-resolve-before-cache semantics do not fit the shared skeleton.

## Optimizations

- `Buckets.WithKey`: govee re-derived its rate-limit bucket specs on every control redemption; the specs are now computed once and re-keyed per broadcaster.
- `Deps.Logger()` replaces six per-provider nil-check blocks.
- clashroyale's private proto-flow helper is replaced by the shared flow (the provider itself stays unwired/dormant, as before).

## Behavior

Wire behavior, cache keys, reply shapes, TTLs and rate budgets are unchanged. The only observable delta: flow failure logs are now one structured message (`gateway fetch failed` with provider/endpoint/id fields) instead of per-provider strings.

## Testing

Full gateway test suite passes with `-race`, plus new builder/flow tests covering the validation matrix, cache hit and negative-cache paths, and fallback shaping.