### PR TITLE
feat(alerts): ad-break chat alert, off by default

### DIFF
--- a/app/outgress/internal/twitch/eventsub.go
+++ b/app/outgress/internal/twitch/eventsub.go
@@ -69,9 +69,16 @@ func ChannelSubscriptions(broadcasterID, botID string) []SubSpec {
 //     a fault. It also 401s for a broadcaster whose stored grant predates the
 //     scope, until they re-consent. Both are permanent and tolerated by the
 //     caller; the mandatory set is unaffected.
+//
+//   - channel.ad_break.begin drives the ads chat alert. It is authorized by the
+//     broadcaster's channel:read:ads grant, which only consents issued after the
+//     scope was added to the dashboard login carry, so it 401s for older grants
+//     until the broadcaster re-consents. Non-affiliates never run ads, but the
+//     subscription itself is accepted; it simply never fires.
 func ChannelOptionalSubscriptions(broadcasterID string) []SubSpec {
 	return []SubSpec{
 		{"channel.channel_points_custom_reward_redemption.add", "1", map[string]string{"broadcaster_user_id": broadcasterID}},
+		{"channel.ad_break.begin", "1", map[string]string{"broadcaster_user_id": broadcasterID}},
 	}
 }
 

--- a/app/sesame/modules/alerts.go
+++ b/app/sesame/modules/alerts.go
@@ -17,6 +17,7 @@ const (
 	defaultSubTemplate    = "Welcome to the community, {user}! Thank you for subscribing!"
 	defaultCheerTemplate  = "Thank you for the {bits} bits, {user}!"
 	defaultRaidTemplate   = "{user} is raiding the channel with {viewers} viewers! Welcome everyone!"
+	defaultAdsTemplate    = "Ads are rolling for {duration} seconds. Hang tight, we'll be right back!"
 )
 
 // alertsConfig holds the broadcaster's per-alert enable flags and customized
@@ -33,11 +34,20 @@ type alertsConfig struct {
 	CheerMessage  string `json:"cheerMessage"`
 	RaidEnabled   string `json:"raidEnabled"`
 	RaidMessage   string `json:"raidMessage"`
+	// AdsEnabled is the one default-OFF toggle in the module: unlike the
+	// alerts above, it fires only on an explicit "on" (see adAlertOn), so
+	// enabling the module never starts announcing ad breaks by surprise.
+	AdsEnabled string `json:"adsEnabled"`
+	AdsMessage string `json:"adsMessage"`
 }
 
 // alertOn reports whether a sub-alert toggle is on. Only an explicit "off"
 // disables it; empty (never set) and "on" both fire, so each alert defaults on.
 func alertOn(v string) bool { return v != "off" }
+
+// adAlertOn is the inverse posture for the ads alert: it stays silent until
+// the broadcaster explicitly turns it on, so only "on" fires.
+func adAlertOn(v string) bool { return v == "on" }
 
 // followEvent is the subset of the channel.follow EventSub payload we use.
 type followEvent struct {
@@ -64,8 +74,16 @@ type cheerEvent struct {
 	Bits              int    `json:"bits"`
 }
 
-// Alerts posts a chat line on channel.follow, channel.subscribe, channel.cheer
-// and channel.raid. It is a named, default-on module (KindDefault): it ships
+// adBreakEvent is the subset of the channel.ad_break.begin EventSub payload we
+// use.
+type adBreakEvent struct {
+	BroadcasterUserID string `json:"broadcaster_user_id"`
+	DurationSeconds   int    `json:"duration_seconds"`
+}
+
+// Alerts posts a chat line on channel.follow, channel.subscribe, channel.cheer,
+// channel.raid and channel.ad_break.begin. It is a named, default-on module
+// (KindDefault): it ships
 // enabled and runs unless the broadcaster disables the whole module on the
 // dashboard. Each alert has its own enable toggle and message template, wired in
 // from the module config the pipeline sets on the Context. Raid is a separate
@@ -236,6 +254,45 @@ func Alerts(_ engine.Deps) module.Module {
 		emit(&module.Output{
 			Type:          outgress.TypeChat,
 			BroadcasterID: ev.ToBroadcasterUserID,
+			Text:          msg,
+		})
+		return nil
+	})
+
+	m.On("channel.ad_break.begin", func(_ context.Context, c *module.Context, emit module.Emit) error {
+		var cfg alertsConfig
+		_ = c.Decode(&cfg)
+		if !adAlertOn(cfg.AdsEnabled) {
+			return nil
+		}
+		if len(c.Env.Event) == 0 {
+			return nil
+		}
+		var ev adBreakEvent
+		if err := json.Unmarshal(c.Env.Event, &ev); err != nil {
+			return err
+		}
+		if ev.BroadcasterUserID == "" {
+			return nil
+		}
+
+		tmpl := cfg.AdsMessage
+		if tmpl == "" {
+			tmpl = defaultAdsTemplate
+		}
+
+		msg := module.ExpandString(tmpl, func(key string) (string, bool) {
+			switch key {
+			case "duration":
+				return strconv.Itoa(ev.DurationSeconds), true
+			default:
+				return module.ParseDynamic(key)
+			}
+		})
+
+		emit(&module.Output{
+			Type:          outgress.TypeChat,
+			BroadcasterID: ev.BroadcasterUserID,
 			Text:          msg,
 		})
 		return nil

--- a/app/sesame/modules/alerts_test.go
+++ b/app/sesame/modules/alerts_test.go
@@ -19,6 +19,7 @@ const (
 	subscribeJSON = `{"user_name":"CoolViewer","user_login":"coolviewer","broadcaster_user_id":"2","tier":"1000"}`
 	cheerJSON     = `{"is_anonymous":false,"user_name":"CoolViewer","user_login":"coolviewer","broadcaster_user_id":"2","bits":100}`
 	anonCheerJSON = `{"is_anonymous":true,"broadcaster_user_id":"2","bits":50}`
+	adBreakJSON   = `{"broadcaster_user_id":"2","duration_seconds":90,"is_automatic":true}`
 )
 
 func alertsCtx(eventType, payload, config string) *module.Context {
@@ -141,6 +142,41 @@ func TestAlertsRaidDisabled(t *testing.T) {
 	var col collector
 	cfg := `{"raidEnabled":"off"}`
 	require.NoError(t, alertsHandler(t, "channel.raid")(context.Background(), alertsCtx("channel.raid", raidJSON, cfg), col.emit))
+	assert.Empty(t, col.out)
+}
+
+func TestAlertsAdBreakDefaultOff(t *testing.T) {
+	// Unlike every other alert, the ads alert must not fire until the
+	// broadcaster explicitly turns it on: absent, empty and "off" all suppress.
+	for _, cfg := range []string{``, `{}`, `{"adsEnabled":""}`, `{"adsEnabled":"off"}`} {
+		var col collector
+		require.NoError(t, alertsHandler(t, "channel.ad_break.begin")(context.Background(), alertsCtx("channel.ad_break.begin", adBreakJSON, cfg), col.emit))
+		assert.Empty(t, col.out, "cfg=%q must stay silent", cfg)
+	}
+}
+
+func TestAlertsAdBreakDefaultTemplate(t *testing.T) {
+	var col collector
+	cfg := `{"adsEnabled":"on"}`
+	require.NoError(t, alertsHandler(t, "channel.ad_break.begin")(context.Background(), alertsCtx("channel.ad_break.begin", adBreakJSON, cfg), col.emit))
+	require.Len(t, col.out, 1)
+	o := col.out[0]
+	assert.Equal(t, outgress.TypeChat, o.Type)
+	assert.Equal(t, "2", o.BroadcasterID)
+	assert.Contains(t, o.Text, "90")
+}
+
+func TestAlertsAdBreakCustomTemplate(t *testing.T) {
+	var col collector
+	cfg := `{"adsEnabled":"on","adsMessage":"break for {duration}s"}`
+	require.NoError(t, alertsHandler(t, "channel.ad_break.begin")(context.Background(), alertsCtx("channel.ad_break.begin", adBreakJSON, cfg), col.emit))
+	require.Len(t, col.out, 1)
+	assert.Equal(t, "break for 90s", col.out[0].Text)
+}
+
+func TestAlertsAdBreakIgnoresEmptyEvent(t *testing.T) {
+	var col collector
+	require.NoError(t, alertsHandler(t, "channel.ad_break.begin")(context.Background(), alertsCtx("channel.ad_break.begin", "", `{"adsEnabled":"on"}`), col.emit))
 	assert.Empty(t, col.out)
 }
 

--- a/console/dashboard/src/lib/server/oauth.ts
+++ b/console/dashboard/src/lib/server/oauth.ts
@@ -18,7 +18,10 @@ export function scopes(): string[] {
   // channel:manage:redemptions covers the whole Channel Points surface: creating,
   // editing and deleting custom rewards, subscribing to redemption events, and
   // resolving redemptions (fulfill/refund) — all on the broadcaster's own token.
-  const bot = 'channel:bot moderator:read:followers user:read:chat user:write:chat channel:read:subscriptions bits:read user:read:moderated_channels clips:edit channel:manage:redemptions'
+  // channel:read:ads authorizes the channel.ad_break.begin EventSub behind the
+  // ads chat alert; grants that predate it skip that (optional) subscription
+  // until the broadcaster re-consents.
+  const bot = 'channel:bot moderator:read:followers user:read:chat user:write:chat channel:read:subscriptions bits:read user:read:moderated_channels clips:edit channel:manage:redemptions channel:read:ads'
     .split(/\s+/)
     .filter(Boolean);
   return ['openid', 'user:read:email', ...bot];

--- a/console/dashboard/src/routes/(app)/modules/[id]/+page.svelte
+++ b/console/dashboard/src/routes/(app)/modules/[id]/+page.svelte
@@ -151,11 +151,22 @@
     return field.followsLevel ? automodToggleDefault(config['level'] || 'moderate', field.key) : false;
   }
 
+  // A reply toggle rests on its declared default until the blob stores an
+  // explicit "on"/"off": default-off replies (defaultOff, e.g. the ad-break
+  // alert) need "on", every other reply fires unless "off". Mirrors sesame's
+  // alertOn/adAlertOn split in app/sesame/modules/alerts.go.
+  function replyOn(reply: ModuleReply): boolean {
+    const v = config[reply.enableKey ?? ''] ?? '';
+    if (v === 'on') return true;
+    if (v === 'off') return false;
+    return !reply.defaultOff;
+  }
+
   // --- Per-reply toggle (optimistic) -----------------------------------------
   async function toggleReply(reply: ModuleReply) {
     if (!reply.enableKey) return;
     const key = reply.enableKey;
-    const was = config[key] !== 'off';
+    const was = replyOn(reply);
     config = { ...config, [key]: was ? 'off' : 'on' };
     setStatus(reply.key, 'saving');
     if (await patch({ [key]: was ? 'off' : 'on' }, enabled)) ackSaved(reply.key);
@@ -659,7 +670,7 @@
                   index={i + 1}
                   status={modStatus[reply.key] ?? 'idle'}
                   expanded={expanded === reply.key}
-                  enabled={reply.enableKey ? config[reply.enableKey] !== 'off' : undefined}
+                  enabled={reply.enableKey ? replyOn(reply) : undefined}
                   onExpand={() => openReply(reply)}
                   onToggle={() => toggleReply(reply)}
                 />

--- a/console/shared/lib/types.ts
+++ b/console/shared/lib/types.ts
@@ -294,6 +294,10 @@ export interface ModuleReply {
   // per-reply switch (it fires whenever the module is on). Stored "on"/"off";
   // empty/absent means on, matching sesame's alertOn semantics.
   enableKey?: string;
+  // Flips the empty/absent default to OFF: the reply fires only on an explicit
+  // "on" (sesame's adAlertOn semantics). Used by alerts the broadcaster must
+  // opt into, like the ad-break announcement.
+  defaultOff?: boolean;
   defaultMessage: string; // sesame default template (placeholder + preview fallback)
 
   // --- command-style replies (gateway modules: urchin, mcsr) ---------------
@@ -670,9 +674,9 @@ export const MODULE_CATALOG: readonly ModuleDef[] = [
   {
     id: 'alerts',
     label: 'Chat Alerts',
-    tagline: 'Announce follows, subs, cheers and raids in chat.',
+    tagline: 'Announce follows, subs, cheers, raids and ad breaks in chat.',
     description:
-      'The bot posts a chat line when someone follows, subscribes, cheers, or raids. Turn each alert on or off and customize its message. New alerts default on.',
+      'The bot posts a chat line when someone follows, subscribes, cheers, or raids, and can announce ad breaks. Turn each alert on or off and customize its message. New alerts default on, except the ad-break alert which stays off until you enable it.',
     icon: 'bell',
     category: 'Community',
     defaultEnabled: true,
@@ -712,6 +716,16 @@ export const MODULE_CATALOG: readonly ModuleDef[] = [
         enableKey: 'raidEnabled',
         messageKey: 'raidMessage',
         defaultMessage: '{user} is raiding the channel with {viewers} viewers! Welcome everyone!'
+      },
+      {
+        key: 'ads',
+        label: 'Ad break alert',
+        tagline: 'When an ad break starts. Off by default.',
+        event: 'on ad break',
+        enableKey: 'adsEnabled',
+        messageKey: 'adsMessage',
+        defaultOff: true,
+        defaultMessage: "Ads are rolling for {duration} seconds. Hang tight, we'll be right back!"
       }
     ]
   },


### PR DESCRIPTION
Adds an ad-break announcement to the Chat Alerts module.

- sesame: `channel.ad_break.begin` handler in the alerts module. The module stays default-on, but this alert only fires on an explicit `adsEnabled="on"` (new `adAlertOn` semantics), so enabling the module never starts announcing ads by surprise. Template key `adsMessage`, token `{duration}` (seconds).
- outgress: subscription added to the optional EventSub set; channels whose grant predates the new scope skip it cleanly until re-consent (same path as channel points).
- dashboard: `channel:read:ads` added to login scopes; new "Ad break alert" reply row with `defaultOff` reply semantics honored by the toggle and row state.
- tests: default-off (absent/empty/off), default template, custom template, empty event.