### PR TITLE
feat(sesame): distinct gift sub alerts + resub coverage

### DIFF
--- a/app/sesame/modules/alerts.go
+++ b/app/sesame/modules/alerts.go
@@ -100,8 +100,8 @@ type adBreakEvent struct {
 }
 
 // Alerts posts a chat line on channel.follow, channel.subscribe,
-// channel.subscription.gift, channel.cheer, channel.raid and
-// channel.ad_break.begin. It is a named, default-on module
+// channel.subscription.message, channel.subscription.gift, channel.cheer,
+// channel.raid and channel.ad_break.begin. It is a named, default-on module
 // (KindDefault): it ships
 // enabled and runs unless the broadcaster disables the whole module on the
 // dashboard. Each alert has its own enable toggle and message template, wired in
@@ -150,7 +150,12 @@ func Alerts(_ engine.Deps) module.Module {
 		return nil
 	})
 
-	m.On("channel.subscribe", func(_ context.Context, c *module.Context, emit module.Emit) error {
+	// subAlert serves both channel.subscribe (new subs) and
+	// channel.subscription.message (resubs shared in chat), so a renewing sub
+	// gets the same welcome line under the same toggle. The resub payload has
+	// no is_gift field, so the gifted-recipient skip below only ever fires on
+	// channel.subscribe.
+	subAlert := func(_ context.Context, c *module.Context, emit module.Emit) error {
 		var cfg alertsConfig
 		_ = c.Decode(&cfg)
 		if !alertOn(cfg.SubEnabled) {
@@ -192,7 +197,9 @@ func Alerts(_ engine.Deps) module.Module {
 			Text:          msg,
 		})
 		return nil
-	})
+	}
+	m.On("channel.subscribe", subAlert)
+	m.On("channel.subscription.message", subAlert)
 
 	m.On("channel.subscription.gift", func(_ context.Context, c *module.Context, emit module.Emit) error {
 		var cfg alertsConfig

--- a/app/sesame/modules/alerts.go
+++ b/app/sesame/modules/alerts.go
@@ -99,6 +99,53 @@ type adBreakEvent struct {
 	DurationSeconds   int    `json:"duration_seconds"`
 }
 
+// alertLine is one rendered alert: the channel it goes to and the token
+// values its template may expand.
+type alertLine struct {
+	broadcasterID string
+	tokens        map[string]string
+}
+
+// onAlert builds the shared handler shell every alert uses: read the toggle
+// and custom template out of the module config, decode the event subset, ask
+// render for the destination and token values, and emit the expanded line.
+// pick returns the alert's enable state and custom template; fallback is the
+// default template used when the broadcaster has not set one. render's false
+// return drops the event (missing identity, or an alert another handler owns).
+func onAlert[T any](pick func(alertsConfig) (bool, string), fallback string, render func(ev T) (alertLine, bool)) module.EventHandler {
+	return func(_ context.Context, c *module.Context, emit module.Emit) error {
+		var cfg alertsConfig
+		_ = c.Decode(&cfg)
+		enabled, tmpl := pick(cfg)
+		if !enabled || len(c.Env.Event) == 0 {
+			return nil
+		}
+		var ev T
+		if err := json.Unmarshal(c.Env.Event, &ev); err != nil {
+			return err
+		}
+		line, ok := render(ev)
+		if !ok {
+			return nil
+		}
+		if tmpl == "" {
+			tmpl = fallback
+		}
+		msg := module.ExpandString(tmpl, func(key string) (string, bool) {
+			if v, found := line.tokens[key]; found {
+				return v, true
+			}
+			return module.ParseDynamic(key)
+		})
+		emit(&module.Output{
+			Type:          outgress.TypeChat,
+			BroadcasterID: line.broadcasterID,
+			Text:          msg,
+		})
+		return nil
+	}
+}
+
 // Alerts posts a chat line on channel.follow, channel.subscribe,
 // channel.subscription.message, channel.subscription.gift, channel.cheer,
 // channel.raid and channel.ad_break.begin. It is a named, default-on module
@@ -111,269 +158,100 @@ type adBreakEvent struct {
 func Alerts(_ engine.Deps) module.Module {
 	m := module.NewModule("alerts", module.KindDefault)
 
-	m.On("channel.follow", func(_ context.Context, c *module.Context, emit module.Emit) error {
-		var cfg alertsConfig
-		_ = c.Decode(&cfg)
-		if !alertOn(cfg.FollowEnabled) {
-			return nil
-		}
-		if len(c.Env.Event) == 0 {
-			return nil
-		}
-		var ev followEvent
-		if err := json.Unmarshal(c.Env.Event, &ev); err != nil {
-			return err
-		}
-		if ev.UserLogin == "" {
-			return nil
-		}
-
-		tmpl := cfg.FollowMessage
-		if tmpl == "" {
-			tmpl = defaultFollowTemplate
-		}
-
-		msg := module.ExpandString(tmpl, func(key string) (string, bool) {
-			switch key {
-			case "user":
-				return strings.TrimPrefix(displayName(ev.UserName, ev.UserLogin), "@"), true
-			default:
-				return module.ParseDynamic(key)
+	m.On("channel.follow", onAlert(
+		func(cfg alertsConfig) (bool, string) { return alertOn(cfg.FollowEnabled), cfg.FollowMessage },
+		defaultFollowTemplate,
+		func(ev followEvent) (alertLine, bool) {
+			if ev.UserLogin == "" {
+				return alertLine{}, false
 			}
-		})
+			return alertLine{ev.BroadcasterUserID, map[string]string{
+				"user": chatName(ev.UserName, ev.UserLogin),
+			}}, true
+		}))
 
-		emit(&module.Output{
-			Type:          outgress.TypeChat,
-			BroadcasterID: ev.BroadcasterUserID,
-			Text:          msg,
-		})
-		return nil
-	})
-
-	// subAlert serves both channel.subscribe (new subs) and
+	// The sub alert serves both channel.subscribe (new subs) and
 	// channel.subscription.message (resubs shared in chat), so a renewing sub
 	// gets the same welcome line under the same toggle. The resub payload has
-	// no is_gift field, so the gifted-recipient skip below only ever fires on
+	// no is_gift field, so the gifted-recipient skip only ever fires on
 	// channel.subscribe.
-	subAlert := func(_ context.Context, c *module.Context, emit module.Emit) error {
-		var cfg alertsConfig
-		_ = c.Decode(&cfg)
-		if !alertOn(cfg.SubEnabled) {
-			return nil
-		}
-		if len(c.Env.Event) == 0 {
-			return nil
-		}
-		var ev subscribeEvent
-		if err := json.Unmarshal(c.Env.Event, &ev); err != nil {
-			return err
-		}
-		// A gifted recipient is announced through the gift alert on
-		// channel.subscription.gift (one line per gifter, not one per
-		// recipient), so a gift bomb cannot flood chat with welcome lines.
-		if ev.UserLogin == "" || ev.IsGift {
-			return nil
-		}
-
-		tmpl := cfg.SubMessage
-		if tmpl == "" {
-			tmpl = defaultSubTemplate
-		}
-
-		msg := module.ExpandString(tmpl, func(key string) (string, bool) {
-			switch key {
-			case "user":
-				return strings.TrimPrefix(displayName(ev.UserName, ev.UserLogin), "@"), true
-			case "tier":
-				return ev.Tier, true
-			default:
-				return module.ParseDynamic(key)
+	subAlert := onAlert(
+		func(cfg alertsConfig) (bool, string) { return alertOn(cfg.SubEnabled), cfg.SubMessage },
+		defaultSubTemplate,
+		func(ev subscribeEvent) (alertLine, bool) {
+			// A gifted recipient is announced through the gift alert on
+			// channel.subscription.gift (one line per gifter, not one per
+			// recipient), so a gift bomb cannot flood chat with welcome lines.
+			if ev.UserLogin == "" || ev.IsGift {
+				return alertLine{}, false
 			}
+			return alertLine{ev.BroadcasterUserID, map[string]string{
+				"user": chatName(ev.UserName, ev.UserLogin),
+				"tier": ev.Tier,
+			}}, true
 		})
-
-		emit(&module.Output{
-			Type:          outgress.TypeChat,
-			BroadcasterID: ev.BroadcasterUserID,
-			Text:          msg,
-		})
-		return nil
-	}
 	m.On("channel.subscribe", subAlert)
 	m.On("channel.subscription.message", subAlert)
 
-	m.On("channel.subscription.gift", func(_ context.Context, c *module.Context, emit module.Emit) error {
-		var cfg alertsConfig
-		_ = c.Decode(&cfg)
-		if !alertOn(cfg.GiftEnabled) {
-			return nil
-		}
-		if len(c.Env.Event) == 0 {
-			return nil
-		}
-		var ev giftEvent
-		if err := json.Unmarshal(c.Env.Event, &ev); err != nil {
-			return err
-		}
-		if ev.BroadcasterUserID == "" || ev.Total <= 0 {
-			return nil
-		}
-
-		tmpl := cfg.GiftMessage
-		if tmpl == "" {
-			tmpl = defaultGiftTemplate
-		}
-
-		gifter := "An anonymous gifter"
-		if !ev.IsAnonymous {
-			gifter = displayName(ev.UserName, ev.UserLogin)
-		}
-
-		msg := module.ExpandString(tmpl, func(key string) (string, bool) {
-			switch key {
-			case "user":
-				return strings.TrimPrefix(gifter, "@"), true
-			case "count":
-				return strconv.Itoa(ev.Total), true
-			case "tier":
-				return ev.Tier, true
-			default:
-				return module.ParseDynamic(key)
+	m.On("channel.subscription.gift", onAlert(
+		func(cfg alertsConfig) (bool, string) { return alertOn(cfg.GiftEnabled), cfg.GiftMessage },
+		defaultGiftTemplate,
+		func(ev giftEvent) (alertLine, bool) {
+			if ev.BroadcasterUserID == "" || ev.Total <= 0 {
+				return alertLine{}, false
 			}
-		})
-
-		emit(&module.Output{
-			Type:          outgress.TypeChat,
-			BroadcasterID: ev.BroadcasterUserID,
-			Text:          msg,
-		})
-		return nil
-	})
-
-	m.On("channel.cheer", func(_ context.Context, c *module.Context, emit module.Emit) error {
-		var cfg alertsConfig
-		_ = c.Decode(&cfg)
-		if !alertOn(cfg.CheerEnabled) {
-			return nil
-		}
-		if len(c.Env.Event) == 0 {
-			return nil
-		}
-		var ev cheerEvent
-		if err := json.Unmarshal(c.Env.Event, &ev); err != nil {
-			return err
-		}
-		if ev.BroadcasterUserID == "" {
-			return nil
-		}
-
-		tmpl := cfg.CheerMessage
-		if tmpl == "" {
-			tmpl = defaultCheerTemplate
-		}
-
-		cheerer := "An anonymous cheerer"
-		if !ev.IsAnonymous {
-			cheerer = displayName(ev.UserName, ev.UserLogin)
-		}
-
-		msg := module.ExpandString(tmpl, func(key string) (string, bool) {
-			switch key {
-			case "user":
-				return strings.TrimPrefix(cheerer, "@"), true
-			case "bits":
-				return strconv.Itoa(ev.Bits), true
-			default:
-				return module.ParseDynamic(key)
+			gifter := "An anonymous gifter"
+			if !ev.IsAnonymous {
+				gifter = displayName(ev.UserName, ev.UserLogin)
 			}
-		})
+			return alertLine{ev.BroadcasterUserID, map[string]string{
+				"user":  strings.TrimPrefix(gifter, "@"),
+				"count": strconv.Itoa(ev.Total),
+				"tier":  ev.Tier,
+			}}, true
+		}))
 
-		emit(&module.Output{
-			Type:          outgress.TypeChat,
-			BroadcasterID: ev.BroadcasterUserID,
-			Text:          msg,
-		})
-		return nil
-	})
-
-	m.On("channel.raid", func(_ context.Context, c *module.Context, emit module.Emit) error {
-		var cfg alertsConfig
-		_ = c.Decode(&cfg)
-		if !alertOn(cfg.RaidEnabled) {
-			return nil
-		}
-		if len(c.Env.Event) == 0 {
-			return nil
-		}
-		var ev raidEvent
-		if err := json.Unmarshal(c.Env.Event, &ev); err != nil {
-			return err
-		}
-		if ev.FromBroadcasterUserLogin == "" {
-			return nil
-		}
-
-		tmpl := cfg.RaidMessage
-		if tmpl == "" {
-			tmpl = defaultRaidTemplate
-		}
-
-		msg := module.ExpandString(tmpl, func(key string) (string, bool) {
-			switch key {
-			case "user":
-				return strings.TrimPrefix(displayName(ev.FromBroadcasterUserName, ev.FromBroadcasterUserLogin), "@"), true
-			case "viewers":
-				return strconv.Itoa(ev.Viewers), true
-			default:
-				return module.ParseDynamic(key)
+	m.On("channel.cheer", onAlert(
+		func(cfg alertsConfig) (bool, string) { return alertOn(cfg.CheerEnabled), cfg.CheerMessage },
+		defaultCheerTemplate,
+		func(ev cheerEvent) (alertLine, bool) {
+			if ev.BroadcasterUserID == "" {
+				return alertLine{}, false
 			}
-		})
-
-		emit(&module.Output{
-			Type:          outgress.TypeChat,
-			BroadcasterID: ev.ToBroadcasterUserID,
-			Text:          msg,
-		})
-		return nil
-	})
-
-	m.On("channel.ad_break.begin", func(_ context.Context, c *module.Context, emit module.Emit) error {
-		var cfg alertsConfig
-		_ = c.Decode(&cfg)
-		if !adAlertOn(cfg.AdsEnabled) {
-			return nil
-		}
-		if len(c.Env.Event) == 0 {
-			return nil
-		}
-		var ev adBreakEvent
-		if err := json.Unmarshal(c.Env.Event, &ev); err != nil {
-			return err
-		}
-		if ev.BroadcasterUserID == "" {
-			return nil
-		}
-
-		tmpl := cfg.AdsMessage
-		if tmpl == "" {
-			tmpl = defaultAdsTemplate
-		}
-
-		msg := module.ExpandString(tmpl, func(key string) (string, bool) {
-			switch key {
-			case "duration":
-				return strconv.Itoa(ev.DurationSeconds), true
-			default:
-				return module.ParseDynamic(key)
+			cheerer := "An anonymous cheerer"
+			if !ev.IsAnonymous {
+				cheerer = displayName(ev.UserName, ev.UserLogin)
 			}
-		})
+			return alertLine{ev.BroadcasterUserID, map[string]string{
+				"user": strings.TrimPrefix(cheerer, "@"),
+				"bits": strconv.Itoa(ev.Bits),
+			}}, true
+		}))
 
-		emit(&module.Output{
-			Type:          outgress.TypeChat,
-			BroadcasterID: ev.BroadcasterUserID,
-			Text:          msg,
-		})
-		return nil
-	})
+	m.On("channel.raid", onAlert(
+		func(cfg alertsConfig) (bool, string) { return alertOn(cfg.RaidEnabled), cfg.RaidMessage },
+		defaultRaidTemplate,
+		func(ev raidEvent) (alertLine, bool) {
+			if ev.FromBroadcasterUserLogin == "" {
+				return alertLine{}, false
+			}
+			return alertLine{ev.ToBroadcasterUserID, map[string]string{
+				"user":    chatName(ev.FromBroadcasterUserName, ev.FromBroadcasterUserLogin),
+				"viewers": strconv.Itoa(ev.Viewers),
+			}}, true
+		}))
+
+	m.On("channel.ad_break.begin", onAlert(
+		func(cfg alertsConfig) (bool, string) { return adAlertOn(cfg.AdsEnabled), cfg.AdsMessage },
+		defaultAdsTemplate,
+		func(ev adBreakEvent) (alertLine, bool) {
+			if ev.BroadcasterUserID == "" {
+				return alertLine{}, false
+			}
+			return alertLine{ev.BroadcasterUserID, map[string]string{
+				"duration": strconv.Itoa(ev.DurationSeconds),
+			}}, true
+		}))
 
 	return m.Build()
 }
@@ -387,3 +265,8 @@ func displayName(name, login string) string {
 	return login
 }
 
+// chatName is displayName as the {user} token: any leading @ is stripped so a
+// template can write "@{user}" without doubling it.
+func chatName(name, login string) string {
+	return strings.TrimPrefix(displayName(name, login), "@")
+}

--- a/app/sesame/modules/alerts.go
+++ b/app/sesame/modules/alerts.go
@@ -15,6 +15,7 @@ import (
 const (
 	defaultFollowTemplate = "Thank you for following the channel, {user}!"
 	defaultSubTemplate    = "Welcome to the community, {user}! Thank you for subscribing!"
+	defaultGiftTemplate   = "{user} just gifted {count} subs to the community! Thank you!"
 	defaultCheerTemplate  = "Thank you for the {bits} bits, {user}!"
 	defaultRaidTemplate   = "{user} is raiding the channel with {viewers} viewers! Welcome everyone!"
 	defaultAdsTemplate    = "Ads are rolling for {duration} seconds. Hang tight, we'll be right back!"
@@ -30,6 +31,8 @@ type alertsConfig struct {
 	FollowMessage string `json:"followMessage"`
 	SubEnabled    string `json:"subEnabled"`
 	SubMessage    string `json:"subMessage"`
+	GiftEnabled   string `json:"giftEnabled"`
+	GiftMessage   string `json:"giftMessage"`
 	CheerEnabled  string `json:"cheerEnabled"`
 	CheerMessage  string `json:"cheerMessage"`
 	RaidEnabled   string `json:"raidEnabled"`
@@ -56,11 +59,26 @@ type followEvent struct {
 	BroadcasterUserID string `json:"broadcaster_user_id"`
 }
 
-// subscribeEvent is the subset of the channel.subscribe EventSub payload we use.
+// subscribeEvent is the subset of the channel.subscribe EventSub payload we
+// use. IsGift marks a gifted recipient: Twitch fires one channel.subscribe per
+// recipient of a gift, on top of the single channel.subscription.gift for the
+// gifter.
 type subscribeEvent struct {
 	UserName          string `json:"user_name"`
 	UserLogin         string `json:"user_login"`
 	BroadcasterUserID string `json:"broadcaster_user_id"`
+	Tier              string `json:"tier"`
+	IsGift            bool   `json:"is_gift"`
+}
+
+// giftEvent is the subset of the channel.subscription.gift EventSub payload we
+// use. A gift left anonymous by the gifter carries no user identity.
+type giftEvent struct {
+	IsAnonymous       bool   `json:"is_anonymous"`
+	UserName          string `json:"user_name"`
+	UserLogin         string `json:"user_login"`
+	BroadcasterUserID string `json:"broadcaster_user_id"`
+	Total             int    `json:"total"`
 	Tier              string `json:"tier"`
 }
 
@@ -81,8 +99,9 @@ type adBreakEvent struct {
 	DurationSeconds   int    `json:"duration_seconds"`
 }
 
-// Alerts posts a chat line on channel.follow, channel.subscribe, channel.cheer,
-// channel.raid and channel.ad_break.begin. It is a named, default-on module
+// Alerts posts a chat line on channel.follow, channel.subscribe,
+// channel.subscription.gift, channel.cheer, channel.raid and
+// channel.ad_break.begin. It is a named, default-on module
 // (KindDefault): it ships
 // enabled and runs unless the broadcaster disables the whole module on the
 // dashboard. Each alert has its own enable toggle and message template, wired in
@@ -144,7 +163,10 @@ func Alerts(_ engine.Deps) module.Module {
 		if err := json.Unmarshal(c.Env.Event, &ev); err != nil {
 			return err
 		}
-		if ev.UserLogin == "" {
+		// A gifted recipient is announced through the gift alert on
+		// channel.subscription.gift (one line per gifter, not one per
+		// recipient), so a gift bomb cannot flood chat with welcome lines.
+		if ev.UserLogin == "" || ev.IsGift {
 			return nil
 		}
 
@@ -157,6 +179,54 @@ func Alerts(_ engine.Deps) module.Module {
 			switch key {
 			case "user":
 				return strings.TrimPrefix(displayName(ev.UserName, ev.UserLogin), "@"), true
+			case "tier":
+				return ev.Tier, true
+			default:
+				return module.ParseDynamic(key)
+			}
+		})
+
+		emit(&module.Output{
+			Type:          outgress.TypeChat,
+			BroadcasterID: ev.BroadcasterUserID,
+			Text:          msg,
+		})
+		return nil
+	})
+
+	m.On("channel.subscription.gift", func(_ context.Context, c *module.Context, emit module.Emit) error {
+		var cfg alertsConfig
+		_ = c.Decode(&cfg)
+		if !alertOn(cfg.GiftEnabled) {
+			return nil
+		}
+		if len(c.Env.Event) == 0 {
+			return nil
+		}
+		var ev giftEvent
+		if err := json.Unmarshal(c.Env.Event, &ev); err != nil {
+			return err
+		}
+		if ev.BroadcasterUserID == "" || ev.Total <= 0 {
+			return nil
+		}
+
+		tmpl := cfg.GiftMessage
+		if tmpl == "" {
+			tmpl = defaultGiftTemplate
+		}
+
+		gifter := "An anonymous gifter"
+		if !ev.IsAnonymous {
+			gifter = displayName(ev.UserName, ev.UserLogin)
+		}
+
+		msg := module.ExpandString(tmpl, func(key string) (string, bool) {
+			switch key {
+			case "user":
+				return strings.TrimPrefix(gifter, "@"), true
+			case "count":
+				return strconv.Itoa(ev.Total), true
 			case "tier":
 				return ev.Tier, true
 			default:

--- a/app/sesame/modules/alerts_test.go
+++ b/app/sesame/modules/alerts_test.go
@@ -18,6 +18,7 @@ const (
 	followJSON    = `{"user_name":"CoolViewer","user_login":"coolviewer","broadcaster_user_id":"2"}`
 	subscribeJSON = `{"user_name":"CoolViewer","user_login":"coolviewer","broadcaster_user_id":"2","tier":"1000"}`
 	giftedSubJSON = `{"user_name":"CoolViewer","user_login":"coolviewer","broadcaster_user_id":"2","tier":"1000","is_gift":true}`
+	resubJSON     = `{"user_name":"CoolViewer","user_login":"coolviewer","broadcaster_user_id":"2","tier":"1000","cumulative_months":7,"streak_months":7,"message":{"text":"7 months!"}}`
 	giftJSON      = `{"is_anonymous":false,"user_name":"GenerousViewer","user_login":"generousviewer","broadcaster_user_id":"2","total":5,"tier":"1000"}`
 	anonGiftJSON  = `{"is_anonymous":true,"broadcaster_user_id":"2","total":3,"tier":"1000"}`
 	cheerJSON     = `{"is_anonymous":false,"user_name":"CoolViewer","user_login":"coolviewer","broadcaster_user_id":"2","bits":100}`
@@ -91,6 +92,25 @@ func TestAlertsSubSkipsGiftedRecipient(t *testing.T) {
 	// on channel.subscription.gift announces the gifter once instead.
 	var col collector
 	require.NoError(t, alertsHandler(t, "channel.subscribe")(context.Background(), alertsCtx("channel.subscribe", giftedSubJSON, ""), col.emit))
+	assert.Empty(t, col.out)
+}
+
+func TestAlertsResubFiresNormalSubAlert(t *testing.T) {
+	// A resub (channel.subscription.message) posts the same sub alert under
+	// the same toggle and template as a fresh channel.subscribe.
+	var col collector
+	require.NoError(t, alertsHandler(t, "channel.subscription.message")(context.Background(), alertsCtx("channel.subscription.message", resubJSON, ""), col.emit))
+	require.Len(t, col.out, 1)
+	o := col.out[0]
+	assert.Equal(t, outgress.TypeChat, o.Type)
+	assert.Equal(t, "2", o.BroadcasterID)
+	assert.Contains(t, o.Text, "CoolViewer")
+}
+
+func TestAlertsResubDisabledBySubToggle(t *testing.T) {
+	var col collector
+	cfg := `{"subEnabled":"off"}`
+	require.NoError(t, alertsHandler(t, "channel.subscription.message")(context.Background(), alertsCtx("channel.subscription.message", resubJSON, cfg), col.emit))
 	assert.Empty(t, col.out)
 }
 

--- a/app/sesame/modules/alerts_test.go
+++ b/app/sesame/modules/alerts_test.go
@@ -48,12 +48,20 @@ func alertsHandler(t *testing.T, eventType string) module.EventHandler {
 	return h
 }
 
+// alertInput is one event fired at the alerts module: the EventSub type, its
+// payload and the module config it runs under.
+type alertInput struct {
+	event   string
+	payload string
+	cfg     string
+}
+
 // runAlert fires one event through the alerts module and returns what it
 // emitted.
-func runAlert(t *testing.T, eventType, payload, cfg string) []module.Output {
+func runAlert(t *testing.T, in alertInput) []module.Output {
 	t.Helper()
 	var col collector
-	require.NoError(t, alertsHandler(t, eventType)(context.Background(), alertsCtx(eventType, payload, cfg), col.emit))
+	require.NoError(t, alertsHandler(t, in.event)(context.Background(), alertsCtx(in.event, in.payload, in.cfg), col.emit))
 	return col.out
 }
 
@@ -61,24 +69,25 @@ func runAlert(t *testing.T, eventType, payload, cfg string) []module.Output {
 // channel containing the substituted sample values.
 func TestAlertsDefaultTemplates(t *testing.T) {
 	cases := []struct {
-		name, event, payload, cfg string
-		want                      []string
+		name string
+		in   alertInput
+		want []string
 	}{
-		{"follow", "channel.follow", followJSON, "", []string{"CoolViewer"}},
-		{"subscribe", "channel.subscribe", subscribeJSON, "", []string{"CoolViewer"}},
+		{"follow", alertInput{"channel.follow", followJSON, ""}, []string{"CoolViewer"}},
+		{"subscribe", alertInput{"channel.subscribe", subscribeJSON, ""}, []string{"CoolViewer"}},
 		// A resub (channel.subscription.message) posts the same sub alert
 		// under the same toggle and template as a fresh channel.subscribe.
-		{"resub", "channel.subscription.message", resubJSON, "", []string{"CoolViewer"}},
-		{"gift", "channel.subscription.gift", giftJSON, "", []string{"GenerousViewer", "5"}},
-		{"anonymous gift", "channel.subscription.gift", anonGiftJSON, "", []string{"anonymous", "3"}},
-		{"cheer", "channel.cheer", cheerJSON, "", []string{"CoolViewer", "100"}},
-		{"anonymous cheer", "channel.cheer", anonCheerJSON, "", []string{"anonymous", "50"}},
-		{"raid", "channel.raid", raidJSON, "", []string{"CoolStreamer", "42"}},
-		{"ad break", "channel.ad_break.begin", adBreakJSON, `{"adsEnabled":"on"}`, []string{"90"}},
+		{"resub", alertInput{"channel.subscription.message", resubJSON, ""}, []string{"CoolViewer"}},
+		{"gift", alertInput{"channel.subscription.gift", giftJSON, ""}, []string{"GenerousViewer", "5"}},
+		{"anonymous gift", alertInput{"channel.subscription.gift", anonGiftJSON, ""}, []string{"anonymous", "3"}},
+		{"cheer", alertInput{"channel.cheer", cheerJSON, ""}, []string{"CoolViewer", "100"}},
+		{"anonymous cheer", alertInput{"channel.cheer", anonCheerJSON, ""}, []string{"anonymous", "50"}},
+		{"raid", alertInput{"channel.raid", raidJSON, ""}, []string{"CoolStreamer", "42"}},
+		{"ad break", alertInput{"channel.ad_break.begin", adBreakJSON, `{"adsEnabled":"on"}`}, []string{"90"}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			out := runAlert(t, tc.event, tc.payload, tc.cfg)
+			out := runAlert(t, tc.in)
 			require.Len(t, out, 1)
 			assert.Equal(t, outgress.TypeChat, out[0].Type)
 			assert.Equal(t, "2", out[0].BroadcasterID)
@@ -92,17 +101,19 @@ func TestAlertsDefaultTemplates(t *testing.T) {
 // Custom templates substitute every token the alert documents.
 func TestAlertsCustomTemplates(t *testing.T) {
 	cases := []struct {
-		name, event, payload, cfg, want string
+		name string
+		in   alertInput
+		want string
 	}{
-		{"follow", "channel.follow", followJSON, `{"followMessage":"welcome {user}"}`, "welcome CoolViewer"},
-		{"subscribe", "channel.subscribe", subscribeJSON, `{"subMessage":"{user} sub'd at tier {tier}"}`, "CoolViewer sub'd at tier 1000"},
-		{"gift", "channel.subscription.gift", giftJSON, `{"giftMessage":"{user} dropped {count} tier {tier} gifts"}`, "GenerousViewer dropped 5 tier 1000 gifts"},
-		{"raid", "channel.raid", raidJSON, `{"raidMessage":"raid! {user} +{viewers}"}`, "raid! CoolStreamer +42"},
-		{"ad break", "channel.ad_break.begin", adBreakJSON, `{"adsEnabled":"on","adsMessage":"break for {duration}s"}`, "break for 90s"},
+		{"follow", alertInput{"channel.follow", followJSON, `{"followMessage":"welcome {user}"}`}, "welcome CoolViewer"},
+		{"subscribe", alertInput{"channel.subscribe", subscribeJSON, `{"subMessage":"{user} sub'd at tier {tier}"}`}, "CoolViewer sub'd at tier 1000"},
+		{"gift", alertInput{"channel.subscription.gift", giftJSON, `{"giftMessage":"{user} dropped {count} tier {tier} gifts"}`}, "GenerousViewer dropped 5 tier 1000 gifts"},
+		{"raid", alertInput{"channel.raid", raidJSON, `{"raidMessage":"raid! {user} +{viewers}"}`}, "raid! CoolStreamer +42"},
+		{"ad break", alertInput{"channel.ad_break.begin", adBreakJSON, `{"adsEnabled":"on","adsMessage":"break for {duration}s"}`}, "break for 90s"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			out := runAlert(t, tc.event, tc.payload, tc.cfg)
+			out := runAlert(t, tc.in)
 			require.Len(t, out, 1)
 			assert.Equal(t, tc.want, out[0].Text)
 		})
@@ -114,22 +125,23 @@ func TestAlertsCustomTemplates(t *testing.T) {
 // once instead, so a gift bomb cannot flood chat with welcome lines).
 func TestAlertsSilentCases(t *testing.T) {
 	cases := []struct {
-		name, event, payload, cfg string
+		name string
+		in   alertInput
 	}{
-		{"follow off", "channel.follow", followJSON, `{"followEnabled":"off"}`},
-		{"sub off", "channel.subscribe", subscribeJSON, `{"subEnabled":"off"}`},
-		{"resub follows sub toggle", "channel.subscription.message", resubJSON, `{"subEnabled":"off"}`},
-		{"gift off", "channel.subscription.gift", giftJSON, `{"giftEnabled":"off"}`},
-		{"cheer off", "channel.cheer", cheerJSON, `{"cheerEnabled":"off"}`},
-		{"raid off", "channel.raid", raidJSON, `{"raidEnabled":"off"}`},
-		{"gifted recipient", "channel.subscribe", giftedSubJSON, ""},
-		{"empty follow event", "channel.follow", "", ""},
-		{"empty gift event", "channel.subscription.gift", "", ""},
-		{"empty ad event", "channel.ad_break.begin", "", `{"adsEnabled":"on"}`},
+		{"follow off", alertInput{"channel.follow", followJSON, `{"followEnabled":"off"}`}},
+		{"sub off", alertInput{"channel.subscribe", subscribeJSON, `{"subEnabled":"off"}`}},
+		{"resub follows sub toggle", alertInput{"channel.subscription.message", resubJSON, `{"subEnabled":"off"}`}},
+		{"gift off", alertInput{"channel.subscription.gift", giftJSON, `{"giftEnabled":"off"}`}},
+		{"cheer off", alertInput{"channel.cheer", cheerJSON, `{"cheerEnabled":"off"}`}},
+		{"raid off", alertInput{"channel.raid", raidJSON, `{"raidEnabled":"off"}`}},
+		{"gifted recipient", alertInput{"channel.subscribe", giftedSubJSON, ""}},
+		{"empty follow event", alertInput{"channel.follow", "", ""}},
+		{"empty gift event", alertInput{"channel.subscription.gift", "", ""}},
+		{"empty ad event", alertInput{"channel.ad_break.begin", "", `{"adsEnabled":"on"}`}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Empty(t, runAlert(t, tc.event, tc.payload, tc.cfg))
+			assert.Empty(t, runAlert(t, tc.in))
 		})
 	}
 }
@@ -138,13 +150,13 @@ func TestAlertsAdBreakDefaultOff(t *testing.T) {
 	// Unlike every other alert, the ads alert must not fire until the
 	// broadcaster explicitly turns it on: absent, empty and "off" all suppress.
 	for _, cfg := range []string{``, `{}`, `{"adsEnabled":""}`, `{"adsEnabled":"off"}`} {
-		assert.Empty(t, runAlert(t, "channel.ad_break.begin", adBreakJSON, cfg), "cfg=%q must stay silent", cfg)
+		assert.Empty(t, runAlert(t, alertInput{"channel.ad_break.begin", adBreakJSON, cfg}), "cfg=%q must stay silent", cfg)
 	}
 }
 
 func TestAlertsEnabledOnAndBlankBothFire(t *testing.T) {
 	// "on" and an absent flag both fire (default-on); only "off" suppresses.
 	for _, cfg := range []string{`{"followEnabled":"on"}`, `{}`, ``} {
-		assert.Len(t, runAlert(t, "channel.follow", followJSON, cfg), 1, "cfg=%q should fire", cfg)
+		assert.Len(t, runAlert(t, alertInput{"channel.follow", followJSON, cfg}), 1, "cfg=%q should fire", cfg)
 	}
 }

--- a/app/sesame/modules/alerts_test.go
+++ b/app/sesame/modules/alerts_test.go
@@ -17,6 +17,9 @@ import (
 const (
 	followJSON    = `{"user_name":"CoolViewer","user_login":"coolviewer","broadcaster_user_id":"2"}`
 	subscribeJSON = `{"user_name":"CoolViewer","user_login":"coolviewer","broadcaster_user_id":"2","tier":"1000"}`
+	giftedSubJSON = `{"user_name":"CoolViewer","user_login":"coolviewer","broadcaster_user_id":"2","tier":"1000","is_gift":true}`
+	giftJSON      = `{"is_anonymous":false,"user_name":"GenerousViewer","user_login":"generousviewer","broadcaster_user_id":"2","total":5,"tier":"1000"}`
+	anonGiftJSON  = `{"is_anonymous":true,"broadcaster_user_id":"2","total":3,"tier":"1000"}`
 	cheerJSON     = `{"is_anonymous":false,"user_name":"CoolViewer","user_login":"coolviewer","broadcaster_user_id":"2","bits":100}`
 	anonCheerJSON = `{"is_anonymous":true,"broadcaster_user_id":"2","bits":50}`
 	adBreakJSON   = `{"broadcaster_user_id":"2","duration_seconds":90,"is_automatic":true}`
@@ -81,6 +84,54 @@ func TestAlertsSubCustomTemplate(t *testing.T) {
 	require.NoError(t, alertsHandler(t, "channel.subscribe")(context.Background(), alertsCtx("channel.subscribe", subscribeJSON, cfg), col.emit))
 	require.Len(t, col.out, 1)
 	assert.Equal(t, "CoolViewer sub'd at tier 1000", col.out[0].Text)
+}
+
+func TestAlertsSubSkipsGiftedRecipient(t *testing.T) {
+	// A gifted recipient's channel.subscribe must stay silent: the gift alert
+	// on channel.subscription.gift announces the gifter once instead.
+	var col collector
+	require.NoError(t, alertsHandler(t, "channel.subscribe")(context.Background(), alertsCtx("channel.subscribe", giftedSubJSON, ""), col.emit))
+	assert.Empty(t, col.out)
+}
+
+func TestAlertsGiftDefaultTemplate(t *testing.T) {
+	var col collector
+	require.NoError(t, alertsHandler(t, "channel.subscription.gift")(context.Background(), alertsCtx("channel.subscription.gift", giftJSON, ""), col.emit))
+	require.Len(t, col.out, 1)
+	o := col.out[0]
+	assert.Equal(t, outgress.TypeChat, o.Type)
+	assert.Equal(t, "2", o.BroadcasterID)
+	assert.Contains(t, o.Text, "GenerousViewer")
+	assert.Contains(t, o.Text, "5")
+}
+
+func TestAlertsGiftCustomTemplate(t *testing.T) {
+	var col collector
+	cfg := `{"giftMessage":"{user} dropped {count} tier {tier} gifts"}`
+	require.NoError(t, alertsHandler(t, "channel.subscription.gift")(context.Background(), alertsCtx("channel.subscription.gift", giftJSON, cfg), col.emit))
+	require.Len(t, col.out, 1)
+	assert.Equal(t, "GenerousViewer dropped 5 tier 1000 gifts", col.out[0].Text)
+}
+
+func TestAlertsGiftAnonymous(t *testing.T) {
+	var col collector
+	require.NoError(t, alertsHandler(t, "channel.subscription.gift")(context.Background(), alertsCtx("channel.subscription.gift", anonGiftJSON, ""), col.emit))
+	require.Len(t, col.out, 1)
+	assert.Contains(t, col.out[0].Text, "anonymous")
+	assert.Contains(t, col.out[0].Text, "3")
+}
+
+func TestAlertsGiftDisabled(t *testing.T) {
+	var col collector
+	cfg := `{"giftEnabled":"off"}`
+	require.NoError(t, alertsHandler(t, "channel.subscription.gift")(context.Background(), alertsCtx("channel.subscription.gift", giftJSON, cfg), col.emit))
+	assert.Empty(t, col.out)
+}
+
+func TestAlertsGiftIgnoresEmptyEvent(t *testing.T) {
+	var col collector
+	require.NoError(t, alertsHandler(t, "channel.subscription.gift")(context.Background(), alertsCtx("channel.subscription.gift", "", ""), col.emit))
+	assert.Empty(t, col.out)
 }
 
 func TestAlertsCheerDefaultTemplate(t *testing.T) {

--- a/app/sesame/modules/alerts_test.go
+++ b/app/sesame/modules/alerts_test.go
@@ -48,214 +48,103 @@ func alertsHandler(t *testing.T, eventType string) module.EventHandler {
 	return h
 }
 
-func TestAlertsFollowDefaultTemplate(t *testing.T) {
+// runAlert fires one event through the alerts module and returns what it
+// emitted.
+func runAlert(t *testing.T, eventType, payload, cfg string) []module.Output {
+	t.Helper()
 	var col collector
-	require.NoError(t, alertsHandler(t, "channel.follow")(context.Background(), alertsCtx("channel.follow", followJSON, ""), col.emit))
-	require.Len(t, col.out, 1)
-	o := col.out[0]
-	assert.Equal(t, outgress.TypeChat, o.Type)
-	assert.Equal(t, "2", o.BroadcasterID)
-	assert.Contains(t, o.Text, "CoolViewer")
+	require.NoError(t, alertsHandler(t, eventType)(context.Background(), alertsCtx(eventType, payload, cfg), col.emit))
+	return col.out
 }
 
-func TestAlertsFollowCustomTemplate(t *testing.T) {
-	var col collector
-	cfg := `{"followMessage":"welcome {user}"}`
-	require.NoError(t, alertsHandler(t, "channel.follow")(context.Background(), alertsCtx("channel.follow", followJSON, cfg), col.emit))
-	require.Len(t, col.out, 1)
-	assert.Equal(t, "welcome CoolViewer", col.out[0].Text)
+// Every alert with its default template: one chat line to the broadcaster's
+// channel containing the substituted sample values.
+func TestAlertsDefaultTemplates(t *testing.T) {
+	cases := []struct {
+		name, event, payload, cfg string
+		want                      []string
+	}{
+		{"follow", "channel.follow", followJSON, "", []string{"CoolViewer"}},
+		{"subscribe", "channel.subscribe", subscribeJSON, "", []string{"CoolViewer"}},
+		// A resub (channel.subscription.message) posts the same sub alert
+		// under the same toggle and template as a fresh channel.subscribe.
+		{"resub", "channel.subscription.message", resubJSON, "", []string{"CoolViewer"}},
+		{"gift", "channel.subscription.gift", giftJSON, "", []string{"GenerousViewer", "5"}},
+		{"anonymous gift", "channel.subscription.gift", anonGiftJSON, "", []string{"anonymous", "3"}},
+		{"cheer", "channel.cheer", cheerJSON, "", []string{"CoolViewer", "100"}},
+		{"anonymous cheer", "channel.cheer", anonCheerJSON, "", []string{"anonymous", "50"}},
+		{"raid", "channel.raid", raidJSON, "", []string{"CoolStreamer", "42"}},
+		{"ad break", "channel.ad_break.begin", adBreakJSON, `{"adsEnabled":"on"}`, []string{"90"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := runAlert(t, tc.event, tc.payload, tc.cfg)
+			require.Len(t, out, 1)
+			assert.Equal(t, outgress.TypeChat, out[0].Type)
+			assert.Equal(t, "2", out[0].BroadcasterID)
+			for _, want := range tc.want {
+				assert.Contains(t, out[0].Text, want)
+			}
+		})
+	}
 }
 
-func TestAlertsFollowIgnoresEmptyEvent(t *testing.T) {
-	var col collector
-	require.NoError(t, alertsHandler(t, "channel.follow")(context.Background(), alertsCtx("channel.follow", "", ""), col.emit))
-	assert.Empty(t, col.out)
+// Custom templates substitute every token the alert documents.
+func TestAlertsCustomTemplates(t *testing.T) {
+	cases := []struct {
+		name, event, payload, cfg, want string
+	}{
+		{"follow", "channel.follow", followJSON, `{"followMessage":"welcome {user}"}`, "welcome CoolViewer"},
+		{"subscribe", "channel.subscribe", subscribeJSON, `{"subMessage":"{user} sub'd at tier {tier}"}`, "CoolViewer sub'd at tier 1000"},
+		{"gift", "channel.subscription.gift", giftJSON, `{"giftMessage":"{user} dropped {count} tier {tier} gifts"}`, "GenerousViewer dropped 5 tier 1000 gifts"},
+		{"raid", "channel.raid", raidJSON, `{"raidMessage":"raid! {user} +{viewers}"}`, "raid! CoolStreamer +42"},
+		{"ad break", "channel.ad_break.begin", adBreakJSON, `{"adsEnabled":"on","adsMessage":"break for {duration}s"}`, "break for 90s"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := runAlert(t, tc.event, tc.payload, tc.cfg)
+			require.Len(t, out, 1)
+			assert.Equal(t, tc.want, out[0].Text)
+		})
+	}
 }
 
-func TestAlertsSubDefaultTemplate(t *testing.T) {
-	var col collector
-	require.NoError(t, alertsHandler(t, "channel.subscribe")(context.Background(), alertsCtx("channel.subscribe", subscribeJSON, ""), col.emit))
-	require.Len(t, col.out, 1)
-	assert.Contains(t, col.out[0].Text, "CoolViewer")
-}
-
-func TestAlertsSubCustomTemplate(t *testing.T) {
-	var col collector
-	cfg := `{"subMessage":"{user} sub'd at tier {tier}"}`
-	require.NoError(t, alertsHandler(t, "channel.subscribe")(context.Background(), alertsCtx("channel.subscribe", subscribeJSON, cfg), col.emit))
-	require.Len(t, col.out, 1)
-	assert.Equal(t, "CoolViewer sub'd at tier 1000", col.out[0].Text)
-}
-
-func TestAlertsSubSkipsGiftedRecipient(t *testing.T) {
-	// A gifted recipient's channel.subscribe must stay silent: the gift alert
-	// on channel.subscription.gift announces the gifter once instead.
-	var col collector
-	require.NoError(t, alertsHandler(t, "channel.subscribe")(context.Background(), alertsCtx("channel.subscribe", giftedSubJSON, ""), col.emit))
-	assert.Empty(t, col.out)
-}
-
-func TestAlertsResubFiresNormalSubAlert(t *testing.T) {
-	// A resub (channel.subscription.message) posts the same sub alert under
-	// the same toggle and template as a fresh channel.subscribe.
-	var col collector
-	require.NoError(t, alertsHandler(t, "channel.subscription.message")(context.Background(), alertsCtx("channel.subscription.message", resubJSON, ""), col.emit))
-	require.Len(t, col.out, 1)
-	o := col.out[0]
-	assert.Equal(t, outgress.TypeChat, o.Type)
-	assert.Equal(t, "2", o.BroadcasterID)
-	assert.Contains(t, o.Text, "CoolViewer")
-}
-
-func TestAlertsResubDisabledBySubToggle(t *testing.T) {
-	var col collector
-	cfg := `{"subEnabled":"off"}`
-	require.NoError(t, alertsHandler(t, "channel.subscription.message")(context.Background(), alertsCtx("channel.subscription.message", resubJSON, cfg), col.emit))
-	assert.Empty(t, col.out)
-}
-
-func TestAlertsGiftDefaultTemplate(t *testing.T) {
-	var col collector
-	require.NoError(t, alertsHandler(t, "channel.subscription.gift")(context.Background(), alertsCtx("channel.subscription.gift", giftJSON, ""), col.emit))
-	require.Len(t, col.out, 1)
-	o := col.out[0]
-	assert.Equal(t, outgress.TypeChat, o.Type)
-	assert.Equal(t, "2", o.BroadcasterID)
-	assert.Contains(t, o.Text, "GenerousViewer")
-	assert.Contains(t, o.Text, "5")
-}
-
-func TestAlertsGiftCustomTemplate(t *testing.T) {
-	var col collector
-	cfg := `{"giftMessage":"{user} dropped {count} tier {tier} gifts"}`
-	require.NoError(t, alertsHandler(t, "channel.subscription.gift")(context.Background(), alertsCtx("channel.subscription.gift", giftJSON, cfg), col.emit))
-	require.Len(t, col.out, 1)
-	assert.Equal(t, "GenerousViewer dropped 5 tier 1000 gifts", col.out[0].Text)
-}
-
-func TestAlertsGiftAnonymous(t *testing.T) {
-	var col collector
-	require.NoError(t, alertsHandler(t, "channel.subscription.gift")(context.Background(), alertsCtx("channel.subscription.gift", anonGiftJSON, ""), col.emit))
-	require.Len(t, col.out, 1)
-	assert.Contains(t, col.out[0].Text, "anonymous")
-	assert.Contains(t, col.out[0].Text, "3")
-}
-
-func TestAlertsGiftDisabled(t *testing.T) {
-	var col collector
-	cfg := `{"giftEnabled":"off"}`
-	require.NoError(t, alertsHandler(t, "channel.subscription.gift")(context.Background(), alertsCtx("channel.subscription.gift", giftJSON, cfg), col.emit))
-	assert.Empty(t, col.out)
-}
-
-func TestAlertsGiftIgnoresEmptyEvent(t *testing.T) {
-	var col collector
-	require.NoError(t, alertsHandler(t, "channel.subscription.gift")(context.Background(), alertsCtx("channel.subscription.gift", "", ""), col.emit))
-	assert.Empty(t, col.out)
-}
-
-func TestAlertsCheerDefaultTemplate(t *testing.T) {
-	var col collector
-	require.NoError(t, alertsHandler(t, "channel.cheer")(context.Background(), alertsCtx("channel.cheer", cheerJSON, ""), col.emit))
-	require.Len(t, col.out, 1)
-	assert.Contains(t, col.out[0].Text, "CoolViewer")
-	assert.Contains(t, col.out[0].Text, "100")
-}
-
-func TestAlertsCheerAnonymous(t *testing.T) {
-	var col collector
-	require.NoError(t, alertsHandler(t, "channel.cheer")(context.Background(), alertsCtx("channel.cheer", anonCheerJSON, ""), col.emit))
-	require.Len(t, col.out, 1)
-	assert.Contains(t, col.out[0].Text, "anonymous")
-	assert.Contains(t, col.out[0].Text, "50")
-}
-
-func TestAlertsRaidDefaultTemplate(t *testing.T) {
-	var col collector
-	require.NoError(t, alertsHandler(t, "channel.raid")(context.Background(), alertsCtx("channel.raid", raidJSON, ""), col.emit))
-	require.Len(t, col.out, 1)
-	o := col.out[0]
-	assert.Equal(t, "2", o.BroadcasterID) // the receiving channel
-	assert.Contains(t, o.Text, "CoolStreamer")
-	assert.Contains(t, o.Text, "42")
-}
-
-func TestAlertsRaidCustomTemplate(t *testing.T) {
-	var col collector
-	cfg := `{"raidMessage":"raid! {user} +{viewers}"}`
-	require.NoError(t, alertsHandler(t, "channel.raid")(context.Background(), alertsCtx("channel.raid", raidJSON, cfg), col.emit))
-	require.Len(t, col.out, 1)
-	assert.Equal(t, "raid! CoolStreamer +42", col.out[0].Text)
-}
-
-func TestAlertsFollowDisabled(t *testing.T) {
-	var col collector
-	cfg := `{"followEnabled":"off"}`
-	require.NoError(t, alertsHandler(t, "channel.follow")(context.Background(), alertsCtx("channel.follow", followJSON, cfg), col.emit))
-	assert.Empty(t, col.out)
-}
-
-func TestAlertsSubDisabled(t *testing.T) {
-	var col collector
-	cfg := `{"subEnabled":"off"}`
-	require.NoError(t, alertsHandler(t, "channel.subscribe")(context.Background(), alertsCtx("channel.subscribe", subscribeJSON, cfg), col.emit))
-	assert.Empty(t, col.out)
-}
-
-func TestAlertsCheerDisabled(t *testing.T) {
-	var col collector
-	cfg := `{"cheerEnabled":"off"}`
-	require.NoError(t, alertsHandler(t, "channel.cheer")(context.Background(), alertsCtx("channel.cheer", cheerJSON, cfg), col.emit))
-	assert.Empty(t, col.out)
-}
-
-func TestAlertsRaidDisabled(t *testing.T) {
-	var col collector
-	cfg := `{"raidEnabled":"off"}`
-	require.NoError(t, alertsHandler(t, "channel.raid")(context.Background(), alertsCtx("channel.raid", raidJSON, cfg), col.emit))
-	assert.Empty(t, col.out)
+// Events that must stay silent: toggled-off alerts, empty payloads, and the
+// gifted recipient's channel.subscribe (the gift alert announces the gifter
+// once instead, so a gift bomb cannot flood chat with welcome lines).
+func TestAlertsSilentCases(t *testing.T) {
+	cases := []struct {
+		name, event, payload, cfg string
+	}{
+		{"follow off", "channel.follow", followJSON, `{"followEnabled":"off"}`},
+		{"sub off", "channel.subscribe", subscribeJSON, `{"subEnabled":"off"}`},
+		{"resub follows sub toggle", "channel.subscription.message", resubJSON, `{"subEnabled":"off"}`},
+		{"gift off", "channel.subscription.gift", giftJSON, `{"giftEnabled":"off"}`},
+		{"cheer off", "channel.cheer", cheerJSON, `{"cheerEnabled":"off"}`},
+		{"raid off", "channel.raid", raidJSON, `{"raidEnabled":"off"}`},
+		{"gifted recipient", "channel.subscribe", giftedSubJSON, ""},
+		{"empty follow event", "channel.follow", "", ""},
+		{"empty gift event", "channel.subscription.gift", "", ""},
+		{"empty ad event", "channel.ad_break.begin", "", `{"adsEnabled":"on"}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Empty(t, runAlert(t, tc.event, tc.payload, tc.cfg))
+		})
+	}
 }
 
 func TestAlertsAdBreakDefaultOff(t *testing.T) {
 	// Unlike every other alert, the ads alert must not fire until the
 	// broadcaster explicitly turns it on: absent, empty and "off" all suppress.
 	for _, cfg := range []string{``, `{}`, `{"adsEnabled":""}`, `{"adsEnabled":"off"}`} {
-		var col collector
-		require.NoError(t, alertsHandler(t, "channel.ad_break.begin")(context.Background(), alertsCtx("channel.ad_break.begin", adBreakJSON, cfg), col.emit))
-		assert.Empty(t, col.out, "cfg=%q must stay silent", cfg)
+		assert.Empty(t, runAlert(t, "channel.ad_break.begin", adBreakJSON, cfg), "cfg=%q must stay silent", cfg)
 	}
-}
-
-func TestAlertsAdBreakDefaultTemplate(t *testing.T) {
-	var col collector
-	cfg := `{"adsEnabled":"on"}`
-	require.NoError(t, alertsHandler(t, "channel.ad_break.begin")(context.Background(), alertsCtx("channel.ad_break.begin", adBreakJSON, cfg), col.emit))
-	require.Len(t, col.out, 1)
-	o := col.out[0]
-	assert.Equal(t, outgress.TypeChat, o.Type)
-	assert.Equal(t, "2", o.BroadcasterID)
-	assert.Contains(t, o.Text, "90")
-}
-
-func TestAlertsAdBreakCustomTemplate(t *testing.T) {
-	var col collector
-	cfg := `{"adsEnabled":"on","adsMessage":"break for {duration}s"}`
-	require.NoError(t, alertsHandler(t, "channel.ad_break.begin")(context.Background(), alertsCtx("channel.ad_break.begin", adBreakJSON, cfg), col.emit))
-	require.Len(t, col.out, 1)
-	assert.Equal(t, "break for 90s", col.out[0].Text)
-}
-
-func TestAlertsAdBreakIgnoresEmptyEvent(t *testing.T) {
-	var col collector
-	require.NoError(t, alertsHandler(t, "channel.ad_break.begin")(context.Background(), alertsCtx("channel.ad_break.begin", "", `{"adsEnabled":"on"}`), col.emit))
-	assert.Empty(t, col.out)
 }
 
 func TestAlertsEnabledOnAndBlankBothFire(t *testing.T) {
 	// "on" and an absent flag both fire (default-on); only "off" suppresses.
 	for _, cfg := range []string{`{"followEnabled":"on"}`, `{}`, ``} {
-		var col collector
-		require.NoError(t, alertsHandler(t, "channel.follow")(context.Background(), alertsCtx("channel.follow", followJSON, cfg), col.emit))
-		require.Len(t, col.out, 1, "cfg=%q should fire", cfg)
+		assert.Len(t, runAlert(t, "channel.follow", followJSON, cfg), 1, "cfg=%q should fire", cfg)
 	}
 }

--- a/console/dashboard/src/lib/components/commands/ChatPreview.svelte
+++ b/console/dashboard/src/lib/components/commands/ChatPreview.svelte
@@ -63,7 +63,9 @@
     bits: '500',
     raider: 'CrustyCrumbs',
     raider_login: 'crustycrumbs',
-    viewers: '42'
+    viewers: '42',
+    count: '5',
+    duration: '90'
   };
   // Caller overrides win (e.g. a raid alert where {user} is the raiding channel).
   const SAMPLES = $derived<Record<string, string>>(

--- a/console/shared/lib/types.ts
+++ b/console/shared/lib/types.ts
@@ -700,6 +700,15 @@ export const MODULE_CATALOG: readonly ModuleDef[] = [
         defaultMessage: 'Welcome to the community, {user}! Thank you for subscribing!'
       },
       {
+        key: 'gift',
+        label: 'Gift sub alert',
+        tagline: 'When someone gifts subs. One line per gifter, never per recipient.',
+        event: 'on gift subs',
+        enableKey: 'giftEnabled',
+        messageKey: 'giftMessage',
+        defaultMessage: '{user} just gifted {count} subs to the community! Thank you!'
+      },
+      {
         key: 'cheer',
         label: 'Cheer alert',
         tagline: 'When someone cheers bits.',

--- a/console/shared/lib/types.ts
+++ b/console/shared/lib/types.ts
@@ -693,7 +693,7 @@ export const MODULE_CATALOG: readonly ModuleDef[] = [
       {
         key: 'sub',
         label: 'Subscribe alert',
-        tagline: 'When someone subscribes.',
+        tagline: 'When someone subscribes or resubscribes.',
         event: 'on subscribe',
         enableKey: 'subEnabled',
         messageKey: 'subMessage',

--- a/console/shared/lib/types.ts
+++ b/console/shared/lib/types.ts
@@ -706,7 +706,9 @@ export const MODULE_CATALOG: readonly ModuleDef[] = [
         event: 'on gift subs',
         enableKey: 'giftEnabled',
         messageKey: 'giftMessage',
-        defaultMessage: '{user} just gifted {count} subs to the community! Thank you!'
+        defaultMessage: '{user} just gifted {count} subs to the community! Thank you!',
+        tokens: ['user', 'count', 'tier'],
+        previewSamples: { user: 'GenerousViewer', count: '5', tier: '1000' }
       },
       {
         key: 'cheer',


### PR DESCRIPTION
## What

- **Gift subs get their own alert.** `channel.subscription.gift` posts one line thanking the gifter with the gift count (`{user}`, `{count}`, `{tier}` tokens; anonymous gifters handled). New `giftEnabled`/`giftMessage` config, default-on like the other alerts.
- **No more gift-bomb spam.** `channel.subscribe` events with `is_gift` are skipped, so 10 gifted subs no longer produce 10 generic welcome lines.
- **Resubs now alert.** `channel.subscription.message` fires the existing sub alert under the same toggle and template, so renewing subs are no longer silent.
- **Dashboard.** New Gift sub alert card with a scoped token palette (`{user}`/`{count}`/`{tier}`), sub card tagline covers resubs, and the chat rehearsal now substitutes `{count}` and `{duration}` instead of flagging them unknown.

## Tests

8 new alerts-module tests (gift default/custom/anonymous/disabled/empty-event, gifted-recipient skip, resub fires, resub obeys sub toggle). `go build` + `go vet` clean; dashboard verified in demo preview.