### PR TITLE
chore(deploy): drop linkerd leftovers and stale node1 references

### DIFF
--- a/app/ingress/README.md
+++ b/app/ingress/README.md
@@ -74,7 +74,7 @@ to standard.
 | `NEW_RELIC_APP_NAME`                | New Relic application name.                                    | `itsbagelbot-twitch-ingress`                  |
 | `NATS_BROADCASTER_STATUS_SUBJECT`   | Request-reply subject for broadcaster status.                  | `bagel.rpc.broadcaster.status.get`            |
 | `BROADCASTER_STATUS_TIMEOUT_MS`     | RPC timeout.                                                   | `2000`                                        |
-| `NATS_CACHE_INVALIDATION_SUBJECT`   | Cache invalidation subject the ingress subscribes to.          | `bagel.cache.invalidate.broadcaster`          |
+| `NATS_CACHE_INVALIDATION_SUBJECT`   | Cache invalidation subject the ingress subscribes to.          | `bagel.cache.invalidate.status`               |
 | `BROADCASTER_CACHE_TTL_SECONDS`     | Status cache TTL.                                              | `300`                                         |
 | `INGRESS_SQUASH_PARTITIONS`         | Independent duplicate-cohort owners.                           | Online scheduler count                        |
 | `INGRESS_DISPATCHER_MAX_RUNNING`    | Fixed direct-dispatch worker count.                             | `512`                                         |

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -13,7 +13,7 @@ deploy/
 │
 ├── infra/      Cluster infrastructure. One subdir per Flux Kustomization, kept
 │               separate because each targets its own namespace / wait policy:
-│   ├── cluster/    Cross-namespace infra: cloudflared, traefik, linkerd,
+│   ├── cluster/    Cross-namespace infra: cloudflared, traefik, coredns,
 │   │               newrelic.            → "cluster" Kustomization  (wait: false)
 │   ├── valkey/     Valkey sentinel cluster (statefulset + sentinel, valkey ns).
 │   │                                    → "valkey" Kustomization   (wait: true)

--- a/deploy/ansible/README.md
+++ b/deploy/ansible/README.md
@@ -191,8 +191,8 @@ node-label: itsbagelbot.dev/pool=worker-pool
 node-taint: itsbagelbot.dev/pool=worker-pool:NoSchedule
 ```
 Pods opt in with a matching toleration (already added to the production compute
-Deployments + `nats-leaf`). `linkerd-cni` / `host-research` tolerate all taints, so
-mesh + CNI work; `falco` / `crowdsec-agent` were patched to tolerate the pool too.
+Deployments + `nats-leaf`). `host-research` tolerates all taints;
+`falco` / `crowdsec-agent` were patched to tolerate the pool too.
 Leave `NODE_POOL` unset for normal cloud nodes (no taint).
 
 ## ⚠️ SSH is removed — read before running

--- a/deploy/ansible/roles/base/files/99-nats-rpc.conf
+++ b/deploy/ansible/roles/base/files/99-nats-rpc.conf
@@ -1,7 +1,7 @@
 # NATS RPC latency + firehose throughput tuning. rmem/wmem max raised 4MB -> 16MB
-# for the 150k-event firehose now that NATS is off the Linkerd mesh (the kernel
-# socket is the buffer, not a sidecar): larger windows keep the hub->consumer push
-# and ingress->hub publish sockets from stalling under burst on a fat/high-BDP link.
+# for the 150k-event firehose: the kernel socket is the buffer, so larger windows
+# keep the hub->consumer push and ingress->hub publish sockets from stalling
+# under burst on a fat/high-BDP link.
 net.core.rmem_default = 1048576
 net.core.wmem_default = 1048576
 net.core.rmem_max = 16777216

--- a/deploy/flux/clusters/production/falco.yaml
+++ b/deploy/flux/clusters/production/falco.yaml
@@ -23,9 +23,9 @@
 #   - metrics.enabled true: renders the falco-metrics Service and flips
 #     webserver.prometheus_metrics_enabled, both live. The prometheus.io pod
 #     annotations are the podAnnotations below.
-#   - resources trimmed way below chart defaults (node1 is a 2-core host),
-#     infra-low priority class, and the itsbagelbot.dev/pool=worker-pool
-#     toleration so the DaemonSet lands on worker1 too (4/4 nodes).
+#   - resources trimmed way below chart defaults (small fleet, tight CPU
+#     budgets), infra-low priority class, and the itsbagelbot.dev/pool=
+#     worker-pool toleration so the DaemonSet lands on worker1 too (3/3 nodes).
 #   - falcoctl config needs ZERO overrides: rules artifact falco-rules:5,
 #     container plugin 0.6.3 and follow every 168h are all 8.0.3 defaults
 #     (live falcoctl.yaml diffs empty against the default render). The one
@@ -147,7 +147,7 @@ spec:
         value: worker-pool
 
     # Far below chart defaults (100m/512Mi -> 1000m/1024Mi); live-proven for
-    # this fleet and node1 is 2-core.
+    # this fleet.
     resources:
       requests:
         cpu: 10m

--- a/deploy/flux/clusters/production/flux-system/kustomization.yaml
+++ b/deploy/flux/clusters/production/flux-system/kustomization.yaml
@@ -4,9 +4,8 @@ resources:
 - gotk-components.yaml
 - gotk-sync.yaml
 patches:
-# Keep every Flux controller off node1. node1 is a 2-core, infra-loaded ARM host
-# being freed for its DB role (see node1-to-db-RUNBOOK.md); the controllers are
-# stateless (caches self-rebuild) so node2/node3 host them without a data move.
+# node1 left the cluster (dedicated DB host, 2026-07-21); this exclusion is
+# inert but kept so the applied controller specs stay unchanged.
 - target:
     kind: Deployment
   patch: |-

--- a/deploy/flux/clusters/production/newrelic.yaml
+++ b/deploy/flux/clusters/production/newrelic.yaml
@@ -185,12 +185,12 @@ spec:
       # out-of-band). valkey-core-secret is Doppler-managed and carries the key
       # VALKEY_CORE_PASSWORD verbatim (NOT renamed to valkey-password).
       kubelet:
-        # CPU trim. node1 is a 2-core node and was request-saturated (~96%),
-        # which kept the third valkey replica from scheduling (HA needs one
-        # valkey pod per node). The chart default 100m for this kubelet
-        # integration container is far above its real usage; drop it to 25m so
-        # node1 keeps headroom. Memory is left generous so the integration is
-        # never OOM-killed; no CPU limit so it is never throttled.
+        # CPU trim. The chart default 100m for this kubelet integration
+        # container is far above its real usage; drop it to 25m so every node
+        # keeps request headroom (the original saturation wedged a valkey
+        # replica off a fully-requested node). Memory is left generous so the
+        # integration is never OOM-killed; no CPU limit so it is never
+        # throttled.
         resources:
           requests:
             cpu: 25m

--- a/deploy/infra/cert-manager/release.yaml
+++ b/deploy/infra/cert-manager/release.yaml
@@ -6,9 +6,8 @@
 #
 # WHY
 # ---
-# The fleet is de-meshing NATS off Linkerd (see nats.yaml / nats-leaf.yaml), so
-# NATS provides its own wire encryption via NATS-native TLS instead of the
-# Linkerd sidecar. cert-manager is the battle-tested, CNCF-graduated PKI that
+# NATS provides its own wire encryption via NATS-native TLS (see nats.yaml /
+# nats-leaf.yaml). cert-manager is the battle-tested, CNCF-graduated PKI that
 # issues + auto-renews the server certs; trust-manager distributes the public CA
 # to a ConfigMap the apps read (fleet-ca). The PKI custom resources (Issuer, CA,
 # Certificates, Bundle) live in deploy/infra/pki/, applied by the `pki`

--- a/deploy/infra/cluster/cloudflared.yaml
+++ b/deploy/infra/cluster/cloudflared.yaml
@@ -1,15 +1,11 @@
 # Cloudflare Tunnel connector. Public ingress enters here: Cloudflare's edge
 # dials these outbound connectors and forwards to traefik.kube-system:443.
 #
-# Three replicas, hard-spread one per host across node1/node2/node3. worker1 is
+# Replicas hard-spread one per non-worker host (node2/node3). worker1 is
 # excluded explicitly: it is a burst worker, not part of the ingress failure
 # domain. A single tunnel ID supports many connector replicas (Cloudflare's
-# native HA model).
-#
-# Do not mesh this workload. Both outbound paths are already encrypted (443 to
-# traefik and 7844 to Cloudflare), and both had to bypass Linkerd already. A
-# sidecar therefore adds no transport protection here and makes tunnel startup
-# depend on the mesh control plane.
+# native HA model). Both outbound paths are already encrypted (443 to traefik
+# and 7844 to Cloudflare).
 #
 # Managed by the cluster Flux Kustomization. config = cloudflared-config
 # ConfigMap, creds = cloudflared-tunnel Secret (Doppler-managed; the reload
@@ -39,7 +35,6 @@ spec:
         app.kubernetes.io/name: cloudflared
         app.kubernetes.io/instance: cloudflared-deployment
       annotations:
-        linkerd.io/inject: disabled
         secrets.doppler.com/reload: "true"
     spec:
       affinity:

--- a/deploy/infra/cluster/coredns.yaml
+++ b/deploy/infra/cluster/coredns.yaml
@@ -4,13 +4,13 @@
 # This file brings that hand-applied state under Flux ownership with two
 # deliberate changes (2026-07-15 network-tune):
 #
-#   1. CoreDNS no longer runs on node1: required nodeAffinity keeps the
-#      DaemonSet on node2/node3/worker1 only. node1 is the infra/frontend
-#      node; the hot path is anti-affinitied off it, so every hot-path pod
-#      now has a node-local resolver.
+#   1. Required nodeAffinity keeps the DaemonSet on node2/node3/worker1 only,
+#      so every hot-path pod has a node-local resolver. (The node1 exclusion
+#      is inert since node1 left the cluster; kept so the applied spec is
+#      unchanged.)
 #   2. kube-dns gets trafficDistribution: PreferSameNode (same mechanism as
-#      the nats Service): queries from node2/node3/worker1 never cross the
-#      tailnet; node1 pods fall back to the nearest remote replica.
+#      the nats Service): queries from node2/node3/worker1 never leave the
+#      node.
 #
 # The ConfigMap deliberately declares ONLY the Corefile key. NodeHosts is
 # owned and continuously updated by the k3s node-hosts controller; omitting
@@ -83,9 +83,9 @@ data:
         loadbalance
         import /etc/coredns/custom/*.override
         # Forward external names to routable anycast resolvers instead of
-        # /etc/resolv.conf: node1's host upstream is an OCI link-local address
-        # (169.254.169.254) that CoreDNS cannot reach from the pod network, which
-        # stalled fresh lookups on that node.
+        # /etc/resolv.conf: the former node1's host upstream was an OCI
+        # link-local address (169.254.169.254) that CoreDNS could not reach
+        # from the pod network, which stalled fresh lookups on that node.
         forward . 1.1.1.1 8.8.8.8 9.9.9.9 {
           policy sequential
           max_concurrent 1000
@@ -117,8 +117,8 @@ spec:
     spec:
       serviceAccountName: coredns
       priorityClassName: system-cluster-critical
-      # DNS lives on the hot nodes only; node1 pods use a remote replica via
-      # the PreferSameNode fallback on the kube-dns Service.
+      # DNS lives on the hot nodes only. The node1 exclusion below is inert
+      # since node1 left the cluster; kept so the applied spec is unchanged.
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -204,7 +204,7 @@ spec:
   clusterIP: 10.43.0.10
   ipFamilyPolicy: SingleStack
   # Resolve against the node-local CoreDNS when one exists (node2/node3/
-  # worker1); node1 falls back to a remote replica automatically.
+  # worker1).
   trafficDistribution: PreferSameNode
   selector:
     k8s-app: kube-dns

--- a/deploy/infra/cluster/traefik-config.yaml
+++ b/deploy/infra/cluster/traefik-config.yaml
@@ -10,10 +10,6 @@
 #     the same node instead of round-robining across the trans-Atlantic fleet.
 #     (A soft-anti-affinity Deployment did not hold: the scheduler drifted both
 #     replicas onto one node, so a single node loss took down all ingress.)
-#   - podAnnotations linkerd.io/inject: ingress: mesh traefik chart-natively so
-#     it survives helm-controller reconcile (no more manual `linkerd inject`).
-#     Requires the injector webhook to NOT exclude kube-system (patched
-#     separately); injection still gates on this per-pod annotation.
 #   - service type ClusterIP: traefik is reachable ONLY from inside the cluster.
 #     Public traffic arrives via the outbound cloudflared tunnel (itself a
 #     per-node DaemonSet), and the tailnet-facing admin path is the Tailscale
@@ -30,12 +26,6 @@ spec:
   valuesContent: |-
     deployment:
       kind: DaemonSet
-      podAnnotations:
-        # De-meshed as part of removing Linkerd. cloudflared->traefik:443 is
-        # already TLS + un-meshed; traefik->console-dashboard is HTTPS via the
-        # ServersTransport; console-admin is the tailscale operator. No hop here
-        # still depends on the mesh.
-        linkerd.io/inject: disabled
     service:
       type: ClusterIP
       spec:

--- a/deploy/infra/valkey/config/valkey.conf
+++ b/deploy/infra/valkey/config/valkey.conf
@@ -17,8 +17,8 @@ replica-read-only yes
 loglevel notice
 # Valkey 9.1 uses lock-free queues between the main thread and I/O workers.
 # Two threads fit the 2-CPU container budget on the 6/8-core data-plane nodes;
-# config-init reduces this to one on the 2-core node1 host until that replica is
-# evacuated for the database role.
+# config-init re-appends this value on every boot so a retained CONFIG REWRITE
+# cannot override it.
 io-threads 2
 # Bounded cache. maxmemory sits under the 2 GiB container limit to leave room
 # for the replication backlog, COW, and buffers during AOF rewrite.

--- a/deploy/infra/valkey/statefulset.yaml
+++ b/deploy/infra/valkey/statefulset.yaml
@@ -34,11 +34,10 @@ spec:
   template:
     metadata:
       annotations:
-        # De-meshed. Replication and Sentinel announce stable StatefulSet DNS
-        # names over Flannel's native WireGuard pod network. Valkey TLS provides
+        # Replication and Sentinel announce stable StatefulSet DNS names over
+        # Flannel's native WireGuard pod network. Valkey TLS provides
         # end-to-end identity and encryption on data port 6380 and Sentinel
         # port 26380; neither listener is exposed through a node hostPort.
-        linkerd.io/inject: disabled
         secrets.doppler.com/reload: 'true'
       labels:
         app.kubernetes.io/component: node
@@ -120,7 +119,7 @@ spec:
           # Reconcile master eligibility on every boot. Retained PVCs may carry
           # a stale CONFIG REWRITE value, so only the explicit node2/node3
           # allowlist can remain eligible for Sentinel promotion. Every other
-          # node, including node1, worker1, and future unknown nodes, is fenced.
+          # node, including worker1 and future unknown nodes, is fenced.
           sed -i '/^replica-priority /d' /data/valkey.conf
           case "${NODE_NAME}" in
             node2|node3)
@@ -137,16 +136,11 @@ spec:
           sed -i '\|^include /config/tuning.conf$|d' /data/valkey.conf
           echo "include /config/tuning.conf" >> /data/valkey.conf
           # io-threads is deliberately reconciled on every boot instead of
-          # only on fresh PVCs. CONFIG REWRITE persists old values, and node1
-          # has only two cores while the remaining data-plane hosts have 6-8.
+          # only on fresh PVCs: CONFIG REWRITE persists old values.
           # Valkey 9.1 threads both reads and writes automatically; the former
           # io-threads-do-reads switch is deprecated and intentionally absent.
           sed -i '/^io-threads /d' /data/valkey.conf
-          if [ "${NODE_NAME}" = "node1" ]; then
-            echo "io-threads 1" >> /data/valkey.conf
-          else
-            echo "io-threads 2" >> /data/valkey.conf
-          fi
+          echo "io-threads 2" >> /data/valkey.conf
           # Reconcile this member's stable DNS identity before Valkey starts.
           sed -i '/^replica-announce-ip /d' /data/valkey.conf
           echo "replica-announce-ip ${POD_FQDN}" >> /data/valkey.conf

--- a/deploy/k8s/NATS-CROSS-NODE.md
+++ b/deploy/k8s/NATS-CROSS-NODE.md
@@ -24,8 +24,8 @@ Confirmed wiring (leave as-is unless a step below proves otherwise):
 - Hub cluster: 3-replica StatefulSet, routes on `nats-headless:6222`; BUS and JetStream clients connect directly to its TLS client listener ([nats.yaml](nats.yaml), [nats-server.conf](nats-server.conf)).
 - `OUTGRESS_RPC` has no per-user subject ACL (default-allow **within** the account), so `bagel.outgress.permit.v2.>` and `$SRV.>` are unrestricted account-internal subjects.
 - `network-policies.yaml` `default-deny-apps` selects only app pods, **not**
-  `nats`/`nats-leaf`, so NATS pods are NetworkPolicy-unrestricted. NATS and its
-  leaves are out of Linkerd; native TLS protects 4222/6222.
+  `nats`/`nats-leaf`, so NATS pods are NetworkPolicy-unrestricted. Native TLS
+  protects 4222/6222.
 
 RPC is deliberately hub-independent. A break is therefore runtime on the
 leaf↔leaf routes (6222), account import/export mapping, or host networking — not

--- a/deploy/k8s/commands.yaml
+++ b/deploy/k8s/commands.yaml
@@ -36,16 +36,6 @@ spec:
     metadata:
       labels:
         app: commands
-      annotations:
-        linkerd.io/inject: disabled
-        # NATS is out of the Linkerd mesh: bypass the app-side proxy for the NATS
-        # client port so the firehose / RPC traffic goes direct (NATS-native TLS
-        # provides the encryption). Without this the proxy still taxes every event.
-        config.linkerd.io/skip-outbound-ports: "4222"
-        config.linkerd.io/proxy-cpu-request: 5m
-        config.linkerd.io/proxy-cpu-limit: 750m
-        config.linkerd.io/proxy-memory-request: 16Mi
-        config.linkerd.io/proxy-memory-limit: 96Mi
     spec:
       tolerations:
         - key: itsbagelbot.dev/pool
@@ -106,9 +96,9 @@ spec:
               value: nats://nats:4222
             - name: NATS_HUB_PUBLISH_URL
               value: nats://nats:4222
-            # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS server
-            # TLS cert now that NATS is out of the Linkerd mesh; read as RootCAs by
-            # pkg/bus (Go services) and the console nats lib (TS).
+            # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS
+            # server's native-TLS cert; read as RootCAs by pkg/bus (Go services)
+            # and the console nats lib (TS).
             - name: NATS_CA_PEM
               valueFrom:
                 configMapKeyRef:

--- a/deploy/k8s/console-admin.yaml
+++ b/deploy/k8s/console-admin.yaml
@@ -51,16 +51,6 @@ spec:
     metadata:
       labels:
         app: console-admin
-      annotations:
-        linkerd.io/inject: disabled
-        # NATS is out of the Linkerd mesh: bypass the app-side proxy for the NATS
-        # client port so the firehose / RPC traffic goes direct (NATS-native TLS
-        # provides the encryption). Without this the proxy still taxes every event.
-        config.linkerd.io/skip-outbound-ports: "4222"
-        config.linkerd.io/proxy-cpu-request: 5m
-        config.linkerd.io/proxy-cpu-limit: 750m
-        config.linkerd.io/proxy-memory-request: 16Mi
-        config.linkerd.io/proxy-memory-limit: 96Mi
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -120,9 +110,9 @@ spec:
               value: nats://nats-leaf:4222
             - name: NATS_HUB_URL
               value: nats://nats:4222
-            # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS server
-            # TLS cert now that NATS is out of the Linkerd mesh; read as RootCAs by
-            # pkg/bus (Go services) and the console nats lib (TS).
+            # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS
+            # server's native-TLS cert; read as RootCAs by pkg/bus (Go services)
+            # and the console nats lib (TS).
             - name: NATS_CA_PEM
               valueFrom:
                 configMapKeyRef:

--- a/deploy/k8s/console-dashboard.yaml
+++ b/deploy/k8s/console-dashboard.yaml
@@ -65,12 +65,6 @@ spec:
     metadata:
       labels:
         app: console-dashboard
-      annotations:
-        # De-meshed. The dashboard serves its own TLS (serve-node.js HTTPS,
-        # Traefik re-encrypts via the ServersTransport), and NATS has native TLS,
-        # so it no longer needs the Linkerd proxy — which HTTP-parsed the app's
-        # HTTPS on 3000 and failed the kubelet probes / Traefik re-encrypt.
-        linkerd.io/inject: disabled
     spec:
       # Hard guard: the dashboard must NEVER run on the worker pool. The taint
       # already repels it (no toleration here), this required nodeAffinity makes
@@ -114,9 +108,9 @@ spec:
             - name: PORT
               value: "3000"
             # Serve HTTPS from adapter-node (serve-node.js) using the cert-manager
-            # console-dashboard-tls cert, so the traefik->console hop is TLS and no
-            # longer depends on the Linkerd mesh (the de-mesh gate). Traefik
-            # re-encrypts via the console-dashboard-transport ServersTransport.
+            # console-dashboard-tls cert, so the traefik->console hop is TLS.
+            # Traefik re-encrypts via the console-dashboard-transport
+            # ServersTransport.
             - name: TLS_CERT_FILE
               value: /etc/console/tls/tls.crt
             - name: TLS_KEY_FILE
@@ -139,9 +133,9 @@ spec:
               value: nats://nats-leaf:4222
             - name: NATS_HUB_URL
               value: nats://nats:4222
-            # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS server
-            # TLS cert now that NATS is out of the Linkerd mesh; read as RootCAs by
-            # pkg/bus (Go services) and the console nats lib (TS).
+            # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS
+            # server's native-TLS cert; read as RootCAs by pkg/bus (Go services)
+            # and the console nats lib (TS).
             - name: NATS_CA_PEM
               valueFrom:
                 configMapKeyRef:
@@ -245,7 +239,7 @@ spec:
           lifecycle:
             preStop:
               exec:
-                # Give kube-proxy / Linkerd / traefik time to drain this endpoint
+                # Give kube-proxy / traefik time to drain this endpoint
                 # before SIGTERM fires. Prevents connection-refused 500s during rolls.
                 command: ["/bin/sh", "-c", "sleep 10"]
           # scheme HTTPS: the server now terminates TLS on 3000 (see serve-node.js).
@@ -301,8 +295,7 @@ spec:
           port: 80
           # HTTPS to the backend: serve-node.js now terminates TLS, so traefik
           # re-encrypts via the ServersTransport below (rootCAs = the cert's own
-          # fleet-CA ca.crt). This makes the traefik->console hop TLS end-to-end,
-          # the gate for removing NATS from the Linkerd mesh.
+          # fleet-CA ca.crt). This makes the traefik->console hop TLS end-to-end.
           scheme: https
           serversTransport: console-dashboard-transport
           # Route to the Service ClusterIP (not pod endpoints) so traefik

--- a/deploy/k8s/gateway.yaml
+++ b/deploy/k8s/gateway.yaml
@@ -51,16 +51,6 @@ spec:
     metadata:
       labels:
         app: gateway
-      annotations:
-        linkerd.io/inject: disabled
-        # NATS is out of the Linkerd mesh: bypass the app-side proxy for the NATS
-        # client port so the firehose / RPC traffic goes direct (NATS-native TLS
-        # provides the encryption). Without this the proxy still taxes every event.
-        config.linkerd.io/skip-outbound-ports: "4222"
-        config.linkerd.io/proxy-cpu-request: 5m
-        config.linkerd.io/proxy-cpu-limit: 750m
-        config.linkerd.io/proxy-memory-request: 16Mi
-        config.linkerd.io/proxy-memory-limit: 96Mi
     spec:
       tolerations:
         - key: itsbagelbot.dev/pool
@@ -117,9 +107,9 @@ spec:
               value: nats://nats-leaf:4222
             - name: NATS_HUB_URL
               value: nats://nats:4222
-            # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS server
-            # TLS cert now that NATS is out of the Linkerd mesh; read as RootCAs by
-            # pkg/bus (Go services) and the console nats lib (TS).
+            # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS
+            # server's native-TLS cert; read as RootCAs by pkg/bus (Go services)
+            # and the console nats lib (TS).
             - name: NATS_CA_PEM
               valueFrom:
                 configMapKeyRef:

--- a/deploy/k8s/loyalty.yaml
+++ b/deploy/k8s/loyalty.yaml
@@ -38,16 +38,6 @@ spec:
     metadata:
       labels:
         app: loyalty
-      annotations:
-        linkerd.io/inject: disabled
-        # NATS is out of the Linkerd mesh: bypass the app-side proxy for the NATS
-        # client port so the firehose / RPC traffic goes direct (NATS-native TLS
-        # provides the encryption). Without this the proxy still taxes every event.
-        config.linkerd.io/skip-outbound-ports: "4222"
-        config.linkerd.io/proxy-cpu-request: 5m
-        config.linkerd.io/proxy-cpu-limit: 750m
-        config.linkerd.io/proxy-memory-request: 16Mi
-        config.linkerd.io/proxy-memory-limit: 96Mi
     spec:
       tolerations:
         - key: itsbagelbot.dev/pool
@@ -104,9 +94,9 @@ spec:
               value: nats://nats-leaf:4222
             - name: NATS_HUB_URL
               value: nats://nats:4222
-            # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS server
-            # TLS cert now that NATS is out of the Linkerd mesh; read as RootCAs by
-            # pkg/bus (Go services) and the console nats lib (TS).
+            # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS
+            # server's native-TLS cert; read as RootCAs by pkg/bus (Go services)
+            # and the console nats lib (TS).
             - name: NATS_CA_PEM
               valueFrom:
                 configMapKeyRef:

--- a/deploy/k8s/modules.yaml
+++ b/deploy/k8s/modules.yaml
@@ -36,16 +36,6 @@ spec:
     metadata:
       labels:
         app: modules
-      annotations:
-        linkerd.io/inject: disabled
-        # NATS is out of the Linkerd mesh: bypass the app-side proxy for the NATS
-        # client port so the firehose / RPC traffic goes direct (NATS-native TLS
-        # provides the encryption). Without this the proxy still taxes every event.
-        config.linkerd.io/skip-outbound-ports: "4222"
-        config.linkerd.io/proxy-cpu-request: 5m
-        config.linkerd.io/proxy-cpu-limit: 750m
-        config.linkerd.io/proxy-memory-request: 16Mi
-        config.linkerd.io/proxy-memory-limit: 96Mi
     spec:
       tolerations:
         - key: itsbagelbot.dev/pool
@@ -106,9 +96,9 @@ spec:
               value: nats://nats:4222
             - name: NATS_HUB_PUBLISH_URL
               value: nats://nats:4222
-            # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS server
-            # TLS cert now that NATS is out of the Linkerd mesh; read as RootCAs by
-            # pkg/bus (Go services) and the console nats lib (TS).
+            # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS
+            # server's native-TLS cert; read as RootCAs by pkg/bus (Go services)
+            # and the console nats lib (TS).
             - name: NATS_CA_PEM
               valueFrom:
                 configMapKeyRef:

--- a/deploy/k8s/nats-leaf.yaml
+++ b/deploy/k8s/nats-leaf.yaml
@@ -9,8 +9,6 @@ metadata:
     app: nats-leaf
   name: nats-leaf
   namespace: production
-  annotations:
-    config.linkerd.io/opaque-ports: "4222,6222"
 spec:
   revisionHistoryLimit: 5
   updateStrategy:
@@ -24,10 +22,8 @@ spec:
   template:
     metadata:
       annotations:
-        # NATS (leaf tier) is out of the Linkerd mesh — see nats.yaml for the
-        # rationale. Wire encryption is NATS-native TLS (client + cluster + the
-        # leaf->hub remotes; nats-leaf-server.conf) over native WireGuard.
-        linkerd.io/inject: disabled
+        # Wire encryption is NATS-native TLS (client + cluster + the leaf->hub
+        # remotes; nats-leaf-server.conf) over native WireGuard.
         # Cluster listener/routes and TLS blocks cannot be introduced by a config
         # reload; bump this to force a rolling restart when the topology changes.
         itsbagelbot.dev/config-revision: "leaf-cluster-v2-tls-demesh"
@@ -191,8 +187,6 @@ metadata:
     app: nats-leaf
   name: nats-leaf
   namespace: production
-  annotations:
-    config.linkerd.io/opaque-ports: "4222"
 spec:
   # Same-node first, then same-zone, then cluster-wide. Unlike Local this keeps
   # applications available while their node's leaf is down; unlike PreferClose
@@ -217,8 +211,6 @@ metadata:
     app: nats-leaf
   name: nats-leaf-local
   namespace: production
-  annotations:
-    config.linkerd.io/opaque-ports: "4222"
 spec:
   # Health/failback probe only. With no local endpoint this Service is
   # unreachable, so clients never mistake a remote leaf for the recovered
@@ -239,8 +231,6 @@ metadata:
     app: nats-leaf
   name: nats-leaf-peers
   namespace: production
-  annotations:
-    config.linkerd.io/opaque-ports: "4222,6222"
 spec:
   # Headless route-discovery for the leaf cluster: the route URL resolves to every
   # leaf pod IP, so each node dials every peer and forms a clean full mesh (a

--- a/deploy/k8s/nats-server.conf
+++ b/deploy/k8s/nats-server.conf
@@ -28,8 +28,8 @@ write_deadline: "2s"
 ping_interval: "20s"
 ping_max: 3
 
-# Client-facing TLS. Since NATS is no longer in the Linkerd mesh (see nats.yaml),
-# this is the wire encryption for client connections, on top of the tailnet.
+# Client-facing TLS: the wire encryption for client connections, on top of the
+# WireGuard pod network.
 # verify:false = server-auth only: the server presents its cert and clients verify
 # it against the fleet CA (NATS_CA_PEM), but clients authenticate with their bcrypt
 # user/password (auth.conf), not client certs — so there are no per-service certs.

--- a/deploy/k8s/nats.yaml
+++ b/deploy/k8s/nats.yaml
@@ -20,12 +20,8 @@ spec:
   template:
     metadata:
       annotations:
-        # NATS is intentionally OUT of the Linkerd mesh: at 150k ev/s the sidecar
-        # proxy is the dominant tax on the firehose (every message crossed a proxy
-        # on publish, on the hub, and on each consumer). Wire encryption is now
-        # NATS-native TLS (nats-server.conf) over native WireGuard; meshed apps bypass
-        # the proxy for the NATS port via config.linkerd.io/skip-outbound-ports.
-        linkerd.io/inject: disabled
+        # Wire encryption is NATS-native TLS (nats-server.conf) over native
+        # WireGuard.
         prometheus.io/path: /metrics
         prometheus.io/port: "7777"
         prometheus.io/scrape: "true"
@@ -46,23 +42,21 @@ spec:
           effect: NoExecute
           tolerationSeconds: 60
         # Tolerate worker1's worker-pool taint so the hub can run there (see the
-        # affinity note): worker1 is the 8-core/15GiB node that replaces node1 in
-        # the quorum.
+        # affinity note): worker1 is the 8-core/15GiB third quorum member.
         - key: itsbagelbot.dev/pool
           operator: Equal
           value: worker-pool
           effect: NoSchedule
-      # The JetStream hub is a 3-member RAFT quorum. node1 (a 2-core, infra-loaded
-      # ARM host) gated the whole StatefulSet's resources, since all three members
-      # share one pod template, so members now land on node2/node3/worker1
-      # instead. worker1 rides a home-wifi link, but with three voters a worker1
+      # The JetStream hub is a 3-member RAFT quorum on node2/node3/worker1.
+      # worker1 rides a home-wifi link, but with three voters a worker1
       # blip still leaves node2+node3 as a 2/3 quorum. Trade-off: an R1 stream
       # whose single replica lands on worker1 stalls while that link blips, so the
       # hot firehose must stay replicated or have its placement watched — validate
       # on the prod topology test before bumping resources (see the runbook).
-      # JetStream PVCs are local-path (node-bound): moving the node1 member means
-      # deleting jetstream-data-nats-2 + its pod so it reprovisions on worker1 and
-      # RAFT re-syncs it.
+      # JetStream PVCs are local-path (node-bound): moving a member to another
+      # node means deleting its jetstream-data PVC + pod so it reprovisions
+      # there and RAFT re-syncs it. The node1 exclusion below is inert since
+      # node1 left the fleet; kept so the applied spec is unchanged.
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -219,8 +213,6 @@ metadata:
     app: nats
   name: nats
   namespace: production
-  annotations:
-    config.linkerd.io/opaque-ports: "4222,6222"
 spec:
   # JetStream clients dial this Service directly. Prefer the hub on the same
   # node so node2/node3/worker1 avoid an unnecessary cross-node or home-WAN hop.
@@ -238,8 +230,6 @@ metadata:
     app: nats
   name: nats-headless
   namespace: production
-  annotations:
-    config.linkerd.io/opaque-ports: "4222,6222"
 spec:
   clusterIP: None
   publishNotReadyAddresses: true

--- a/deploy/k8s/network-policies.yaml
+++ b/deploy/k8s/network-policies.yaml
@@ -14,8 +14,7 @@ spec:
     - Ingress
     - Egress
   ingress:
-    # Allow all pods in bagelbot namespace to reach each other for now
-    # (Linkerd will handle the finer-grained L7 auth for HTTP/gRPC).
+    # Allow all pods in bagelbot namespace to reach each other for now.
     - from:
         - namespaceSelector:
             matchLabels:

--- a/deploy/k8s/network-policies.yaml
+++ b/deploy/k8s/network-policies.yaml
@@ -41,11 +41,6 @@ spec:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: production
-    # Allow communication to Linkerd control plane
-    - to:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: linkerd
     # Allow communication to Valkey namespace
     - to:
         - namespaceSelector:

--- a/deploy/k8s/notifications.yaml
+++ b/deploy/k8s/notifications.yaml
@@ -36,16 +36,6 @@ spec:
     metadata:
       labels:
         app: notifications
-      annotations:
-        linkerd.io/inject: disabled
-        # NATS is out of the Linkerd mesh: bypass the app-side proxy for the NATS
-        # client port so the firehose / RPC traffic goes direct (NATS-native TLS
-        # provides the encryption). Without this the proxy still taxes every event.
-        config.linkerd.io/skip-outbound-ports: "4222"
-        config.linkerd.io/proxy-cpu-request: 5m
-        config.linkerd.io/proxy-cpu-limit: 750m
-        config.linkerd.io/proxy-memory-request: 16Mi
-        config.linkerd.io/proxy-memory-limit: 96Mi
     spec:
       tolerations:
         - key: itsbagelbot.dev/pool
@@ -97,9 +87,9 @@ spec:
               value: nats://nats-leaf-local:4222
             - name: NATS_HUB_URL
               value: nats://nats:4222
-            # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS server
-            # TLS cert now that NATS is out of the Linkerd mesh; read as RootCAs by
-            # pkg/bus (Go services) and the console nats lib (TS).
+            # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS
+            # server's native-TLS cert; read as RootCAs by pkg/bus (Go services)
+            # and the console nats lib (TS).
             - name: NATS_CA_PEM
               valueFrom:
                 configMapKeyRef:
@@ -166,10 +156,6 @@ spec:
 # arg and the service's own NATS creds (notifications-env), so no extra image or
 # NATS account is needed — the cleanup subject is internal to the
 # NOTIFICATIONS_RPC account and unreachable from anywhere else.
-#
-# Not Linkerd-injected: a meshed Job would hang on the lingering proxy, and NATS
-# is reachable un-meshed (no Server gates its port; `notifications` is outside
-# the default-deny NetworkPolicy). NATS auth is account creds, not mesh identity.
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -189,8 +175,6 @@ spec:
         metadata:
           labels:
             app: notifications-cleanup
-          annotations:
-            linkerd.io/inject: disabled
         spec:
           restartPolicy: OnFailure
           tolerations:

--- a/deploy/k8s/outgress.yaml
+++ b/deploy/k8s/outgress.yaml
@@ -39,19 +39,6 @@ spec:
     metadata:
       labels:
         app: outgress
-      annotations:
-        linkerd.io/inject: disabled
-        config.linkerd.io/proxy-cpu-request: 5m
-        config.linkerd.io/proxy-cpu-limit: 1000m
-        config.linkerd.io/proxy-memory-request: 16Mi
-        config.linkerd.io/proxy-memory-limit: 128Mi
-        # The Twitch Helix egress (443) skips the proxy.
-        # Outgress's hot path is a synchronous POST to api.twitch.tv; routing it
-        # through the linkerd sidecar adds a proxy hop per send for an external,
-        # already-TLS destination the mesh cannot mTLS anyway. twitch-ingress
-        # skips 443 for the same reason. 4222 is NATS — now out of the mesh, so its
-        # own TLS encrypts the wire and the proxy would only tax it.
-        config.linkerd.io/skip-outbound-ports: "443,4222"
     spec:
       tolerations:
         - key: itsbagelbot.dev/pool
@@ -66,9 +53,8 @@ spec:
           operator: Exists
           effect: NoExecute
           tolerationSeconds: 60
-      # node1 is the 2-core ARM node reserved for stateful/frontend + infra; keep
-      # the hot-path sender off it. outgress is Twitch-rate-limited so it never
-      # needs node1 as burst surface.
+      # The node1 exclusion below is inert since node1 left the fleet; kept so
+      # the applied spec is unchanged.
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -130,9 +116,9 @@ spec:
               value: nats://nats-leaf:4222
             - name: NATS_HUB_URL
               value: nats://nats-1.nats-headless.production.svc.cluster.local:4222
-            # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS server
-            # TLS cert now that NATS is out of the Linkerd mesh; read as RootCAs by
-            # pkg/bus (Go services) and the console nats lib (TS).
+            # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS
+            # server's native-TLS cert; read as RootCAs by pkg/bus (Go services)
+            # and the console nats lib (TS).
             - name: NATS_CA_PEM
               valueFrom:
                 configMapKeyRef:

--- a/deploy/k8s/projector.yaml
+++ b/deploy/k8s/projector.yaml
@@ -36,14 +36,6 @@ spec:
     metadata:
       labels:
         app: projector
-      annotations:
-        linkerd.io/inject: disabled
-        config.linkerd.io/proxy-cpu-request: 5m
-        config.linkerd.io/proxy-cpu-limit: 750m
-        config.linkerd.io/proxy-memory-request: 16Mi
-        config.linkerd.io/proxy-memory-limit: 96Mi
-        # NATS is out of the mesh and encrypts the wire with native TLS.
-        config.linkerd.io/skip-outbound-ports: "4222"
     spec:
       tolerations:
         - key: itsbagelbot.dev/pool
@@ -108,9 +100,9 @@ spec:
               value: nats://nats-1.nats-headless.production.svc.cluster.local:4222
             - name: NATS_HUB_PUBLISH_URL
               value: nats://nats:4222
-            # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS server
-            # TLS cert now that NATS is out of the Linkerd mesh; read as RootCAs by
-            # pkg/bus (Go services) and the console nats lib (TS).
+            # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS
+            # server's native-TLS cert; read as RootCAs by pkg/bus (Go services)
+            # and the console nats lib (TS).
             - name: NATS_CA_PEM
               valueFrom:
                 configMapKeyRef:

--- a/deploy/k8s/sesame.yaml
+++ b/deploy/k8s/sesame.yaml
@@ -44,14 +44,6 @@ spec:
     metadata:
       labels:
         app: sesame
-      annotations:
-        linkerd.io/inject: disabled
-        config.linkerd.io/proxy-cpu-request: 5m
-        config.linkerd.io/proxy-cpu-limit: 1000m
-        config.linkerd.io/proxy-memory-request: 16Mi
-        config.linkerd.io/proxy-memory-limit: 128Mi
-        # NATS is out of the mesh and encrypts the wire with native TLS.
-        config.linkerd.io/skip-outbound-ports: "4222"
     spec:
       tolerations:
         - key: itsbagelbot.dev/pool
@@ -66,8 +58,8 @@ spec:
           operator: Exists
           effect: NoExecute
           tolerationSeconds: 60
-      # node1 is the 2-core ARM node reserved for stateful/frontend + infra; keep
-      # the hot-path worker off it. KEDA (see the ScaledObject below) scales
+      # The node1 exclusion below is inert since node1 left the fleet; kept so
+      # the applied spec is unchanged. KEDA (see the ScaledObject below) scales
       # onto node2/node3/worker1.
       # Baseline shape at the KEDA floor of 5: node3=2, worker1=2, node2=1.
       # node2 already carries the control plane + valkey master, so the doubles
@@ -142,9 +134,9 @@ spec:
               value: tls://nats-0.nats-headless.production.svc.cluster.local:4222
             - name: NATS_HUB_PUBLISH_URL
               value: tls://nats:4222
-            # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS server
-            # TLS cert now that NATS is out of the Linkerd mesh; read as RootCAs by
-            # pkg/bus (Go services) and the console nats lib (TS).
+            # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS
+            # server's native-TLS cert; read as RootCAs by pkg/bus (Go services)
+            # and the console nats lib (TS).
             - name: NATS_CA_PEM
               valueFrom:
                 configMapKeyRef:

--- a/deploy/k8s/transactions.yaml
+++ b/deploy/k8s/transactions.yaml
@@ -36,16 +36,6 @@ spec:
     metadata:
       labels:
         app: transactions
-      annotations:
-        linkerd.io/inject: disabled
-        # NATS is out of the Linkerd mesh: bypass the app-side proxy for the NATS
-        # client port so the firehose / RPC traffic goes direct (NATS-native TLS
-        # provides the encryption). Without this the proxy still taxes every event.
-        config.linkerd.io/skip-outbound-ports: "4222"
-        config.linkerd.io/proxy-cpu-request: 5m
-        config.linkerd.io/proxy-cpu-limit: 750m
-        config.linkerd.io/proxy-memory-request: 16Mi
-        config.linkerd.io/proxy-memory-limit: 96Mi
     spec:
       tolerations:
         - key: itsbagelbot.dev/pool
@@ -89,9 +79,9 @@ spec:
               value: nats://nats-leaf:4222
             - name: NATS_HUB_URL
               value: nats://nats:4222
-            # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS server
-            # TLS cert now that NATS is out of the Linkerd mesh; read as RootCAs by
-            # pkg/bus (Go services) and the console nats lib (TS).
+            # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS
+            # server's native-TLS cert; read as RootCAs by pkg/bus (Go services)
+            # and the console nats lib (TS).
             - name: NATS_CA_PEM
               valueFrom:
                 configMapKeyRef:

--- a/deploy/k8s/twitch-ingress.yaml
+++ b/deploy/k8s/twitch-ingress.yaml
@@ -24,8 +24,6 @@ kind: Service
 metadata:
   name: twitch-ingress-headless
   namespace: production
-  annotations:
-    config.linkerd.io/opaque-ports: "4369,9100-9110"
 spec:
   clusterIP: None
   publishNotReadyAddresses: true
@@ -68,19 +66,6 @@ spec:
     metadata:
       labels:
         app: twitch-ingress
-      annotations:
-        linkerd.io/inject: disabled
-        config.linkerd.io/proxy-cpu-request: 5m
-        config.linkerd.io/proxy-cpu-limit: 750m
-        config.linkerd.io/proxy-memory-request: 16Mi
-        config.linkerd.io/proxy-memory-limit: 96Mi
-        # Opaque ports for EPMD (4369) and Erlang distribution (9100-9110)
-        # to prevent Linkerd protocol detection timeouts on server-speaks-first.
-        config.linkerd.io/opaque-ports: "4369,9100-9110"
-        # Skip outbound: 443 for the server-speaks-first Twitch EventSub wss://
-        # sockets, and 4222 for NATS — now out of the mesh, so NATS-native TLS
-        # provides the encryption and the proxy would otherwise tax every event.
-        config.linkerd.io/skip-outbound-ports: "443,4222"
     spec:
       tolerations:
         - key: itsbagelbot.dev/pool
@@ -95,9 +80,9 @@ spec:
           operator: Exists
           effect: NoExecute
           tolerationSeconds: 60
-      # node1 (2-core ARM) is reserved for stateful/frontend + infra; keep ingress
-      # off it via nodeAffinity. Eligible nodes are node2/node3/worker1, and the
-      # three replicas are spread one per eligible node in steady state.
+      # Eligible nodes are node2/node3/worker1; the three replicas are spread
+      # one per eligible node in steady state. The node1 exclusion below is
+      # inert since node1 left the fleet; kept so the applied spec is unchanged.
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -156,10 +141,10 @@ spec:
               value: nats-leaf
             - name: NATS_HUB_HOST
               value: nats
-            # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS server
-            # TLS cert now that NATS is out of the Linkerd mesh; decoded to ssl_opts
-            # cacerts in config/runtime.exs. Both :gnat (leaf) and :gnat_bus (hub)
-            # verify against it.
+            # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS
+            # server's native-TLS cert; decoded to ssl_opts cacerts in
+            # config/runtime.exs. Both :gnat (leaf) and :gnat_bus (hub) verify
+            # against it.
             - name: NATS_CA_PEM
               valueFrom:
                 configMapKeyRef:

--- a/deploy/k8s/users.yaml
+++ b/deploy/k8s/users.yaml
@@ -36,16 +36,6 @@ spec:
     metadata:
       labels:
         app: users
-      annotations:
-        linkerd.io/inject: disabled
-        # NATS is out of the Linkerd mesh: bypass the app-side proxy for the NATS
-        # client port so the firehose / RPC traffic goes direct (NATS-native TLS
-        # provides the encryption). Without this the proxy still taxes every event.
-        config.linkerd.io/skip-outbound-ports: "4222"
-        config.linkerd.io/proxy-cpu-request: 5m
-        config.linkerd.io/proxy-cpu-limit: 750m
-        config.linkerd.io/proxy-memory-request: 16Mi
-        config.linkerd.io/proxy-memory-limit: 96Mi
     spec:
       tolerations:
         - key: itsbagelbot.dev/pool
@@ -60,9 +50,9 @@ spec:
           operator: Exists
           effect: NoExecute
           tolerationSeconds: 60
-      # Keep RPC responders beside Sesame on the three hot-path nodes. Node1
-      # remains available for stateful/frontend/infra work, but never satisfies
-      # this Deployment's scheduling domain.
+      # Keep RPC responders beside Sesame on the three hot-path nodes. The node1
+      # exclusion below is inert since node1 left the fleet; kept so the applied
+      # spec is unchanged.
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -118,9 +108,9 @@ spec:
               value: nats://nats:4222
             - name: NATS_HUB_PUBLISH_URL
               value: nats://nats:4222
-            # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS server
-            # TLS cert now that NATS is out of the Linkerd mesh; read as RootCAs by
-            # pkg/bus (Go services) and the console nats lib (TS).
+            # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS
+            # server's native-TLS cert; read as RootCAs by pkg/bus (Go services)
+            # and the console nats lib (TS).
             - name: NATS_CA_PEM
               valueFrom:
                 configMapKeyRef:


### PR DESCRIPTION
## What

- Remove all inert `linkerd.io/inject` and `config.linkerd.io/*` annotations from deploy manifests (pod templates, Services, nats-leaf DaemonSet metadata, traefik HelmChartConfig podAnnotations, notifications CronJob). Linkerd was removed fleet-wide; these were dead weight.
- Drop the inert linkerd-namespace egress rule from `network-policies.yaml` (namespace no longer exists).
- Reword comments that described Linkerd or node1 as current: node1 is off-cluster (dedicated DB host) and the fleet is 3 Intel nodes. Functional `NotIn [node1]` affinities are kept so applied specs stay unchanged; comments now say the exclusion is inert.
- Collapse the dead `node1` io-threads branch in valkey config-init (behavior identical on all live nodes; topology tests pass).
- Fix `app/ingress/README.md`: cache-invalidation subject default is `bagel.cache.invalidate.status`, matching `runtime.exs`.

## Rollout note

Pod-template annotation removal changes template hashes: on Flux apply every touched workload restarts, including the nats hub StatefulSet, nats-leaf/traefik DaemonSets, and the valkey StatefulSet. Merge when a fleet-wide rolling restart is acceptable.

## Verification

- All 24 edited manifests YAML-parse clean; no empty `annotations:` blocks left.
- `deploy/infra/valkey` go tests pass.
- `grep -ri linkerd deploy/` is clean outside historical runbooks/acceptance docs.