### PR TITLE
Instrument and tune NATS and Valkey hot paths

### DIFF
--- a/app/ingress/config/runtime.exs
+++ b/app/ingress/config/runtime.exs
@@ -129,6 +129,9 @@ config :ingress,
     String.to_integer(System.get_env("INGRESS_DISPATCHER_COMPLETION_BATCH_SIZE", "4")),
   dispatcher_completion_flush_ms:
     String.to_integer(System.get_env("INGRESS_DISPATCHER_COMPLETION_FLUSH_MS", "25")),
+  # Full trace/header creation is deliberately sparse at firehose rates. Set 1
+  # only during a bounded diagnostic; set 0 to disable per-event traces.
+  trace_sample_rate: String.to_integer(System.get_env("INGRESS_TRACE_SAMPLE_RATE", "1024")),
   squash_partitions:
     String.to_integer(
       System.get_env("INGRESS_SQUASH_PARTITIONS", Integer.to_string(System.schedulers_online()))

--- a/app/ingress/lib/ingress/broadcaster_status.ex
+++ b/app/ingress/lib/ingress/broadcaster_status.ex
@@ -19,26 +19,38 @@ defmodule Ingress.BroadcasterStatus do
 
   require Logger
 
+  alias Ingress.Trace
+
   @connection :gnat
 
   @spec lane_for(String.t()) :: {:ok, :premium | :standard | :drop} | {:error, term()}
   def lane_for(broadcaster_id) do
     request = Jason.encode!(%{broadcaster_id: broadcaster_id})
 
-    with {:ok, %{body: body}} <-
-           Gnat.request(@connection, Ingress.Config.broadcaster_status_subject(), request,
-             receive_timeout: Ingress.Config.broadcaster_status_timeout_ms()
-           ),
-         {:ok, reply} <- Jason.decode(body) do
-      case reply do
-        %{"banned" => true} -> {:ok, :drop}
-        %{"tier" => "premium"} -> {:ok, :premium}
-        %{"error" => error} -> {:error, {:rpc, error}}
-        _ -> {:ok, :standard}
-      end
-    else
-      {:error, reason} -> {:error, reason}
-    end
+    Trace.span("broadcaster_status.request", [dependency: "nats"], fn ->
+      result =
+        with {:ok, %{body: body}} <- request_status(request),
+             {:ok, reply} <- Jason.decode(body) do
+          case reply do
+            %{"banned" => true} -> {:ok, :drop}
+            %{"tier" => "premium"} -> {:ok, :premium}
+            %{"error" => error} -> {:error, {:rpc, error}}
+            _ -> {:ok, :standard}
+          end
+        else
+          {:error, reason} -> {:error, reason}
+        end
+
+      Trace.add_span_attributes(result: Trace.result(result))
+      result
+    end)
+  end
+
+  defp request_status(request) do
+    Gnat.request(@connection, Ingress.Config.broadcaster_status_subject(), request,
+      receive_timeout: Ingress.Config.broadcaster_status_timeout_ms(),
+      headers: Trace.trace_headers()
+    )
   catch
     # Gnat.request exits when the connection process is down; degrade instead.
     :exit, reason -> {:error, {:nats_down, reason}}

--- a/app/ingress/lib/ingress/config.ex
+++ b/app/ingress/lib/ingress/config.ex
@@ -144,6 +144,11 @@ defmodule Ingress.Config do
   def dispatcher_completion_flush_ms,
     do: Application.get_env(:ingress, :dispatcher_completion_flush_ms, 25)
 
+  # One in N notifications receives a transaction and trace headers. Zero
+  # disables per-event tracing; one is reserved for controlled diagnostics.
+  def trace_sample_rate,
+    do: Application.get_env(:ingress, :trace_sample_rate, 1_024)
+
   # How long an outstanding publish waits for its PubAck before
   # the collector reconciles it (see Ingress.Nats.Publisher).
   def publish_ack_timeout_ms,

--- a/app/ingress/lib/ingress/dispatcher.ex
+++ b/app/ingress/lib/ingress/dispatcher.ex
@@ -141,7 +141,7 @@ defmodule Ingress.Dispatcher do
         # whereis/1 but before attribution was recorded, its DOWN cleanup may
         # already have run. In that case reclaim this event here.
         if Process.alive?(worker) do
-          send(worker, {:process, payload, meta})
+          send(worker, {:process, System.monotonic_time(), payload, meta})
         else
           release(ctx, worker, broadcaster_id, 1)
           drop(meta, "unavailable")

--- a/app/ingress/lib/ingress/dispatcher/worker.ex
+++ b/app/ingress/lib/ingress/dispatcher/worker.ex
@@ -5,7 +5,7 @@ defmodule Ingress.Dispatcher.Worker do
 
   require Logger
 
-  alias Ingress.Dispatcher
+  alias Ingress.{Dispatcher, Trace}
 
   def start_link(opts) do
     GenServer.start_link(__MODULE__, opts, name: Keyword.fetch!(opts, :name))
@@ -44,10 +44,10 @@ defmodule Ingress.Dispatcher.Worker do
   end
 
   @impl true
-  def handle_info({:process, payload, meta}, state) do
+  def handle_info({:process, enqueued_at, payload, meta}, state) do
     _result =
       try do
-        state.handler.(payload, meta)
+        Trace.notification(enqueued_at, payload, meta, fn -> state.handler.(payload, meta) end)
       catch
         kind, reason ->
           Logger.error("Worker pipeline failed: #{kind} #{inspect(reason)}")

--- a/app/ingress/lib/ingress/nats.ex
+++ b/app/ingress/lib/ingress/nats.ex
@@ -23,7 +23,7 @@ defmodule Ingress.Nats do
   the twitch_ingress account's request/reply traffic.
   """
 
-  alias Ingress.{JSON, Metrics, Nats.Publisher}
+  alias Ingress.{JSON, Metrics, Nats.Publisher, Trace}
 
   @connection :gnat_bus
 
@@ -77,9 +77,23 @@ defmodule Ingress.Nats do
   def publish_acked(subject, payload) do
     # OTP JSON, Gnat and the TCP/SSL transports all keep this as iodata, so no
     # flattened copy is made before the socket write or PubAck retry storage.
-    json = JSON.encode(payload)
+    json =
+      Trace.span("encode", fn ->
+        JSON.encode(payload)
+      end)
 
-    case Publisher.enqueue(subject, json) do
+    result =
+      Trace.span(
+        "nats.publish.admit",
+        ["messaging.destination": Trace.destination(subject)],
+        fn ->
+          result = Publisher.enqueue(subject, json, Trace.trace_headers())
+          Trace.add_span_attributes(result: Trace.result(result))
+          result
+        end
+      )
+
+    case result do
       :ok ->
         :ok
 

--- a/app/ingress/lib/ingress/nats/publisher.ex
+++ b/app/ingress/lib/ingress/nats/publisher.ex
@@ -41,33 +41,34 @@ defmodule Ingress.Nats.Publisher do
   @inbox_prefix "_INBOX.ingresspub."
   @sweep_interval_ms 500
   @gauge_interval_ms 5_000
+  @ack_latency_sample_rate 64
 
   ## Scheduler-local admission
 
-  @spec enqueue(String.t(), iodata()) :: :ok | {:error, term()}
-  def enqueue(subject, json) do
+  @spec enqueue(String.t(), iodata(), Gnat.headers()) :: :ok | {:error, term()}
+  def enqueue(subject, json, trace_headers \\ []) do
     case :persistent_term.get({__MODULE__, :n}, 0) do
       0 ->
         {:error, :not_connected}
 
       n ->
         index = rem(max(:erlang.system_info(:scheduler_id), 1) - 1, n)
-        enqueue_from(index, n, subject, json, nil)
+        enqueue_from(index, n, subject, json, trace_headers, nil)
     end
   end
 
-  defp enqueue_from(_index, 0, _subject, _json, nil),
+  defp enqueue_from(_index, 0, _subject, _json, _headers, nil),
     do: {:error, :not_connected}
 
-  defp enqueue_from(_index, 0, _subject, _json, last_error), do: last_error
+  defp enqueue_from(_index, 0, _subject, _json, _headers, last_error), do: last_error
 
-  defp enqueue_from(index, remaining, subject, json, _last_error) do
+  defp enqueue_from(index, remaining, subject, json, trace_headers, _last_error) do
     n = :persistent_term.get({__MODULE__, :n})
 
     result =
       case :persistent_term.get({__MODULE__, :ctx, index}, nil) do
         nil -> {:error, :not_connected}
-        ctx -> admit(ctx, subject, json)
+        ctx -> admit(ctx, subject, json, trace_headers)
       end
 
     case result do
@@ -75,14 +76,19 @@ defmodule Ingress.Nats.Publisher do
         :ok
 
       {:error, reason} = error when reason in [:overloaded, :not_connected] ->
-        enqueue_from(rem(index + 1, n), remaining - 1, subject, json, error)
+        enqueue_from(rem(index + 1, n), remaining - 1, subject, json, trace_headers, error)
 
       error ->
         error
     end
   end
 
-  defp admit(%{pid: pid, conn: conn, counter: counter, max_pending: max_pending}, subject, json) do
+  defp admit(
+         %{pid: pid, conn: conn, counter: counter, max_pending: max_pending},
+         subject,
+         json,
+         trace_headers
+       ) do
     cond do
       :atomics.add_get(counter, @idx_pending, 1) > max_pending ->
         :atomics.sub(counter, @idx_pending, 1)
@@ -93,10 +99,17 @@ defmodule Ingress.Nats.Publisher do
         {:error, :not_connected}
 
       true ->
-        GenServer.cast(pid, {:enqueue, subject, json})
+        enqueue_cast(pid, subject, json, trace_headers)
         :ok
     end
   end
+
+  # Preserve the allocation profile of the unsampled firehose. Only the sparse
+  # traced messages carry the wider tuple and header list through the cohort.
+  defp enqueue_cast(pid, subject, json, []), do: GenServer.cast(pid, {:enqueue, subject, json})
+
+  defp enqueue_cast(pid, subject, json, trace_headers),
+    do: GenServer.cast(pid, {:enqueue, subject, json, trace_headers})
 
   ## Collector lifecycle
 
@@ -171,9 +184,17 @@ defmodule Ingress.Nats.Publisher do
 
   @impl true
   def handle_cast({:enqueue, subject, json}, state) do
+    enqueue_entry({subject, json, nil}, state)
+  end
+
+  def handle_cast({:enqueue, subject, json, trace_headers}, state) do
+    enqueue_entry({subject, json, trace_headers, nil}, state)
+  end
+
+  defp enqueue_entry(entry, state) do
     state = %{
       state
-      | queue: [{subject, json, nil} | state.queue],
+      | queue: [entry | state.queue],
         queue_count: state.queue_count + 1
     }
 
@@ -212,8 +233,8 @@ defmodule Ingress.Nats.Publisher do
 
     for row <- :ets.tab2list(state.table) do
       case row do
-        {id, :single, subject, json, attempts, timestamp} when timestamp <= deadline ->
-          retry_or_drop(id, subject, json, attempts, :ack_timeout, state)
+        {id, :single, subject, payload, attempts, timestamp} when timestamp <= deadline ->
+          retry_or_drop(id, subject, payload, attempts, :ack_timeout, state)
 
         {id, :batch, entries, timestamp} when timestamp <= deadline ->
           expire_batch(id, entries, state)
@@ -311,6 +332,15 @@ defmodule Ingress.Nats.Publisher do
     {token, subject, json, opts}
   end
 
+  defp stage_single({subject, json, trace_headers, from}, state) do
+    id = :atomics.add_get(state.counter, @idx_next_id, 1)
+    :ets.insert(state.table, {id, :single, subject, {json, trace_headers}, 1, now_ms()})
+
+    token = {id, from}
+    opts = publish_opts([reply_to: single_reply_subject(state.prefix, id)], trace_headers)
+    {token, subject, json, opts}
+  end
+
   defp finish_single_send({{_id, from}, :ok}, _state), do: reply_entry(from, :ok)
 
   defp finish_single_send({{id, from}, {:error, reason}}, state) do
@@ -347,8 +377,9 @@ defmodule Ingress.Nats.Publisher do
 
     entries
     |> Enum.with_index(1)
-    |> Enum.reduce_while(:ok, fn {{subject, json, _from}, seq}, :ok ->
-      headers = batch_headers(batch_id, seq, last)
+    |> Enum.reduce_while(:ok, fn {entry, seq}, :ok ->
+      {subject, json, trace_headers} = wire_entry(entry)
+      headers = batch_headers(batch_id, seq, last) ++ trace_headers
 
       case safe_pub(state.conn, subject, json, batch_pub_opts(headers, seq, last, id, state)) do
         :ok -> {:cont, :ok}
@@ -356,6 +387,11 @@ defmodule Ingress.Nats.Publisher do
       end
     end)
   end
+
+  defp wire_entry({subject, json, _from}), do: {subject, json, []}
+
+  defp wire_entry({subject, json, trace_headers, _from}),
+    do: {subject, json, trace_headers}
 
   defp batch_headers(batch_id, seq, last) do
     commit = if seq == last, do: [{"Nats-Batch-Commit", "1"}], else: []
@@ -397,17 +433,21 @@ defmodule Ingress.Nats.Publisher do
     state
   end
 
-  defp resolve_batch(id, entries, state) do
+  defp resolve_batch(id, entries, timestamp, state) do
     :ets.delete(state.table, id)
     count = length(entries)
+    record_ack_latency(id, timestamp, count)
     :atomics.sub(state.counter, @idx_pending, count)
     :atomics.add(state.counter, @idx_acked, count)
     :atomics.sub(state.counter, @idx_batch_inflight, 1)
     state
   end
 
-  defp pub(conn, subject, json, reply),
-    do: safe_pub(conn, subject, json, reply_to: reply)
+  defp pub(conn, subject, json, reply, trace_headers),
+    do: safe_pub(conn, subject, json, publish_opts([reply_to: reply], trace_headers))
+
+  defp publish_opts(opts, []), do: opts
+  defp publish_opts(opts, headers), do: Keyword.put(opts, :headers, headers)
 
   defp safe_pub(conn, subject, json, opts) do
     Gnat.pub(conn, subject, json, opts)
@@ -422,10 +462,10 @@ defmodule Ingress.Nats.Publisher do
 
   defp apply_ack({:single, id}, body, state) do
     case :ets.lookup(state.table, id) do
-      [{^id, :single, subject, json, attempts, _timestamp}] ->
+      [{^id, :single, subject, payload, attempts, timestamp}] ->
         case Nats.parse_pub_ack(body) do
-          :ok -> resolve_single(id, state)
-          {:error, reason} -> retry_or_drop(id, subject, json, attempts, reason, state)
+          :ok -> resolve_single(id, timestamp, state)
+          {:error, reason} -> retry_or_drop(id, subject, payload, attempts, reason, state)
         end
 
       [] ->
@@ -453,9 +493,9 @@ defmodule Ingress.Nats.Publisher do
 
   defp apply_ack({:batch_commit, id}, body, state) do
     case :ets.lookup(state.table, id) do
-      [{^id, :batch, entries, _timestamp}] ->
+      [{^id, :batch, entries, timestamp}] ->
         case Nats.parse_pub_ack(body) do
-          :ok -> resolve_batch(id, entries, state)
+          :ok -> resolve_batch(id, entries, timestamp, state)
           {:error, {:pub_ack, _reason}} -> fallback_batch(id, entries, state)
           _ambiguous -> fail_batch(id, entries, state)
         end
@@ -465,24 +505,57 @@ defmodule Ingress.Nats.Publisher do
     end
   end
 
-  defp resolve_single(id, state) do
+  defp resolve_single(id, timestamp, state) do
+    record_ack_latency(id, timestamp, 1)
     :ets.delete(state.table, id)
     :atomics.sub(state.counter, @idx_pending, 1)
     :atomics.add(state.counter, @idx_acked, 1)
     state
   end
 
-  defp retry_or_drop(id, subject, json, attempts, reason, state) do
+  defp record_ack_latency(id, timestamp, count) when rem(id, @ack_latency_sample_rate) == 0 do
+    bucket = ack_latency_bucket(max(now_ms() - timestamp, 0))
+    Metrics.count("Nats/PubAckLatency/#{bucket}", count)
+    Metrics.count("Nats/PubAckLatency/Sampled", count)
+  end
+
+  defp record_ack_latency(_id, _timestamp, _count), do: :ok
+
+  defp ack_latency_bucket(ms) when ms <= 1, do: "Le1ms"
+  defp ack_latency_bucket(ms) when ms <= 2, do: "Le2ms"
+  defp ack_latency_bucket(ms) when ms <= 4, do: "Le4ms"
+  defp ack_latency_bucket(ms) when ms <= 8, do: "Le8ms"
+  defp ack_latency_bucket(ms) when ms <= 16, do: "Le16ms"
+  defp ack_latency_bucket(ms) when ms <= 32, do: "Le32ms"
+  defp ack_latency_bucket(ms) when ms <= 64, do: "Le64ms"
+  defp ack_latency_bucket(ms) when ms <= 128, do: "Le128ms"
+  defp ack_latency_bucket(_ms), do: "Gt128ms"
+
+  defp retry_or_drop(id, subject, {json, trace_headers} = payload, attempts, reason, state) do
     if retry?(attempts, reason, state) do
       :ets.insert(
         state.table,
-        {id, :single, subject, json, attempts + 1, now_ms()}
+        {id, :single, subject, payload, attempts + 1, now_ms()}
       )
 
       :atomics.add(state.counter, @idx_retried, 1)
 
-      _ = pub(state.conn, subject, json, single_reply_subject(state.prefix, id))
+      _ = pub(state.conn, subject, json, single_reply_subject(state.prefix, id), trace_headers)
 
+      :ok
+    else
+      :ets.delete(state.table, id)
+      :atomics.sub(state.counter, @idx_pending, 1)
+      :atomics.add(state.counter, @idx_failed, 1)
+      :ok
+    end
+  end
+
+  defp retry_or_drop(id, subject, json, attempts, reason, state) do
+    if retry?(attempts, reason, state) do
+      :ets.insert(state.table, {id, :single, subject, json, attempts + 1, now_ms()})
+      :atomics.add(state.counter, @idx_retried, 1)
+      _ = pub(state.conn, subject, json, single_reply_subject(state.prefix, id), [])
       :ok
     else
       :ets.delete(state.table, id)

--- a/app/ingress/lib/ingress/pipeline.ex
+++ b/app/ingress/lib/ingress/pipeline.ex
@@ -42,7 +42,7 @@ defmodule Ingress.Pipeline do
 
   require Logger
 
-  alias Ingress.{BroadcasterCache, Config, Metrics, Nats, Squash}
+  alias Ingress.{BroadcasterCache, Config, Metrics, Nats, Squash, Trace}
 
   @type decision :: :special | :command | :chat
 
@@ -51,7 +51,19 @@ defmodule Ingress.Pipeline do
   @stream_types ["stream.online", "stream.offline"]
 
   def handle_event(payload, meta) do
-    case route(payload, meta) do
+    decision =
+      Trace.span("route", fn ->
+        decision = route(payload, meta)
+
+        Trace.add_span_attributes(
+          result: Trace.result(decision),
+          "event.lane": decision_lane(decision)
+        )
+
+        decision
+      end)
+
+    case decision do
       {:publish, subject, message} ->
         publish_one(subject, message)
 
@@ -71,6 +83,13 @@ defmodule Ingress.Pipeline do
         :drop
     end
   end
+
+  defp decision_lane({:publish, _subject, %{lane: lane}}), do: to_string(lane)
+
+  defp decision_lane({:publish_many, [{_subject, %{lane: lane}} | _]}),
+    do: to_string(lane)
+
+  defp decision_lane(_decision), do: "none"
 
   defp publish_one(subject, message) do
     Metrics.count("Published/#{message.lane}")

--- a/app/ingress/lib/ingress/trace.ex
+++ b/app/ingress/lib/ingress/trace.ex
@@ -1,0 +1,101 @@
+defmodule Ingress.Trace do
+  @moduledoc false
+
+  # Runs exactly one notification in a short-lived transaction on the worker
+  # process. The dispatcher timestamp uses the same monotonic clock, so queue
+  # wait remains meaningful across scheduler migration without wall-clock skew.
+  alias Ingress.Config
+
+  @active_key {__MODULE__, :active}
+
+  def notification(enqueued_at, payload, meta, fun) when is_function(fun, 0) do
+    if sampled?(meta) do
+      traced_notification(enqueued_at, payload, fun)
+    else
+      fun.()
+    end
+  end
+
+  defp traced_notification(enqueued_at, payload, fun) do
+    wait_us =
+      System.monotonic_time()
+      |> Kernel.-(enqueued_at)
+      |> max(0)
+      |> System.convert_time_unit(:native, :microsecond)
+
+    NewRelic.start_transaction("Ingress", "Notification")
+    Process.put(@active_key, true)
+
+    NewRelic.add_attributes(
+      "dispatcher.wait_ms": wait_us / 1_000,
+      "event.type": event_type(payload)
+    )
+
+    try do
+      fun.()
+    after
+      Process.delete(@active_key)
+      NewRelic.stop_transaction()
+    end
+  end
+
+  defp sampled?(meta) do
+    case Config.trace_sample_rate() do
+      rate when rate <= 0 -> false
+      1 -> true
+      rate -> :erlang.phash2({Map.get(meta, :msg_id), Map.get(meta, :shard_id)}, rate) == 0
+    end
+  end
+
+  defp event_type(%{"subscription" => %{"type" => type}}) when is_binary(type), do: type
+  defp event_type(_payload), do: "invalid"
+
+  def trace_headers do
+    if active?() do
+      :other
+      |> NewRelic.distributed_trace_headers()
+      |> Map.to_list()
+    else
+      []
+    end
+  end
+
+  def span(name, attributes \\ [], fun) when is_function(fun, 0) do
+    if active?() do
+      id = make_ref()
+      NewRelic.Tracer.Direct.start_span(id, name, attributes: attributes)
+
+      try do
+        fun.()
+      after
+        NewRelic.Tracer.Direct.stop_span(id)
+      end
+    else
+      fun.()
+    end
+  end
+
+  def add_span_attributes(attributes) do
+    if active?(), do: NewRelic.add_span_attributes(attributes)
+    :ok
+  end
+
+  defp active?, do: Process.get(@active_key, false)
+
+  def destination(subject) do
+    case subject do
+      "twitch.ingress.event.premium" -> subject
+      "twitch.ingress.event.standard" -> subject
+      "twitch.ingress.event.stream" -> subject
+      _other -> "twitch.ingress.event.other"
+    end
+  end
+
+  def result(:ok), do: "ok"
+  def result({:error, :timeout}), do: "timeout"
+  def result({:error, _reason}), do: "error"
+  def result(:squash), do: "filtered"
+  def result(:oversized), do: "invalid"
+  def result(:drop), do: "dropped"
+  def result(_other), do: "ok"
+end

--- a/app/ingress/test/nats_publisher_test.exs
+++ b/app/ingress/test/nats_publisher_test.exs
@@ -203,6 +203,31 @@ defmodule Ingress.Nats.PublisherTest do
       assert :atomics.get(ctx.counter, 1) == 0
       assert :ets.info(ctx.table, :size) == 0
     end
+
+    test "sampled trace headers survive the asynchronous publisher handoff", %{
+      publisher: publisher
+    } do
+      traceparent = "00-050c91b77efca9b0ef38b30c182355ce-560ccffb087d1906-01"
+
+      assert Publisher.enqueue(
+               "twitch.ingress.event.standard",
+               ~s({"n":1}),
+               [{"traceparent", traceparent}]
+             ) == :ok
+
+      assert_receive {:pub, _, _, opts}, 500
+      assert prepared_headers(opts)["traceparent"] == traceparent
+
+      send(publisher, {
+        :msg,
+        %{
+          topic: Keyword.fetch!(opts, :reply_to),
+          body: ~s({"stream":"TWITCH_INGRESS","seq":1})
+        }
+      })
+
+      _state = :sys.get_state(publisher)
+    end
   end
 
   defp restore_env(key, nil), do: Application.delete_env(:ingress, key)

--- a/app/ingress/test/trace_test.exs
+++ b/app/ingress/test/trace_test.exs
@@ -1,0 +1,49 @@
+defmodule Ingress.TraceTest do
+  use ExUnit.Case, async: false
+
+  alias Ingress.Trace
+
+  setup do
+    previous = Application.get_env(:ingress, :trace_sample_rate)
+
+    on_exit(fn ->
+      if is_nil(previous) do
+        Application.delete_env(:ingress, :trace_sample_rate)
+      else
+        Application.put_env(:ingress, :trace_sample_rate, previous)
+      end
+    end)
+
+    :ok
+  end
+
+  test "disabled tracing bypasses transaction work and still runs the event" do
+    Application.put_env(:ingress, :trace_sample_rate, 0)
+
+    assert Trace.notification(System.monotonic_time(), %{}, %{}, fn -> :handled end) == :handled
+    assert Trace.trace_headers() == []
+  end
+
+  test "diagnostic sampling cleans up transaction-local trace state" do
+    Application.put_env(:ingress, :trace_sample_rate, 1)
+
+    assert Trace.notification(System.monotonic_time(), %{}, %{msg_id: "event-1"}, fn ->
+             assert is_list(Trace.trace_headers())
+             :handled
+           end) == :handled
+
+    assert Trace.trace_headers() == []
+  end
+
+  test "destination and result facets stay finite" do
+    assert Trace.destination("twitch.ingress.event.standard") ==
+             "twitch.ingress.event.standard"
+
+    assert Trace.destination("twitch.ingress.event.tenant.123") ==
+             "twitch.ingress.event.other"
+
+    assert Trace.result({:error, :timeout}) == "timeout"
+    assert Trace.result({:error, :anything}) == "error"
+    assert Trace.result(:squash) == "filtered"
+  end
+end

--- a/app/sesame/engine/greet_valkey.go
+++ b/app/sesame/engine/greet_valkey.go
@@ -17,41 +17,34 @@ const greetKeyPrefix = "bagel:greeted:"
 // the first-message check atomic: a new member returns 1, an existing one 0.
 type ValkeyGreetStore struct {
 	client valkey.Client
-	ttl    time.Duration // safety expiry so an abandoned set is reclaimed
-	log    *zap.Logger
+	ttlArg string // safety expiry so an abandoned set is reclaimed
 }
+
+// SADD and its safety expiry execute atomically in the same server call. This
+// preserves the one-round-trip response path while avoiding one goroutine per
+// newly seen chatter and the race where a process dies before EXPIRE lands.
+var firstGreetScript = valkey.NewLuaScript(`
+local added = redis.call('SADD', KEYS[1], ARGV[1])
+if added == 1 then redis.call('EXPIRE', KEYS[1], ARGV[2]) end
+return added`)
 
 func NewValkeyGreetStore(client valkey.Client, ttl time.Duration, log *zap.Logger) *ValkeyGreetStore {
 	if ttl <= 0 {
 		ttl = 12 * time.Hour
 	}
-	if log == nil {
-		log = zap.NewNop()
-	}
-	return &ValkeyGreetStore{client: client, ttl: ttl, log: log}
+	_ = log // retained in the constructor contract for stable dependency wiring
+	return &ValkeyGreetStore{client: client, ttlArg: strconv.FormatInt(int64(ttl.Seconds()), 10)}
 }
 
 func greetKey(id uint64) string { return greetKeyPrefix + strconv.FormatUint(id, 10) }
 
 func (s *ValkeyGreetStore) FirstGreet(ctx context.Context, broadcasterID uint64, chatterID string) (bool, error) {
 	key := greetKey(broadcasterID)
-	added, err := s.client.Do(ctx, s.client.B().Sadd().Key(key).Member(chatterID).Build()).AsInt64()
+	added, err := firstGreetScript.Exec(ctx, s.client, []string{key}, []string{
+		chatterID, s.ttlArg,
+	}).AsInt64()
 	if err != nil {
 		return false, err
-	}
-	if added > 0 {
-		// First greet this session: (re)arm the safety expiry. Fire-and-forget so
-		// the EXPIRE round-trip never lands on the response path of the chat message
-		// that won the SADD (the single Valkey master is transatlantic). The SADD
-		// already decided the greet; the TTL is only a janitorial backstop.
-		seconds := int64(s.ttl.Seconds())
-		go func() {
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			defer cancel()
-			if err := s.client.Do(ctx, s.client.B().Expire().Key(key).Seconds(seconds).Build()).Error(); err != nil {
-				s.log.Warn("greet: failed to re-arm greeted-set expiry", zap.String("key", key), zap.Error(err))
-			}
-		}()
 	}
 	return added > 0, nil
 }

--- a/app/sesame/engine/loyalty_valkey.go
+++ b/app/sesame/engine/loyalty_valkey.go
@@ -51,6 +51,32 @@ const scopeCacheTTL = 5 * time.Minute
 // TTL without holding the generic cache.DefaultCapacity ten thousand at rest.
 const scopeCacheCapacity int64 = 4096
 
+// These scripts keep a warm counter bump to one master round trip. A missing
+// key/field returns nil without mutating anything so the caller can obtain the
+// authoritative seed from the loyalty service. The second execution installs
+// that seed only when the key is still cold, then applies this caller's delta.
+// Concurrent seeders are safe: one creates the value and every caller's INCR
+// still lands exactly once.
+var (
+	counterTTLArg     = strconv.FormatInt(int64(counterTTL.Seconds()), 10)
+	bumpChannelScript = valkey.NewLuaScript(`
+if redis.call('EXISTS', KEYS[1]) == 0 then
+  if ARGV[1] == '' then return false end
+  redis.call('SET', KEYS[1], ARGV[1])
+end
+local value = redis.call('INCRBY', KEYS[1], ARGV[2])
+redis.call('EXPIRE', KEYS[1], ARGV[3])
+return value`)
+	bumpEntryScript = valkey.NewLuaScript(`
+if redis.call('HEXISTS', KEYS[1], ARGV[1]) == 0 then
+  if ARGV[2] == '' then return false end
+  redis.call('HSET', KEYS[1], ARGV[1], ARGV[2])
+end
+local value = redis.call('HINCRBY', KEYS[1], ARGV[1], ARGV[3])
+redis.call('EXPIRE', KEYS[1], ARGV[4])
+return value`)
+)
+
 // ValkeyLoyaltyStore is the worker-side loyalty surface: counter bumps/reads
 // with a Valkey live view over the loyalty service, cached balance peeks, and
 // pass-through management verbs. It implements LoyaltyStore.
@@ -177,65 +203,53 @@ func (s *ValkeyLoyaltyStore) CounterBump(ctx context.Context, broadcasterID uint
 	return value, nil
 }
 
-// bumpChannel seeds (SET NX from the service) then INCRs the shared string.
-// The seed race across replicas is benign: one SET NX wins, both INCRs apply.
+// bumpChannel increments and refreshes a warm shared string atomically in one
+// master round trip. Only a cold key pays the loyalty RPC and a second script
+// call to seed it; the seed race across replicas is benign and every delta is
+// still applied exactly once.
 func (s *ValkeyLoyaltyStore) bumpChannel(ctx context.Context, broadcasterID uint64, name string, delta int64) (int64, error) {
 	key := counterChannelKey(broadcasterID, name)
+	deltaArg := strconv.FormatInt(delta, 10)
 
-	exists, err := s.client.Do(ctx, s.client.B().Exists().Key(key).Build()).AsInt64()
-	if err != nil {
+	value, err := bumpChannelScript.Exec(ctx, s.client, []string{key}, []string{"", deltaArg, counterTTLArg}).AsInt64()
+	if err == nil {
+		return value, nil
+	}
+	if !valkey.IsValkeyNil(err) {
 		return 0, err
 	}
-	if exists == 0 {
-		seed := int64(0)
-		if c, found, err := s.rpc.CounterGet(ctx, broadcasterID, name, 0, ""); err == nil && found {
-			seed = c.Value
-		}
-		// NX: a concurrent seeder winning is fine, the value is the same.
-		_ = s.client.Do(ctx, s.client.B().Set().Key(key).Value(strconv.FormatInt(seed, 10)).Nx().ExSeconds(int64(counterTTL.Seconds())).Build()).Error()
-	}
 
-	// One pipelined flush: the increment and its TTL refresh share a round
-	// trip to the master instead of paying two sequential cross-node RTTs.
-	resps := s.client.DoMulti(ctx,
-		s.client.B().Incrby().Key(key).Increment(delta).Build(),
-		s.client.B().Expire().Key(key).Seconds(int64(counterTTL.Seconds())).Build(),
-	)
-	value, err := resps[0].AsInt64()
-	if err != nil {
-		return 0, err
+	seed := int64(0)
+	if c, found, loadErr := s.rpc.CounterGet(ctx, broadcasterID, name, 0, ""); loadErr == nil && found {
+		seed = c.Value
 	}
-	return value, nil
+	return bumpChannelScript.Exec(ctx, s.client, []string{key}, []string{
+		strconv.FormatInt(seed, 10), deltaArg, counterTTLArg,
+	}).AsInt64()
 }
 
-// bumpEntry seeds one entry-scoped hash field (HSETNX from the service) then
-// HINCRBYs it, refreshing the whole hash's TTL.
+// bumpEntry is the hash-field equivalent of bumpChannel: warm increment and
+// TTL refresh are one atomic master call, while a cold field is seeded from
+// the loyalty service before the caller's delta is applied.
 func (s *ValkeyLoyaltyStore) bumpEntry(ctx context.Context, broadcasterID uint64, name, field string, viewerID uint64, command string, delta int64) (int64, error) {
 	key := counterViewerKey(broadcasterID, name)
+	deltaArg := strconv.FormatInt(delta, 10)
 
-	exists, err := s.client.Do(ctx, s.client.B().Hexists().Key(key).Field(field).Build()).AsBool()
-	if err != nil {
+	value, err := bumpEntryScript.Exec(ctx, s.client, []string{key}, []string{field, "", deltaArg, counterTTLArg}).AsInt64()
+	if err == nil {
+		return value, nil
+	}
+	if !valkey.IsValkeyNil(err) {
 		return 0, err
 	}
-	if !exists {
-		seed := int64(0)
-		if c, found, err := s.rpc.CounterGet(ctx, broadcasterID, name, viewerID, command); err == nil && found {
-			seed = c.Value
-		}
-		_ = s.client.Do(ctx, s.client.B().Hsetnx().Key(key).Field(field).Value(strconv.FormatInt(seed, 10)).Build()).Error()
-	}
 
-	// One pipelined flush, matching bumpChannel: increment + hash TTL refresh
-	// in a single master round trip.
-	resps := s.client.DoMulti(ctx,
-		s.client.B().Hincrby().Key(key).Field(field).Increment(delta).Build(),
-		s.client.B().Expire().Key(key).Seconds(int64(counterTTL.Seconds())).Build(),
-	)
-	value, err := resps[0].AsInt64()
-	if err != nil {
-		return 0, err
+	seed := int64(0)
+	if c, found, loadErr := s.rpc.CounterGet(ctx, broadcasterID, name, viewerID, command); loadErr == nil && found {
+		seed = c.Value
 	}
-	return value, nil
+	return bumpEntryScript.Exec(ctx, s.client, []string{key}, []string{
+		field, strconv.FormatInt(seed, 10), deltaArg, counterTTLArg,
+	}).AsInt64()
 }
 
 // CounterPeek reads a counter without bumping it: the live Valkey view when

--- a/app/sesame/engine/personality_valkey.go
+++ b/app/sesame/engine/personality_valkey.go
@@ -58,6 +58,39 @@ const feedTodayKey = "personality:feed:global"
 // reply path never waits on an RPC once the view is warm.
 const feedTotalKey = "personality:feed:total"
 
+// A warm feed updates both counters in one atomic master round trip. A cold
+// total returns nil without touching today's count, allowing the caller to
+// synchronously persist this feeding through FeedBump before seeding the live
+// view. The seed script keeps the larger of an already-raced live value and
+// the DB total, so concurrent cold callers never move the view backwards.
+var (
+	personalityTTLArg = strconv.FormatInt(int64(personalityTTL.Seconds()), 10)
+	feedKeys          = []string{feedTotalKey, feedTodayKey}
+	feedWarmArgs      = []string{personalityTTLArg}
+	feedWarmScript    = valkey.NewLuaScript(`
+if redis.call('EXISTS', KEYS[1]) == 0 then return false end
+local total = redis.call('INCR', KEYS[1])
+local today = redis.call('INCR', KEYS[2])
+if today == 1 then redis.call('EXPIRE', KEYS[2], ARGV[1]) end
+return {today, total}`)
+	feedSeedScript = valkey.NewLuaScript(`
+local seed = tonumber(ARGV[1])
+local current = redis.call('GET', KEYS[1])
+if not current then
+  current = seed
+  redis.call('SET', KEYS[1], seed)
+else
+  current = tonumber(current)
+  if current < seed then
+    current = seed
+    redis.call('SET', KEYS[1], seed)
+  end
+end
+local today = redis.call('INCR', KEYS[2])
+if today == 1 then redis.call('EXPIRE', KEYS[2], ARGV[2]) end
+return {today, current}`)
+)
+
 // Feed records one feeding on both counters and returns them: the lifetime
 // total from the valkey live view (DB-seeded, persisted behind the reply) and
 // the valkey today window. An error on either side errors the whole call; the
@@ -66,40 +99,21 @@ func (s *ValkeyPersonality) Feed(ctx context.Context) (FeedCounts, error) {
 	if s.total == nil {
 		return FeedCounts{}, errors.New("personality: no feed total backend")
 	}
-	total, err := s.feedTotal(ctx)
-	if err != nil {
-		return FeedCounts{}, err
-	}
-	today, err := s.feedToday(ctx)
-	if err != nil {
-		return FeedCounts{}, err
-	}
-	return FeedCounts{Today: today, Total: total}, nil
-}
-
-// feedTotal serves the lifetime total from the valkey view. A warm view
-// answers locally and lets the DB bump ride behind the reply; a cold view
-// (INCR landed on a fresh key after a flush or failover) seeds itself from the
-// synchronous RPC bump, which also counts this feeding. Two pods racing a cold
-// key can briefly answer a low number; the seed's SET snaps the view back to
-// the DB total, so drift self-heals at every cold start.
-func (s *ValkeyPersonality) feedTotal(ctx context.Context) (uint64, error) {
-	n, err := s.client.Do(ctx, s.client.B().Incr().Key(feedTotalKey).Build()).AsInt64()
-	if err != nil {
-		return 0, err
-	}
-	if n > 1 {
+	counts, err := decodeFeedCounts(feedWarmScript.Exec(ctx, s.client, feedKeys, feedWarmArgs))
+	if err == nil {
 		s.bumpBehind()
-		return uint64(n), nil
+		return counts, nil
 	}
+	if !valkey.IsValkeyNil(err) {
+		return FeedCounts{}, err
+	}
+
 	dbTotal, err := s.total.FeedBump(ctx)
 	if err != nil {
-		return 0, err
+		return FeedCounts{}, err
 	}
-	if err := s.client.Do(ctx, s.client.B().Set().Key(feedTotalKey).Value(strconv.FormatUint(dbTotal, 10)).Build()).Error(); err != nil {
-		s.log.Warn("personality: feed total seed failed", zap.Error(err))
-	}
-	return dbTotal, nil
+	return decodeFeedCounts(feedSeedScript.Exec(ctx, s.client,
+		feedKeys, []string{strconv.FormatUint(dbTotal, 10), personalityTTLArg}))
 }
 
 // bumpBehind persists one feeding to the modules service off the reply path,
@@ -115,21 +129,26 @@ func (s *ValkeyPersonality) bumpBehind() {
 	}()
 }
 
-// feedToday bumps and returns the today window. The first feed of the window
-// claims the TTL; later feeds leave it in place so the count reads as "today",
-// not a sliding forever-window.
-func (s *ValkeyPersonality) feedToday(ctx context.Context) (uint64, error) {
-	n, err := s.client.Do(ctx, s.client.B().Incr().Key(feedTodayKey).Build()).AsInt64()
+func decodeFeedCounts(result valkey.ValkeyResult) (FeedCounts, error) {
+	values, err := result.ToArray()
 	if err != nil {
-		return 0, err
+		return FeedCounts{}, err
 	}
-	if n == 1 {
-		seconds := int64(personalityTTL.Seconds())
-		if err := s.client.Do(ctx, s.client.B().Expire().Key(feedTodayKey).Seconds(seconds).Build()).Error(); err != nil {
-			s.log.Warn("personality: feed expire failed", zap.Error(err))
-		}
+	if len(values) != 2 {
+		return FeedCounts{}, errors.New("personality: invalid feed script result")
 	}
-	return uint64(n), nil
+	today, err := values[0].AsInt64()
+	if err != nil {
+		return FeedCounts{}, err
+	}
+	total, err := values[1].AsInt64()
+	if err != nil {
+		return FeedCounts{}, err
+	}
+	if today < 0 || total < 0 {
+		return FeedCounts{}, errors.New("personality: negative feed counter")
+	}
+	return FeedCounts{Today: uint64(today), Total: uint64(total)}, nil
 }
 
 // Mood returns the channel's mood for the current window, seeding it with

--- a/app/sesame/engine/pipeline.go
+++ b/app/sesame/engine/pipeline.go
@@ -133,23 +133,33 @@ func (p *Pipeline) Process(msg *bus.Message) (err error) {
 	// Decode into a pooled envelope so the plain-chat path allocates nothing here.
 	env := GetEnvelope()
 	defer PutEnvelope(env)
+	decodeSegment := startStage(ctx, "sesame.decode")
 	if err := sonic.Unmarshal(msg.Payload, env); err != nil {
+		endStage(decodeSegment, "invalid")
+		traceResult(ctx, "invalid")
 		return p.dropPoison(ctx, msg.UUID, err)
 	}
+	endStage(decodeSegment, "ok")
 	if !p.eligible(env) {
+		traceResult(ctx, "filtered")
 		return nil
 	}
 
 	broadcasterID, ok := env.BroadcasterID()
 	if !ok {
+		traceResult(ctx, "invalid")
 		return nil
 	}
-	traceEvent(ctx, env.Type, broadcasterID)
+	traceEvent(ctx, env.Type, env.Lane, broadcasterID)
 
+	projectionSegment := startStage(ctx, "sesame.dependency.projection")
 	views, err := p.moduleViews(ctx, env.Type, broadcasterID)
 	if err != nil {
+		endStage(projectionSegment, "error")
+		traceResult(ctx, "error")
 		return err // infrastructure failure: nack
 	}
+	endStage(projectionSegment, "ok")
 
 	mctx := p.leaseContext(env, broadcasterID)
 	defer PutContext(mctx)
@@ -159,14 +169,31 @@ func (p *Pipeline) Process(msg *bus.Message) (err error) {
 		replayBase: outputReplayBase(env),
 	}
 	emit := p.newEmit(ctx, env.BroadcasterUserID, &emission)
+	engineSegment := startStage(ctx, "sesame.engine")
 	p.runStages(ctx, mctx, views, emit)
+	if emission.err != nil {
+		endStage(engineSegment, "error")
+	} else {
+		endStage(engineSegment, "ok")
+	}
 	if emission.err == nil && emission.needsFlush {
 		// Legacy envelopes without EventID cannot use a stable confirmed publish;
 		// flush their asynchronous admission before confirming the input ack.
+		flushSegment := startStage(ctx, "sesame.output.flush")
 		emission.err = p.pub.Flush(ctx)
+		if emission.err != nil {
+			endStage(flushSegment, "error")
+		} else {
+			endStage(flushSegment, "ok")
+		}
 	}
 
 	// nil = ack; a publish/marshal failure on the emit path = nack.
+	if emission.err != nil {
+		traceResult(ctx, "error")
+	} else {
+		traceResult(ctx, "ok")
+	}
 	return emission.err
 }
 
@@ -284,10 +311,13 @@ func (p *Pipeline) floorSuppressed(o *module.Output) bool {
 // publishOutput translates one Output to the outgress wire contract and
 // publishes it on the lane subject.
 func (p *Pipeline) publishOutput(ctx context.Context, subject, replayID string, o *module.Output) error {
+	encodeSegment := startStage(ctx, "sesame.output.encode")
 	body, err := buildOutgress(o)
 	if err != nil {
+		endStage(encodeSegment, "error")
 		return err
 	}
+	endStage(encodeSegment, "ok")
 	if replayID == "" {
 		return bus.PublishRaw(ctx, p.pub, subject, body)
 	}
@@ -430,9 +460,10 @@ func (p *Pipeline) handlerFailed(ctx context.Context, mctx *module.Context, m mo
 }
 
 // traceEvent tags the current New Relic transaction with the event identity.
-func traceEvent(ctx context.Context, eventType string, broadcasterID uint64) {
+func traceEvent(ctx context.Context, eventType, eventLane string, broadcasterID uint64) {
 	if txn := newrelic.FromContext(ctx); txn != nil {
 		txn.AddAttribute("event.type", eventType)
+		txn.AddAttribute("event.lane", eventLane)
 		txn.AddAttribute("event.broadcaster_id", broadcasterID)
 	}
 }

--- a/app/sesame/engine/pipeline.go
+++ b/app/sesame/engine/pipeline.go
@@ -127,19 +127,16 @@ const chatType = "channel.chat.message"
 // the event handlers registered for the type, and publishes what they emit. It
 // reads as a short sequence of guards and stages; the loops and the failure
 // bookkeeping live in the helpers below.
-func (p *Pipeline) Process(msg *bus.Message) (err error) {
+func (p *Pipeline) Process(msg *bus.Message) error {
 	ctx := msg.Context()
 
 	// Decode into a pooled envelope so the plain-chat path allocates nothing here.
 	env := GetEnvelope()
 	defer PutEnvelope(env)
-	decodeSegment := startStage(ctx, "sesame.decode")
-	if err := sonic.Unmarshal(msg.Payload, env); err != nil {
-		endStage(decodeSegment, "invalid")
+	if err := decodeEnvelope(ctx, msg.Payload, env); err != nil {
 		traceResult(ctx, "invalid")
 		return p.dropPoison(ctx, msg.UUID, err)
 	}
-	endStage(decodeSegment, "ok")
 	if !p.eligible(env) {
 		traceResult(ctx, "filtered")
 		return nil
@@ -152,14 +149,11 @@ func (p *Pipeline) Process(msg *bus.Message) (err error) {
 	}
 	traceEvent(ctx, env.Type, env.Lane, broadcasterID)
 
-	projectionSegment := startStage(ctx, "sesame.dependency.projection")
-	views, err := p.moduleViews(ctx, env.Type, broadcasterID)
+	views, err := p.tracedModuleViews(ctx, env.Type, broadcasterID)
 	if err != nil {
-		endStage(projectionSegment, "error")
 		traceResult(ctx, "error")
 		return err // infrastructure failure: nack
 	}
-	endStage(projectionSegment, "ok")
 
 	mctx := p.leaseContext(env, broadcasterID)
 	defer PutContext(mctx)
@@ -169,32 +163,59 @@ func (p *Pipeline) Process(msg *bus.Message) (err error) {
 		replayBase: outputReplayBase(env),
 	}
 	emit := p.newEmit(ctx, env.BroadcasterUserID, &emission)
-	engineSegment := startStage(ctx, "sesame.engine")
-	p.runStages(ctx, mctx, views, emit)
-	if emission.err != nil {
-		endStage(engineSegment, "error")
-	} else {
-		endStage(engineSegment, "ok")
-	}
-	if emission.err == nil && emission.needsFlush {
-		// Legacy envelopes without EventID cannot use a stable confirmed publish;
-		// flush their asynchronous admission before confirming the input ack.
-		flushSegment := startStage(ctx, "sesame.output.flush")
-		emission.err = p.pub.Flush(ctx)
-		if emission.err != nil {
-			endStage(flushSegment, "error")
-		} else {
-			endStage(flushSegment, "ok")
-		}
-	}
+	p.runTracedStages(ctx, mctx, views, emit, &emission)
+	p.flushLegacyOutput(ctx, &emission)
 
 	// nil = ack; a publish/marshal failure on the emit path = nack.
-	if emission.err != nil {
-		traceResult(ctx, "error")
-	} else {
-		traceResult(ctx, "ok")
-	}
+	tracePipelineResult(ctx, emission.err)
 	return emission.err
+}
+
+func decodeEnvelope(ctx context.Context, payload []byte, env *lane.Envelope) error {
+	segment := startStage(ctx, "sesame.decode")
+	err := sonic.Unmarshal(payload, env)
+	endStageForError(segment, err, "invalid")
+	return err
+}
+
+func (p *Pipeline) tracedModuleViews(ctx context.Context, eventType string, broadcasterID uint64) (map[string]projection.ModuleView, error) {
+	segment := startStage(ctx, "sesame.dependency.projection")
+	views, err := p.moduleViews(ctx, eventType, broadcasterID)
+	endStageForError(segment, err, "error")
+	return views, err
+}
+
+func (p *Pipeline) runTracedStages(ctx context.Context, mctx *module.Context, views map[string]projection.ModuleView, emit module.Emit, emission *emitState) {
+	segment := startStage(ctx, "sesame.engine")
+	p.runStages(ctx, mctx, views, emit)
+	endStageForError(segment, emission.err, "error")
+}
+
+func (p *Pipeline) flushLegacyOutput(ctx context.Context, emission *emitState) {
+	if emission.err != nil || !emission.needsFlush {
+		return
+	}
+	// Legacy envelopes without EventID cannot use a stable confirmed publish;
+	// flush their asynchronous admission before confirming the input ack.
+	segment := startStage(ctx, "sesame.output.flush")
+	emission.err = p.pub.Flush(ctx)
+	endStageForError(segment, emission.err, "error")
+}
+
+func endStageForError(segment *newrelic.Segment, err error, failure string) {
+	if err != nil {
+		endStage(segment, failure)
+		return
+	}
+	endStage(segment, "ok")
+}
+
+func tracePipelineResult(ctx context.Context, err error) {
+	if err != nil {
+		traceResult(ctx, "error")
+		return
+	}
+	traceResult(ctx, "ok")
 }
 
 // eligible reports whether this envelope needs any work: the bot's own chat is

--- a/app/sesame/engine/telemetry.go
+++ b/app/sesame/engine/telemetry.go
@@ -1,0 +1,34 @@
+package engine
+
+import (
+	"context"
+
+	"github.com/newrelic/go-agent/v3/newrelic"
+)
+
+const telemetryResultAttribute = "result"
+
+// startStage deliberately accepts only a fixed call-site name. Event types,
+// module names and broadcaster IDs are attributes on the sampled transaction,
+// never part of a span or metric name.
+func startStage(ctx context.Context, name string) *newrelic.Segment {
+	txn := newrelic.FromContext(ctx)
+	if txn == nil {
+		return nil
+	}
+	return txn.StartSegment(name)
+}
+
+func endStage(segment *newrelic.Segment, result string) {
+	if segment == nil {
+		return
+	}
+	segment.AddAttribute(telemetryResultAttribute, result)
+	segment.End()
+}
+
+func traceResult(ctx context.Context, result string) {
+	if txn := newrelic.FromContext(ctx); txn != nil {
+		txn.AddAttribute(telemetryResultAttribute, result)
+	}
+}

--- a/app/sesame/engine/valkey_hotpath_test.go
+++ b/app/sesame/engine/valkey_hotpath_test.go
@@ -41,19 +41,13 @@ type hotPathFixture struct {
 }
 
 func (f hotPathFixture) testChannelBump(t *testing.T) {
-	key := f.prefix + ":counter"
-	f.cleanupKeys(t, key)
-
-	_, err := bumpChannelScript.Exec(f.ctx, f.client, []string{key}, []string{"", "2", "60"}).AsInt64()
-	require.True(t, valkey.IsValkeyNil(err), "empty seed must decode as Valkey nil")
-	seeded, err := bumpChannelScript.Exec(f.ctx, f.client, []string{key}, []string{"41", "2", "60"}).AsInt64()
-	require.NoError(t, err)
-	require.EqualValues(t, 43, seeded)
-	warm, err := bumpChannelScript.Exec(f.ctx, f.client, []string{key}, []string{"", "3", "60"}).AsInt64()
-	require.NoError(t, err)
-	require.EqualValues(t, 46, warm)
+	key := f.testBump(t, bumpCase{
+		keySuffix: ":counter", script: bumpChannelScript,
+		missingArgs: []string{"", "2", "60"},
+		seedArgs:    []string{"41", "2", "60"}, seedValue: 43,
+		warmArgs: []string{"", "3", "60"}, warmValue: 46,
+	})
 	f.requireConcurrentBumps(t, key, 46)
-	requirePositiveTTL(t, f.ctx, f.client, key)
 }
 
 func (f hotPathFixture) requireConcurrentBumps(t *testing.T, key string, initial int) {
@@ -79,17 +73,37 @@ func (f hotPathFixture) requireConcurrentBumps(t *testing.T, key string, initial
 }
 
 func (f hotPathFixture) testEntryBump(t *testing.T) {
-	key := f.prefix + ":entries"
+	f.testBump(t, bumpCase{
+		keySuffix: ":entries", script: bumpEntryScript,
+		missingArgs: []string{"viewer", "", "1", "60"},
+		seedArgs:    []string{"viewer", "9", "1", "60"}, seedValue: 10,
+		warmArgs: []string{"viewer", "", "4", "60"}, warmValue: 14,
+	})
+}
+
+type bumpCase struct {
+	keySuffix   string
+	script      *valkey.Lua
+	missingArgs []string
+	seedArgs    []string
+	seedValue   int64
+	warmArgs    []string
+	warmValue   int64
+}
+
+func (f hotPathFixture) testBump(t *testing.T, test bumpCase) string {
+	key := f.prefix + test.keySuffix
 	f.cleanupKeys(t, key)
-	_, err := bumpEntryScript.Exec(f.ctx, f.client, []string{key}, []string{"viewer", "", "1", "60"}).AsInt64()
+	_, err := test.script.Exec(f.ctx, f.client, []string{key}, test.missingArgs).AsInt64()
 	require.True(t, valkey.IsValkeyNil(err), "empty seed must decode as Valkey nil")
-	seeded, err := bumpEntryScript.Exec(f.ctx, f.client, []string{key}, []string{"viewer", "9", "1", "60"}).AsInt64()
+	seeded, err := test.script.Exec(f.ctx, f.client, []string{key}, test.seedArgs).AsInt64()
 	require.NoError(t, err)
-	require.EqualValues(t, 10, seeded)
-	warm, err := bumpEntryScript.Exec(f.ctx, f.client, []string{key}, []string{"viewer", "", "4", "60"}).AsInt64()
+	require.EqualValues(t, test.seedValue, seeded)
+	warm, err := test.script.Exec(f.ctx, f.client, []string{key}, test.warmArgs).AsInt64()
 	require.NoError(t, err)
-	require.EqualValues(t, 14, warm)
+	require.EqualValues(t, test.warmValue, warm)
 	requirePositiveTTL(t, f.ctx, f.client, key)
+	return key
 }
 
 func (f hotPathFixture) testGreetClaim(t *testing.T) {

--- a/app/sesame/engine/valkey_hotpath_test.go
+++ b/app/sesame/engine/valkey_hotpath_test.go
@@ -15,139 +15,158 @@ import (
 // These tests are opt-in because atomic script semantics need a real Valkey
 // interpreter. They use the same VALKEY_TEST_ADDR convention as pkg/ratelimit.
 func TestValkeyHotPathScriptsIntegration(t *testing.T) {
-	client := newHotPathTestClient(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	t.Cleanup(cancel)
-	prefix := "test:sesame:hot:" + strconv.FormatInt(time.Now().UnixNano(), 10)
-
-	t.Run("loyalty channel seed and warm bump", func(t *testing.T) {
-		key := prefix + ":counter"
-		t.Cleanup(func() { client.Do(context.Background(), client.B().Del().Key(key).Build()) })
-
-		_, err := bumpChannelScript.Exec(ctx, client, []string{key}, []string{"", "2", "60"}).AsInt64()
-		require.True(t, valkey.IsValkeyNil(err), "empty seed must decode as Valkey nil")
-
-		seeded, err := bumpChannelScript.Exec(ctx, client, []string{key}, []string{"41", "2", "60"}).AsInt64()
-		require.NoError(t, err)
-		require.EqualValues(t, 43, seeded)
-
-		warm, err := bumpChannelScript.Exec(ctx, client, []string{key}, []string{"", "3", "60"}).AsInt64()
-		require.NoError(t, err)
-		require.EqualValues(t, 46, warm)
-
-		// The script is the only write for each caller, so concurrent replicas
-		// cannot lose or double-apply an accepted delta.
-		const replicas = 16
-		errs := make(chan error, replicas)
-		var wg sync.WaitGroup
-		wg.Add(replicas)
-		for range replicas {
-			go func() {
-				defer wg.Done()
-				errs <- bumpChannelScript.Exec(context.Background(), client,
-					[]string{key}, []string{"", "1", "60"}).Error()
-			}()
-		}
-		wg.Wait()
-		close(errs)
-		for err := range errs {
-			require.NoError(t, err)
-		}
-		final, err := client.Do(ctx, client.B().Get().Key(key).Build()).AsInt64()
-		require.NoError(t, err)
-		require.EqualValues(t, 46+replicas, final)
-		requirePositiveTTL(t, ctx, client, key)
-	})
-
-	t.Run("loyalty entry seed and warm bump", func(t *testing.T) {
-		key := prefix + ":entries"
-		t.Cleanup(func() { client.Do(context.Background(), client.B().Del().Key(key).Build()) })
-
-		_, err := bumpEntryScript.Exec(ctx, client, []string{key}, []string{"viewer", "", "1", "60"}).AsInt64()
-		require.True(t, valkey.IsValkeyNil(err), "empty seed must decode as Valkey nil")
-
-		seeded, err := bumpEntryScript.Exec(ctx, client, []string{key}, []string{"viewer", "9", "1", "60"}).AsInt64()
-		require.NoError(t, err)
-		require.EqualValues(t, 10, seeded)
-
-		warm, err := bumpEntryScript.Exec(ctx, client, []string{key}, []string{"viewer", "", "4", "60"}).AsInt64()
-		require.NoError(t, err)
-		require.EqualValues(t, 14, warm)
-		requirePositiveTTL(t, ctx, client, key)
-	})
-
-	t.Run("greet claim and expiry", func(t *testing.T) {
-		key := prefix + ":greet"
-		t.Cleanup(func() { client.Do(context.Background(), client.B().Del().Key(key).Build()) })
-
-		first, err := firstGreetScript.Exec(ctx, client, []string{key}, []string{"viewer", "60"}).AsInt64()
-		require.NoError(t, err)
-		require.EqualValues(t, 1, first)
-		second, err := firstGreetScript.Exec(ctx, client, []string{key}, []string{"viewer", "60"}).AsInt64()
-		require.NoError(t, err)
-		require.EqualValues(t, 0, second)
-		requirePositiveTTL(t, ctx, client, key)
-	})
-
-	t.Run("feed counters share one atomic call", func(t *testing.T) {
-		totalKey, todayKey := prefix+":feed-total", prefix+":feed-today"
-		t.Cleanup(func() { client.Do(context.Background(), client.B().Del().Key(totalKey, todayKey).Build()) })
-
-		_, err := decodeFeedCounts(feedWarmScript.Exec(ctx, client,
-			[]string{totalKey, todayKey}, []string{"60"}))
-		require.True(t, valkey.IsValkeyNil(err), "missing total must decode as Valkey nil")
-
-		// The DB seed already includes this feeding, so seeding must preserve
-		// 100 rather than incrementing it to 101. Only today's live window is
-		// incremented by the cold completion script.
-		seeded, err := decodeFeedCounts(feedSeedScript.Exec(ctx, client,
-			[]string{totalKey, todayKey}, []string{"100", "60"}))
-		require.NoError(t, err)
-		require.Equal(t, FeedCounts{Today: 1, Total: 100}, seeded)
-
-		warm, err := decodeFeedCounts(feedWarmScript.Exec(ctx, client,
-			[]string{totalKey, todayKey}, []string{"60"}))
-		require.NoError(t, err)
-		require.Equal(t, FeedCounts{Today: 2, Total: 101}, warm)
-
-		// A late cold seeder can only advance the view, never overwrite a
-		// newer live total with an older database reply.
-		stale, err := decodeFeedCounts(feedSeedScript.Exec(ctx, client,
-			[]string{totalKey, todayKey}, []string{"99", "60"}))
-		require.NoError(t, err)
-		require.Equal(t, FeedCounts{Today: 3, Total: 101}, stale)
-		requirePositiveTTL(t, ctx, client, todayKey)
-	})
+	fixture := hotPathFixture{
+		ctx:    ctx,
+		client: newHotPathTestClient(t),
+		prefix: "test:sesame:hot:" + strconv.FormatInt(time.Now().UnixNano(), 10),
+	}
+	t.Run("loyalty channel seed and warm bump", fixture.testChannelBump)
+	t.Run("loyalty entry seed and warm bump", fixture.testEntryBump)
+	t.Run("greet claim and expiry", fixture.testGreetClaim)
+	t.Run("feed counters share one atomic call", fixture.testFeedCounters)
 }
 
 func BenchmarkValkeyHotPathScriptsIntegration(b *testing.B) {
+	fixture := newHotPathBenchmark(b)
+	b.Run("loyalty_warm_one_rtt", fixture.benchmarkLoyalty)
+	b.Run("feed_warm_one_rtt", fixture.benchmarkFeed)
+}
+
+type hotPathFixture struct {
+	ctx    context.Context
+	client valkey.Client
+	prefix string
+}
+
+func (f hotPathFixture) testChannelBump(t *testing.T) {
+	key := f.prefix + ":counter"
+	f.cleanupKeys(t, key)
+
+	_, err := bumpChannelScript.Exec(f.ctx, f.client, []string{key}, []string{"", "2", "60"}).AsInt64()
+	require.True(t, valkey.IsValkeyNil(err), "empty seed must decode as Valkey nil")
+	seeded, err := bumpChannelScript.Exec(f.ctx, f.client, []string{key}, []string{"41", "2", "60"}).AsInt64()
+	require.NoError(t, err)
+	require.EqualValues(t, 43, seeded)
+	warm, err := bumpChannelScript.Exec(f.ctx, f.client, []string{key}, []string{"", "3", "60"}).AsInt64()
+	require.NoError(t, err)
+	require.EqualValues(t, 46, warm)
+	f.requireConcurrentBumps(t, key, 46)
+	requirePositiveTTL(t, f.ctx, f.client, key)
+}
+
+func (f hotPathFixture) requireConcurrentBumps(t *testing.T, key string, initial int) {
+	const replicas = 16
+	errs := make(chan error, replicas)
+	var wg sync.WaitGroup
+	wg.Add(replicas)
+	for range replicas {
+		go func() {
+			defer wg.Done()
+			errs <- bumpChannelScript.Exec(context.Background(), f.client,
+				[]string{key}, []string{"", "1", "60"}).Error()
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+	final, err := f.client.Do(f.ctx, f.client.B().Get().Key(key).Build()).AsInt64()
+	require.NoError(t, err)
+	require.EqualValues(t, initial+replicas, final)
+}
+
+func (f hotPathFixture) testEntryBump(t *testing.T) {
+	key := f.prefix + ":entries"
+	f.cleanupKeys(t, key)
+	_, err := bumpEntryScript.Exec(f.ctx, f.client, []string{key}, []string{"viewer", "", "1", "60"}).AsInt64()
+	require.True(t, valkey.IsValkeyNil(err), "empty seed must decode as Valkey nil")
+	seeded, err := bumpEntryScript.Exec(f.ctx, f.client, []string{key}, []string{"viewer", "9", "1", "60"}).AsInt64()
+	require.NoError(t, err)
+	require.EqualValues(t, 10, seeded)
+	warm, err := bumpEntryScript.Exec(f.ctx, f.client, []string{key}, []string{"viewer", "", "4", "60"}).AsInt64()
+	require.NoError(t, err)
+	require.EqualValues(t, 14, warm)
+	requirePositiveTTL(t, f.ctx, f.client, key)
+}
+
+func (f hotPathFixture) testGreetClaim(t *testing.T) {
+	key := f.prefix + ":greet"
+	f.cleanupKeys(t, key)
+	first, err := firstGreetScript.Exec(f.ctx, f.client, []string{key}, []string{"viewer", "60"}).AsInt64()
+	require.NoError(t, err)
+	require.EqualValues(t, 1, first)
+	second, err := firstGreetScript.Exec(f.ctx, f.client, []string{key}, []string{"viewer", "60"}).AsInt64()
+	require.NoError(t, err)
+	require.EqualValues(t, 0, second)
+	requirePositiveTTL(t, f.ctx, f.client, key)
+}
+
+func (f hotPathFixture) testFeedCounters(t *testing.T) {
+	totalKey, todayKey := f.prefix+":feed-total", f.prefix+":feed-today"
+	f.cleanupKeys(t, totalKey, todayKey)
+	_, err := decodeFeedCounts(feedWarmScript.Exec(f.ctx, f.client, []string{totalKey, todayKey}, []string{"60"}))
+	require.True(t, valkey.IsValkeyNil(err), "missing total must decode as Valkey nil")
+	seeded, err := decodeFeedCounts(feedSeedScript.Exec(f.ctx, f.client, []string{totalKey, todayKey}, []string{"100", "60"}))
+	require.NoError(t, err)
+	require.Equal(t, FeedCounts{Today: 1, Total: 100}, seeded)
+	warm, err := decodeFeedCounts(feedWarmScript.Exec(f.ctx, f.client, []string{totalKey, todayKey}, []string{"60"}))
+	require.NoError(t, err)
+	require.Equal(t, FeedCounts{Today: 2, Total: 101}, warm)
+	stale, err := decodeFeedCounts(feedSeedScript.Exec(f.ctx, f.client, []string{totalKey, todayKey}, []string{"99", "60"}))
+	require.NoError(t, err)
+	require.Equal(t, FeedCounts{Today: 3, Total: 101}, stale)
+	requirePositiveTTL(t, f.ctx, f.client, todayKey)
+}
+
+func (f hotPathFixture) cleanupKeys(tb testingTB, keys ...string) {
+	tb.Cleanup(func() {
+		f.client.Do(context.Background(), f.client.B().Del().Key(keys...).Build())
+	})
+}
+
+type hotPathBenchmark struct {
+	ctx     context.Context
+	client  valkey.Client
+	counter string
+	total   string
+	today   string
+}
+
+func newHotPathBenchmark(b *testing.B) hotPathBenchmark {
 	client := newHotPathTestClient(b)
-	ctx := context.Background()
 	prefix := "bench:sesame:hot:" + strconv.FormatInt(time.Now().UnixNano(), 10)
+	fixture := hotPathBenchmark{
+		ctx: context.Background(), client: client,
+		counter: prefix + ":counter", total: prefix + ":total", today: prefix + ":today",
+	}
 	b.Cleanup(func() {
-		client.Do(context.Background(), client.B().Del().Key(prefix+":counter", prefix+":total", prefix+":today").Build())
+		client.Do(context.Background(), client.B().Del().Key(fixture.counter, fixture.total, fixture.today).Build())
 	})
+	require.NoError(b, client.Do(fixture.ctx, client.B().Set().Key(fixture.counter).Value("0").Build()).Error())
+	require.NoError(b, client.Do(fixture.ctx, client.B().Set().Key(fixture.total).Value("1").Build()).Error())
+	return fixture
+}
 
-	require.NoError(b, client.Do(ctx, client.B().Set().Key(prefix+":counter").Value("0").Build()).Error())
-	require.NoError(b, client.Do(ctx, client.B().Set().Key(prefix+":total").Value("1").Build()).Error())
+func (f hotPathBenchmark) benchmarkLoyalty(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		if err := bumpChannelScript.Exec(f.ctx, f.client, []string{f.counter}, []string{"", "1", "60"}).Error(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
 
-	b.Run("loyalty_warm_one_rtt", func(b *testing.B) {
-		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
-			if err := bumpChannelScript.Exec(ctx, client, []string{prefix + ":counter"}, []string{"", "1", "60"}).Error(); err != nil {
-				b.Fatal(err)
-			}
+func (f hotPathBenchmark) benchmarkFeed(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := decodeFeedCounts(feedWarmScript.Exec(f.ctx, f.client,
+			[]string{f.total, f.today}, []string{"60"})); err != nil {
+			b.Fatal(err)
 		}
-	})
-	b.Run("feed_warm_one_rtt", func(b *testing.B) {
-		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
-			if _, err := decodeFeedCounts(feedWarmScript.Exec(ctx, client,
-				[]string{prefix + ":total", prefix + ":today"}, []string{"60"})); err != nil {
-				b.Fatal(err)
-			}
-		}
-	})
+	}
 }
 
 type testingTB interface {

--- a/app/sesame/engine/valkey_hotpath_test.go
+++ b/app/sesame/engine/valkey_hotpath_test.go
@@ -1,0 +1,182 @@
+package engine
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/valkey-io/valkey-go"
+)
+
+// These tests are opt-in because atomic script semantics need a real Valkey
+// interpreter. They use the same VALKEY_TEST_ADDR convention as pkg/ratelimit.
+func TestValkeyHotPathScriptsIntegration(t *testing.T) {
+	client := newHotPathTestClient(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	prefix := "test:sesame:hot:" + strconv.FormatInt(time.Now().UnixNano(), 10)
+
+	t.Run("loyalty channel seed and warm bump", func(t *testing.T) {
+		key := prefix + ":counter"
+		t.Cleanup(func() { client.Do(context.Background(), client.B().Del().Key(key).Build()) })
+
+		_, err := bumpChannelScript.Exec(ctx, client, []string{key}, []string{"", "2", "60"}).AsInt64()
+		require.True(t, valkey.IsValkeyNil(err), "empty seed must decode as Valkey nil")
+
+		seeded, err := bumpChannelScript.Exec(ctx, client, []string{key}, []string{"41", "2", "60"}).AsInt64()
+		require.NoError(t, err)
+		require.EqualValues(t, 43, seeded)
+
+		warm, err := bumpChannelScript.Exec(ctx, client, []string{key}, []string{"", "3", "60"}).AsInt64()
+		require.NoError(t, err)
+		require.EqualValues(t, 46, warm)
+
+		// The script is the only write for each caller, so concurrent replicas
+		// cannot lose or double-apply an accepted delta.
+		const replicas = 16
+		errs := make(chan error, replicas)
+		var wg sync.WaitGroup
+		wg.Add(replicas)
+		for range replicas {
+			go func() {
+				defer wg.Done()
+				errs <- bumpChannelScript.Exec(context.Background(), client,
+					[]string{key}, []string{"", "1", "60"}).Error()
+			}()
+		}
+		wg.Wait()
+		close(errs)
+		for err := range errs {
+			require.NoError(t, err)
+		}
+		final, err := client.Do(ctx, client.B().Get().Key(key).Build()).AsInt64()
+		require.NoError(t, err)
+		require.EqualValues(t, 46+replicas, final)
+		requirePositiveTTL(t, ctx, client, key)
+	})
+
+	t.Run("loyalty entry seed and warm bump", func(t *testing.T) {
+		key := prefix + ":entries"
+		t.Cleanup(func() { client.Do(context.Background(), client.B().Del().Key(key).Build()) })
+
+		_, err := bumpEntryScript.Exec(ctx, client, []string{key}, []string{"viewer", "", "1", "60"}).AsInt64()
+		require.True(t, valkey.IsValkeyNil(err), "empty seed must decode as Valkey nil")
+
+		seeded, err := bumpEntryScript.Exec(ctx, client, []string{key}, []string{"viewer", "9", "1", "60"}).AsInt64()
+		require.NoError(t, err)
+		require.EqualValues(t, 10, seeded)
+
+		warm, err := bumpEntryScript.Exec(ctx, client, []string{key}, []string{"viewer", "", "4", "60"}).AsInt64()
+		require.NoError(t, err)
+		require.EqualValues(t, 14, warm)
+		requirePositiveTTL(t, ctx, client, key)
+	})
+
+	t.Run("greet claim and expiry", func(t *testing.T) {
+		key := prefix + ":greet"
+		t.Cleanup(func() { client.Do(context.Background(), client.B().Del().Key(key).Build()) })
+
+		first, err := firstGreetScript.Exec(ctx, client, []string{key}, []string{"viewer", "60"}).AsInt64()
+		require.NoError(t, err)
+		require.EqualValues(t, 1, first)
+		second, err := firstGreetScript.Exec(ctx, client, []string{key}, []string{"viewer", "60"}).AsInt64()
+		require.NoError(t, err)
+		require.EqualValues(t, 0, second)
+		requirePositiveTTL(t, ctx, client, key)
+	})
+
+	t.Run("feed counters share one atomic call", func(t *testing.T) {
+		totalKey, todayKey := prefix+":feed-total", prefix+":feed-today"
+		t.Cleanup(func() { client.Do(context.Background(), client.B().Del().Key(totalKey, todayKey).Build()) })
+
+		_, err := decodeFeedCounts(feedWarmScript.Exec(ctx, client,
+			[]string{totalKey, todayKey}, []string{"60"}))
+		require.True(t, valkey.IsValkeyNil(err), "missing total must decode as Valkey nil")
+
+		// The DB seed already includes this feeding, so seeding must preserve
+		// 100 rather than incrementing it to 101. Only today's live window is
+		// incremented by the cold completion script.
+		seeded, err := decodeFeedCounts(feedSeedScript.Exec(ctx, client,
+			[]string{totalKey, todayKey}, []string{"100", "60"}))
+		require.NoError(t, err)
+		require.Equal(t, FeedCounts{Today: 1, Total: 100}, seeded)
+
+		warm, err := decodeFeedCounts(feedWarmScript.Exec(ctx, client,
+			[]string{totalKey, todayKey}, []string{"60"}))
+		require.NoError(t, err)
+		require.Equal(t, FeedCounts{Today: 2, Total: 101}, warm)
+
+		// A late cold seeder can only advance the view, never overwrite a
+		// newer live total with an older database reply.
+		stale, err := decodeFeedCounts(feedSeedScript.Exec(ctx, client,
+			[]string{totalKey, todayKey}, []string{"99", "60"}))
+		require.NoError(t, err)
+		require.Equal(t, FeedCounts{Today: 3, Total: 101}, stale)
+		requirePositiveTTL(t, ctx, client, todayKey)
+	})
+}
+
+func BenchmarkValkeyHotPathScriptsIntegration(b *testing.B) {
+	client := newHotPathTestClient(b)
+	ctx := context.Background()
+	prefix := "bench:sesame:hot:" + strconv.FormatInt(time.Now().UnixNano(), 10)
+	b.Cleanup(func() {
+		client.Do(context.Background(), client.B().Del().Key(prefix+":counter", prefix+":total", prefix+":today").Build())
+	})
+
+	require.NoError(b, client.Do(ctx, client.B().Set().Key(prefix+":counter").Value("0").Build()).Error())
+	require.NoError(b, client.Do(ctx, client.B().Set().Key(prefix+":total").Value("1").Build()).Error())
+
+	b.Run("loyalty_warm_one_rtt", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			if err := bumpChannelScript.Exec(ctx, client, []string{prefix + ":counter"}, []string{"", "1", "60"}).Error(); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	b.Run("feed_warm_one_rtt", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			if _, err := decodeFeedCounts(feedWarmScript.Exec(ctx, client,
+				[]string{prefix + ":total", prefix + ":today"}, []string{"60"})); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+type testingTB interface {
+	Helper()
+	Skip(args ...any)
+	Fatal(args ...any)
+	Cleanup(func())
+}
+
+func newHotPathTestClient(tb testingTB) valkey.Client {
+	tb.Helper()
+	address := os.Getenv("VALKEY_TEST_ADDR")
+	if address == "" {
+		tb.Skip("VALKEY_TEST_ADDR is not set")
+	}
+	client, err := valkey.NewClient(valkey.ClientOption{
+		InitAddress: []string{address},
+		Password:    os.Getenv("VALKEY_TEST_PASSWORD"),
+	})
+	if err != nil {
+		tb.Fatal(err)
+	}
+	tb.Cleanup(client.Close)
+	return client
+}
+
+func requirePositiveTTL(t *testing.T, ctx context.Context, client valkey.Client, key string) {
+	t.Helper()
+	ttl, err := client.Do(ctx, client.B().Ttl().Key(key).Build()).AsInt64()
+	require.NoError(t, err)
+	require.Positive(t, ttl)
+}

--- a/deploy/k8s/nats-live-acceptance/README.md
+++ b/deploy/k8s/nats-live-acceptance/README.md
@@ -131,11 +131,13 @@ The sequence is:
    qualify the Elixir ingress path.
 4. Offer 126,000 events/second for five minutes and require at least 120,000
    acknowledged events/second.
-5. Offer exactly 90,000 events/second for fifteen minutes as the 75% operating
+5. Offer exactly 90,000 events/second for thirty minutes as the 75% operating
    soak and require at least 89,100 acknowledged events/second (99% delivery
    cadence, with all messages still acknowledged).
-6. Require zero message/connection errors, p95 <= 20 ms, p99 <= 2 ms, no
-   stream-leader election advisory during load, all three peers current,
+6. Require zero message/connection errors, p95 <= 20 ms and p99 <= 2 ms at both
+   the 12k/s normal-load canary and higher offered load, broker CPU below 75%
+   of its four-core limit, no stream-leader election advisory during load, all
+   three peers current,
    follower lag returned to zero, and no queue, slow-consumer, write-deadline,
    or quorum error in NATS logs.
 
@@ -196,7 +198,7 @@ CONFIRM_R3_SHADOW=R3-120K R3_CANARY_ONLY=true \
   deploy/k8s/nats-live-acceptance/r3-120k.sh
 
 # Full qualification. OPERATING_SECONDS=3600 extends the 75% operating soak to
-# one hour for the long-run stability gate; omit it for the 15-minute contract.
+# one hour for the long-run stability gate; omit it for the 30-minute contract.
 CONFIRM_R3_SHADOW=R3-120K OPERATING_SECONDS=3600 \
   NATS_BENCH_SETUP_SECRET="$setup_secret" \
   deploy/k8s/nats-live-acceptance/r3-120k.sh
@@ -217,6 +219,10 @@ default. The three SLI pods read the existing `ADMIN_RPC` keys from
 neither BUS publishing nor stream-management credentials. Override Secret
 names only with `NATS_BENCH_PUBLISHER_SECRET` and
 `NATS_BENCH_ADMIN_RPC_SECRET`.
+
+Publishers use their node-local hub by default, matching the live Service
+locality policy. `R3_PUBLISH_TARGET=preferred` is a comparison-only override;
+it cannot qualify the node-local operating contract.
 
 Each trial uses a shared start barrier and computes fleet throughput over the
 earliest publisher start through the latest publisher finish, so delayed or
@@ -240,6 +246,17 @@ CONFIRM_R3_SHADOW=R3-120K R3_SLI_ONLY=true \
 
 This mode needs `console-admin-env` and the existing Valkey credential only;
 it does not need the temporary JetStream setup Secret.
+
+Compare retained R1/R3 and node-local/preferred summaries without touching the
+cluster. The reporter exits non-zero until it sees a node-local R3 result that
+passes the 90k/s, 30-minute, 2 ms loaded-p99, and 75%-CPU gates:
+
+```sh
+deploy/k8s/nats-live-acceptance/r3-matrix-report.sh \
+  /tmp/nats-r3-isolated-* /tmp/nats-r3-results-*
+```
+
+Use `--report-only` to render an incomplete calibration matrix.
 
 ## Direct leaf RPC test
 

--- a/deploy/k8s/nats-live-acceptance/capacity_test.go
+++ b/deploy/k8s/nats-live-acceptance/capacity_test.go
@@ -42,10 +42,15 @@ type capacityProfile struct {
 	CalibrationTargetEPS        int      `json:"calibration_target_eps"`
 	CalibrationDuration         string   `json:"calibration_duration"`
 	LatencySamplesPerSecond     int      `json:"latency_samples_per_second"`
-	PubAckP99Max                string   `json:"puback_p99_max"`
+	NormalLoadEPS               int      `json:"normal_load_eps"`
+	NormalLoadPubAckP99Max      string   `json:"normal_load_puback_p99_max"`
+	LoadedPubAckP99Max          string   `json:"loaded_puback_p99_max"`
+	BrokerCPULimitCores         int      `json:"broker_cpu_limit_cores"`
+	BrokerCPUMaxPct             int      `json:"broker_cpu_max_pct"`
 	RPCP99Max                   string   `json:"rpc_p99_max"`
 	RPCP99MinSamples            int      `json:"rpc_p99_min_samples"`
 	MaxAckGap                   string   `json:"max_ack_gap"`
+	OperatingDuration           string   `json:"operating_duration"`
 }
 
 func TestR3CapacityProfileDefinesRateEnvelope(t *testing.T) {
@@ -102,10 +107,15 @@ func TestR3CapacityProfileDefinesCalibrationMatrix(t *testing.T) {
 	require.Equal(t, 120_000, profile.CalibrationTargetEPS)
 	require.Equal(t, "10s", profile.CalibrationDuration)
 	require.Equal(t, 20, profile.LatencySamplesPerSecond)
-	require.Equal(t, "2ms", profile.PubAckP99Max)
+	require.Equal(t, 12_000, profile.NormalLoadEPS)
+	require.Equal(t, "2ms", profile.NormalLoadPubAckP99Max)
+	require.Equal(t, "2ms", profile.LoadedPubAckP99Max)
+	require.Equal(t, 4, profile.BrokerCPULimitCores)
+	require.Equal(t, 75, profile.BrokerCPUMaxPct)
 	require.Equal(t, "8ms", profile.RPCP99Max)
 	require.Equal(t, 330, profile.RPCP99MinSamples)
 	require.Equal(t, "2s", profile.MaxAckGap)
+	require.Equal(t, "30m", profile.OperatingDuration)
 }
 
 func TestTemporaryR3StreamMatchesProductionShapedRetention(t *testing.T) {

--- a/deploy/k8s/nats-live-acceptance/matrix_report_test.go
+++ b/deploy/k8s/nats-live-acceptance/matrix_report_test.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestR3RunnerDefaultsToNodeLocalPublishAndCapturesBrokerPressure(t *testing.T) {
+	script, err := os.ReadFile("r3-120k.sh")
+	require.NoError(t, err)
+	body := string(script)
+	for _, required := range []string{
+		`publish_target=${R3_PUBLISH_TARGET:-local}`,
+		`publisher_url_for_node`,
+		`proxy/routez?subs=0`,
+		`broker_metrics`,
+		`max_broker_cpu_pct`,
+		`trial_max_p99_ms`,
+	} {
+		require.Contains(t, body, required)
+	}
+	require.NotContains(t, body, `-hub-url="$leader_url" -domain= -replicas=3 -required-peers=3 \
+      -stream "$current_stream" -subject "$current_subject" \
+      -create-stream=false -cleanup=false \
+      -producer-id=`)
+}
+
+func TestIsolatedR3RunnerCapturesBrokerAndRouteDiagnostics(t *testing.T) {
+	script, err := os.ReadFile("r3-isolated-tune.sh")
+	require.NoError(t, err)
+	body := string(script)
+	for _, required := range []string{
+		`broker_metrics_snapshot`,
+		`proxy/routez?subs=0`,
+		`peak_route_pending_bytes`,
+		`peak_follower_lag`,
+		`R3_ISOLATED_BROKER_CPU_MAX_PCT`,
+	} {
+		require.Contains(t, body, required)
+	}
+}
+
+func TestR3MatrixReportQualifiesOnlyTheFullOperatingGate(t *testing.T) {
+	dir := t.TempDir()
+	qualified := matrixFixture(90_000, 89_500, 1_800_000, 1.9, 74, true)
+	qualifiedPath := filepath.Join(dir, "summary.json")
+	writeJSON(t, qualifiedPath, qualified)
+
+	cmd := exec.Command("bash", "r3-matrix-report.sh", qualifiedPath)
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(output))
+	var report struct {
+		Qualified     bool             `json:"qualified"`
+		QualifiedRuns []map[string]any `json:"qualified_runs"`
+	}
+	require.NoError(t, json.Unmarshal(output, &report))
+	require.True(t, report.Qualified)
+	require.Len(t, report.QualifiedRuns, 1)
+
+	short := matrixFixture(90_000, 89_500, 1_799_999, 1.9, 74, true)
+	shortPath := filepath.Join(dir, "short.json")
+	writeJSON(t, shortPath, short)
+	cmd = exec.Command("bash", "r3-matrix-report.sh", shortPath)
+	output, err = cmd.CombinedOutput()
+	require.Error(t, err, string(output))
+	require.Contains(t, string(output), "not yet qualified")
+
+	cmd = exec.Command("bash", "r3-matrix-report.sh", "--report-only", shortPath)
+	output, err = cmd.CombinedOutput()
+	require.NoError(t, err, string(output))
+
+	tooSlow := matrixFixture(90_000, 89_500, 1_800_000, 2.01, 74, true)
+	tooSlowPath := filepath.Join(dir, "too-slow.json")
+	writeJSON(t, tooSlowPath, tooSlow)
+	cmd = exec.Command("bash", "r3-matrix-report.sh", tooSlowPath)
+	output, err = cmd.CombinedOutput()
+	require.Error(t, err, string(output))
+	require.Contains(t, string(output), "not yet qualified")
+}
+
+func matrixFixture(target int, acknowledged float64, durationMS int, p99, cpu float64, passed bool) map[string]any {
+	return map[string]any{
+		"stream_replicas":               3,
+		"publish_target":                "local",
+		"publish_mode":                  "async",
+		"target_messages_per_second":    target,
+		"aggregate_messages_per_second": acknowledged,
+		"conservative_duration_ms":      durationMS,
+		"worst_node_puback_p50_ms":      1.0,
+		"worst_node_puback_p95_ms":      4.0,
+		"worst_node_puback_p99_ms":      p99,
+		"puback_max_ms":                 10.0,
+		"broker_metrics": map[string]any{
+			"peak_cpu_limit_utilization_pct": cpu,
+			"peak_memory_bytes":              1_000_000,
+			"peak_route_pending_bytes":       0,
+			"peak_follower_lag":              0,
+		},
+		"errors":     0,
+		"timeouts":   0,
+		"reconnects": 0,
+		"passed":     passed,
+	}
+}
+
+func writeJSON(t *testing.T, path string, value any) {
+	t.Helper()
+	data, err := json.Marshal(value)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, data, 0o600))
+}

--- a/deploy/k8s/nats-live-acceptance/matrix_report_test.go
+++ b/deploy/k8s/nats-live-acceptance/matrix_report_test.go
@@ -47,7 +47,10 @@ func TestIsolatedR3RunnerCapturesBrokerAndRouteDiagnostics(t *testing.T) {
 
 func TestR3MatrixReportQualifiesOnlyTheFullOperatingGate(t *testing.T) {
 	dir := t.TempDir()
-	qualified := matrixFixture(90_000, 89_500, 1_800_000, 1.9, 74, true)
+	qualified := matrixFixture(matrixRun{
+		target: 90_000, acknowledged: 89_500, durationMS: 1_800_000,
+		p99: 1.9, cpu: 74, passed: true,
+	})
 	qualifiedPath := filepath.Join(dir, "summary.json")
 	writeJSON(t, qualifiedPath, qualified)
 
@@ -62,7 +65,10 @@ func TestR3MatrixReportQualifiesOnlyTheFullOperatingGate(t *testing.T) {
 	require.True(t, report.Qualified)
 	require.Len(t, report.QualifiedRuns, 1)
 
-	short := matrixFixture(90_000, 89_500, 1_799_999, 1.9, 74, true)
+	short := matrixFixture(matrixRun{
+		target: 90_000, acknowledged: 89_500, durationMS: 1_799_999,
+		p99: 1.9, cpu: 74, passed: true,
+	})
 	shortPath := filepath.Join(dir, "short.json")
 	writeJSON(t, shortPath, short)
 	cmd = exec.Command("bash", "r3-matrix-report.sh", shortPath)
@@ -74,7 +80,10 @@ func TestR3MatrixReportQualifiesOnlyTheFullOperatingGate(t *testing.T) {
 	output, err = cmd.CombinedOutput()
 	require.NoError(t, err, string(output))
 
-	tooSlow := matrixFixture(90_000, 89_500, 1_800_000, 2.01, 74, true)
+	tooSlow := matrixFixture(matrixRun{
+		target: 90_000, acknowledged: 89_500, durationMS: 1_800_000,
+		p99: 2.01, cpu: 74, passed: true,
+	})
 	tooSlowPath := filepath.Join(dir, "too-slow.json")
 	writeJSON(t, tooSlowPath, tooSlow)
 	cmd = exec.Command("bash", "r3-matrix-report.sh", tooSlowPath)
@@ -83,20 +92,29 @@ func TestR3MatrixReportQualifiesOnlyTheFullOperatingGate(t *testing.T) {
 	require.Contains(t, string(output), "not yet qualified")
 }
 
-func matrixFixture(target int, acknowledged float64, durationMS int, p99, cpu float64, passed bool) map[string]any {
+type matrixRun struct {
+	target       int
+	acknowledged float64
+	durationMS   int
+	p99          float64
+	cpu          float64
+	passed       bool
+}
+
+func matrixFixture(run matrixRun) map[string]any {
 	return map[string]any{
 		"stream_replicas":               3,
 		"publish_target":                "local",
 		"publish_mode":                  "async",
-		"target_messages_per_second":    target,
-		"aggregate_messages_per_second": acknowledged,
-		"conservative_duration_ms":      durationMS,
+		"target_messages_per_second":    run.target,
+		"aggregate_messages_per_second": run.acknowledged,
+		"conservative_duration_ms":      run.durationMS,
 		"worst_node_puback_p50_ms":      1.0,
 		"worst_node_puback_p95_ms":      4.0,
-		"worst_node_puback_p99_ms":      p99,
+		"worst_node_puback_p99_ms":      run.p99,
 		"puback_max_ms":                 10.0,
 		"broker_metrics": map[string]any{
-			"peak_cpu_limit_utilization_pct": cpu,
+			"peak_cpu_limit_utilization_pct": run.cpu,
 			"peak_memory_bytes":              1_000_000,
 			"peak_route_pending_bytes":       0,
 			"peak_follower_lag":              0,
@@ -104,7 +122,7 @@ func matrixFixture(target int, acknowledged float64, durationMS int, p99, cpu fl
 		"errors":     0,
 		"timeouts":   0,
 		"reconnects": 0,
-		"passed":     passed,
+		"passed":     run.passed,
 	}
 }
 

--- a/deploy/k8s/nats-live-acceptance/r3-120k.sh
+++ b/deploy/k8s/nats-live-acceptance/r3-120k.sh
@@ -17,7 +17,8 @@ R3 shadow plan (no actions performed):
 	  - R3_SLI_ONLY=true measures the three node-local RPC/Valkey lanes without
 	    creating a stream or publisher pod
 	  - gate 120,000 events/s at a 126,000/s offered load for five minutes
-  - soak the 90,000 events/s operating point for fifteen minutes
+  - publish node-locally by default; R3_PUBLISH_TARGET=preferred is comparison-only
+  - soak the 90,000 events/s operating point for thirty minutes
   - delete the owned shadow stream and every temporary pod on exit
 
 Set CONFIRM_R3_SHADOW=R3-120K to run this controlled live-cluster test.
@@ -75,8 +76,13 @@ payload_bytes=$(jq -er '.payload_bytes' "$profile")
 payload_variants=$(jq -er '.payload_variants' "$profile")
 atomic_inflight=$(jq -er '.atomic_inflight_per_connection' "$profile")
 max_p95_ms=${R3_PUBACK_P95_MAX_MS:-$(jq -er '.puback_p95_max | rtrimstr("ms") | tonumber' "$profile")}
-max_p99_ms=${R3_PUBACK_P99_MAX_MS:-$(jq -er '.puback_p99_max | rtrimstr("ms") | tonumber' "$profile")}
+normal_load_eps=$(jq -er '.normal_load_eps' "$profile")
+normal_load_max_p99_ms=${R3_NORMAL_LOAD_PUBACK_P99_MAX_MS:-${R3_PUBACK_P99_MAX_MS:-$(jq -er '.normal_load_puback_p99_max | rtrimstr("ms") | tonumber' "$profile")}}
+loaded_max_p99_ms=${R3_LOADED_PUBACK_P99_MAX_MS:-${R3_PUBACK_P99_MAX_MS:-$(jq -er '.loaded_puback_p99_max | rtrimstr("ms") | tonumber' "$profile")}}
+max_broker_cpu_pct=${R3_BROKER_CPU_MAX_PCT:-$(jq -er '.broker_cpu_max_pct' "$profile")}
+broker_cpu_limit_cores=$(jq -er '.broker_cpu_limit_cores' "$profile")
 max_ack_gap=$(jq -er '.max_ack_gap' "$profile")
+publish_target=${R3_PUBLISH_TARGET:-local}
 
 calibration_messages=${CALIBRATION_MESSAGES:-$(jq -er '.calibration_messages' "$profile")}
 calibration_target_eps=${CALIBRATION_TARGET_EPS:-$(jq -er '.calibration_target_eps' "$profile")}
@@ -127,6 +133,7 @@ health_monitor_stop="$results_dir/production-health.stop"
 health_monitor_ready="$results_dir/production-health.ready"
 health_monitor_pid=
 health_monitor_started=false
+nats_topology=
 sli_monitor_files=()
 sli_monitor_errs=()
 sli_monitor_ready_files=()
@@ -141,6 +148,14 @@ done
 positive_integer() {
 	[[ $1 =~ ^[1-9][0-9]*$ ]]
 }
+
+case $publish_target in
+	local|preferred) ;;
+	*)
+		echo "R3_PUBLISH_TARGET must be local or preferred" >&2
+		exit 1
+		;;
+esac
 
 duration_seconds() {
 	local remaining=$1 total=0 amount unit
@@ -186,7 +201,9 @@ configure_run_lifetime_and_canaries() {
 	for value in "$calibration_seconds" "$ceiling_seconds" "$operating_seconds" \
 		"$meta_cooldown_seconds" "$canary_seconds" "$health_freshness_seconds" "$quick_seconds" \
 		"$fast_sustain_eps" "$fast_sustain_min_eps" "$fast_sustain_seconds" \
-		"$fast_sustain_batch" "$fast_sustain_outstanding"; do
+		"$fast_sustain_batch" "$fast_sustain_outstanding" "$normal_load_eps" \
+		"$normal_load_max_p99_ms" "$loaded_max_p99_ms" "$max_broker_cpu_pct" \
+		"$broker_cpu_limit_cores"; do
 		if ! positive_integer "$value"; then
 			echo "benchmark durations and cooldowns must be positive integer seconds" >&2
 			return 1
@@ -484,28 +501,38 @@ create_pod() {
 }
 
 require_nats_topology() {
-  local topology
-	topology=$(kubectl --request-timeout="$deployment_query_timeout" -n "$namespace" get pods -l app=nats -o json | jq -c '
+	nats_topology=$(kubectl --request-timeout="$deployment_query_timeout" -n "$namespace" get pods -l app=nats -o json | jq -c '
     [.items[] | {
       server:.metadata.name,
       node:.spec.nodeName,
       ready:([.status.containerStatuses[]? | select(.name == "nats") | .ready] | any)
     }]
   ')
-  if [[ $(jq '[.[] | select(.ready)] | length' <<<"$topology") != 3 ]]; then
-    echo "R3 shadow requires exactly the three ready NATS servers in the capacity profile: $topology" >&2
+	if [[ $(jq '[.[] | select(.ready)] | length' <<<"$nats_topology") != 3 ]]; then
+	  echo "R3 shadow requires exactly the three ready NATS servers in the capacity profile: $nats_topology" >&2
     exit 1
   fi
   for node in "${nodes[@]}"; do
-    if [[ $(jq --arg node "$node" '[.[] | select(.node == $node and .ready)] | length' <<<"$topology") != 1 ]]; then
-      echo "expected exactly one ready NATS server on $node: $topology" >&2
+	  if [[ $(jq --arg node "$node" '[.[] | select(.node == $node and .ready)] | length' <<<"$nats_topology") != 1 ]]; then
+	    echo "expected exactly one ready NATS server on $node: $nats_topology" >&2
       exit 1
     fi
   done
-  preferred_server=$(jq -er '.[] | select(.node == "node3") | .server' <<<"$topology")
-  forbidden_server=$(jq -er '.[] | select(.node == "worker1") | .server' <<<"$topology")
-  echo "NATS map: $topology"
+  preferred_server=$(jq -er '.[] | select(.node == "node3") | .server' <<<"$nats_topology")
+  forbidden_server=$(jq -er '.[] | select(.node == "worker1") | .server' <<<"$nats_topology")
+  echo "NATS map: $nats_topology"
   echo "preferred leader on node3: $preferred_server; forbidden leader on worker1: $forbidden_server"
+}
+
+publisher_url_for_node() {
+	local node=$1 server
+	if [[ $publish_target == preferred ]]; then
+		printf '%s\n' "$leader_url"
+		return
+	fi
+	server=$(jq -er --arg node "$node" '.[] | select(.node == $node and .ready) | .server' \
+		<<<"$nats_topology")
+	printf 'tls://%s.nats-headless.%s.svc.cluster.local:4222\n' "$server" "$namespace"
 }
 
 extract_authoritative_stream_topologies() {
@@ -539,7 +566,7 @@ extract_authoritative_stream_topologies() {
 }
 
 cluster_health_snapshot() {
-	local deployments production_pods valkey_pods nats_pods pod varz jsz broker consumers topologies
+	local deployments production_pods valkey_pods nats_pods pod varz routez jsz broker consumers topologies
 	local brokers_json='[]' consumers_json='[]' topologies_json='[]'
 	if ! deployments=$(kubectl --request-timeout="$deployment_query_timeout" -n "$namespace" get deployments -o json); then
 		echo "failed to query production Deployments within $deployment_query_timeout" >&2
@@ -568,13 +595,37 @@ cluster_health_snapshot() {
 			echo "failed to query $pod jsz within $broker_query_timeout" >&2
 			return 1
 		fi
-		if ! broker=$(jq -ce --arg pod "$pod" '{
+		if ! routez=$(kubectl --request-timeout="$broker_query_timeout" get --raw \
+			"/api/v1/namespaces/${namespace}/pods/${pod}:8222/proxy/routez?subs=0"); then
+			echo "failed to query $pod routez within $broker_query_timeout" >&2
+			return 1
+		fi
+		if ! broker=$(jq -nce --arg pod "$pod" --argjson cpu_limit_cores "$broker_cpu_limit_cores" \
+			--argjson varz "$varz" --argjson routez "$routez" '{
 			name:$pod,
-			slow_consumers:(.slow_consumers // 0),
-			meta_pending:(.jetstream.meta.pending // 0),
-			meta_pending_requests:(.jetstream.meta.pending_requests // 0),
-			meta_pending_infos:(.jetstream.meta.pending_infos // 0)
-		}' <<<"$varz"); then
+			cpu_pct:($varz.cpu // 0),
+			cpu_cores:(($varz.cpu // 0) / 100),
+			cpu_limit_utilization_pct:(($varz.cpu // 0) / $cpu_limit_cores),
+			memory_bytes:($varz.mem // 0),
+			connections:($varz.connections // 0),
+			in_msgs:($varz.in_msgs // 0),
+			out_msgs:($varz.out_msgs // 0),
+			in_bytes:($varz.in_bytes // 0),
+			out_bytes:($varz.out_bytes // 0),
+			slow_consumers:($varz.slow_consumers // 0),
+			meta_pending:($varz.jetstream.meta.pending // 0),
+			meta_pending_requests:($varz.jetstream.meta.pending_requests // 0),
+			meta_pending_infos:($varz.jetstream.meta.pending_infos // 0),
+			routes:{
+				count:(($routez.routes // []) | length),
+				pending_bytes:([($routez.routes // [])[].pending_size] | add // 0),
+				max_pending_bytes:([($routez.routes // [])[].pending_size] | max // 0),
+				in_msgs:([($routez.routes // [])[].in_msgs] | add // 0),
+				out_msgs:([($routez.routes // [])[].out_msgs] | add // 0),
+				in_bytes:([($routez.routes // [])[].in_bytes] | add // 0),
+				out_bytes:([($routez.routes // [])[].out_bytes] | add // 0)
+			}
+		}'); then
 			return 1
 		fi
 		if ! consumers=$(jq -ce --arg pod "$pod" '[
@@ -1088,8 +1139,8 @@ check_nats_logs() {
 }
 
 summarize_trial() {
-  local label=$1 target=$2 minimum=$3 expected_seconds=$4 compatible=$5 topology_file=$6
-  shift 6
+  local label=$1 target=$2 minimum=$3 expected_seconds=$4 compatible=$5 topology_file=$6 trial_max_p99_ms=$7
+	shift 7
   local result_files=("$@")
   if ((${#result_files[@]} != ${#nodes[@]})); then
     echo "expected ${#nodes[@]} result files, got ${#result_files[@]}" >&2
@@ -1101,9 +1152,12 @@ summarize_trial() {
     --argjson target "$target" \
     --argjson minimum "$minimum" \
     --argjson expected_ms "$((expected_seconds * 1000))" \
-    --argjson max_p95_ms "$max_p95_ms" \
-    --argjson max_p99_ms "$max_p99_ms" \
-    --argjson compatible "$compatible" '
+		--argjson max_p95_ms "$max_p95_ms" \
+		--argjson max_p99_ms "$trial_max_p99_ms" \
+		--argjson max_broker_cpu_pct "$max_broker_cpu_pct" \
+		--arg publish_target "$publish_target" \
+		--slurpfile health "$health_monitor_file" \
+		--argjson compatible "$compatible" '
       [.[].results[0]] as $r |
       ($r | map(.acknowledged) | add) as $acked |
       ($r | map(.started_unix_ms) | min) as $started |
@@ -1115,8 +1169,23 @@ summarize_trial() {
       ($r | map(.reconnects) | add) as $reconnects |
       ($r | map(.disconnects) | add) as $disconnects |
       ($r | map(.async_errors) | add) as $async_errors |
+	  ([$health[] |
+		select(((.observed_at | fromdateiso8601) * 1000) >= $started and
+		       ((.observed_at | fromdateiso8601) * 1000) <= $finished) |
+		.brokers[]]) as $broker_samples |
+	  ($broker_samples | group_by(.name) | map({
+		name:.[0].name,
+		samples:length,
+		max_cpu_cores:(map(.cpu_cores) | max),
+		max_cpu_limit_utilization_pct:(map(.cpu_limit_utilization_pct) | max),
+		max_memory_bytes:(map(.memory_bytes) | max),
+		max_route_pending_bytes:(map(.routes.max_pending_bytes) | max),
+		max_total_route_pending_bytes:(map(.routes.pending_bytes) | max)
+	  })) as $broker_metrics |
       {
         trial:$label,
+		stream_replicas:3,
+		publish_target:$publish_target,
         mode:$r[0].mode,
         batch_size:($r[0].batch_size // 0),
         fast_outstanding_acks:($r[0].fast_outstanding_acks // 0),
@@ -1130,6 +1199,7 @@ summarize_trial() {
         worst_node_puback_p50_ms:($r | map(.puback_p50_ms) | max),
         worst_node_puback_p95_ms:($r | map(.puback_p95_ms) | max),
         worst_node_puback_p99_ms:($r | map(.puback_p99_ms) | max),
+		puback_p99_gate_ms:$max_p99_ms,
         puback_max_ms:($r | map(.puback_max_ms) | max),
 		max_publish_progress_gap_ms:($r | map(.max_publish_progress_gap_ms) | max),
         errors:$errors,
@@ -1137,6 +1207,15 @@ summarize_trial() {
         reconnects:$reconnects,
         disconnects:$disconnects,
         async_errors:$async_errors,
+		broker_metrics:{
+		  gate_cpu_pct:$max_broker_cpu_pct,
+		  sample_count:($broker_samples | length),
+		  peak_cpu_cores:([$broker_samples[].cpu_cores] | max // null),
+		  peak_cpu_limit_utilization_pct:([$broker_samples[].cpu_limit_utilization_pct] | max // null),
+		  peak_memory_bytes:([$broker_samples[].memory_bytes] | max // null),
+		  peak_route_pending_bytes:([$broker_samples[].routes.max_pending_bytes] | max // null),
+		  brokers:$broker_metrics
+		},
         topology:$topology[0].topology,
         nodes:$r,
         passed:(
@@ -1148,6 +1227,8 @@ summarize_trial() {
           $disconnects == 0 and $async_errors == 0 and
           ($r | map(.puback_p95_ms) | max) <= $max_p95_ms and
           ($r | map(.puback_p99_ms) | max) <= $max_p99_ms and
+		  ($broker_samples | length) >= 3 and
+		  ([$broker_samples[].cpu_limit_utilization_pct] | max) <= $max_broker_cpu_pct and
           $topology[0].topology.passed == true and
           ($minimum <= 0 or $rate >= $minimum) and
           (if $target <= 0 then
@@ -1249,6 +1330,7 @@ run_trial() {
   local topology_file="$results_dir/${label}-topology.json"
   local topology_err="$results_dir/${label}-topology.err"
 	local start_ms node_target monitor_seconds latency_samples run_timeout_seconds ack_gap
+	local trial_max_p99_ms publisher_url
 	local prepare_status=0
 
 	prepare_trial_stream "$label" "$topology_file" || prepare_status=$?
@@ -1266,6 +1348,11 @@ run_trial() {
   node_target=$(target_for_node "$target")
 	ack_gap="$max_ack_gap"
 	if [[ $mode == fast ]]; then ack_gap=0s; fi
+	if ((target <= normal_load_eps)); then
+		trial_max_p99_ms=$normal_load_max_p99_ms
+	else
+		trial_max_p99_ms=$loaded_max_p99_ms
+	fi
 
 	setup_exec /tmp/nats-live-acceptance \
     -hub-url="$leader_url" -domain= -replicas=3 -required-peers=3 \
@@ -1278,14 +1365,15 @@ run_trial() {
 	local topology_pid=$!
 	active_pids=("$topology_pid")
 
-  echo "trial=$label mode=$mode batch=$batch_size target=$target messages=$total_messages leader=$leader_url"
+  echo "trial=$label mode=$mode batch=$batch_size target=$target messages=$total_messages publish_target=$publish_target leader=$leader_url p99_gate=${trial_max_p99_ms}ms"
   local pids=()
   for i in "${!nodes[@]}"; do
     local node_messages
     node_messages=$(messages_for_node "$total_messages" "$i")
+	 publisher_url=$(publisher_url_for_node "${nodes[$i]}")
     kubectl -n "$namespace" exec "${pods[$i]}" -- env NATS_CA=/etc/nats-ca/ca.pem \
       /tmp/nats-live-acceptance \
-      -hub-url="$leader_url" -domain= -replicas=3 -required-peers=3 \
+      -hub-url="$publisher_url" -domain= -replicas=3 -required-peers=3 \
       -stream "$current_stream" -subject "$current_subject" \
       -create-stream=false -cleanup=false \
       -producer-id="${nodes[$i]}" -messages="$node_messages" \
@@ -1296,7 +1384,7 @@ run_trial() {
       -start-at-unix-ms="$start_ms" -latency-samples="$latency_samples" \
 			-run-timeout="${run_timeout_seconds}s" \
 			-max-ack-gap="$ack_gap" \
-      -latency-interval=50ms -max-p95="${max_p95_ms}ms" -max-p99="${max_p99_ms}ms" -min-rate=0 \
+      -latency-interval=50ms -max-p95="${max_p95_ms}ms" -max-p99="${trial_max_p99_ms}ms" -min-rate=0 \
       >"$results_dir/${label}-${nodes[$i]}.json" \
       2>"$results_dir/${label}-${nodes[$i]}.err" &
     pids+=("$!")
@@ -1340,7 +1428,7 @@ run_trial() {
     result_files+=("$results_dir/${label}-${node}.json")
   done
   if ! summarize_trial \
-    "$label" "$target" "$minimum" "$load_seconds" "$compatible" "$topology_file" \
+    "$label" "$target" "$minimum" "$load_seconds" "$compatible" "$topology_file" "$trial_max_p99_ms" \
     "${result_files[@]}" >"$summary_file"; then
     if delete_current_stream; then return 1; else return 2; fi
   fi

--- a/deploy/k8s/nats-live-acceptance/r3-capacity.json
+++ b/deploy/k8s/nats-live-acceptance/r3-capacity.json
@@ -30,11 +30,15 @@
   "calibration_target_eps": 120000,
   "calibration_duration": "10s",
   "latency_samples_per_second": 20,
+  "normal_load_eps": 12000,
   "puback_p95_max": "20ms",
-  "puback_p99_max": "2ms",
+  "normal_load_puback_p99_max": "2ms",
+  "loaded_puback_p99_max": "2ms",
+  "broker_cpu_limit_cores": 4,
+  "broker_cpu_max_pct": 75,
   "rpc_p99_max": "8ms",
   "rpc_p99_min_samples": 330,
   "max_ack_gap": "2s",
   "ceiling_duration": "5m",
-  "operating_duration": "15m"
+  "operating_duration": "30m"
 }

--- a/deploy/k8s/nats-live-acceptance/r3-isolated-tune.sh
+++ b/deploy/k8s/nats-live-acceptance/r3-isolated-tune.sh
@@ -46,6 +46,9 @@ preferred_node=${R3_ISOLATED_PREFERRED_NODE:-node3}
 max_msgs_per_subject=${R3_ISOLATED_MAX_MSGS_PER_SUBJECT:-400000}
 compression=${R3_ISOLATED_COMPRESSION:-s2_fast}
 puback_p99=${R3_ISOLATED_PUBACK_P99_MAX:-5ms}
+broker_cpu_max_pct=${R3_ISOLATED_BROKER_CPU_MAX_PCT:-75}
+broker_cpu_limit_cores=${R3_ISOLATED_BROKER_CPU_LIMIT_CORES:-4}
+broker_poll_seconds=${R3_ISOLATED_BROKER_POLL_SECONDS:-5}
 topology_grace=${R3_ISOLATED_TOPOLOGY_GRACE:-5s}
 run_id=$(date -u +%Y%m%d%H%M%S)-$(printf '%05d' "$RANDOM")
 lower_run_id=$(printf '%s' "$run_id" | tr '[:upper:]' '[:lower:]')
@@ -70,8 +73,11 @@ nodes=(node2 node3 worker1)
 publishers=()
 publisher_pids=()
 topology_pid=
+broker_monitor_pid=
 cleaned=false
 production_baseline="$results_dir/production-baseline.json"
+broker_metrics_file="$results_dir/broker-metrics.jsonl"
+broker_metrics_stop="$results_dir/broker-metrics.stop"
 
 positive_integer() { [[ $1 =~ ^[1-9][0-9]*$ ]]; }
 production_deployments_healthy() {
@@ -88,7 +94,8 @@ production_valkey_healthy() {
 		(.items | length) == 4 and ([.items[] | (.status.containerStatuses | all(.ready == true))] | all)
 	' >/dev/null
 }
-for value in "$seconds" "$fleet_rate" "$min_rate" "$batch" "$outstanding" "$publisher_connections" "$route_pool_size"; do
+for value in "$seconds" "$fleet_rate" "$min_rate" "$batch" "$outstanding" "$publisher_connections" "$route_pool_size" \
+	"$broker_cpu_max_pct" "$broker_cpu_limit_cores" "$broker_poll_seconds"; do
 	positive_integer "$value" || { echo "rates, duration, batch, and outstanding values must be positive integers" >&2; exit 1; }
 done
 case $stream_replicas in
@@ -151,10 +158,10 @@ cleanup() {
 	set +u
 	if [[ $cleaned == false ]]; then
 		cleaned=true
-		for pid in "${publisher_pids[@]}" ${topology_pid:-}; do
+		for pid in "${publisher_pids[@]}" ${topology_pid:-} ${broker_monitor_pid:-}; do
 			[[ -n $pid ]] && kill "$pid" >/dev/null 2>&1 || true
 		done
-		for pid in "${publisher_pids[@]}" ${topology_pid:-}; do
+		for pid in "${publisher_pids[@]}" ${topology_pid:-} ${broker_monitor_pid:-}; do
 			[[ -n $pid ]] && wait "$pid" >/dev/null 2>&1 || true
 		done
 		kubectl -n "$namespace" delete pod -l "itsbagelbot.dev/r3-tune-run=$run_id" --ignore-not-found --wait=false >/dev/null 2>&1 || true
@@ -410,6 +417,98 @@ if ((${#placements[@]} != 3)) || [[ $(printf '%s\n' "${placements[@]}" | cut -f2
 fi
 printf '%s\n' "${placements[@]}" | tee "$results_dir/placements.tsv"
 
+broker_metrics_snapshot() {
+	local observed_ms broker varz routez jsz sample
+	local brokers_json='[]'
+	observed_ms=$(($(date +%s) * 1000))
+	while IFS= read -r broker; do
+		varz=$(kubectl --request-timeout=5s get --raw \
+			"/api/v1/namespaces/${namespace}/pods/${broker}:8222/proxy/varz") || return 1
+		routez=$(kubectl --request-timeout=5s get --raw \
+			"/api/v1/namespaces/${namespace}/pods/${broker}:8222/proxy/routez?subs=0") || return 1
+		jsz=$(kubectl --request-timeout=5s get --raw \
+			"/api/v1/namespaces/${namespace}/pods/${broker}:8222/proxy/jsz?streams=1") || return 1
+		sample=$(jq -nce --arg broker "$broker" --arg stream "$stream" \
+			--argjson cpu_limit_cores "$broker_cpu_limit_cores" \
+			--argjson varz "$varz" --argjson routez "$routez" --argjson jsz "$jsz" '{
+				name:$broker,
+				cpu_pct:($varz.cpu // 0),
+				cpu_cores:(($varz.cpu // 0) / 100),
+				cpu_limit_utilization_pct:(($varz.cpu // 0) / $cpu_limit_cores),
+				memory_bytes:($varz.mem // 0),
+				connections:($varz.connections // 0),
+				slow_consumers:($varz.slow_consumers // 0),
+				routes:{
+					count:(($routez.routes // []) | length),
+					pending_bytes:([($routez.routes // [])[].pending_size] | add // 0),
+					max_pending_bytes:([($routez.routes // [])[].pending_size] | max // 0),
+					in_msgs:([($routez.routes // [])[].in_msgs] | add // 0),
+					out_msgs:([($routez.routes // [])[].out_msgs] | add // 0),
+					in_bytes:([($routez.routes // [])[].in_bytes] | add // 0),
+					out_bytes:([($routez.routes // [])[].out_bytes] | add // 0)
+				},
+				jetstream:{
+					memory_bytes:($jsz.memory // 0),
+					store_bytes:($jsz.store // 0),
+					stream:([
+						$jsz.account_details[]?.stream_detail[]?
+						| select(.name == $stream)
+						| {
+							leader:(.cluster.leader // ""),
+							messages:(.state.messages // 0),
+							bytes:(.state.bytes // 0),
+							max_follower_lag:([.cluster.replicas[]?.lag] | max // 0),
+							all_followers_current:([.cluster.replicas[]?.current] | all)
+						}
+					] | first // null)
+				}
+			}') || return 1
+		brokers_json=$(jq -c --argjson sample "$sample" '. + [$sample]' <<<"$brokers_json") || return 1
+	done < <(printf '%s\n' "${placements[@]}" | cut -f1)
+	jq -nc --argjson observed_unix_ms "$observed_ms" --argjson brokers "$brokers_json" \
+		'{observed_unix_ms:$observed_unix_ms,brokers:$brokers}'
+}
+
+monitor_broker_metrics() {
+	local i
+	while [[ ! -e $broker_metrics_stop ]]; do
+		broker_metrics_snapshot >>"$broker_metrics_file" || return 1
+		for ((i = 0; i < broker_poll_seconds; i++)); do
+			[[ -e $broker_metrics_stop ]] && return 0
+			sleep 1
+		done
+	done
+}
+
+start_broker_monitor() {
+	local deadline=$((SECONDS + 30))
+	rm -f "$broker_metrics_stop"
+	: >"$broker_metrics_file"
+	monitor_broker_metrics &
+	broker_monitor_pid=$!
+	while [[ ! -s $broker_metrics_file ]]; do
+		if ! kill -0 "$broker_monitor_pid" 2>/dev/null; then
+			echo "isolated broker diagnostics exited before the first sample" >&2
+			return 1
+		fi
+		if ((SECONDS >= deadline)); then
+			echo "isolated broker diagnostics did not produce a sample within 30s" >&2
+			return 1
+		fi
+		sleep 0.2
+	done
+}
+
+stop_broker_monitor() {
+	if [[ -z ${broker_monitor_pid:-} ]]; then return 0; fi
+	: >"$broker_metrics_stop"
+	if ! wait "$broker_monitor_pid"; then
+		broker_monitor_pid=
+		return 1
+	fi
+	broker_monitor_pid=
+}
+
 GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o "$binary" ./deploy/k8s/nats-live-acceptance
 phase=publisher-creation
 for node in "${nodes[@]}"; do
@@ -464,6 +563,7 @@ else
 fi
 
 phase=load
+start_broker_monitor
 for i in "${!nodes[@]}"; do
 	node=${nodes[$i]}
 	pod=${publishers[$i]}
@@ -525,6 +625,7 @@ for pid in "${publisher_pids[@]}"; do wait "$pid" || status=1; done
 if [[ -n ${topology_pid:-} ]]; then
 	wait "$topology_pid" || status=1
 fi
+stop_broker_monitor || status=1
 publisher_pids=()
 topology_pid=
 
@@ -537,6 +638,7 @@ if grep -Eina 'IPQ len limit|slow consumer|write deadline( exceeded)?|no quorum|
 fi
 
 jq -s --slurpfile topology "$results_dir/topology.json" \
+	--slurpfile metrics "$broker_metrics_file" \
 	--arg compression "$compression" --arg publishTarget "$publish_target" \
 	--arg publishMode "$publish_mode" \
 	--argjson publishers "$publisher_connections" \
@@ -544,11 +646,25 @@ jq -s --slurpfile topology "$results_dir/topology.json" \
 	--argjson routePoolSize "$route_pool_size" \
 	--arg preferredNode "$preferred_node" \
 	--argjson maxMsgsPerSubject "$max_msgs_per_subject" \
-	--argjson target "$fleet_rate" --argjson minimum "$min_rate" '
+	--argjson target "$fleet_rate" --argjson minimum "$min_rate" \
+	--argjson brokerCpuMaxPct "$broker_cpu_max_pct" '
 	[.[].results[0]] as $r |
 	($r|map(.started_unix_ms)|min) as $start |
 	($r|map(.finished_unix_ms)|max) as $finish |
 	($r|map(.acknowledged)|add) as $acked |
+	([$metrics[] |
+		select(.observed_unix_ms >= $start and .observed_unix_ms <= $finish) |
+		.brokers[]]) as $brokerSamples |
+	($brokerSamples | group_by(.name) | map({
+		name:.[0].name,
+		samples:length,
+		max_cpu_cores:(map(.cpu_cores) | max),
+		max_cpu_limit_utilization_pct:(map(.cpu_limit_utilization_pct) | max),
+		max_memory_bytes:(map(.memory_bytes) | max),
+		max_route_pending_bytes:(map(.routes.max_pending_bytes) | max),
+		max_total_route_pending_bytes:(map(.routes.pending_bytes) | max),
+		max_follower_lag:(map(.jetstream.stream.max_follower_lag // 0) | max)
+	})) as $brokerMetrics |
 	{
 	  route_compression:$compression,
 	  publish_target:$publishTarget,
@@ -570,9 +686,25 @@ jq -s --slurpfile topology "$results_dir/topology.json" \
 	  puback_max_ms:($r|map(.puback_max_ms)|max),
 	  errors:($r|map(.errors)|add),
 	  timeouts:($r|map(.timeouts)|add),
+	  broker_metrics:{
+		gate_cpu_pct:$brokerCpuMaxPct,
+		sample_count:($brokerSamples | length),
+		peak_cpu_cores:([$brokerSamples[].cpu_cores] | max // null),
+		peak_cpu_limit_utilization_pct:([$brokerSamples[].cpu_limit_utilization_pct] | max // null),
+		peak_memory_bytes:([$brokerSamples[].memory_bytes] | max // null),
+		peak_route_pending_bytes:([$brokerSamples[].routes.max_pending_bytes] | max // null),
+		peak_follower_lag:([$brokerSamples[].jetstream.stream.max_follower_lag // 0] | max // null),
+		brokers:$brokerMetrics
+	  },
 	  topology:$topology[0].topology,
 	  nodes:$r,
-	  passed:(($r|all(.passed == true)) and $topology[0].topology.passed == true and ($acked/(($finish-$start)/1000)) >= $minimum)
+	  passed:(
+		($r|all(.passed == true)) and
+		$topology[0].topology.passed == true and
+		($acked/(($finish-$start)/1000)) >= $minimum and
+		($brokerSamples | length) >= 3 and
+		([$brokerSamples[].cpu_limit_utilization_pct] | max) <= $brokerCpuMaxPct
+	  )
 	}' "$results_dir"/node2.json "$results_dir"/node3.json "$results_dir"/worker1.json >"$results_dir/summary.json" || status=1
 
 kubectl -n "$namespace" exec "$control" -- /tmp/nats-live-acceptance \

--- a/deploy/k8s/nats-live-acceptance/r3-matrix-report.sh
+++ b/deploy/k8s/nats-live-acceptance/r3-matrix-report.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Compare retained R1/R3 and local/preferred benchmark summaries. This script
+# is read-only: it never connects to Kubernetes or NATS.
+set -euo pipefail
+
+usage() {
+	cat <<'USAGE'
+usage: r3-matrix-report.sh [--report-only] SUMMARY_OR_RESULTS_DIR [...]
+
+Reads summary JSON emitted by r3-isolated-tune.sh or r3-120k.sh and prints one
+normalized matrix. By default it exits non-zero until a node-local R3 run has
+sustained 90,000 offered events/s for 30 minutes while acknowledging at least
+89,100/s, keeping loaded PubAck p99 <= 2ms and broker CPU <= 75%.
+
+Use --report-only to compare incomplete/calibration runs without qualifying the
+90k operating gate.
+USAGE
+}
+
+report_only=false
+inputs=()
+for argument in "$@"; do
+	case $argument in
+		--report-only) report_only=true ;;
+		-h|--help) usage; exit 0 ;;
+		-*) echo "unknown option: $argument" >&2; usage >&2; exit 2 ;;
+		*) inputs+=("$argument") ;;
+	esac
+done
+
+if ((${#inputs[@]} == 0)); then
+	usage >&2
+	exit 2
+fi
+command -v jq >/dev/null 2>&1 || { echo "missing required command: jq" >&2; exit 1; }
+
+summaries=()
+for input in "${inputs[@]}"; do
+	if [[ -d $input ]]; then
+		while IFS= read -r summary; do summaries+=("$summary"); done < <(
+			find "$input" -type f \( -name 'summary.json' -o -name 'summary-operating-*.json' \) -print | sort
+		)
+	elif [[ -f $input ]]; then
+		summaries+=("$input")
+	else
+		echo "summary path does not exist: $input" >&2
+		exit 2
+	fi
+done
+
+if ((${#summaries[@]} == 0)); then
+	echo "no benchmark summary JSON found" >&2
+	exit 2
+fi
+
+report=$(jq -s '
+	def normalized:
+		select((.aggregate_messages_per_second // null) != null) |
+		{
+			trial:(.trial // "isolated"),
+			stream_replicas:(.stream_replicas // .replicas // 3),
+			publish_target:(.publish_target // "unknown"),
+			publish_mode:(.publish_mode // .mode // "unknown"),
+			route_compression:(.route_compression // "production"),
+			target_messages_per_second,
+			acknowledged_messages_per_second:.aggregate_messages_per_second,
+			duration_seconds:(.conservative_duration_ms / 1000),
+			puback_p50_ms:.worst_node_puback_p50_ms,
+			puback_p95_ms:.worst_node_puback_p95_ms,
+			puback_p99_ms:.worst_node_puback_p99_ms,
+			puback_max_ms,
+			broker_peak_cpu_pct:(.broker_metrics.peak_cpu_limit_utilization_pct // null),
+			broker_peak_memory_bytes:(.broker_metrics.peak_memory_bytes // null),
+			broker_peak_route_pending_bytes:(.broker_metrics.peak_route_pending_bytes // null),
+			broker_peak_follower_lag:(.broker_metrics.peak_follower_lag // null),
+			errors:(.errors // 0),
+			timeouts:(.timeouts // 0),
+			reconnects:(.reconnects // 0),
+			passed:(.passed // false)
+		};
+	[.[] | normalized] as $runs |
+	{
+		qualification_gates:{
+			stream_replicas:3,
+			publish_target:"local",
+			offered_messages_per_second:90000,
+			minimum_acknowledged_messages_per_second:89100,
+			minimum_duration_seconds:1800,
+			maximum_loaded_puback_p99_ms:2,
+			maximum_broker_cpu_pct:75
+		},
+		runs:($runs | sort_by(.stream_replicas,.publish_target,.target_messages_per_second,.publish_mode)),
+		qualified_runs:[$runs[] | select(
+			.stream_replicas == 3 and
+			.publish_target == "local" and
+			.target_messages_per_second == 90000 and
+			.acknowledged_messages_per_second >= 89100 and
+			.duration_seconds >= 1800 and
+			.puback_p99_ms <= 2 and
+			.broker_peak_cpu_pct != null and .broker_peak_cpu_pct <= 75 and
+			.errors == 0 and .timeouts == 0 and .reconnects == 0 and .passed == true
+		)],
+		qualified:false
+	} | .qualified = ((.qualified_runs | length) > 0)
+' "${summaries[@]}")
+
+jq . <<<"$report"
+if [[ $report_only == false ]] && ! jq -e '.qualified == true' >/dev/null <<<"$report"; then
+	echo "R3 90k/30m sustain gate is not yet qualified" >&2
+	exit 1
+fi

--- a/deploy/k8s/nats-server.conf
+++ b/deploy/k8s/nats-server.conf
@@ -50,13 +50,14 @@ cluster {
   name: "bagelbot"
   port: 6222
   # BUS gets its own route connection instead of sharing a pooled route with
-  # control accounts. s2_auto leaves the low-RTT node2<->node3 path uncompressed
-  # and compresses the higher-RTT worker1 route, protecting worker1's existing
-  # internet link without changing its speed plan.
+  # control accounts. The isolated 2026-07-16 R3 matrix found s2_fast sustained
+  # ~75k/s with zero final lag, while s2_auto left the low-RTT route
+  # uncompressed, accumulated a 275MB slow-consumer write, reconnected, and
+  # reached only ~70k/s. Keep the measured winner explicit; auto is unsafe for
+  # this asymmetric three-voter topology.
   accounts: ["BUS"]
   compression: {
-    mode: s2_auto
-    rtt_thresholds: [5ms, 20ms, 50ms]
+    mode: s2_fast
   }
   # Mutual TLS between the hub RAFT peers: low cardinality (3 members), all present
   # the CA-signed cert, so verify:true is cheap defense-in-depth for the JetStream

--- a/deploy/k8s/nats_server_config_test.go
+++ b/deploy/k8s/nats_server_config_test.go
@@ -1,0 +1,38 @@
+package k8s
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func TestHubRoutesRetainMeasuredCompressionMode(t *testing.T) {
+	config := sourceFile{name: "nats-server.conf"}.read(t)
+	cluster := regexp.MustCompile(`(?s)cluster \{.*?\n\}`).FindString(config)
+	if cluster == "" {
+		t.Fatal("nats-server.conf has no cluster block")
+	}
+	if !regexp.MustCompile(`(?m)^\s*mode:\s*s2_fast\s*$`).MatchString(cluster) {
+		t.Fatal("BUS routes must retain the measured s2_fast compression mode")
+	}
+	if regexp.MustCompile(`(?m)^\s*mode:\s*s2_auto\s*$`).MatchString(cluster) ||
+		regexp.MustCompile(`(?m)^\s*rtt_thresholds:`).MatchString(cluster) {
+		t.Fatal("adaptive route compression regressed the asymmetric R3 topology")
+	}
+}
+
+func TestHubJetStreamIngestWindowStaysByteBounded(t *testing.T) {
+	config := sourceFile{name: "nats-server.conf"}.read(t)
+	jetstream := regexp.MustCompile(`(?s)jetstream \{.*?\n\}`).FindString(config)
+	if jetstream == "" {
+		t.Fatal("nats-server.conf has no JetStream block")
+	}
+	for _, required := range []string{
+		"max_buffered_msgs: 262144",
+		"max_buffered_size: 128MB",
+	} {
+		if !strings.Contains(jetstream, required) {
+			t.Fatalf("JetStream ingest guard %q is missing", required)
+		}
+	}
+}

--- a/docs/src/content/docs/infrastructure/performance-roadmap.md
+++ b/docs/src/content/docs/infrastructure/performance-roadmap.md
@@ -1,0 +1,136 @@
+---
+title: Performance and cleanup roadmap
+description: Evidence-gated latency, NATS R3, Valkey, and 20,000-channel capacity work after the native data-plane migration.
+---
+
+## Objective
+
+Certify the bot for 20,000 channels without hiding a latency regression behind a
+throughput number. Work proceeds in measurement order: make the full path
+explainable, qualify NATS R3, tune the real Valkey commands, then run the
+production-shaped soak. Sharding and additional hardware are capacity-triggered
+decisions, not prerequisites.
+
+## Baseline that must not be conflated
+
+| Path | Verified result | Meaning |
+| --- | ---: | --- |
+| R1 ingress JetStream | 123,834 events/s, 3M acknowledged, zero errors | Current throughput ceiling with deduplication off and leader-direct publishing |
+| R3 JetStream | 11,996.6 events/s for 60s, 13.681 ms fleet p99 | Stable at the tested rate, but not latency-qualified for the old 2 ms JetStream target |
+| R3 `s2_fast` calibration | About 75,000 events/s, zero final lag | Best retained high-load calibration; it is not a 90k/30-minute or 2 ms p99 qualification |
+| Sesame engine + input, memory output | 20,074 commands/s, 67 us p95 | The command engine is not the present bottleneck |
+| Sesame full confirmed-output fleet | 22,971 commands/s | Worst case where every input emits an output; NATS confirmation dominates |
+| Valkey node-local reads | 0.247-0.790 ms p99 | Already inside the 2 ms read SLO on every node |
+| Valkey primary writes | 2.416-10.207 ms p99 | Physical distance to the elected primary determines the tail |
+
+R1 and R3 are different products. The 123k R1 result must never be reported as
+R3 capacity, and an R3 throughput pass must never override a failed latency gate.
+
+## Phase 1: full-path latency attribution
+
+Instrument bounded stage names across the complete internal command journey:
+
+1. ingress dispatcher wait;
+2. filter and route;
+3. JSON encode;
+4. NATS publish and JetStream acknowledgement;
+5. consumer delivery wait;
+6. Sesame decode and engine execution;
+7. Valkey and RPC dependency time;
+8. output encode and confirmed publish;
+9. outgress processing.
+
+Use distributed trace headers on core NATS RPC and JetStream messages. Aggregate
+names may contain only configured subjects, finite stages, lanes, operations,
+and outcomes. IDs remain sampled trace/log attributes and never become metric
+names or dashboard facets.
+
+Phase 1 passes when a controlled command workload reports p50, p95, p99,
+minimum, and maximum for every stage without reconstructing the path from raw
+logs.
+
+## Phase 2: NATS R3 qualification
+
+The architecture is fixed during this phase:
+
+- hubs own JetStream and leaves serve RPC only;
+- broker deduplication remains off;
+- publishers dial the node-local hub Service;
+- worker1 participates as a replica but is not the preferred leader;
+- no stream partitioning or sharding;
+- production streams remain unchanged during isolated qualification.
+
+Run the same isolated stream across a matrix of R1/R3, leader-local/non-leader,
+payload size, publish mode, cohort size, and connection count. Capture PubAck
+percentiles beside server CPU, route pending bytes, follower lag, reconnects,
+retransmits, and leader changes. Change one server setting at a time and retain
+it only when a repeat run improves the result.
+
+The desired R3 operating point is 90,000 events/s for at least 30 minutes with
+zero errors and zero final follower lag. It is not promotable unless its loaded
+latency target is explicitly accepted. The historical 2 ms p99 remains the
+normal-load JetStream SLO; the current hardware evidence shows that a
+fleet-wide R3 p99 near 14 ms may be the physical worker1 floor.
+
+If 90k throughput and the accepted latency cannot coexist, record the lower
+stable ceiling. Do not weaken an automated gate merely to make the run pass.
+
+## Phase 3: Valkey hot commands
+
+Benchmark the exact Sesame, projector, and outgress commands rather than generic
+GET/SET traffic. Separate the same-node replica read path from Sentinel-routed
+primary writes.
+
+Priorities are:
+
+1. keep TLS connections persistent and pooled;
+2. remove transport replay claims from Valkey while retaining domain cooldown,
+   timer, loyalty, live-state, and reputation data;
+3. pipeline independent cold reads;
+4. collapse related rate-limit state into one atomic server operation;
+5. serve frequently-read global state from a versioned local snapshot repaired
+   by Valkey and NATS invalidation;
+6. measure snapshot/failover pauses before changing persistence settings.
+
+The local read p99 target is 2 ms and is already met. Primary writes are judged
+against a topology-aware target: a remote write tail is not justification for
+enabling replica writes that can be lost during resynchronization.
+
+## Phase 4: 20,000-channel certification
+
+After phases 1-3, run a six-hour isolated soak with realistic online ratios,
+chat rates, command bursts, raids, one NATS member restart, one Valkey failover,
+and one Sesame replacement. Ingress remains one pod per NATS node and does not
+add WebSocket shards below 75% occupancy.
+
+Capacity is calculated from the measured event rate, not the channel count:
+
+```text
+safe events/s = verified sustained ceiling * 0.70
+safe channels = safe events/s / measured peak events/s per channel
+```
+
+At a verified 90k ceiling, the operating budget is 63k events/s. Twenty
+thousand channels fit while the measured simultaneous peak stays below 3.15
+events/s per channel.
+
+## Expansion gates
+
+Do not shard NATS, add a server, replace Valkey, or migrate the CNI until either
+the verified operating envelope exceeds 70% for 15 minutes or a latency SLO
+fails after application and server tuning. Any expansion proposal must include
+the triggering telemetry, the expected headroom, cost, rollback, and a repeatable
+acceptance run.
+
+## Cleanup that travels with the phases
+
+- move the Tailscale operator OAuth credential into Doppler/Flux ownership and
+  rotate it;
+- remove stale Watermill, Linkerd, Tailscale-data-plane, and Valkey replay-dedup
+  documentation;
+- make every benchmark clean its stream, consumers, pods, temporary ACL, and
+  result objects after success, failure, or interruption;
+- render Helm values and resource requests in CI so ignored chart keys fail
+  before production;
+- keep benchmark results dated and immutable, with one current capacity profile
+  as the source of truth.

--- a/docs/src/content/docs/microservices/sesame.md
+++ b/docs/src/content/docs/microservices/sesame.md
@@ -13,11 +13,16 @@ Sesame operates as a highly concurrent NATS JetStream consumer. It pulls from th
 
 Every message flows through `engine.Pipeline`, an allocation-free (for non-emissions) decoding and dispatch stage:
 1. **Decode**: The JSON payload is unmarshaled into a pooled `lane.Envelope`.
-2. **Deduplication**: `ValkeyDedup` ensures that an event is only processed once, claiming a short-lived key in Valkey based on the event ID.
+2. **Eligibility**: Unsupported events and envelopes without a valid broadcaster are discarded before projection or command work.
 3. **Module Views**: If the event requires configurable behavior, the `Projector` is queried for the broadcaster's `ModuleView` set.
 4. **Command Dispatch**: If the event is a chat message (`channel.chat.message`), the pipeline checks the command registry. Baked commands are evaluated for their permissions, cooldowns, and live-only gates.
 5. **Event Handlers**: Non-command event handlers registered by modules are executed in registration order.
 6. **Emission**: Module handlers do not publish directly to NATS. They yield an `Output` struct to an `Emit` callback, which builds the `outgress.Message` wire contract and publishes it to either `twitch.outgress.premium` or `twitch.outgress.standard`.
+
+Transport replay does not claim a Valkey key. Outputs derived from an input with
+a stable event ID use a stable publication ID and wait for the NATS confirmation
+before the input is acknowledged. Valkey remains domain state, not a second
+transport acknowledgement system.
 
 ### Module Authoring
 
@@ -78,4 +83,5 @@ Additionally, the `module.ParseDynamic` helper provides built-in support for gen
 Sesame maintains high throughput by avoiding database reads on the hot path:
 - **Projection Cache**: `projection.Reader` provides an in-memory cache of broadcaster settings (modules, users, custom commands), falling back to NATS RPC (`bagel.rpc.internal.projection.*`) and listening for `bagel.cache.invalidate.*` broadcasts.
 - **Live Store**: `ValkeyLiveStore` checks if a broadcaster is currently live. It caches locally, falls back to Valkey, and can trigger a system outgress lane check to Twitch if the key is cold.
-- **Cooldown & Dedup**: Backed directly by Valkey.
+- **Domain State**: Cooldowns, timers, loyalty live views, greeting windows, and
+  reputation state are backed by Valkey. Transport replay is not.

--- a/pkg/bus/concurrent_subscriber.go
+++ b/pkg/bus/concurrent_subscriber.go
@@ -234,7 +234,11 @@ func messageFromNATS(wire *nats.Msg) (*Message, error) {
 	if err != nil {
 		return nil, err
 	}
-	return newMessage(messageIdentity(wire), wire.Data, metadata), nil
+	return newMessage(messageData{
+		id:       messageIdentity(wire),
+		payload:  wire.Data,
+		metadata: metadata,
+	}), nil
 }
 
 func fleetMetadata(headers nats.Header) (Metadata, error) {

--- a/pkg/bus/consume.go
+++ b/pkg/bus/consume.go
@@ -3,8 +3,9 @@ package bus
 import (
 	"context"
 	"errors"
-	"net/http"
+	"time"
 
+	"github.com/nats-io/nats.go"
 	"github.com/newrelic/go-agent/v3/newrelic"
 
 	"go.uber.org/zap"
@@ -44,17 +45,18 @@ func Consume(ctx context.Context, app *newrelic.Application, sub Subscriber, sub
 // makes the New Relic calls no-ops.
 func process(app *newrelic.Application, subject string, msg *Message, handle func(*Message) error, log *zap.Logger) {
 
-	txn := app.StartTransaction("consume " + subject)
-
-	headers := http.Header{}
-	for key, value := range msg.Metadata {
-		headers.Set(key, value)
-	}
-	txn.AcceptDistributedTraceHeaders(newrelic.TransportQueue, headers)
+	txn := app.StartTransaction("consume " + normalizedDestination(subject))
+	acceptTraceHeaders(txn, metadataHeaders(msg.Metadata))
+	addMessagingTransactionAttributes(txn, "process", subject)
+	txn.AddAttribute("messaging.queue_ms", float64(msg.deliveryWait(time.Now()).Microseconds())/1000)
 
 	msg.SetContext(newrelic.NewContext(msg.Context(), txn))
 
-	if err := handle(msg); err != nil {
+	processSegment := txn.StartSegment("message.process")
+	err := handle(msg)
+	processSegment.AddAttribute(resultAttribute, processResult(err))
+	processSegment.End()
+	if err != nil {
 		// Expected backpressure (rate limits and a deliberate system pause) still
 		// nacks, but must not turn an overload into one New Relic error and warning
 		// log per delivery attempt. Packages opt in through this tiny structural
@@ -63,6 +65,7 @@ func process(app *newrelic.Application, subject string, msg *Message, handle fun
 		if !quiet {
 			txn.NoticeError(err)
 		}
+		txn.AddAttribute(resultAttribute, processResult(err))
 		txn.End()
 
 		if quiet {
@@ -80,8 +83,27 @@ func process(app *newrelic.Application, subject string, msg *Message, handle fun
 		return
 	}
 
+	txn.AddAttribute(resultAttribute, "ok")
 	txn.End()
 	msg.Ack()
+}
+
+func metadataHeaders(metadata Metadata) nats.Header {
+	headers := make(nats.Header, len(metadata))
+	for key, value := range metadata {
+		headers.Set(key, value)
+	}
+	return headers
+}
+
+func processResult(err error) string {
+	if err == nil {
+		return "ok"
+	}
+	if isExpectedNack(err) {
+		return "deferred"
+	}
+	return messagingResult(err)
 }
 
 func isExpectedNack(err error) bool {

--- a/pkg/bus/consume.go
+++ b/pkg/bus/consume.go
@@ -47,7 +47,7 @@ func process(app *newrelic.Application, subject string, msg *Message, handle fun
 
 	txn := app.StartTransaction("consume " + normalizedDestination(subject))
 	acceptTraceHeaders(txn, metadataHeaders(msg.Metadata))
-	addMessagingTransactionAttributes(txn, "process", subject)
+	addMessagingTransactionAttributes(txn, messagingAttributes{operation: "process", destination: subject})
 	txn.AddAttribute("messaging.queue_ms", float64(msg.deliveryWait(time.Now()).Microseconds())/1000)
 
 	msg.SetContext(newrelic.NewContext(msg.Context(), txn))

--- a/pkg/bus/message.go
+++ b/pkg/bus/message.go
@@ -3,6 +3,7 @@ package bus
 import (
 	"context"
 	"sync"
+	"time"
 )
 
 const (
@@ -41,6 +42,9 @@ type Message struct {
 	mu    sync.Mutex
 	state messageState
 	ctx   context.Context
+	// receivedAt is set at the native subscriber boundary. It lets the consumer
+	// transaction distinguish delivery/admission wait from handler execution.
+	receivedAt time.Time
 }
 
 type messageState uint8
@@ -59,7 +63,7 @@ func NewMessage(id string, payload []byte) *Message {
 func newMessage(id string, payload []byte, metadata Metadata) *Message {
 	return &Message{
 		UUID: id, Metadata: metadata, Payload: payload,
-		ack: make(chan struct{}), nack: make(chan struct{}),
+		ack: make(chan struct{}), nack: make(chan struct{}), receivedAt: time.Now(),
 	}
 }
 
@@ -138,6 +142,17 @@ func (m *Message) Context() context.Context {
 
 // SetContext attaches tracing, cancellation, and request-scoped values.
 func (m *Message) SetContext(ctx context.Context) { m.ctx = ctx }
+
+func (m *Message) deliveryWait(now time.Time) time.Duration {
+	if m.receivedAt.IsZero() {
+		return 0
+	}
+	wait := now.Sub(m.receivedAt)
+	if wait < 0 {
+		return 0
+	}
+	return wait
+}
 
 // Subscriber is the fleet-owned consuming contract. Implementations close the
 // returned channel when ctx is cancelled or Close releases the subscription.

--- a/pkg/bus/message.go
+++ b/pkg/bus/message.go
@@ -49,6 +49,12 @@ type Message struct {
 
 type messageState uint8
 
+type messageData struct {
+	id       string
+	payload  []byte
+	metadata Metadata
+}
+
 const (
 	messagePending messageState = iota
 	messageAcked
@@ -57,12 +63,12 @@ const (
 
 // NewMessage constructs a delivery with independent acknowledgement state.
 func NewMessage(id string, payload []byte) *Message {
-	return newMessage(id, payload, make(Metadata))
+	return newMessage(messageData{id: id, payload: payload, metadata: make(Metadata)})
 }
 
-func newMessage(id string, payload []byte, metadata Metadata) *Message {
+func newMessage(data messageData) *Message {
 	return &Message{
-		UUID: id, Metadata: metadata, Payload: payload,
+		UUID: data.id, Metadata: data.metadata, Payload: data.payload,
 		ack: make(chan struct{}), nack: make(chan struct{}), receivedAt: time.Now(),
 	}
 }

--- a/pkg/bus/publish.go
+++ b/pkg/bus/publish.go
@@ -62,7 +62,9 @@ func NewPublisherForStream(url, stream string, log *zap.Logger) (Publisher, erro
 // PublishJSON gives Sonic's result buffer directly to the asynchronous
 // publisher. There is no intermediate message object or payload copy.
 func PublishJSON(ctx context.Context, pub Publisher, subject string, payload any) error {
-	encodeSegment := startMessagingSegment(ctx, "nats.publish.encode", "publish", subject)
+	encodeSegment := startMessagingSegment(ctx, messagingSpan{
+		name: "nats.publish.encode", operation: "publish", destination: subject,
+	})
 	body, err := sonic.ConfigFastest.Marshal(payload)
 	endMessagingSegment(encodeSegment, err)
 	if err != nil {
@@ -95,14 +97,18 @@ func PublishConfirmed(ctx context.Context, pub Publisher, publication Publicatio
 		return errors.New("bus: confirmed publish requires a message ID")
 	}
 	body := append([]byte(nil), publication.Payload...)
-	segment := startMessagingSegment(ctx, "nats.publish", "publish", publication.Subject)
+	segment := startMessagingSegment(ctx, messagingSpan{
+		name: "nats.publish", operation: "publish", destination: publication.Subject,
+	})
 	err := pub.PublishOwnedWithID(ctx, publication.Subject, publication.ID, body)
 	endMessagingSegment(segment, err)
 	return err
 }
 
 func publishOwned(ctx context.Context, pub Publisher, subject string, body []byte) error {
-	segment := startMessagingSegment(ctx, "nats.publish", "publish", subject)
+	segment := startMessagingSegment(ctx, messagingSpan{
+		name: "nats.publish", operation: "publish", destination: subject,
+	})
 	err := pub.PublishOwned(ctx, subject, body)
 	endMessagingSegment(segment, err)
 	return err

--- a/pkg/bus/publish.go
+++ b/pkg/bus/publish.go
@@ -62,11 +62,13 @@ func NewPublisherForStream(url, stream string, log *zap.Logger) (Publisher, erro
 // PublishJSON gives Sonic's result buffer directly to the asynchronous
 // publisher. There is no intermediate message object or payload copy.
 func PublishJSON(ctx context.Context, pub Publisher, subject string, payload any) error {
+	encodeSegment := startMessagingSegment(ctx, "nats.publish.encode", "publish", subject)
 	body, err := sonic.ConfigFastest.Marshal(payload)
+	endMessagingSegment(encodeSegment, err)
 	if err != nil {
 		return err
 	}
-	return pub.PublishOwned(ctx, subject, body)
+	return publishOwned(ctx, pub, subject, body)
 }
 
 // PublishRaw copies caller-owned bytes once so they may be reused immediately
@@ -74,7 +76,7 @@ func PublishJSON(ctx context.Context, pub Publisher, subject string, payload any
 // freshly allocated buffer intentionally.
 func PublishRaw(ctx context.Context, pub Publisher, subject string, payload []byte) error {
 	body := append([]byte(nil), payload...)
-	return pub.PublishOwned(ctx, subject, body)
+	return publishOwned(ctx, pub, subject, body)
 }
 
 // Publication is one caller-owned payload and its stable fleet message identity.
@@ -93,5 +95,15 @@ func PublishConfirmed(ctx context.Context, pub Publisher, publication Publicatio
 		return errors.New("bus: confirmed publish requires a message ID")
 	}
 	body := append([]byte(nil), publication.Payload...)
-	return pub.PublishOwnedWithID(ctx, publication.Subject, publication.ID, body)
+	segment := startMessagingSegment(ctx, "nats.publish", "publish", publication.Subject)
+	err := pub.PublishOwnedWithID(ctx, publication.Subject, publication.ID, body)
+	endMessagingSegment(segment, err)
+	return err
+}
+
+func publishOwned(ctx context.Context, pub Publisher, subject string, body []byte) error {
+	segment := startMessagingSegment(ctx, "nats.publish", "publish", subject)
+	err := pub.PublishOwned(ctx, subject, body)
+	endMessagingSegment(segment, err)
+	return err
 }

--- a/pkg/bus/respond.go
+++ b/pkg/bus/respond.go
@@ -10,9 +10,13 @@ import (
 // handlers may ignore the returned error, but new shared RPC helpers log it so
 // responder-side failures do not disappear silently.
 func Respond(msg *nats.Msg, v any) error {
-	body, err := json.Marshal(v)
+	body, err := marshalResponse(v)
 	if err != nil {
 		return err
 	}
-	return msg.Respond(body)
+	return sendResponse(msg, body)
 }
+
+func marshalResponse(v any) ([]byte, error) { return json.Marshal(v) }
+
+func sendResponse(msg *nats.Msg, body []byte) error { return msg.Respond(body) }

--- a/pkg/bus/rpc.go
+++ b/pkg/bus/rpc.go
@@ -34,24 +34,35 @@ func (e RPCReplyError) Error() string {
 func RequestJSON[T any](ctx context.Context, nc *nats.Conn, subject string, request any) (T, error) {
 	var zero T
 
+	encodeSegment := startMessagingSegment(ctx, "rpc.request.encode", "request", subject)
 	body, err := json.Marshal(request)
+	endMessagingSegment(encodeSegment, err)
 	if err != nil {
 		return zero, fmt.Errorf("rpc %s marshal request: %w", subject, err)
 	}
 
-	msg, err := nc.RequestWithContext(ctx, subject, body)
+	requestMsg := nats.NewMsg(subject)
+	requestMsg.Data = body
+	insertTraceHeaders(ctx, requestMsg)
+
+	segment := startMessagingSegment(ctx, "nats.request", "request", subject)
+	msg, err := nc.RequestMsgWithContext(ctx, requestMsg)
+	endMessagingSegment(segment, err)
 	if err != nil {
 		return zero, fmt.Errorf("rpc %s request: %w", subject, err)
 	}
 
-	if msg := rpcErrorMessage(msg.Data); msg != "" {
-		return zero, RPCReplyError{Subject: subject, Message: msg}
+	if errorMessage := rpcErrorMessage(msg.Data); errorMessage != "" {
+		return zero, RPCReplyError{Subject: subject, Message: errorMessage}
 	}
 
+	decodeSegment := startMessagingSegment(ctx, "rpc.response.decode", "request", subject)
 	var reply T
 	if err := json.Unmarshal(msg.Data, &reply); err != nil {
+		endMessagingSegment(decodeSegment, err)
 		return zero, fmt.Errorf("rpc %s unmarshal reply: %w", subject, err)
 	}
+	endMessagingSegment(decodeSegment, nil)
 	return reply, nil
 }
 
@@ -83,24 +94,35 @@ func QueueSubscribeJSON[Req any, Resp any](
 	_, err := nc.QueueSubscribe(subject, queueGroup, func(msg *nats.Msg) {
 		start := time.Now()
 
-		txn := app.StartTransaction("rpc " + subject)
+		txn := app.StartTransaction("rpc " + normalizedDestination(subject))
 		defer txn.End()
+		acceptTraceHeaders(txn, msg.Header)
+		addMessagingTransactionAttributes(txn, "process", subject)
 
 		var req Req
 		// Empty bodies are allowed for no-argument RPCs; handlers validate any
 		// required fields on the zero-value request.
 		if len(msg.Data) > 0 {
+			decodeSegment := txn.StartSegment("rpc.decode")
 			if err := json.Unmarshal(msg.Data, &req); err != nil {
+				decodeSegment.AddAttribute(resultAttribute, "invalid")
+				decodeSegment.End()
 				txn.NoticeError(err)
-				respondAndLog(msg, subject, start, log, map[string]string{"error": "bad request"})
+				txn.AddAttribute(resultAttribute, "invalid")
+				respondAndLog(msg, subject, start, log, txn, map[string]string{"error": "bad request"})
 				return
 			}
+			decodeSegment.AddAttribute(resultAttribute, "ok")
+			decodeSegment.End()
 		}
 
 		ctx, cancel := context.WithTimeout(newrelic.NewContext(context.Background(), txn), timeout)
 		defer cancel()
 
-		respondAndLog(msg, subject, start, log, handle(ctx, req))
+		handleSegment := txn.StartSegment("rpc.handler")
+		reply := handle(ctx, req)
+		handleSegment.End()
+		respondAndLog(msg, subject, start, log, txn, reply)
 	})
 	if err != nil {
 		return fmt.Errorf("subscribe %s: %w", subject, err)
@@ -111,9 +133,30 @@ func QueueSubscribeJSON[Req any, Resp any](
 	return nil
 }
 
-func respondAndLog(msg *nats.Msg, subject string, start time.Time, log *zap.Logger, reply any) {
+func respondAndLog(msg *nats.Msg, subject string, start time.Time, log *zap.Logger, txn *newrelic.Transaction, reply any) {
 	elapsed := time.Since(start)
-	if err := Respond(msg, reply); err != nil && log != nil {
+	encodeSegment := txn.StartSegment("rpc.reply.encode")
+	body, err := marshalResponse(reply)
+	encodeSegment.AddAttribute(resultAttribute, messagingResult(err))
+	encodeSegment.End()
+	if err != nil {
+		txn.AddAttribute(resultAttribute, "error")
+		txn.NoticeError(err)
+		if log != nil {
+			log.Warn("rpc encode reply failed", zap.String("subject", subject), zap.Duration("elapsed", elapsed), zap.Error(err))
+		}
+		return
+	}
+	segment := txn.StartSegment("nats.reply")
+	segment.AddAttribute(messagingSystemAttribute, "nats")
+	segment.AddAttribute(messagingOperationAttribute, "reply")
+	segment.AddAttribute(messagingDestinationAttribute, normalizedDestination(subject))
+	err = sendResponse(msg, body)
+	segment.AddAttribute(resultAttribute, messagingResult(err))
+	segment.End()
+	txn.AddAttribute(resultAttribute, messagingResult(err))
+	if err != nil && log != nil {
+		txn.NoticeError(err)
 		log.Warn("rpc respond failed", zap.String("subject", subject), zap.Duration("elapsed", elapsed), zap.Error(err))
 		return
 	}

--- a/pkg/bus/rpc.go
+++ b/pkg/bus/rpc.go
@@ -34,7 +34,9 @@ func (e RPCReplyError) Error() string {
 func RequestJSON[T any](ctx context.Context, nc *nats.Conn, subject string, request any) (T, error) {
 	var zero T
 
-	encodeSegment := startMessagingSegment(ctx, "rpc.request.encode", "request", subject)
+	encodeSegment := startMessagingSegment(ctx, messagingSpan{
+		name: "rpc.request.encode", operation: "request", destination: subject,
+	})
 	body, err := json.Marshal(request)
 	endMessagingSegment(encodeSegment, err)
 	if err != nil {
@@ -45,7 +47,9 @@ func RequestJSON[T any](ctx context.Context, nc *nats.Conn, subject string, requ
 	requestMsg.Data = body
 	insertTraceHeaders(ctx, requestMsg)
 
-	segment := startMessagingSegment(ctx, "nats.request", "request", subject)
+	segment := startMessagingSegment(ctx, messagingSpan{
+		name: "nats.request", operation: "request", destination: subject,
+	})
 	msg, err := nc.RequestMsgWithContext(ctx, requestMsg)
 	endMessagingSegment(segment, err)
 	if err != nil {
@@ -56,7 +60,9 @@ func RequestJSON[T any](ctx context.Context, nc *nats.Conn, subject string, requ
 		return zero, RPCReplyError{Subject: subject, Message: errorMessage}
 	}
 
-	decodeSegment := startMessagingSegment(ctx, "rpc.response.decode", "request", subject)
+	decodeSegment := startMessagingSegment(ctx, messagingSpan{
+		name: "rpc.response.decode", operation: "request", destination: subject,
+	})
 	var reply T
 	if err := json.Unmarshal(msg.Data, &reply); err != nil {
 		endMessagingSegment(decodeSegment, err)
@@ -97,7 +103,7 @@ func QueueSubscribeJSON[Req any, Resp any](
 		txn := app.StartTransaction("rpc " + normalizedDestination(subject))
 		defer txn.End()
 		acceptTraceHeaders(txn, msg.Header)
-		addMessagingTransactionAttributes(txn, "process", subject)
+		addMessagingTransactionAttributes(txn, messagingAttributes{operation: "process", destination: subject})
 
 		var req Req
 		// Empty bodies are allowed for no-argument RPCs; handlers validate any

--- a/pkg/bus/telemetry.go
+++ b/pkg/bus/telemetry.go
@@ -1,0 +1,124 @@
+package bus
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/nats-io/nats.go"
+	"github.com/newrelic/go-agent/v3/newrelic"
+)
+
+const (
+	messagingSystemAttribute      = "messaging.system"
+	messagingOperationAttribute   = "messaging.operation"
+	messagingDestinationAttribute = "messaging.destination"
+	resultAttribute               = "result"
+)
+
+// startMessagingSegment creates a fixed-name span and puts the configured
+// destination in an attribute. Keeping subjects out of span names prevents an
+// accidentally ID-expanded subject from creating unbounded metric names.
+func startMessagingSegment(ctx context.Context, name, operation, destination string) *newrelic.Segment {
+	txn := newrelic.FromContext(ctx)
+	if txn == nil {
+		return nil
+	}
+	segment := txn.StartSegment(name)
+	segment.AddAttribute(messagingSystemAttribute, "nats")
+	segment.AddAttribute(messagingOperationAttribute, operation)
+	segment.AddAttribute(messagingDestinationAttribute, normalizedDestination(destination))
+	return segment
+}
+
+func endMessagingSegment(segment *newrelic.Segment, err error) {
+	if segment == nil {
+		return
+	}
+	segment.AddAttribute(resultAttribute, messagingResult(err))
+	segment.End()
+}
+
+func messagingResult(err error) string {
+	switch {
+	case err == nil:
+		return "ok"
+	case errors.Is(err, context.DeadlineExceeded), errors.Is(err, nats.ErrTimeout):
+		return "timeout"
+	default:
+		return "error"
+	}
+}
+
+func insertTraceHeaders(ctx context.Context, msg *nats.Msg) {
+	txn := newrelic.FromContext(ctx)
+	if txn == nil {
+		return
+	}
+	headers := http.Header{}
+	txn.InsertDistributedTraceHeaders(headers)
+	for key := range headers {
+		msg.Header.Set(key, headers.Get(key))
+	}
+}
+
+func acceptTraceHeaders(txn *newrelic.Transaction, headers nats.Header) {
+	if txn == nil || len(headers) == 0 {
+		return
+	}
+	httpHeaders := make(http.Header, len(headers))
+	for key, values := range headers {
+		for _, value := range values {
+			httpHeaders.Add(key, value)
+		}
+	}
+	txn.AcceptDistributedTraceHeaders(newrelic.TransportQueue, httpHeaders)
+}
+
+func addMessagingTransactionAttributes(txn *newrelic.Transaction, operation, destination string) {
+	if txn == nil {
+		return
+	}
+	txn.AddAttribute(messagingSystemAttribute, "nats")
+	txn.AddAttribute(messagingOperationAttribute, operation)
+	txn.AddAttribute(messagingDestinationAttribute, normalizedDestination(destination))
+}
+
+// normalizedDestination intentionally reports a configured family rather than
+// the raw wire subject. Raw subjects are still available in correlated logs;
+// keeping them out of APM facets prevents IDs or tenant tokens from creating
+// unbounded cardinality.
+func normalizedDestination(subject string) string {
+	parts := strings.Split(subject, ".")
+	if len(parts) >= 3 && parts[0] == "bagel" && parts[1] == "rpc" {
+		switch parts[2] {
+		case "admin", "broadcaster", "commands", "dashboard", "delegation", "gateway",
+			"health", "ingress", "internal", "loyalty", "modules", "notifications",
+			"outgress", "projector", "transactions", "users":
+			return "bagel.rpc." + parts[2]
+		default:
+			return "bagel.rpc.other"
+		}
+	}
+	if len(parts) == 4 && strings.Join(parts[:3], ".") == "twitch.ingress.event" {
+		switch parts[3] {
+		case "premium", "standard", "stream":
+			return subject
+		default:
+			return "twitch.ingress.event.other"
+		}
+	}
+	if len(parts) == 3 && parts[0] == "twitch" && parts[1] == "outgress" {
+		switch parts[2] {
+		case "premium", "standard", "system":
+			return subject
+		default:
+			return "twitch.outgress.other"
+		}
+	}
+	if strings.HasPrefix(subject, "bagel.cache.invalidate") {
+		return "bagel.cache.invalidate"
+	}
+	return "other"
+}

--- a/pkg/bus/telemetry.go
+++ b/pkg/bus/telemetry.go
@@ -33,6 +33,17 @@ type destinationFamily struct {
 	allowed  map[string]struct{}
 }
 
+type messagingSpan struct {
+	name        string
+	operation   string
+	destination string
+}
+
+type messagingAttributes struct {
+	operation   string
+	destination string
+}
+
 var ingressDestinations = destinationFamily{
 	fallback: ingressDestinationPrefix + "other",
 	allowed: map[string]struct{}{
@@ -54,15 +65,15 @@ var outgressDestinations = destinationFamily{
 // startMessagingSegment creates a fixed-name span and puts the configured
 // destination in an attribute. Keeping subjects out of span names prevents an
 // accidentally ID-expanded subject from creating unbounded metric names.
-func startMessagingSegment(ctx context.Context, name, operation, destination string) *newrelic.Segment {
+func startMessagingSegment(ctx context.Context, span messagingSpan) *newrelic.Segment {
 	txn := newrelic.FromContext(ctx)
 	if txn == nil {
 		return nil
 	}
-	segment := txn.StartSegment(name)
+	segment := txn.StartSegment(span.name)
 	segment.AddAttribute(messagingSystemAttribute, "nats")
-	segment.AddAttribute(messagingOperationAttribute, operation)
-	segment.AddAttribute(messagingDestinationAttribute, normalizedDestination(destination))
+	segment.AddAttribute(messagingOperationAttribute, span.operation)
+	segment.AddAttribute(messagingDestinationAttribute, normalizedDestination(span.destination))
 	return segment
 }
 
@@ -110,13 +121,13 @@ func acceptTraceHeaders(txn *newrelic.Transaction, headers nats.Header) {
 	txn.AcceptDistributedTraceHeaders(newrelic.TransportQueue, httpHeaders)
 }
 
-func addMessagingTransactionAttributes(txn *newrelic.Transaction, operation, destination string) {
+func addMessagingTransactionAttributes(txn *newrelic.Transaction, attributes messagingAttributes) {
 	if txn == nil {
 		return
 	}
 	txn.AddAttribute(messagingSystemAttribute, "nats")
-	txn.AddAttribute(messagingOperationAttribute, operation)
-	txn.AddAttribute(messagingDestinationAttribute, normalizedDestination(destination))
+	txn.AddAttribute(messagingOperationAttribute, attributes.operation)
+	txn.AddAttribute(messagingDestinationAttribute, normalizedDestination(attributes.destination))
 }
 
 // normalizedDestination intentionally reports a configured family rather than

--- a/pkg/bus/telemetry.go
+++ b/pkg/bus/telemetry.go
@@ -15,7 +15,41 @@ const (
 	messagingOperationAttribute   = "messaging.operation"
 	messagingDestinationAttribute = "messaging.destination"
 	resultAttribute               = "result"
+	rpcDestinationPrefix          = "bagel.rpc."
+	ingressDestinationPrefix      = "twitch.ingress.event."
+	outgressDestinationPrefix     = "twitch.outgress."
+	cacheDestinationPrefix        = "bagel.cache.invalidate"
 )
+
+var rpcDestinations = map[string]struct{}{
+	"admin": {}, "broadcaster": {}, "commands": {}, "dashboard": {},
+	"delegation": {}, "gateway": {}, "health": {}, "ingress": {},
+	"internal": {}, "loyalty": {}, "modules": {}, "notifications": {},
+	"outgress": {}, "projector": {}, "transactions": {}, "users": {},
+}
+
+type destinationFamily struct {
+	fallback string
+	allowed  map[string]struct{}
+}
+
+var ingressDestinations = destinationFamily{
+	fallback: ingressDestinationPrefix + "other",
+	allowed: map[string]struct{}{
+		ingressDestinationPrefix + "premium":  {},
+		ingressDestinationPrefix + "standard": {},
+		ingressDestinationPrefix + "stream":   {},
+	},
+}
+
+var outgressDestinations = destinationFamily{
+	fallback: outgressDestinationPrefix + "other",
+	allowed: map[string]struct{}{
+		outgressDestinationPrefix + "premium":  {},
+		outgressDestinationPrefix + "standard": {},
+		outgressDestinationPrefix + "system":   {},
+	},
+}
 
 // startMessagingSegment creates a fixed-name span and puts the configured
 // destination in an attribute. Keeping subjects out of span names prevents an
@@ -90,35 +124,32 @@ func addMessagingTransactionAttributes(txn *newrelic.Transaction, operation, des
 // keeping them out of APM facets prevents IDs or tenant tokens from creating
 // unbounded cardinality.
 func normalizedDestination(subject string) string {
-	parts := strings.Split(subject, ".")
-	if len(parts) >= 3 && parts[0] == "bagel" && parts[1] == "rpc" {
-		switch parts[2] {
-		case "admin", "broadcaster", "commands", "dashboard", "delegation", "gateway",
-			"health", "ingress", "internal", "loyalty", "modules", "notifications",
-			"outgress", "projector", "transactions", "users":
-			return "bagel.rpc." + parts[2]
-		default:
-			return "bagel.rpc.other"
-		}
+	switch {
+	case strings.HasPrefix(subject, rpcDestinationPrefix):
+		return normalizedRPCDestination(subject)
+	case strings.HasPrefix(subject, ingressDestinationPrefix):
+		return ingressDestinations.normalize(subject)
+	case strings.HasPrefix(subject, outgressDestinationPrefix):
+		return outgressDestinations.normalize(subject)
+	case strings.HasPrefix(subject, cacheDestinationPrefix):
+		return cacheDestinationPrefix
+	default:
+		return "other"
 	}
-	if len(parts) == 4 && strings.Join(parts[:3], ".") == "twitch.ingress.event" {
-		switch parts[3] {
-		case "premium", "standard", "stream":
-			return subject
-		default:
-			return "twitch.ingress.event.other"
-		}
+}
+
+func normalizedRPCDestination(subject string) string {
+	remainder := strings.TrimPrefix(subject, rpcDestinationPrefix)
+	service, _, _ := strings.Cut(remainder, ".")
+	if _, ok := rpcDestinations[service]; ok {
+		return rpcDestinationPrefix + service
 	}
-	if len(parts) == 3 && parts[0] == "twitch" && parts[1] == "outgress" {
-		switch parts[2] {
-		case "premium", "standard", "system":
-			return subject
-		default:
-			return "twitch.outgress.other"
-		}
+	return rpcDestinationPrefix + "other"
+}
+
+func (family destinationFamily) normalize(subject string) string {
+	if _, ok := family.allowed[subject]; ok {
+		return subject
 	}
-	if strings.HasPrefix(subject, "bagel.cache.invalidate") {
-		return "bagel.cache.invalidate"
-	}
-	return "other"
+	return family.fallback
 }

--- a/pkg/bus/telemetry_test.go
+++ b/pkg/bus/telemetry_test.go
@@ -1,0 +1,115 @@
+package bus
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/newrelic/go-agent/v3/newrelic"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) { return fn(req) }
+
+func localCollectorResponse(req *http.Request) (*http.Response, error) {
+	body := `{"return_value":[]}`
+	switch req.URL.Query().Get("method") {
+	case "preconnect":
+		body = `{"return_value":{"redirect_host":"collector.invalid"}}`
+	case "connect":
+		body = `{"return_value":{"agent_run_id":"local","account_id":"123","trusted_account_key":"123","primary_application_id":"456"}}`
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Request:    req,
+	}, nil
+}
+
+func TestRPCTraceHeadersRoundTripWithoutCollector(t *testing.T) {
+	app, err := newrelic.NewApplication(func(cfg *newrelic.Config) {
+		cfg.AppName = "bus-telemetry-test"
+		cfg.License = strings.Repeat("a", 40)
+		cfg.Enabled = true
+		cfg.DistributedTracer.Enabled = true
+		cfg.Transport = roundTripFunc(localCollectorResponse)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Shutdown(time.Second)
+	if err := app.WaitForConnection(time.Second); err != nil {
+		t.Fatal(err)
+	}
+
+	parent := app.StartTransaction("parent")
+	msg := nats.NewMsg("bagel.rpc.test")
+	insertTraceHeaders(newrelic.NewContext(context.Background(), parent), msg)
+
+	traceparent := msg.Header.Get(newrelic.DistributedTraceW3CTraceParentHeader)
+	if traceparent == "" {
+		t.Fatalf("request message has no W3C traceparent header (metadata=%+v, headers=%v)", parent.GetTraceMetadata(), msg.Header)
+	}
+	parts := strings.Split(traceparent, "-")
+	if len(parts) != 4 {
+		t.Fatalf("invalid traceparent %q", traceparent)
+	}
+
+	child := app.StartTransaction("child")
+	acceptTraceHeaders(child, msg.Header)
+	if got := child.GetTraceMetadata().TraceID; got != parts[1] {
+		t.Fatalf("accepted trace id = %q, want %q", got, parts[1])
+	}
+}
+
+func TestMessageDeliveryWaitIsBoundedAtZero(t *testing.T) {
+	msg := NewMessage("id", nil)
+	msg.receivedAt = time.Now().Add(-2 * time.Millisecond)
+	if got := msg.deliveryWait(time.Now()); got < time.Millisecond {
+		t.Fatalf("delivery wait = %v, want at least 1ms", got)
+	}
+	msg.receivedAt = time.Now().Add(time.Second)
+	if got := msg.deliveryWait(time.Now()); got != 0 {
+		t.Fatalf("future delivery wait = %v, want 0", got)
+	}
+}
+
+func TestMessagingResultsAreFinite(t *testing.T) {
+	for _, tc := range []struct {
+		err  error
+		want string
+	}{
+		{nil, "ok"},
+		{context.DeadlineExceeded, "timeout"},
+		{nats.ErrTimeout, "timeout"},
+		{context.Canceled, "error"},
+	} {
+		if got := messagingResult(tc.err); got != tc.want {
+			t.Fatalf("messagingResult(%v) = %q, want %q", tc.err, got, tc.want)
+		}
+	}
+}
+
+func TestDestinationFamiliesAreBounded(t *testing.T) {
+	for _, tc := range []struct {
+		subject string
+		want    string
+	}{
+		{"bagel.rpc.projector.dashboard.commands.get", "bagel.rpc.projector"},
+		{"bagel.rpc.projector.tenant-123.private", "bagel.rpc.projector"},
+		{"bagel.rpc.untrusted.tenant-123", "bagel.rpc.other"},
+		{"twitch.ingress.event.premium", "twitch.ingress.event.premium"},
+		{"twitch.ingress.event.tenant-123", "twitch.ingress.event.other"},
+		{"arbitrary.tenant-123", "other"},
+	} {
+		if got := normalizedDestination(tc.subject); got != tc.want {
+			t.Fatalf("normalizedDestination(%q) = %q, want %q", tc.subject, got, tc.want)
+		}
+	}
+}

--- a/pkg/valkey/client.go
+++ b/pkg/valkey/client.go
@@ -119,33 +119,45 @@ type Client struct {
 // Do sends read-only commands to the local instance and everything else to the
 // master via Sentinel.
 func (c *Client) Do(ctx context.Context, cmd valkey_go.Completed) valkey_go.ValkeyResult {
-	operation := "valkey.write"
-	client := c.Client
-	if cmd.IsReadOnly() {
-		operation = "valkey.read"
-		if c.local != nil {
-			client = c.local
-		}
-	}
-	return traceValkeyCall(ctx, operation, func() valkey_go.ValkeyResult {
-		return client.Do(ctx, cmd)
+	route := c.commandRoute(cmd.IsReadOnly(), singleCommand)
+	return traceValkeyCall(ctx, route.operation, func() valkey_go.ValkeyResult {
+		return route.client.Do(ctx, cmd)
 	}, classifyValkeyResult)
 }
 
 // DoMulti sends a batch to the local instance only when every command is
 // read-only; any write in the batch routes the whole batch to the master.
 func (c *Client) DoMulti(ctx context.Context, multi ...valkey_go.Completed) []valkey_go.ValkeyResult {
-	operation := "valkey.write_batch"
-	client := c.Client
-	if allReadOnly(multi) {
-		operation = "valkey.read_batch"
+	route := c.commandRoute(allReadOnly(multi), commandBatch)
+	return traceValkeyCall(ctx, route.operation, func() []valkey_go.ValkeyResult {
+		return route.client.DoMulti(ctx, multi...)
+	}, classifyValkeyResults)
+}
+
+type commandShape uint8
+
+const (
+	singleCommand commandShape = iota
+	commandBatch
+)
+
+type valkeyRoute struct {
+	client    valkey_go.Client
+	operation string
+}
+
+func (c *Client) commandRoute(readOnly bool, shape commandShape) valkeyRoute {
+	route := valkeyRoute{client: c.Client, operation: "valkey.write"}
+	if readOnly {
+		route.operation = "valkey.read"
 		if c.local != nil {
-			client = c.local
+			route.client = c.local
 		}
 	}
-	return traceValkeyCall(ctx, operation, func() []valkey_go.ValkeyResult {
-		return client.DoMulti(ctx, multi...)
-	}, classifyValkeyResults)
+	if shape == commandBatch {
+		route.operation += "_batch"
+	}
+	return route
 }
 
 // Valkey spans are emitted only for transactions selected by New Relic's own

--- a/pkg/valkey/client.go
+++ b/pkg/valkey/client.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/newrelic/go-agent/v3/newrelic"
 	valkey_go "github.com/valkey-io/valkey-go"
 )
 
@@ -118,19 +119,80 @@ type Client struct {
 // Do sends read-only commands to the local instance and everything else to the
 // master via Sentinel.
 func (c *Client) Do(ctx context.Context, cmd valkey_go.Completed) valkey_go.ValkeyResult {
-	if c.local != nil && cmd.IsReadOnly() {
-		return c.local.Do(ctx, cmd)
+	operation := "valkey.write"
+	client := c.Client
+	if cmd.IsReadOnly() {
+		operation = "valkey.read"
+		if c.local != nil {
+			client = c.local
+		}
 	}
-	return c.Client.Do(ctx, cmd)
+	return traceValkey(ctx, operation, func() valkey_go.ValkeyResult {
+		return client.Do(ctx, cmd)
+	})
 }
 
 // DoMulti sends a batch to the local instance only when every command is
 // read-only; any write in the batch routes the whole batch to the master.
 func (c *Client) DoMulti(ctx context.Context, multi ...valkey_go.Completed) []valkey_go.ValkeyResult {
-	if c.local != nil && allReadOnly(multi) {
-		return c.local.DoMulti(ctx, multi...)
+	operation := "valkey.write_batch"
+	client := c.Client
+	if allReadOnly(multi) {
+		operation = "valkey.read_batch"
+		if c.local != nil {
+			client = c.local
+		}
 	}
-	return c.Client.DoMulti(ctx, multi...)
+	return traceValkeyMulti(ctx, operation, func() []valkey_go.ValkeyResult {
+		return client.DoMulti(ctx, multi...)
+	})
+}
+
+// Valkey spans are emitted only for transactions selected by New Relic's own
+// sampler. The unsampled command path remains one context lookup and a branch,
+// while sampled traces get fixed-name read/write dependency attribution without
+// exposing keys or commands as high-cardinality facets.
+func traceValkey(ctx context.Context, operation string, do func() valkey_go.ValkeyResult) valkey_go.ValkeyResult {
+	txn := newrelic.FromContext(ctx)
+	if txn == nil || !txn.IsSampled() {
+		return do()
+	}
+	segment := txn.StartSegment(operation)
+	result := do()
+	segment.AddAttribute("result", valkeyResult(result.Error()))
+	segment.End()
+	return result
+}
+
+func traceValkeyMulti(ctx context.Context, operation string, do func() []valkey_go.ValkeyResult) []valkey_go.ValkeyResult {
+	txn := newrelic.FromContext(ctx)
+	if txn == nil || !txn.IsSampled() {
+		return do()
+	}
+	segment := txn.StartSegment(operation)
+	results := do()
+	result := "ok"
+	for i := range results {
+		if current := valkeyResult(results[i].Error()); current == "error" {
+			result = current
+			break
+		} else if current == "miss" {
+			result = current
+		}
+	}
+	segment.AddAttribute("result", result)
+	segment.End()
+	return results
+}
+
+func valkeyResult(err error) string {
+	if err == nil {
+		return "ok"
+	}
+	if valkey_go.IsValkeyNil(err) {
+		return "miss"
+	}
+	return "error"
 }
 
 // Receive routes pub/sub to the master-pinned client. Keyspace notifications
@@ -184,9 +246,10 @@ func NewClient(address, password string) (valkey_go.Client, error) {
 	}
 
 	// Standalone (dev / single instance): that one node is the master, so its
-	// own Do/Receive already land on the right place. No wrapper needed.
+	// own Do/Receive already land on the right place. Keep the lightweight
+	// wrapper so sampled dependency telemetry behaves the same in every mode.
 	if !isSentinelAddress(address) {
-		return master, nil
+		return &Client{Client: master}, nil
 	}
 
 	// Sentinel: pub/sub must be pinned to the master (no SendToReplicas) or the

--- a/pkg/valkey/client.go
+++ b/pkg/valkey/client.go
@@ -127,9 +127,9 @@ func (c *Client) Do(ctx context.Context, cmd valkey_go.Completed) valkey_go.Valk
 			client = c.local
 		}
 	}
-	return traceValkey(ctx, operation, func() valkey_go.ValkeyResult {
+	return traceValkeyCall(ctx, operation, func() valkey_go.ValkeyResult {
 		return client.Do(ctx, cmd)
-	})
+	}, classifyValkeyResult)
 }
 
 // DoMulti sends a batch to the local instance only when every command is
@@ -143,34 +143,32 @@ func (c *Client) DoMulti(ctx context.Context, multi ...valkey_go.Completed) []va
 			client = c.local
 		}
 	}
-	return traceValkeyMulti(ctx, operation, func() []valkey_go.ValkeyResult {
+	return traceValkeyCall(ctx, operation, func() []valkey_go.ValkeyResult {
 		return client.DoMulti(ctx, multi...)
-	})
+	}, classifyValkeyResults)
 }
 
 // Valkey spans are emitted only for transactions selected by New Relic's own
 // sampler. The unsampled command path remains one context lookup and a branch,
 // while sampled traces get fixed-name read/write dependency attribution without
 // exposing keys or commands as high-cardinality facets.
-func traceValkey(ctx context.Context, operation string, do func() valkey_go.ValkeyResult) valkey_go.ValkeyResult {
+func traceValkeyCall[T any](ctx context.Context, operation string, do func() T, classify func(T) string) T {
 	txn := newrelic.FromContext(ctx)
 	if txn == nil || !txn.IsSampled() {
 		return do()
 	}
 	segment := txn.StartSegment(operation)
 	result := do()
-	segment.AddAttribute("result", valkeyResult(result.Error()))
+	segment.AddAttribute("result", classify(result))
 	segment.End()
 	return result
 }
 
-func traceValkeyMulti(ctx context.Context, operation string, do func() []valkey_go.ValkeyResult) []valkey_go.ValkeyResult {
-	txn := newrelic.FromContext(ctx)
-	if txn == nil || !txn.IsSampled() {
-		return do()
-	}
-	segment := txn.StartSegment(operation)
-	results := do()
+func classifyValkeyResult(result valkey_go.ValkeyResult) string {
+	return valkeyResult(result.Error())
+}
+
+func classifyValkeyResults(results []valkey_go.ValkeyResult) string {
 	result := "ok"
 	for i := range results {
 		if current := valkeyResult(results[i].Error()); current == "error" {
@@ -180,9 +178,7 @@ func traceValkeyMulti(ctx context.Context, operation string, do func() []valkey_
 			result = current
 		}
 	}
-	segment.AddAttribute("result", result)
-	segment.End()
-	return results
+	return result
 }
 
 func valkeyResult(err error) string {

--- a/pkg/valkey/client_test.go
+++ b/pkg/valkey/client_test.go
@@ -2,11 +2,18 @@ package valkey
 
 import (
 	"crypto/tls"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	valkey_go "github.com/valkey-io/valkey-go"
 )
+
+func TestValkeyTelemetryResultsStayFinite(t *testing.T) {
+	assert.Equal(t, "ok", valkeyResult(nil))
+	assert.Equal(t, "miss", valkeyResult(valkey_go.Nil))
+	assert.Equal(t, "error", valkeyResult(errors.New("unavailable")))
+}
 
 // TestReadScaling verifies that the Valkey client option configuration correctly
 // sets the SendToReplicas predicate when connecting to a Sentinel cluster.


### PR DESCRIPTION
## What changed

- adds sampled full-path ingress, NATS RPC, Sesame, and Valkey telemetry with bounded-cardinality stage names
- records actual ingress JetStream PubAck latency separately from asynchronous admission
- keeps the ingress tracing default sparse (1/1024) and bypasses New Relic/header allocation for unsampled events
- switches the measured R3 route-compression setting from `s2_auto` to `s2_fast`
- makes node-local R3 publishing the qualification default and records broker CPU, memory, route pressure, and follower lag
- retains the 2 ms JetStream p99 and 8 ms RPC p99 as separate gates
- reduces Sesame loyalty, greeting, and personality Valkey hot commands to one warm master RTT through atomic scripts
- removes stale documentation that described Valkey transport replay deduplication
- adds the evidence-gated 20,000-channel performance roadmap

## Why

The full command path could not attribute dispatcher, projection, RPC, Valkey, engine, and confirmed-output latency consistently. The R3 qualification also lacked broker/route pressure evidence, while several Sesame domain-state operations paid avoidable sequential cross-node Valkey RTTs.

## Impact

- no stream sharding or partitioning
- hubs remain JetStream-only and leaves remain RPC-only
- broker deduplication remains off
- worker1 remains a replica but not the preferred stream leader
- R3 promotion still requires an isolated 90k events/s, 30-minute run with p99 <= 2 ms
- no live production benchmark result is claimed by this PR

## Validation

- `GOCACHE=/private/tmp/itsbagelbot-go-build-cache go test ./...`
- `go vet ./...`
- ingress: 146 tests, zero failures
- Astro documentation build
- shell syntax and NATS configuration regression gates
- Sesame benchmarks: 673–684 ns/op without output; 2.98–3.12 µs/op with chat output
- local ingress dispatcher benchmark: 664k/s with default tracing vs 663k/s with tracing disabled
