### PR TITLE
fix(network): scope production egress by workload

### DIFF
--- a/deploy/k8s/network-policies.yaml
+++ b/deploy/k8s/network-policies.yaml
@@ -9,7 +9,7 @@ spec:
     matchExpressions:
       - key: app
         operator: In
-        values: [users, commands, loyalty, modules, transactions, projector, sesame, twitch-ingress, outgress, console-dashboard, console-admin, gateway, notifications]
+        values: [users, commands, loyalty, modules, transactions, projector, sesame, twitch-ingress, outgress, console-dashboard, console-admin, gateway, notifications, notifications-cleanup]
   policyTypes:
     - Ingress
     - Egress
@@ -30,8 +30,13 @@ spec:
             matchLabels:
               kubernetes.io/metadata.name: tailscale
   egress:
-    # Allow DNS resolution
-    - ports:
+    # Resolve through cluster DNS only. Leaving `to` empty here would turn port
+    # 53 into a DNS-tunnelling escape hatch to any Internet address.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
         - port: 53
           protocol: UDP
         - port: 53
@@ -46,11 +51,50 @@ spec:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: valkey
-    # Allow outbound HTTPS for Twitch OAuth
+---
+# Every long-running application currently exports APM directly to New Relic
+# over HTTPS. Product integrations also use HTTPS from gateway, ingress,
+# outgress, sesame, transactions and the consoles. Keep this grant explicit so
+# a workload cannot silently inherit it merely by joining default-deny-apps.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-public-https
+  namespace: production
+spec:
+  podSelector:
+    matchExpressions:
+      - key: app
+        operator: In
+        values: [users, commands, loyalty, modules, transactions, projector, sesame, twitch-ingress, outgress, console-dashboard, console-admin, gateway, notifications]
+  policyTypes:
+    - Egress
+  egress:
     - ports:
         - port: 443
           protocol: TCP
-    # Allow communication to external HeatWave MySQL database
-    - ports:
+---
+# Data owners reach the managed HeatWave endpoint over the routed OCI private
+# subnet. Restricting both the workloads and destination prevents port 3306
+# from becoming a generic public-Internet exfiltration path. console-admin is
+# included for its explicit schema-credential administration workflow.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-heatwave
+  namespace: production
+spec:
+  podSelector:
+    matchExpressions:
+      - key: app
+        operator: In
+        values: [users, commands, loyalty, modules, transactions, notifications, console-admin]
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 10.0.0.0/16
+      ports:
         - port: 3306
           protocol: TCP

--- a/deploy/k8s/network_policies_test.go
+++ b/deploy/k8s/network_policies_test.go
@@ -81,44 +81,61 @@ func sorted(values ...string) []string {
 	return values
 }
 
-func TestInternetAndHeatWaveEgressAreWorkloadScoped(t *testing.T) {
-	policies := loadNetworkPolicies(t)
-
-	base, ok := policies["default-deny-apps"]
+func requirePolicy(t *testing.T, policies map[string]networkPolicyManifest, name string) networkPolicyManifest {
+	t.Helper()
+	policy, ok := policies[name]
 	if !ok {
-		t.Fatal("default-deny-apps policy is missing")
+		t.Fatalf("%s policy is missing", name)
 	}
-	if !slices.Contains(selectedApps(t, base), "notifications-cleanup") {
-		t.Fatal("notifications cleanup job escaped the default-deny policy")
-	}
-	for _, rule := range base.Spec.Egress {
+	return policy
+}
+
+func policyHasPort(policy networkPolicyManifest, target int) bool {
+	for _, rule := range policy.Spec.Egress {
 		for _, port := range rule.Ports {
-			if port.Port == 443 || port.Port == 3306 {
-				t.Fatalf("default policy grants blanket external port %d", port.Port)
+			if port.Port == target {
+				return true
 			}
 		}
 	}
+	return false
+}
 
-	publicHTTPS, ok := policies["allow-public-https"]
-	if !ok {
-		t.Fatal("allow-public-https policy is missing")
+func TestDefaultPolicyHasNoBlanketExternalEgress(t *testing.T) {
+	base := requirePolicy(t, loadNetworkPolicies(t), "default-deny-apps")
+	if !slices.Contains(selectedApps(t, base), "notifications-cleanup") {
+		t.Fatal("notifications cleanup job escaped the default-deny policy")
 	}
+	if policyHasPort(base, 443) {
+		t.Fatal("default policy grants blanket external port 443")
+	}
+	if policyHasPort(base, 3306) {
+		t.Fatal("default policy grants blanket external port 3306")
+	}
+}
+
+func TestPublicHTTPSEgressAllowlist(t *testing.T) {
+	publicHTTPS := requirePolicy(t, loadNetworkPolicies(t), "allow-public-https")
 	wantHTTPS := sorted("commands", "console-admin", "console-dashboard", "gateway", "loyalty", "modules", "notifications", "outgress", "projector", "sesame", "transactions", "twitch-ingress", "users")
 	if got := selectedApps(t, publicHTTPS); !slices.Equal(got, wantHTTPS) {
 		t.Fatalf("public HTTPS allowlist = %v, want %v", got, wantHTTPS)
 	}
+}
 
-	heatwave, ok := policies["allow-heatwave"]
-	if !ok {
-		t.Fatal("allow-heatwave policy is missing")
-	}
+func TestHeatWaveEgressAllowlist(t *testing.T) {
+	heatwave := requirePolicy(t, loadNetworkPolicies(t), "allow-heatwave")
 	wantHeatWave := sorted("commands", "console-admin", "loyalty", "modules", "notifications", "transactions", "users")
 	if got := selectedApps(t, heatwave); !slices.Equal(got, wantHeatWave) {
 		t.Fatalf("HeatWave allowlist = %v, want %v", got, wantHeatWave)
 	}
-	if len(heatwave.Spec.Egress) != 1 || len(heatwave.Spec.Egress[0].To) != 1 ||
-		heatwave.Spec.Egress[0].To[0].IPBlock == nil ||
-		heatwave.Spec.Egress[0].To[0].IPBlock.CIDR != "10.0.0.0/16" {
+	if len(heatwave.Spec.Egress) != 1 {
+		t.Fatal("HeatWave policy must have exactly one egress rule")
+	}
+	if len(heatwave.Spec.Egress[0].To) != 1 {
+		t.Fatal("HeatWave rule must have exactly one destination")
+	}
+	ipBlock := heatwave.Spec.Egress[0].To[0].IPBlock
+	if ipBlock == nil || ipBlock.CIDR != "10.0.0.0/16" {
 		t.Fatal("HeatWave egress must stay confined to the routed OCI private subnet")
 	}
 }

--- a/deploy/k8s/network_policies_test.go
+++ b/deploy/k8s/network_policies_test.go
@@ -1,0 +1,124 @@
+package k8s
+
+import (
+	"io"
+	"os"
+	"slices"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+type networkPolicyManifest struct {
+	Kind     string `yaml:"kind"`
+	Metadata struct {
+		Name string `yaml:"name"`
+	} `yaml:"metadata"`
+	Spec struct {
+		PodSelector struct {
+			MatchExpressions []struct {
+				Key    string   `yaml:"key"`
+				Values []string `yaml:"values"`
+			} `yaml:"matchExpressions"`
+		} `yaml:"podSelector"`
+		Egress []struct {
+			To []struct {
+				NamespaceSelector *struct {
+					MatchLabels map[string]string `yaml:"matchLabels"`
+				} `yaml:"namespaceSelector"`
+				IPBlock *struct {
+					CIDR string `yaml:"cidr"`
+				} `yaml:"ipBlock"`
+			} `yaml:"to"`
+			Ports []struct {
+				Port     int    `yaml:"port"`
+				Protocol string `yaml:"protocol"`
+			} `yaml:"ports"`
+		} `yaml:"egress"`
+	} `yaml:"spec"`
+}
+
+func loadNetworkPolicies(t *testing.T) map[string]networkPolicyManifest {
+	t.Helper()
+	f, err := os.Open("network-policies.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	policies := make(map[string]networkPolicyManifest)
+	decoder := yaml.NewDecoder(f)
+	for {
+		var manifest networkPolicyManifest
+		if err := decoder.Decode(&manifest); err != nil {
+			if err == io.EOF {
+				break
+			}
+			t.Fatal(err)
+		}
+		if manifest.Kind == "NetworkPolicy" {
+			policies[manifest.Metadata.Name] = manifest
+		}
+	}
+	return policies
+}
+
+func selectedApps(t *testing.T, policy networkPolicyManifest) []string {
+	t.Helper()
+	for _, expression := range policy.Spec.PodSelector.MatchExpressions {
+		if expression.Key == "app" {
+			apps := slices.Clone(expression.Values)
+			slices.Sort(apps)
+			return apps
+		}
+	}
+	t.Fatal("policy has no app selector")
+	return nil
+}
+
+func sorted(values ...string) []string {
+	slices.Sort(values)
+	return values
+}
+
+func TestInternetAndHeatWaveEgressAreWorkloadScoped(t *testing.T) {
+	policies := loadNetworkPolicies(t)
+
+	base, ok := policies["default-deny-apps"]
+	if !ok {
+		t.Fatal("default-deny-apps policy is missing")
+	}
+	if !slices.Contains(selectedApps(t, base), "notifications-cleanup") {
+		t.Fatal("notifications cleanup job escaped the default-deny policy")
+	}
+	for _, rule := range base.Spec.Egress {
+		for _, port := range rule.Ports {
+			if port.Port == 443 || port.Port == 3306 {
+				t.Fatalf("default policy grants blanket external port %d", port.Port)
+			}
+		}
+	}
+
+	publicHTTPS, ok := policies["allow-public-https"]
+	if !ok {
+		t.Fatal("allow-public-https policy is missing")
+	}
+	wantHTTPS := sorted("commands", "console-admin", "console-dashboard", "gateway", "loyalty", "modules", "notifications", "outgress", "projector", "sesame", "transactions", "twitch-ingress", "users")
+	if got := selectedApps(t, publicHTTPS); !slices.Equal(got, wantHTTPS) {
+		t.Fatalf("public HTTPS allowlist = %v, want %v", got, wantHTTPS)
+	}
+
+	heatwave, ok := policies["allow-heatwave"]
+	if !ok {
+		t.Fatal("allow-heatwave policy is missing")
+	}
+	wantHeatWave := sorted("commands", "console-admin", "loyalty", "modules", "notifications", "transactions", "users")
+	if got := selectedApps(t, heatwave); !slices.Equal(got, wantHeatWave) {
+		t.Fatalf("HeatWave allowlist = %v, want %v", got, wantHeatWave)
+	}
+	if len(heatwave.Spec.Egress) != 1 || len(heatwave.Spec.Egress[0].To) != 1 ||
+		heatwave.Spec.Egress[0].To[0].IPBlock == nil ||
+		heatwave.Spec.Egress[0].To[0].IPBlock.CIDR != "10.0.0.0/16" {
+		t.Fatal("HeatWave egress must stay confined to the routed OCI private subnet")
+	}
+}


### PR DESCRIPTION
## What changed

- move public HTTPS and HeatWave access out of the shared application policy into explicit workload allowlists
- constrain HeatWave traffic to the routed OCI `10.0.0.0/16` subnet
- restrict DNS egress to `kube-system`
- include the notifications cleanup job in the default-deny boundary
- add regression tests for the workload allowlists and database destination

## Why

The shared policy granted every selected application arbitrary TCP/443 and TCP/3306 egress. Keeping New Relic APM requires HTTPS for every long-running application today, but those grants should remain explicit, and only database clients should be able to reach HeatWave.

## Impact

New Relic APM remains enabled for all long-running services. Product HTTPS integrations remain available. The notifications cleanup job is limited to cluster DNS and internal services, while non-database workloads lose TCP/3306 egress.

## Validation

- `GOCACHE=/private/tmp/itsbagelbot-go-build-cache go test ./deploy/k8s`
- `kubectl kustomize deploy/k8s`
- `git diff --check`
