### PR TITLE
refactor(outgress): sesame-style action builder dispatch

### DIFF
--- a/app/outgress/internal/action/action.go
+++ b/app/outgress/internal/action/action.go
@@ -1,0 +1,100 @@
+// Package action is outgress's action authoring surface, mirroring sesame's
+// module builder. Every message type the worker executes is declared as one
+// Action built by a fluent Builder: it names its type, declares the Helix
+// route it defaults to (or that it is internal / a passthrough), and registers
+// its Run handler. The Builder produces an immutable Registry the worker
+// dispatches from with one lock-free map lookup per message.
+//
+// This package is intentionally standalone: it holds only the authoring value
+// types and the Builder. It carries no runtime wiring (no worker, limiter,
+// registry, or Twitch client), so a Run handler captures whatever services it
+// needs by closure and this package never has to know about them.
+package action
+
+import (
+	"context"
+	"strings"
+
+	"ItsBagelBot/internal/domain/outgress"
+)
+
+// Kind classifies how an action's request routing is resolved before Run.
+type Kind int
+
+const (
+	// KindHelix is a routed Helix call: the action carries the default
+	// method/endpoint/identity, filled onto the message when the producer left
+	// them empty. An explicit field always wins.
+	KindHelix Kind = iota
+	// KindPassthrough is a generic Helix call ("api"): the action carries no
+	// route of its own, so the message must bring a valid /helix/ endpoint.
+	KindPassthrough
+	// KindInternal is a job that never resolves a Helix route here (EventSub
+	// management, stream re-checks, typed client calls); its Run owns every
+	// Twitch interaction itself.
+	KindInternal
+)
+
+// String renders the kind for validation errors.
+func (k Kind) String() string {
+	switch k {
+	case KindHelix:
+		return "helix"
+	case KindPassthrough:
+		return "passthrough"
+	case KindInternal:
+		return "internal"
+	default:
+		return "unknown"
+	}
+}
+
+// RunFunc executes one admitted, route-resolved message. The handler owns its
+// rate-bucket takes and the Twitch call; the returned error follows the lane
+// ack discipline (nil acks, an error nacks for paced redelivery).
+type RunFunc func(ctx context.Context, m *outgress.Message) error
+
+// Action is the immutable artifact Build returns for one message type: the
+// route defaults FillRoute applies plus the Run handler the worker invokes.
+type Action struct {
+	Type     string
+	Kind     Kind
+	Method   string
+	Endpoint string
+	As       string
+	Run      RunFunc
+}
+
+// FillRoute fills the message's empty routing fields from the action's
+// declared route and reports whether the resulting request is executable. An
+// explicit field set by the producer always wins. Internal actions carry no
+// route and always pass; helix and passthrough actions must end up with a
+// /helix/ endpoint and a method, or the message must be dropped.
+func (a Action) FillRoute(m *outgress.Message) bool {
+	if a.Kind == KindInternal {
+		return true
+	}
+	if m.Endpoint == "" {
+		m.Endpoint = a.Endpoint
+	}
+	if m.Method == "" {
+		m.Method = a.Method
+	}
+	if m.As == "" {
+		m.As = a.As
+	}
+	return strings.HasPrefix(m.Endpoint, "/helix/") && m.Method != ""
+}
+
+// Registry is the immutable action set the worker dispatches from. It is
+// built once at startup and never mutated after, so lookups on the hot path
+// are lock-free.
+type Registry struct {
+	byType map[string]Action
+}
+
+// Lookup returns the action registered for one message type.
+func (r Registry) Lookup(messageType string) (Action, bool) {
+	a, ok := r.byType[messageType]
+	return a, ok
+}

--- a/app/outgress/internal/action/builder.go
+++ b/app/outgress/internal/action/builder.go
@@ -1,0 +1,212 @@
+package action
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"ItsBagelBot/internal/domain/outgress"
+)
+
+// Endpoint is a Helix path an action defaults to, so route declarations read
+// as domain values rather than bare strings.
+type Endpoint string
+
+// Identity is the token identity a call executes under (outgress.AsApp,
+// AsBot, AsBroadcaster); empty keeps the client's endpoint-based auto routing.
+type Identity string
+
+// Builder is the fluent authoring surface for the worker's action set. The
+// worker creates one with NewSet, declares every message type it executes,
+// then calls Build to get the immutable Registry it dispatches from:
+//
+//	b := action.NewSet()
+//	b.Action(outgress.TypeChat).Post("/helix/chat/messages").As(outgress.AsApp).Run(w.processChat)
+//	b.Action(outgress.TypeAPI).Passthrough().Run(w.processAPI)
+//	b.Action(outgress.TypeEventSub).Internal().Run(w.processEventSub)
+//	registry := b.Build()
+//
+// The Builder holds the actions while they are being assembled so the chained
+// ActionBuilder setters mutate the action in place; Build copies them into
+// the immutable Registry. A Builder is single-use and not safe for concurrent
+// use.
+type Builder struct {
+	acts []*builderAction
+}
+
+// builderAction pairs the action under assembly with its route-form
+// bookkeeping: routed records that one of Post/Put/Delete, Passthrough or
+// Internal was chosen (Build rejects an action without one), redeclared that
+// a second form was chained (Build rejects the conflict instead of letting
+// the last declaration silently win).
+type builderAction struct {
+	act        Action
+	routed     bool
+	redeclared bool
+}
+
+// NewSet starts an empty action set.
+func NewSet() *Builder {
+	return &Builder{}
+}
+
+// Action starts the declaration for one message type, returning an
+// ActionBuilder to chain its route and handler. The action is not complete
+// until Run is called; an ActionBuilder left without Run is reported by Build.
+func (b *Builder) Action(messageType string) *ActionBuilder {
+	entry := &builderAction{act: Action{Type: messageType}}
+	b.acts = append(b.acts, entry)
+	return &ActionBuilder{entry: entry}
+}
+
+// Build validates the assembled set and returns its immutable form. It panics
+// on a programmer error (empty or duplicate type, a missing or conflicting
+// route form, an invalid Helix route, a missing Run): these are startup
+// misconfigurations, not runtime data, so failing loud at boot is the right
+// behavior. Use Validate to check without panicking.
+func (b *Builder) Build() Registry {
+	if err := b.Validate(); err != nil {
+		panic("outgress/action: " + err.Error())
+	}
+	byType := make(map[string]Action, len(b.acts))
+	for _, entry := range b.acts {
+		byType[entry.act.Type] = entry.act
+	}
+	return Registry{byType: byType}
+}
+
+// Validate reports the first problem with the assembled set, or nil when it
+// is well formed. Build calls it and panics on a non-nil result; tests can
+// call it directly.
+func (b *Builder) Validate() error {
+	claimed := make(map[string]struct{}, len(b.acts))
+	for _, entry := range b.acts {
+		if err := validateAction(claimed, entry); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateAction checks one action's type, route form, route shape, and Run,
+// then claims its type.
+func validateAction(claimed map[string]struct{}, entry *builderAction) error {
+	a := entry.act
+	if a.Type == "" {
+		return errors.New("action with an empty type")
+	}
+	if _, dup := claimed[a.Type]; dup {
+		return fmt.Errorf("duplicate action type %q", a.Type)
+	}
+	claimed[a.Type] = struct{}{}
+	if err := validateRouteForm(entry); err != nil {
+		return err
+	}
+	if a.Run == nil {
+		return fmt.Errorf("action %q has no Run (chain .Run to finish it)", a.Type)
+	}
+	return nil
+}
+
+// validateRouteForm checks that exactly one route form was declared, then
+// hands the shape check to validateRoute.
+func validateRouteForm(entry *builderAction) error {
+	if !entry.routed {
+		return fmt.Errorf("action %q declares no route form (chain Post/Put/Delete, Passthrough, or Internal)", entry.act.Type)
+	}
+	if entry.redeclared {
+		return fmt.Errorf("action %q declares more than one route form", entry.act.Type)
+	}
+	return validateRoute(entry.act)
+}
+
+// validateRoute checks the route shape against the action's kind: a helix
+// action must default to a real /helix/ call, the other kinds must not carry
+// route defaults (their setters cannot produce a method or endpoint, so only
+// a stray As can violate this).
+func validateRoute(a Action) error {
+	if a.Kind == KindHelix {
+		return validateHelixRoute(a)
+	}
+	if a.As != "" {
+		return fmt.Errorf("%s action %q must not carry a token identity", a.Kind, a.Type)
+	}
+	return nil
+}
+
+// validateHelixRoute checks a routed action's defaults: a method, a /helix/
+// endpoint, and a known token identity.
+func validateHelixRoute(a Action) error {
+	if a.Method == "" || !strings.HasPrefix(a.Endpoint, "/helix/") {
+		return fmt.Errorf("helix action %q has an invalid route %s %q", a.Type, a.Method, a.Endpoint)
+	}
+	switch a.As {
+	case "", outgress.AsApp, outgress.AsBot, outgress.AsBroadcaster:
+		return nil
+	default:
+		return fmt.Errorf("helix action %q has an unknown identity %q", a.Type, a.As)
+	}
+}
+
+// ActionBuilder chains a single action's route and handler. Every setter
+// returns the same ActionBuilder so a declaration reads as one line; Run is
+// the terminal that finishes the action.
+type ActionBuilder struct {
+	entry *builderAction
+}
+
+// Post declares a routed Helix call defaulting to POST endpoint.
+func (a *ActionBuilder) Post(endpoint Endpoint) *ActionBuilder {
+	return a.helix(http.MethodPost, endpoint)
+}
+
+// Put declares a routed Helix call defaulting to PUT endpoint.
+func (a *ActionBuilder) Put(endpoint Endpoint) *ActionBuilder {
+	return a.helix(http.MethodPut, endpoint)
+}
+
+// Delete declares a routed Helix call defaulting to DELETE endpoint.
+func (a *ActionBuilder) Delete(endpoint Endpoint) *ActionBuilder {
+	return a.helix(http.MethodDelete, endpoint)
+}
+
+func (a *ActionBuilder) helix(method string, endpoint Endpoint) *ActionBuilder {
+	a.claimRouteForm(KindHelix)
+	a.entry.act.Method = method
+	a.entry.act.Endpoint = string(endpoint)
+	return a
+}
+
+// As sets the default token identity the call executes under.
+func (a *ActionBuilder) As(identity Identity) *ActionBuilder {
+	a.entry.act.As = string(identity)
+	return a
+}
+
+// Passthrough declares a generic Helix call that must bring its own endpoint.
+func (a *ActionBuilder) Passthrough() *ActionBuilder {
+	a.claimRouteForm(KindPassthrough)
+	return a
+}
+
+// Internal declares a job with no Helix route of its own; Run owns every
+// Twitch interaction itself.
+func (a *ActionBuilder) Internal() *ActionBuilder {
+	a.claimRouteForm(KindInternal)
+	return a
+}
+
+// claimRouteForm records the chosen route form; a second claim marks the
+// action redeclared so Validate rejects the conflict.
+func (a *ActionBuilder) claimRouteForm(kind Kind) {
+	if a.entry.routed {
+		a.entry.redeclared = true
+	}
+	a.entry.routed = true
+	a.entry.act.Kind = kind
+}
+
+// Run sets the action's handler and finishes it. It is terminal: it returns
+// nothing so a declaration cannot accidentally continue past it.
+func (a *ActionBuilder) Run(fn RunFunc) { a.entry.act.Run = fn }

--- a/app/outgress/internal/action/builder_test.go
+++ b/app/outgress/internal/action/builder_test.go
@@ -1,0 +1,171 @@
+package action
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	"ItsBagelBot/internal/domain/outgress"
+)
+
+func nopRun(context.Context, *outgress.Message) error { return nil }
+
+// route flattens an action's route triple for single-comparison assertions.
+func route(a Action) [3]string { return [3]string{a.Method, a.Endpoint, a.As} }
+
+func TestBuildProducesImmutableRegistry(t *testing.T) {
+	b := NewSet()
+	b.Action("chat").Post("/helix/chat/messages").As(outgress.AsApp).Run(nopRun)
+	b.Action("unban").Delete("/helix/moderation/bans").As(outgress.AsBot).Run(nopRun)
+	b.Action("pin").Put("/helix/chat/pins").As(outgress.AsApp).Run(nopRun)
+	b.Action("api").Passthrough().Run(nopRun)
+	b.Action("eventsub").Internal().Run(nopRun)
+	registry := b.Build()
+
+	chat, ok := registry.Lookup("chat")
+	if !ok {
+		t.Fatal("chat action missing")
+	}
+	if got, want := route(chat), [3]string{http.MethodPost, "/helix/chat/messages", outgress.AsApp}; got != want {
+		t.Fatalf("chat route = %v, want %v", got, want)
+	}
+	if unban, _ := registry.Lookup("unban"); unban.Method != http.MethodDelete {
+		t.Fatalf("unban method = %q, want DELETE", unban.Method)
+	}
+	if api, _ := registry.Lookup("api"); api.Kind != KindPassthrough {
+		t.Fatalf("api kind = %v, want passthrough", api.Kind)
+	}
+	if es, _ := registry.Lookup("eventsub"); es.Kind != KindInternal {
+		t.Fatalf("eventsub kind = %v, want internal", es.Kind)
+	}
+	if _, ok := registry.Lookup("unknown"); ok {
+		t.Fatal("unknown type unexpectedly resolved")
+	}
+}
+
+func TestValidateRejectsMisdeclaredActions(t *testing.T) {
+	tests := []struct {
+		name    string
+		declare func(*Builder)
+		wantErr string
+	}{
+		{
+			name:    "empty type",
+			declare: func(b *Builder) { b.Action("").Post("/helix/x").Run(nopRun) },
+			wantErr: "empty type",
+		},
+		{
+			name: "duplicate type",
+			declare: func(b *Builder) {
+				b.Action("chat").Post("/helix/chat/messages").Run(nopRun)
+				b.Action("chat").Post("/helix/chat/messages").Run(nopRun)
+			},
+			wantErr: "duplicate action type",
+		},
+		{
+			name:    "no route form",
+			declare: func(b *Builder) { b.Action("chat").Run(nopRun) },
+			wantErr: "no route form",
+		},
+		{
+			name:    "two helix routes",
+			declare: func(b *Builder) { b.Action("chat").Post("/helix/a").Post("/helix/b").Run(nopRun) },
+			wantErr: "more than one route form",
+		},
+		{
+			name:    "internal then helix route",
+			declare: func(b *Builder) { b.Action("chat").Internal().Post("/helix/a").Run(nopRun) },
+			wantErr: "more than one route form",
+		},
+		{
+			name:    "helix route then passthrough",
+			declare: func(b *Builder) { b.Action("chat").Post("/helix/a").Passthrough().Run(nopRun) },
+			wantErr: "more than one route form",
+		},
+		{
+			name:    "non-helix endpoint",
+			declare: func(b *Builder) { b.Action("chat").Post("/v5/chat").Run(nopRun) },
+			wantErr: "invalid route",
+		},
+		{
+			name:    "unknown identity",
+			declare: func(b *Builder) { b.Action("chat").Post("/helix/chat/messages").As("nobody").Run(nopRun) },
+			wantErr: "unknown identity",
+		},
+		{
+			name:    "identity on internal action",
+			declare: func(b *Builder) { b.Action("eventsub").Internal().As(outgress.AsApp).Run(nopRun) },
+			wantErr: "must not carry a token identity",
+		},
+		{
+			name:    "missing run",
+			declare: func(b *Builder) { b.Action("chat").Post("/helix/chat/messages") },
+			wantErr: "has no Run",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			b := NewSet()
+			tc.declare(b)
+			err := b.Validate()
+			if err == nil {
+				t.Fatalf("Validate() = nil, want error containing %q", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("Validate() = %v, want error containing %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestBuildPanicsOnInvalidSet(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("Build did not panic on an invalid set")
+		}
+	}()
+	b := NewSet()
+	b.Action("chat").Run(nopRun)
+	b.Build()
+}
+
+func TestFillRouteExplicitFieldsWin(t *testing.T) {
+	b := NewSet()
+	b.Action("chat").Post("/helix/chat/messages").As(outgress.AsApp).Run(nopRun)
+	b.Action("api").Passthrough().Run(nopRun)
+	b.Action("eventsub").Internal().Run(nopRun)
+	registry := b.Build()
+
+	chat, _ := registry.Lookup("chat")
+	m := &outgress.Message{Type: "chat"}
+	if !chat.FillRoute(m) {
+		t.Fatal("chat route did not fill")
+	}
+	filled := [3]string{m.Method, m.Endpoint, m.As}
+	if want := [3]string{http.MethodPost, "/helix/chat/messages", outgress.AsApp}; filled != want {
+		t.Fatalf("filled message route = %v, want %v", filled, want)
+	}
+
+	explicit := &outgress.Message{Type: "chat", Method: http.MethodPut, Endpoint: "/helix/other", As: outgress.AsBot}
+	if !chat.FillRoute(explicit) {
+		t.Fatal("explicit route rejected")
+	}
+	kept := [3]string{explicit.Method, explicit.Endpoint, explicit.As}
+	if want := [3]string{http.MethodPut, "/helix/other", outgress.AsBot}; kept != want {
+		t.Fatalf("explicit fields overwritten: %v, want %v", kept, want)
+	}
+
+	api, _ := registry.Lookup("api")
+	if api.FillRoute(&outgress.Message{Type: "api"}) {
+		t.Fatal("passthrough without an endpoint unexpectedly admitted")
+	}
+	if !api.FillRoute(&outgress.Message{Type: "api", Method: http.MethodGet, Endpoint: "/helix/users"}) {
+		t.Fatal("passthrough with a full route rejected")
+	}
+
+	es, _ := registry.Lookup("eventsub")
+	if !es.FillRoute(&outgress.Message{Type: "eventsub"}) {
+		t.Fatal("internal action rejected")
+	}
+}

--- a/app/outgress/internal/channels/registry.go
+++ b/app/outgress/internal/channels/registry.go
@@ -552,6 +552,23 @@ func firstMessageError(messages []valkey.ValkeyMessage) error {
 	return nil
 }
 
+// SeedPause installs an in-process pause snapshot directly, bypassing Valkey
+// and NATS. The snapshot's observedAt is pinned far in the future so it never
+// trips the staleness guard, however long a benchmark runs; without the
+// reconciler nothing would refresh it. It exists for tests and benchmarks
+// that need Paused to answer without the listener running; wiring never calls
+// it, and a versioned snapshot from the real listener always supersedes it.
+func (r *Registry) SeedPause(paused bool) {
+	r.applyPauseSnapshot(pauseSnapshot{paused: paused, observedAt: time.Now().Add(24 * time.Hour)})
+}
+
+// Prime seeds the per-pod channel cache directly, bypassing Valkey. It exists
+// for tests and benchmarks that need a warm Get without a backing store;
+// wiring never calls it.
+func (r *Registry) Prime(ch manage.Channel) {
+	r.cache.Set(ch.BroadcasterID, ch)
+}
+
 // Paused reports the global kill switch from one lock-free in-process snapshot.
 // The reconciler bounds staleness without putting Valkey I/O on the message path.
 func (r *Registry) Paused(_ context.Context) (bool, error) {

--- a/app/outgress/internal/twitch/client.go
+++ b/app/outgress/internal/twitch/client.go
@@ -86,16 +86,27 @@ func (c *Client) Warmup(ctx context.Context) error {
 	return nil
 }
 
+// clientTimeout bounds every Helix call end to end, including a slow body;
+// drainResponse relies on it as the backstop for a non-terminating response.
+const clientTimeout = 10 * time.Second
+
 func newHTTPClient() *http.Client {
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	transport.MaxIdleConns = maxIdleConnections
 	transport.MaxIdleConnsPerHost = maxIdleConnectionsPerHost
 	transport.ForceAttemptHTTP2 = true
-	return &http.Client{Transport: transport, Timeout: 10 * time.Second}
+	return &http.Client{Transport: transport, Timeout: clientTimeout}
 }
 
 // CloseIdleConnections releases pooled Twitch connections during shutdown.
 func (c *Client) CloseIdleConnections() { c.http.CloseIdleConnections() }
+
+// SetTransport swaps the underlying HTTP transport, keeping the client's
+// overall timeout. It exists for tests and benchmarks that must run the full
+// request path without the network; wiring never calls it.
+func (c *Client) SetTransport(rt http.RoundTripper) {
+	c.http = &http.Client{Transport: rt, Timeout: clientTimeout}
+}
 
 // Identity names whose token a job runs under. IdentityAuto keeps the
 // endpoint-based routing (sourceFor); the rest are explicit producer choices

--- a/app/outgress/internal/twitch/token.go
+++ b/app/outgress/internal/twitch/token.go
@@ -73,6 +73,15 @@ func NewAppTokenSource(creds ClientCredentials) *Source {
 	}}
 }
 
+// NewStaticTokenSource returns a Source that always yields token without any
+// network. It exists for tests and benchmarks that must run the full request
+// path offline; production wiring never uses it.
+func NewStaticTokenSource(token string) *Source {
+	return &Source{refresh: func(context.Context) (string, time.Duration, error) {
+		return token, 24 * time.Hour, nil
+	}}
+}
+
 // NewUserTokenSource mints user access tokens for the bot account through
 // the refresh token grant. Twitch may rotate the refresh token on every
 // renewal, so the latest one is kept in memory.

--- a/app/outgress/internal/worker/actions.go
+++ b/app/outgress/internal/worker/actions.go
@@ -1,0 +1,47 @@
+package worker
+
+import (
+	"ItsBagelBot/app/outgress/internal/action"
+	"ItsBagelBot/internal/domain/outgress"
+)
+
+// buildActions declares every message type this worker executes, in the same
+// fluent builder style sesame's modules use. The Registry it produces owns the
+// Helix route per type, so producers send intent ("chat", "ban", "ad", "clip")
+// plus the body instead of hardcoding paths; Build panics at boot on a
+// misdeclared action. Handlers capture the worker by method value, so the set
+// is built once per lane worker in New.
+//
+//   - chat/announce/shoutout/pin: cloud-bot chat actions on the app token.
+//     Twitch only awards the Chat Bot badge to Send Chat Message calls made
+//     with an app access token, backed by the bot's user:bot/action grants and
+//     the broadcaster's channel:bot grant.
+//   - ban/timeout/unban/shield_mode/delete/warn: the bot acts as moderator
+//     (/helix/moderation/* → bot user token). Timeout shares ban's endpoint;
+//     the body's duration makes it a timeout.
+//   - ad/commercial/clip: the broadcaster's own grant starts the ad
+//     (channel:edit:commercial) or creates the clip (clips:edit).
+//   - api: generic passthrough; the message must carry its own endpoint.
+//   - eventsub/stream_status/redemption_update: internal jobs whose handlers
+//     own their Twitch calls (typed client methods, no route resolution here).
+func (w *Worker) buildActions() action.Registry {
+	b := action.NewSet()
+	b.Action(outgress.TypeChat).Post("/helix/chat/messages").As(outgress.AsApp).Run(w.processChat)
+	b.Action(outgress.TypeAnnounce).Post("/helix/chat/announcements").As(outgress.AsApp).Run(w.processAnnounce)
+	b.Action(outgress.TypeShoutout).Post("/helix/chat/shoutouts").As(outgress.AsApp).Run(w.processShoutout)
+	b.Action(outgress.TypePin).Put("/helix/chat/pins").As(outgress.AsApp).Run(w.processPin)
+	b.Action(outgress.TypeBan).Post("/helix/moderation/bans").As(outgress.AsBot).Run(w.processBan)
+	b.Action(outgress.TypeTimeout).Post("/helix/moderation/bans").As(outgress.AsBot).Run(w.processBan)
+	b.Action(outgress.TypeUnban).Delete("/helix/moderation/bans").As(outgress.AsBot).Run(w.processAPI)
+	b.Action(outgress.TypeShieldMode).Put("/helix/moderation/shield_mode").As(outgress.AsBot).Run(w.processShieldMode)
+	b.Action(outgress.TypeDelete).Delete("/helix/moderation/chat").As(outgress.AsBot).Run(w.processDelete)
+	b.Action(outgress.TypeWarn).Post("/helix/moderation/warnings").As(outgress.AsBot).Run(w.processWarn)
+	b.Action(outgress.TypeAd).Post("/helix/channels/commercial").As(outgress.AsBroadcaster).Run(w.processAPI)
+	b.Action(outgress.TypeCommercial).Post("/helix/channels/commercial").As(outgress.AsBroadcaster).Run(w.processAPI)
+	b.Action(outgress.TypeClip).Post("/helix/clips").As(outgress.AsBroadcaster).Run(w.processClip)
+	b.Action(outgress.TypeAPI).Passthrough().Run(w.processAPI)
+	b.Action(outgress.TypeEventSub).Internal().Run(w.processEventSub)
+	b.Action(outgress.TypeStreamStatus).Internal().Run(w.processStreamStatus)
+	b.Action(outgress.TypeRedemptionUpdate).Internal().Run(w.processRedemptionUpdate)
+	return b.Build()
+}

--- a/app/outgress/internal/worker/batch.go
+++ b/app/outgress/internal/worker/batch.go
@@ -87,7 +87,7 @@ func (w *Worker) processBatchItem(ctx context.Context, item outgress.Message, br
 	if item.BroadcasterID == "" {
 		item.BroadcasterID = broadcasterID
 	}
-	return w.processPayload(ctx, item)
+	return w.processPayload(ctx, &item)
 }
 
 func (w *Worker) releaseBatch(lease BatchLease) {

--- a/app/outgress/internal/worker/buckets.go
+++ b/app/outgress/internal/worker/buckets.go
@@ -56,7 +56,7 @@ var (
 // generalHelixRequests maps a message to the standard and shared bucket
 // requests for the token identity it will execute under, mirroring
 // twitch.ResolveIdentity so accounting and token selection cannot disagree.
-func generalHelixRequests(payload outgress.Message) (standard, shared ratelimit.Request) {
+func generalHelixRequests(payload *outgress.Message) (standard, shared ratelimit.Request) {
 	identity := twitch.ResolveIdentity(twitch.ParseIdentity(payload.As), payload.Endpoint)
 	switch identity {
 	case twitch.IdentityBot:
@@ -93,7 +93,7 @@ func (w *Worker) takeChat(ctx context.Context, broadcasterID string, isMod bool)
 // takeGeneralHelix consumes one token from the Helix budget backing the
 // message's token identity: the general app partition, the bot user budget,
 // or the target broadcaster's own user budget.
-func (w *Worker) takeGeneralHelix(ctx context.Context, payload outgress.Message) error {
+func (w *Worker) takeGeneralHelix(ctx context.Context, payload *outgress.Message) error {
 	standard, shared := generalHelixRequests(payload)
 	if w.lane == LaneStandard {
 		return w.takeOrdered(ctx, standard, shared)

--- a/app/outgress/internal/worker/chat.go
+++ b/app/outgress/internal/worker/chat.go
@@ -7,7 +7,7 @@ import (
 	"ItsBagelBot/internal/domain/outgress"
 )
 
-func (w *Worker) processChat(ctx context.Context, payload outgress.Message) error {
+func (w *Worker) processChat(ctx context.Context, payload *outgress.Message) error {
 	// The enabled/disabled decision belongs to the worker, not outgress: by the
 	// time a chat send reaches here it is already authorized. Outgress only reads
 	// the registry for the bot's mod status (which sets the chat rate capacity).

--- a/app/outgress/internal/worker/clip.go
+++ b/app/outgress/internal/worker/clip.go
@@ -53,7 +53,7 @@ type clipCreateReply struct {
 // what happens to the reply — re-running the message would create a DUPLICATE
 // clip, far worse than a missing reply line. Only failures BEFORE the clip
 // exists (rate bucket, transport, 429, 5xx) return an error to redeliver.
-func (w *Worker) processClip(ctx context.Context, payload outgress.Message) error {
+func (w *Worker) processClip(ctx context.Context, payload *outgress.Message) error {
 	var meta clipMeta
 	if len(payload.Payload) > 0 {
 		_ = sonic.Unmarshal(payload.Payload, &meta)
@@ -157,32 +157,11 @@ func clipID(body io.Reader) (string, error) {
 }
 
 // sendClipReply posts the chat line announcing a freshly created clip through
-// the normal chat path (rate buckets, sender-id injection). Its error is only
-// for the caller to log; the clip already exists, so the caller must not
-// redeliver on a reply failure.
-//
-// processChat runs the send with payload.Endpoint/Method/As already resolved: on
-// the normal chat path the dispatcher fills them from typeRoutes before calling
-// it. This synthetic reply bypasses the dispatcher, so it must set the same chat
-// route itself — otherwise the request goes out with an empty endpoint/method
-// and Twitch's edge rejects it (403).
+// the normal chat action (registry route, rate buckets, sender-id injection).
+// Its error is only for the caller to log; the clip already exists, so the
+// caller must not redeliver on a reply failure.
 func (w *Worker) sendClipReply(ctx context.Context, broadcasterID string, meta clipMeta, clipURL string) error {
-	body, err := sonic.Marshal(struct {
-		BroadcasterID string `json:"broadcaster_id"`
-		Message       string `json:"message"`
-	}{broadcasterID, clipReplyText(meta, clipURL)})
-	if err != nil {
-		return err
-	}
-	route := typeRoutes[outgress.TypeChat]
-	return w.processChat(ctx, outgress.Message{
-		Type:          outgress.TypeChat,
-		BroadcasterID: broadcasterID,
-		Endpoint:      route.endpoint,
-		Method:        route.method,
-		As:            route.as,
-		Payload:       body,
-	})
+	return w.sendBotChat(ctx, broadcasterID, clipReplyText(meta, clipURL))
 }
 
 // clipReplyText composes the chat line for a new clip. When the broadcaster set

--- a/app/outgress/internal/worker/dispatch.go
+++ b/app/outgress/internal/worker/dispatch.go
@@ -2,80 +2,16 @@ package worker
 
 import (
 	"context"
-	"net/http"
-	"strings"
 	"time"
 
 	"ItsBagelBot/internal/domain/outgress"
 	"ItsBagelBot/pkg/bus"
 
+	"github.com/bytedance/sonic"
 	"github.com/newrelic/go-agent/v3/newrelic"
 
 	"go.uber.org/zap"
 )
-
-// helixRoute is the Helix call a message type maps to when the producer leaves
-// endpoint/method empty. as is the default token identity for the type ("" =
-// route by endpoint), applied only when the message does not set its own.
-type helixRoute struct {
-	method   string
-	endpoint string
-	as       string
-}
-
-// typeRoutes lets outgress own the Helix endpoint per type, so producers send
-// intent ("chat", "ban", "ad", "clip") plus the body instead of hardcoding
-// paths. Types absent here (e.g. "api") are generic passthroughs and must carry
-// their own endpoint.
-//
-//   - chat:        bot send (app token honors user:bot + channel:bot).
-//   - ban/unban:   bot acts as moderator (/helix/moderation/* → bot user token).
-//   - timeout:     same endpoint as ban; the body's duration makes it a timeout.
-//   - ad/commercial: the broadcaster starts the ad (channel:edit:commercial).
-//   - clip:        the broadcaster's grant creates the clip (clips:edit).
-var typeRoutes = map[string]helixRoute{
-	outgress.TypeChat:       {http.MethodPost, "/helix/chat/messages", outgress.AsApp},
-	outgress.TypeBan:        {http.MethodPost, "/helix/moderation/bans", outgress.AsBot},
-	outgress.TypeTimeout:    {http.MethodPost, "/helix/moderation/bans", outgress.AsBot},
-	outgress.TypeUnban:      {http.MethodDelete, "/helix/moderation/bans", outgress.AsBot},
-	outgress.TypeAd:         {http.MethodPost, "/helix/channels/commercial", outgress.AsBroadcaster},
-	outgress.TypeCommercial: {http.MethodPost, "/helix/channels/commercial", outgress.AsBroadcaster},
-	outgress.TypeClip:       {http.MethodPost, "/helix/clips", outgress.AsBroadcaster},
-	// Cloud-bot chat actions use the app token. Twitch only awards the Chat Bot
-	// badge to Send Chat Message calls made with an app access token, backed by
-	// the bot's user:bot/action grants and the broadcaster's channel:bot grant.
-	outgress.TypeAnnounce: {http.MethodPost, "/helix/chat/announcements", outgress.AsApp},
-	outgress.TypeShoutout: {http.MethodPost, "/helix/chat/shoutouts", outgress.AsApp},
-	// Pin is a two-call action handled by processPin: send the chat message, then
-	// PUT its returned message id here. Both calls use the cloud-bot app token.
-	outgress.TypePin: {http.MethodPut, "/helix/chat/pins", outgress.AsApp},
-	// Shield Mode is a moderator action (PUT /helix/moderation/shield_mode → bot
-	// user token, moderator:manage:shield_mode). Like ban it needs broadcaster_id +
-	// moderator_id on the query string, handled in processShieldMode.
-	outgress.TypeShieldMode: {http.MethodPut, "/helix/moderation/shield_mode", outgress.AsBot},
-	// Delete Chat Messages (moderator:manage:chat_messages) and Warn Chat User
-	// (moderator:manage:warnings) are moderator actions too; query strings are
-	// assembled in processDelete / processWarn.
-	outgress.TypeDelete: {http.MethodDelete, "/helix/moderation/chat", outgress.AsBot},
-	outgress.TypeWarn:   {http.MethodPost, "/helix/moderation/warnings", outgress.AsBot},
-}
-
-// helixHandlers routes the types that need their own request assembly (query
-// string identities, response reads, chat rate buckets) instead of the generic
-// helix passthrough. Every entry runs after resolveHelixRoute has filled the
-// message's endpoint/method/as defaults.
-var helixHandlers = map[string]func(*Worker, context.Context, outgress.Message) error{
-	outgress.TypeChat:       (*Worker).processChat,
-	outgress.TypeAnnounce:   (*Worker).processAnnounce,
-	outgress.TypeShoutout:   (*Worker).processShoutout,
-	outgress.TypePin:        (*Worker).processPin,
-	outgress.TypeClip:       (*Worker).processClip,
-	outgress.TypeBan:        (*Worker).processBan,
-	outgress.TypeTimeout:    (*Worker).processBan,
-	outgress.TypeShieldMode: (*Worker).processShieldMode,
-	outgress.TypeDelete:     (*Worker).processDelete,
-	outgress.TypeWarn:       (*Worker).processWarn,
-}
 
 func (w *Worker) Process(msg *bus.Message) error {
 	ctx := msg.Context()
@@ -86,7 +22,7 @@ func (w *Worker) Process(msg *bus.Message) error {
 	if !w.decodePayload(ctx, msg.Payload, &payload) {
 		return nil
 	}
-	annotateTxn(ctx, payload)
+	annotateTxn(ctx, &payload)
 
 	if err := w.checkPaused(ctx); err != nil {
 		return err
@@ -100,31 +36,48 @@ func (w *Worker) Process(msg *bus.Message) error {
 		}
 		return w.processBatch(ctx, &batch, payload.BroadcasterID, msg.UUID)
 	}
-	return w.processPayload(ctx, payload)
+	return w.processPayload(ctx, &payload)
 }
 
-// processPayload dispatches one decoded, admitted action. Batch jobs call it
-// serially for each child; ordinary jobs call it once.
-func (w *Worker) processPayload(ctx context.Context, payload outgress.Message) error {
-	switch payload.Type {
-	case outgress.TypeEventSub:
-		return w.processEventSub(ctx, payload)
-	case outgress.TypeStreamStatus:
-		return w.processStreamStatus(ctx, payload)
-	case outgress.TypeRedemptionUpdate:
-		// Channel-points redemption resolution runs under the broadcaster token
-		// and pays the general Helix budget, so it is handled before the
-		// endpoint-routed path (it carries no endpoint of its own).
-		return w.processRedemptionUpdate(ctx, payload)
-	}
-
-	if !w.resolveHelixRoute(&payload) {
+// processPayload dispatches one decoded, admitted action through the immutable
+// action registry: an O(1) lookup by type, the route fill (declared defaults,
+// explicit fields win), then the action's Run. Batch jobs call it serially for
+// each child; ordinary jobs call it once. Everything before Run is in-process,
+// so the only wait a message pays after this point is its own Twitch call.
+func (w *Worker) processPayload(ctx context.Context, payload *outgress.Message) error {
+	act, ok := w.actions.Lookup(payload.Type)
+	if !ok {
+		w.log.Error("dropping message with unknown type", zap.String("type", payload.Type))
 		return nil
 	}
-	if handle, ok := helixHandlers[payload.Type]; ok {
-		return handle(w, ctx, payload)
+	if !act.FillRoute(payload) {
+		w.log.Error("dropping message with invalid request",
+			zap.String("type", payload.Type),
+			zap.String("endpoint", payload.Endpoint),
+			zap.String("method", payload.Method))
+		return nil
 	}
-	return w.processAPI(ctx, payload)
+	return act.Run(ctx, payload)
+}
+
+// sendBotChat routes one synthetic bot chat line (a clip reply, the reauth
+// beacon) through the ordinary chat action — registry route defaults, bot
+// sender injection, per-channel chat rate bucket — exactly as if a lane job
+// carried it.
+func (w *Worker) sendBotChat(ctx context.Context, broadcasterID, text string) error {
+	body, err := sonic.Marshal(struct {
+		BroadcasterID string `json:"broadcaster_id"`
+		Message       string `json:"message"`
+	}{broadcasterID, text})
+	if err != nil {
+		return err
+	}
+	chat := outgress.Message{
+		Type:          outgress.TypeChat,
+		BroadcasterID: broadcasterID,
+		Payload:       body,
+	}
+	return w.processPayload(ctx, &chat)
 }
 
 func (w *Worker) decodePayload(ctx context.Context, data []byte, payload *outgress.Message) bool {
@@ -139,7 +92,7 @@ func (w *Worker) decodePayload(ctx context.Context, data []byte, payload *outgre
 	return true
 }
 
-func annotateTxn(ctx context.Context, payload outgress.Message) {
+func annotateTxn(ctx context.Context, payload *outgress.Message) {
 	txn := newrelic.FromContext(ctx)
 	if txn == nil {
 		return
@@ -164,35 +117,4 @@ func (w *Worker) checkPaused(ctx context.Context) error {
 		return ErrPaused
 	}
 	return nil
-}
-
-// resolveHelixRoute fills endpoint/method/as from the message type when the
-// producer left them empty, so a job only needs its intent + body. "api" has
-// no mapping (generic passthrough) and must carry its own endpoint. An
-// explicit field always wins, so any default can be overridden. It reports
-// false (after logging) when the type is unknown or the resulting request is
-// not a Helix call, and the message must be dropped.
-func (w *Worker) resolveHelixRoute(payload *outgress.Message) bool {
-	route, known := typeRoutes[payload.Type]
-	if !known && payload.Type != outgress.TypeAPI {
-		w.log.Error("dropping message with unknown type", zap.String("type", payload.Type))
-		return false
-	}
-	if payload.Endpoint == "" {
-		payload.Endpoint = route.endpoint
-	}
-	if payload.Method == "" {
-		payload.Method = route.method
-	}
-	if payload.As == "" {
-		payload.As = route.as
-	}
-	if !strings.HasPrefix(payload.Endpoint, "/helix/") || payload.Method == "" {
-		w.log.Error("dropping message with invalid request",
-			zap.String("type", payload.Type),
-			zap.String("endpoint", payload.Endpoint),
-			zap.String("method", payload.Method))
-		return false
-	}
-	return true
 }

--- a/app/outgress/internal/worker/dispatch_bench_test.go
+++ b/app/outgress/internal/worker/dispatch_bench_test.go
@@ -1,0 +1,102 @@
+package worker
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"ItsBagelBot/app/outgress/internal/channels"
+	"ItsBagelBot/app/outgress/internal/twitch"
+	"ItsBagelBot/internal/domain/rpc/manage"
+	"ItsBagelBot/pkg/bus"
+	"ItsBagelBot/pkg/ratelimit"
+
+	"go.uber.org/zap"
+)
+
+// The dispatch benchmarks mirror sesame's pipeline_bench_test.go contract: on
+// a warm pod the entire pre-Twitch path — decode, pause check, action lookup,
+// route fill, registry read, rate take, body assembly — is in-process, so the
+// only wait a chat send pays is its own Twitch round trip. The Twitch call is
+// pinned to a canned in-process transport here, which makes any regression
+// that puts network or heavy allocation back on the path show up as ns/op and
+// allocs/op movement.
+
+// allowAll is the warm-path limiter stand-in: the production LeaseManager's
+// common case is an in-process token-bucket hit, so a constant admit models it
+// without Valkey.
+type allowAll struct{}
+
+func (allowAll) Allow(context.Context, ratelimit.Request) (bool, error) { return true, nil }
+func (allowAll) AllowOrdered(context.Context, ratelimit.Request, ratelimit.Request) (uint8, error) {
+	return 0, nil
+}
+
+type cannedTransport struct{ status int }
+
+func (t cannedTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	return &http.Response{StatusCode: t.status, Body: http.NoBody}, nil
+}
+
+// benchWorker assembles a lane worker whose collaborators answer without any
+// network: seeded pause snapshot, primed channel cache, constant-admit
+// limiter, static tokens, and a canned Twitch transport.
+func benchWorker(tb testing.TB) *Worker {
+	tb.Helper()
+	registry := channels.New(nil)
+	registry.SeedPause(false)
+	registry.Prime(manage.Channel{BroadcasterID: "44322889", Enabled: true, IsMod: true})
+
+	tw := twitch.NewClient("bench-client-id",
+		twitch.NewStaticTokenSource("app-token"),
+		twitch.NewStaticTokenSource("bot-token"), nil)
+	tw.SetTransport(cannedTransport{status: http.StatusNoContent})
+
+	return New(Config{
+		Log:      zap.NewNop(),
+		Limiter:  allowAll{},
+		Registry: registry,
+		Twitch:   tw,
+		BotID:    "987654",
+		Lane:     LanePremium,
+	})
+}
+
+const benchChatBody = `{"type":"chat","broadcaster_id":"44322889","payload":{"broadcaster_id":"44322889","message":"hello chat"}}`
+
+func BenchmarkProcessChat(b *testing.B) {
+	w := benchWorker(b)
+	payload := []byte(benchChatBody)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		if err := w.Process(bus.NewMessage("bench", payload)); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// TestProcessChatAllocCeiling guards the hot path's allocation budget the same
+// way sesame's TestProcessNoOutputAllocCeiling does: the ceiling is
+// deliberately loose (decoder floor, sender-id splice, one HTTP request
+// through the canned transport), so it only trips on structural regressions —
+// a re-marshal sneaking into the body path, per-message registry rebuilding,
+// or dispatch falling back to reflection.
+func TestProcessChatAllocCeiling(t *testing.T) {
+	w := benchWorker(t)
+	payload := []byte(benchChatBody)
+	// Loose on purpose: ~43 allocs/op on arm64 today, with headroom for cache
+	// internals and sonic's per-platform decoder differences. A structural
+	// regression (an extra marshal round-trip, per-message registry work)
+	// costs well more than the slack.
+	const ceiling = 96.0
+
+	allocs := testing.AllocsPerRun(500, func() {
+		if err := w.Process(bus.NewMessage("bench", payload)); err != nil {
+			t.Fatal(err)
+		}
+	})
+	if allocs > ceiling {
+		t.Fatalf("chat hot path allocates %.1f allocs/op, ceiling %.0f", allocs, ceiling)
+	}
+}

--- a/app/outgress/internal/worker/eventsub.go
+++ b/app/outgress/internal/worker/eventsub.go
@@ -57,7 +57,7 @@ type enrollment struct {
 // moderator:read:followers). No bot user token is involved here. Creates are
 // 409-idempotent and deletes 404-idempotent, so a job nacked halfway (rate
 // limit, transient Twitch error) converges when redelivery re-runs it.
-func (w *Worker) processEventSub(ctx context.Context, payload outgress.Message) error {
+func (w *Worker) processEventSub(ctx context.Context, payload *outgress.Message) error {
 	if payload.BroadcasterID == "" {
 		w.log.Error("dropping eventsub job without broadcaster id")
 		return nil

--- a/app/outgress/internal/worker/execute.go
+++ b/app/outgress/internal/worker/execute.go
@@ -13,7 +13,7 @@ import (
 	"go.uber.org/zap"
 )
 
-func (w *Worker) processAPI(ctx context.Context, payload outgress.Message) error {
+func (w *Worker) processAPI(ctx context.Context, payload *outgress.Message) error {
 	if err := w.takeGeneralHelix(ctx, payload); err != nil {
 		return err
 	}
@@ -21,7 +21,7 @@ func (w *Worker) processAPI(ctx context.Context, payload outgress.Message) error
 	return w.execute(ctx, payload)
 }
 
-func (w *Worker) execute(ctx context.Context, payload outgress.Message) error {
+func (w *Worker) execute(ctx context.Context, payload *outgress.Message) error {
 	res, err := w.executeRequest(ctx, payload)
 	if err != nil {
 		return err
@@ -34,7 +34,7 @@ func (w *Worker) execute(ctx context.Context, payload outgress.Message) error {
 // executeRequest performs one Twitch call and returns the still-open response.
 // Most actions use execute, which consumes status and drains it immediately;
 // compound actions such as /pin need to decode a successful response first.
-func (w *Worker) executeRequest(ctx context.Context, payload outgress.Message) (*http.Response, error) {
+func (w *Worker) executeRequest(ctx context.Context, payload *outgress.Message) (*http.Response, error) {
 	started := time.Now()
 	defer recordStageDuration(ctx, "outgress.twitch_ms", started)
 
@@ -50,7 +50,7 @@ func (w *Worker) executeRequest(ctx context.Context, payload outgress.Message) (
 // helixResult maps the Helix response status to the lane's ack/nack decision:
 // 429 and 5xx nack for paced redelivery, everything 4xx is dropped (acked)
 // because redelivering it can never succeed.
-func (w *Worker) helixResult(ctx context.Context, payload outgress.Message, res *http.Response) error {
+func (w *Worker) helixResult(ctx context.Context, payload *outgress.Message, res *http.Response) error {
 	switch {
 	case res.StatusCode == http.StatusTooManyRequests:
 		w.log.Warn("twitch rate limited the app",
@@ -80,7 +80,7 @@ func (w *Worker) helixResult(ctx context.Context, payload outgress.Message, res 
 // recoverable token expiry, so redelivering it just loops forever and poisons
 // the lane. Drop it (ack) and surface it loudly + to New Relic for a human to
 // fix (re-auth / mod the bot). Twitch's body states which of the three.
-func (w *Worker) dropAuthFailure(ctx context.Context, payload outgress.Message, res *http.Response) {
+func (w *Worker) dropAuthFailure(ctx context.Context, payload *outgress.Message, res *http.Response) {
 	body := readErrorBody(res)
 	w.log.Error("dropping request: twitch rejected our credentials (permanent authz problem, not retryable)",
 		zap.Int("status", res.StatusCode),
@@ -90,7 +90,7 @@ func (w *Worker) dropAuthFailure(ctx context.Context, payload outgress.Message, 
 	noticeError(ctx, fmt.Errorf("twitch auth failure: %d %s", res.StatusCode, body))
 }
 
-func (w *Worker) dropRejected(ctx context.Context, payload outgress.Message, res *http.Response) {
+func (w *Worker) dropRejected(ctx context.Context, payload *outgress.Message, res *http.Response) {
 	body := readErrorBody(res)
 	w.log.Error("dropping request twitch rejected",
 		zap.Int("status", res.StatusCode),

--- a/app/outgress/internal/worker/modactions.go
+++ b/app/outgress/internal/worker/modactions.go
@@ -38,7 +38,7 @@ var (
 // processModAction issues one moderator action as the bot. It pays the general
 // Helix budget, then hands the assembled request to execute() for the shared
 // status handling.
-func (w *Worker) processModAction(ctx context.Context, payload outgress.Message, action modAction) error {
+func (w *Worker) processModAction(ctx context.Context, payload *outgress.Message, action modAction) error {
 	mod, ok := w.botIdentity(action.name, payload)
 	if !ok {
 		return nil
@@ -55,15 +55,15 @@ func (w *Worker) processModAction(ctx context.Context, payload outgress.Message,
 	return w.execute(ctx, payload)
 }
 
-func (w *Worker) processBan(ctx context.Context, payload outgress.Message) error {
+func (w *Worker) processBan(ctx context.Context, payload *outgress.Message) error {
 	return w.processModAction(ctx, payload, banAction)
 }
 
-func (w *Worker) processShieldMode(ctx context.Context, payload outgress.Message) error {
+func (w *Worker) processShieldMode(ctx context.Context, payload *outgress.Message) error {
 	return w.processModAction(ctx, payload, shieldAction)
 }
 
-func (w *Worker) processWarn(ctx context.Context, payload outgress.Message) error {
+func (w *Worker) processWarn(ctx context.Context, payload *outgress.Message) error {
 	return w.processModAction(ctx, payload, warnAction)
 }
 
@@ -77,7 +77,7 @@ func modEndpoint(path, broadcasterID, moderatorID string) string {
 // processAnnounce sends a Helix chat announcement as the bot. The endpoint
 // carries broadcaster_id + moderator_id as query params, while the body
 // carries the message plus a color (defaulting to "primary").
-func (w *Worker) processAnnounce(ctx context.Context, payload outgress.Message) error {
+func (w *Worker) processAnnounce(ctx context.Context, payload *outgress.Message) error {
 	mod, ok := w.botIdentity("announce", payload)
 	if !ok {
 		return nil
@@ -108,7 +108,7 @@ func (w *Worker) processAnnounce(ctx context.Context, payload outgress.Message) 
 // delete for an already-gone message is a 404 Twitch treats as permanent,
 // which execute() drops - exactly right for a race with another bot or a
 // human mod.
-func (w *Worker) processDelete(ctx context.Context, payload outgress.Message) error {
+func (w *Worker) processDelete(ctx context.Context, payload *outgress.Message) error {
 	mod, ok := w.botIdentity("delete", payload)
 	if !ok {
 		return nil
@@ -144,7 +144,7 @@ func deleteEndpoint(broadcasterID, moderatorID, msgID string) string {
 // outgress resolves the login to a numeric id (cached, single-flight) and owns
 // the moderator identity. from/to/moderator ids ride the query string, never a
 // body.
-func (w *Worker) processShoutout(ctx context.Context, payload outgress.Message) error {
+func (w *Worker) processShoutout(ctx context.Context, payload *outgress.Message) error {
 	if payload.To == "" {
 		w.log.Error("dropping shoutout: no target login",
 			zap.String("broadcaster_id", payload.BroadcasterID))
@@ -179,7 +179,7 @@ func (w *Worker) processShoutout(ctx context.Context, payload outgress.Message) 
 // single-flight). A loader error is transient (nack so paced redelivery
 // retries); a "" id with nil error means no such user, which retrying can
 // never fix, so the caller drops instead of nacking.
-func (w *Worker) resolveShoutoutTarget(ctx context.Context, payload outgress.Message) (string, error) {
+func (w *Worker) resolveShoutoutTarget(ctx context.Context, payload *outgress.Message) (string, error) {
 	toID, err := w.userIDs.GetOrLoad(ctx, "login:"+strings.ToLower(payload.To),
 		func(ctx context.Context) (string, error) {
 			return w.twitch.UserIDByLogin(ctx, payload.To)

--- a/app/outgress/internal/worker/pin.go
+++ b/app/outgress/internal/worker/pin.go
@@ -17,7 +17,7 @@ import (
 // message id Twitch assigns it, then pins that id. duration_seconds is
 // intentionally absent from pinEndpoint: Twitch therefore keeps the pin for the
 // remainder of the current stream instead of applying a 30-1800 second timer.
-func (w *Worker) processPin(ctx context.Context, payload outgress.Message) error {
+func (w *Worker) processPin(ctx context.Context, payload *outgress.Message) error {
 	pin, mod, ok, err := w.preparePin(ctx, payload)
 	if err != nil {
 		return err
@@ -35,14 +35,14 @@ func (w *Worker) processPin(ctx context.Context, payload outgress.Message) error
 	}
 
 	pin.Endpoint = pinEndpoint(payload.BroadcasterID, mod, messageID)
-	w.finishPin(ctx, pin, messageID)
+	w.finishPin(ctx, &pin, messageID)
 	return nil
 }
 
 // preparePin reserves both rate-limit paths before the chat send. Once the
 // message exists, retrying the whole queue item would duplicate it just to retry
 // the pin, so every locally predictable wait must happen first.
-func (w *Worker) preparePin(ctx context.Context, payload outgress.Message) (outgress.Message, string, bool, error) {
+func (w *Worker) preparePin(ctx context.Context, payload *outgress.Message) (outgress.Message, string, bool, error) {
 	mod, ok := w.botIdentity("pin", payload)
 	if !ok {
 		return outgress.Message{}, "", false, nil
@@ -56,7 +56,7 @@ func (w *Worker) preparePin(ctx context.Context, payload outgress.Message) (outg
 		Method:        http.MethodPut,
 		As:            outgress.AsApp,
 	}
-	if err := w.takeGeneralHelix(ctx, pin); err != nil {
+	if err := w.takeGeneralHelix(ctx, &pin); err != nil {
 		return outgress.Message{}, "", false, err
 	}
 	if err := w.takePinChat(ctx, payload); err != nil {
@@ -65,7 +65,7 @@ func (w *Worker) preparePin(ctx context.Context, payload outgress.Message) (outg
 	return pin, mod, true, nil
 }
 
-func (w *Worker) takePinChat(ctx context.Context, payload outgress.Message) error {
+func (w *Worker) takePinChat(ctx context.Context, payload *outgress.Message) error {
 	registryStarted := time.Now()
 	ch, found, err := w.registry.Get(ctx, payload.BroadcasterID)
 	recordStageDuration(ctx, "outgress.registry_ms", registryStarted)
@@ -78,24 +78,27 @@ func (w *Worker) takePinChat(ctx context.Context, payload outgress.Message) erro
 // sendPinChat posts the text through the ordinary chat route and returns the id
 // Twitch assigned. An empty id means Twitch rejected or dropped the send and the
 // pin action is safely consumed.
-func (w *Worker) sendPinChat(ctx context.Context, payload outgress.Message, mod string) (string, error) {
-	chatRoute := typeRoutes[outgress.TypeChat]
-	chat := payload
+func (w *Worker) sendPinChat(ctx context.Context, payload *outgress.Message, mod string) (string, error) {
+	// The pin job arrives with the pin route resolved; the embedded send must
+	// carry the chat action's route instead, read from the same registry the
+	// dispatcher fills from (chat is always registered; Build guarantees it).
+	chatAction, _ := w.actions.Lookup(outgress.TypeChat)
+	chat := *payload
 	chat.Type = outgress.TypeChat
-	chat.Endpoint = chatRoute.endpoint
-	chat.Method = chatRoute.method
-	chat.As = chatRoute.as
+	chat.Endpoint = chatAction.Endpoint
+	chat.Method = chatAction.Method
+	chat.As = chatAction.As
 	chat.Payload = withSenderID(chat.Payload, mod)
 
-	res, err := w.executeRequest(ctx, chat)
+	res, err := w.executeRequest(ctx, &chat)
 	if err != nil {
 		return "", err
 	}
 	defer drainResponse(res)
-	return w.pinMessageID(ctx, payload, chat, res)
+	return w.pinMessageID(ctx, payload, &chat, res)
 }
 
-func (w *Worker) pinMessageID(ctx context.Context, payload, chat outgress.Message, res *http.Response) (string, error) {
+func (w *Worker) pinMessageID(ctx context.Context, payload, chat *outgress.Message, res *http.Response) (string, error) {
 	status := res.StatusCode
 	if err := w.helixResult(ctx, chat, res); err != nil {
 		return "", err
@@ -121,7 +124,7 @@ func (w *Worker) pinMessageID(ctx context.Context, payload, chat outgress.Messag
 	return messageID, nil
 }
 
-func (w *Worker) finishPin(ctx context.Context, pin outgress.Message, messageID string) {
+func (w *Worker) finishPin(ctx context.Context, pin *outgress.Message, messageID string) {
 	if err := w.execute(ctx, pin); err != nil {
 		// The chat message already exists. Retrying this compound action would send
 		// it again, so report the pin failure but consume the queue item.

--- a/app/outgress/internal/worker/redemption.go
+++ b/app/outgress/internal/worker/redemption.go
@@ -16,7 +16,7 @@ import (
 // budget under the broadcaster's own user bucket. Twitch only allows updating a
 // redemption still in the UNFULFILLED state, so a redemption already resolved
 // (by a mod, or a skip-queue reward) returns a 4xx that is dropped, not retried.
-func (w *Worker) processRedemptionUpdate(ctx context.Context, payload outgress.Message) error {
+func (w *Worker) processRedemptionUpdate(ctx context.Context, payload *outgress.Message) error {
 	if !w.validRedemption(payload) {
 		return nil
 	}
@@ -45,7 +45,7 @@ func (w *Worker) processRedemptionUpdate(ctx context.Context, payload outgress.M
 
 // validRedemption reports whether a redemption job carries the ids and a target
 // status Twitch accepts; a malformed job is logged and dropped (returns false).
-func (w *Worker) validRedemption(payload outgress.Message) bool {
+func (w *Worker) validRedemption(payload *outgress.Message) bool {
 	if missingRedemptionIDs(payload) {
 		w.log.Error("dropping redemption update: missing ids",
 			zap.String("broadcaster_id", payload.BroadcasterID),
@@ -61,8 +61,13 @@ func (w *Worker) validRedemption(payload outgress.Message) bool {
 	return true
 }
 
-func missingRedemptionIDs(payload outgress.Message) bool {
-	return payload.BroadcasterID == "" || payload.RewardID == "" || payload.RedemptionID == ""
+func missingRedemptionIDs(payload *outgress.Message) bool {
+	switch "" {
+	case payload.BroadcasterID, payload.RewardID, payload.RedemptionID:
+		return true
+	default:
+		return false
+	}
 }
 
 func validRedemptionStatus(status string) bool {

--- a/app/outgress/internal/worker/streamstatus.go
+++ b/app/outgress/internal/worker/streamstatus.go
@@ -2,7 +2,6 @@ package worker
 
 import (
 	"context"
-	"errors"
 	"strconv"
 	"time"
 
@@ -10,8 +9,6 @@ import (
 	"ItsBagelBot/internal/domain/outgress"
 	"ItsBagelBot/internal/domain/rpc/manage"
 	"ItsBagelBot/pkg/bus"
-
-	"github.com/bytedance/sonic"
 
 	"go.uber.org/zap"
 )
@@ -21,7 +18,7 @@ import (
 // system Helix bucket and runs only on the system lane (where SetLiveWriter has
 // attached the write-back). A permanent Twitch rejection is dropped; transient
 // errors nack so the paced redelivery retries.
-func (w *Worker) processStreamStatus(ctx context.Context, payload outgress.Message) error {
+func (w *Worker) processStreamStatus(ctx context.Context, payload *outgress.Message) error {
 	if w.live == nil {
 		w.log.Error("dropping stream_status job off the system lane")
 		return nil
@@ -204,28 +201,8 @@ func liveNotice(ch manage.Channel) (notice, bool) {
 }
 
 // sendReauthChat pushes the localized reconnect line through the ordinary
-// chat send path (type route defaults + bot sender injection + per-channel
+// chat action (registry route defaults + bot sender injection + per-channel
 // chat rate bucket), exactly as if a lane job carried it.
 func (w *Worker) sendReauthChat(ctx context.Context, broadcasterID, locale string, n notice) error {
-	body, err := sonic.Marshal(struct {
-		BroadcasterID string `json:"broadcaster_id"`
-		Message       string `json:"message"`
-	}{broadcasterID, w.reauth.ChatLine(locale, n)})
-	if err != nil {
-		return err
-	}
-
-	payload := outgress.Message{
-		Type:          outgress.TypeChat,
-		BroadcasterID: broadcasterID,
-		Payload:       body,
-	}
-	if !w.resolveHelixRoute(&payload) {
-		return errReauthChatRoute
-	}
-	return w.processChat(ctx, payload)
+	return w.sendBotChat(ctx, broadcasterID, w.reauth.ChatLine(locale, n))
 }
-
-// errReauthChatRoute only fires if the chat type route table loses its "chat"
-// entry, which would be a programming error.
-var errReauthChatRoute = errors.New("reauth beacon: chat route unresolved")

--- a/app/outgress/internal/worker/worker.go
+++ b/app/outgress/internal/worker/worker.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"time"
 
+	"ItsBagelBot/app/outgress/internal/action"
 	"ItsBagelBot/app/outgress/internal/channels"
 	"ItsBagelBot/app/outgress/internal/conduit"
 	"ItsBagelBot/app/outgress/internal/twitch"
@@ -71,6 +72,10 @@ type Worker struct {
 	conduit  *conduit.Resolver
 	lane     Lane
 	batch    BatchStore
+	// actions is the immutable per-type dispatch registry built once in New
+	// (see buildActions); every lane message resolves through one lock-free
+	// lookup in it.
+	actions action.Registry
 	// userIDs caches login->id resolutions (shoutout targets) so a repeated
 	// /shoutout to the same channel does not re-hit Helix Get Users each time.
 	// Wiring injects one instance shared by all three lane workers via
@@ -127,7 +132,7 @@ func New(cfg Config) *Worker {
 	if cfg.Registry != nil {
 		grants = cfg.Registry
 	}
-	return &Worker{
+	w := &Worker{
 		grants:   grants,
 		log:      cfg.Log,
 		limiter:  cfg.Limiter,
@@ -140,6 +145,10 @@ func New(cfg Config) *Worker {
 		batch:    cfg.Batch,
 		userIDs:  userIDs,
 	}
+	// Handlers capture w by method value, so late-attached collaborators
+	// (SetModVerifier, SetReauthNotifier, SetLiveWriter) are still seen.
+	w.actions = w.buildActions()
+	return w
 }
 
 // SetLiveWriter attaches the live re-check write-back, used by the system lane
@@ -187,7 +196,7 @@ func noticeError(ctx context.Context, err error) {
 // moderator): an explicit message sender wins, else the configured bot id.
 // ok=false means neither is set - there is nobody to act as, so the caller
 // must drop the job (already logged here, ack).
-func (w *Worker) botIdentity(action string, payload outgress.Message) (string, bool) {
+func (w *Worker) botIdentity(action string, payload *outgress.Message) (string, bool) {
 	id := payload.SenderID
 	if id == "" {
 		id = w.botID
@@ -202,7 +211,7 @@ func (w *Worker) botIdentity(action string, payload outgress.Message) (string, b
 
 // modStatus is deliberately non-blocking: use the last known value and let the
 // shared verifier refresh stale state away from the chat handler.
-func (w *Worker) modStatus(_ context.Context, payload outgress.Message, ch manage.Channel, found bool) bool {
+func (w *Worker) modStatus(_ context.Context, payload *outgress.Message, ch manage.Channel, found bool) bool {
 	if w.modVerifier == nil {
 		return found && ch.IsMod
 	}

--- a/app/outgress/internal/worker/worker_test.go
+++ b/app/outgress/internal/worker/worker_test.go
@@ -10,7 +10,10 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"ItsBagelBot/app/outgress/internal/action"
 	"ItsBagelBot/internal/domain/outgress"
+
+	"go.uber.org/zap"
 )
 
 func TestDrainResponseEnablesHTTP11ConnectionReuse(t *testing.T) {
@@ -66,12 +69,22 @@ func TestDrainResponseIsBounded(t *testing.T) {
 }
 
 func TestCloudBotChatActionsUseAppToken(t *testing.T) {
+	actions := testActions()
 	for _, typ := range []string{outgress.TypeChat, outgress.TypeAnnounce, outgress.TypeShoutout, outgress.TypePin} {
-		route := typeRoutes[typ]
-		if route.as != outgress.AsApp {
-			t.Fatalf("%s route identity = %q, want %q", typ, route.as, outgress.AsApp)
+		act, ok := actions.Lookup(typ)
+		if !ok {
+			t.Fatalf("%s has no action", typ)
+		}
+		if act.As != outgress.AsApp {
+			t.Fatalf("%s action identity = %q, want %q", typ, act.As, outgress.AsApp)
 		}
 	}
+}
+
+// testActions builds the production action registry off a bare worker, so
+// tests can pin routes without any collaborator wiring.
+func testActions() action.Registry {
+	return New(Config{Log: zap.NewNop()}).actions
 }
 
 func TestGeneralHelixRequestsUseTokenSpecificBuckets(t *testing.T) {
@@ -107,7 +120,7 @@ func TestGeneralHelixRequestsUseTokenSpecificBuckets(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			_, shared := generalHelixRequests(tc.message)
+			_, shared := generalHelixRequests(&tc.message)
 			got := [4]string{shared.Key, shared.DynamicPrefix, shared.Bucket.Scope, shared.Bucket.Value}
 			want := [4]string{tc.sharedKey, tc.sharedPref, tc.scope, tc.value}
 			if got != want {
@@ -274,8 +287,7 @@ func TestShoutoutEndpoint(t *testing.T) {
 }
 
 func TestPinRouteAndStreamLifetimeEndpoint(t *testing.T) {
-	assertRoute(t, outgress.TypePin,
-		helixRoute{http.MethodPut, "/helix/chat/pins", outgress.AsApp})
+	assertRoute(t, outgress.TypePin, wantRoute{http.MethodPut, "/helix/chat/pins", outgress.AsApp})
 
 	got := pinEndpoint("44322889", "987654", "abc-123")
 	want := "/helix/chat/pins?broadcaster_id=44322889&moderator_id=987654&message_id=abc-123"
@@ -321,16 +333,24 @@ func TestSentChatMessageID(t *testing.T) {
 	}
 }
 
-// assertRoute pins one type's Helix routing: method, endpoint, and token
-// identity.
-func assertRoute(t *testing.T, typ string, want helixRoute) {
+// wantRoute is one type's expected Helix routing: method, endpoint, and token
+// identity, mirroring the retired typeRoutes entry shape.
+type wantRoute struct {
+	method   string
+	endpoint string
+	as       string
+}
+
+// assertRoute pins one type's Helix routing, read from the production action
+// registry.
+func assertRoute(t *testing.T, typ string, want wantRoute) {
 	t.Helper()
-	route, ok := typeRoutes[typ]
+	act, ok := testActions().Lookup(typ)
 	if !ok {
-		t.Fatalf("%s has no type route", typ)
+		t.Fatalf("%s has no action", typ)
 	}
-	if route != want {
-		t.Fatalf("%s route = %+v, want %+v", typ, route, want)
+	if got := (wantRoute{act.Method, act.Endpoint, act.As}); got != want {
+		t.Fatalf("%s route = %+v, want %+v", typ, got, want)
 	}
 }
 
@@ -338,8 +358,7 @@ func assertRoute(t *testing.T, typ string, want helixRoute) {
 // shield_mode endpoint under the bot's moderator token, so the automod's
 // mass-raid escalation lands as a moderator action, not an app call.
 func TestShieldModeRoute(t *testing.T) {
-	assertRoute(t, outgress.TypeShieldMode,
-		helixRoute{http.MethodPut, "/helix/moderation/shield_mode", outgress.AsBot})
+	assertRoute(t, outgress.TypeShieldMode, wantRoute{http.MethodPut, "/helix/moderation/shield_mode", outgress.AsBot})
 }
 
 // TestShieldModeEndpoint mirrors the query-param assembly processShieldMode uses:
@@ -356,10 +375,8 @@ func TestShieldModeEndpoint(t *testing.T) {
 // TestDeleteAndWarnRoutes pins the moderator-action routing for the automod's
 // delete (Delete Chat Messages) and warn (Warn Chat User) intents.
 func TestDeleteAndWarnRoutes(t *testing.T) {
-	assertRoute(t, outgress.TypeDelete,
-		helixRoute{http.MethodDelete, "/helix/moderation/chat", outgress.AsBot})
-	assertRoute(t, outgress.TypeWarn,
-		helixRoute{http.MethodPost, "/helix/moderation/warnings", outgress.AsBot})
+	assertRoute(t, outgress.TypeDelete, wantRoute{http.MethodDelete, "/helix/moderation/chat", outgress.AsBot})
+	assertRoute(t, outgress.TypeWarn, wantRoute{http.MethodPost, "/helix/moderation/warnings", outgress.AsBot})
 }
 
 // TestDeleteEndpoint pins the query assembly processDelete uses: all three ids


### PR DESCRIPTION
Replaces the outgress worker's typeRoutes/helixHandlers maps and processPayload type switch with a fluent action builder mirroring sesame's module builder.

## What changed

- New `app/outgress/internal/action` package: every message type is declared once (`Action(type).Post(endpoint).As(identity).Run(handler)`), validated at boot — Build panics on a duplicated type, missing/conflicting route form, invalid Helix route, unknown identity, or missing Run — and compiled into an immutable registry dispatched with one lock-free lookup per message.
- Handlers take `*outgress.Message` instead of values, dropping repeated struct copies on the hot path.
- Synthetic bot chat sends (clip reply, reauth beacon, pin's embedded send) resolve their route from the same registry via `sendBotChat` instead of hand-copying route fields (three duplicated route-assembly sites removed).
- Hot-path benchmark + alloc ceiling mirroring sesame's pipeline bench: with the pause snapshot, channel cache, lease limiter, and tokens all in-process and a canned Twitch transport, a full chat `Process` runs in ~4.5µs / ~43 allocs — the only per-message wait is the Twitch call itself.
- Test seams (documented, wiring never calls them): `twitch.NewStaticTokenSource`, `twitch.Client.SetTransport` (keeps the 10s timeout), `channels.Registry.SeedPause`/`Prime`.

## Behavior

Dispatch semantics are behavior-identical to the old maps: route defaults per type unchanged, explicit producer fields still win, internal types (eventsub / stream_status / redemption_update) still bypass route resolution, api passthrough still requires its own /helix/ endpoint, ack/nack decisions unchanged. The one removed path is `errReauthChatRoute`, whose trigger (chat route missing from the table) is now a boot panic instead of a runtime possibility.