### PR TITLE
fix(outgress): tell the streamer when their Twitch grant dies

### DIFF
--- a/app/outgress/internal/channels/registry.go
+++ b/app/outgress/internal/channels/registry.go
@@ -227,6 +227,7 @@ func (r *Registry) Get(ctx context.Context, broadcasterID string) (manage.Channe
 			SubState:      fields["sub_state"],
 			SubError:      fields["sub_error"],
 			SubCheckedAt:  unixField(fields["sub_checked_at"]),
+			GrantState:    manage.GrantState(fields["grant_state"]),
 		}, nil
 	})
 
@@ -242,30 +243,47 @@ func (r *Registry) Get(ctx context.Context, broadcasterID string) (manage.Channe
 	return ch, true, nil
 }
 
+// savedFields renders every persisted field of a channel. Save writes exactly
+// this set, and TestSaveCoversEveryChannelField asserts it covers every json
+// field of manage.Channel.
+//
+// It is a map rather than an inline builder chain because Save is a full
+// overwrite: a field added to manage.Channel but forgotten here is not a
+// compile error, it is a field that silently reverts to empty whenever anyone
+// calls Save. That is how a grant marker would be erased by an operator
+// toggling "enabled" in the admin console, with no error logged anywhere.
+func savedFields(ch manage.Channel) map[string]string {
+	return map[string]string{
+		"enabled":        utils.BoolField(ch.Enabled),
+		"is_mod":         utils.BoolField(ch.IsMod),
+		"mod_checked_at": unixOrZero(ch.ModCheckedAt),
+		"updated_at":     strconv.FormatInt(time.Now().Unix(), 10),
+		"sub_state":      ch.SubState,
+		"sub_error":      ch.SubError,
+		"sub_checked_at": unixOrZero(ch.SubCheckedAt),
+		"grant_state":    string(ch.GrantState),
+	}
+}
+
+func unixOrZero(t time.Time) string {
+	if t.IsZero() {
+		return "0"
+	}
+	return strconv.FormatInt(t.Unix(), 10)
+}
+
 // Save overwrites the full state of one channel and indexes it for List.
 func (r *Registry) Save(ctx context.Context, ch manage.Channel) error {
 
 	key := keyPrefix + ch.BroadcasterID
 
-	modCheckedAt := "0"
-	if !ch.ModCheckedAt.IsZero() {
-		modCheckedAt = strconv.FormatInt(ch.ModCheckedAt.Unix(), 10)
-	}
-	subCheckedAt := "0"
-	if !ch.SubCheckedAt.IsZero() {
-		subCheckedAt = strconv.FormatInt(ch.SubCheckedAt.Unix(), 10)
+	hset := r.client.B().Hset().Key(key).FieldValue()
+	for field, value := range savedFields(ch) {
+		hset = hset.FieldValue(field, value)
 	}
 
 	for _, res := range r.client.DoMulti(ctx,
-		r.client.B().Hset().Key(key).FieldValue().
-			FieldValue("enabled", utils.BoolField(ch.Enabled)).
-			FieldValue("is_mod", utils.BoolField(ch.IsMod)).
-			FieldValue("mod_checked_at", modCheckedAt).
-			FieldValue("updated_at", strconv.FormatInt(time.Now().Unix(), 10)).
-			FieldValue("sub_state", ch.SubState).
-			FieldValue("sub_error", ch.SubError).
-			FieldValue("sub_checked_at", subCheckedAt).
-			Build(),
+		hset.Build(),
 		r.client.B().Sadd().Key(indexKey).Member(ch.BroadcasterID).Build(),
 	) {
 		if err := res.Error(); err != nil {
@@ -308,6 +326,24 @@ func (r *Registry) SetSubState(ctx context.Context, broadcasterID, state, errMsg
 			FieldValue("sub_state", state).
 			FieldValue("sub_error", errMsg).
 			FieldValue("sub_checked_at", now).
+			FieldValue("updated_at", now).
+			Build(),
+		r.client.B().Sadd().Key(indexKey).Member(broadcasterID).Build(),
+	)
+}
+
+// SetGrantState records the health of the broadcaster's own OAuth grant without
+// touching enabled/is_mod/sub_state. Like SetMod it seeds enabled on a channel
+// first seen here, so the marker can never conjure a disabled channel into the
+// registry.
+func (r *Registry) SetGrantState(ctx context.Context, broadcasterID string, state manage.GrantState) error {
+	key := keyPrefix + broadcasterID
+	now := strconv.FormatInt(time.Now().Unix(), 10)
+
+	return r.applyChannelUpdate(ctx, broadcasterID,
+		r.client.B().Hsetnx().Key(key).Field("enabled").Value("1").Build(),
+		r.client.B().Hset().Key(key).FieldValue().
+			FieldValue("grant_state", string(state)).
 			FieldValue("updated_at", now).
 			Build(),
 		r.client.B().Sadd().Key(indexKey).Member(broadcasterID).Build(),

--- a/app/outgress/internal/channels/registry_test.go
+++ b/app/outgress/internal/channels/registry_test.go
@@ -92,12 +92,22 @@ func TestSaveCoversEveryChannelField(t *testing.T) {
 	}
 }
 
-// TestSaveRoundTripsGrantState pins the field the beacon reads.
+// TestSaveRoundTripsGrantState pins the field the go-live beacon reads.
 func TestSaveRoundTripsGrantState(t *testing.T) {
-	if got := savedFields(manage.Channel{GrantState: manage.GrantDead})["grant_state"]; got != "dead" {
-		t.Errorf("grant_state = %q, want %q", got, "dead")
+	tests := []struct {
+		name    string
+		channel manage.Channel
+		want    string
+	}{
+		{"dead", manage.Channel{GrantState: manage.GrantDead}, "dead"},
+		{"healthy", manage.Channel{}, ""},
 	}
-	if got := savedFields(manage.Channel{})["grant_state"]; got != "" {
-		t.Errorf("healthy grant_state = %q, want empty", got)
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := savedFields(tc.channel)["grant_state"]; got != tc.want {
+				t.Errorf("grant_state = %q, want %q", got, tc.want)
+			}
+		})
 	}
 }

--- a/app/outgress/internal/channels/registry_test.go
+++ b/app/outgress/internal/channels/registry_test.go
@@ -12,29 +12,50 @@ import (
 	pkg_valkey "ItsBagelBot/pkg/valkey"
 )
 
-func TestPauseSnapshotRejectsOlderVersion(t *testing.T) {
-	r := &Registry{}
-	r.applyPauseSnapshot(pauseSnapshot{paused: true, version: 4, observedAt: time.Now()})
-	r.applyPauseSnapshot(pauseSnapshot{paused: false, version: 3, observedAt: time.Now()})
-
-	paused, err := r.Paused(context.Background())
-	if err != nil {
-		t.Fatal(err)
+// TestPauseSnapshotOrdering covers how two snapshots resolve against each
+// other: a lower version never wins, and an equal version does, which is what
+// repairs a legacy writer that does not bump the version at all.
+func TestPauseSnapshotOrdering(t *testing.T) {
+	tests := []struct {
+		name    string
+		first   pauseSnapshot
+		second  pauseSnapshot
+		wantErr bool
+	}{
+		{
+			name:   "older version does not revert paused state",
+			first:  pauseSnapshot{paused: true, version: 4},
+			second: pauseSnapshot{paused: false, version: 3},
+		},
+		{
+			name:   "same version repairs a legacy writer",
+			first:  pauseSnapshot{paused: false, version: 2},
+			second: pauseSnapshot{paused: true, version: 2},
+		},
 	}
-	if !paused {
-		t.Fatal("older snapshot reverted paused state")
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &Registry{}
+			r.applyPauseSnapshot(stamp(tc.first))
+			r.applyPauseSnapshot(stamp(tc.second))
+
+			paused, err := r.Paused(context.Background())
+			if err != nil {
+				t.Fatalf("Paused() error = %v", err)
+			}
+			if !paused {
+				t.Fatal("paused = false, want true")
+			}
+		})
 	}
 }
 
-func TestPauseSnapshotSameVersionRepairsLegacyWriter(t *testing.T) {
-	r := &Registry{}
-	r.applyPauseSnapshot(pauseSnapshot{paused: false, version: 2, observedAt: time.Now()})
-	r.applyPauseSnapshot(pauseSnapshot{paused: true, version: 2, observedAt: time.Now()})
-
-	paused, err := r.Paused(context.Background())
-	if err != nil || !paused {
-		t.Fatalf("paused/error = %v/%v, want true/nil", paused, err)
-	}
+// stamp gives a snapshot a fresh observedAt so Paused does not fail it closed
+// as stale.
+func stamp(s pauseSnapshot) pauseSnapshot {
+	s.observedAt = time.Now()
+	return s
 }
 
 func TestPausedFailsClosedWhenSnapshotIsStale(t *testing.T) {
@@ -76,13 +97,17 @@ func TestNewPinsRegistryReadsToThePrimary(t *testing.T) {
 //
 // broadcaster_id is excluded because it is the Valkey key, not a hash field.
 func TestSaveCoversEveryChannelField(t *testing.T) {
+	// broadcaster_id is the Valkey key rather than a hash field; the other two
+	// are the absent and explicitly-ignored json tags.
+	notPersisted := map[string]bool{"": true, "-": true, "broadcaster_id": true}
+
 	written := savedFields(manage.Channel{})
 
 	typ := reflect.TypeOf(manage.Channel{})
 	for i := range typ.NumField() {
 		tag := typ.Field(i).Tag.Get("json")
 		name, _, _ := strings.Cut(tag, ",")
-		if name == "" || name == "-" || name == "broadcaster_id" {
+		if notPersisted[name] {
 			continue
 		}
 		if _, ok := written[name]; !ok {

--- a/app/outgress/internal/channels/registry_test.go
+++ b/app/outgress/internal/channels/registry_test.go
@@ -3,9 +3,12 @@ package channels
 import (
 	"context"
 	"errors"
+	"reflect"
+	"strings"
 	"testing"
 	"time"
 
+	"ItsBagelBot/internal/domain/rpc/manage"
 	pkg_valkey "ItsBagelBot/pkg/valkey"
 )
 
@@ -62,5 +65,39 @@ func TestPauseReconcileDelayIsJitteredWithinBounds(t *testing.T) {
 func TestNewPinsRegistryReadsToThePrimary(t *testing.T) {
 	if !pkg_valkey.IsPrimary(New(nil).client) {
 		t.Fatal("registry reads are served by the node-local replica; they read back its own writes")
+	}
+}
+
+// TestSaveCoversEveryChannelField is the guard against the silent-revert bug
+// class: Save is a full overwrite, so any persisted field of manage.Channel it
+// forgets is quietly reset to empty on the next Save. That is how a grant-death
+// marker would disappear when an operator toggles "enabled" in the admin
+// console, with nothing logged and no test failing.
+//
+// broadcaster_id is excluded because it is the Valkey key, not a hash field.
+func TestSaveCoversEveryChannelField(t *testing.T) {
+	written := savedFields(manage.Channel{})
+
+	typ := reflect.TypeOf(manage.Channel{})
+	for i := range typ.NumField() {
+		tag := typ.Field(i).Tag.Get("json")
+		name, _, _ := strings.Cut(tag, ",")
+		if name == "" || name == "-" || name == "broadcaster_id" {
+			continue
+		}
+		if _, ok := written[name]; !ok {
+			t.Errorf("manage.Channel field %q is never written by Save, so it silently "+
+				"reverts to empty on every full overwrite", name)
+		}
+	}
+}
+
+// TestSaveRoundTripsGrantState pins the field the beacon reads.
+func TestSaveRoundTripsGrantState(t *testing.T) {
+	if got := savedFields(manage.Channel{GrantState: manage.GrantDead})["grant_state"]; got != "dead" {
+		t.Errorf("grant_state = %q, want %q", got, "dead")
+	}
+	if got := savedFields(manage.Channel{})["grant_state"]; got != "" {
+		t.Errorf("healthy grant_state = %q, want empty", got)
 	}
 }

--- a/app/outgress/internal/twitch/granterr.go
+++ b/app/outgress/internal/twitch/granterr.go
@@ -1,0 +1,57 @@
+package twitch
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+)
+
+// ErrNoRefreshToken marks a stored-token source with nothing to refresh from:
+// the account never authorized, or its grant row is empty. Distinct from a
+// grant Twitch actively rejects, though both mean the same thing to a caller.
+var ErrNoRefreshToken = errors.New("no refresh token available")
+
+// TokenError is a rejection from the OAuth token endpoint (id.twitch.tv), as
+// opposed to StatusError which comes from the Helix API. The two are kept
+// separate deliberately: worker.isPermanent switches on *StatusError and
+// treats 401 as recoverable, because a Helix 401 usually clears after a token
+// refresh. A token-endpoint 401 is the refresh itself failing, so folding
+// these together would silently reclassify every grant failure.
+type TokenError struct {
+	Status int
+	Body   string
+}
+
+func (e *TokenError) Error() string {
+	return fmt.Sprintf("token request failed: %d %s", e.Status, e.Body)
+}
+
+// PermanentAuth reports whether Twitch rejected the grant itself, rather than
+// failing transiently. A dead refresh token answers 400; 401 and 403 carry the
+// same meaning for a grant. Everything else (429, 5xx, transport) may recover.
+func (e *TokenError) PermanentAuth() bool {
+	switch e.Status {
+	case http.StatusBadRequest, http.StatusUnauthorized, http.StatusForbidden:
+		return true
+	default:
+		return false
+	}
+}
+
+// GrantDead reports whether err means a broadcaster's stored grant can no
+// longer produce a token, so no retry will help and only re-consent will.
+//
+// This gates a user-visible, publicly-posted chat line, so it is deliberately
+// narrow: only a rejection from Twitch's own token endpoint counts. A 500, a
+// timeout or a DNS blip must never tell a streamer their connection expired.
+func GrantDead(err error) bool {
+	if errors.Is(err, ErrNoUserToken) || errors.Is(err, ErrNoRefreshToken) {
+		return true
+	}
+
+	var te *TokenError
+	if errors.As(err, &te) {
+		return te.PermanentAuth()
+	}
+	return false
+}

--- a/app/outgress/internal/twitch/granterr_test.go
+++ b/app/outgress/internal/twitch/granterr_test.go
@@ -1,0 +1,70 @@
+package twitch
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+// incidentBody is the exact payload Twitch returned for the dead grant that
+// this classification exists to catch.
+const incidentBody = `{"status":400,"message":"Invalid refresh token"}`
+
+func TestGrantDeadClassification(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"the incident: 400 invalid refresh token", &TokenError{Status: 400, Body: incidentBody}, true},
+		{"401 unauthorized", &TokenError{Status: 401, Body: "unauthorized"}, true},
+		{"403 forbidden", &TokenError{Status: 403, Body: "forbidden"}, true},
+		{"no user token", ErrNoUserToken, true},
+		{"no refresh token", ErrNoRefreshToken, true},
+
+		{"429 rate limited", &TokenError{Status: 429, Body: "slow down"}, false},
+		{"500 twitch broke", &TokenError{Status: 500, Body: "internal"}, false},
+		{"503 unavailable", &TokenError{Status: 503, Body: "unavailable"}, false},
+		{"transport failure", errors.New("dial tcp: i/o timeout"), false},
+		{"nil", nil, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := GrantDead(tc.err); got != tc.want {
+				t.Errorf("GrantDead(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestGrantDeadThroughWrapping matters because the incident's error reached the
+// worker wrapped by client.do as "twitch token: %w".
+func TestGrantDeadThroughWrapping(t *testing.T) {
+	wrapped := fmt.Errorf("twitch token: %w", &TokenError{Status: 400, Body: incidentBody})
+	if !GrantDead(wrapped) {
+		t.Fatal("GrantDead did not see through the twitch token wrap")
+	}
+}
+
+// TestStatusErrorIsNotGrantDead pins the separation from Helix errors. A Helix
+// 401 is recoverable by refreshing, and worker.isPermanent depends on that, so
+// it must never be mistaken for a dead grant.
+func TestStatusErrorIsNotGrantDead(t *testing.T) {
+	for _, status := range []int{400, 401, 403} {
+		err := &StatusError{Status: status, Body: "helix says no"}
+		if GrantDead(err) {
+			t.Errorf("Helix StatusError %d was classified as a dead grant", status)
+		}
+	}
+}
+
+// TestTokenErrorMessageUnchanged keeps the rendered text byte-identical to the
+// fmt.Errorf it replaced, so existing log greps and dashboards keep matching.
+func TestTokenErrorMessageUnchanged(t *testing.T) {
+	got := (&TokenError{Status: 400, Body: incidentBody}).Error()
+	want := fmt.Sprintf("token request failed: %d %s", 400, incidentBody)
+	if got != want {
+		t.Errorf("Error() = %q, want %q", got, want)
+	}
+}

--- a/app/outgress/internal/twitch/token.go
+++ b/app/outgress/internal/twitch/token.go
@@ -3,8 +3,6 @@ package twitch
 import (
 	"context"
 	"encoding/json"
-	"errors"
-	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -120,7 +118,7 @@ func NewStoredUserTokenSource(creds ClientCredentials, fallbackRefresh string, i
 			current = stored
 		}
 		if current == "" {
-			return "", 0, errors.New("no bot refresh token available")
+			return "", 0, ErrNoRefreshToken
 		}
 
 		res, err := postToken(ctx, creds.refreshGrant(current))
@@ -230,7 +228,7 @@ func postToken(ctx context.Context, form url.Values) (oauthResponse, error) {
 
 	if res.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(io.LimitReader(res.Body, 2048))
-		return oauthResponse{}, fmt.Errorf("token request failed: %d %s", res.StatusCode, string(body))
+		return oauthResponse{}, &TokenError{Status: res.StatusCode, Body: string(body)}
 	}
 
 	var parsed oauthResponse

--- a/app/outgress/internal/worker/authz.go
+++ b/app/outgress/internal/worker/authz.go
@@ -71,6 +71,13 @@ func (w *Worker) HandleAuthzGranted(msg *bus.Message) error {
 	if !found || !ch.Enabled {
 		return nil
 	}
+
+	// Clear the grant marker BEFORE the re-enroll gate below. A grant that died
+	// without being revoked leaves sub_state "ok", which reenrollableSubState
+	// rejects, so a clear placed after it would never run and the streamer who
+	// just did what the chat line asked would be nagged forever.
+	w.clearGrantDead(ctx, ev.UserID, ch)
+
 	if !reenrollableSubState(ch.SubState) {
 		return nil
 	}
@@ -219,7 +226,7 @@ func (w *Worker) notifyReauthNeeded(ctx context.Context, broadcasterID string) {
 	if w.reauth == nil {
 		return
 	}
-	w.reauth.NotifyRevoked(ctx, broadcasterID)
+	w.reauth.Notify(ctx, broadcasterID, noticeRevoked)
 }
 
 // EnsureClientEventSubs creates the client-scoped authorization subscriptions

--- a/app/outgress/internal/worker/clip.go
+++ b/app/outgress/internal/worker/clip.go
@@ -64,7 +64,7 @@ func (w *Worker) processClip(ctx context.Context, payload outgress.Message) erro
 		return err // no clip created yet: safe to redeliver
 	}
 
-	res, err := w.twitch.ExecuteAs(ctx, twitch.ParseIdentity(outgress.AsBroadcaster), payload.BroadcasterID,
+	res, err := w.callTwitch(ctx, twitch.ParseIdentity(outgress.AsBroadcaster), payload.BroadcasterID,
 		twitch.HelixCall{Method: http.MethodPost, Endpoint: clipEndpoint(payload.BroadcasterID, meta)})
 	if err != nil {
 		w.log.Error("clip create failed",

--- a/app/outgress/internal/worker/execute.go
+++ b/app/outgress/internal/worker/execute.go
@@ -38,7 +38,7 @@ func (w *Worker) executeRequest(ctx context.Context, payload outgress.Message) (
 	started := time.Now()
 	defer recordStageDuration(ctx, "outgress.twitch_ms", started)
 
-	res, err := w.twitch.ExecuteAs(ctx, twitch.ParseIdentity(payload.As), payload.BroadcasterID,
+	res, err := w.callTwitch(ctx, twitch.ParseIdentity(payload.As), payload.BroadcasterID,
 		twitch.HelixCall{Method: payload.Method, Endpoint: payload.Endpoint, Body: payload.Payload})
 	if err != nil {
 		w.log.Error("twitch request failed", zap.Error(err))

--- a/app/outgress/internal/worker/grantstate.go
+++ b/app/outgress/internal/worker/grantstate.go
@@ -1,0 +1,112 @@
+package worker
+
+import (
+	"context"
+	"net/http"
+
+	"ItsBagelBot/app/outgress/internal/twitch"
+	"ItsBagelBot/internal/domain/rpc/manage"
+
+	"go.uber.org/zap"
+)
+
+// grantRegistry is the slice of the channel registry the grant marker needs.
+// Narrow on purpose: it exists so the marker's transition logic is testable
+// without standing up Valkey, and *channels.Registry satisfies it as-is.
+type grantRegistry interface {
+	Get(ctx context.Context, broadcasterID string) (manage.Channel, bool, error)
+	SetGrantState(ctx context.Context, broadcasterID string, state manage.GrantState) error
+}
+
+// callTwitch is ExecuteAs plus grant bookkeeping. Every broadcaster-identity
+// call goes through here so a dead grant is learned from traffic the bot was
+// going to send anyway: no probe, no scheduled refresh, and therefore no way
+// for this path to burn a refresh token or manufacture the very breakage it
+// reports.
+func (w *Worker) callTwitch(ctx context.Context, id twitch.Identity, broadcasterID string, call twitch.HelixCall) (*http.Response, error) {
+	res, err := w.twitch.ExecuteAs(ctx, id, broadcasterID, call)
+	w.noteGrantHealth(ctx, id, broadcasterID, err)
+	return res, err
+}
+
+// noteGrantHealth records what the call just proved about the broadcaster's own
+// grant. Best-effort throughout: this is a notification signal, and it must
+// never change whether the caller's job succeeds.
+func (w *Worker) noteGrantHealth(ctx context.Context, id twitch.Identity, broadcasterID string, err error) {
+	if !w.grantTrackable(id, broadcasterID) {
+		return
+	}
+	if twitch.GrantDead(err) {
+		w.setGrantState(ctx, broadcasterID, manage.GrantDead)
+		return
+	}
+	if err == nil {
+		w.setGrantState(ctx, broadcasterID, manage.GrantUnknown)
+	}
+}
+
+// grantTrackable gates the marker to calls that actually say something about
+// the broadcaster's own grant.
+//
+// The identity check is load-bearing, not defensive. execute.go carries app
+// chat sends and bot moderation actions under real broadcaster ids, and
+// postToken is shared by the app, bot and broadcaster grants. Without this
+// gate, one client-credentials failure would mark every broadcaster whose
+// traffic happened to pass during it, and chat being the highest-volume type,
+// that is the entire enrolled fleet within seconds.
+func (w *Worker) grantTrackable(id twitch.Identity, broadcasterID string) bool {
+	return id == twitch.IdentityBroadcaster && broadcasterID != "" && w.grants != nil
+}
+
+// setGrantState writes only on an observed transition. The read is served by
+// the registry's own cache, so the common case (a healthy channel making a
+// successful call) costs nothing.
+func (w *Worker) setGrantState(ctx context.Context, broadcasterID string, state manage.GrantState) {
+	ch, found, err := w.grants.Get(ctx, broadcasterID)
+	if err != nil || !found || ch.GrantState == state {
+		return
+	}
+
+	if err := w.grants.SetGrantState(ctx, broadcasterID, state); err != nil {
+		w.log.Warn("grant state write failed",
+			zap.String("broadcaster_id", broadcasterID),
+			zap.String("grant_state", string(state)),
+			zap.Error(err))
+		return
+	}
+
+	w.log.Info("grant state changed",
+		zap.String("broadcaster_id", broadcasterID),
+		zap.String("from", string(ch.GrantState)),
+		zap.String("to", string(state)))
+
+	w.notifyGrantDead(ctx, broadcasterID, state)
+}
+
+// clearGrantDead drops the marker on re-consent, using a channel the caller
+// already read. This is the escape hatch that does not depend on the enroll
+// lifecycle: user.authorization.grant fires on every re-consent, so a streamer
+// who reconnects always reaches it.
+func (w *Worker) clearGrantDead(ctx context.Context, broadcasterID string, ch manage.Channel) {
+	if w.grants == nil || ch.GrantState != manage.GrantDead {
+		return
+	}
+	if err := w.grants.SetGrantState(ctx, broadcasterID, manage.GrantUnknown); err != nil {
+		w.log.Warn("clearing grant state failed",
+			zap.String("broadcaster_id", broadcasterID), zap.Error(err))
+		return
+	}
+	w.log.Info("grant restored by re-consent", zap.String("broadcaster_id", broadcasterID))
+}
+
+// notifyGrantDead raises the dashboard bell the moment the grant is first seen
+// dead, rather than waiting for the next go-live. The go-live beacon still
+// posts the chat line; this is the surface that reaches a streamer who is
+// offline, or mid-stream when the grant dies. The notifications service dedupes
+// on request id per day, so a repeat within the day collapses server-side.
+func (w *Worker) notifyGrantDead(ctx context.Context, broadcasterID string, state manage.GrantState) {
+	if state != manage.GrantDead || w.reauth == nil {
+		return
+	}
+	w.reauth.Notify(ctx, broadcasterID, noticeGrantDead)
+}

--- a/app/outgress/internal/worker/grantstate.go
+++ b/app/outgress/internal/worker/grantstate.go
@@ -58,12 +58,27 @@ func (w *Worker) grantTrackable(id twitch.Identity, broadcasterID string) bool {
 	return id == twitch.IdentityBroadcaster && broadcasterID != "" && w.grants != nil
 }
 
+// currentGrantState reads the channel's recorded grant health. The second
+// return is false when the channel is unreadable or not registered, which are
+// the two cases where the marker must stay out of the way rather than conjure
+// a registry entry.
+func (w *Worker) currentGrantState(ctx context.Context, broadcasterID string) (manage.GrantState, bool) {
+	ch, found, err := w.grants.Get(ctx, broadcasterID)
+	if err != nil || !found {
+		return manage.GrantUnknown, false
+	}
+	return ch.GrantState, true
+}
+
 // setGrantState writes only on an observed transition. The read is served by
 // the registry's own cache, so the common case (a healthy channel making a
 // successful call) costs nothing.
 func (w *Worker) setGrantState(ctx context.Context, broadcasterID string, state manage.GrantState) {
-	ch, found, err := w.grants.Get(ctx, broadcasterID)
-	if err != nil || !found || ch.GrantState == state {
+	current, ok := w.currentGrantState(ctx, broadcasterID)
+	if !ok {
+		return
+	}
+	if current == state {
 		return
 	}
 
@@ -77,7 +92,7 @@ func (w *Worker) setGrantState(ctx context.Context, broadcasterID string, state 
 
 	w.log.Info("grant state changed",
 		zap.String("broadcaster_id", broadcasterID),
-		zap.String("from", string(ch.GrantState)),
+		zap.String("from", string(current)),
 		zap.String("to", string(state)))
 
 	w.notifyGrantDead(ctx, broadcasterID, state)

--- a/app/outgress/internal/worker/grantstate_test.go
+++ b/app/outgress/internal/worker/grantstate_test.go
@@ -38,132 +38,123 @@ func deadGrantErr() error {
 	return &twitch.TokenError{Status: 400, Body: `{"status":400,"message":"Invalid refresh token"}`}
 }
 
-// TestMarkerIgnoresNonBroadcasterIdentity is the fleet-safety test. execute.go
-// carries app chat sends and bot moderation under real broadcaster ids, and the
-// app/bot/broadcaster grants all fail through the same postToken. Without the
-// identity gate, one client-credentials outage would mark the whole enrolled
-// fleet dead and nag every streamer in chat at their next go-live.
-func TestMarkerIgnoresNonBroadcasterIdentity(t *testing.T) {
-	for _, id := range []twitch.Identity{twitch.IdentityApp, twitch.IdentityBot, twitch.IdentityAuto} {
-		g := &fakeGrants{channel: manage.Channel{BroadcasterID: "1"}, found: true}
-		w := testWorker(g)
+func TestNoteGrantHealth(t *testing.T) {
+	registered := manage.Channel{BroadcasterID: "1"}
+	alreadyDead := manage.Channel{BroadcasterID: "1", GrantState: manage.GrantDead}
 
-		w.noteGrantHealth(context.Background(), id, "1", deadGrantErr())
+	tests := []struct {
+		name     string
+		identity twitch.Identity
+		channel  manage.Channel
+		found    bool
+		err      error
+		want     []manage.GrantState
+	}{
+		// The fleet-safety cases. execute.go carries app chat sends and bot
+		// moderation under real broadcaster ids, and the app, bot and broadcaster
+		// grants all fail through the same postToken. Without the identity gate,
+		// one client-credentials outage would mark every broadcaster whose
+		// traffic happened to pass during it, and chat being the highest-volume
+		// type, that is the entire enrolled fleet within seconds.
+		{"app identity never marks", twitch.IdentityApp, registered, true, deadGrantErr(), nil},
+		{"bot identity never marks", twitch.IdentityBot, registered, true, deadGrantErr(), nil},
+		{"auto identity never marks", twitch.IdentityAuto, registered, true, deadGrantErr(), nil},
 
-		if len(g.writes) != 0 {
-			t.Errorf("identity %v: wrote %v, want no write", id, g.writes)
-		}
+		// A dead grant, seen under the broadcaster's own identity.
+		{
+			"broadcaster identity marks dead",
+			twitch.IdentityBroadcaster, registered, true, deadGrantErr(),
+			[]manage.GrantState{manage.GrantDead},
+		},
+
+		// Transient failures must never tell a streamer their connection expired.
+		{
+			"500 does not mark",
+			twitch.IdentityBroadcaster, registered, true,
+			&twitch.TokenError{Status: 500, Body: "internal"}, nil,
+		},
+		{
+			"429 does not mark",
+			twitch.IdentityBroadcaster, registered, true,
+			&twitch.TokenError{Status: 429, Body: "slow down"}, nil,
+		},
+		{
+			"transport failure does not mark",
+			twitch.IdentityBroadcaster, registered, true,
+			errors.New("dial tcp: i/o timeout"), nil,
+		},
+
+		// Success is the inverse write, and the self-heal for a false positive.
+		{
+			"success clears a dead marker",
+			twitch.IdentityBroadcaster, alreadyDead, true, nil,
+			[]manage.GrantState{manage.GrantUnknown},
+		},
+		{"success on a healthy channel is a no-op", twitch.IdentityBroadcaster, registered, true, nil, nil},
+
+		// Transition-only, so a channel failing every few seconds does not
+		// hammer Valkey or re-log forever.
+		{"already dead does not rewrite", twitch.IdentityBroadcaster, alreadyDead, true, deadGrantErr(), nil},
+
+		// Never conjure a registry entry for a channel the bot does not serve.
+		{"unregistered channel is skipped", twitch.IdentityBroadcaster, manage.Channel{}, false, deadGrantErr(), nil},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := &fakeGrants{channel: tc.channel, found: tc.found}
+			w := testWorker(g)
+
+			w.noteGrantHealth(context.Background(), tc.identity, "1", tc.err)
+
+			assertWrites(t, g.writes, tc.want)
+		})
 	}
 }
 
-func TestMarkerWritesDeadForBroadcasterIdentity(t *testing.T) {
-	g := &fakeGrants{channel: manage.Channel{BroadcasterID: "1"}, found: true}
-	w := testWorker(g)
-
-	w.noteGrantHealth(context.Background(), twitch.IdentityBroadcaster, "1", deadGrantErr())
-
-	if len(g.writes) != 1 || g.writes[0] != manage.GrantDead {
-		t.Fatalf("writes = %v, want [dead]", g.writes)
-	}
-}
-
-// TestMarkerIgnoresTransientFailures keeps a Twitch outage or a network blip
-// from telling streamers their connection expired.
-func TestMarkerIgnoresTransientFailures(t *testing.T) {
-	transient := []error{
-		&twitch.TokenError{Status: 500, Body: "internal"},
-		&twitch.TokenError{Status: 429, Body: "slow down"},
-		errors.New("dial tcp: i/o timeout"),
-	}
-
-	for _, err := range transient {
-		g := &fakeGrants{channel: manage.Channel{BroadcasterID: "1"}, found: true}
-		w := testWorker(g)
-
-		w.noteGrantHealth(context.Background(), twitch.IdentityBroadcaster, "1", err)
-
-		if len(g.writes) != 0 {
-			t.Errorf("err %v: wrote %v, want no write", err, g.writes)
-		}
-	}
-}
-
-// TestMarkerClearsOnSuccess is one of the two escape hatches: a false positive
-// heals itself on the next successful broadcaster call.
-func TestMarkerClearsOnSuccess(t *testing.T) {
-	g := &fakeGrants{
-		channel: manage.Channel{BroadcasterID: "1", GrantState: manage.GrantDead},
-		found:   true,
-	}
+// TestNoteGrantHealthUnreadableRegistry keeps a Valkey blip from being read as
+// a healthy channel and clearing a real marker.
+func TestNoteGrantHealthUnreadableRegistry(t *testing.T) {
+	g := &fakeGrants{getErr: errors.New("valkey down")}
 	w := testWorker(g)
 
 	w.noteGrantHealth(context.Background(), twitch.IdentityBroadcaster, "1", nil)
 
-	if len(g.writes) != 1 || g.writes[0] != manage.GrantUnknown {
-		t.Fatalf("writes = %v, want [unknown]", g.writes)
-	}
+	assertWrites(t, g.writes, nil)
 }
 
-// TestMarkerWritesOnlyOnTransition keeps a channel that fails every few seconds
-// from hammering Valkey and re-logging forever.
-func TestMarkerWritesOnlyOnTransition(t *testing.T) {
-	g := &fakeGrants{
-		channel: manage.Channel{BroadcasterID: "1", GrantState: manage.GrantDead},
-		found:   true,
-	}
-	w := testWorker(g)
-
-	for range 5 {
-		w.noteGrantHealth(context.Background(), twitch.IdentityBroadcaster, "1", deadGrantErr())
-	}
-
-	if len(g.writes) != 0 {
-		t.Fatalf("writes = %v, want none (already dead)", g.writes)
-	}
-}
-
-// TestMarkerSkipsUnregisteredChannel stops the marker conjuring a registry entry
-// for a channel the bot does not serve.
-func TestMarkerSkipsUnregisteredChannel(t *testing.T) {
-	g := &fakeGrants{found: false}
-	w := testWorker(g)
-
-	w.noteGrantHealth(context.Background(), twitch.IdentityBroadcaster, "1", deadGrantErr())
-
-	if len(g.writes) != 0 {
-		t.Fatalf("writes = %v, want none (channel not registered)", g.writes)
-	}
-}
-
-func TestMarkerNoRegistryIsNoop(t *testing.T) {
+func TestNoteGrantHealthNoRegistryIsNoop(t *testing.T) {
 	w := testWorker(nil)
 	// Must not panic.
 	w.noteGrantHealth(context.Background(), twitch.IdentityBroadcaster, "1", deadGrantErr())
 }
 
-// TestClearGrantDeadOnReconsent covers the second escape hatch. It must run for
-// a channel whose sub_state is "ok", which is exactly the state a grant-dead
-// channel sits in and the state the re-enroll gate rejects.
-func TestClearGrantDeadOnReconsent(t *testing.T) {
-	g := &fakeGrants{found: true}
-	w := testWorker(g)
-	ch := manage.Channel{BroadcasterID: "1", SubState: "ok", GrantState: manage.GrantDead}
-
-	w.clearGrantDead(context.Background(), "1", ch)
-
-	if len(g.writes) != 1 || g.writes[0] != manage.GrantUnknown {
-		t.Fatalf("writes = %v, want [unknown]", g.writes)
+func TestClearGrantDead(t *testing.T) {
+	tests := []struct {
+		name    string
+		channel manage.Channel
+		want    []manage.GrantState
+	}{
+		// sub_state "ok" is exactly the state a grant-dead channel sits in, and
+		// exactly the state the re-enroll gate rejects. This is why the clear is
+		// placed above that gate.
+		{
+			"dead grant on an ok channel clears",
+			manage.Channel{BroadcasterID: "1", SubState: "ok", GrantState: manage.GrantDead},
+			[]manage.GrantState{manage.GrantUnknown},
+		},
+		{"healthy channel is untouched", manage.Channel{BroadcasterID: "1"}, nil},
 	}
-}
 
-func TestClearGrantDeadSkipsHealthyChannel(t *testing.T) {
-	g := &fakeGrants{found: true}
-	w := testWorker(g)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := &fakeGrants{found: true}
+			w := testWorker(g)
 
-	w.clearGrantDead(context.Background(), "1", manage.Channel{BroadcasterID: "1"})
+			w.clearGrantDead(context.Background(), "1", tc.channel)
 
-	if len(g.writes) != 0 {
-		t.Fatalf("writes = %v, want none", g.writes)
+			assertWrites(t, g.writes, tc.want)
+		})
 	}
 }
 
@@ -208,5 +199,17 @@ func TestNoticeRequestPrefixesDiffer(t *testing.T) {
 	if noticeRevoked.request == noticeGrantDead.request {
 		t.Fatalf("both notices share request prefix %q, so one would be deduped away",
 			noticeRevoked.request)
+	}
+}
+
+func assertWrites(t *testing.T, got, want []manage.GrantState) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("writes = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("writes = %v, want %v", got, want)
+		}
 	}
 }

--- a/app/outgress/internal/worker/grantstate_test.go
+++ b/app/outgress/internal/worker/grantstate_test.go
@@ -1,0 +1,212 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"ItsBagelBot/app/outgress/internal/twitch"
+	"ItsBagelBot/internal/domain/rpc/manage"
+
+	"go.uber.org/zap"
+)
+
+// fakeGrants records writes so a test can assert on transitions without Valkey.
+type fakeGrants struct {
+	channel manage.Channel
+	found   bool
+	getErr  error
+	writes  []manage.GrantState
+}
+
+func (f *fakeGrants) Get(context.Context, string) (manage.Channel, bool, error) {
+	return f.channel, f.found, f.getErr
+}
+
+func (f *fakeGrants) SetGrantState(_ context.Context, _ string, state manage.GrantState) error {
+	f.writes = append(f.writes, state)
+	f.channel.GrantState = state
+	return nil
+}
+
+func testWorker(g grantRegistry) *Worker {
+	return &Worker{log: zap.NewNop(), grants: g}
+}
+
+// deadGrantErr is the incident's error, wrapped the way client.do wraps it.
+func deadGrantErr() error {
+	return &twitch.TokenError{Status: 400, Body: `{"status":400,"message":"Invalid refresh token"}`}
+}
+
+// TestMarkerIgnoresNonBroadcasterIdentity is the fleet-safety test. execute.go
+// carries app chat sends and bot moderation under real broadcaster ids, and the
+// app/bot/broadcaster grants all fail through the same postToken. Without the
+// identity gate, one client-credentials outage would mark the whole enrolled
+// fleet dead and nag every streamer in chat at their next go-live.
+func TestMarkerIgnoresNonBroadcasterIdentity(t *testing.T) {
+	for _, id := range []twitch.Identity{twitch.IdentityApp, twitch.IdentityBot, twitch.IdentityAuto} {
+		g := &fakeGrants{channel: manage.Channel{BroadcasterID: "1"}, found: true}
+		w := testWorker(g)
+
+		w.noteGrantHealth(context.Background(), id, "1", deadGrantErr())
+
+		if len(g.writes) != 0 {
+			t.Errorf("identity %v: wrote %v, want no write", id, g.writes)
+		}
+	}
+}
+
+func TestMarkerWritesDeadForBroadcasterIdentity(t *testing.T) {
+	g := &fakeGrants{channel: manage.Channel{BroadcasterID: "1"}, found: true}
+	w := testWorker(g)
+
+	w.noteGrantHealth(context.Background(), twitch.IdentityBroadcaster, "1", deadGrantErr())
+
+	if len(g.writes) != 1 || g.writes[0] != manage.GrantDead {
+		t.Fatalf("writes = %v, want [dead]", g.writes)
+	}
+}
+
+// TestMarkerIgnoresTransientFailures keeps a Twitch outage or a network blip
+// from telling streamers their connection expired.
+func TestMarkerIgnoresTransientFailures(t *testing.T) {
+	transient := []error{
+		&twitch.TokenError{Status: 500, Body: "internal"},
+		&twitch.TokenError{Status: 429, Body: "slow down"},
+		errors.New("dial tcp: i/o timeout"),
+	}
+
+	for _, err := range transient {
+		g := &fakeGrants{channel: manage.Channel{BroadcasterID: "1"}, found: true}
+		w := testWorker(g)
+
+		w.noteGrantHealth(context.Background(), twitch.IdentityBroadcaster, "1", err)
+
+		if len(g.writes) != 0 {
+			t.Errorf("err %v: wrote %v, want no write", err, g.writes)
+		}
+	}
+}
+
+// TestMarkerClearsOnSuccess is one of the two escape hatches: a false positive
+// heals itself on the next successful broadcaster call.
+func TestMarkerClearsOnSuccess(t *testing.T) {
+	g := &fakeGrants{
+		channel: manage.Channel{BroadcasterID: "1", GrantState: manage.GrantDead},
+		found:   true,
+	}
+	w := testWorker(g)
+
+	w.noteGrantHealth(context.Background(), twitch.IdentityBroadcaster, "1", nil)
+
+	if len(g.writes) != 1 || g.writes[0] != manage.GrantUnknown {
+		t.Fatalf("writes = %v, want [unknown]", g.writes)
+	}
+}
+
+// TestMarkerWritesOnlyOnTransition keeps a channel that fails every few seconds
+// from hammering Valkey and re-logging forever.
+func TestMarkerWritesOnlyOnTransition(t *testing.T) {
+	g := &fakeGrants{
+		channel: manage.Channel{BroadcasterID: "1", GrantState: manage.GrantDead},
+		found:   true,
+	}
+	w := testWorker(g)
+
+	for range 5 {
+		w.noteGrantHealth(context.Background(), twitch.IdentityBroadcaster, "1", deadGrantErr())
+	}
+
+	if len(g.writes) != 0 {
+		t.Fatalf("writes = %v, want none (already dead)", g.writes)
+	}
+}
+
+// TestMarkerSkipsUnregisteredChannel stops the marker conjuring a registry entry
+// for a channel the bot does not serve.
+func TestMarkerSkipsUnregisteredChannel(t *testing.T) {
+	g := &fakeGrants{found: false}
+	w := testWorker(g)
+
+	w.noteGrantHealth(context.Background(), twitch.IdentityBroadcaster, "1", deadGrantErr())
+
+	if len(g.writes) != 0 {
+		t.Fatalf("writes = %v, want none (channel not registered)", g.writes)
+	}
+}
+
+func TestMarkerNoRegistryIsNoop(t *testing.T) {
+	w := testWorker(nil)
+	// Must not panic.
+	w.noteGrantHealth(context.Background(), twitch.IdentityBroadcaster, "1", deadGrantErr())
+}
+
+// TestClearGrantDeadOnReconsent covers the second escape hatch. It must run for
+// a channel whose sub_state is "ok", which is exactly the state a grant-dead
+// channel sits in and the state the re-enroll gate rejects.
+func TestClearGrantDeadOnReconsent(t *testing.T) {
+	g := &fakeGrants{found: true}
+	w := testWorker(g)
+	ch := manage.Channel{BroadcasterID: "1", SubState: "ok", GrantState: manage.GrantDead}
+
+	w.clearGrantDead(context.Background(), "1", ch)
+
+	if len(g.writes) != 1 || g.writes[0] != manage.GrantUnknown {
+		t.Fatalf("writes = %v, want [unknown]", g.writes)
+	}
+}
+
+func TestClearGrantDeadSkipsHealthyChannel(t *testing.T) {
+	g := &fakeGrants{found: true}
+	w := testWorker(g)
+
+	w.clearGrantDead(context.Background(), "1", manage.Channel{BroadcasterID: "1"})
+
+	if len(g.writes) != 0 {
+		t.Fatalf("writes = %v, want none", g.writes)
+	}
+}
+
+// TestLiveNotice pins which notice a go-live picks, including the tie-break.
+func TestLiveNotice(t *testing.T) {
+	tests := []struct {
+		name    string
+		channel manage.Channel
+		want    notice
+		wantOK  bool
+	}{
+		{"healthy", manage.Channel{SubState: "ok"}, notice{}, false},
+		{"unknown", manage.Channel{}, notice{}, false},
+		{"revoked", manage.Channel{SubState: subStateRevoked}, noticeRevoked, true},
+		{"grant dead", manage.Channel{SubState: "ok", GrantState: manage.GrantDead}, noticeGrantDead, true},
+		{
+			"both: revoked wins",
+			manage.Channel{SubState: subStateRevoked, GrantState: manage.GrantDead},
+			noticeRevoked,
+			true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := liveNotice(tc.channel)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if got != tc.want {
+				t.Errorf("notice = %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestNoticeRequestPrefixesDiffer guards the dedupe. The notifications unique
+// index on request_id has no time component and the send verb skips cache
+// invalidation on the dedupe path, so a shared prefix would make the second
+// notice of the day silently vanish.
+func TestNoticeRequestPrefixesDiffer(t *testing.T) {
+	if noticeRevoked.request == noticeGrantDead.request {
+		t.Fatalf("both notices share request prefix %q, so one would be deduped away",
+			noticeRevoked.request)
+	}
+}

--- a/app/outgress/internal/worker/reauth.go
+++ b/app/outgress/internal/worker/reauth.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"time"
 
+	"ItsBagelBot/internal/domain/i18n"
 	notificationsrpc "ItsBagelBot/internal/domain/rpc/notifications"
 	usersrpc "ItsBagelBot/internal/domain/rpc/users"
 	"ItsBagelBot/pkg/bus"
@@ -14,36 +15,37 @@ import (
 	"go.uber.org/zap"
 )
 
-// dashboardURL is where a streamer re-consents; baked into the reauth copy.
-const dashboardURL = "https://dashboard.itsbagelbot.com"
-
-// reauthCopy is one locale's reauth wording: the dashboard bell notification
-// (title + body) and the go-live chat beacon line.
-type reauthCopy struct {
-	title string
-	body  string
-	chat  string
+// notice is one reason to nudge a streamer to reconnect: the catalog keys for
+// each surface, plus the request-id prefix that scopes the bell's daily dedupe.
+//
+// The prefix must differ per reason. The notifications table's unique index on
+// request_id carries no time component and the send verb skips cache
+// invalidation on the dedupe path, so two reasons sharing a prefix would make
+// the second one silently produce nothing for the rest of the UTC day.
+type notice struct {
+	title   string
+	body    string
+	chat    string
+	request string
 }
 
-// reauthMessages carries every supported locale, keyed by the users service's
-// locale codes. English is the fallback for unknown codes, mirroring the
-// console's translate() fallback.
-var reauthMessages = map[string]reauthCopy{
-	"en": {
-		title: "Bot lost access to your channel",
-		body: "Twitch revoked the bot's authorization for your channel (this happens after a password change or if the app was disconnected). " +
-			"Chat replies and alerts are paused. Log in at " + dashboardURL + " and reconnect your Twitch account to bring the bot back.",
-		chat: "The bot lost its Twitch authorization for this channel (password change or app disconnect). " +
-			"Log in at " + dashboardURL + " to reconnect it.",
-	},
-	"fr": {
-		title: "Le bot a perdu l'accès à votre chaîne",
-		body: "Twitch a révoqué l'autorisation du bot pour votre chaîne (cela arrive après un changement de mot de passe ou si l'application a été déconnectée). " +
-			"Les réponses et alertes sont en pause. Connectez-vous sur " + dashboardURL + " et reconnectez votre compte Twitch pour rétablir le bot.",
-		chat: "Le bot a perdu son autorisation Twitch pour cette chaîne (changement de mot de passe ou déconnexion de l'application). " +
-			"Connectez-vous sur " + dashboardURL + " pour le reconnecter.",
-	},
-}
+var (
+	// noticeRevoked: Twitch told us over EventSub that the grant is gone.
+	noticeRevoked = notice{
+		title:   i18n.KeyReauthRevokedTitle,
+		body:    i18n.KeyReauthRevokedBody,
+		chat:    i18n.KeyReauthRevokedChat,
+		request: "authz-revoked-",
+	}
+	// noticeGrantDead: the stored grant stopped working without ever being
+	// revoked, so Twitch announced nothing and we only know because a call failed.
+	noticeGrantDead = notice{
+		title:   i18n.KeyGrantDeadTitle,
+		body:    i18n.KeyGrantDeadBody,
+		chat:    i18n.KeyGrantDeadChat,
+		request: "grant-dead-",
+	}
+)
 
 // ReauthConfig carries the NATS wiring for the reauth messaging: the
 // notifications admin send verb, the users state_get verb the locale comes
@@ -55,7 +57,7 @@ type ReauthConfig struct {
 	BotID        string
 }
 
-// ReauthNotifier tells a streamer their consent died and how to fix it, in
+// ReauthNotifier tells a streamer their grant died and how to fix it, in
 // their dashboard language. It rides outgress's RPC connection: the locale
 // comes from the users service (state_get) and the bell notification goes
 // through the notifications admin send verb, the same one the gift
@@ -70,33 +72,41 @@ func NewReauthNotifier(nc *nats.Conn, cfg ReauthConfig, log *zap.Logger) *Reauth
 	return &ReauthNotifier{nc: nc, cfg: cfg, log: log}
 }
 
-// NotifyRevoked sends the dashboard bell notification. Best-effort: the
-// revoked registry state is already persisted by the caller and the console
-// surfaces it on its own; a lost notification loses only the nudge. The
-// request id folds the repeated per-subscription revocations of one outage
-// into a single row per day.
-func (r *ReauthNotifier) NotifyRevoked(ctx context.Context, broadcasterID string) {
+// Notify resolves the locale and sends the dashboard bell.
+func (r *ReauthNotifier) Notify(ctx context.Context, broadcasterID string, n notice) {
+	r.NotifyLocalized(ctx, broadcasterID, r.ResolveLocale(ctx, broadcasterID), n)
+}
+
+// NotifyLocalized sends the dashboard bell with an already-resolved locale, so
+// a caller that also posts the chat line pays one locale lookup rather than two.
+//
+// Best-effort: the registry state is already persisted by the caller and the
+// console surfaces it independently, so a lost notification loses only the nudge.
+func (r *ReauthNotifier) NotifyLocalized(ctx context.Context, broadcasterID, locale string, n notice) {
 	if _, err := strconv.ParseUint(r.cfg.BotID, 10, 64); err != nil {
 		r.log.Warn("reauth notification skipped: bot id not numeric, no actor to send as",
 			zap.String("broadcaster_id", broadcasterID))
 		return
 	}
 
-	copyFor := r.localizedCopy(ctx, broadcasterID)
 	day := time.Now().UTC().Format("2006-01-02")
 
 	reply, err := bus.RequestJSONTimeout[notificationsrpc.SendReply](ctx, r.nc, r.cfg.SendSubject,
 		notificationsrpc.SendRequest{
 			Scope:        "direct",
 			TargetUserID: broadcasterID,
-			Title:        copyFor.title,
-			Body:         copyFor.body,
+			Title:        i18n.T(locale, n.title),
+			Body:         i18n.T(locale, n.body),
 			Level:        "warning",
 			ActorID:      r.cfg.BotID,
 			ActorLogin:   "system",
-			RequestID:    "authz-revoked-" + broadcasterID + "-" + day,
+			RequestID:    n.request + broadcasterID + "-" + day,
 		}, 5*time.Second)
 
+	r.logSendResult(broadcasterID, reply, err)
+}
+
+func (r *ReauthNotifier) logSendResult(broadcasterID string, reply notificationsrpc.SendReply, err error) {
 	switch {
 	case err != nil:
 		r.log.Warn("reauth notification send failed",
@@ -109,28 +119,24 @@ func (r *ReauthNotifier) NotifyRevoked(ctx context.Context, broadcasterID string
 	}
 }
 
-// ChatBeacon returns the localized go-live chat line asking the streamer to
+// ChatLine returns the localized go-live chat line asking the streamer to
 // reconnect.
-func (r *ReauthNotifier) ChatBeacon(ctx context.Context, broadcasterID string) string {
-	return r.localizedCopy(ctx, broadcasterID).chat
+func (r *ReauthNotifier) ChatLine(locale string, n notice) string {
+	return i18n.T(locale, n.chat)
 }
 
-// localizedCopy resolves the broadcaster's dashboard locale, falling back to
+// ResolveLocale returns the broadcaster's dashboard locale, falling back to
 // English on any failure or unknown code.
-func (r *ReauthNotifier) localizedCopy(ctx context.Context, broadcasterID string) reauthCopy {
-	locale := "en"
-
+func (r *ReauthNotifier) ResolveLocale(ctx context.Context, broadcasterID string) string {
 	reply, err := bus.RequestJSONTimeout[usersrpc.StateGetReply](ctx, r.nc, r.cfg.StateSubject,
 		usersrpc.StateGetRequest{BroadcasterUserID: broadcasterID}, 3*time.Second)
 	if err != nil {
 		r.log.Debug("locale lookup failed, defaulting to en",
 			zap.String("broadcaster_id", broadcasterID), zap.Error(err))
-	} else if reply.Locale != "" {
-		locale = reply.Locale
+		return i18n.DefaultLocale
 	}
-
-	if c, ok := reauthMessages[locale]; ok {
-		return c
+	if reply.Locale == "" {
+		return i18n.DefaultLocale
 	}
-	return reauthMessages["en"]
+	return reply.Locale
 }

--- a/app/outgress/internal/worker/streamstatus.go
+++ b/app/outgress/internal/worker/streamstatus.go
@@ -8,6 +8,7 @@ import (
 
 	eventtwitch "ItsBagelBot/internal/domain/event/twitch"
 	"ItsBagelBot/internal/domain/outgress"
+	"ItsBagelBot/internal/domain/rpc/manage"
 	"ItsBagelBot/pkg/bus"
 
 	"github.com/bytedance/sonic"
@@ -162,7 +163,8 @@ func (w *Worker) reauthBeaconOnLive(ctx context.Context, broadcasterID string) {
 	if err != nil || !found {
 		return
 	}
-	if ch.SubState != subStateRevoked {
+	n, ok := liveNotice(ch)
+	if !ok {
 		return
 	}
 
@@ -171,22 +173,44 @@ func (w *Worker) reauthBeaconOnLive(ctx context.Context, broadcasterID string) {
 		return
 	}
 
-	if err := w.sendReauthChat(ctx, broadcasterID); err != nil {
+	// One locale lookup feeds both surfaces.
+	locale := w.reauth.ResolveLocale(ctx, broadcasterID)
+	w.reauth.NotifyLocalized(ctx, broadcasterID, locale, n)
+
+	if err := w.sendReauthChat(ctx, broadcasterID, locale, n); err != nil {
 		w.log.Warn("reauth chat beacon failed",
 			zap.String("broadcaster_id", broadcasterID), zap.Error(err))
 		return
 	}
-	w.log.Info("reauth chat beacon sent", zap.String("broadcaster_id", broadcasterID))
+	w.log.Info("reauth chat beacon sent",
+		zap.String("broadcaster_id", broadcasterID),
+		zap.String("reason", n.request))
+}
+
+// liveNotice picks which reconnect notice a channel needs at go-live, if any.
+//
+// Revocation wins when both are set: it is the stronger statement (Twitch threw
+// the grant away) and the remedy is identical, so the shared beacon claim
+// deliberately yields one line rather than two for one problem.
+func liveNotice(ch manage.Channel) (notice, bool) {
+	switch {
+	case ch.SubState == subStateRevoked:
+		return noticeRevoked, true
+	case ch.GrantState == manage.GrantDead:
+		return noticeGrantDead, true
+	default:
+		return notice{}, false
+	}
 }
 
 // sendReauthChat pushes the localized reconnect line through the ordinary
 // chat send path (type route defaults + bot sender injection + per-channel
 // chat rate bucket), exactly as if a lane job carried it.
-func (w *Worker) sendReauthChat(ctx context.Context, broadcasterID string) error {
+func (w *Worker) sendReauthChat(ctx context.Context, broadcasterID, locale string, n notice) error {
 	body, err := sonic.Marshal(struct {
 		BroadcasterID string `json:"broadcaster_id"`
 		Message       string `json:"message"`
-	}{broadcasterID, w.reauth.ChatBeacon(ctx, broadcasterID)})
+	}{broadcasterID, w.reauth.ChatLine(locale, n)})
 	if err != nil {
 		return err
 	}

--- a/app/outgress/internal/worker/worker.go
+++ b/app/outgress/internal/worker/worker.go
@@ -83,11 +83,18 @@ type Worker struct {
 	// live writes the result of a Twitch live re-check back into the projection.
 	// Only the system lane sets it (via SetLiveWriter); nil elsewhere.
 	live *LiveWriter
-	// reauth tells a streamer their Twitch consent died (dashboard bell + the
-	// go-live chat beacon copy). Only the system lane sets it (via
-	// SetReauthNotifier); nil elsewhere and in tests, where every call site
-	// degrades to a no-op.
+	// reauth tells a streamer their Twitch grant died (dashboard bell + the
+	// go-live chat beacon copy). Wiring attaches one shared instance to all
+	// three lanes: the system lane drives the beacon and the authz consumers,
+	// and the chat lanes raise the bell the moment a broadcaster-identity call
+	// proves the grant dead. Nil in tests, where every call site degrades to a
+	// no-op.
 	reauth *ReauthNotifier
+	// grants is the narrow registry slice the grant marker uses. It points at
+	// the same *channels.Registry as the field above; the separate, smaller
+	// interface exists so the marker's transition logic is testable without
+	// Valkey. Nil when no registry is configured, which disables the marker.
+	grants grantRegistry
 }
 
 // Config wires one lane worker's collaborators.
@@ -113,7 +120,15 @@ func New(cfg Config) *Worker {
 	if userIDs == nil {
 		userIDs = NewUserIDCache()
 	}
+	// Assign through a nil check rather than directly: a nil *channels.Registry
+	// stored in an interface field is a non-nil interface, which would defeat
+	// every nil guard on the grant marker path.
+	var grants grantRegistry
+	if cfg.Registry != nil {
+		grants = cfg.Registry
+	}
 	return &Worker{
+		grants:   grants,
 		log:      cfg.Log,
 		limiter:  cfg.Limiter,
 		registry: cfg.Registry,
@@ -133,8 +148,10 @@ func (w *Worker) SetLiveWriter(lw *LiveWriter) { w.live = lw }
 
 func (w *Worker) SetModVerifier(v *ModVerifier) { w.modVerifier = v }
 
-// SetReauthNotifier attaches the streamer-facing reauth messaging, used by
-// the system lane worker that consumes the authorization lifecycle events.
+// SetReauthNotifier attaches the streamer-facing reauth messaging. Every lane
+// gets it: the system lane for the go-live beacon and the authorization
+// lifecycle events, the chat lanes for the dashboard bell raised the moment a
+// broadcaster-identity call proves the grant dead.
 func (w *Worker) SetReauthNotifier(r *ReauthNotifier) { w.reauth = r }
 
 // Login->id resolutions (shoutout targets) are a small, fleet-shared keyspace,

--- a/app/outgress/main.go
+++ b/app/outgress/main.go
@@ -126,22 +126,29 @@ func main() {
 	premiumSub, standardSub, systemSub, closeSubs := d.laneSubscribers()
 	defer closeSubs()
 
+	// Streamer-facing messaging attaches before ANY consumer that can reach it.
+	// The system lane needs it for the go-live beacon and the authz consumers;
+	// the chat lanes need it because a broadcaster-identity call failing there
+	// is what discovers a dead grant in the first place, and that raises the
+	// dashboard bell immediately rather than waiting for the next go-live.
+	// The notifier holds no per-lane state, so one instance serves all three.
+	reauth := worker.NewReauthNotifier(nc, worker.ReauthConfig{
+		SendSubject:  cfg.NotifySendSubject,
+		StateSubject: cfg.UsersStateSubject,
+		BotID:        cfg.TwitchBotUserID,
+	}, log.Named("reauth"))
+	premium.SetReauthNotifier(reauth)
+	standard.SetReauthNotifier(reauth)
+	system.SetReauthNotifier(reauth)
+
 	d.startChatLanes(ctx, []bus.WeightedLane{
 		{Sub: premiumSub, Subject: cfg.PremiumSubject, Handle: premium.Process, Reserve: cfg.PremiumReserve},
 		{Sub: standardSub, Subject: cfg.StandardSubject, Handle: standard.Process},
 	})
 	d.startSystemLane(ctx, systemSub, system)
 
-	// Authorization lifecycle: streamer-facing messaging attaches before any
-	// consumer that can call it (the stream lane's go-live beacon and the
-	// authz consumers below), then the client-scoped user.authorization.*
-	// subscriptions that feed them are ensured in the background.
-	system.SetReauthNotifier(worker.NewReauthNotifier(nc, worker.ReauthConfig{
-		SendSubject:  cfg.NotifySendSubject,
-		StateSubject: cfg.UsersStateSubject,
-		BotID:        cfg.TwitchBotUserID,
-	}, log.Named("reauth")))
-
+	// The client-scoped user.authorization.* subscriptions that feed the
+	// notifier are ensured in the background below.
 	closeStreamLane := d.startStreamLane(ctx, system)
 	defer closeStreamLane()
 

--- a/app/sesame/modules/cmd.go
+++ b/app/sesame/modules/cmd.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"ItsBagelBot/app/sesame/engine"
-	"ItsBagelBot/app/sesame/i18n"
+	"ItsBagelBot/internal/domain/i18n"
 	"ItsBagelBot/app/sesame/module"
 	"ItsBagelBot/internal/domain/outgress"
 

--- a/app/sesame/modules/core.go
+++ b/app/sesame/modules/core.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"ItsBagelBot/app/sesame/engine"
-	"ItsBagelBot/app/sesame/i18n"
+	"ItsBagelBot/internal/domain/i18n"
 	"ItsBagelBot/app/sesame/module"
 	"ItsBagelBot/internal/domain/outgress"
 

--- a/app/sesame/modules/external.go
+++ b/app/sesame/modules/external.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"strings"
 
-	"ItsBagelBot/app/sesame/i18n"
+	"ItsBagelBot/internal/domain/i18n"
 	"ItsBagelBot/app/sesame/module"
 	"ItsBagelBot/internal/domain/outgress"
 	"ItsBagelBot/pkg/bus"

--- a/app/sesame/modules/followage.go
+++ b/app/sesame/modules/followage.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"ItsBagelBot/app/sesame/engine"
-	"ItsBagelBot/app/sesame/i18n"
+	"ItsBagelBot/internal/domain/i18n"
 	"ItsBagelBot/app/sesame/module"
 	"ItsBagelBot/internal/domain/outgress"
 

--- a/app/sesame/modules/fortnite.go
+++ b/app/sesame/modules/fortnite.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"ItsBagelBot/app/sesame/engine"
-	"ItsBagelBot/app/sesame/i18n"
+	"ItsBagelBot/internal/domain/i18n"
 	"ItsBagelBot/app/sesame/module"
 	"ItsBagelBot/internal/domain/outgress"
 	gatewayrpc "ItsBagelBot/internal/domain/rpc/gateway"

--- a/app/sesame/modules/live.go
+++ b/app/sesame/modules/live.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"ItsBagelBot/app/sesame/engine"
-	"ItsBagelBot/app/sesame/i18n"
+	"ItsBagelBot/internal/domain/i18n"
 	"ItsBagelBot/app/sesame/module"
 	"ItsBagelBot/internal/domain/outgress"
 

--- a/app/sesame/modules/loyalty.go
+++ b/app/sesame/modules/loyalty.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"ItsBagelBot/app/sesame/engine"
-	"ItsBagelBot/app/sesame/i18n"
+	"ItsBagelBot/internal/domain/i18n"
 	"ItsBagelBot/app/sesame/module"
 	"ItsBagelBot/internal/domain/event/data"
 	"ItsBagelBot/internal/domain/outgress"

--- a/app/sesame/modules/mcsr.go
+++ b/app/sesame/modules/mcsr.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"ItsBagelBot/app/sesame/engine"
-	"ItsBagelBot/app/sesame/i18n"
+	"ItsBagelBot/internal/domain/i18n"
 	"ItsBagelBot/app/sesame/module"
 	"ItsBagelBot/internal/domain/outgress"
 	gatewayrpc "ItsBagelBot/internal/domain/rpc/gateway"

--- a/app/sesame/modules/queue.go
+++ b/app/sesame/modules/queue.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"ItsBagelBot/app/sesame/engine"
-	"ItsBagelBot/app/sesame/i18n"
+	"ItsBagelBot/internal/domain/i18n"
 	"ItsBagelBot/app/sesame/module"
 	"ItsBagelBot/internal/domain/outgress"
 

--- a/app/sesame/modules/quotes.go
+++ b/app/sesame/modules/quotes.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"ItsBagelBot/app/sesame/engine"
-	"ItsBagelBot/app/sesame/i18n"
+	"ItsBagelBot/internal/domain/i18n"
 	"ItsBagelBot/app/sesame/module"
 	"ItsBagelBot/internal/domain/outgress"
 	modulesrpc "ItsBagelBot/internal/domain/rpc/modules"

--- a/internal/domain/i18n/i18n.go
+++ b/internal/domain/i18n/i18n.go
@@ -137,10 +137,12 @@ var catalog = map[string]map[string]string{
 		// Twitch's side. Deliberately worded WITHOUT blaming the streamer, who
 		// would otherwise go hunting in Twitch Connections and find nothing wrong.
 		"grant.dead.title": "Reconnect your Twitch account",
-		"grant.dead.body": "The bot's saved Twitch connection for your channel has expired. Clips, channel point rewards and anything else the bot runs as you will keep failing until you reconnect. " +
-			"Open " + DashboardURL + " and reconnect your Twitch account.",
-		"grant.dead.chat": "My saved Twitch connection for this channel has expired, so clips and channel point actions will fail until it is renewed. " +
-			"Log in at " + DashboardURL + " to reconnect it.",
+		// The bell is read from inside the dashboard, so it points at the
+		// settings page rather than repeating the URL.
+		"grant.dead.body": "Some connections for your channel have expired. " +
+			"Just head to settings and reconnect your account to fix the problem.",
+		"grant.dead.chat": "Some connections for your channel have expired. " +
+			"Just log in to the dashboard to fix the problem: " + DashboardURL,
 	},
 	"fr": {
 		"ping":         "Pong ! ItsBagelBot est actif depuis %s",
@@ -234,10 +236,10 @@ var catalog = map[string]map[string]string{
 			"Connectez-vous sur " + DashboardURL + " pour le reconnecter.",
 
 		"grant.dead.title": "Reconnectez votre compte Twitch",
-		"grant.dead.body": "La connexion Twitch enregistrée du bot pour votre chaîne a expiré. Les clips, les récompenses de points de chaîne et tout ce que le bot effectue en votre nom continueront d'échouer jusqu'à la reconnexion. " +
-			"Ouvrez " + DashboardURL + " et reconnectez votre compte Twitch.",
-		"grant.dead.chat": "Ma connexion Twitch enregistrée pour cette chaîne a expiré, donc les clips et les actions de points de chaîne échoueront jusqu'à son renouvellement. " +
-			"Connectez-vous sur " + DashboardURL + " pour la reconnecter.",
+		"grant.dead.body": "Quelques connexions de votre chaîne ont expiré. " +
+			"Veuillez simplement vous rendre dans les paramètres et reconnecter votre compte pour régler le problème.",
+		"grant.dead.chat": "Quelques connexions de votre chaîne ont expiré. " +
+			"Veuillez simplement vous connecter au dashboard pour régler le problème : " + DashboardURL,
 	},
 }
 

--- a/internal/domain/i18n/i18n.go
+++ b/internal/domain/i18n/i18n.go
@@ -1,15 +1,41 @@
-// Package i18n is a tiny, dependency-free catalog for sesame's built-in (system)
-// chat output. The broadcaster's locale rides the module Context
-// (module.Context.Locale), sourced from the Valkey user projection, so system
-// commands answer in the broadcaster's console language.
+// Package i18n is a tiny, dependency-free catalog for the Go services'
+// user-facing chat and notification copy. sesame's built-in (system) commands
+// take the broadcaster's locale from the module Context (module.Context.Locale),
+// sourced from the Valkey user projection; outgress resolves it over the users
+// state_get RPC. Either way system output answers in the broadcaster's console
+// language.
+//
+// It lives under internal/domain so both services share one catalog rather than
+// each carrying its own table. It stays dependency-free on purpose: nothing here
+// may import a service package or pkg/bus, so locale RESOLUTION belongs to the
+// caller and only the lookup lives here.
 //
 // It mirrors the console/site i18n set: add a locale here and to the users
 // service's supportedLocales map together. English is the source of truth and
 // every unknown locale or key falls back to it.
 package i18n
 
+import "sort"
+
 // DefaultLocale is used when a message's locale is empty or unknown.
 const DefaultLocale = "en"
+
+// DashboardURL is where a streamer re-consents; baked into the reauth and
+// grant-dead copy below.
+const DashboardURL = "https://dashboard.itsbagelbot.com"
+
+// Keys for the copy shared across services. Constants rather than raw strings
+// because T falls back to returning the key itself, so a typo in one of these
+// would post the literal key into a streamer's public chat.
+const (
+	KeyReauthRevokedTitle = "reauth.revoked.title"
+	KeyReauthRevokedBody  = "reauth.revoked.body"
+	KeyReauthRevokedChat  = "reauth.revoked.chat"
+
+	KeyGrantDeadTitle = "grant.dead.title"
+	KeyGrantDeadBody  = "grant.dead.body"
+	KeyGrantDeadChat  = "grant.dead.chat"
+)
 
 // catalog[locale][key] -> template. Templates may carry fmt verbs (see T).
 var catalog = map[string]map[string]string{
@@ -97,6 +123,24 @@ var catalog = map[string]map[string]string{
 
 		"fortnite.shop.empty": "empty today",
 		"fortnite.shop.more":  "+%d more",
+
+		// Twitch revoked the grant outright: the streamer changed a password or
+		// disconnected the app, and Twitch told us so over EventSub.
+		"reauth.revoked.title": "Bot lost access to your channel",
+		"reauth.revoked.body": "Twitch revoked the bot's authorization for your channel (this happens after a password change or if the app was disconnected). " +
+			"Chat replies and alerts are paused. Log in at " + DashboardURL + " and reconnect your Twitch account to bring the bot back.",
+		"reauth.revoked.chat": "The bot lost its Twitch authorization for this channel (password change or app disconnect). " +
+			"Log in at " + DashboardURL + " to reconnect it.",
+
+		// The stored grant simply stopped working: Twitch rejects the refresh
+		// token but never revoked anything, so the app is still connected on
+		// Twitch's side. Deliberately worded WITHOUT blaming the streamer, who
+		// would otherwise go hunting in Twitch Connections and find nothing wrong.
+		"grant.dead.title": "Reconnect your Twitch account",
+		"grant.dead.body": "The bot's saved Twitch connection for your channel has expired. Clips, channel point rewards and anything else the bot runs as you will keep failing until you reconnect. " +
+			"Open " + DashboardURL + " and reconnect your Twitch account.",
+		"grant.dead.chat": "My saved Twitch connection for this channel has expired, so clips and channel point actions will fail until it is renewed. " +
+			"Log in at " + DashboardURL + " to reconnect it.",
 	},
 	"fr": {
 		"ping":         "Pong ! ItsBagelBot est actif depuis %s",
@@ -182,7 +226,43 @@ var catalog = map[string]map[string]string{
 
 		"fortnite.shop.empty": "vide aujourd'hui",
 		"fortnite.shop.more":  "+%d de plus",
+
+		"reauth.revoked.title": "Le bot a perdu l'accès à votre chaîne",
+		"reauth.revoked.body": "Twitch a révoqué l'autorisation du bot pour votre chaîne (cela arrive après un changement de mot de passe ou si l'application a été déconnectée). " +
+			"Les réponses et alertes sont en pause. Connectez-vous sur " + DashboardURL + " et reconnectez votre compte Twitch pour rétablir le bot.",
+		"reauth.revoked.chat": "Le bot a perdu son autorisation Twitch pour cette chaîne (changement de mot de passe ou déconnexion de l'application). " +
+			"Connectez-vous sur " + DashboardURL + " pour le reconnecter.",
+
+		"grant.dead.title": "Reconnectez votre compte Twitch",
+		"grant.dead.body": "La connexion Twitch enregistrée du bot pour votre chaîne a expiré. Les clips, les récompenses de points de chaîne et tout ce que le bot effectue en votre nom continueront d'échouer jusqu'à la reconnexion. " +
+			"Ouvrez " + DashboardURL + " et reconnectez votre compte Twitch.",
+		"grant.dead.chat": "Ma connexion Twitch enregistrée pour cette chaîne a expiré, donc les clips et les actions de points de chaîne échoueront jusqu'à son renouvellement. " +
+			"Connectez-vous sur " + DashboardURL + " pour la reconnecter.",
 	},
+}
+
+// Missing reports the keys present in the default locale but absent from
+// locale, so a parity test can fail on a half-translated addition instead of
+// letting T silently fall back to English in a French streamer's chat.
+func Missing(locale string) []string {
+	var missing []string
+	for key := range catalog[DefaultLocale] {
+		if _, ok := catalog[locale][key]; !ok {
+			missing = append(missing, key)
+		}
+	}
+	sort.Strings(missing)
+	return missing
+}
+
+// Locales lists every locale the catalog carries.
+func Locales() []string {
+	out := make([]string, 0, len(catalog))
+	for locale := range catalog {
+		out = append(out, locale)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // T returns the template for key in locale, falling back to English, then to

--- a/internal/domain/i18n/i18n_test.go
+++ b/internal/domain/i18n/i18n_test.go
@@ -1,0 +1,79 @@
+package i18n
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestLocaleParity fails on a half-translated addition. Without it, a key added
+// to en but forgotten in fr degrades silently through T's English fallback, so a
+// French streamer gets an English line in their own chat and nothing reports it.
+func TestLocaleParity(t *testing.T) {
+	for _, locale := range Locales() {
+		if locale == DefaultLocale {
+			continue
+		}
+		if missing := Missing(locale); len(missing) > 0 {
+			t.Errorf("locale %q is missing %d key(s) present in %q: %v",
+				locale, len(missing), DefaultLocale, missing)
+		}
+	}
+}
+
+// TestSharedKeysResolve guards the cross-service copy specifically. T falls back
+// to returning the key itself, so a typo in one of these constants would post
+// the literal string "grant.dead.chat" into a streamer's public chat.
+func TestSharedKeysResolve(t *testing.T) {
+	keys := []string{
+		KeyReauthRevokedTitle, KeyReauthRevokedBody, KeyReauthRevokedChat,
+		KeyGrantDeadTitle, KeyGrantDeadBody, KeyGrantDeadChat,
+	}
+
+	for _, locale := range Locales() {
+		for _, key := range keys {
+			got := T(locale, key)
+			if got == key {
+				t.Errorf("T(%q, %q) fell through to the key itself", locale, key)
+			}
+			if got == "" {
+				t.Errorf("T(%q, %q) is empty", locale, key)
+			}
+		}
+	}
+}
+
+// TestGrantDeadCopyAvoidsRevocationBlame pins the distinction the copy exists to
+// make. A stale refresh token is not a revocation: the app is still connected on
+// Twitch's side, so telling the streamer their authorization was revoked sends
+// them hunting in Twitch Connections for a problem that is not there.
+func TestGrantDeadCopyAvoidsRevocationBlame(t *testing.T) {
+	blame := map[string][]string{
+		"en": {"revoked", "password"},
+		"fr": {"révoqué", "mot de passe"},
+	}
+
+	for locale, terms := range blame {
+		for _, key := range []string{KeyGrantDeadTitle, KeyGrantDeadBody, KeyGrantDeadChat} {
+			body := T(locale, key)
+			for _, term := range terms {
+				if strings.Contains(body, term) {
+					t.Errorf("T(%q, %q) misattributes cause: contains %q", locale, key, term)
+				}
+			}
+		}
+	}
+}
+
+// TestFallbackChain covers T's three stages: exact hit, English fallback for an
+// unknown locale, and the key itself for an unknown key.
+func TestFallbackChain(t *testing.T) {
+	if got, want := T("fr", KeyGrantDeadTitle), T(DefaultLocale, KeyGrantDeadTitle); got == want {
+		t.Errorf("fr and en copy for %q are identical, so the fr entry is not being used", KeyGrantDeadTitle)
+	}
+	if got, want := T("zz", KeyGrantDeadTitle), T(DefaultLocale, KeyGrantDeadTitle); got != want {
+		t.Errorf("unknown locale did not fall back to %q: got %q", DefaultLocale, got)
+	}
+	if got := T(DefaultLocale, "nope.not.a.key"); got != "nope.not.a.key" {
+		t.Errorf("unknown key should return itself, got %q", got)
+	}
+}

--- a/internal/domain/rpc/manage/manage.go
+++ b/internal/domain/rpc/manage/manage.go
@@ -3,18 +3,35 @@ package manage
 
 import "time"
 
+// GrantState is the health of a broadcaster's own stored OAuth grant, which is
+// separate from SubState. Twitch announces a revocation over EventSub, so
+// SubState learns about it; a refresh token that simply stops working announces
+// nothing, so it is only ever observed when a call under the broadcaster's
+// identity fails.
+type GrantState string
+
+const (
+	// GrantUnknown is the healthy default. An absent Valkey field decodes to
+	// this, so every pre-existing channel reads correct without a backfill.
+	GrantUnknown GrantState = ""
+	// GrantDead means Twitch rejected the stored grant and only re-consent
+	// will fix it.
+	GrantDead GrantState = "dead"
+)
+
 // Channel is the canonical per-broadcaster registry entry: it is both the
 // outgress channel registry's stored model and the wire shape for the
 // channel.get / channel.set / channel.list verbs.
 type Channel struct {
-	BroadcasterID string    `json:"broadcaster_id"`
-	Enabled       bool      `json:"enabled"`
-	IsMod         bool      `json:"is_mod"`
-	ModCheckedAt  time.Time `json:"mod_checked_at"`
-	UpdatedAt     time.Time `json:"updated_at"`
-	SubState      string    `json:"sub_state"` // "ok" | "pending" | "failing" | "" (unknown)
-	SubError      string    `json:"sub_error"` // last failure detail; empty when ok
-	SubCheckedAt  time.Time `json:"sub_checked_at"`
+	BroadcasterID string     `json:"broadcaster_id"`
+	Enabled       bool       `json:"enabled"`
+	IsMod         bool       `json:"is_mod"`
+	ModCheckedAt  time.Time  `json:"mod_checked_at"`
+	UpdatedAt     time.Time  `json:"updated_at"`
+	SubState      string     `json:"sub_state"` // "ok" | "pending" | "failing" | "revoked" | "" (unknown)
+	SubError      string     `json:"sub_error"` // last failure detail; empty when ok
+	SubCheckedAt  time.Time  `json:"sub_checked_at"`
+	GrantState    GrantState `json:"grant_state"` // "" (healthy/unknown) | "dead"
 }
 
 // ChannelRequest is the input shape for channel.get and channel.set verbs.


### PR DESCRIPTION
## Problem

A viewer ran `!clip` against broadcaster 1299059812. It failed four times with `400 {"status":400,"message":"Invalid refresh token"}`, then the message was dropped. The viewer got silence, the streamer was never told, and the dashboard kept showing the channel as connected.

The stored refresh token was dead. Broadcaster-identity calls need the channel's own grant, so every one of them fails; the bot and app token paths keep working, which is why mod-status refresh succeeded the same evening and nothing looked wrong.

Twitch fires no revocation webhook for a stale refresh token, so `sub_state` stays `ok` and nothing in the system ever learns the grant is gone.

## What this changes

**The announce machinery already existed.** `reauthBeaconOnLive` posts a localized chat line at go-live on the app token (which survives a dead broadcaster grant, by design) and `ReauthNotifier` raises a dashboard bell. Both were gated on `sub_state == revoked`, which a dead grant never reaches. This widens that guard into `liveNotice()` rather than building a second announce path.

- **Typed token errors.** `postToken` flattened the status into a `fmt.Errorf`, so nothing downstream could tell a dead grant from a transport blip. Adds `TokenError` + `GrantDead()`, kept deliberately separate from `StatusError`: `worker.isPermanent` switches on `StatusError` and treats 401 as recoverable, and folding them together would have silently reclassified retries as drops across EventSub enroll, stream status and redemptions. `Error()` renders byte-identically, so existing log greps keep matching.

- **Reactive grant marker.** Grant health is learned from calls the bot was already making. No probe, no scheduled refresh, so this path can never burn a refresh token or manufacture the breakage it reports.

- **Shared i18n catalog.** `app/sesame/i18n` moves to `internal/domain/i18n` so outgress and sesame share one catalog instead of each carrying a table. The package was already dependency-free, so this is a relocation: `T` and its fallback chain are unchanged and all 31 sesame call sites stay byte-identical.

## Safety

Two gates matter more than the rest, and both are tested:

- **Identity gate.** Chat and moderation calls carry real broadcaster ids under the app and bot tokens, and all three grants fail through the same `postToken`. Without gating the marker on the resolved identity being the broadcaster, one client-credentials outage would mark the entire enrolled fleet dead and nag every streamer in chat at their next go-live.

- **Clearing paths.** Two, neither depending on the enroll lifecycle: the first successful broadcaster call, and re-consent. The re-consent clear sits *above* the re-enroll gate deliberately, because that gate rejects `sub_state == "ok"` and a grant-dead channel sits in exactly that state. Below it, the clear would never run and a streamer who fixed the problem would be nagged forever.

`GrantDead` is narrow because it gates a publicly posted chat line: only a rejection from Twitch's own token endpoint counts, so a 500 or a timeout can never tell a streamer their connection expired.

`Save` now builds its write from a declared field map, with a reflection test asserting that map covers every field of `manage.Channel`. `Save` is a full overwrite, so a forgotten field silently reverts to empty — without this, toggling `enabled` in the admin console would erase a grant marker with nothing logged.

## Scope

No DB migration, no NATS ACL change. The new verbs ride existing wildcard imports (`bagel.rpc.dashboard.state_get` and `bagel.rpc.admin.notifications.send` are already imported by `OUTGRESS_RPC`). One additive Valkey hash field; an absent value decodes to healthy, so every existing channel is correct with no backfill.

Console surfacing of `grant_state` and the `persistGrant` swallow fix are deliberately not here — they follow in the next change.

## Verification

Build, vet and the full test suite pass, including sesame (touched by the i18n move). New coverage: grant classification against the incident's exact payload, the fleet-safety identity gate, transition-only writes, both clearing paths, the `liveNotice` tie-break, and the first locale-parity test in the repo.

Not exercised against real infra: the Valkey marker round-trip, the actual chat send and the bell delivery need Valkey, NATS and Twitch, so those are unverified until this deploys.