### PR TITLE
fix(falco): pin GOMAXPROCS=1 on falcoctl-artifact-follow to stop CPU throttling

### DIFF
--- a/deploy/flux/clusters/production/falco.yaml
+++ b/deploy/flux/clusters/production/falco.yaml
@@ -28,7 +28,10 @@
 #     toleration so the DaemonSet lands on worker1 too (4/4 nodes).
 #   - falcoctl config needs ZERO overrides: rules artifact falco-rules:5,
 #     container plugin 0.6.3 and follow every 168h are all 8.0.3 defaults
-#     (live falcoctl.yaml diffs empty against the default render).
+#     (live falcoctl.yaml diffs empty against the default render). The one
+#     falcoctl delta is the follow container's GOMAXPROCS=1 env below, a CFS
+#     CPU-throttling tune (see the comment there) -- a k8s container env, not a
+#     falcoctl.yaml change, so the config-diff-empty claim above still holds.
 #   - Intentionally NOT carried over: falco.http_output.url pointing at the
 #     long-gone falco-falcosidekick Service. http_output is disabled, the URL
 #     was inert cruft from the era when falcosidekick was installed (its
@@ -156,6 +159,21 @@ spec:
     falcoctl:
       artifact:
         follow:
+          # CPU-throttling tune (NOT a falcoctl.yaml/config change; the follow
+          # container is near-idle, waking only every 168h to poll). falcoctl
+          # 0.12.2 predates Go 1.25's CFS-aware GOMAXPROCS default, so its
+          # runtime sets GOMAXPROCS to the node core count (2-4 here) and fans
+          # background work (sysmon/GC/scavenger) across that many Ps. Against
+          # the 25m limit (2.5ms per 100ms CFS period) any multi-P burst blows
+          # the quota, so the sidecar showed >90% throttled periods for 5m+
+          # despite ~zero real CPU use (New Relic "Container cpu throttling is
+          # high", CRITICAL). Pinning GOMAXPROCS=1 serializes that work onto one
+          # P and kills the sustained throttling WITHOUT raising the limit (tune
+          # before room). Same mechanism automaxprocs implements for low-limit
+          # Go sidecars. If throttling persists after this, THEN bump limits.
+          env:
+            - name: GOMAXPROCS
+              value: "1"
           resources:
             requests:
               cpu: 5m


### PR DESCRIPTION
## Alert

New Relic **Container cpu throttling is high** — `falcoctl-artifact-follow`, CRITICAL, `> 90.0` for 5 minutes ([issue 42099806](https://radar-api.service.newrelic.com/accounts/3823179/issues/42099806-24a6-4fc0-ac73-0b3611cf970d)).

## Root cause

The `falcoctl-artifact-follow` sidecar is near-idle — it wakes only every `168h` to poll the rules registry, so its real CPU use is ~zero. The throttling is a CFS artifact, not load:

- falcoctl **0.12.2** predates Go **1.25**'s CFS-aware `GOMAXPROCS` default.
- Its runtime therefore sets `GOMAXPROCS` to the **node core count** (2–4 on this fleet) and fans background work (sysmon / GC / scavenger) across that many Ps.
- Against the `25m` CPU limit (**2.5ms per 100ms** CFS period), any multi-P burst blows the quota, so throttled-periods / total-periods sits `> 90%` for minutes despite ~no real CPU use. The alert measures the *throttle ratio*, not usage — a tiny limit plus multi-P scheduling produces a high ratio at near-zero load.

## Fix

Pin `GOMAXPROCS=1` on the follow container (via chart-supported `falcoctl.artifact.follow.env`). This serializes the runtime's background work onto a single P, so it no longer bursts across cores and blows the quota — the same mechanism `automaxprocs` implements for low-limit Go sidecars.

**Tune before more room:** the CPU limit stays at `25m`. Raising the limit is the documented escalation *if* throttling persists after this — it is not done here.

## Verification

Rendered from the actual HelmRelease `spec.values` against chart `8.0.3`:

- `env: [{name: GOMAXPROCS, value: "1"}]` lands on `falcoctl-artifact-follow`.
- `resources.limits` unchanged (`25m` / `32Mi`); follow `args` intact.
- falco container `args: [/usr/bin/falco, -U]` unchanged (the mandatory unbuffered-stdout flag).

Restart-free change — the sidecar rolls with the DaemonSet on the new pod spec. Falco is detection-only, so a brief pod roll costs nothing at runtime.