### PR TITLE
Prefer node-local NATS RPC responders

### DIFF
--- a/app/gateway/internal/engine/engine.go
+++ b/app/gateway/internal/engine/engine.go
@@ -15,6 +15,7 @@ import (
 
 	"ItsBagelBot/app/gateway/internal/provider"
 	gatewayrpc "ItsBagelBot/internal/domain/rpc/gateway"
+	"ItsBagelBot/pkg/bus"
 
 	"github.com/bytedance/sonic"
 	"github.com/nats-io/nats.go"
@@ -55,7 +56,7 @@ func subscribe(nc *nats.Conn, subject, queueGroup string, ep provider.Endpoint, 
 	}
 	handle := ep.Handle
 
-	_, err := nc.QueueSubscribe(subject, queueGroup, func(msg *nats.Msg) {
+	err := bus.QueueSubscribeRPC(nc, subject, queueGroup, func(msg *nats.Msg) {
 		start := time.Now()
 
 		txn := nrApp.StartTransaction("rpc " + subject)

--- a/app/ingress/config/runtime.exs
+++ b/app/ingress/config/runtime.exs
@@ -204,7 +204,9 @@ nats_cacerts =
   end
 
 nats_server = fn host, user, pass ->
-  base = %{host: host, port: nats_port}
+  # Required for local-first HA: a missing node-qualified responder must return
+  # immediately so Ingress.Rpc can safely fall back to the generic queue.
+  base = %{host: host, port: nats_port, no_responders: true}
 
   base =
     if nats_cacerts do

--- a/app/ingress/lib/ingress/application.ex
+++ b/app/ingress/lib/ingress/application.ex
@@ -129,23 +129,26 @@ defmodule Ingress.Application do
         Config.invalidation_subject()
       ),
       # Request-reply endpoint for the admin tool.
-      consumer_child(:admin_consumer, Ingress.AdminRpc, AdminConfig.admin_subject(),
+      rpc_consumer_child(:admin_consumer, Ingress.AdminRpc, AdminConfig.admin_subject(),
         queue_group: @admin_queue
       ),
       # Manual shard scaling: {"count": N}.
-      consumer_child(:scale_consumer, Ingress.ScaleRpc, AdminConfig.scale_subject(),
+      rpc_consumer_child(:scale_consumer, Ingress.ScaleRpc, AdminConfig.scale_subject(),
         queue_group: @admin_queue
       ),
       # Toggle the load-based autoscaler: {"enabled": bool}.
-      consumer_child(:autoscale_consumer, Ingress.AutoscaleRpc, AdminConfig.autoscale_subject(),
+      rpc_consumer_child(
+        :autoscale_consumer,
+        Ingress.AutoscaleRpc,
+        AdminConfig.autoscale_subject(),
         queue_group: @admin_queue
       ),
       # Live conduit id: body {}, replies {"conduit_id": "<uuid>"}.
-      consumer_child(:conduit_consumer, Ingress.ConduitRpc, AdminConfig.conduit_subject(),
+      rpc_consumer_child(:conduit_consumer, Ingress.ConduitRpc, AdminConfig.conduit_subject(),
         queue_group: @admin_queue
       ),
       # Side-effect-free fleet RPC latency probe.
-      consumer_child(:health_consumer, Ingress.HealthRpc, AdminConfig.rpc_health_subject(),
+      rpc_consumer_child(:health_consumer, Ingress.HealthRpc, AdminConfig.rpc_health_subject(),
         queue_group: @admin_queue
       ),
       Ingress.Bootstrapper
@@ -166,11 +169,19 @@ defmodule Ingress.Application do
   # to topic on the RPC connection. opts may carry :queue_group for the admin-
   # plane endpoints; the plain invalidation consumer passes none.
   defp consumer_child(id, module, topic, opts \\ []) do
-    subscription = Enum.into(opts, %{topic: topic})
+    consumer_topics_child(id, module, [topic], opts)
+  end
+
+  defp rpc_consumer_child(id, module, topic, opts) do
+    consumer_topics_child(id, module, Ingress.Rpc.subjects(topic), opts)
+  end
+
+  defp consumer_topics_child(id, module, topics, opts) do
+    subscriptions = Enum.map(topics, &Enum.into(opts, %{topic: &1}))
 
     Supervisor.child_spec(
       {Gnat.ConsumerSupervisor,
-       %{connection_name: :gnat, module: module, subscription_topics: [subscription]}},
+       %{connection_name: :gnat, module: module, subscription_topics: subscriptions}},
       id: id
     )
   end

--- a/app/ingress/lib/ingress/broadcaster_status.ex
+++ b/app/ingress/lib/ingress/broadcaster_status.ex
@@ -47,7 +47,7 @@ defmodule Ingress.BroadcasterStatus do
   end
 
   defp request_status(request) do
-    Gnat.request(@connection, Ingress.Config.broadcaster_status_subject(), request,
+    Ingress.Rpc.request(@connection, Ingress.Config.broadcaster_status_subject(), request,
       receive_timeout: Ingress.Config.broadcaster_status_timeout_ms(),
       headers: Trace.trace_headers()
     )

--- a/app/ingress/lib/ingress/rpc.ex
+++ b/app/ingress/lib/ingress/rpc.ex
@@ -1,0 +1,38 @@
+defmodule Ingress.Rpc do
+  @moduledoc """
+  Node-local-first Core NATS routing with the generic queue retained for HA.
+
+  A generic retry is safe only after NATS returns `:no_responders`. Timeouts and
+  connection failures are returned unchanged because a mutation may have run.
+  """
+
+  @node_token "node"
+
+  def subjects(subject, node \\ System.get_env("NODE_NAME")) do
+    case local_subject(subject, node) do
+      nil -> [subject]
+      local -> [subject, local]
+    end
+  end
+
+  def request(connection, subject, body, opts \\ []) do
+    case subjects(subject) do
+      [generic] ->
+        Gnat.request(connection, generic, body, opts)
+
+      [generic, local] ->
+        case Gnat.request(connection, local, body, opts) do
+          {:error, :no_responders} -> Gnat.request(connection, generic, body, opts)
+          result -> result
+        end
+    end
+  end
+
+  defp local_subject(_subject, node) when not is_binary(node) or node == "", do: nil
+
+  defp local_subject(subject, node) do
+    if Regex.match?(~r/^[^.*>\s]+$/u, node) do
+      Enum.join([subject, @node_token, node], ".")
+    end
+  end
+end

--- a/app/ingress/test/rpc_test.exs
+++ b/app/ingress/test/rpc_test.exs
@@ -1,0 +1,16 @@
+defmodule Ingress.RpcTest do
+  use ExUnit.Case, async: true
+
+  test "builds generic and node-qualified subscription subjects" do
+    assert Ingress.Rpc.subjects("bagel.rpc.health.ingress", "node2") == [
+             "bagel.rpc.health.ingress",
+             "bagel.rpc.health.ingress.node.node2"
+           ]
+  end
+
+  test "keeps generic-only routing without a safe node token" do
+    assert Ingress.Rpc.subjects("rpc.get", nil) == ["rpc.get"]
+    assert Ingress.Rpc.subjects("rpc.get", "zone.node2") == ["rpc.get"]
+    assert Ingress.Rpc.subjects("rpc.get", "node*") == ["rpc.get"]
+  end
+end

--- a/app/sesame/engine/gateway_rpc.go
+++ b/app/sesame/engine/gateway_rpc.go
@@ -55,7 +55,7 @@ func (g *GatewayRPC) Call(ctx context.Context, provider, endpoint string, req ga
 	if err != nil {
 		return fmt.Errorf("rpc %s marshal request: %w", subject, err)
 	}
-	msg, err := g.nc.RequestWithContext(ctx, subject, body)
+	msg, err := bus.RequestWithContext(ctx, g.nc, subject, body)
 	if err != nil {
 		return fmt.Errorf("rpc %s request: %w", subject, err)
 	}

--- a/app/sesame/engine/loyalty_rpc.go
+++ b/app/sesame/engine/loyalty_rpc.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	loyaltyrpc "ItsBagelBot/internal/domain/rpc/loyalty"
+	"ItsBagelBot/pkg/bus"
 
 	"github.com/nats-io/nats.go"
 )
@@ -43,7 +44,7 @@ func (l *LoyaltyRPC) call(ctx context.Context, verb string, req loyaltyrpc.Reque
 	if err != nil {
 		return loyaltyrpc.Reply{}, fmt.Errorf("rpc %s marshal request: %w", subject, err)
 	}
-	msg, err := l.nc.RequestWithContext(ctx, subject, body)
+	msg, err := bus.RequestWithContext(ctx, l.nc, subject, body)
 	if err != nil {
 		return loyaltyrpc.Reply{}, fmt.Errorf("rpc %s request: %w", subject, err)
 	}

--- a/app/sesame/engine/loyalty_tick.go
+++ b/app/sesame/engine/loyalty_tick.go
@@ -12,6 +12,7 @@ import (
 	livekey "ItsBagelBot/internal/domain/live"
 	"ItsBagelBot/internal/domain/rpc/manage"
 	"ItsBagelBot/internal/projection"
+	"ItsBagelBot/pkg/bus"
 
 	"github.com/nats-io/nats.go"
 	"github.com/valkey-io/valkey-go"
@@ -360,7 +361,7 @@ func (s *ValkeyLoyaltyClock) fetchChatters(ctx context.Context, broadcasterID ui
 	if err != nil {
 		return nil, err
 	}
-	msg, err := s.nc.RequestWithContext(ctx, s.chattersSubject, body)
+	msg, err := bus.RequestWithContext(ctx, s.nc, s.chattersSubject, body)
 	if err != nil {
 		return nil, err
 	}

--- a/app/users/rpc/dashboard.go
+++ b/app/users/rpc/dashboard.go
@@ -52,7 +52,7 @@ func SubscribeDashboard(w Wiring, prefix, invalidationPrefix string) error {
 	for verb, fn := range verbs {
 		subject := prefix + "." + verb
 		fn := fn
-		if _, err := w.NC.QueueSubscribe(subject, w.Queue, tracedHandler(w.App, subject, fn)); err != nil {
+		if err := bus.QueueSubscribeRPC(w.NC, subject, w.Queue, tracedHandler(w.App, subject, fn)); err != nil {
 			return fmt.Errorf("subscribe %s: %w", subject, err)
 		}
 	}

--- a/app/users/rpc/delegation.go
+++ b/app/users/rpc/delegation.go
@@ -41,7 +41,7 @@ func SubscribeDelegation(w Wiring, prefix, invalidationPrefix string) error {
 	for verb, fn := range verbs {
 		subject := prefix + "." + verb
 		fn := fn
-		if _, err := w.NC.QueueSubscribe(subject, w.Queue, tracedHandler(w.App, subject, fn)); err != nil {
+		if err := bus.QueueSubscribeRPC(w.NC, subject, w.Queue, tracedHandler(w.App, subject, fn)); err != nil {
 			return fmt.Errorf("subscribe %s: %w", subject, err)
 		}
 	}

--- a/console/shared/lib/server/nats-rpc-locality.test.ts
+++ b/console/shared/lib/server/nats-rpc-locality.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from 'bun:test';
+import { ErrorCode } from 'nats';
+import { requestLocalFirst, rpcSubjectsForNode } from './nats-rpc-locality';
+
+describe('RPC node locality', () => {
+  test('builds a restricted node-qualified subject', () => {
+    expect(rpcSubjectsForNode('bagel.rpc.users.get', 'node2')).toEqual([
+      'bagel.rpc.users.get.node.node2',
+      'bagel.rpc.users.get'
+    ]);
+  });
+
+  test('keeps generic-only routing for missing or unsafe node tokens', () => {
+    expect(rpcSubjectsForNode('rpc.get', undefined)).toEqual(['rpc.get']);
+    expect(rpcSubjectsForNode('rpc.get', 'zone.node2')).toEqual(['rpc.get']);
+    expect(rpcSubjectsForNode('rpc.get', 'node*')).toEqual(['rpc.get']);
+  });
+
+  test('falls back to the generic subject only for no responders', async () => {
+    const called: string[] = [];
+    const result = await requestLocalFirst(['rpc.get.node.node2', 'rpc.get'], async (subject) => {
+      called.push(subject);
+      if (subject.endsWith('.node.node2')) throw { code: ErrorCode.NoResponders };
+      return 'generic reply';
+    });
+    expect(result).toBe('generic reply');
+    expect(called).toEqual(['rpc.get.node.node2', 'rpc.get']);
+  });
+
+  test('does not replay an ambiguous timeout', async () => {
+    const called: string[] = [];
+    await expect(
+      requestLocalFirst(['rpc.write.node.node2', 'rpc.write'], async (subject) => {
+        called.push(subject);
+        throw { code: ErrorCode.Timeout };
+      })
+    ).rejects.toEqual({ code: ErrorCode.Timeout });
+    expect(called).toEqual(['rpc.write.node.node2']);
+  });
+});

--- a/console/shared/lib/server/nats-rpc-locality.ts
+++ b/console/shared/lib/server/nats-rpc-locality.ts
@@ -1,0 +1,32 @@
+import { ErrorCode } from 'nats';
+
+const RPC_NODE_TOKEN = 'node';
+
+export function rpcSubjectsForNode(subject: string, node: string | undefined): string[] {
+  if (!node || !/^[^.*>\s]+$/.test(node)) return [subject];
+  return [`${subject}.${RPC_NODE_TOKEN}.${node}`, subject];
+}
+
+function isNoResponders(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    (error as { code?: string }).code === ErrorCode.NoResponders
+  );
+}
+
+// A generic retry is safe only when NATS proves no local responder exists.
+export async function requestLocalFirst<T>(
+  subjects: string[],
+  request: (subject: string) => Promise<T>
+): Promise<T> {
+  for (let i = 0; i < subjects.length; i++) {
+    try {
+      return await request(subjects[i]);
+    } catch (error) {
+      if (i === subjects.length - 1 || !isNoResponders(error)) throw error;
+    }
+  }
+  throw new Error('no responders');
+}

--- a/console/shared/lib/server/nats.ts
+++ b/console/shared/lib/server/nats.ts
@@ -11,6 +11,7 @@ import {
   type JetStreamManager,
   type JetStreamManagerOptions
 } from 'nats';
+import { requestLocalFirst, rpcSubjectsForNode } from './nats-rpc-locality';
 
 const jc = JSONCodec();
 
@@ -30,8 +31,10 @@ function rpcSegment(subject: string): string {
 //   * 'bus'  — the shared BUS account (NATS_USER/PASSWORD): the JetStream lane
 //     view (admin) and the outgress-system stream-feed publish (twitch.*).
 //
-// RPC prefers the strict same-node leaf and falls back to the hub. BUS connects
-// directly to the hub so JetStream never pays a leaf hop.
+// RPC connects to the strict same-node leaf. Requests use a node-qualified
+// subject first, then the canonical subject only when NATS reports that no
+// local responder exists; the leaf route cluster supplies that HA fallback.
+// BUS connects directly to the hub so JetStream never pays a leaf hop.
 type Role = 'rpc' | 'bus';
 
 interface Pool {
@@ -281,7 +284,11 @@ export async function rpc<T>(subject: string, payload: unknown = {}, timeoutMs =
   // handler directly) when no agent/transaction is active.
   return newrelic.startSegment(`NATS/request/${rpcSegment(subject)}`, true, async () => {
     const nc = await get('rpc');
-    const msg = await nc.request(subject, jc.encode(payload), { timeout: timeoutMs });
+    const subjects = rpcSubjectsForNode(subject, process.env.NODE_NAME);
+    const data = jc.encode(payload);
+    const msg = await requestLocalFirst(subjects, (routedSubject) =>
+      nc.request(routedSubject, data, { timeout: timeoutMs })
+    );
     const reply = jc.decode(msg.data) as T & { error?: string };
     if (reply && typeof reply === 'object' && reply.error) throw new RpcError(reply.error);
     return reply as T;

--- a/deploy/k8s/NATS-ACCOUNTS.md
+++ b/deploy/k8s/NATS-ACCOUNTS.md
@@ -74,7 +74,8 @@ go test -v ./deploy/k8s -run TestScopedBusUsersBindAllowedStreams
 The smoke test reconciles each owner stream, binds representative broadcast and
 durable consumers, checks both NATS ACK subject formats, proves `loyalty_bus`
 cannot create a `TWITCH_INGRESS` consumer, and proves every non-admin BUS user
-is denied stream purge/delete.
+is denied stream purge/delete. It also sends a node-qualified health RPC from
+`admin_rpc` to `users_rpc`, exercising the real cross-account service import.
 
 ## 2. `nats-auth-env` secret keys (broker side)
 
@@ -114,6 +115,24 @@ is needed for the credentials — only the keys below.
 Leaf-first endpoint env is set in the manifests already: Go/console get
 `NATS_LEAF_URL`/`NATS_HUB_URL`, ingress gets `NATS_LEAF_HOST`/`NATS_HUB_HOST`.
 
+### RPC locality and HA
+
+Every RPC responder keeps its canonical queue subscription and also registers
+the same handler on `<canonical-subject>.node.<NODE_NAME>`. Callers try the
+node-qualified subject first, so a healthy request stays on the local leaf and
+local service replica instead of being randomly routed to another node.
+
+The canonical subscription remains the permanent HA path. A caller retries it
+only when NATS returns `no responders` for the local subject. It must not replay
+on a timeout or connection error because the first request may already have
+executed, and retrying a mutating RPC could apply it twice.
+
+The authorization config therefore grants every exact RPC service subject
+together with its `.node.*` form. Deploy `nats-auth.conf` before the application
+rollout: older applications continue using canonical subjects, while newer
+applications need the node-qualified publish and subscribe grants. The static
+Go test enforces that each exact service grant retains both forms.
+
 ## 4. Generating bcrypt hashes
 
 Use the `nats` CLI (one hash per user); store the plaintext in Doppler / the
@@ -132,7 +151,8 @@ htpasswd -bnBC 11 "" "$PLAINTEXT" | tr -d ':\n' | sed 's/^\$2y/\$2a/'
 staged before clients cut over.
 
 1. Push the broker and leaf account config (Flux) and verify `leafz` reports no
-   hub remotes; cross-node RPC uses leaf cluster routes only.
+   hub remotes; cross-node RPC uses leaf cluster routes only. This authorization
+   step must precede apps that publish or subscribe to `.node.<NODE_NAME>`.
 2. Ship the app code (already in this branch); `NATS_RPC_*` falls back to
    `NATS_USER`/`PASSWORD`, so apps keep working on their BUS user until RPC creds
    exist.

--- a/deploy/k8s/nats-auth.conf
+++ b/deploy/k8s/nats-auth.conf
@@ -353,15 +353,19 @@ accounts: {
     users: [ { user: "users_rpc", password: $NATS_BCRYPT_USERS_RPC } ]
     exports: [
       { service: "bagel.rpc.health.users" }
+      { service: "bagel.rpc.health.users.node.*" }
       { service: "bagel.rpc.dashboard.>" }
       { service: "bagel.rpc.admin.user.>" }
       { service: "bagel.rpc.delegation.>" }
       { service: "bagel.rpc.internal.billing.apply" }
+      { service: "bagel.rpc.internal.billing.apply.node.*" }
       { service: "bagel.rpc.internal.projection.users.get" }
+      { service: "bagel.rpc.internal.projection.users.get.node.*" }
       { service: "bagel.rpc.internal.tokens.>" }
       # Decrypted contact email for transactional mail; import-gated like the
       # token RPCs so only mail-sending services can reach it.
       { service: "bagel.rpc.internal.users.email.get" }
+      { service: "bagel.rpc.internal.users.email.get.node.*" }
       { stream: "bagel.cache.invalidate.grant" }
       { stream: "bagel.cache.invalidate.status" }
       { stream: "bagel.cache.invalidate.delegation" }
@@ -375,8 +379,10 @@ accounts: {
     users: [ { user: "commands_rpc", password: $NATS_BCRYPT_COMMANDS_RPC } ]
     exports: [
       { service: "bagel.rpc.health.commands" }
+      { service: "bagel.rpc.health.commands.node.*" }
       { service: "bagel.rpc.commands.>" }
       { service: "bagel.rpc.internal.projection.commands.get" }
+      { service: "bagel.rpc.internal.projection.commands.get.node.*" }
     ]
   }
 
@@ -387,8 +393,10 @@ accounts: {
     users: [ { user: "modules_rpc", password: $NATS_BCRYPT_MODULES_RPC } ]
     exports: [
       { service: "bagel.rpc.health.modules" }
+      { service: "bagel.rpc.health.modules.node.*" }
       { service: "bagel.rpc.modules.>" }
       { service: "bagel.rpc.internal.projection.modules.get" }
+      { service: "bagel.rpc.internal.projection.modules.get.node.*" }
       # Decrypted per-broadcaster Govee API key; import-gated to GATEWAY_RPC
       # alone (the one service that dials Govee), mirroring USERS_RPC's tokens.
       # The dashboard set/clear/status verbs ride the public bagel.rpc.modules.>
@@ -403,6 +411,7 @@ accounts: {
     users: [ { user: "loyalty_rpc", password: $NATS_BCRYPT_LOYALTY_RPC } ]
     exports: [
       { service: "bagel.rpc.health.loyalty" }
+      { service: "bagel.rpc.health.loyalty.node.*" }
       { service: "bagel.rpc.loyalty.>" }
     ]
   }
@@ -414,9 +423,12 @@ accounts: {
     users: [ { user: "projector_rpc", password: $NATS_BCRYPT_PROJECTOR_RPC } ]
     exports: [
       { service: "bagel.rpc.health.projector" }
+      { service: "bagel.rpc.health.projector.node.*" }
       { service: "bagel.rpc.projector.dashboard.>" }
       { service: "bagel.rpc.broadcaster.status.get" }
+      { service: "bagel.rpc.broadcaster.status.get.node.*" }
       { service: "bagel.rpc.broadcaster.live.get" }
+      { service: "bagel.rpc.broadcaster.live.get.node.*" }
       { stream: "bagel.cache.invalidate.commands" }
       { stream: "bagel.cache.invalidate.modules" }
       # Live-state pings from the stream-event fold (broadcastLiveInvalidate):
@@ -426,8 +438,11 @@ accounts: {
     ]
     imports: [
       { service: { account: "USERS_RPC",    subject: "bagel.rpc.internal.projection.users.get" } }
+      { service: { account: "USERS_RPC",    subject: "bagel.rpc.internal.projection.users.get.node.*" } }
       { service: { account: "COMMANDS_RPC", subject: "bagel.rpc.internal.projection.commands.get" } }
+      { service: { account: "COMMANDS_RPC", subject: "bagel.rpc.internal.projection.commands.get.node.*" } }
       { service: { account: "MODULES_RPC",  subject: "bagel.rpc.internal.projection.modules.get" } }
+      { service: { account: "MODULES_RPC",  subject: "bagel.rpc.internal.projection.modules.get.node.*" } }
     ]
   }
 
@@ -437,16 +452,20 @@ accounts: {
     users: [ { user: "outgress_rpc", password: $NATS_BCRYPT_OUTGRESS_RPC } ]
     exports: [
       { service: "bagel.rpc.health.outgress" }
+      { service: "bagel.rpc.health.outgress.node.*" }
       { service: "bagel.rpc.outgress.>" }
     ]
     imports: [
       { service: { account: "USERS_RPC",          subject: "bagel.rpc.internal.tokens.>" } }
       { service: { account: "TWITCH_INGRESS_RPC",  subject: "bagel.rpc.ingress.conduit.get" } }
+      { service: { account: "TWITCH_INGRESS_RPC",  subject: "bagel.rpc.ingress.conduit.get.node.*" } }
       # Reauth nudge when Twitch revokes a broadcaster's authorization: the
       # locale read localizes the copy, the notifications send delivers the
       # dashboard bell entry (same verb the transactions gift notice uses).
       { service: { account: "USERS_RPC",          subject: "bagel.rpc.dashboard.state_get" } }
+      { service: { account: "USERS_RPC",          subject: "bagel.rpc.dashboard.state_get.node.*" } }
       { service: { account: "NOTIFICATIONS_RPC",  subject: "bagel.rpc.admin.notifications.send" } }
+      { service: { account: "NOTIFICATIONS_RPC",  subject: "bagel.rpc.admin.notifications.send.node.*" } }
     ]
   }
 
@@ -458,13 +477,18 @@ accounts: {
     users: [ { user: "transactions_rpc", password: $NATS_BCRYPT_TRANSACTIONS_RPC } ]
     exports: [
       { service: "bagel.rpc.health.transactions" }
+      { service: "bagel.rpc.health.transactions.node.*" }
       { service: "bagel.rpc.transactions.>" }
     ]
     imports: [
       { service: { account: "USERS_RPC",         subject: "bagel.rpc.admin.user.get" } }
+      { service: { account: "USERS_RPC",         subject: "bagel.rpc.admin.user.get.node.*" } }
       { service: { account: "USERS_RPC",         subject: "bagel.rpc.internal.billing.apply" } }
+      { service: { account: "USERS_RPC",         subject: "bagel.rpc.internal.billing.apply.node.*" } }
       { service: { account: "USERS_RPC",         subject: "bagel.rpc.internal.users.email.get" } }
+      { service: { account: "USERS_RPC",         subject: "bagel.rpc.internal.users.email.get.node.*" } }
       { service: { account: "NOTIFICATIONS_RPC", subject: "bagel.rpc.admin.notifications.send" } }
+      { service: { account: "NOTIFICATIONS_RPC", subject: "bagel.rpc.admin.notifications.send.node.*" } }
     ]
   }
 
@@ -475,12 +499,14 @@ accounts: {
     users: [ { user: "notifications_rpc", password: $NATS_BCRYPT_NOTIFICATIONS_RPC } ]
     exports: [
       { service: "bagel.rpc.health.notifications" }
+      { service: "bagel.rpc.health.notifications.node.*" }
       { service: "bagel.rpc.notifications.>" }
       { service: "bagel.rpc.admin.notifications.>" }
       { stream: "bagel.cache.invalidate.notifications" }
     ]
     imports: [
       { service: { account: "USERS_RPC", subject: "bagel.rpc.admin.user.get" } }
+      { service: { account: "USERS_RPC", subject: "bagel.rpc.admin.user.get.node.*" } }
     ]
   }
 
@@ -492,6 +518,7 @@ accounts: {
     users: [ { user: "gateway_rpc", password: $NATS_BCRYPT_GATEWAY_RPC } ]
     exports: [
       { service: "bagel.rpc.health.gateway" }
+      { service: "bagel.rpc.health.gateway.node.*" }
       { service: "bagel.rpc.gateway.>" }
     ]
     imports: [
@@ -510,9 +537,11 @@ accounts: {
     users: [ { user: "worker_rpc", password: $NATS_BCRYPT_WORKER_RPC } ]
     exports: [
       { service: "bagel.rpc.health.sesame" }
+      { service: "bagel.rpc.health.sesame.node.*" }
     ]
     imports: [
       { service: { account: "USERS_RPC",    subject: "bagel.rpc.internal.projection.users.get" } }
+      { service: { account: "USERS_RPC",    subject: "bagel.rpc.internal.projection.users.get.node.*" } }
       { service: { account: "COMMANDS_RPC", subject: "bagel.rpc.commands.>" } }
       # Quotes book: the quotes module reads/writes rows through the modules
       # service's quote verbs. Scoped to the quote subtree, not the whole
@@ -522,9 +551,13 @@ accounts: {
       # global "feed the bagel" tally through the modules service. Scoped to
       # the one verb, same rationale as the quote subtree above.
       { service: { account: "MODULES_RPC", subject: "bagel.rpc.modules.personality.feed" } }
+      { service: { account: "MODULES_RPC", subject: "bagel.rpc.modules.personality.feed.node.*" } }
       { service: { account: "PROJECTOR_RPC", subject: "bagel.rpc.projector.dashboard.commands.get" } }
+      { service: { account: "PROJECTOR_RPC", subject: "bagel.rpc.projector.dashboard.commands.get.node.*" } }
       { service: { account: "PROJECTOR_RPC", subject: "bagel.rpc.projector.dashboard.modules.get" } }
+      { service: { account: "PROJECTOR_RPC", subject: "bagel.rpc.projector.dashboard.modules.get.node.*" } }
       { service: { account: "PROJECTOR_RPC", subject: "bagel.rpc.broadcaster.live.get" } }
+      { service: { account: "PROJECTOR_RPC", subject: "bagel.rpc.broadcaster.live.get.node.*" } }
       { service: { account: "GATEWAY_RPC",  subject: "bagel.rpc.gateway.>" } }
       # Loyalty: cold-read loader for the counter/balance Valkey view plus the
       # !counter management verbs.
@@ -532,12 +565,15 @@ accounts: {
       # Chatters listing for the loyalty watch tick — scoped to the one verb,
       # not the whole outgress management surface.
       { service: { account: "OUTGRESS_RPC", subject: "bagel.rpc.outgress.chatters.get" } }
+      { service: { account: "OUTGRESS_RPC", subject: "bagel.rpc.outgress.chatters.get.node.*" } }
       # Followage read for the !followage command — the authenticated Twitch
       # Get Channel Followers behind outgress, scoped to the one verb.
       { service: { account: "OUTGRESS_RPC", subject: "bagel.rpc.outgress.followage.get" } }
+      { service: { account: "OUTGRESS_RPC", subject: "bagel.rpc.outgress.followage.get.node.*" } }
       # Account-age read for the !accountage command — the authenticated Twitch
       # Get Users behind outgress, scoped to the one verb.
       { service: { account: "OUTGRESS_RPC", subject: "bagel.rpc.outgress.accountage.get" } }
+      { service: { account: "OUTGRESS_RPC", subject: "bagel.rpc.outgress.accountage.get.node.*" } }
       { stream: { account: "USERS_RPC",     subject: "bagel.cache.invalidate.status" } }
       { stream: { account: "USERS_RPC",     subject: "bagel.cache.invalidate.grant" } }
       { stream: { account: "USERS_RPC",     subject: "bagel.cache.invalidate.locale" } }
@@ -561,7 +597,9 @@ accounts: {
       { service: { account: "MODULES_RPC",   subject: "bagel.rpc.modules.>" } }
       { service: { account: "PROJECTOR_RPC", subject: "bagel.rpc.projector.dashboard.>" } }
       { service: { account: "PROJECTOR_RPC", subject: "bagel.rpc.broadcaster.status.get" } }
+      { service: { account: "PROJECTOR_RPC", subject: "bagel.rpc.broadcaster.status.get.node.*" } }
       { service: { account: "OUTGRESS_RPC",  subject: "bagel.rpc.outgress.channel.get" } }
+      { service: { account: "OUTGRESS_RPC",  subject: "bagel.rpc.outgress.channel.get.node.*" } }
       { service: { account: "OUTGRESS_RPC",  subject: "bagel.rpc.outgress.channelpoints.>" } }
       # Loyalty tab reads/manages standings and counters through the same verbs
       # sesame uses.
@@ -569,6 +607,7 @@ accounts: {
       # Govee device picker: the dashboard lists the broadcaster's lights through
       # the gateway (which holds the decrypted key), scoped to just that verb.
       { service: { account: "GATEWAY_RPC",   subject: "bagel.rpc.gateway.govee.devices" } }
+      { service: { account: "GATEWAY_RPC",   subject: "bagel.rpc.gateway.govee.devices.node.*" } }
       { service: { account: "NOTIFICATIONS_RPC", subject: "bagel.rpc.notifications.>" } }
       { service: { account: "TRANSACTIONS_RPC",  subject: "bagel.rpc.transactions.>" } }
       { stream: { account: "USERS_RPC",     subject: "bagel.cache.invalidate.grant" } }
@@ -587,18 +626,30 @@ accounts: {
     users: [ { user: "admin_rpc", password: $NATS_BCRYPT_ADMIN_RPC } ]
     imports: [
       { service: { account: "USERS_RPC",          subject: "bagel.rpc.health.users" } }
+      { service: { account: "USERS_RPC",          subject: "bagel.rpc.health.users.node.*" } }
       { service: { account: "COMMANDS_RPC",       subject: "bagel.rpc.health.commands" } }
+      { service: { account: "COMMANDS_RPC",       subject: "bagel.rpc.health.commands.node.*" } }
       { service: { account: "MODULES_RPC",        subject: "bagel.rpc.health.modules" } }
+      { service: { account: "MODULES_RPC",        subject: "bagel.rpc.health.modules.node.*" } }
       { service: { account: "LOYALTY_RPC",        subject: "bagel.rpc.health.loyalty" } }
+      { service: { account: "LOYALTY_RPC",        subject: "bagel.rpc.health.loyalty.node.*" } }
       { service: { account: "PROJECTOR_RPC",      subject: "bagel.rpc.health.projector" } }
+      { service: { account: "PROJECTOR_RPC",      subject: "bagel.rpc.health.projector.node.*" } }
       { service: { account: "OUTGRESS_RPC",       subject: "bagel.rpc.health.outgress" } }
+      { service: { account: "OUTGRESS_RPC",       subject: "bagel.rpc.health.outgress.node.*" } }
       { service: { account: "TRANSACTIONS_RPC",   subject: "bagel.rpc.health.transactions" } }
+      { service: { account: "TRANSACTIONS_RPC",   subject: "bagel.rpc.health.transactions.node.*" } }
       { service: { account: "NOTIFICATIONS_RPC",  subject: "bagel.rpc.health.notifications" } }
+      { service: { account: "NOTIFICATIONS_RPC",  subject: "bagel.rpc.health.notifications.node.*" } }
       { service: { account: "GATEWAY_RPC",        subject: "bagel.rpc.health.gateway" } }
+      { service: { account: "GATEWAY_RPC",        subject: "bagel.rpc.health.gateway.node.*" } }
       { service: { account: "WORKER_RPC",         subject: "bagel.rpc.health.sesame" } }
+      { service: { account: "WORKER_RPC",         subject: "bagel.rpc.health.sesame.node.*" } }
       { service: { account: "TWITCH_INGRESS_RPC", subject: "bagel.rpc.health.ingress" } }
+      { service: { account: "TWITCH_INGRESS_RPC", subject: "bagel.rpc.health.ingress.node.*" } }
       { service: { account: "USERS_RPC",          subject: "bagel.rpc.admin.user.>" } }
       { service: { account: "OUTGRESS_RPC",       subject: "bagel.rpc.outgress.channel.get" } }
+      { service: { account: "OUTGRESS_RPC",       subject: "bagel.rpc.outgress.channel.get.node.*" } }
       { service: { account: "TWITCH_INGRESS_RPC", subject: "twitch.ingress.admin.shards.>" } }
       { service: { account: "NOTIFICATIONS_RPC",  subject: "bagel.rpc.admin.notifications.>" } }
       { stream: { account: "USERS_RPC", subject: "bagel.cache.invalidate.status" } }
@@ -613,11 +664,14 @@ accounts: {
     users: [ { user: "twitch_ingress_rpc", password: $NATS_BCRYPT_TWITCH_INGRESS_RPC } ]
     exports: [
       { service: "bagel.rpc.health.ingress" }
+      { service: "bagel.rpc.health.ingress.node.*" }
       { service: "twitch.ingress.admin.shards.>" }
       { service: "bagel.rpc.ingress.conduit.get" }
+      { service: "bagel.rpc.ingress.conduit.get.node.*" }
     ]
     imports: [
       { service: { account: "PROJECTOR_RPC", subject: "bagel.rpc.broadcaster.status.get" } }
+      { service: { account: "PROJECTOR_RPC", subject: "bagel.rpc.broadcaster.status.get.node.*" } }
       { stream: { account: "USERS_RPC", subject: "bagel.cache.invalidate.status" } }
     ]
   }

--- a/deploy/k8s/nats-leaf-server.conf
+++ b/deploy/k8s/nats-leaf-server.conf
@@ -68,9 +68,9 @@ lame_duck_duration: "30s"
 #
 # A clustered queue group does not provide responder locality: requests are
 # balanced randomly across interested members and may take a direct
-# leaf-to-leaf hop even when a local responder exists. This topology removes
-# the hub dependency, but gateway/supercluster semantics are required when RPC
-# queues must prefer a same-cluster responder before remote failover.
+# leaf-to-leaf hop even when a local responder exists. Applications therefore
+# publish to a node-qualified RPC subject first and retain the generic queue as
+# their no-responder HA fallback.
 cluster {
   name: "nats-leaf"
   port: 6222

--- a/deploy/k8s/nats_auth_acceptance_test.go
+++ b/deploy/k8s/nats_auth_acceptance_test.go
@@ -68,6 +68,7 @@ func TestScopedBusUsersBindAllowedStreams(t *testing.T) {
 	harness.assertRequiredAckPermissions(t)
 	harness.assertConsumerIsolation(t)
 	harness.assertDestructiveOperationsDenied(t)
+	harness.assertNodeLocalRPCImport(t)
 }
 
 func newAcceptanceHarness(t *testing.T) *acceptanceHarness {
@@ -227,6 +228,41 @@ func (h *acceptanceHarness) assertDestructiveOperationsDenied(t *testing.T) {
 	}
 }
 
+func (h *acceptanceHarness) assertNodeLocalRPCImport(t *testing.T) {
+	t.Helper()
+	const subject = "bagel.rpc.health.users"
+	const localSubject = subject + ".node.node2"
+	const traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+	t.Setenv("NODE_NAME", "node2")
+
+	responder, responderErr := h.connectWithPermissionErrors(t, serviceIdentity{"users_rpc"})
+	defer responder.Close()
+	if _, err := responder.QueueSubscribe(localSubject, "authz-locality", func(msg *nats.Msg) {
+		_ = msg.Respond([]byte("node2:" + msg.Header.Get("traceparent")))
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := responder.Flush(); err != nil {
+		t.Fatal(err)
+	}
+
+	requester, requesterErr := h.connectWithPermissionErrors(t, serviceIdentity{"admin_rpc"})
+	defer requester.Close()
+	request := nats.NewMsg(subject)
+	request.Header.Set("traceparent", traceparent)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	reply, err := bus.RequestMsgWithContext(ctx, requester, request)
+	if err != nil {
+		t.Fatalf("node-qualified cross-account request failed: %v", err)
+	}
+	if want := "node2:" + traceparent; string(reply.Data) != want {
+		t.Fatalf("node-qualified cross-account reply = %q, want %q", reply.Data, want)
+	}
+	assertNoPermissionViolation(t, responderErr, subject)
+	assertNoPermissionViolation(t, requesterErr, subject)
+}
+
 func (h *acceptanceHarness) assertDestructiveOperationsDeniedFor(t *testing.T, identity serviceIdentity) {
 	t.Helper()
 	for _, operation := range []string{"PURGE", "DELETE"} {
@@ -311,5 +347,14 @@ func assertAuthorizationViolation(t *testing.T, expectation violationExpectation
 		}
 	case <-time.After(time.Second):
 		t.Fatalf("no authorization violation reported for forbidden subject %s", expectation.subject)
+	}
+}
+
+func assertNoPermissionViolation(t *testing.T, permissionErr <-chan error, subject string) {
+	t.Helper()
+	select {
+	case err := <-permissionErr:
+		t.Fatalf("unexpected authorization error for %s: %v", subject, err)
+	case <-time.After(25 * time.Millisecond):
 	}
 }

--- a/deploy/k8s/nats_rpc_locality_test.go
+++ b/deploy/k8s/nats_rpc_locality_test.go
@@ -10,6 +10,22 @@ var serviceSubjectPattern = regexp.MustCompile(`\{ service:.*(?:subject: )?"([^"
 
 func TestExactRPCGrantsIncludeNodeLocalVariant(t *testing.T) {
 	config := sourceFile{name: "nats-auth.conf"}.read(t)
+	counts := serviceGrantCounts(config)
+	exact := exactServiceGrants(counts)
+
+	for subject, count := range exact {
+		local := subject + ".node.*"
+		if counts[local] < count {
+			t.Errorf("exact service grant %q occurs %d times; local grant %q occurs %d times",
+				subject, count, local, counts[local])
+		}
+	}
+	if len(exact) < 10 {
+		t.Fatalf("checked only %d exact RPC grants; parser likely stopped matching the config", len(exact))
+	}
+}
+
+func serviceGrantCounts(config string) map[string]int {
 	counts := make(map[string]int)
 	for _, line := range strings.Split(config, "\n") {
 		match := serviceSubjectPattern.FindStringSubmatch(line)
@@ -17,20 +33,15 @@ func TestExactRPCGrantsIncludeNodeLocalVariant(t *testing.T) {
 			counts[match[1]]++
 		}
 	}
+	return counts
+}
 
-	checked := 0
+func exactServiceGrants(counts map[string]int) map[string]int {
+	exact := make(map[string]int)
 	for subject, count := range counts {
-		if strings.HasSuffix(subject, ".>") || strings.HasSuffix(subject, ".node.*") {
-			continue
-		}
-		checked++
-		local := subject + ".node.*"
-		if counts[local] < count {
-			t.Errorf("exact service grant %q occurs %d times; local grant %q occurs %d times",
-				subject, count, local, counts[local])
+		if !strings.HasSuffix(subject, ".>") && !strings.HasSuffix(subject, ".node.*") {
+			exact[subject] = count
 		}
 	}
-	if checked < 10 {
-		t.Fatalf("checked only %d exact RPC grants; parser likely stopped matching the config", checked)
-	}
+	return exact
 }

--- a/deploy/k8s/nats_rpc_locality_test.go
+++ b/deploy/k8s/nats_rpc_locality_test.go
@@ -1,0 +1,36 @@
+package k8s
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+var serviceSubjectPattern = regexp.MustCompile(`\{ service:.*(?:subject: )?"([^"]+)"`)
+
+func TestExactRPCGrantsIncludeNodeLocalVariant(t *testing.T) {
+	config := sourceFile{name: "nats-auth.conf"}.read(t)
+	counts := make(map[string]int)
+	for _, line := range strings.Split(config, "\n") {
+		match := serviceSubjectPattern.FindStringSubmatch(line)
+		if len(match) == 2 {
+			counts[match[1]]++
+		}
+	}
+
+	checked := 0
+	for subject, count := range counts {
+		if strings.HasSuffix(subject, ".>") || strings.HasSuffix(subject, ".node.*") {
+			continue
+		}
+		checked++
+		local := subject + ".node.*"
+		if counts[local] < count {
+			t.Errorf("exact service grant %q occurs %d times; local grant %q occurs %d times",
+				subject, count, local, counts[local])
+		}
+	}
+	if checked < 10 {
+		t.Fatalf("checked only %d exact RPC grants; parser likely stopped matching the config", checked)
+	}
+}

--- a/deploy/k8s/notifications.yaml
+++ b/deploy/k8s/notifications.yaml
@@ -209,6 +209,10 @@ spec:
               imagePullPolicy: IfNotPresent
               args: ["cleanup"]
               env:
+                - name: NODE_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: spec.nodeName
                 - name: NATS_URL
                   value: nats://nats:4222
                 - name: NATS_RPC_URL

--- a/pkg/bus/health_rpc.go
+++ b/pkg/bus/health_rpc.go
@@ -42,7 +42,7 @@ func SubscribeRPCHealth(nc *nats.Conn, service, queueGroup string) error {
 	}
 
 	subject := RPCHealthSubject(service)
-	if _, err := nc.QueueSubscribe(subject, queueGroup, func(msg *nats.Msg) {
+	if err := QueueSubscribeRPC(nc, subject, queueGroup, func(msg *nats.Msg) {
 		_ = msg.Respond(reply)
 	}); err != nil {
 		return fmt.Errorf("subscribe %s: %w", subject, err)

--- a/pkg/bus/rpc.go
+++ b/pkg/bus/rpc.go
@@ -50,7 +50,7 @@ func RequestJSON[T any](ctx context.Context, nc *nats.Conn, subject string, requ
 	segment := startMessagingSegment(ctx, messagingSpan{
 		name: "nats.request", operation: "request", destination: subject,
 	})
-	msg, err := nc.RequestMsgWithContext(ctx, requestMsg)
+	msg, err := RequestMsgWithContext(ctx, nc, requestMsg)
 	endMessagingSegment(segment, err)
 	if err != nil {
 		return zero, fmt.Errorf("rpc %s request: %w", subject, err)
@@ -97,7 +97,7 @@ func QueueSubscribeJSON[Req any, Resp any](
 		timeout = defaultRPCTimeout
 	}
 
-	_, err := nc.QueueSubscribe(subject, queueGroup, func(msg *nats.Msg) {
+	err := QueueSubscribeRPC(nc, subject, queueGroup, func(msg *nats.Msg) {
 		start := time.Now()
 
 		txn := app.StartTransaction("rpc " + normalizedDestination(subject))

--- a/pkg/bus/rpc_locality.go
+++ b/pkg/bus/rpc_locality.go
@@ -1,0 +1,90 @@
+package bus
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"unicode"
+
+	"github.com/nats-io/nats.go"
+)
+
+const rpcNodeToken = "node"
+
+// rpcSubscriptionSubjects returns the stable HA subject followed by this pod's
+// node-local subject. Local development and invalid node names retain the
+// generic subject only.
+func rpcSubscriptionSubjects(subject string) []string {
+	return rpcSubjectsForNode(subject, os.Getenv("NODE_NAME"))
+}
+
+func rpcRequestSubjects(subject string) []string {
+	subjects := rpcSubscriptionSubjects(subject)
+	if len(subjects) == 1 {
+		return subjects
+	}
+	return []string{subjects[1], subjects[0]}
+}
+
+func rpcSubjectsForNode(subject, node string) []string {
+	if !validSubjectToken(node) {
+		return []string{subject}
+	}
+	return []string{subject, subject + "." + rpcNodeToken + "." + node}
+}
+
+func validSubjectToken(token string) bool {
+	return token != "" && !strings.ContainsAny(token, ".*> ") &&
+		!strings.ContainsFunc(token, unicode.IsSpace)
+}
+
+// RequestWithContext targets the same-node responder first and falls back to
+// the generic queue only when NATS proves that no local responder exists.
+func RequestWithContext(ctx context.Context, nc *nats.Conn, subject string, data []byte) (*nats.Msg, error) {
+	return requestLocalFirst(rpcRequestSubjects(subject), func(routedSubject string) (*nats.Msg, error) {
+		return nc.RequestWithContext(ctx, routedSubject, data)
+	})
+}
+
+// RequestMsgWithContext is the header-preserving form used by traced RPCs. It
+// does not retry timeouts or connection errors because the request may already
+// have executed and replaying a mutation could apply it twice.
+func RequestMsgWithContext(ctx context.Context, nc *nats.Conn, msg *nats.Msg) (*nats.Msg, error) {
+	return requestLocalFirst(rpcRequestSubjects(msg.Subject), func(routedSubject string) (*nats.Msg, error) {
+		routed := nats.NewMsg(routedSubject)
+		routed.Data = msg.Data
+		routed.Header = msg.Header
+		return nc.RequestMsgWithContext(ctx, routed)
+	})
+}
+
+func requestLocalFirst(subjects []string, request func(string) (*nats.Msg, error)) (*nats.Msg, error) {
+	for i, subject := range subjects {
+		msg, err := request(subject)
+		if err == nil {
+			return msg, nil
+		}
+		if i == len(subjects)-1 || !errors.Is(err, nats.ErrNoResponders) {
+			return nil, err
+		}
+	}
+	return nil, nats.ErrNoResponders
+}
+
+// QueueSubscribeRPC registers the generic HA subject and the node-qualified
+// local subject with the same handler. A partial registration is rolled back.
+func QueueSubscribeRPC(nc *nats.Conn, subject, queueGroup string, handler nats.MsgHandler) error {
+	var subscriptions []*nats.Subscription
+	for _, routedSubject := range rpcSubscriptionSubjects(subject) {
+		sub, err := nc.QueueSubscribe(routedSubject, queueGroup, handler)
+		if err != nil {
+			for _, registered := range subscriptions {
+				_ = registered.Unsubscribe()
+			}
+			return err
+		}
+		subscriptions = append(subscriptions, sub)
+	}
+	return nil
+}

--- a/pkg/bus/rpc_locality.go
+++ b/pkg/bus/rpc_locality.go
@@ -12,14 +12,17 @@ import (
 
 const rpcNodeToken = "node"
 
+type rpcSubject string
+type rpcNodeName string
+
 // rpcSubscriptionSubjects returns the stable HA subject followed by this pod's
 // node-local subject. Local development and invalid node names retain the
 // generic subject only.
-func rpcSubscriptionSubjects(subject string) []string {
-	return rpcSubjectsForNode(subject, os.Getenv("NODE_NAME"))
+func rpcSubscriptionSubjects(subject rpcSubject) []string {
+	return rpcSubjectsForNode(subject, rpcNodeName(os.Getenv("NODE_NAME")))
 }
 
-func rpcRequestSubjects(subject string) []string {
+func rpcRequestSubjects(subject rpcSubject) []string {
 	subjects := rpcSubscriptionSubjects(subject)
 	if len(subjects) == 1 {
 		return subjects
@@ -27,22 +30,23 @@ func rpcRequestSubjects(subject string) []string {
 	return []string{subjects[1], subjects[0]}
 }
 
-func rpcSubjectsForNode(subject, node string) []string {
+func rpcSubjectsForNode(subject rpcSubject, node rpcNodeName) []string {
 	if !validSubjectToken(node) {
-		return []string{subject}
+		return []string{string(subject)}
 	}
-	return []string{subject, subject + "." + rpcNodeToken + "." + node}
+	return []string{string(subject), string(subject) + "." + rpcNodeToken + "." + string(node)}
 }
 
-func validSubjectToken(token string) bool {
-	return token != "" && !strings.ContainsAny(token, ".*> ") &&
-		!strings.ContainsFunc(token, unicode.IsSpace)
+func validSubjectToken(token rpcNodeName) bool {
+	value := string(token)
+	return value != "" && !strings.ContainsAny(value, ".*> ") &&
+		!strings.ContainsFunc(value, unicode.IsSpace)
 }
 
 // RequestWithContext targets the same-node responder first and falls back to
 // the generic queue only when NATS proves that no local responder exists.
 func RequestWithContext(ctx context.Context, nc *nats.Conn, subject string, data []byte) (*nats.Msg, error) {
-	return requestLocalFirst(rpcRequestSubjects(subject), func(routedSubject string) (*nats.Msg, error) {
+	return requestLocalFirst(rpcRequestSubjects(rpcSubject(subject)), func(routedSubject string) (*nats.Msg, error) {
 		return nc.RequestWithContext(ctx, routedSubject, data)
 	})
 }
@@ -51,7 +55,7 @@ func RequestWithContext(ctx context.Context, nc *nats.Conn, subject string, data
 // does not retry timeouts or connection errors because the request may already
 // have executed and replaying a mutation could apply it twice.
 func RequestMsgWithContext(ctx context.Context, nc *nats.Conn, msg *nats.Msg) (*nats.Msg, error) {
-	return requestLocalFirst(rpcRequestSubjects(msg.Subject), func(routedSubject string) (*nats.Msg, error) {
+	return requestLocalFirst(rpcRequestSubjects(rpcSubject(msg.Subject)), func(routedSubject string) (*nats.Msg, error) {
 		routed := nats.NewMsg(routedSubject)
 		routed.Data = msg.Data
 		routed.Header = msg.Header
@@ -76,7 +80,7 @@ func requestLocalFirst(subjects []string, request func(string) (*nats.Msg, error
 // local subject with the same handler. A partial registration is rolled back.
 func QueueSubscribeRPC(nc *nats.Conn, subject, queueGroup string, handler nats.MsgHandler) error {
 	var subscriptions []*nats.Subscription
-	for _, routedSubject := range rpcSubscriptionSubjects(subject) {
+	for _, routedSubject := range rpcSubscriptionSubjects(rpcSubject(subject)) {
 		sub, err := nc.QueueSubscribe(routedSubject, queueGroup, handler)
 		if err != nil {
 			for _, registered := range subscriptions {

--- a/pkg/bus/rpc_locality_test.go
+++ b/pkg/bus/rpc_locality_test.go
@@ -1,0 +1,75 @@
+package bus
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/nats-io/nats.go"
+)
+
+func TestRPCSubjectsForNode(t *testing.T) {
+	tests := []struct {
+		name string
+		node string
+		want []string
+	}{
+		{name: "production node", node: "node2", want: []string{"bagel.rpc.users.get", "bagel.rpc.users.get.node.node2"}},
+		{name: "worker node", node: "worker-1", want: []string{"bagel.rpc.users.get", "bagel.rpc.users.get.node.worker-1"}},
+		{name: "local development", want: []string{"bagel.rpc.users.get"}},
+		{name: "multi token rejected", node: "zone.node2", want: []string{"bagel.rpc.users.get"}},
+		{name: "wildcard rejected", node: "node*", want: []string{"bagel.rpc.users.get"}},
+		{name: "whitespace rejected", node: "node 2", want: []string{"bagel.rpc.users.get"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := rpcSubjectsForNode("bagel.rpc.users.get", tt.node); !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("rpcSubjectsForNode() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRPCRequestSubjectsAreLocalFirst(t *testing.T) {
+	t.Setenv("NODE_NAME", "node2")
+	want := []string{"bagel.rpc.users.get.node.node2", "bagel.rpc.users.get"}
+	if got := rpcRequestSubjects("bagel.rpc.users.get"); !reflect.DeepEqual(got, want) {
+		t.Fatalf("rpcRequestSubjects() = %v, want %v", got, want)
+	}
+}
+
+func TestRequestLocalFirstFallsBackOnlyWithoutResponders(t *testing.T) {
+	local := "bagel.rpc.users.get.node.node2"
+	generic := "bagel.rpc.users.get"
+	var called []string
+	request := func(subject string) (*nats.Msg, error) {
+		called = append(called, subject)
+		if subject == local {
+			return nil, nats.ErrNoResponders
+		}
+		return &nats.Msg{Subject: generic}, nil
+	}
+
+	msg, err := requestLocalFirst([]string{local, generic}, request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if msg.Subject != generic || !reflect.DeepEqual(called, []string{local, generic}) {
+		t.Fatalf("fallback result = (%q, %v)", msg.Subject, called)
+	}
+}
+
+func TestRequestLocalFirstDoesNotReplayAmbiguousFailure(t *testing.T) {
+	want := errors.New("timeout after delivery")
+	called := 0
+	request := func(string) (*nats.Msg, error) {
+		called++
+		return nil, want
+	}
+
+	_, err := requestLocalFirst([]string{"rpc.write.node.node2", "rpc.write"}, request)
+	if !errors.Is(err, want) || called != 1 {
+		t.Fatalf("requestLocalFirst() = (%v, %d calls), want original error and one call", err, called)
+	}
+}

--- a/pkg/bus/rpc_locality_test.go
+++ b/pkg/bus/rpc_locality_test.go
@@ -24,7 +24,7 @@ func TestRPCSubjectsForNode(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := rpcSubjectsForNode("bagel.rpc.users.get", tt.node); !reflect.DeepEqual(got, tt.want) {
+			if got := rpcSubjectsForNode(rpcSubject("bagel.rpc.users.get"), rpcNodeName(tt.node)); !reflect.DeepEqual(got, tt.want) {
 				t.Fatalf("rpcSubjectsForNode() = %v, want %v", got, tt.want)
 			}
 		})
@@ -34,7 +34,7 @@ func TestRPCSubjectsForNode(t *testing.T) {
 func TestRPCRequestSubjectsAreLocalFirst(t *testing.T) {
 	t.Setenv("NODE_NAME", "node2")
 	want := []string{"bagel.rpc.users.get.node.node2", "bagel.rpc.users.get"}
-	if got := rpcRequestSubjects("bagel.rpc.users.get"); !reflect.DeepEqual(got, want) {
+	if got := rpcRequestSubjects(rpcSubject("bagel.rpc.users.get")); !reflect.DeepEqual(got, want) {
 		t.Fatalf("rpcRequestSubjects() = %v, want %v", got, want)
 	}
 }


### PR DESCRIPTION
## What changed

- route Core NATS RPC requests to a node-qualified subject before the canonical queue
- register responders on both node-qualified and canonical subjects across Go and Elixir
- preserve the canonical queue as the permanent HA path and retry it only on `no responders`
- add the required exact `.node.*` service imports/exports and enforce parity in tests
- extend the NATS authorization smoke test through a real cross-account local RPC

## Why

The leaf tier is a standard Core NATS route cluster. Queue members are selected across local and routed subscriptions, so requests from the admin console were frequently sent to another node even when a local responder existed. The worker route added roughly 4–12 ms and pushed the dashboard health burst above 10 ms.

Node-qualified subjects keep the healthy path on the same node. The canonical subject remains available when a node has no responder, preserving HA and mixed-version rollout compatibility. Timeouts and transport failures are not replayed because a mutating RPC may already have executed.

## Validation

- `GOCACHE=/private/tmp/itsbagelbot-go-build-cache go test ./...`
- `mix test` — 148 tests
- Bun locality and existing failback tests — 8 tests
- admin and dashboard `svelte-check`
- NATS Server 2.14.3 configuration parse
- live `admin_rpc` → `users_rpc` node-qualified authorization smoke, including trace-header preservation

## Rollout

Apply the additive `nats-auth.conf` update before rolling application workloads. Old and new callers/responders remain compatible through the canonical queue.
