### PR TITLE
Observability: fix New Relic log forwarding gaps + scrape NATS metrics

### DIFF
--- a/deploy/infra/cluster/newrelic-logging.yaml
+++ b/deploy/infra/cluster/newrelic-logging.yaml
@@ -132,9 +132,14 @@ data:
         ["commands"] = true,
         ["transactions"] = true,
         ["projector"] = true,
-        ["worker"] = true,
+        ["sesame"] = true,
+        ["loyalty"] = true,
+        ["notifications"] = true,
+        ["gateway"] = true,
         ["outgress"] = true,
-        ["twitch-ingress"] = true,
+        -- The twitch-ingress Deployment's container is named "ingress"; the
+        -- allowlist keys on container_name, so "twitch-ingress" never matched.
+        ["ingress"] = true,
         ["console-dashboard"] = true,
         ["console-admin"] = true,
     }

--- a/deploy/k8s/nats-leaf.yaml
+++ b/deploy/k8s/nats-leaf.yaml
@@ -34,6 +34,9 @@ spec:
         prometheus.io/path: /metrics
         prometheus.io/port: "7777"
         prometheus.io/scrape: "true"
+        # See nats.yaml: the prometheus agent's default job never matches nats;
+        # this annotation hits the unfiltered "newrelic" job.
+        newrelic.io/scrape: "true"
       labels:
         app: nats-leaf
     spec:

--- a/deploy/k8s/nats.yaml
+++ b/deploy/k8s/nats.yaml
@@ -29,6 +29,10 @@ spec:
         prometheus.io/path: /metrics
         prometheus.io/port: "7777"
         prometheus.io/scrape: "true"
+        # newrelic-prometheus-agent's default job gates prometheus.io/scrape
+        # behind its integrations_filter app allowlist, which has no nats entry;
+        # the chart's "newrelic" job scrapes this annotation unfiltered.
+        newrelic.io/scrape: "true"
       labels:
         app: nats
     spec:


### PR DESCRIPTION
## What

- **fluent-bit allowlist**: `level_extract.lua` keys on `container_name` but was never updated for newer services. `sesame`, `loyalty`, `notifications` and `gateway` logs were silently dropped, and the `twitch-ingress` entry never matched (that Deployment's container is named `ingress`). Dead `worker` entry removed.
- **NATS metrics**: the prometheus-nats-exporter sidecars were never scraped — newrelic-prometheus-agent's default job gates `prometheus.io/scrape` behind its integrations_filter app allowlist (no nats entry). Added `newrelic.io/scrape: "true"`, which the chart's unfiltered job picks up.

## Rollout note

The nats/nats-leaf annotation is a pod-template change: merging rolls the NATS hub StatefulSet and leaf DaemonSet. The fluent-bit ConfigMap change additionally needs a DaemonSet restart to reload the lua script (done post-merge).