### PR TITLE
Tune Valkey tails and prove local-first RPC

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -25,6 +25,7 @@ on:
           - users
           - sesame
           - twitch-ingress
+          - valkey-live-acceptance
           - console-dashboard
           - console-admin
 
@@ -133,6 +134,12 @@ jobs:
               "description": "ItsBagelBot Twitch ingress service"
             },
             {
+              "image": "valkey-live-acceptance",
+              "context": ".",
+              "containerfile": "deploy/k8s/valkey-live-acceptance/Containerfile",
+              "description": "ItsBagelBot Valkey live-acceptance probe"
+            },
+            {
               "image": "console-dashboard",
               "context": "console",
               "containerfile": "console/dashboard/Containerfile",
@@ -163,6 +170,7 @@ jobs:
             add "users"
             add "sesame"
             add "gateway"
+            add "valkey-live-acceptance"
           }
 
           add_all_services() {
@@ -177,6 +185,7 @@ jobs:
             add "sesame"
             add "gateway"
             add "twitch-ingress"
+            add "valkey-live-acceptance"
             add "console-dashboard"
             add "console-admin"
           }
@@ -203,6 +212,9 @@ jobs:
                 ;;
               app/ingress/*)
                 add "twitch-ingress"
+                ;;
+              deploy/k8s/valkey-live-acceptance/*)
+                add "valkey-live-acceptance"
                 ;;
               app/loyalty/*)
                 add "loyalty"

--- a/deploy/ansible/README.md
+++ b/deploy/ansible/README.md
@@ -145,6 +145,34 @@ server-first rollback is fully automated:
 ansible-playbook -i inventory.cluster.ini cluster-network-rollback.yml
 ```
 
+### Existing cluster: Valkey host latency policy
+
+Before a change that restarts the Valkey StatefulSet, run the read-only topology
+gate. It requires all four members to be ready and the current primary to live
+on node2 or node3:
+
+```bash
+ansible-playbook valkey-rollout-preflight.yml
+```
+
+The first deployment of the deterministic cold-bootstrap policy also changes
+the immutable StatefulSet `podManagementPolicy` from `OrderedReady` to
+`Parallel`. Perform that as a controlled orphan/delete-and-recreate while
+retaining the pods and PVCs. Only for that reviewed migration, acknowledge it to
+the preflight with `-e valkey_allow_parallel_migration=true`; subsequent runs
+must pass without the acknowledgement.
+
+Reconcile swap pressure and transparent huge pages across all four production
+nodes with the explicit cluster inventory:
+
+```bash
+ansible-playbook -i inventory.cluster.ini valkey-host-tuning.yml
+```
+
+The play asserts that node1, node2, node3, and worker1 are all present before it
+changes a host. Running it against the default single-node provisioning
+inventory fails loudly instead of reporting a successful no-op.
+
 `provision.sh` is just a thin `doppler run -- ansible-playbook …` wrapper.
 
 ### Compute-only nodes (taint + label)

--- a/deploy/ansible/roles/base/files/99-valkey-latency.conf
+++ b/deploy/ansible/roles/base/files/99-valkey-latency.conf
@@ -1,0 +1,4 @@
+# Valkey host latency policy. Managed by Ansible on every cluster node.
+# Keep emergency swap available, but only after the kernel has exhausted less
+# latency-sensitive reclaim options.
+vm.swappiness = 1

--- a/deploy/ansible/roles/base/files/valkey-thp-never.service
+++ b/deploy/ansible/roles/base/files/valkey-thp-never.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Disable transparent huge pages for Valkey tail latency
+Documentation=https://valkey.io/topics/latency/
+After=local-fs.target
+Before=k3s.service k3s-agent.service
+ConditionPathExists=/sys/kernel/mm/transparent_hugepage/enabled
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -ec 'echo never > /sys/kernel/mm/transparent_hugepage/enabled; if [ -e /sys/kernel/mm/transparent_hugepage/defrag ]; then echo never > /sys/kernel/mm/transparent_hugepage/defrag; fi'
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/ansible/roles/base/tasks/main.yml
+++ b/deploy/ansible/roles/base/tasks/main.yml
@@ -121,6 +121,12 @@
     mode: "0644"
   notify: reload sysctl
 
+# Valkey's fork/COW persistence path suffers severe tail-latency spikes when
+# transparent huge pages are active. Keep the host policy reusable by both the
+# fresh-node role and the existing-cluster reconciliation playbook.
+- name: Apply Valkey host latency tuning
+  ansible.builtin.import_tasks: valkey_host_tuning.yml
+
 # --- ulimits -----------------------------------------------------------------
 - name: Raise nofile / disable core dumps (matches fleet)
   ansible.builtin.copy:

--- a/deploy/ansible/roles/base/tasks/valkey_host_tuning.yml
+++ b/deploy/ansible/roles/base/tasks/valkey_host_tuning.yml
@@ -1,0 +1,55 @@
+---
+- name: Install Valkey latency sysctl policy
+  ansible.builtin.copy:
+    src: 99-valkey-latency.conf
+    dest: /etc/sysctl.d/99-valkey-latency.conf
+    mode: "0644"
+  notify: reload sysctl
+
+- name: Install Valkey transparent-huge-page latency tuning
+  ansible.builtin.copy:
+    src: valkey-thp-never.service
+    dest: /etc/systemd/system/valkey-thp-never.service
+    mode: "0644"
+  register: valkey_thp_unit
+
+- name: Inspect the live transparent-huge-page policy
+  ansible.builtin.command: cat /sys/kernel/mm/transparent_hugepage/enabled
+  register: valkey_thp_mode
+  changed_when: false
+  failed_when: false
+
+- name: Inspect whether transparent-huge-page defrag policy is available
+  ansible.builtin.stat:
+    path: /sys/kernel/mm/transparent_hugepage/defrag
+  register: valkey_thp_defrag_path
+
+- name: Inspect the live transparent-huge-page defrag policy
+  ansible.builtin.command: cat /sys/kernel/mm/transparent_hugepage/defrag
+  register: valkey_thp_defrag_mode
+  changed_when: false
+  when: valkey_thp_defrag_path.stat.exists
+
+- name: Enable Valkey transparent-huge-page latency tuning
+  ansible.builtin.systemd:
+    name: valkey-thp-never.service
+    enabled: true
+    daemon_reload: true
+
+- name: Apply Valkey transparent-huge-page latency tuning after unit or runtime drift
+  ansible.builtin.systemd:
+    name: valkey-thp-never.service
+    state: restarted
+  when:
+    - valkey_thp_mode.rc == 0
+    - >-
+      valkey_thp_unit is changed or
+      '[never]' not in valkey_thp_mode.stdout or
+      (valkey_thp_defrag_path.stat.exists and
+       '[never]' not in (valkey_thp_defrag_mode.stdout | default('')))
+
+- name: Keep Valkey transparent-huge-page latency tuning active
+  ansible.builtin.systemd:
+    name: valkey-thp-never.service
+    state: started
+  when: valkey_thp_mode.rc == 0

--- a/deploy/ansible/valkey-host-tuning.yml
+++ b/deploy/ansible/valkey-host-tuning.yml
@@ -1,0 +1,34 @@
+---
+# Reconcile latency-sensitive host policy on the existing cluster without
+# re-running the fresh-node provisioning roles.
+- name: Validate the explicit production-cluster inventory
+  hosts: localhost
+  connection: local
+  become: false
+  gather_facts: false
+  vars:
+    valkey_required_nodes:
+      - node1
+      - node2
+      - node3
+      - worker1
+  tasks:
+    - name: Refuse an empty or partial cluster target
+      ansible.builtin.assert:
+        that:
+          - groups.get('cluster', []) | length > 0
+          - valkey_required_nodes | difference(groups.get('cluster', [])) | length == 0
+        fail_msg: >-
+          valkey-host-tuning.yml requires the complete production inventory.
+          Run it with -i inventory.cluster.ini; the default inventory.ini only
+          describes a fresh provisioning target.
+
+- name: Apply Valkey host latency tuning
+  hosts: cluster
+  become: true
+  gather_facts: false
+  tasks:
+    - name: Apply the base role's Valkey host policy
+      ansible.builtin.include_role:
+        name: base
+        tasks_from: valkey_host_tuning

--- a/deploy/ansible/valkey-rollout-preflight.yml
+++ b/deploy/ansible/valkey-rollout-preflight.yml
@@ -1,0 +1,97 @@
+---
+# Read-only guard for changes that restart the Sentinel/Valkey StatefulSet.
+- name: Validate Valkey rollout topology
+  hosts: localhost
+  connection: local
+  become: false
+  gather_facts: false
+  vars:
+    valkey_allow_parallel_migration: false
+  tasks:
+    - name: Read the live Valkey StatefulSet
+      ansible.builtin.command:
+        argv:
+          - kubectl
+          - --namespace
+          - valkey
+          - get
+          - statefulset
+          - valkey-node
+          - --output
+          - json
+      register: valkey_statefulset_result
+      changed_when: false
+
+    - name: Parse the live Valkey StatefulSet
+      ansible.builtin.set_fact:
+        valkey_statefulset: "{{ valkey_statefulset_result.stdout | from_json }}"
+
+    - name: Require every Valkey member to be ready before rollout
+      ansible.builtin.assert:
+        that:
+          - valkey_statefulset.status.readyReplicas | default(0) == valkey_statefulset.spec.replicas
+        fail_msg: Refusing a Valkey rollout while the existing StatefulSet is not fully ready.
+
+    - name: Require explicit acknowledgement of the immutable Parallel migration
+      ansible.builtin.assert:
+        that:
+          - valkey_statefulset.spec.podManagementPolicy == 'Parallel' or valkey_allow_parallel_migration | bool
+        fail_msg: >-
+          The live StatefulSet still uses immutable podManagementPolicy=OrderedReady.
+          Use a controlled orphan/delete-and-recreate that retains pods and PVCs;
+          rerun this preflight with -e valkey_allow_parallel_migration=true only
+          as part of that reviewed migration.
+
+    - name: Ask a live Sentinel for the elected primary
+      ansible.builtin.command:
+        argv:
+          - kubectl
+          - --namespace
+          - valkey
+          - exec
+          - valkey-node-0
+          - --container
+          - sentinel
+          - --
+          - valkey-cli
+          - --port
+          - "26380"
+          - --tls
+          - --cacert
+          - /etc/valkey/tls/ca.crt
+          - --sni
+          - valkey.valkey.svc.cluster.local
+          - --raw
+          - --no-auth-warning
+          - sentinel
+          - get-master-addr-by-name
+          - myprimary
+      register: valkey_primary_result
+      changed_when: false
+      failed_when: valkey_primary_result.rc != 0 or valkey_primary_result.stdout_lines | length < 2
+
+    - name: Resolve the elected primary pod
+      ansible.builtin.set_fact:
+        valkey_primary_pod: "{{ valkey_primary_result.stdout_lines[0].split('.')[0] }}"
+
+    - name: Read the elected primary node
+      ansible.builtin.command:
+        argv:
+          - kubectl
+          - --namespace
+          - valkey
+          - get
+          - pod
+          - "{{ valkey_primary_pod }}"
+          - --output
+          - jsonpath={.spec.nodeName}
+      register: valkey_primary_node
+      changed_when: false
+
+    - name: Refuse rollout with a primary outside node2 and node3
+      ansible.builtin.assert:
+        that:
+          - valkey_primary_node.stdout in ['node2', 'node3']
+        fail_msg: >-
+          Refusing rollout: Sentinel primary {{ valkey_primary_pod }} is on
+          {{ valkey_primary_node.stdout | default('an unknown node') }}, not node2/node3.

--- a/deploy/infra/valkey/benchmark-priority-class.yaml
+++ b/deploy/infra/valkey/benchmark-priority-class.yaml
@@ -1,0 +1,8 @@
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: valkey-bench-nonpreempting
+value: -100000
+globalDefault: false
+preemptionPolicy: Never
+description: Non-preempting priority for isolated Valkey qualification workloads

--- a/deploy/infra/valkey/config/tuning.conf
+++ b/deploy/infra/valkey/config/tuning.conf
@@ -1,0 +1,51 @@
+# Runtime policy included from the read-only ConfigMap. config-init moves this
+# include to the end of every retained /data/valkey.conf before boot, so a
+# previous CONFIG REWRITE cannot leave stale performance or safety defaults.
+
+# Keep the documented durability/latency compromise explicit. Never trade this
+# for appendfsync=no or always without a separately approved RPO change.
+appendonly yes
+appendfsync everysec
+no-appendfsync-on-rewrite no
+aof-use-rdb-preamble yes
+aof-rewrite-incremental-fsync yes
+# Avoid an unnecessary fork/rewrite cycle at the 64 MiB default as write volume
+# grows. Percentage-based rewrites continue after the first base is established.
+auto-aof-rewrite-min-size 1gb
+auto-aof-rewrite-percentage 100
+save ""
+
+# Emit expired-key keyevents for Sesame's live/timer/loyalty dispatcher.
+notify-keyspace-events Ex
+# Keep deletion, expiry, eviction, and replica resync frees off the event loop.
+lazyfree-lazy-eviction yes
+lazyfree-lazy-expire yes
+lazyfree-lazy-server-del yes
+lazyfree-lazy-user-del yes
+replica-lazy-flush yes
+# The live dataset is currently small and has no demonstrated fragmentation
+# pressure. Active defragmentation spends event-loop and CPU time, so keep it
+# off until allocator fragmentation telemetry proves it is needed.
+activedefrag no
+
+# Preserve partial resynchronization through worker1 or datacenter network
+# interruptions instead of falling off the current 10 MiB history cliff.
+repl-backlog-size 128mb
+repl-diskless-sync yes
+
+# Match the live host receive queue and keep dead peers discoverable promptly.
+tcp-backlog 4096
+tcp-keepalive 60
+
+# Retain evidence that separates event-loop, fork, AOF, and scheduler spikes
+# from the normal microsecond command execution time.
+latency-monitor-threshold 1
+latency-tracking yes
+latency-tracking-info-percentiles 50 95 99 99.9
+slowlog-log-slower-than 1000
+slowlog-max-len 512
+
+# Refuse an isolated primary instead of acknowledging writes with no online
+# replica. This does not synchronously wait for replica acknowledgement.
+min-replicas-to-write 1
+min-replicas-max-lag 10

--- a/deploy/infra/valkey/config/valkey.conf
+++ b/deploy/infra/valkey/config/valkey.conf
@@ -20,21 +20,18 @@ loglevel notice
 # config-init reduces this to one on the 2-core node1 host until that replica is
 # evacuated for the database role.
 io-threads 2
-appendonly yes
-save ""
-# Bounded cache. maxmemory sits under the 1Gi container limit to leave COW and
-# buffer overhead room during AOF rewrite. volatile-lru evicts only keys that
+# Bounded cache. maxmemory sits under the 2 GiB container limit to leave room
+# for the replication backlog, COW, and buffers during AOF rewrite.
+# volatile-lru evicts only keys that
 # carry a TTL (cooldowns, live keys, cached projections) under pressure, so the
 # ACL/persistent keys are never evicted; when only non-TTL keys remain, writes
 # fail closed rather than dropping durable state.
 maxmemory 512mb
 maxmemory-policy volatile-lru
-# Emit expired-key keyevents (__keyevent@<db>__:expired) so the worker's live
-# store can re-check a stream against Twitch when its live key lapses, instead
-# of letting a long stream silently fall to offline.
-notify-keyspace-events Ex
 rename-command FLUSHDB ""
 rename-command FLUSHALL ""
 aclfile /secrets/users/users.acl
-min-replicas-to-write 0
-min-replicas-max-lag 10
+# ConfigMap-backed policy is deliberately included after retained state is
+# reconciled by config-init, so updates apply to existing PVCs as well as new
+# members. Node-specific io-threads and replica-priority are appended later.
+include /config/tuning.conf

--- a/deploy/infra/valkey/kustomization.yaml
+++ b/deploy/infra/valkey/kustomization.yaml
@@ -7,6 +7,7 @@ namespace: valkey
 # container flags for retained PVCs. topology_test.go is discovered by the
 # repository's normal `go test ./...` CI run and rejects configuration drift.
 resources:
+  - benchmark-priority-class.yaml
   - services.yaml
   - pdb.yaml
   - dopplersecrets.yaml
@@ -23,4 +24,5 @@ configMapGenerator:
   - name: valkey-config
     files:
       - config/sentinel.conf
+      - config/tuning.conf
       - config/valkey.conf

--- a/deploy/infra/valkey/statefulset.yaml
+++ b/deploy/infra/valkey/statefulset.yaml
@@ -15,7 +15,11 @@ spec:
   persistentVolumeClaimRetentionPolicy:
     whenDeleted: Retain
     whenScaled: Retain
-  podManagementPolicy: OrderedReady
+  # Parallel startup is required for a safe cold bootstrap: the pod placed on
+  # node2 is the sole deterministic bootstrap candidate, while fresh members on
+  # every other node wait for its Sentinel view. OrderedReady could deadlock the
+  # fleet when ordinal zero is scheduled on a fenced node.
+  podManagementPolicy: Parallel
   # Four colocated Valkey+Sentinel voters produce one writable primary and
   # three replicas. This count is a CI-enforced configuration invariant.
   replicas: 4
@@ -54,21 +58,48 @@ spec:
         - /bin/sh
         - -ec
         - |
-          # Resolve the CURRENT master: ask a live Sentinel first (the fleet may
-          # have failed over any number of times since pod-0 was master), falling
-          # back to pod-0 only for a full cold start where no
-          # Sentinel answers. Blindly seeding replicaof from pod-0 chains a new
-          # replica under whatever pod-0 happens to be — on worker1 that is the
-          # fenced priority-0 replica — creating a sub-replica that Sentinel
-          # neither discovers nor manages (hit live on the 2026-07-09 scale-out).
+          # Ask a live Sentinel before deriving any role. Stable pod DNS is
+          # authoritative and node2 is the sole deterministic fresh-cluster
+          # bootstrap candidate. Fresh pods on every other node wait for that
+          # view, which avoids making an arbitrary StatefulSet ordinal primary.
           #
-          # Every step here must tolerate a retained /data directory and a
-          # partially available quorum. Stable pod DNS is authoritative.
+          # A retained fenced primary also waits until the remaining Sentinels
+          # elect node2 or node3. Retained replicas may start immediately so
+          # their colocated Sentinels can form the majority needed for failover.
+          # This turns the placement policy into a fail-closed invariant instead
+          # of relying on replica-priority, which only controls future elections.
           POD_FQDN="${POD_NAME}.valkey-headless.valkey.svc.cluster.local"
-          MASTER_ENDPOINT="valkey-node-0.valkey-headless.valkey.svc.cluster.local"
-          LIVE_MASTER=$( { REDISCLI_AUTH="${CORE}" valkey-cli -h valkey.valkey.svc.cluster.local -p 26380 --tls --cacert /etc/valkey/tls/ca.crt --sni valkey.valkey.svc.cluster.local --no-auth-warning sentinel get-master-addr-by-name myprimary 2>/dev/null || true; } | head -n 1)
+          lookup_master() {
+            { REDISCLI_AUTH="${CORE}" valkey-cli -h valkey.valkey.svc.cluster.local -p 26380 --tls --cacert /etc/valkey/tls/ca.crt --sni valkey.valkey.svc.cluster.local --no-auth-warning sentinel get-master-addr-by-name myprimary 2>/dev/null || true; } \
+              | head -n 1 | tr -d '"'
+          }
+          CONFIG_PRESENT=false
+          if [ -f /data/valkey.conf ]; then
+            CONFIG_PRESENT=true
+          fi
+          FENCED=true
+          case "${NODE_NAME}" in
+            node2|node3) FENCED=false ;;
+          esac
+          LIVE_MASTER=$(lookup_master)
+          WAIT_FOR_PRIMARY=false
+          if [ "${FENCED}" = "true" ]; then
+            if [ "${CONFIG_PRESENT}" = "false" ] || ! grep -q '^replicaof ' /data/valkey.conf 2>/dev/null || [ "${LIVE_MASTER}" = "${POD_FQDN}" ]; then
+              WAIT_FOR_PRIMARY=true
+            fi
+          elif [ "${CONFIG_PRESENT}" = "false" ] && [ "${NODE_NAME}" != "node2" ]; then
+            WAIT_FOR_PRIMARY=true
+          fi
+          if [ "${WAIT_FOR_PRIMARY}" = "true" ]; then
+            echo "Waiting for a node2/node3 Sentinel primary before starting ${POD_FQDN}"
+            while [ -z "${LIVE_MASTER}" ] || { [ "${FENCED}" = "true" ] && [ "${LIVE_MASTER}" = "${POD_FQDN}" ]; }; do
+              sleep 2
+              LIVE_MASTER=$(lookup_master)
+            done
+          fi
+          MASTER_ENDPOINT="${POD_FQDN}"
           if [ -n "${LIVE_MASTER}" ]; then
-            MASTER_ENDPOINT=$(printf '%s' "${LIVE_MASTER}" | tr -d '"')
+            MASTER_ENDPOINT="${LIVE_MASTER}"
           fi
           if [ ! -f /data/valkey.conf ]; then
             cp /config/valkey.conf /data/valkey.conf
@@ -77,29 +108,33 @@ spec:
               echo "replica-announce-ip ${POD_FQDN}"
               echo "replica-announce-port 6380"
             } >> /data/valkey.conf
-            # First-boot seed only: every pod but the master's begins as its
-            # replica; Sentinel owns all failovers afterwards. Skipped once
-            # valkey has rewritten its own replication state. Empty master endpoint
-            # (resolution failed on a true cold start) falls back to pod-0.
-            if [ "${POD_INDEX}" != "0" ]; then
-              echo "replicaof ${MASTER_ENDPOINT:-valkey-node-0.valkey-headless.valkey.svc.cluster.local} 6380" >> /data/valkey.conf
-            fi
-            # The home node (worker1, flaky wifi) keeps a read replica but must never
-            # be promoted: Sentinel never elects a priority-0 replica. Keyed on the
-            # node, not the ordinal, so whichever pod lands on worker1 is fenced. The
-            # live cluster was set the same way via CONFIG SET + REWRITE; this only
-            # re-seeds it after a fresh-PVC disaster rebuild.
-            if [ "${NODE_NAME}" = "worker1" ]; then
-              echo "replica-priority 0" >> /data/valkey.conf
-            fi
-            # node1 (2-core, future DB node) is the last-resort master: higher
-            # number = less preferred, so failovers pick node3/node2 (100) first.
-            # Mirrors the live CONFIG SET applied 2026-07-09.
-            if [ "${NODE_NAME}" = "node1" ]; then
-              echo "replica-priority 200" >> /data/valkey.conf
+            # The only fresh member allowed to see an empty Sentinel view is the
+            # pod placed on node2. It bootstraps itself; every other fresh member
+            # has waited for and follows the discovered primary.
+            if [ -n "${LIVE_MASTER}" ] && [ "${POD_FQDN}" != "${MASTER_ENDPOINT}" ]; then
+              echo "replicaof ${MASTER_ENDPOINT} 6380" >> /data/valkey.conf
             fi
             chmod 600 /data/valkey.conf
           fi
+          # Reconcile master eligibility on every boot. Retained PVCs may carry
+          # a stale CONFIG REWRITE value, so only the explicit node2/node3
+          # allowlist can remain eligible for Sentinel promotion. Every other
+          # node, including node1, worker1, and future unknown nodes, is fenced.
+          sed -i '/^replica-priority /d' /data/valkey.conf
+          case "${NODE_NAME}" in
+            node2|node3)
+              echo "replica-priority 100" >> /data/valkey.conf
+              ;;
+            *)
+              echo "replica-priority 0" >> /data/valkey.conf
+              ;;
+          esac
+          # Keep ConfigMap-backed runtime policy authoritative over retained
+          # CONFIG REWRITE output. Moving the include to the end on every boot
+          # makes a config change roll out without discarding Sentinel-owned
+          # replication state in the writable file.
+          sed -i '\|^include /config/tuning.conf$|d' /data/valkey.conf
+          echo "include /config/tuning.conf" >> /data/valkey.conf
           # io-threads is deliberately reconciled on every boot instead of
           # only on fresh PVCs. CONFIG REWRITE persists old values, and node1
           # has only two cores while the remaining data-plane hosts have 6-8.
@@ -178,10 +213,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        - name: POD_INDEX
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.labels['apps.kubernetes.io/pod-index']
         - name: CORE
           valueFrom:
             secretKeyRef:
@@ -322,10 +353,13 @@ spec:
         resources:
           limits:
             cpu: '2'
-            memory: 1Gi
+            # 512 MiB maxmemory + 128 MiB replication backlog still need room
+            # for allocator overhead, TLS buffers, AOF fork/COW and full sync.
+            # A 2 GiB ceiling leaves a defensible worst-case fork/COW margin.
+            memory: 2Gi
           requests:
             cpu: 250m
-            memory: 256Mi
+            memory: 384Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/deploy/infra/valkey/topology_test.go
+++ b/deploy/infra/valkey/topology_test.go
@@ -24,7 +24,6 @@ func TestSentinelSinglePrimaryTopologyIsConfigured(t *testing.T) {
 	assert.Contains(t, statefulSet, partitioningGuard)
 	assert.Contains(t, statefulSet, "- --sentinel")
 	assert.Contains(t, statefulSet, "sentinel monitor myprimary")
-	assert.Contains(t, statefulSet, `echo "replica-priority 0"`)
 	assert.Contains(t, statefulSet, "replica-announce-ip ${POD_FQDN}")
 	assert.Contains(t, statefulSet, "sentinel announce-hostnames yes")
 	assert.NotContains(t, statefulSet, "status.hostIP", "Valkey must not use the Tailscale-backed Kubernetes host IP")
@@ -44,12 +43,48 @@ func TestSentinelSinglePrimaryTopologyIsConfigured(t *testing.T) {
 	)
 }
 
+func TestMasterEligibilityIsReconciledOnEveryBoot(t *testing.T) {
+	statefulSet := readFile(t, "statefulset.yaml")
+
+	assert.Contains(t, statefulSet, `case "${NODE_NAME}" in`)
+	assert.Contains(t, statefulSet, `node2|node3)`)
+	assert.Equal(t, 1, strings.Count(statefulSet, `echo "replica-priority 100"`), "node2/node3 are the only eligible nodes")
+	assert.Equal(t, 1, strings.Count(statefulSet, `echo "replica-priority 0"`), "all non-allowlisted nodes are fenced")
+	assert.NotContains(t, statefulSet, `replica-priority 200`, "node1 must never remain a last-resort master")
+}
+
+func TestColdBootstrapCannotMakeAnArbitraryOrdinalPrimary(t *testing.T) {
+	statefulSet := readFile(t, "statefulset.yaml")
+
+	assert.Regexp(t, `(?m)^  podManagementPolicy: Parallel$`, statefulSet)
+	assert.Contains(t, statefulSet, `elif [ "${CONFIG_PRESENT}" = "false" ] && [ "${NODE_NAME}" != "node2" ]; then`)
+	assert.Contains(t, statefulSet, `Waiting for a node2/node3 Sentinel primary`)
+	assert.Contains(t, statefulSet, `[ "${FENCED}" = "true" ] && [ "${LIVE_MASTER}" = "${POD_FQDN}" ]`)
+	assert.NotContains(t, statefulSet, "POD_INDEX", "StatefulSet ordinal must not confer primary eligibility")
+	assert.NotContains(t, statefulSet, "MASTER_ENDPOINT:-valkey-node-0", "pod zero must not be a cold-start fallback")
+}
+
 func TestLocalReadServiceRemainsNodeLocal(t *testing.T) {
 	services := readFile(t, "services.yaml")
 	localService := regexp.MustCompile(`(?s)name: valkey-local\n.*?internalTrafficPolicy: Local\n.*?port: 6380`).FindString(services)
 	if localService == "" {
 		t.Fatal("valkey-local must retain internalTrafficPolicy: Local on TLS port 6380")
 	}
+}
+
+func TestRuntimeTuningOverridesRetainedConfig(t *testing.T) {
+	statefulSet := readFile(t, "statefulset.yaml")
+	baseConfig := readFile(t, "config/valkey.conf")
+	tuning := readFile(t, "config/tuning.conf")
+	kustomization := readFile(t, "kustomization.yaml")
+
+	assert.Contains(t, baseConfig, "include /config/tuning.conf")
+	assert.Contains(t, statefulSet, `sed -i '\|^include /config/tuning.conf$|d' /data/valkey.conf`)
+	assert.Contains(t, statefulSet, `echo "include /config/tuning.conf" >> /data/valkey.conf`)
+	assert.Contains(t, kustomization, "- config/tuning.conf")
+	assert.Regexp(t, `(?m)^appendfsync everysec$`, tuning)
+	assert.Regexp(t, `(?m)^repl-backlog-size 128mb$`, tuning)
+	assert.Regexp(t, `(?m)^min-replicas-to-write 1$`, tuning)
 }
 
 func infrastructureSources(t *testing.T) string {

--- a/deploy/k8s/nats-leaf-server.conf
+++ b/deploy/k8s/nats-leaf-server.conf
@@ -53,9 +53,11 @@ lame_duck_duration: "30s"
 # is still discoverable). The cluster name differs from the hub's ("bagelbot")
 # so the two never merge.
 #
-# NATS prefers a locally-connected queue member before routing across the
-# cluster, so an RPC answered by a node-local responder pays zero hops; only a
-# call with no local responder takes one direct leaf-to-leaf hop.
+# A clustered queue group does not provide responder locality: requests are
+# balanced randomly across interested members and may take a direct
+# leaf-to-leaf hop even when a local responder exists. This topology removes
+# the hub dependency, but gateway/supercluster semantics are required when RPC
+# queues must prefer a same-cluster responder before remote failover.
 cluster {
   name: "nats-leaf"
   port: 6222

--- a/deploy/k8s/nats-live-acceptance/gateway/README.md
+++ b/deploy/k8s/nats-live-acceptance/gateway/README.md
@@ -1,0 +1,78 @@
+# Local-first NATS gateway acceptance
+
+This opt-in lane proves the topology needed for strict local-first queue RPC
+without changing the production NATS hub, leaf DaemonSet, streams, or client
+configuration. It creates a temporary native-TLS supercluster:
+
+- `rpc-core`: two routed servers, pinned to node2 and node3;
+- `rpc-worker1`: one edge server pinned to worker1;
+- `rpc-node1`: one edge server pinned to node1.
+
+This follows NATS' documented [gateway queue behavior](https://docs.nats.io/running-a-nats-service/configuration/gateways):
+a server selects a queue member in its own cluster and forwards to another
+cluster only when local interest is absent. Among eligible remote clusters,
+NATS selects the lowest-RTT cluster.
+
+All four servers reuse the production account/import/export configuration and
+the existing RPC users. cert-manager issues a 24-hour server/client certificate
+from `fleet-ca-issuer`, following the current NATS PKI pattern. The certificate
+contains only the temporary Service names and gateway/route SAN verification is
+enabled. The topology does not enable JetStream or leaf nodes.
+
+The acceptance NetworkPolicy allows its pods to reach only each other and
+CoreDNS. Consequently the temporary clients and servers cannot fall through to
+the production hub or leaf tier.
+
+Without the exact confirmation token the runner prints its plan and exits:
+
+```sh
+deploy/k8s/nats-live-acceptance/gateway/local-first.sh
+```
+
+Run the live-hardware proof in a controlled, quiet window:
+
+```sh
+CONFIRM_NATS_GATEWAY_ACCEPTANCE=LOCAL-FIRST-RPC \
+  deploy/k8s/nats-live-acceptance/gateway/local-first.sh
+```
+
+No local binary or container image is built. The runner uses the existing
+multi-architecture `nats:2.14.3-alpine` and `natsio/nats-box:0.17.0` images on
+the cluster. Temporary resources are deleted on success, interruption, or
+failure. It refuses to adopt a prior run's resources and verifies that the
+production NATS/leaf pod identities and restart counts remain unchanged.
+
+For each cluster, the runner:
+
+1. starts one queue responder in the requester's cluster and one in a remote
+   cluster, then requires every response to come from the local responder;
+2. removes the local responder and requires every request to use the remote
+   responder;
+3. measures local and remote-fallback request/reply tails and applies the same
+   p99 ceiling used by production: 8 ms, never a relaxed value;
+4. verifies native TLS on RPC client connections and that JetStream is absent.
+
+The default correctness sample is 500 requests per phase. Latency phases use
+5,000 requests and four clients. `CORRECTNESS_REQUESTS`, `LATENCY_REQUESTS`, and
+`LATENCY_CLIENTS` may increase coverage; `RPC_P99_MAX_MS` may only tighten the
+8 ms gate.
+
+## Migration caveats
+
+- Local-first behavior applies to queue subscriptions. Ordinary subscriptions
+  still fan out across the supercluster and must not be used for RPC workers.
+- A production migration needs stable per-cluster names and certificates whose
+  SANs match every advertised route/gateway address. Each cluster must carry an
+  identical account/import/export definition.
+- Keep JetStream on the current hub. RPC gateway servers are core-NATS-only and
+  should not receive BUS or `$JS.API` permissions.
+- Do not run the gateway and the routed leaf tier as two paths for the same RPC
+  account during migration; parallel interest paths can duplicate or bypass the
+  locality guarantee. Move one canary account/service at a time.
+- worker1 and node1 are single-server edge clusters. They prefer same-cluster
+  responders while healthy and fall back remotely, but they do not provide
+  local RPC availability during their own server restart. That trade-off should
+  be handled with fast client reconnect and a staged rolling procedure.
+- The 8 ms fallback gate is intentionally strict. A worker1-to-core fallback
+  failure is evidence that the WAN path cannot satisfy the historical RPC SLA;
+  it is not a reason to loosen the ceiling.

--- a/deploy/k8s/nats-live-acceptance/gateway/common.conf
+++ b/deploy/k8s/nats-live-acceptance/gateway/common.conf
@@ -1,0 +1,20 @@
+port: 4222
+http_port: 8222
+max_connections: 512
+max_payload: 8MB
+max_pending: 64MB
+write_deadline: "2s"
+ping_interval: "20s"
+ping_max: 3
+
+tls {
+  cert_file: "/etc/nats/certs/tls.crt"
+  key_file: "/etc/nats/certs/tls.key"
+  ca_file: "/etc/nats/certs/ca.crt"
+  min_version: "1.2"
+  timeout: 2
+}
+
+max_subscriptions: 0
+max_control_line: 4KB
+include "/etc/nats/auth/auth.conf"

--- a/deploy/k8s/nats-live-acceptance/gateway/core-0.conf
+++ b/deploy/k8s/nats-live-acceptance/gateway/core-0.conf
@@ -1,0 +1,39 @@
+server_name: "gateway-accept-core-0"
+include "/etc/nats/config/common.conf"
+
+cluster {
+  name: "rpc-core"
+  listen: "0.0.0.0:6222"
+  advertise: "nats-gw-accept-core-0.production.svc.cluster.local:6222"
+  no_advertise: true
+  tls {
+    cert_file: "/etc/nats/certs/tls.crt"
+    key_file: "/etc/nats/certs/tls.key"
+    ca_file: "/etc/nats/certs/ca.crt"
+    verify: true
+    verify_cert_and_check_known_urls: true
+    timeout: 2
+  }
+  routes: ["nats://nats-gw-accept-core-1.production.svc.cluster.local:6222"]
+}
+
+gateway {
+  name: "rpc-core"
+  listen: "0.0.0.0:7222"
+  advertise: "nats-gw-accept-core-0.production.svc.cluster.local:7222"
+  reject_unknown_cluster: true
+  connect_retries: 30
+  connect_backoff: true
+  tls {
+    cert_file: "/etc/nats/certs/tls.crt"
+    key_file: "/etc/nats/certs/tls.key"
+    ca_file: "/etc/nats/certs/ca.crt"
+    verify: true
+    verify_cert_and_check_known_urls: true
+    timeout: 2
+  }
+  gateways: [
+    {name: "rpc-worker1", url: "nats://nats-gw-accept-worker1.production.svc.cluster.local:7222"},
+    {name: "rpc-node1", url: "nats://nats-gw-accept-node1.production.svc.cluster.local:7222"}
+  ]
+}

--- a/deploy/k8s/nats-live-acceptance/gateway/core-1.conf
+++ b/deploy/k8s/nats-live-acceptance/gateway/core-1.conf
@@ -1,0 +1,39 @@
+server_name: "gateway-accept-core-1"
+include "/etc/nats/config/common.conf"
+
+cluster {
+  name: "rpc-core"
+  listen: "0.0.0.0:6222"
+  advertise: "nats-gw-accept-core-1.production.svc.cluster.local:6222"
+  no_advertise: true
+  tls {
+    cert_file: "/etc/nats/certs/tls.crt"
+    key_file: "/etc/nats/certs/tls.key"
+    ca_file: "/etc/nats/certs/ca.crt"
+    verify: true
+    verify_cert_and_check_known_urls: true
+    timeout: 2
+  }
+  routes: ["nats://nats-gw-accept-core-0.production.svc.cluster.local:6222"]
+}
+
+gateway {
+  name: "rpc-core"
+  listen: "0.0.0.0:7222"
+  advertise: "nats-gw-accept-core-1.production.svc.cluster.local:7222"
+  reject_unknown_cluster: true
+  connect_retries: 30
+  connect_backoff: true
+  tls {
+    cert_file: "/etc/nats/certs/tls.crt"
+    key_file: "/etc/nats/certs/tls.key"
+    ca_file: "/etc/nats/certs/ca.crt"
+    verify: true
+    verify_cert_and_check_known_urls: true
+    timeout: 2
+  }
+  gateways: [
+    {name: "rpc-worker1", url: "nats://nats-gw-accept-worker1.production.svc.cluster.local:7222"},
+    {name: "rpc-node1", url: "nats://nats-gw-accept-node1.production.svc.cluster.local:7222"}
+  ]
+}

--- a/deploy/k8s/nats-live-acceptance/gateway/kustomization.yaml
+++ b/deploy/k8s/nats-live-acceptance/gateway/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: production
+resources:
+  - topology.yaml
+configMapGenerator:
+  - name: nats-gateway-acceptance-config
+    files:
+      - common.conf
+      - core-0.conf
+      - core-1.conf
+      - worker1.conf
+      - node1.conf
+generatorOptions:
+  labels:
+    app.kubernetes.io/name: nats-gateway-acceptance
+    app.kubernetes.io/part-of: nats-gateway-acceptance

--- a/deploy/k8s/nats-live-acceptance/gateway/local-first.sh
+++ b/deploy/k8s/nats-live-acceptance/gateway/local-first.sh
@@ -1,0 +1,327 @@
+#!/usr/bin/env bash
+# Opt-in, isolated proof of NATS gateway local-first queue behavior.
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+namespace=${NAMESPACE:-production}
+confirmation=${CONFIRM_NATS_GATEWAY_ACCEPTANCE:-}
+correctness_requests=${CORRECTNESS_REQUESTS:-500}
+latency_requests=${LATENCY_REQUESTS:-5000}
+latency_clients=${LATENCY_CLIENTS:-4}
+rpc_p99_max_ms=${RPC_P99_MAX_MS:-8}
+queue_group=${QUEUE_GROUP:-RPC_GATEWAY_ACCEPTANCE}
+run_id=$(date -u +%Y%m%d%H%M%S)
+results_file=${RESULTS_FILE:-/tmp/nats-gateway-local-first-${run_id}.json}
+phase_results=""
+owns_resources=false
+
+servers=(
+  nats-gw-accept-core-0
+  nats-gw-accept-core-1
+  nats-gw-accept-worker1
+  nats-gw-accept-node1
+)
+clients=(
+  nats-gw-accept-client-node2
+  nats-gw-accept-client-node3
+  nats-gw-accept-client-worker1
+  nats-gw-accept-client-node1
+)
+
+if [[ "$confirmation" != "LOCAL-FIRST-RPC" ]]; then
+  cat <<'EOF'
+Plan only; no actions performed.
+
+This guarded lane creates four temporary, core-NATS-only servers and four
+nats-box clients. node2+node3 form rpc-core; worker1 and node1 are independent
+edge clusters joined through mutually verified native-TLS gateways. A NetworkPolicy
+prevents every acceptance pod from reaching the production NATS hub or leaf tier.
+
+Run only in a controlled window:
+  CONFIRM_NATS_GATEWAY_ACCEPTANCE=LOCAL-FIRST-RPC \
+    deploy/k8s/nats-live-acceptance/gateway/local-first.sh
+EOF
+  exit 0
+fi
+
+fail() {
+  echo "gateway acceptance failed: $*" >&2
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || fail "$1 is required"
+}
+
+cleanup() {
+  if [[ -n "$phase_results" ]]; then rm -f "$phase_results"; fi
+  if $owns_resources; then
+    delete_lane >/dev/null 2>&1 || echo "warning: bounded gateway acceptance cleanup did not complete" >&2
+  fi
+}
+phase_results=$(mktemp /tmp/nats-gateway-local-first-phases.XXXXXX)
+
+delete_lane() {
+  local secret_json
+  kubectl delete -k "$script_dir" --ignore-not-found --wait=true --timeout=120s >/dev/null || return 1
+
+  if ! secret_json=$(kubectl -n "$namespace" get secret nats-gateway-acceptance-tls -o json 2>/dev/null); then
+    return 0
+  fi
+  jq -e '
+    .metadata.name == "nats-gateway-acceptance-tls" and
+    .metadata.labels["itsbagelbot.dev/acceptance-owner"] == "local-first-rpc" and
+    .metadata.labels["app.kubernetes.io/name"] == "nats-gateway-acceptance" and
+    .metadata.annotations["itsbagelbot.dev/acceptance-certificate"] == "nats-gateway-acceptance-tls"
+  ' <<<"$secret_json" >/dev/null || {
+    echo "refusing to delete nats-gateway-acceptance-tls: ownership metadata does not match this lane" >&2
+    return 1
+  }
+  kubectl -n "$namespace" delete secret nats-gateway-acceptance-tls \
+    --wait=true --timeout=30s >/dev/null
+}
+trap cleanup EXIT INT TERM
+
+monitor() {
+  local pod=$1 endpoint=$2
+  kubectl -n "$namespace" exec "$pod" -c nats -- \
+    wget -qO- "http://127.0.0.1:8222/$endpoint"
+}
+
+production_nats_baseline() {
+  kubectl -n "$namespace" get pods -l 'app in (nats,nats-leaf)' -o json |
+    jq -Sc '[.items[] | {
+      name:.metadata.name,
+      uid:.metadata.uid,
+      node:.spec.nodeName,
+      restarts:([.status.containerStatuses[]?.restartCount] | add // 0)
+    }] | sort_by(.name)'
+}
+
+assert_no_existing_lane() {
+  local names=(
+    certificate/nats-gateway-acceptance-tls
+    secret/nats-gateway-acceptance-tls
+    networkpolicy/nats-gateway-acceptance-isolation
+    service/nats-gw-accept-core-0
+    service/nats-gw-accept-core-1
+    service/nats-gw-accept-worker1
+    service/nats-gw-accept-node1
+    pod/nats-gw-accept-core-0
+    pod/nats-gw-accept-core-1
+    pod/nats-gw-accept-worker1
+    pod/nats-gw-accept-node1
+    pod/nats-gw-accept-client-node2
+    pod/nats-gw-accept-client-node3
+    pod/nats-gw-accept-client-worker1
+    pod/nats-gw-accept-client-node1
+  )
+  local resource
+  for resource in "${names[@]}"; do
+    if kubectl -n "$namespace" get "$resource" >/dev/null 2>&1; then
+      fail "$resource already exists; refusing to adopt or delete it"
+    fi
+  done
+  if kubectl -n "$namespace" get configmap \
+    -l app.kubernetes.io/name=nats-gateway-acceptance \
+    -o json | jq -e '.items | length > 0' >/dev/null; then
+    fail "an acceptance ConfigMap already exists; clean up its owning run first"
+  fi
+}
+
+assert_prerequisites() {
+  [[ "$namespace" == "production" ]] || fail "NAMESPACE must be production because credentials and fleet PKI are namespace-scoped"
+  [[ "$correctness_requests" =~ ^[1-9][0-9]*$ ]] || fail "CORRECTNESS_REQUESTS must be positive"
+  [[ "$latency_requests" =~ ^[1-9][0-9]*$ ]] || fail "LATENCY_REQUESTS must be positive"
+  [[ "$latency_clients" =~ ^[1-9][0-9]*$ ]] || fail "LATENCY_CLIENTS must be positive"
+  awk -v gate="$rpc_p99_max_ms" 'BEGIN { exit !(gate > 0 && gate <= 8) }' || \
+    fail "RPC_P99_MAX_MS must be positive and cannot relax the 8ms production ceiling"
+
+  local priority_value preemption
+  priority_value=$(kubectl get priorityclass nats-r3-bench-nonpreempting -o jsonpath='{.value}')
+  preemption=$(kubectl get priorityclass nats-r3-bench-nonpreempting -o jsonpath='{.preemptionPolicy}')
+  [[ "$priority_value" =~ ^-?[0-9]+$ ]] || fail "invalid benchmark PriorityClass value"
+  (( priority_value <= 0 )) || fail "benchmark PriorityClass must not outrank production"
+  [[ "$preemption" == "Never" ]] || fail "benchmark PriorityClass must never preempt production"
+
+  local node ready
+  for node in node1 node2 node3 worker1; do
+    ready=$(kubectl get node "$node" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+    [[ "$ready" == "True" ]] || fail "$node is not Ready"
+  done
+  kubectl -n "$namespace" get secret nats-auth-env users-env console-admin-env >/dev/null
+  kubectl -n "$namespace" get configmap nats-leaf-config fleet-ca >/dev/null
+  kubectl get clusterissuer fleet-ca-issuer >/dev/null
+
+  local rendered
+  rendered=$(kubectl kustomize "$script_dir")
+  if grep -Eq '(^|[[:space:]])(jetstream|leafnodes)[[:space:]]*[{:]' <<<"$rendered"; then
+    fail "isolated topology must not enable JetStream or leaf nodes"
+  fi
+  grep -q 'kind: NetworkPolicy' <<<"$rendered" || fail "isolation NetworkPolicy is missing"
+}
+
+wait_for_connection() {
+  local server=$1 name=$2 expected=${3:-present}
+  local count=0
+  for _ in $(seq 1 100); do
+    count=$(monitor "$server" 'connz?subs=detail' |
+      jq --arg name "$name" '[.connections[]? | select((.name // "") | startswith($name))] | length')
+    if [[ "$expected" == "present" && "$count" -gt 0 ]]; then
+      monitor "$server" 'connz?subs=detail' |
+        jq -e --arg name "$name" '[.connections[]? | select(((.name // "") | startswith($name)) and (.tls_version // "") != "")] | length > 0' >/dev/null ||
+        fail "$name connected without verified client TLS"
+      return 0
+    fi
+    if [[ "$expected" == "absent" && "$count" -eq 0 ]]; then
+      return 0
+    fi
+    sleep 0.1
+  done
+  fail "$name did not become $expected on $server"
+}
+
+start_tagged_responder() {
+  local pod=$1 server=$2 subject=$3 tag=$4 id=$5
+  kubectl -n "$namespace" exec "$pod" -- sh -c '
+    nats --no-context --connection-name "$5" \
+      --server "$LOCAL_NATS_URL" --user "$RESPONSE_USER" --password "$RESPONSE_PASSWORD" \
+      reply --queue "$4" --count "$3" "$1" "$2" >"/tmp/$5.log" 2>&1 &
+    echo $! >"/tmp/$5.pid"
+  ' sh "$subject" "$tag" "$((correctness_requests * 4))" "$queue_group" "$id" >/dev/null
+  wait_for_connection "$server" "$id"
+}
+
+start_bench_responder() {
+  local pod=$1 server=$2 subject=$3 id=$4
+  kubectl -n "$namespace" exec "$pod" -- sh -c '
+    nats --no-context --connection-name "$4" \
+      --server "$LOCAL_NATS_URL" --user "$RESPONSE_USER" --password "$RESPONSE_PASSWORD" \
+      bench service serve --msgs "$2" --clients "$3" --no-progress "$1" >"/tmp/$4.log" 2>&1 &
+    echo $! >"/tmp/$4.pid"
+  ' sh "$subject" "$latency_requests" "$latency_clients" "$id" >/dev/null
+  wait_for_connection "$server" "$id"
+}
+
+stop_responder() {
+  local pod=$1 server=$2 id=$3
+  kubectl -n "$namespace" exec "$pod" -- sh -c '
+    pid=$(cat "/tmp/$1.pid" 2>/dev/null || true)
+    if [ -n "$pid" ]; then kill "$pid" 2>/dev/null || true; fi
+    rm -f "/tmp/$1.pid"
+  ' sh "$id" >/dev/null
+  wait_for_connection "$server" "$id" absent
+}
+
+assert_responses() {
+  local requester=$1 subject=$2 expected=$3 label=$4
+  local output total matching
+  output=$(kubectl -n "$namespace" exec "$requester" -- sh -c '
+    nats --no-context --server "$LOCAL_NATS_URL" \
+      --user "$REQUEST_USER" --password "$REQUEST_PASSWORD" \
+      request --raw --count "$2" "$1" acceptance
+  ' sh "$subject" "$correctness_requests")
+  total=$(awk 'NF {count++} END {print count+0}' <<<"$output")
+  matching=$(awk -v expected="$expected" '$0 == expected {count++} END {print count+0}' <<<"$output")
+  [[ "$total" -eq "$correctness_requests" ]] || fail "$label returned $total/$correctness_requests replies"
+  [[ "$matching" -eq "$correctness_requests" ]] || fail "$label routed $((total - matching)) requests to a non-$expected responder"
+  jq -nc --arg phase "$label" --arg responder "$expected" --argjson requests "$total" \
+    '{phase:$phase,expected_responder:$responder,requests:$requests,passed:true}'
+}
+
+duration_ms() {
+  local value=$1
+  awk -v value="$value" 'BEGIN {
+    if (value ~ /ns$/) { sub(/ns$/, "", value); print value / 1000000; exit }
+    if (value ~ /(µs|us)$/) { sub(/(µs|us)$/, "", value); print value / 1000; exit }
+    if (value ~ /ms$/) { sub(/ms$/, "", value); print value; exit }
+    if (value ~ /s$/) { sub(/s$/, "", value); print value * 1000; exit }
+    exit 1
+  }'
+}
+
+measure_p99() {
+  local requester=$1 subject=$2 label=$3
+  local output raw_p99 p99_ms
+  output=$(kubectl -n "$namespace" exec "$requester" -- sh -c '
+    nats --no-context --server "$LOCAL_NATS_URL" \
+      --user "$REQUEST_USER" --password "$REQUEST_PASSWORD" \
+      bench service request --msgs "$2" --clients "$3" --no-progress "$1"
+  ' sh "$subject" "$latency_requests" "$latency_clients")
+  raw_p99=$(awk '$1 == "99:" {print $2; exit}' <<<"$output")
+  [[ -n "$raw_p99" ]] || fail "$label did not report a p99 latency"
+  p99_ms=$(duration_ms "$raw_p99") || fail "$label reported an unknown p99 duration: $raw_p99"
+  awk -v actual="$p99_ms" -v gate="$rpc_p99_max_ms" 'BEGIN {exit !(actual <= gate)}' ||
+    fail "$label p99 ${p99_ms}ms exceeds the ${rpc_p99_max_ms}ms ceiling"
+  jq -nc --arg phase "$label" --argjson p99_ms "$p99_ms" --argjson gate_ms "$rpc_p99_max_ms" \
+    --argjson requests "$latency_requests" \
+    '{phase:$phase,requests:$requests,p99_ms:$p99_ms,gate_ms:$gate_ms,passed:true}'
+}
+
+run_scenario() {
+  local name=$1 requester=$2 local_client=$3 local_server=$4 remote_client=$5 remote_server=$6
+  local subject="bagel.rpc.admin.user.bench.gatewaylocal.${name}.${run_id}"
+  local local_tag="local-${name}" remote_tag="remote-${name}"
+  local local_id="gw-local-${name}" remote_id="gw-remote-${name}"
+  local bench_local_id="gw-bench-local-${name}" bench_remote_id="gw-bench-remote-${name}"
+
+  start_tagged_responder "$remote_client" "$remote_server" "$subject" "$remote_tag" "$remote_id"
+  start_tagged_responder "$local_client" "$local_server" "$subject" "$local_tag" "$local_id"
+  sleep 1
+  assert_responses "$requester" "$subject" "$local_tag" "${name}-local-priority"
+
+  stop_responder "$local_client" "$local_server" "$local_id"
+  sleep 1
+  assert_responses "$requester" "$subject" "$remote_tag" "${name}-remote-fallback"
+  stop_responder "$remote_client" "$remote_server" "$remote_id"
+
+  start_bench_responder "$local_client" "$local_server" "$subject" "$bench_local_id"
+  measure_p99 "$requester" "$subject" "${name}-local-latency"
+  wait_for_connection "$local_server" "$bench_local_id" absent
+
+  start_bench_responder "$remote_client" "$remote_server" "$subject" "$bench_remote_id"
+  measure_p99 "$requester" "$subject" "${name}-remote-fallback-latency"
+  wait_for_connection "$remote_server" "$bench_remote_id" absent
+}
+
+for command in kubectl jq awk grep; do require_command "$command"; done
+assert_prerequisites
+assert_no_existing_lane
+baseline_before=$(production_nats_baseline)
+
+owns_resources=true
+kubectl apply -k "$script_dir" >/dev/null
+kubectl -n "$namespace" wait --for=condition=Ready \
+  certificate/nats-gateway-acceptance-tls --timeout=90s >/dev/null
+kubectl -n "$namespace" wait --for=condition=Ready \
+  $(printf 'pod/%s ' "${servers[@]}" "${clients[@]}") --timeout=180s >/dev/null
+
+expected_placements='{"nats-gw-accept-core-0":"node2","nats-gw-accept-core-1":"node3","nats-gw-accept-worker1":"worker1","nats-gw-accept-node1":"node1","nats-gw-accept-client-node2":"node2","nats-gw-accept-client-node3":"node3","nats-gw-accept-client-worker1":"worker1","nats-gw-accept-client-node1":"node1"}'
+for pod in "${servers[@]}" "${clients[@]}"; do
+  actual_node=$(kubectl -n "$namespace" get pod "$pod" -o jsonpath='{.spec.nodeName}')
+  expected_node=$(jq -r --arg pod "$pod" '.[$pod]' <<<"$expected_placements")
+  [[ "$actual_node" == "$expected_node" ]] || fail "$pod landed on $actual_node instead of $expected_node"
+done
+
+for server in "${servers[@]}"; do
+  if jsz=$(monitor "$server" jsz 2>/dev/null); then
+    jq -e '(.error // "") | test("not enabled"; "i")' <<<"$jsz" >/dev/null ||
+      fail "$server exposed an enabled JetStream plane"
+  fi
+done
+
+run_scenario core nats-gw-accept-client-node2 nats-gw-accept-client-node3 nats-gw-accept-core-1 nats-gw-accept-client-node1 nats-gw-accept-node1 >>"$phase_results"
+run_scenario worker1 nats-gw-accept-client-worker1 nats-gw-accept-client-worker1 nats-gw-accept-worker1 nats-gw-accept-client-node2 nats-gw-accept-core-0 >>"$phase_results"
+run_scenario node1 nats-gw-accept-client-node1 nats-gw-accept-client-node1 nats-gw-accept-node1 nats-gw-accept-client-node3 nats-gw-accept-core-1 >>"$phase_results"
+
+jq -s --arg topology "node2+node3 core; worker1 edge; node1 edge" \
+  --argjson p99_gate_ms "$rpc_p99_max_ms" \
+  '{topology:$topology,rpc_p99_gate_ms:$p99_gate_ms,jetstream:false,hub_dependency:false,phases:.,passed:all(.[];.passed)}' \
+  "$phase_results" | tee "$results_file"
+
+delete_lane || fail "bounded cleanup did not remove the owned acceptance resources"
+owns_resources=false
+baseline_after=$(production_nats_baseline)
+[[ "$baseline_after" == "$baseline_before" ]] || fail "production NATS/leaf pod identity or restart count changed during the isolated lane"
+
+echo "gateway acceptance passed; results: $results_file"

--- a/deploy/k8s/nats-live-acceptance/gateway/node1.conf
+++ b/deploy/k8s/nats-live-acceptance/gateway/node1.conf
@@ -1,0 +1,26 @@
+server_name: "gateway-accept-node1"
+include "/etc/nats/config/common.conf"
+
+gateway {
+  name: "rpc-node1"
+  listen: "0.0.0.0:7222"
+  advertise: "nats-gw-accept-node1.production.svc.cluster.local:7222"
+  reject_unknown_cluster: true
+  connect_retries: 30
+  connect_backoff: true
+  tls {
+    cert_file: "/etc/nats/certs/tls.crt"
+    key_file: "/etc/nats/certs/tls.key"
+    ca_file: "/etc/nats/certs/ca.crt"
+    verify: true
+    verify_cert_and_check_known_urls: true
+    timeout: 2
+  }
+  gateways: [
+    {name: "rpc-core", urls: [
+      "nats://nats-gw-accept-core-0.production.svc.cluster.local:7222",
+      "nats://nats-gw-accept-core-1.production.svc.cluster.local:7222"
+    ]},
+    {name: "rpc-worker1", url: "nats://nats-gw-accept-worker1.production.svc.cluster.local:7222"}
+  ]
+}

--- a/deploy/k8s/nats-live-acceptance/gateway/topology.yaml
+++ b/deploy/k8s/nats-live-acceptance/gateway/topology.yaml
@@ -1,0 +1,410 @@
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: cert-manager.io/v1
+    kind: Certificate
+    metadata:
+      name: nats-gateway-acceptance-tls
+      labels: &commonLabels
+        app.kubernetes.io/name: nats-gateway-acceptance
+        app.kubernetes.io/part-of: nats-gateway-acceptance
+      annotations:
+        itsbagelbot.dev/acceptance-owner: local-first-rpc
+    spec:
+      secretName: nats-gateway-acceptance-tls
+      secretTemplate:
+        labels:
+          app.kubernetes.io/name: nats-gateway-acceptance
+          app.kubernetes.io/part-of: nats-gateway-acceptance
+          itsbagelbot.dev/acceptance-owner: local-first-rpc
+        annotations:
+          itsbagelbot.dev/acceptance-certificate: nats-gateway-acceptance-tls
+      duration: 24h
+      renewBefore: 1h
+      privateKey:
+        algorithm: ECDSA
+        size: 256
+      usages:
+        - server auth
+        - client auth
+      issuerRef:
+        name: fleet-ca-issuer
+        kind: ClusterIssuer
+        group: cert-manager.io
+      dnsNames:
+        - nats-gw-accept-core-0
+        - nats-gw-accept-core-0.production.svc.cluster.local
+        - nats-gw-accept-core-1
+        - nats-gw-accept-core-1.production.svc.cluster.local
+        - nats-gw-accept-worker1
+        - nats-gw-accept-worker1.production.svc.cluster.local
+        - nats-gw-accept-node1
+        - nats-gw-accept-node1.production.svc.cluster.local
+  - apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      name: nats-gateway-acceptance-isolation
+      labels: *commonLabels
+    spec:
+      podSelector:
+        matchLabels:
+          app.kubernetes.io/name: nats-gateway-acceptance
+      policyTypes: [Ingress, Egress]
+      ingress:
+        - from:
+            - podSelector:
+                matchLabels:
+                  app.kubernetes.io/name: nats-gateway-acceptance
+      egress:
+        - to:
+            - podSelector:
+                matchLabels:
+                  app.kubernetes.io/name: nats-gateway-acceptance
+        - to:
+            - namespaceSelector:
+                matchLabels:
+                  kubernetes.io/metadata.name: kube-system
+              podSelector:
+                matchLabels:
+                  k8s-app: kube-dns
+          ports:
+            - {protocol: UDP, port: 53}
+            - {protocol: TCP, port: 53}
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: nats-gw-accept-core-0
+      labels: *commonLabels
+    spec:
+      selector: &core0Selector
+        app.kubernetes.io/name: nats-gateway-acceptance
+        app.kubernetes.io/component: server
+        app.kubernetes.io/instance: core-0
+      ports: &serverPorts
+        - {name: client, port: 4222, targetPort: client}
+        - {name: cluster, port: 6222, targetPort: cluster}
+        - {name: gateway, port: 7222, targetPort: gateway}
+        - {name: monitor, port: 8222, targetPort: monitor}
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: nats-gw-accept-core-1
+      labels: *commonLabels
+    spec:
+      selector: &core1Selector
+        app.kubernetes.io/name: nats-gateway-acceptance
+        app.kubernetes.io/component: server
+        app.kubernetes.io/instance: core-1
+      ports: *serverPorts
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: nats-gw-accept-worker1
+      labels: *commonLabels
+    spec:
+      selector: &workerSelector
+        app.kubernetes.io/name: nats-gateway-acceptance
+        app.kubernetes.io/component: server
+        app.kubernetes.io/instance: worker1
+      ports: *serverPorts
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: nats-gw-accept-node1
+      labels: *commonLabels
+    spec:
+      selector: &node1Selector
+        app.kubernetes.io/name: nats-gateway-acceptance
+        app.kubernetes.io/component: server
+        app.kubernetes.io/instance: node1
+      ports: *serverPorts
+  - apiVersion: v1
+    kind: Pod
+    metadata:
+      name: nats-gw-accept-core-0
+      labels: *core0Selector
+      annotations:
+        linkerd.io/inject: disabled
+    spec: &core0Pod
+      automountServiceAccountToken: false
+      priorityClassName: nats-r3-bench-nonpreempting
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: node2
+      securityContext: &podSecurity
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile: {type: RuntimeDefault}
+      containers:
+        - name: nats
+          image: nats:2.14.3-alpine
+          args: ["--config", "/etc/nats/config/core-0.conf"]
+          envFrom:
+            - secretRef: {name: nats-auth-env}
+          ports:
+            - {name: client, containerPort: 4222}
+            - {name: cluster, containerPort: 6222}
+            - {name: gateway, containerPort: 7222}
+            - {name: monitor, containerPort: 8222}
+          volumeMounts: &serverMounts
+            - {name: config, mountPath: /etc/nats/config, readOnly: true}
+            - {name: auth, mountPath: /etc/nats/auth, readOnly: true}
+            - {name: certs, mountPath: /etc/nats/certs, readOnly: true}
+          resources: &serverResources
+            requests: {cpu: 50m, memory: 96Mi}
+            limits: {cpu: "1", memory: 256Mi}
+          securityContext: &containerSecurity
+            allowPrivilegeEscalation: false
+            capabilities: {drop: ["ALL"]}
+            readOnlyRootFilesystem: true
+          readinessProbe:
+            httpGet: {path: /healthz, port: monitor}
+            periodSeconds: 2
+            timeoutSeconds: 1
+            failureThreshold: 30
+      volumes: &serverVolumes
+        - name: config
+          configMap: {name: nats-gateway-acceptance-config}
+        - name: auth
+          configMap:
+            name: nats-leaf-config
+            items: [{key: auth.conf, path: auth.conf}]
+        - name: certs
+          secret: {secretName: nats-gateway-acceptance-tls}
+  - apiVersion: v1
+    kind: Pod
+    metadata:
+      name: nats-gw-accept-core-1
+      labels: *core1Selector
+      annotations:
+        linkerd.io/inject: disabled
+    spec:
+      <<: *core0Pod
+      nodeSelector:
+        kubernetes.io/hostname: node3
+      containers:
+        - name: nats
+          image: nats:2.14.3-alpine
+          args: ["--config", "/etc/nats/config/core-1.conf"]
+          envFrom:
+            - secretRef: {name: nats-auth-env}
+          ports:
+            - {name: client, containerPort: 4222}
+            - {name: cluster, containerPort: 6222}
+            - {name: gateway, containerPort: 7222}
+            - {name: monitor, containerPort: 8222}
+          volumeMounts: *serverMounts
+          resources: *serverResources
+          securityContext: *containerSecurity
+          readinessProbe:
+            httpGet: {path: /healthz, port: monitor}
+            periodSeconds: 2
+            timeoutSeconds: 1
+            failureThreshold: 30
+  - apiVersion: v1
+    kind: Pod
+    metadata:
+      name: nats-gw-accept-worker1
+      labels: *workerSelector
+      annotations:
+        linkerd.io/inject: disabled
+    spec:
+      <<: *core0Pod
+      nodeSelector:
+        kubernetes.io/hostname: worker1
+      tolerations:
+        - key: itsbagelbot.dev/pool
+          operator: Equal
+          value: worker-pool
+          effect: NoSchedule
+      containers:
+        - name: nats
+          image: nats:2.14.3-alpine
+          args: ["--config", "/etc/nats/config/worker1.conf"]
+          envFrom:
+            - secretRef: {name: nats-auth-env}
+          ports:
+            - {name: client, containerPort: 4222}
+            - {name: cluster, containerPort: 6222}
+            - {name: gateway, containerPort: 7222}
+            - {name: monitor, containerPort: 8222}
+          volumeMounts: *serverMounts
+          resources: *serverResources
+          securityContext: *containerSecurity
+          readinessProbe:
+            httpGet: {path: /healthz, port: monitor}
+            periodSeconds: 2
+            timeoutSeconds: 1
+            failureThreshold: 30
+  - apiVersion: v1
+    kind: Pod
+    metadata:
+      name: nats-gw-accept-node1
+      labels: *node1Selector
+      annotations:
+        linkerd.io/inject: disabled
+    spec:
+      <<: *core0Pod
+      nodeSelector:
+        kubernetes.io/hostname: node1
+      containers:
+        - name: nats
+          image: nats:2.14.3-alpine
+          args: ["--config", "/etc/nats/config/node1.conf"]
+          envFrom:
+            - secretRef: {name: nats-auth-env}
+          ports:
+            - {name: client, containerPort: 4222}
+            - {name: cluster, containerPort: 6222}
+            - {name: gateway, containerPort: 7222}
+            - {name: monitor, containerPort: 8222}
+          volumeMounts: *serverMounts
+          resources: *serverResources
+          securityContext: *containerSecurity
+          readinessProbe:
+            httpGet: {path: /healthz, port: monitor}
+            periodSeconds: 2
+            timeoutSeconds: 1
+            failureThreshold: 30
+  - apiVersion: v1
+    kind: Pod
+    metadata:
+      name: nats-gw-accept-client-node2
+      labels: &clientLabels
+        app.kubernetes.io/name: nats-gateway-acceptance
+        app.kubernetes.io/part-of: nats-gateway-acceptance
+        app.kubernetes.io/component: client
+        app.kubernetes.io/instance: node2
+      annotations:
+        linkerd.io/inject: disabled
+    spec: &clientPod
+      automountServiceAccountToken: false
+      priorityClassName: nats-r3-bench-nonpreempting
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: node2
+      securityContext: *podSecurity
+      containers:
+        - name: nats-box
+          image: natsio/nats-box:0.17.0
+          command: ["sleep", "1800"]
+          env:
+            - {name: LOCAL_NATS_URL, value: "tls://nats-gw-accept-core-0:4222"}
+            - {name: NATS_CA, value: "/etc/nats-ca/ca.pem"}
+            - name: REQUEST_USER
+              valueFrom: {secretKeyRef: {name: console-admin-env, key: NATS_RPC_USER}}
+            - name: REQUEST_PASSWORD
+              valueFrom: {secretKeyRef: {name: console-admin-env, key: NATS_RPC_PASSWORD}}
+            - name: RESPONSE_USER
+              valueFrom: {secretKeyRef: {name: users-env, key: NATS_RPC_USER}}
+            - name: RESPONSE_PASSWORD
+              valueFrom: {secretKeyRef: {name: users-env, key: NATS_RPC_PASSWORD}}
+          volumeMounts: &clientMounts
+            - {name: fleet-ca, mountPath: /etc/nats-ca, readOnly: true}
+          resources: &clientResources
+            requests: {cpu: 50m, memory: 64Mi}
+            limits: {cpu: "1", memory: 192Mi}
+          securityContext: *containerSecurity
+      volumes: &clientVolumes
+        - name: fleet-ca
+          configMap: {name: fleet-ca}
+  - apiVersion: v1
+    kind: Pod
+    metadata:
+      name: nats-gw-accept-client-node3
+      labels:
+        <<: *clientLabels
+        app.kubernetes.io/instance: node3
+      annotations:
+        linkerd.io/inject: disabled
+    spec:
+      <<: *clientPod
+      nodeSelector:
+        kubernetes.io/hostname: node3
+      containers:
+        - name: nats-box
+          image: natsio/nats-box:0.17.0
+          command: ["sleep", "1800"]
+          env:
+            - {name: LOCAL_NATS_URL, value: "tls://nats-gw-accept-core-1:4222"}
+            - {name: NATS_CA, value: "/etc/nats-ca/ca.pem"}
+            - name: REQUEST_USER
+              valueFrom: {secretKeyRef: {name: console-admin-env, key: NATS_RPC_USER}}
+            - name: REQUEST_PASSWORD
+              valueFrom: {secretKeyRef: {name: console-admin-env, key: NATS_RPC_PASSWORD}}
+            - name: RESPONSE_USER
+              valueFrom: {secretKeyRef: {name: users-env, key: NATS_RPC_USER}}
+            - name: RESPONSE_PASSWORD
+              valueFrom: {secretKeyRef: {name: users-env, key: NATS_RPC_PASSWORD}}
+          volumeMounts: *clientMounts
+          resources: *clientResources
+          securityContext: *containerSecurity
+  - apiVersion: v1
+    kind: Pod
+    metadata:
+      name: nats-gw-accept-client-worker1
+      labels:
+        <<: *clientLabels
+        app.kubernetes.io/instance: worker1
+      annotations:
+        linkerd.io/inject: disabled
+    spec:
+      <<: *clientPod
+      nodeSelector:
+        kubernetes.io/hostname: worker1
+      tolerations:
+        - key: itsbagelbot.dev/pool
+          operator: Equal
+          value: worker-pool
+          effect: NoSchedule
+      containers:
+        - name: nats-box
+          image: natsio/nats-box:0.17.0
+          command: ["sleep", "1800"]
+          env:
+            - {name: LOCAL_NATS_URL, value: "tls://nats-gw-accept-worker1:4222"}
+            - {name: NATS_CA, value: "/etc/nats-ca/ca.pem"}
+            - name: REQUEST_USER
+              valueFrom: {secretKeyRef: {name: console-admin-env, key: NATS_RPC_USER}}
+            - name: REQUEST_PASSWORD
+              valueFrom: {secretKeyRef: {name: console-admin-env, key: NATS_RPC_PASSWORD}}
+            - name: RESPONSE_USER
+              valueFrom: {secretKeyRef: {name: users-env, key: NATS_RPC_USER}}
+            - name: RESPONSE_PASSWORD
+              valueFrom: {secretKeyRef: {name: users-env, key: NATS_RPC_PASSWORD}}
+          volumeMounts: *clientMounts
+          resources: *clientResources
+          securityContext: *containerSecurity
+  - apiVersion: v1
+    kind: Pod
+    metadata:
+      name: nats-gw-accept-client-node1
+      labels:
+        <<: *clientLabels
+        app.kubernetes.io/instance: node1
+      annotations:
+        linkerd.io/inject: disabled
+    spec:
+      <<: *clientPod
+      nodeSelector:
+        kubernetes.io/hostname: node1
+      containers:
+        - name: nats-box
+          image: natsio/nats-box:0.17.0
+          command: ["sleep", "1800"]
+          env:
+            - {name: LOCAL_NATS_URL, value: "tls://nats-gw-accept-node1:4222"}
+            - {name: NATS_CA, value: "/etc/nats-ca/ca.pem"}
+            - name: REQUEST_USER
+              valueFrom: {secretKeyRef: {name: console-admin-env, key: NATS_RPC_USER}}
+            - name: REQUEST_PASSWORD
+              valueFrom: {secretKeyRef: {name: console-admin-env, key: NATS_RPC_PASSWORD}}
+            - name: RESPONSE_USER
+              valueFrom: {secretKeyRef: {name: users-env, key: NATS_RPC_USER}}
+            - name: RESPONSE_PASSWORD
+              valueFrom: {secretKeyRef: {name: users-env, key: NATS_RPC_PASSWORD}}
+          volumeMounts: *clientMounts
+          resources: *clientResources
+          securityContext: *containerSecurity

--- a/deploy/k8s/nats-live-acceptance/gateway/worker1.conf
+++ b/deploy/k8s/nats-live-acceptance/gateway/worker1.conf
@@ -1,0 +1,26 @@
+server_name: "gateway-accept-worker1"
+include "/etc/nats/config/common.conf"
+
+gateway {
+  name: "rpc-worker1"
+  listen: "0.0.0.0:7222"
+  advertise: "nats-gw-accept-worker1.production.svc.cluster.local:7222"
+  reject_unknown_cluster: true
+  connect_retries: 30
+  connect_backoff: true
+  tls {
+    cert_file: "/etc/nats/certs/tls.crt"
+    key_file: "/etc/nats/certs/tls.key"
+    ca_file: "/etc/nats/certs/ca.crt"
+    verify: true
+    verify_cert_and_check_known_urls: true
+    timeout: 2
+  }
+  gateways: [
+    {name: "rpc-core", urls: [
+      "nats://nats-gw-accept-core-0.production.svc.cluster.local:7222",
+      "nats://nats-gw-accept-core-1.production.svc.cluster.local:7222"
+    ]},
+    {name: "rpc-node1", url: "nats://nats-gw-accept-node1.production.svc.cluster.local:7222"}
+  ]
+}

--- a/deploy/k8s/nats-live-acceptance/gateway_acceptance_test.go
+++ b/deploy/k8s/nats-live-acceptance/gateway_acceptance_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGatewayAcceptanceIsGuardedAndNotReconciled(t *testing.T) {
+	kustomization, err := os.ReadFile("../kustomization.yaml")
+	require.NoError(t, err)
+	require.NotContains(t, string(kustomization), "nats-live-acceptance/gateway")
+
+	cmd := exec.Command("bash", "gateway/local-first.sh")
+	cmd.Env = withoutEnv(os.Environ(), "CONFIRM_NATS_GATEWAY_ACCEPTANCE")
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(output))
+	require.Contains(t, string(output), "no actions performed")
+	require.Contains(t, string(output), "LOCAL-FIRST-RPC")
+}
+
+func TestGatewayAcceptanceModelsLocalCoreAndEdges(t *testing.T) {
+	topology := readGatewayFixture(t, "topology.yaml")
+	require.Contains(t, topology, "kubernetes.io/hostname: node2")
+	require.Contains(t, topology, "kubernetes.io/hostname: node3")
+	require.Contains(t, topology, "kubernetes.io/hostname: worker1")
+	require.Contains(t, topology, "kubernetes.io/hostname: node1")
+	require.Contains(t, topology, "name: nats-gateway-acceptance-isolation")
+	require.Contains(t, topology, "name: fleet-ca-issuer")
+	require.Contains(t, topology, "server auth")
+	require.Contains(t, topology, "client auth")
+	require.Contains(t, topology, "priorityClassName: nats-r3-bench-nonpreempting")
+	require.NotContains(t, topology, "kind: Secret")
+	require.NotContains(t, topology, "nodeName:")
+}
+
+func TestGatewayAcceptanceConfigsAreCoreNATSWithVerifiedTLS(t *testing.T) {
+	common := readGatewayFixture(t, "common.conf")
+	require.Contains(t, common, `include "/etc/nats/auth/auth.conf"`)
+	require.Contains(t, common, `min_version: "1.2"`)
+	require.NotContains(t, common, "jetstream")
+	require.NotContains(t, common, "leafnodes")
+
+	tests := []struct {
+		file        string
+		clusterName string
+		clustered   bool
+	}{
+		{file: "core-0.conf", clusterName: `name: "rpc-core"`, clustered: true},
+		{file: "core-1.conf", clusterName: `name: "rpc-core"`, clustered: true},
+		{file: "worker1.conf", clusterName: `name: "rpc-worker1"`},
+		{file: "node1.conf", clusterName: `name: "rpc-node1"`},
+	}
+	for _, test := range tests {
+		t.Run(test.file, func(t *testing.T) {
+			config := readGatewayFixture(t, test.file)
+			require.Contains(t, config, test.clusterName)
+			require.Contains(t, config, `include "/etc/nats/config/common.conf"`)
+			require.Contains(t, config, "verify: true")
+			require.Contains(t, config, "verify_cert_and_check_known_urls: true")
+			require.Contains(t, config, "gateway {")
+			require.Equal(t, test.clustered, strings.Contains(config, "cluster {"))
+			require.NotContains(t, config, "jetstream")
+			require.NotContains(t, config, "leafnodes")
+			require.NotContains(t, config, "nats.production.svc")
+			require.NotContains(t, config, "nats-leaf")
+		})
+	}
+}
+
+func TestGatewayAcceptanceKeepsEightMillisecondGateAndCleanup(t *testing.T) {
+	runner := readGatewayFixture(t, "local-first.sh")
+	for _, invariant := range []string{
+		`RPC_P99_MAX_MS:-8`,
+		`gate > 0 && gate <= 8`,
+		`local-priority`,
+		`remote-fallback`,
+		`kubectl apply -k "$script_dir"`,
+		`kubectl delete -k "$script_dir"`,
+		`production_nats_baseline`,
+		`kind: NetworkPolicy`,
+	} {
+		require.Contains(t, runner, invariant)
+	}
+	require.NotContains(t, runner, "go build")
+	require.NotContains(t, runner, "docker")
+	require.NotContains(t, runner, "podman")
+}
+
+func readGatewayFixture(t *testing.T, name string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("gateway", name))
+	require.NoError(t, err)
+	return string(data)
+}

--- a/deploy/k8s/valkey-live-acceptance/Containerfile
+++ b/deploy/k8s/valkey-live-acceptance/Containerfile
@@ -1,0 +1,20 @@
+# Valkey live-acceptance probe - build from the repository root:
+#   podman build -t itsbagelbot/valkey-live-acceptance \
+#     -f deploy/k8s/valkey-live-acceptance/Containerfile .
+FROM docker.io/library/golang:1.26.5-bookworm AS build
+
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY pkg/valkey pkg/valkey
+COPY deploy/k8s/valkey-live-acceptance deploy/k8s/valkey-live-acceptance
+RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" \
+    -o /valkey-live-acceptance ./deploy/k8s/valkey-live-acceptance
+
+FROM gcr.io/distroless/static-debian12:nonroot
+
+COPY --from=build /valkey-live-acceptance /valkey-live-acceptance
+
+USER nonroot
+ENTRYPOINT ["/valkey-live-acceptance"]

--- a/deploy/k8s/valkey-live-acceptance/README.md
+++ b/deploy/k8s/valkey-live-acceptance/README.md
@@ -8,21 +8,33 @@ separates the two routes that have different physical limits:
 
 The isolated key has a five-minute TTL and is deleted after each run. Temporary
 pods are pinned to the requested node, use the production CA and ACL password,
-match Sesame's two-CPU limit, and are cleaned up automatically.
+match Sesame's two-CPU limit, and are cleaned up automatically. The runner
+requires one immutable digest of the CI-published multi-architecture image, so
+it never compiles on the operator's computer, copies an executable into a pod,
+or silently changes the executable between qualification runs.
 
 Run a diagnostic fleet pass without failing on a missed target:
 
 ```sh
+CONFIRM_LIVE_VALKEY_BENCH=I-understand-this-runs-on-live-Valkey \
+BENCH_IMAGE=ghcr.io/adamousmer/itsbagelbot/valkey-live-acceptance@sha256:<digest> \
 deploy/k8s/valkey-live-acceptance/run.sh
 ```
 
 Make sub-2 ms p99 a hard acceptance gate:
 
 ```sh
+CONFIRM_LIVE_VALKEY_BENCH=I-understand-this-runs-on-live-Valkey \
+BENCH_IMAGE=ghcr.io/adamousmer/itsbagelbot/valkey-live-acceptance@sha256:<digest> \
 REQUIRE_TARGET=true TARGET=2ms deploy/k8s/valkey-live-acceptance/run.sh
 ```
 
-`NODES`, `CONCURRENCY`, `REQUESTS`, `WARMUP`, and `MODE=read|write|both` are
-configurable. A write failure on a remote node is an architectural signal, not
-a reason to enable replica writes: those writes are local-only and can be lost
-or overwritten during resynchronization.
+`NODES`, `CONCURRENCY`, `REQUESTS`, `WARMUP`, `CPU_REQUEST`,
+`POD_TIMEOUT_SECONDS`, `CLEANUP_TIMEOUT_SECONDS`, `MODE=read|write|both`, and
+`WRITE_PROFILE=pooled|pipeline` are configurable. The default `pooled` profile
+matches reply-critical production mutations; `pipeline` selectively exercises
+valkey-go's automatic pipeline without changing the deployed client default.
+`BENCH_IMAGE` must use `repository@sha256:digest`; mutable tags are rejected
+before any pod is created. A write failure on a remote node is an architectural
+signal, not a reason to enable replica writes: those writes are local-only and
+can be lost or overwritten during resynchronization.

--- a/deploy/k8s/valkey-live-acceptance/main.go
+++ b/deploy/k8s/valkey-live-acceptance/main.go
@@ -23,6 +23,7 @@ type config struct {
 	address       string
 	caFile        string
 	mode          string
+	writeProfile  string
 	node          string
 	concurrency   int
 	requests      int
@@ -40,9 +41,11 @@ type operation struct {
 type result struct {
 	Node               string  `json:"node"`
 	Operation          string  `json:"operation"`
+	WriteProfile       string  `json:"write_profile"`
 	Concurrency        int     `json:"concurrency"`
 	Requests           int     `json:"requests"`
 	Throughput         float64 `json:"throughput_per_second"`
+	MinMicroseconds    float64 `json:"min_us"`
 	P50Microseconds    float64 `json:"p50_us"`
 	P95Microseconds    float64 `json:"p95_us"`
 	P99Microseconds    float64 `json:"p99_us"`
@@ -125,7 +128,9 @@ func emit(report result) {
 }
 
 func (app *application) close() {
-	app.client.Do(context.Background(), app.client.B().Del().Key(app.key).Build())
+	cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cleanupCancel()
+	app.client.Do(cleanupCtx, app.client.B().Del().Key(app.key).Build())
 	app.client.Close()
 	app.cancel()
 }
@@ -142,15 +147,16 @@ func parseFlags() config {
 
 func defaultConfig() config {
 	return config{
-		address:     "valkey.valkey.svc.cluster.local:26380",
-		caFile:      "/etc/valkey/tls/ca.crt",
-		mode:        "both",
-		node:        os.Getenv("NODE_NAME"),
-		concurrency: 5,
-		requests:    100000,
-		warmup:      5000,
-		timeout:     5 * time.Minute,
-		target:      2 * time.Millisecond,
+		address:      "valkey.valkey.svc.cluster.local:26380",
+		caFile:       "/etc/valkey/tls/ca.crt",
+		mode:         "both",
+		writeProfile: "pooled",
+		node:         os.Getenv("NODE_NAME"),
+		concurrency:  5,
+		requests:     100000,
+		warmup:       5000,
+		timeout:      5 * time.Minute,
+		target:       2 * time.Millisecond,
 	}
 }
 
@@ -158,6 +164,7 @@ func bindFlags(cfg *config) {
 	flag.StringVar(&cfg.address, "address", "valkey.valkey.svc.cluster.local:26380", "Sentinel address")
 	flag.StringVar(&cfg.caFile, "ca-file", "/etc/valkey/tls/ca.crt", "fleet CA file")
 	flag.StringVar(&cfg.mode, "mode", "both", "read, write, or both")
+	flag.StringVar(&cfg.writeProfile, "write-profile", "pooled", "pooled or pipeline")
 	flag.StringVar(&cfg.node, "node", os.Getenv("NODE_NAME"), "source node label")
 	flag.IntVar(&cfg.concurrency, "concurrency", 5, "concurrent callers")
 	flag.IntVar(&cfg.requests, "requests", 100000, "requests per measured operation")
@@ -185,9 +192,16 @@ func (cfg config) validate() error {
 	}
 	switch cfg.mode {
 	case "read", "write", "both":
-		return nil
+		// Validated below with the write profile so both independent enum-like
+		// inputs stay explicit and easy to extend.
 	default:
 		return errors.New("mode must be read, write, or both")
+	}
+	switch cfg.writeProfile {
+	case "pooled", "pipeline":
+		return nil
+	default:
+		return errors.New("write-profile must be pooled or pipeline")
 	}
 }
 
@@ -265,6 +279,13 @@ func (r operationRunner) execute() valkey.ValkeyResult {
 		return r.client.Do(r.ctx, r.client.B().Get().Key(r.op.key).Build())
 	}
 	cmd := r.client.B().Set().Key(r.op.key).Value("01234567890123456789012345678901").ExSeconds(300).Build()
+	if r.cfg.writeProfile == "pipeline" {
+		// The shared client intentionally uses the dedicated-connection pool by
+		// default for reply-critical mutations. ToPipe opts this benchmark write
+		// into valkey-go's automatic pipeline without creating another client or
+		// changing production behavior before the live matrix proves the trade.
+		cmd = cmd.ToPipe()
+	}
 	return r.client.Do(r.ctx, cmd)
 }
 
@@ -272,8 +293,10 @@ func summarize(cfg config, op operation, measured measurement) result {
 	sort.Slice(measured.latencies, func(i, j int) bool { return measured.latencies[i] < measured.latencies[j] })
 	p99 := percentile(measured.latencies, 99)
 	return result{
-		Node: cfg.node, Operation: op.name, Concurrency: cfg.concurrency, Requests: len(measured.latencies),
+		Node: cfg.node, Operation: op.name, WriteProfile: cfg.writeProfile,
+		Concurrency: cfg.concurrency, Requests: len(measured.latencies),
 		Throughput:      float64(len(measured.latencies)) / measured.elapsed.Seconds(),
+		MinMicroseconds: micros(measured.latencies[0]),
 		P50Microseconds: micros(percentile(measured.latencies, 50)),
 		P95Microseconds: micros(percentile(measured.latencies, 95)),
 		P99Microseconds: micros(p99), MaxMicroseconds: micros(measured.latencies[len(measured.latencies)-1]),

--- a/deploy/k8s/valkey-live-acceptance/main_test.go
+++ b/deploy/k8s/valkey-live-acceptance/main_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigValidatesWriteProfile(t *testing.T) {
+	for _, profile := range []string{"pooled", "pipeline"} {
+		t.Run(profile, func(t *testing.T) {
+			cfg := validTestConfig()
+			cfg.writeProfile = profile
+			require.NoError(t, cfg.validate())
+		})
+	}
+
+	cfg := validTestConfig()
+	cfg.writeProfile = "unbounded-connections"
+	require.EqualError(t, cfg.validate(), "write-profile must be pooled or pipeline")
+}
+
+func TestSummarizeReportsProfileAndFullLatencyRange(t *testing.T) {
+	cfg := validTestConfig()
+	cfg.writeProfile = "pipeline"
+	measured := measurement{
+		latencies: []time.Duration{4 * time.Millisecond, time.Millisecond, 2 * time.Millisecond},
+		elapsed:   time.Second,
+	}
+
+	report := summarize(cfg, operation{name: "write-master"}, measured)
+
+	assert.Equal(t, "pipeline", report.WriteProfile)
+	assert.Equal(t, float64(1000), report.MinMicroseconds)
+	assert.Equal(t, float64(4000), report.MaxMicroseconds)
+	assert.Equal(t, float64(3), report.Throughput)
+}
+
+func validTestConfig() config {
+	cfg := defaultConfig()
+	cfg.node = "node3"
+	return cfg
+}

--- a/deploy/k8s/valkey-live-acceptance/run.sh
+++ b/deploy/k8s/valkey-live-acceptance/run.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Fleet-wide production Valkey p99 acceptance. Temporary probe pods and binaries
-# are removed even when a node misses the target.
+# Fleet-wide production Valkey p99 acceptance. Temporary probe pods are removed
+# even when a node misses the target.
 set -euo pipefail
 
 namespace=${NAMESPACE:-valkey}
@@ -9,42 +9,99 @@ requests=${REQUESTS:-100000}
 warmup=${WARMUP:-5000}
 concurrency=${CONCURRENCY:-5}
 mode=${MODE:-both}
+write_profile=${WRITE_PROFILE:-pooled}
 target=${TARGET:-2ms}
 require_target=${REQUIRE_TARGET:-false}
-image=${BENCH_IMAGE:-alpine:3.22}
+image=${BENCH_IMAGE:-}
 cpu_request=${CPU_REQUEST:-50m}
+pod_timeout_seconds=${POD_TIMEOUT_SECONDS:-420}
+cleanup_timeout_seconds=${CLEANUP_TIMEOUT_SECONDS:-30}
+priority_class=${BENCH_PRIORITY_CLASS:-valkey-bench-nonpreempting}
 run_id=$(date -u +%Y%m%d%H%M%S)
 declare -a pods=()
-amd64_binary="/tmp/valkey-live-acceptance-amd64-${run_id}"
-arm64_binary="/tmp/valkey-live-acceptance-arm64-${run_id}"
 
 cleanup() {
-  for pod in "${pods[@]}"; do
-    kubectl -n "$namespace" delete pod "$pod" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+  # The default expansion keeps cleanup safe under Bash 3.2 + nounset before
+  # the first pod has been appended (for example when a safety gate rejects).
+  for pod in "${pods[@]-}"; do
+    [[ -n $pod ]] || continue
+    kubectl -n "$namespace" delete pod "$pod" --ignore-not-found --wait=true \
+      --timeout="${cleanup_timeout_seconds}s" >/dev/null 2>&1 || true
   done
-  rm -f "$amd64_binary" "$arm64_binary"
 }
 trap cleanup EXIT INT TERM
 
-GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -trimpath \
-  -o "$amd64_binary" ./deploy/k8s/valkey-live-acceptance
-GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -trimpath \
-  -o "$arm64_binary" ./deploy/k8s/valkey-live-acceptance
+if [[ ${CONFIRM_LIVE_VALKEY_BENCH:-} != "I-understand-this-runs-on-live-Valkey" ]]; then
+  echo "Refusing live Valkey benchmark without explicit confirmation." >&2
+  echo "Set CONFIRM_LIVE_VALKEY_BENCH=I-understand-this-runs-on-live-Valkey" >&2
+  exit 1
+fi
+
+if [[ ! $image =~ ^[^@[:space:]]+@sha256:[0-9a-f]{64}$ ]]; then
+  echo "BENCH_IMAGE must identify one immutable image digest (repository@sha256:<64 lowercase hex characters>)" >&2
+  exit 1
+fi
+
+if [[ $require_target != true && $require_target != false ]]; then
+  echo "REQUIRE_TARGET must be true or false" >&2
+  exit 1
+fi
+if [[ ! $pod_timeout_seconds =~ ^[1-9][0-9]*$ || ! $cleanup_timeout_seconds =~ ^[1-9][0-9]*$ ]]; then
+  echo "POD_TIMEOUT_SECONDS and CLEANUP_TIMEOUT_SECONDS must be positive integers" >&2
+  exit 1
+fi
+
+priority_json=$(kubectl get priorityclass "$priority_class" -o json)
+if ! jq -e '.value <= 0 and .preemptionPolicy == "Never"' <<<"$priority_json" >/dev/null; then
+  echo "Valkey benchmark priority class $priority_class must have value <= 0 and preemptionPolicy Never" >&2
+  exit 1
+fi
+
+wait_for_termination() {
+  local pod=$1
+  local deadline=$((SECONDS + pod_timeout_seconds))
+  local exit_code
+  local wait_reason
+
+  while ((SECONDS < deadline)); do
+    exit_code=$(kubectl -n "$namespace" get pod "$pod" \
+      -o jsonpath='{.status.containerStatuses[0].state.terminated.exitCode}' 2>/dev/null || true)
+    if [[ $exit_code =~ ^[0-9]+$ ]]; then
+      return 0
+    fi
+
+    wait_reason=$(kubectl -n "$namespace" get pod "$pod" \
+      -o jsonpath='{.status.containerStatuses[0].state.waiting.reason}' 2>/dev/null || true)
+    case "$wait_reason" in
+      CreateContainerConfigError|CreateContainerError|ErrImagePull|ImagePullBackOff|InvalidImageName)
+        return 1
+        ;;
+    esac
+    sleep 1
+  done
+  return 1
+}
 
 status=0
 for node in $nodes; do
-  arch=$(kubectl get node "$node" -o jsonpath='{.status.nodeInfo.architecture}')
-  if [[ $arch == arm64 ]]; then
-    binary=$arm64_binary
-  else
-    binary=$amd64_binary
-  fi
   pod="valkey-p99-${node}-${run_id}"
   pods+=("$pod")
 
-  overrides=$(jq -nc --arg pod "$pod" --arg node "$node" --arg image "$image" --arg cpuRequest "$cpu_request" '{
-    spec:{nodeName:$node,restartPolicy:"Never",containers:[{
-      name:$pod,image:$image,command:["sleep","1800"],
+  args=(
+    -node "$node" -mode "$mode" -requests "$requests" -warmup "$warmup"
+    -concurrency "$concurrency" -target "$target" -write-profile "$write_profile"
+  )
+  if [[ $require_target == true ]]; then
+    args+=(-require-target)
+  fi
+  args_json=$(jq -nc '$ARGS.positional' --args -- "${args[@]}")
+
+  overrides=$(jq -nc --arg pod "$pod" --arg node "$node" --arg image "$image" \
+    --arg cpuRequest "$cpu_request" --arg priorityClass "$priority_class" \
+    --argjson args "$args_json" '{
+    spec:{nodeName:$node,restartPolicy:"Never",priorityClassName:$priorityClass,
+    automountServiceAccountToken:false,containers:[{
+      name:$pod,image:$image,imagePullPolicy:"Always",args:$args,
       env:[
         {name:"NODE_NAME",valueFrom:{fieldRef:{fieldPath:"spec.nodeName"}}},
         {name:"NODE_IP",valueFrom:{fieldRef:{fieldPath:"status.hostIP"}}},
@@ -53,26 +110,31 @@ for node in $nodes; do
       ],
       volumeMounts:[{name:"tls",mountPath:"/etc/valkey/tls",readOnly:true}],
       resources:{requests:{cpu:$cpuRequest,memory:"128Mi"},limits:{cpu:"2",memory:"768Mi"}},
-      securityContext:{runAsUser:999,runAsGroup:999,allowPrivilegeEscalation:false,capabilities:{drop:["ALL"]}}
+      securityContext:{runAsUser:65532,runAsGroup:65532,allowPrivilegeEscalation:false,capabilities:{drop:["ALL"]}}
     }],volumes:[{name:"tls",secret:{secretName:"valkey-server-tls"}}],
-    securityContext:{runAsNonRoot:true,runAsUser:999,runAsGroup:999,seccompProfile:{type:"RuntimeDefault"}}
+    securityContext:{runAsNonRoot:true,runAsUser:65532,runAsGroup:65532,seccompProfile:{type:"RuntimeDefault"}}
   }}')
 
-  kubectl -n "$namespace" run "$pod" --image="$image" --restart=Never --overrides="$overrides" -- sleep 1800 >/dev/null
-  kubectl -n "$namespace" wait --for=condition=Ready "pod/$pod" --timeout=120s >/dev/null
-  kubectl -n "$namespace" cp "$binary" "$pod:/tmp/valkey-live-acceptance"
-
-  args=(
-    -node "$node" -mode "$mode" -requests "$requests" -warmup "$warmup"
-    -concurrency "$concurrency" -target "$target"
-  )
-  if [[ $require_target == true ]]; then
-    args+=(-require-target)
+  kubectl -n "$namespace" run "$pod" --image="$image" --restart=Never --overrides="$overrides" >/dev/null
+  if ! wait_for_termination "$pod"; then
+    kubectl -n "$namespace" logs "$pod" || true
+    kubectl -n "$namespace" get pod "$pod" -o wide || true
+    status=1
+    kubectl -n "$namespace" delete pod "$pod" --wait=true \
+      --timeout="${cleanup_timeout_seconds}s" >/dev/null 2>&1 || true
+    continue
   fi
-  if ! kubectl -n "$namespace" exec "$pod" -- /tmp/valkey-live-acceptance "${args[@]}"; then
+
+  if ! kubectl -n "$namespace" logs "$pod"; then
     status=1
   fi
-  kubectl -n "$namespace" delete pod "$pod" --wait=false >/dev/null
+  exit_code=$(kubectl -n "$namespace" get pod "$pod" \
+    -o jsonpath='{.status.containerStatuses[0].state.terminated.exitCode}')
+  if [[ $exit_code != 0 ]]; then
+    status=1
+  fi
+  kubectl -n "$namespace" delete pod "$pod" --wait=true \
+    --timeout="${cleanup_timeout_seconds}s" >/dev/null 2>&1 || true
 done
 
 exit "$status"

--- a/pkg/valkey/client.go
+++ b/pkg/valkey/client.go
@@ -1,14 +1,12 @@
 package valkey
 
 import (
-	"context"
 	"crypto/tls"
 	"log"
 	"net"
 	"os"
 	"time"
 
-	"github.com/newrelic/go-agent/v3/newrelic"
 	valkey_go "github.com/valkey-io/valkey-go"
 )
 
@@ -30,15 +28,15 @@ const (
 	localBufferSize        = 8 << 10
 )
 
-// BuildClientOption constructs the Valkey client option for the master/write
-// path. For a Sentinel deployment (detected via the :26379 port) it configures
-// Sentinel auth and offloads read-only commands to a replica. This is the
-// fallback read path used when no node-local instance is available; the local
-// read path is wired separately in NewClient.
+// BuildClientOption constructs the Valkey client option for the primary path.
+// For a Sentinel deployment (detected via the plaintext or TLS Sentinel port)
+// it configures
+// Sentinel auth. Read-only commands stay primary-consistent unless Client
+// explicitly routes them to its node-local client.
 //
 // Exported for testing.
 func BuildClientOption(address, password string) valkey_go.ClientOption {
-	return withWritePool(buildOption(address, password, true, nil))
+	return withWritePool(buildOption(address, password, nil))
 }
 
 func withWritePool(opts valkey_go.ClientOption) valkey_go.ClientOption {
@@ -51,16 +49,11 @@ func withWritePool(opts valkey_go.ClientOption) valkey_go.ClientOption {
 	return opts
 }
 
-// buildOption builds a Valkey client option. replicaReads enables the
-// SendToReplicas read-offload for a Sentinel deployment.
-//
-// It MUST stay off for the pub/sub client: keyspace notifications (the expired
-// events the timer + live-recheck watchers subscribe to) are published only by
-// the master, so SendToReplicas — which routes the pub/sub SUBSCRIBE to a
-// replica — pins the subscription to a node that never emits them, silently
-// dropping every expiry. Reads still offload via the node-local client (Do),
-// so the pub/sub client losing replica-reads costs nothing.
-func buildOption(address, password string, replicaReads bool, tlsConfig *tls.Config) valkey_go.ClientOption {
+// buildOption builds a primary-consistent Valkey client option. Replica reads
+// are deliberately not enabled here: Client owns the node-local read route,
+// while this connection remains the authoritative primary route used by
+// writes, Primary views and keyspace-notification subscriptions.
+func buildOption(address, password string, tlsConfig *tls.Config) valkey_go.ClientOption {
 	opts := valkey_go.ClientOption{
 		InitAddress:  []string{address},
 		Password:     password,
@@ -80,13 +73,6 @@ func buildOption(address, password string, replicaReads bool, tlsConfig *tls.Con
 			Password:  password,
 			TLSConfig: cloneTLSConfig(tlsConfig),
 		}
-		if replicaReads {
-			// Without a node-local read client, fall back to sending read-only
-			// commands to a Sentinel replica. Writes still go to the master.
-			opts.SendToReplicas = func(cmd valkey_go.Completed) bool {
-				return cmd.IsReadOnly()
-			}
-		}
 	}
 	return opts
 }
@@ -100,139 +86,22 @@ func buildOption(address, password string, replicaReads bool, tlsConfig *tls.Con
 // (master on the primary node, a replica elsewhere) it is the lowest-latency
 // instance for pods on that node. So:
 //
-//   - writes and topology  -> the embedded Sentinel client, which always tracks
-//     the current master and fails over automatically;
+//   - writes, topology and primary-consistent reads -> the embedded Sentinel
+//     client, which always tracks the current master and fails over
+//     automatically;
 //   - pub/sub (Receive)     -> a dedicated master-pinned Sentinel client with no
 //     replica-read offload, so expiry notifications (master-only) are actually
 //     received;
 //   - read-only commands    -> valkey-local over TLS, with no cross-node hop.
 //
 // valkey-go's Sentinel client cannot prefer a local replica on its own:
-// ReadNodeSelector is cluster-mode only, and the Sentinel path picks a replica
-// at random. Splitting the read path out is what makes node-local reads work.
+// ReadNodeSelector is cluster-mode only. Splitting the read path out is what
+// makes node-local reads deterministic while keeping a no-extra-pool primary
+// route available for read-after-write consistency.
 type Client struct {
-	valkey_go.Client                  // master/write path plus everything not overridden
-	local            valkey_go.Client // node-local read path; nil when unavailable
-	pubsub           valkey_go.Client // master-pinned pub/sub path; nil for standalone
-}
-
-// Do sends read-only commands to the local instance and everything else to the
-// master via Sentinel.
-func (c *Client) Do(ctx context.Context, cmd valkey_go.Completed) valkey_go.ValkeyResult {
-	route := c.commandRoute(cmd.IsReadOnly(), singleCommand)
-	return traceValkeyCall(ctx, route.operation, func() valkey_go.ValkeyResult {
-		return route.client.Do(ctx, cmd)
-	}, classifyValkeyResult)
-}
-
-// DoMulti sends a batch to the local instance only when every command is
-// read-only; any write in the batch routes the whole batch to the master.
-func (c *Client) DoMulti(ctx context.Context, multi ...valkey_go.Completed) []valkey_go.ValkeyResult {
-	route := c.commandRoute(allReadOnly(multi), commandBatch)
-	return traceValkeyCall(ctx, route.operation, func() []valkey_go.ValkeyResult {
-		return route.client.DoMulti(ctx, multi...)
-	}, classifyValkeyResults)
-}
-
-type commandShape uint8
-
-const (
-	singleCommand commandShape = iota
-	commandBatch
-)
-
-type valkeyRoute struct {
-	client    valkey_go.Client
-	operation string
-}
-
-func (c *Client) commandRoute(readOnly bool, shape commandShape) valkeyRoute {
-	route := valkeyRoute{client: c.Client, operation: "valkey.write"}
-	if readOnly {
-		route.operation = "valkey.read"
-		if c.local != nil {
-			route.client = c.local
-		}
-	}
-	if shape == commandBatch {
-		route.operation += "_batch"
-	}
-	return route
-}
-
-// Valkey spans are emitted only for transactions selected by New Relic's own
-// sampler. The unsampled command path remains one context lookup and a branch,
-// while sampled traces get fixed-name read/write dependency attribution without
-// exposing keys or commands as high-cardinality facets.
-func traceValkeyCall[T any](ctx context.Context, operation string, do func() T, classify func(T) string) T {
-	txn := newrelic.FromContext(ctx)
-	if txn == nil || !txn.IsSampled() {
-		return do()
-	}
-	segment := txn.StartSegment(operation)
-	result := do()
-	segment.AddAttribute("result", classify(result))
-	segment.End()
-	return result
-}
-
-func classifyValkeyResult(result valkey_go.ValkeyResult) string {
-	return valkeyResult(result.Error())
-}
-
-func classifyValkeyResults(results []valkey_go.ValkeyResult) string {
-	result := "ok"
-	for i := range results {
-		if current := valkeyResult(results[i].Error()); current == "error" {
-			result = current
-			break
-		} else if current == "miss" {
-			result = current
-		}
-	}
-	return result
-}
-
-func valkeyResult(err error) string {
-	if err == nil {
-		return "ok"
-	}
-	if valkey_go.IsValkeyNil(err) {
-		return "miss"
-	}
-	return "error"
-}
-
-// Receive routes pub/sub to the master-pinned client. Keyspace notifications
-// (the expired events the timer + live-recheck watchers subscribe to) are
-// emitted only by the master; the default client's SendToReplicas read-offload
-// would otherwise pin the subscription to a replica that never delivers them.
-func (c *Client) Receive(ctx context.Context, subscribe valkey_go.Completed, fn func(msg valkey_go.PubSubMessage)) error {
-	if c.pubsub != nil {
-		return c.pubsub.Receive(ctx, subscribe, fn)
-	}
-	return c.Client.Receive(ctx, subscribe, fn)
-}
-
-// Close releases the master/write client, the local read client and the
-// master-pinned pub/sub client.
-func (c *Client) Close() {
-	if c.local != nil {
-		c.local.Close()
-	}
-	if c.pubsub != nil {
-		c.pubsub.Close()
-	}
-	c.Client.Close()
-}
-
-func allReadOnly(multi []valkey_go.Completed) bool {
-	for i := range multi {
-		if !multi[i].IsReadOnly() {
-			return false
-		}
-	}
-	return true
+	valkey_go.Client                   // master/write path plus everything not overridden
+	local            valkey_go.Client  // node-local read path; nil when unavailable
+	pubsub           *lazyValkeyClient // master-pinned pub/sub path; nil for standalone
 }
 
 // NewClient initializes a Valkey client.
@@ -240,15 +109,16 @@ func allReadOnly(multi []valkey_go.Completed) bool {
 // Writes always go to the Sentinel-elected master. For a Sentinel deployment
 // with NODE_IP set, read-only commands go to VALKEY_LOCAL_ADDR when configured,
 // otherwise to NODE_IP. The production Service uses internalTrafficPolicy=Local
-// so each node reads its own Valkey without a cross-node hop. Otherwise reads
-// fall back to a Sentinel replica (or the single instance, for standalone).
+// so each node reads its own Valkey without a cross-node hop. Without a local
+// endpoint, reads stay on the primary for correctness instead of choosing a
+// random remote replica.
 func NewClient(address, password string) (valkey_go.Client, error) {
 	tlsConfig, err := clientTLSConfig()
 	if err != nil {
 		return nil, err
 	}
 	address = secureAddress(address, tlsConfig != nil)
-	master, err := valkey_go.NewClient(withWritePool(buildOption(address, password, true, tlsConfig)))
+	master, err := valkey_go.NewClient(withWritePool(buildOption(address, password, tlsConfig)))
 	if err != nil {
 		return nil, err
 	}
@@ -260,14 +130,16 @@ func NewClient(address, password string) (valkey_go.Client, error) {
 		return &Client{Client: master}, nil
 	}
 
-	// Sentinel: pub/sub must be pinned to the master (no SendToReplicas) or the
-	// expiry watchers subscribe to a replica that never emits expired events.
-	pubsub, err := valkey_go.NewClient(buildOption(address, password, false, tlsConfig))
-	if err != nil {
-		master.Close()
-		return nil, err
+	// Sentinel pub/sub is isolated on its own master-pinned client so long-lived
+	// expiry watchers do not share the ordinary command path. Construct it lazily
+	// because most services never call Receive and need no additional pool.
+	wrapped := &Client{
+		Client: master,
+		pubsub: newLazyValkeyClient(
+			buildOption(address, password, tlsConfig),
+			valkey_go.NewClient,
+		),
 	}
-	wrapped := &Client{Client: master, pubsub: pubsub}
 
 	// Node-local read path: a Sentinel deployment where every node hosts a
 	// Valkey instance on NODE_IP:6380 in production.
@@ -288,7 +160,7 @@ func NewClient(address, password string) (valkey_go.Client, error) {
 	}).option())
 	if err != nil {
 		// Local instance unreachable at startup: degrade to Sentinel-only
-		// rather than fail the service. Reads go to a Sentinel replica;
+		// rather than fail the service. Reads stay primary-consistent;
 		// correctness is unaffected, only locality is lost.
 		log.Printf("valkey: node-local read client unavailable (%v); reading via Sentinel", err)
 		return wrapped, nil

--- a/pkg/valkey/client_fake_test.go
+++ b/pkg/valkey/client_fake_test.go
@@ -1,0 +1,41 @@
+package valkey
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+
+	valkey_go "github.com/valkey-io/valkey-go"
+)
+
+type recordingValkeyClient struct {
+	valkey_go.Client
+	mu       sync.Mutex
+	commands []valkey_go.Completed
+	batches  [][]valkey_go.Completed
+	receives atomic.Int64
+	closes   atomic.Int64
+}
+
+func (c *recordingValkeyClient) Do(_ context.Context, cmd valkey_go.Completed) valkey_go.ValkeyResult {
+	c.mu.Lock()
+	c.commands = append(c.commands, cmd)
+	c.mu.Unlock()
+	return valkey_go.ValkeyResult{}
+}
+
+func (c *recordingValkeyClient) DoMulti(_ context.Context, multi ...valkey_go.Completed) []valkey_go.ValkeyResult {
+	c.mu.Lock()
+	c.batches = append(c.batches, append([]valkey_go.Completed(nil), multi...))
+	c.mu.Unlock()
+	return make([]valkey_go.ValkeyResult, len(multi))
+}
+
+func (c *recordingValkeyClient) Receive(context.Context, valkey_go.Completed, func(valkey_go.PubSubMessage)) error {
+	c.receives.Add(1)
+	return nil
+}
+
+func (c *recordingValkeyClient) Close() {
+	c.closes.Add(1)
+}

--- a/pkg/valkey/client_test.go
+++ b/pkg/valkey/client_test.go
@@ -2,23 +2,15 @@ package valkey
 
 import (
 	"crypto/tls"
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	valkey_go "github.com/valkey-io/valkey-go"
 )
 
-func TestValkeyTelemetryResultsStayFinite(t *testing.T) {
-	assert.Equal(t, "ok", valkeyResult(nil))
-	assert.Equal(t, "miss", valkeyResult(valkey_go.Nil))
-	assert.Equal(t, "error", valkeyResult(errors.New("unavailable")))
-}
-
-// TestReadScaling verifies that the Valkey client option configuration correctly
-// sets the SendToReplicas predicate when connecting to a Sentinel cluster.
-// This is critical to ensure that local read-only queries are offloaded to local replicas!
-func TestReadScaling_IsReadOnly(t *testing.T) {
+// TestPrimaryOption verifies that the authoritative client never delegates
+// reads to a random Sentinel replica. Node-local routing belongs to Client.
+func TestPrimaryOption(t *testing.T) {
 	t.Run("Standard Address", func(t *testing.T) {
 		opts := BuildClientOption("valkey:6379", "password")
 		assert.Nil(t, opts.SendToReplicas, "SendToReplicas should be nil for standard connections")
@@ -27,10 +19,8 @@ func TestReadScaling_IsReadOnly(t *testing.T) {
 
 	t.Run("Sentinel Address", func(t *testing.T) {
 		opts := BuildClientOption("valkey.svc.cluster.local:26379", "password")
-		assert.NotNil(t, opts.SendToReplicas, "SendToReplicas must be configured for Sentinel to enforce local preferred reads")
+		assert.Nil(t, opts.SendToReplicas, "the primary route must remain primary-consistent")
 
-		// We can't easily construct a valkey_go.Completed without a real client,
-		// but we can assert the option was configured and the master set logic applied.
 		assert.Equal(t, "myprimary", opts.Sentinel.MasterSet)
 		assert.Equal(t, "password", opts.Sentinel.Password)
 		assertWritePool(t, opts)
@@ -49,7 +39,7 @@ func assertWritePool(t *testing.T, opts valkey_go.ClientOption) {
 
 func TestTLSOptionSecuresSentinelAndDataConnections(t *testing.T) {
 	config := &tls.Config{ServerName: defaultTLSServerName, MinVersion: tls.VersionTLS12}
-	opts := buildOption("valkey.valkey.svc.cluster.local:26380", "password", true, config)
+	opts := buildOption("valkey.valkey.svc.cluster.local:26380", "password", config)
 
 	assert.NotNil(t, opts.TLSConfig)
 	assert.NotSame(t, config, opts.TLSConfig)

--- a/pkg/valkey/pubsub.go
+++ b/pkg/valkey/pubsub.go
@@ -1,0 +1,84 @@
+package valkey
+
+import (
+	"context"
+	"sync"
+
+	valkey_go "github.com/valkey-io/valkey-go"
+)
+
+// Receive routes pub/sub to the master-pinned client. Keyspace notifications
+// (the expired events the timer + live-recheck watchers subscribe to) are
+// emitted only by the master. A separate lazy client isolates the long-lived
+// subscription from the ordinary command pool without charging services that
+// never subscribe.
+func (c *Client) Receive(ctx context.Context, subscribe valkey_go.Completed, fn func(msg valkey_go.PubSubMessage)) error {
+	if c.pubsub != nil {
+		pubsub, err := c.pubsub.get()
+		if err != nil {
+			return err
+		}
+		return pubsub.Receive(ctx, subscribe, fn)
+	}
+	return c.Client.Receive(ctx, subscribe, fn)
+}
+
+// Close releases the primary, node-local read and lazy pub/sub clients.
+func (c *Client) Close() {
+	if c.local != nil {
+		c.local.Close()
+	}
+	if c.pubsub != nil {
+		c.pubsub.close()
+	}
+	c.Client.Close()
+}
+
+type valkeyClientFactory func(valkey_go.ClientOption) (valkey_go.Client, error)
+
+// lazyValkeyClient avoids allocating a dedicated master-pinned connection pool
+// in services that never subscribe. Holding the mutex during construction makes
+// first use single-flight and prevents Close from racing a newly created client.
+type lazyValkeyClient struct {
+	mu        sync.Mutex
+	client    valkey_go.Client
+	option    valkey_go.ClientOption
+	newClient valkeyClientFactory
+	closed    bool
+}
+
+func newLazyValkeyClient(option valkey_go.ClientOption, factory valkeyClientFactory) *lazyValkeyClient {
+	return &lazyValkeyClient{option: option, newClient: factory}
+}
+
+func (c *lazyValkeyClient) get() (valkey_go.Client, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return nil, valkey_go.ErrClosing
+	}
+	if c.client != nil {
+		return c.client, nil
+	}
+	client, err := c.newClient(c.option)
+	if err != nil {
+		return nil, err
+	}
+	c.client = client
+	return client, nil
+}
+
+func (c *lazyValkeyClient) close() {
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return
+	}
+	c.closed = true
+	client := c.client
+	c.client = nil
+	c.mu.Unlock()
+	if client != nil {
+		client.Close()
+	}
+}

--- a/pkg/valkey/pubsub_test.go
+++ b/pkg/valkey/pubsub_test.go
@@ -1,0 +1,59 @@
+package valkey
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	valkey_go "github.com/valkey-io/valkey-go"
+)
+
+func TestPubSubClientIsLazyAndSingleFlight(t *testing.T) {
+	primary := &recordingValkeyClient{}
+	pubsub := &recordingValkeyClient{}
+	var creates atomic.Int64
+	client := &Client{
+		Client: primary,
+		pubsub: newLazyValkeyClient(valkey_go.ClientOption{}, func(valkey_go.ClientOption) (valkey_go.Client, error) {
+			creates.Add(1)
+			return pubsub, nil
+		}),
+	}
+	assert.Zero(t, creates.Load())
+
+	const receivers = 32
+	var group sync.WaitGroup
+	group.Add(receivers)
+	for range receivers {
+		go func() {
+			defer group.Done()
+			assert.NoError(t, client.Receive(context.Background(), valkey_go.Completed{}, nil))
+		}()
+	}
+	group.Wait()
+
+	assert.Equal(t, int64(1), creates.Load())
+	assert.Equal(t, int64(receivers), pubsub.receives.Load())
+	client.Close()
+	assert.Equal(t, int64(1), pubsub.closes.Load())
+	assert.Equal(t, int64(1), primary.closes.Load())
+}
+
+func TestClosedClientCannotCreateLazyPubSubClient(t *testing.T) {
+	primary := &recordingValkeyClient{}
+	var creates atomic.Int64
+	client := &Client{
+		Client: primary,
+		pubsub: newLazyValkeyClient(valkey_go.ClientOption{}, func(valkey_go.ClientOption) (valkey_go.Client, error) {
+			creates.Add(1)
+			return &recordingValkeyClient{}, nil
+		}),
+	}
+
+	client.Close()
+	err := client.Receive(context.Background(), valkey_go.Completed{}, nil)
+	assert.ErrorIs(t, err, valkey_go.ErrClosing)
+	assert.Zero(t, creates.Load())
+}

--- a/pkg/valkey/routing.go
+++ b/pkg/valkey/routing.go
@@ -1,0 +1,141 @@
+package valkey
+
+import (
+	"context"
+
+	valkey_go "github.com/valkey-io/valkey-go"
+)
+
+// Do sends read-only commands to the local instance and everything else to the
+// primary via Sentinel.
+func (c *Client) Do(ctx context.Context, cmd valkey_go.Completed) valkey_go.ValkeyResult {
+	return c.do(ctx, cmd, false, false)
+}
+
+func (c *Client) do(ctx context.Context, cmd valkey_go.Completed, primary, throughput bool) valkey_go.ValkeyResult {
+	if throughput && !cmd.IsReadOnly() {
+		cmd = cmd.ToPipe()
+	}
+	route := c.commandRoute(cmd.IsReadOnly(), primary, singleCommand)
+	return traceValkeyCall(ctx, route.operation, func() valkey_go.ValkeyResult {
+		return route.client.Do(ctx, cmd)
+	}, classifyValkeyResult)
+}
+
+// DoMulti sends a batch to the local instance only when every command is
+// read-only; any write in the batch routes the whole batch to the primary.
+func (c *Client) DoMulti(ctx context.Context, multi ...valkey_go.Completed) []valkey_go.ValkeyResult {
+	return c.doMulti(ctx, multi, false)
+}
+
+func (c *Client) doMulti(ctx context.Context, multi []valkey_go.Completed, primary bool) []valkey_go.ValkeyResult {
+	route := c.commandRoute(allReadOnly(multi), primary, commandBatch)
+	return traceValkeyCall(ctx, route.operation, func() []valkey_go.ValkeyResult {
+		return route.client.DoMulti(ctx, multi...)
+	}, classifyValkeyResults)
+}
+
+type commandShape uint8
+
+const (
+	singleCommand commandShape = iota
+	commandBatch
+)
+
+type valkeyRoute struct {
+	client    valkey_go.Client
+	operation string
+}
+
+func (c *Client) commandRoute(readOnly, primary bool, shape commandShape) valkeyRoute {
+	route := valkeyRoute{client: c.Client, operation: "valkey.write"}
+	if readOnly {
+		route.operation = "valkey.read"
+		if !primary && c.local != nil {
+			route.client = c.local
+		}
+	}
+	if shape == commandBatch {
+		route.operation += "_batch"
+	}
+	return route
+}
+
+func allReadOnly(multi []valkey_go.Completed) bool {
+	for i := range multi {
+		if !multi[i].IsReadOnly() {
+			return false
+		}
+	}
+	return true
+}
+
+// Primary returns a lightweight borrowed view whose commands are routed to the
+// Sentinel-elected primary. It shares the original client's connections and
+// telemetry. Closing the view is a no-op; the source client owns the shared
+// connection lifecycle.
+//
+// Primary consistency is available for clients created by this package. A
+// foreign valkey-go Client is delegated to unchanged because its native
+// replica-routing policy cannot be overridden after construction.
+func Primary(client valkey_go.Client) valkey_go.Client {
+	return clientViewFor(client, true, false)
+}
+
+// Throughput returns a lightweight borrowed view that opts single write
+// commands into valkey-go auto-pipelining with Completed.ToPipe. Node-local
+// reads already auto-pipeline, while primary reads remain on the consistency
+// and latency path. Explicit DoMulti calls retain their existing batch and
+// routing semantics. No additional pool or connection is created.
+func Throughput(client valkey_go.Client) valkey_go.Client {
+	return clientViewFor(client, false, true)
+}
+
+// PrimaryThroughput combines primary-consistent routing with the selective
+// single-command throughput policy of Throughput, using the same client pool.
+func PrimaryThroughput(client valkey_go.Client) valkey_go.Client {
+	return clientViewFor(client, true, true)
+}
+
+type clientView struct {
+	valkey_go.Client
+	routed     *Client
+	primary    bool
+	throughput bool
+}
+
+func clientViewFor(client valkey_go.Client, primary, throughput bool) valkey_go.Client {
+	if view, ok := client.(*clientView); ok {
+		primary = primary || view.primary
+		throughput = throughput || view.throughput
+		client = view.Client
+	}
+	routed, _ := client.(*Client)
+	return &clientView{
+		Client:     client,
+		routed:     routed,
+		primary:    primary,
+		throughput: throughput,
+	}
+}
+
+func (v *clientView) Do(ctx context.Context, cmd valkey_go.Completed) valkey_go.ValkeyResult {
+	if v.routed != nil {
+		return v.routed.do(ctx, cmd, v.primary, v.throughput)
+	}
+	if v.throughput && !cmd.IsReadOnly() {
+		cmd = cmd.ToPipe()
+	}
+	return v.Client.Do(ctx, cmd)
+}
+
+func (v *clientView) DoMulti(ctx context.Context, multi ...valkey_go.Completed) []valkey_go.ValkeyResult {
+	if v.routed != nil {
+		return v.routed.doMulti(ctx, multi, v.primary)
+	}
+	return v.Client.DoMulti(ctx, multi...)
+}
+
+// Close is intentionally a no-op: clientView borrows the source client's
+// connection pools and must not invalidate other users of that source.
+func (v *clientView) Close() {}

--- a/pkg/valkey/routing_test.go
+++ b/pkg/valkey/routing_test.go
@@ -1,0 +1,63 @@
+package valkey
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	valkey_go "github.com/valkey-io/valkey-go"
+)
+
+func TestClientViewsSelectRoutingAndPipelineSingleCommands(t *testing.T) {
+	master := &recordingValkeyClient{}
+	local := &recordingValkeyClient{}
+	client := &Client{Client: master, local: local}
+
+	localRoute := client.commandRoute(true, false, singleCommand)
+	assert.Same(t, local, localRoute.client)
+	assert.Equal(t, "valkey.read", localRoute.operation)
+	primaryRoute := client.commandRoute(true, true, singleCommand)
+	assert.Same(t, master, primaryRoute.client)
+	assert.Equal(t, "valkey.read", primaryRoute.operation)
+
+	view := Primary(Throughput(client)).(*clientView)
+	assert.Same(t, client, view.routed)
+	assert.True(t, view.primary)
+	assert.True(t, view.throughput)
+
+	read := (valkey_go.Builder{}).Arbitrary("GET", "key").ReadOnly()
+	view.Do(context.Background(), read)
+	assert.Len(t, master.commands, 1)
+	assert.True(t, master.commands[0].IsReadOnly())
+	assert.False(t, master.commands[0].IsPipe(), "primary reads remain on the consistency and latency path")
+	assert.Empty(t, local.commands)
+
+	view.Do(context.Background(), valkey_go.Completed{})
+	assert.Len(t, master.commands, 2)
+	assert.True(t, master.commands[1].IsPipe())
+
+	view.DoMulti(context.Background(), valkey_go.Completed{}, valkey_go.Completed{})
+	assert.Len(t, master.batches, 1)
+	assert.Len(t, master.batches[0], 2)
+	assert.False(t, master.batches[0][0].IsPipe(), "DoMulti already batches and must not be retagged")
+	assert.False(t, master.batches[0][1].IsPipe(), "DoMulti already batches and must not be retagged")
+
+	view.Close()
+	assert.Zero(t, master.closes.Load(), "a borrowed view must not close its source")
+}
+
+func TestThroughputViewDelegatesForeignClientWithoutAnotherPool(t *testing.T) {
+	client := &recordingValkeyClient{}
+	view := Throughput(client)
+
+	view.Do(context.Background(), valkey_go.Completed{})
+	assert.Len(t, client.commands, 1)
+	assert.True(t, client.commands[0].IsPipe())
+	view.Do(context.Background(), (valkey_go.Builder{}).Arbitrary("GET", "key").ReadOnly())
+	assert.Len(t, client.commands, 2)
+	assert.False(t, client.commands[1].IsPipe(), "read-only commands are not forced into throughput mode")
+
+	view.DoMulti(context.Background(), valkey_go.Completed{})
+	assert.Len(t, client.batches, 1)
+	assert.False(t, client.batches[0][0].IsPipe())
+}

--- a/pkg/valkey/telemetry.go
+++ b/pkg/valkey/telemetry.go
@@ -1,0 +1,51 @@
+package valkey
+
+import (
+	"context"
+
+	"github.com/newrelic/go-agent/v3/newrelic"
+	valkey_go "github.com/valkey-io/valkey-go"
+)
+
+// Valkey spans are emitted only for transactions selected by New Relic's own
+// sampler. The unsampled command path remains one context lookup and a branch,
+// while sampled traces get fixed-name read/write dependency attribution without
+// exposing keys or commands as high-cardinality facets.
+func traceValkeyCall[T any](ctx context.Context, operation string, do func() T, classify func(T) string) T {
+	txn := newrelic.FromContext(ctx)
+	if txn == nil || !txn.IsSampled() {
+		return do()
+	}
+	segment := txn.StartSegment(operation)
+	result := do()
+	segment.AddAttribute("result", classify(result))
+	segment.End()
+	return result
+}
+
+func classifyValkeyResult(result valkey_go.ValkeyResult) string {
+	return valkeyResult(result.Error())
+}
+
+func classifyValkeyResults(results []valkey_go.ValkeyResult) string {
+	result := "ok"
+	for i := range results {
+		if current := valkeyResult(results[i].Error()); current == "error" {
+			result = current
+			break
+		} else if current == "miss" {
+			result = current
+		}
+	}
+	return result
+}
+
+func valkeyResult(err error) string {
+	if err == nil {
+		return "ok"
+	}
+	if valkey_go.IsValkeyNil(err) {
+		return "miss"
+	}
+	return "error"
+}

--- a/pkg/valkey/telemetry_test.go
+++ b/pkg/valkey/telemetry_test.go
@@ -1,0 +1,15 @@
+package valkey
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	valkey_go "github.com/valkey-io/valkey-go"
+)
+
+func TestValkeyTelemetryResultsStayFinite(t *testing.T) {
+	assert.Equal(t, "ok", valkeyResult(nil))
+	assert.Equal(t, "miss", valkeyResult(valkey_go.Nil))
+	assert.Equal(t, "error", valkeyResult(errors.New("unavailable")))
+}


### PR DESCRIPTION
## Outcome

- enforces node2/node3-only Valkey primary eligibility, including fail-closed cold bootstrap
- disables THP and reduces swap pressure through idempotent host policy
- makes node-local reads deterministic and keeps primary-consistent and throughput views explicit
- adds immutable, guarded Valkey p99 acceptance image and isolated NATS gateway proof
- retains AOF every-second durability and replica write safety

## Safety

- no production resources are reconciled by the acceptance lanes
- live Valkey benchmark requires an exact confirmation and immutable image digest
- first StatefulSet migration is guarded because podManagementPolicy is immutable
- NATS lane is isolated by NetworkPolicy and verifies production pod identity/restarts

## Validation

- focused Valkey and topology tests
- Ansible syntax checks
- Kustomize rendering for Valkey and NATS gateway lanes
- shell syntax and no-op safety guards
- staged diff check