### PR TITLE
Fix Valkey 9.1 rollout preflight

### DIFF
--- a/deploy/ansible/valkey-rollout-preflight.yml
+++ b/deploy/ansible/valkey-rollout-preflight.yml
@@ -54,7 +54,7 @@
           - sentinel
           - --
           - valkey-cli
-          - --port
+          - -p
           - "26380"
           - --tls
           - --cacert


### PR DESCRIPTION
Uses the Valkey 9.1-compatible short port flag in the read-only rollout gate. The original gate failed closed before any production mutation. The corrected gate has been rerun successfully against the live cluster: all four members are Ready and Sentinel reports the primary on node2/node3.