### PR TITLE
fix(valkey): pin read-after-write paths to the primary

### DIFF
--- a/app/outgress/internal/channels/registry.go
+++ b/app/outgress/internal/channels/registry.go
@@ -20,6 +20,7 @@ import (
 	"ItsBagelBot/internal/domain/rpc/manage"
 	"ItsBagelBot/internal/utils"
 	"ItsBagelBot/pkg/cache"
+	pkg_valkey "ItsBagelBot/pkg/valkey"
 
 	"github.com/nats-io/nats.go"
 	"github.com/valkey-io/valkey-go"
@@ -80,9 +81,19 @@ type Registry struct {
 	pauseWG     sync.WaitGroup
 }
 
+// New builds the registry on a primary-consistent view of the client. The
+// registry is control-plane state at a few reads per second, and every read it
+// makes is a read-back of a write it just issued: Get reloads the hash right
+// after applyChannelUpdate invalidated the cache, List reads the index set the
+// same pipeline just SADDed, and EnrollCooldownActive checks a key
+// ArmEnrollCooldown set moments earlier. Served by a lagging node-local
+// replica, those reads would re-cache the pre-write value for the cache's full
+// TTL (the NATS invalidation has already fired by then) and bypass the enroll
+// cooldown. The view borrows the client's existing connections, so pinning
+// costs no extra pool.
 func New(client valkey.Client) *Registry {
 	return &Registry{
-		client: client,
+		client: pkg_valkey.Primary(client),
 		cache:  cache.New[manage.Channel](channelCacheCapacity, channelCacheTTL),
 	}
 }

--- a/app/outgress/internal/channels/registry_test.go
+++ b/app/outgress/internal/channels/registry_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"testing"
 	"time"
+
+	pkg_valkey "ItsBagelBot/pkg/valkey"
 )
 
 func TestPauseSnapshotRejectsOlderVersion(t *testing.T) {
@@ -49,5 +51,16 @@ func TestPauseReconcileDelayIsJitteredWithinBounds(t *testing.T) {
 			delay >= pauseReconcileInterval+pauseReconcileJitter/2 {
 			t.Fatalf("delay %s is outside jitter bounds", delay)
 		}
+	}
+}
+
+// The registry only ever reads state it just wrote: Get reloads the hash whose
+// cache applyChannelUpdate invalidated, List reads the index set the same
+// pipeline SADDed, and EnrollCooldownActive checks the key ArmEnrollCooldown
+// set. Served by a lagging node-local replica those reads re-cache the
+// pre-write value and bypass the cooldown, so the constructor must pin them.
+func TestNewPinsRegistryReadsToThePrimary(t *testing.T) {
+	if !pkg_valkey.IsPrimary(New(nil).client) {
+		t.Fatal("registry reads are served by the node-local replica; they read back its own writes")
 	}
 }

--- a/app/outgress/internal/worker/batch_test.go
+++ b/app/outgress/internal/worker/batch_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"ItsBagelBot/internal/domain/outgress"
+	pkg_valkey "ItsBagelBot/pkg/valkey"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -78,4 +79,13 @@ func TestBatchJSONDecoderPrecompiles(t *testing.T) {
 	if err := PrepareJSON(); err != nil {
 		t.Fatal(err)
 	}
+}
+
+// Acquire takes the lock, then Next reads back the cursor SaveNext wrote on the
+// previous pass. A node-local replica that has not yet received that write
+// hands the lock holder an older cursor and the batch resends chat lines it
+// already delivered, so the store's reads must be primary-consistent.
+func TestNewValkeyBatchStorePinsProgressReadsToThePrimary(t *testing.T) {
+	assert.True(t, pkg_valkey.IsPrimary(NewValkeyBatchStore(nil).client),
+		"batch progress is read back by the lock holder that wrote it")
 }

--- a/app/outgress/internal/worker/batch_valkey.go
+++ b/app/outgress/internal/worker/batch_valkey.go
@@ -5,6 +5,8 @@ import (
 	"strconv"
 	"time"
 
+	pkg_valkey "ItsBagelBot/pkg/valkey"
+
 	"github.com/valkey-io/valkey-go"
 )
 
@@ -17,8 +19,13 @@ type ValkeyBatchStore struct {
 	client valkey.Client
 }
 
+// NewValkeyBatchStore builds the store on a primary-consistent view. The lock
+// holder reads back its own progress: Acquire takes the lock, then Next reads
+// the cursor SaveNext wrote on the previous pass. A node-local replica that has
+// not yet received that SaveNext returns an older cursor, and the batch resends
+// chat lines it already delivered. The view reuses the client's connections.
 func NewValkeyBatchStore(client valkey.Client) *ValkeyBatchStore {
-	return &ValkeyBatchStore{client: client}
+	return &ValkeyBatchStore{client: pkg_valkey.Primary(client)}
 }
 
 func (s *ValkeyBatchStore) Acquire(ctx context.Context, lease BatchLease, ttl time.Duration) (bool, error) {

--- a/app/sesame/engine/loyalty_valkey.go
+++ b/app/sesame/engine/loyalty_valkey.go
@@ -9,6 +9,7 @@ import (
 	"ItsBagelBot/internal/domain/event/data"
 	loyaltyrpc "ItsBagelBot/internal/domain/rpc/loyalty"
 	"ItsBagelBot/pkg/cache"
+	pkg_valkey "ItsBagelBot/pkg/valkey"
 
 	"github.com/valkey-io/valkey-go"
 	"go.uber.org/zap"
@@ -81,7 +82,14 @@ return value`)
 // with a Valkey live view over the loyalty service, cached balance peeks, and
 // pass-through management verbs. It implements LoyaltyStore.
 type ValkeyLoyaltyStore struct {
-	client   valkey.Client
+	client valkey.Client
+	// primary serves the counter view. Bumps are exact because their script
+	// runs on the master; peeking the same counter from a lagging node-local
+	// replica would contradict that, and would keep serving a value
+	// CounterInvalidate already deleted instead of re-seeding from the service.
+	// The balance cache deliberately does not use this: its staleness budget is
+	// balanceTTL, which dwarfs replication lag.
+	primary  valkey.Client
 	rpc      *LoyaltyRPC
 	reporter *LoyaltyReporter
 	scopes   *cache.Cache[string]
@@ -96,6 +104,7 @@ func NewValkeyLoyaltyStore(client valkey.Client, rpc *LoyaltyRPC, reporter *Loya
 	}
 	return &ValkeyLoyaltyStore{
 		client:   client,
+		primary:  pkg_valkey.Primary(client),
 		rpc:      rpc,
 		reporter: reporter,
 		scopes:   cache.New[string](scopeCacheCapacity, scopeCacheTTL),
@@ -272,7 +281,9 @@ func (s *ValkeyLoyaltyStore) CounterPeek(ctx context.Context, broadcasterID uint
 // peekView reads the live Valkey view of one counter value: the entry hash
 // field for the entry scopes (when a viewer is known), the plain string
 // otherwise. ok=false means the view is cold (or unreadable) and the caller
-// should fall back to the service.
+// should fall back to the service. It reads the primary so a peek agrees with
+// the bump that produced the value and so CounterInvalidate's delete is
+// actually observed as a cold view rather than as the pre-delete count.
 func (s *ValkeyLoyaltyStore) peekView(ctx context.Context, broadcasterID uint64, name, scope string, viewerID uint64, command string) (int64, bool) {
 	var (
 		v   int64
@@ -280,9 +291,9 @@ func (s *ValkeyLoyaltyStore) peekView(ctx context.Context, broadcasterID uint64,
 	)
 	if scope != data.CounterScopeChannel && viewerID != 0 {
 		field := entryField(scope, viewerID, command)
-		v, err = s.client.Do(ctx, s.client.B().Hget().Key(counterViewerKey(broadcasterID, name)).Field(field).Build()).AsInt64()
+		v, err = s.primary.Do(ctx, s.primary.B().Hget().Key(counterViewerKey(broadcasterID, name)).Field(field).Build()).AsInt64()
 	} else {
-		v, err = s.client.Do(ctx, s.client.B().Get().Key(counterChannelKey(broadcasterID, name)).Build()).AsInt64()
+		v, err = s.primary.Do(ctx, s.primary.B().Get().Key(counterChannelKey(broadcasterID, name)).Build()).AsInt64()
 	}
 	if err != nil {
 		if !valkey.IsValkeyNil(err) {

--- a/app/sesame/engine/queue_valkey.go
+++ b/app/sesame/engine/queue_valkey.go
@@ -5,6 +5,8 @@ import (
 	"strconv"
 	"time"
 
+	pkg_valkey "ItsBagelBot/pkg/valkey"
+
 	"github.com/valkey-io/valkey-go"
 	"go.uber.org/zap"
 )
@@ -52,6 +54,15 @@ type ValkeyQueueStore struct {
 	log    *zap.Logger
 }
 
+// NewValkeyQueueStore builds the store on a primary-consistent view. One
+// broadcaster's chat drives the whole queue in sequence, so every read follows
+// a write chat just made: IsOpen gates joins against the flag SetOpen wrote,
+// and List renders the line Join and Pop just changed. Join and Pop already
+// reach the master because their batches mix in a write, but a node-local
+// replica serving IsOpen or List makes chat contradict itself — a viewer told
+// the queue is closed right after the streamer opened it, or a !list missing
+// the person who just joined. This is one broadcaster's feature, not the
+// firehose, and the view borrows the client's connections.
 func NewValkeyQueueStore(client valkey.Client, ttl time.Duration, log *zap.Logger) *ValkeyQueueStore {
 	if ttl <= 0 {
 		ttl = 24 * time.Hour
@@ -59,7 +70,7 @@ func NewValkeyQueueStore(client valkey.Client, ttl time.Duration, log *zap.Logge
 	if log == nil {
 		log = zap.NewNop()
 	}
-	return &ValkeyQueueStore{client: client, ttl: ttl, log: log}
+	return &ValkeyQueueStore{client: pkg_valkey.Primary(client), ttl: ttl, log: log}
 }
 
 func queueOpenKey(id uint64) string { return queueOpenPrefix + strconv.FormatUint(id, 10) }

--- a/app/sesame/engine/valkey_routing_test.go
+++ b/app/sesame/engine/valkey_routing_test.go
@@ -1,0 +1,30 @@
+package engine
+
+import (
+	"testing"
+
+	pkg_valkey "ItsBagelBot/pkg/valkey"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Reads default to the node-local replica, which lags the primary. These stores
+// read back state their own caller just wrote, so their reads are pinned; a
+// refactor that drops a Primary wrap fails here instead of silently serving
+// chat a value that contradicts the write that produced it.
+
+func TestLoyaltyCounterViewIsPrimaryAndTheBalanceCacheIsNot(t *testing.T) {
+	store := NewValkeyLoyaltyStore(nil, nil, nil, nil)
+
+	assert.True(t, pkg_valkey.IsPrimary(store.primary),
+		"a counter peek must agree with the master-run script that bumped it, and must observe CounterInvalidate's delete")
+	assert.False(t, pkg_valkey.IsPrimary(store.client),
+		"the balance cache keeps node-local reads: its staleness budget is balanceTTL, which dwarfs replication lag")
+}
+
+func TestQueueStoreReadsArePrimary(t *testing.T) {
+	store := NewValkeyQueueStore(nil, 0, nil)
+
+	assert.True(t, pkg_valkey.IsPrimary(store.client),
+		"IsOpen gates joins on the flag SetOpen wrote and List renders the line Join just changed")
+}

--- a/internal/projection/valkey.go
+++ b/internal/projection/valkey.go
@@ -11,6 +11,7 @@ import (
 	contract "ItsBagelBot/internal/domain/rpc/projection"
 	"ItsBagelBot/internal/utils"
 	"ItsBagelBot/pkg/cache"
+	pkg_valkey "ItsBagelBot/pkg/valkey"
 
 	"github.com/newrelic/go-agent/v3/newrelic"
 
@@ -47,11 +48,14 @@ const (
 // write is an overwrite, so replays and redeliveries are harmless.
 type Store struct {
 	client valkey.Client
+	// primary serves the reads that must observe this Store's own writes.
+	// Ordinary reads stay on client and its node-local route.
+	primary valkey.Client
 }
 
 // NewStore creates a new Store instance using the provided Valkey client.
 func NewStore(client valkey.Client) *Store {
-	return &Store{client: client}
+	return &Store{client: client, primary: pkg_valkey.Primary(client)}
 }
 
 // UserProjection is the projected account state of one user: tier status, the
@@ -263,9 +267,17 @@ func (v *Store) SetCommand(ctx context.Context, dto data.CommandChangedDTO) erro
 
 // retireStaleAliases reads the command's previous row and returns the HDEL (if
 // any) that removes the alias pointers it no longer carries.
+//
+// This read is pinned to the primary: it is the read half of a
+// read-modify-write over the row SetCommand is about to overwrite. A node-local
+// replica that has not yet received the previous SetCommand returns an empty or
+// older row, so the HDEL is either skipped or computed from the wrong alias
+// list, and the retired aliases stay resolvable forever. Unlike a stale cache
+// read this never converges, because nothing revisits the row. Only the reading
+// side is pinned; the rest of the Store keeps node-local reads.
 func (v *Store) retireStaleAliases(ctx context.Context, key, field string) []valkey.Completed {
 	cmds := make([]valkey.Completed, 0, 4)
-	old, _ := v.client.Do(ctx, v.client.B().Hget().Key(key).Field(field).Build()).ToString()
+	old, _ := v.primary.Do(ctx, v.primary.B().Hget().Key(key).Field(field).Build()).ToString()
 	if old == "" {
 		return cmds
 	}

--- a/internal/projection/valkey_test.go
+++ b/internal/projection/valkey_test.go
@@ -3,10 +3,23 @@ package projection
 import (
 	"testing"
 
+	pkg_valkey "ItsBagelBot/pkg/valkey"
+
 	"github.com/stretchr/testify/require"
 )
 
 func TestHydrationStateComplete(t *testing.T) {
 	require.False(t, (HydrationState{User: true, Modules: true}).Complete())
 	require.True(t, (HydrationState{User: true, Modules: true, Commands: true}).Complete())
+}
+
+// retireStaleAliases is the read half of a read-modify-write over the row
+// SetCommand overwrites. Read from a lagging node-local replica it computes the
+// HDEL from an empty or older alias list, leaving retired aliases resolvable
+// forever with nothing to revisit the row, so that read is pinned while the
+// rest of the Store keeps node-local reads.
+func TestNewStorePinsTheAliasRetirementRead(t *testing.T) {
+	store := NewStore(nil)
+	require.True(t, pkg_valkey.IsPrimary(store.primary))
+	require.False(t, pkg_valkey.IsPrimary(store.client), "ordinary projection reads stay node-local")
 }

--- a/pkg/valkey/routing.go
+++ b/pkg/valkey/routing.go
@@ -97,6 +97,16 @@ func PrimaryThroughput(client valkey_go.Client) valkey_go.Client {
 	return clientViewFor(client, true, true)
 }
 
+// IsPrimary reports whether client routes its read-only commands to the
+// Sentinel-elected primary rather than the node-local replica. Stores that
+// read back their own writes assert this on the client they were built with,
+// so dropping a Primary wrap during a refactor fails a test instead of
+// silently reintroducing replica-lag staleness.
+func IsPrimary(client valkey_go.Client) bool {
+	view, ok := client.(*clientView)
+	return ok && view.primary
+}
+
 type clientView struct {
 	valkey_go.Client
 	routed     *Client

--- a/pkg/valkey/routing_test.go
+++ b/pkg/valkey/routing_test.go
@@ -61,3 +61,13 @@ func TestThroughputViewDelegatesForeignClientWithoutAnotherPool(t *testing.T) {
 	assert.Len(t, client.batches, 1)
 	assert.False(t, client.batches[0][0].IsPipe())
 }
+
+func TestIsPrimaryReportsTheReadRouteOfAView(t *testing.T) {
+	client := &recordingValkeyClient{}
+
+	assert.False(t, IsPrimary(client), "a bare client reads wherever its own policy sends it")
+	assert.False(t, IsPrimary(Throughput(client)), "throughput alone does not pin reads to the primary")
+	assert.True(t, IsPrimary(Primary(client)))
+	assert.True(t, IsPrimary(PrimaryThroughput(client)))
+	assert.True(t, IsPrimary(Throughput(Primary(client))), "wrapping a primary view keeps it primary")
+}


### PR DESCRIPTION
## Outcome

#447 moved every read-only Valkey command to the node's own replica and shipped `Primary`, `Throughput` and `PrimaryThroughput` to opt back out. Nothing ever called those views, so every read-after-write in the fleet has been served by a lagging replica since it merged.

Pins the five reads where the lag is not self-correcting:

- **outgress channel registry** reads only state it just wrote. `Get` reloads the hash whose cache `applyChannelUpdate` invalidated, `List` reads the index set the same pipeline SADDed, `EnrollCooldownActive` checks a key `ArmEnrollCooldown` set moments earlier. A lagging replica re-caches the pre-write value for the cache's full TTL, after the NATS invalidation has already fired, and lets the enroll cooldown be bypassed.
- **outgress batch store** has the lock holder read back its own progress: `Acquire` takes the lock, `Next` reads the cursor `SaveNext` wrote on the previous pass. An older cursor resends chat lines already delivered.
- **projection `retireStaleAliases`** is the read half of a read-modify-write over the row `SetCommand` overwrites. An empty or older row skips the HDEL, so retired aliases stay resolvable forever with nothing to revisit them. Only that read is pinned; the rest of the Store keeps node-local reads.
- **loyalty counter view** claims an exact chat-visible count and the bump path earns it by running its INCR script on the master; the peek did not. `CounterInvalidate` deletes the key so the next read re-seeds from the service, but a replica that has not applied the delete answers with the pre-delete count, so a moderator's counter set or reset appears not to have taken.
- **sesame queue store** is driven by one broadcaster's chat in sequence. `Join` and `Pop` already reach the master because their batches mix in a write, but `IsOpen` and `List` did not: a viewer told the queue is closed moments after the streamer opened it, or a `!list` omitting whoever just joined.

## Deliberately left node-local

Audited, not assumed. Gateway's response cache `Del` only evicts a poison entry on shape drift, which converges on a refetch, and it is a TTL cache over external APIs where staleness is the design. `ProposePlan` runs WATCH/MULTI on a dedicated master connection. Lease member presence scores sit a full TTL ahead. `LoadPlan` is ordered behind WAIT-replicas before the commit marker. The live and reputation views fall back to an authoritative source on a miss. The loyalty balance cache keeps its node-local reads because its staleness budget is `balanceTTL`, a full minute, which dwarfs replication lag.

## Safety

Views borrow the source client's existing connections, so no store gains a pool and `Close` on a view stays a no-op. Writes are unaffected — they already routed to the Sentinel-elected primary. Pinning only moves reads back to where they were before #447.

## Validation

`go build ./...`, `go vet ./...` and the full `go test ./...` suite pass; gofmt clean on every touched file. Adds `IsPrimary` so each store asserts its own route, and a refactor that drops a `Primary` wrap fails a test instead of silently regressing.