### PR TITLE
fix(outgress): notify chat when clip never publishes

### DIFF
--- a/app/outgress/internal/worker/clip.go
+++ b/app/outgress/internal/worker/clip.go
@@ -48,6 +48,10 @@ type clipCreateReply struct {
 // public slug, and Get Clips reports exactly that link once processing
 // finishes, so polling it first only delayed the reply by seconds while
 // pinning a lane routine — the link resolves the moment Twitch publishes.
+// Create Clip is async, though, and a clip can die in processing AFTER the
+// 2xx, leaving the posted link permanently dead with no error to us. A
+// detached background check (scheduleClipVerify) polls Get Clips past the
+// publication window and posts a follow-up notice on confirmed absence.
 //
 // Redelivery safety: once the clip is created (2xx) this returns nil no matter
 // what happens to the reply — re-running the message would create a DUPLICATE
@@ -127,7 +131,8 @@ func (w *Worker) clipCreated(ctx context.Context, broadcasterID string, res *htt
 
 // replyWithClip reads the created clip's id off the response and posts the
 // public URL back to chat. The clip already exists, so failures here only
-// log; the caller acks regardless.
+// log; the caller acks regardless. A posted reply also arms the background
+// publication check: only then is there a link in chat that could go dead.
 func (w *Worker) replyWithClip(ctx context.Context, broadcasterID string, meta clipMeta, res *http.Response) {
 	id, err := clipID(res.Body)
 	if err != nil || id == "" {
@@ -140,7 +145,9 @@ func (w *Worker) replyWithClip(ctx context.Context, broadcasterID string, meta c
 	if err := w.sendClipReply(ctx, broadcasterID, meta, clipURL); err != nil {
 		w.log.Warn("clip created but reply chat failed",
 			zap.String("broadcaster_id", broadcasterID), zap.Error(err))
+		return
 	}
+	w.scheduleClipVerify(broadcasterID, meta.Clipper, id)
 }
 
 // clipID decodes the Create Clip response body and returns the new clip's id

--- a/app/outgress/internal/worker/clip_verify.go
+++ b/app/outgress/internal/worker/clip_verify.go
@@ -1,0 +1,128 @@
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	"ItsBagelBot/app/outgress/internal/twitch"
+	"ItsBagelBot/internal/domain/outgress"
+
+	"go.uber.org/zap"
+)
+
+// Create Clip acks before processing finishes, and a clip can die in
+// processing after the 2xx: the posted link is then permanently dead and
+// Twitch sends no error. Twitch's own guidance is to poll Get Clips and treat
+// a clip that has not appeared within ~15 seconds of creation as failed. The
+// chat reply has already been posted by then, so the check runs detached from
+// the lane and only speaks up on confirmed absence.
+const (
+	clipVerifyDelay   = 16 * time.Second // first Get Clips poll, past Twitch's 15s window
+	clipVerifyRecheck = 5 * time.Second  // gap before the confirming re-poll
+	clipVerifyTimeout = 30 * time.Second // hard bound on one whole background check
+	// clipVerifySlots bounds the in-flight checks per lane worker. Clips are
+	// throttled to one per channel per 15s and a check lives under 30s, so the
+	// bound only trips under abnormal load — and tripping merely skips the
+	// failure notice, never the clip or its reply.
+	clipVerifySlots = 16
+)
+
+// scheduleClipVerify starts the background publication check for a clip whose
+// URL was just posted to chat. Detached from the lane context on purpose: the
+// lane acked the message when the clip was created, and holding a lane routine
+// through the publication window is exactly what processClip avoids.
+func (w *Worker) scheduleClipVerify(broadcasterID, clipper, clipID string) {
+	select {
+	case w.clipVerify <- struct{}{}:
+	default:
+		w.log.Warn("clip verify skipped: checks saturated",
+			zap.String("broadcaster_id", broadcasterID), zap.String("clip_id", clipID))
+		return
+	}
+	go func() {
+		defer func() { <-w.clipVerify }()
+		ctx, cancel := context.WithTimeout(context.Background(), clipVerifyTimeout)
+		defer cancel()
+		w.verifyClipPublished(ctx, broadcasterID, clipper, clipID)
+	}()
+}
+
+// verifyClipPublished waits out Twitch's publication window and posts the
+// failure notice if the clip is confirmed absent. A live clip needs no action:
+// the link already posted is the final link.
+func (w *Worker) verifyClipPublished(ctx context.Context, broadcasterID, clipper, clipID string) {
+	if !w.clipConfirmedAbsent(ctx, broadcasterID, clipID, clipVerifyDelay, clipVerifyRecheck) {
+		return
+	}
+	w.log.Warn("clip never published; posting failure notice",
+		zap.String("broadcaster_id", broadcasterID), zap.String("clip_id", clipID))
+	if err := w.sendBotChat(ctx, broadcasterID, clipFailedText(clipper)); err != nil {
+		w.log.Warn("clip failure notice not sent",
+			zap.String("broadcaster_id", broadcasterID), zap.Error(err))
+	}
+}
+
+// clipConfirmedAbsent reports whether Get Clips cleanly said "no such clip" on
+// two polls past the publication window. Absence must be proven twice so one
+// slow publish or read blip cannot fabricate a failure notice for a clip that
+// is actually fine; anything indeterminate stays silent.
+func (w *Worker) clipConfirmedAbsent(ctx context.Context, broadcasterID, clipID string, first, recheck time.Duration) bool {
+	return w.clipAbsentAfter(ctx, broadcasterID, clipID, first) &&
+		w.clipAbsentAfter(ctx, broadcasterID, clipID, recheck)
+}
+
+// clipAbsentAfter sleeps, then reports whether one clean Get Clips lookup said
+// the clip does not exist. Any error (denied bucket, transport, non-200,
+// context end) counts as "not absent": only proven absence may notify.
+func (w *Worker) clipAbsentAfter(ctx context.Context, broadcasterID, clipID string, wait time.Duration) bool {
+	if !sleepCtx(ctx, wait) {
+		return false
+	}
+	absent, err := w.clipAbsent(ctx, broadcasterID, clipID)
+	if err != nil {
+		w.log.Warn("clip verify poll failed; staying silent",
+			zap.String("broadcaster_id", broadcasterID),
+			zap.String("clip_id", clipID), zap.Error(err))
+		return false
+	}
+	return absent
+}
+
+// clipAbsent performs one Get Clips lookup by id under the app token, paying
+// the app Helix bucket like any other read. (true, nil) means a clean 200
+// whose data carries no clip — Twitch does not know the id.
+func (w *Worker) clipAbsent(ctx context.Context, broadcasterID, clipID string) (bool, error) {
+	if err := w.takeGeneralHelix(ctx, &outgress.Message{As: outgress.AsApp}); err != nil {
+		return false, err
+	}
+	res, err := w.callTwitch(ctx, twitch.IdentityApp, broadcasterID,
+		twitch.HelixCall{Method: http.MethodGet, Endpoint: "/helix/clips?id=" + url.QueryEscape(clipID)})
+	if err != nil {
+		return false, err
+	}
+	defer drainResponse(res)
+	if res.StatusCode != http.StatusOK {
+		return false, fmt.Errorf("get clips: %d", res.StatusCode)
+	}
+	var reply clipCreateReply
+	if err := json.NewDecoder(io.LimitReader(res.Body, 4096)).Decode(&reply); err != nil {
+		return false, err
+	}
+	return len(reply.Data) == 0, nil
+}
+
+// clipFailedText composes the follow-up chat line for a clip Twitch acked but
+// never published. It names the clipper when known, so they see why their link
+// is dead and know a retry is worth it.
+func clipFailedText(clipper string) string {
+	notice := "the clip didn't make it through Twitch's processing, so the link won't work. Try !clip again."
+	if clipper == "" {
+		return "Heads up: " + notice
+	}
+	return "@" + clipper + " " + notice
+}

--- a/app/outgress/internal/worker/clip_verify.go
+++ b/app/outgress/internal/worker/clip_verify.go
@@ -37,6 +37,7 @@ const (
 // lane acked the message when the clip was created, and holding a lane routine
 // through the publication window is exactly what processClip avoids.
 func (w *Worker) scheduleClipVerify(broadcasterID, clipper, clipID string) {
+	probe := clipProbe{broadcasterID: broadcasterID, clipper: clipper, clipID: clipID}
 	select {
 	case w.clipVerify <- struct{}{}:
 	default:
@@ -48,22 +49,30 @@ func (w *Worker) scheduleClipVerify(broadcasterID, clipper, clipID string) {
 		defer func() { <-w.clipVerify }()
 		ctx, cancel := context.WithTimeout(context.Background(), clipVerifyTimeout)
 		defer cancel()
-		w.verifyClipPublished(ctx, broadcasterID, clipper, clipID)
+		w.verifyClipPublished(ctx, probe)
 	}()
+}
+
+// clipProbe identifies one background publication check: which clip to look
+// for, whose channel to notify, and whom to name in the notice.
+type clipProbe struct {
+	broadcasterID string
+	clipper       string
+	clipID        string
 }
 
 // verifyClipPublished waits out Twitch's publication window and posts the
 // failure notice if the clip is confirmed absent. A live clip needs no action:
 // the link already posted is the final link.
-func (w *Worker) verifyClipPublished(ctx context.Context, broadcasterID, clipper, clipID string) {
-	if !w.clipConfirmedAbsent(ctx, broadcasterID, clipID, clipVerifyDelay, clipVerifyRecheck) {
+func (w *Worker) verifyClipPublished(ctx context.Context, probe clipProbe) {
+	if !w.clipConfirmedAbsent(ctx, probe, clipVerifyDelay, clipVerifyRecheck) {
 		return
 	}
 	w.log.Warn("clip never published; posting failure notice",
-		zap.String("broadcaster_id", broadcasterID), zap.String("clip_id", clipID))
-	if err := w.sendBotChat(ctx, broadcasterID, clipFailedText(clipper)); err != nil {
+		zap.String("broadcaster_id", probe.broadcasterID), zap.String("clip_id", probe.clipID))
+	if err := w.sendBotChat(ctx, probe.broadcasterID, clipFailedText(probe.clipper)); err != nil {
 		w.log.Warn("clip failure notice not sent",
-			zap.String("broadcaster_id", broadcasterID), zap.Error(err))
+			zap.String("broadcaster_id", probe.broadcasterID), zap.Error(err))
 	}
 }
 
@@ -71,23 +80,23 @@ func (w *Worker) verifyClipPublished(ctx context.Context, broadcasterID, clipper
 // two polls past the publication window. Absence must be proven twice so one
 // slow publish or read blip cannot fabricate a failure notice for a clip that
 // is actually fine; anything indeterminate stays silent.
-func (w *Worker) clipConfirmedAbsent(ctx context.Context, broadcasterID, clipID string, first, recheck time.Duration) bool {
-	return w.clipAbsentAfter(ctx, broadcasterID, clipID, first) &&
-		w.clipAbsentAfter(ctx, broadcasterID, clipID, recheck)
+func (w *Worker) clipConfirmedAbsent(ctx context.Context, probe clipProbe, first, recheck time.Duration) bool {
+	return w.clipAbsentAfter(ctx, probe, first) &&
+		w.clipAbsentAfter(ctx, probe, recheck)
 }
 
 // clipAbsentAfter sleeps, then reports whether one clean Get Clips lookup said
 // the clip does not exist. Any error (denied bucket, transport, non-200,
 // context end) counts as "not absent": only proven absence may notify.
-func (w *Worker) clipAbsentAfter(ctx context.Context, broadcasterID, clipID string, wait time.Duration) bool {
+func (w *Worker) clipAbsentAfter(ctx context.Context, probe clipProbe, wait time.Duration) bool {
 	if !sleepCtx(ctx, wait) {
 		return false
 	}
-	absent, err := w.clipAbsent(ctx, broadcasterID, clipID)
+	absent, err := w.clipAbsent(ctx, probe)
 	if err != nil {
 		w.log.Warn("clip verify poll failed; staying silent",
-			zap.String("broadcaster_id", broadcasterID),
-			zap.String("clip_id", clipID), zap.Error(err))
+			zap.String("broadcaster_id", probe.broadcasterID),
+			zap.String("clip_id", probe.clipID), zap.Error(err))
 		return false
 	}
 	return absent
@@ -96,12 +105,12 @@ func (w *Worker) clipAbsentAfter(ctx context.Context, broadcasterID, clipID stri
 // clipAbsent performs one Get Clips lookup by id under the app token, paying
 // the app Helix bucket like any other read. (true, nil) means a clean 200
 // whose data carries no clip — Twitch does not know the id.
-func (w *Worker) clipAbsent(ctx context.Context, broadcasterID, clipID string) (bool, error) {
+func (w *Worker) clipAbsent(ctx context.Context, probe clipProbe) (bool, error) {
 	if err := w.takeGeneralHelix(ctx, &outgress.Message{As: outgress.AsApp}); err != nil {
 		return false, err
 	}
-	res, err := w.callTwitch(ctx, twitch.IdentityApp, broadcasterID,
-		twitch.HelixCall{Method: http.MethodGet, Endpoint: "/helix/clips?id=" + url.QueryEscape(clipID)})
+	res, err := w.callTwitch(ctx, twitch.IdentityApp, probe.broadcasterID,
+		twitch.HelixCall{Method: http.MethodGet, Endpoint: "/helix/clips?id=" + url.QueryEscape(probe.clipID)})
 	if err != nil {
 		return false, err
 	}

--- a/app/outgress/internal/worker/clip_verify_test.go
+++ b/app/outgress/internal/worker/clip_verify_test.go
@@ -102,7 +102,7 @@ func TestClipConfirmedAbsent(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			rt := &scriptedTransport{responses: tc.responses}
 			w := clipVerifyWorker(t, rt)
-			got := w.clipConfirmedAbsent(context.Background(), "123", "AbCdEf", 0, 0)
+			got := w.clipConfirmedAbsent(context.Background(), clipProbe{broadcasterID: "123", clipID: "AbCdEf"}, 0, 0)
 			if got != tc.want {
 				t.Errorf("clipConfirmedAbsent = %v, want %v", got, tc.want)
 			}
@@ -119,7 +119,7 @@ func TestClipConfirmedAbsentCanceledContextStaysSilent(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	// Non-zero waits so the done context, not the expired timer, wins the select.
-	if w.clipConfirmedAbsent(ctx, "123", "AbCdEf", clipVerifyDelay, clipVerifyRecheck) {
+	if w.clipConfirmedAbsent(ctx, clipProbe{broadcasterID: "123", clipID: "AbCdEf"}, clipVerifyDelay, clipVerifyRecheck) {
 		t.Error("clipConfirmedAbsent = true on canceled context")
 	}
 	if rt.callCount() != 0 {

--- a/app/outgress/internal/worker/clip_verify_test.go
+++ b/app/outgress/internal/worker/clip_verify_test.go
@@ -1,0 +1,137 @@
+package worker
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+
+	"ItsBagelBot/app/outgress/internal/twitch"
+
+	"go.uber.org/zap"
+)
+
+// scriptedTransport serves one canned response per call, in order, and counts
+// the calls so tests can assert how many polls actually went out.
+type scriptedTransport struct {
+	mu        sync.Mutex
+	responses []scriptedResponse
+	calls     int
+}
+
+type scriptedResponse struct {
+	status int
+	body   string
+}
+
+func (t *scriptedTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.calls >= len(t.responses) {
+		panic("scriptedTransport: more calls than scripted responses")
+	}
+	r := t.responses[t.calls]
+	t.calls++
+	return &http.Response{
+		StatusCode: r.status,
+		Body:       io.NopCloser(strings.NewReader(r.body)),
+	}, nil
+}
+
+func (t *scriptedTransport) callCount() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.calls
+}
+
+func clipVerifyWorker(t *testing.T, rt http.RoundTripper) *Worker {
+	t.Helper()
+	tw := twitch.NewClient("test-client-id",
+		twitch.NewStaticTokenSource("app-token"),
+		twitch.NewStaticTokenSource("bot-token"), nil)
+	tw.SetTransport(rt)
+	return New(Config{Log: zap.NewNop(), Limiter: allowAll{}, Twitch: tw})
+}
+
+const (
+	clipFoundBody = `{"data":[{"id":"AbCdEf"}]}`
+	clipEmptyBody = `{"data":[]}`
+)
+
+func TestClipConfirmedAbsent(t *testing.T) {
+	cases := []struct {
+		name      string
+		responses []scriptedResponse
+		want      bool
+		wantCalls int
+	}{
+		{
+			name: "absent twice confirms",
+			responses: []scriptedResponse{
+				{http.StatusOK, clipEmptyBody},
+				{http.StatusOK, clipEmptyBody},
+			},
+			want:      true,
+			wantCalls: 2,
+		},
+		{
+			name: "late publish on recheck stays silent",
+			responses: []scriptedResponse{
+				{http.StatusOK, clipEmptyBody},
+				{http.StatusOK, clipFoundBody},
+			},
+			want:      false,
+			wantCalls: 2,
+		},
+		{
+			name:      "found on first poll stops",
+			responses: []scriptedResponse{{http.StatusOK, clipFoundBody}},
+			want:      false,
+			wantCalls: 1,
+		},
+		{
+			name:      "non-200 is indeterminate",
+			responses: []scriptedResponse{{http.StatusServiceUnavailable, ""}},
+			want:      false,
+			wantCalls: 1,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rt := &scriptedTransport{responses: tc.responses}
+			w := clipVerifyWorker(t, rt)
+			got := w.clipConfirmedAbsent(context.Background(), "123", "AbCdEf", 0, 0)
+			if got != tc.want {
+				t.Errorf("clipConfirmedAbsent = %v, want %v", got, tc.want)
+			}
+			if rt.callCount() != tc.wantCalls {
+				t.Errorf("polls = %d, want %d", rt.callCount(), tc.wantCalls)
+			}
+		})
+	}
+}
+
+func TestClipConfirmedAbsentCanceledContextStaysSilent(t *testing.T) {
+	rt := &scriptedTransport{}
+	w := clipVerifyWorker(t, rt)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	// Non-zero waits so the done context, not the expired timer, wins the select.
+	if w.clipConfirmedAbsent(ctx, "123", "AbCdEf", clipVerifyDelay, clipVerifyRecheck) {
+		t.Error("clipConfirmedAbsent = true on canceled context")
+	}
+	if rt.callCount() != 0 {
+		t.Errorf("polls = %d, want 0", rt.callCount())
+	}
+}
+
+func TestClipFailedText(t *testing.T) {
+	if got := clipFailedText("viewer"); !strings.HasPrefix(got, "@viewer ") {
+		t.Errorf("clipFailedText with clipper = %q, want @viewer mention", got)
+	}
+	if got := clipFailedText(""); !strings.HasPrefix(got, "Heads up: ") {
+		t.Errorf("clipFailedText without clipper = %q, want generic line", got)
+	}
+}

--- a/app/outgress/internal/worker/worker.go
+++ b/app/outgress/internal/worker/worker.go
@@ -100,6 +100,10 @@ type Worker struct {
 	// interface exists so the marker's transition logic is testable without
 	// Valkey. Nil when no registry is configured, which disables the marker.
 	grants grantRegistry
+	// clipVerify bounds the in-flight background clip publication checks (see
+	// scheduleClipVerify). A full channel skips the check instead of queueing:
+	// the clip and its reply are unaffected, only the failure notice is lost.
+	clipVerify chan struct{}
 }
 
 // Config wires one lane worker's collaborators.
@@ -133,17 +137,18 @@ func New(cfg Config) *Worker {
 		grants = cfg.Registry
 	}
 	w := &Worker{
-		grants:   grants,
-		log:      cfg.Log,
-		limiter:  cfg.Limiter,
-		registry: cfg.Registry,
-		twitch:   cfg.Twitch,
-		botID:    cfg.BotID,
-		owner:    cfg.Owner,
-		conduit:  cfg.Conduit,
-		lane:     cfg.Lane,
-		batch:    cfg.Batch,
-		userIDs:  userIDs,
+		grants:     grants,
+		log:        cfg.Log,
+		limiter:    cfg.Limiter,
+		registry:   cfg.Registry,
+		twitch:     cfg.Twitch,
+		botID:      cfg.BotID,
+		owner:      cfg.Owner,
+		conduit:    cfg.Conduit,
+		lane:       cfg.Lane,
+		batch:      cfg.Batch,
+		userIDs:    userIDs,
+		clipVerify: make(chan struct{}, clipVerifySlots),
 	}
 	// Handlers capture w by method value, so late-attached collaborators
 	// (SetModVerifier, SetReauthNotifier, SetLiveWriter) are still seen.


### PR DESCRIPTION
Create Clip acks before processing finishes; a clip dying after the 2xx left a permanently dead link in chat with no signal (seen live: `ApatheticImpartialAdminRitzMitz-lxEzj72i2rtBUomb`).

- Reply still posts instantly after create; behavior unchanged on success.
- New detached background check polls Get Clips at 16s (past Twitch's 15s publication window) and re-polls at +5s; a follow-up chat notice posts only on twice-confirmed absence, naming the clipper.
- Anything indeterminate (429, 5xx, transport, denied bucket, context end) stays silent, so a live clip can never be flagged.
- Bounded: 16 in-flight checks per lane worker, 30s hard timeout, saturated semaphore skips the check (loses only the notice). Polls pay the app Helix bucket like any other read.