### PR TITLE
Declare isolated R3 benchmark priority class

### DIFF
--- a/deploy/k8s/kustomization.yaml
+++ b/deploy/k8s/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: production
 resources:
+  - nats-r3-benchmark-priority-class.yaml
   - console-admin.yaml
   - commands.yaml
   - console-dashboard.yaml

--- a/deploy/k8s/nats-r3-benchmark-priority-class.yaml
+++ b/deploy/k8s/nats-r3-benchmark-priority-class.yaml
@@ -1,0 +1,8 @@
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: nats-r3-bench-nonpreempting
+value: -100000
+globalDefault: false
+preemptionPolicy: Never
+description: Non-preempting priority for isolated NATS R3 qualification workloads


### PR DESCRIPTION
Adds the non-preempting, negative-priority PriorityClass required by the guarded live R3 qualification runner. This keeps isolated benchmark pods schedulable without allowing them to displace production workloads.\n\nValidated with:\n- kubectl kustomize deploy/k8s\n- GOCACHE=/private/tmp/itsbagelbot-go-build-cache go test ./deploy/k8s/...\n- git diff --check