### PR TITLE
fix(cloudflared): avoid rollout scheduling deadlock

### DIFF
--- a/deploy/infra/cluster/cloudflared.yaml
+++ b/deploy/infra/cluster/cloudflared.yaml
@@ -23,8 +23,11 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
+      # Hard one-per-node anti-affinity consumes both eligible hosts at steady
+      # state, so a surge pod can never schedule. Replace one connector at a
+      # time while the other continues serving the tunnel.
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: cloudflared


### PR DESCRIPTION
## What changed

- switch cloudflared rolling updates to `maxSurge: 0` and `maxUnavailable: 1`
- document why hard one-per-node anti-affinity cannot support a surge pod

## Root cause

Cloudflared has two replicas, exactly two eligible nodes, and required pod anti-affinity. The rollout requested a third surge pod while allowing zero existing pods to become unavailable, leaving the new pod permanently unschedulable.

## Impact

Rollouts replace one connector at a time. The other connector remains ready, preserving tunnel availability without requiring a third eligible node.

## Validation

- `kubectl kustomize deploy/infra/cluster`
- verified rendered strategy is `maxSurge: 0`, `maxUnavailable: 1`
- `git diff --check`
