### PR TITLE
Fold counters into modules

### DIFF
--- a/console/dashboard/src/lib/server/guard.ts
+++ b/console/dashboard/src/lib/server/guard.ts
@@ -37,10 +37,8 @@ function wipe(event: RequestEvent): void {
 // granted section's own page, plus every bespoke module page whose catalog def
 // is opened by one of those grants (moduleDelegateSections — the same source
 // the per-page gates and the tile grid read, so the three can never drift and
-// a new module page needs no edit here). Counters has its own nav entry but
-// deliberately no grant of its own: management rides the modules grant, and
-// the read-only name list additionally opens to the commands grant so the
-// command editor's counter picker works for commands-only delegates.
+// a new module page needs no edit here). The read-only counter name list also
+// opens to the commands grant so commands-only delegates can use the picker.
 function delegateAllowedPaths(sections: readonly string[]): string[] {
   const allowed = sections.map((sec) => `/${sec}`);
   for (const def of MODULE_CATALOG) {
@@ -48,8 +46,7 @@ function delegateAllowedPaths(sections: readonly string[]): string[] {
       allowed.push(def.href);
     }
   }
-  if (sections.includes('modules')) allowed.push('/counters');
-  else if (sections.includes('commands')) allowed.push('/counters/list');
+  if (sections.includes('commands')) allowed.push('/counters/list');
   return allowed;
 }
 

--- a/console/dashboard/src/routes/(app)/+layout.svelte
+++ b/console/dashboard/src/routes/(app)/+layout.svelte
@@ -60,14 +60,13 @@
   const section = $derived(
     path.startsWith('/commands')
       ? 'commands'
-      : path.startsWith('/counters')
-        ? 'counters'
-        : path.startsWith('/modules') ||
-            path.startsWith('/quotes') ||
-            path.startsWith('/govee') ||
-            path.startsWith('/channelpoints') ||
-            path.startsWith('/timers') ||
-            path.startsWith('/loyalty')
+      : path.startsWith('/modules') ||
+          path.startsWith('/counters') ||
+          path.startsWith('/quotes') ||
+          path.startsWith('/govee') ||
+          path.startsWith('/channelpoints') ||
+          path.startsWith('/timers') ||
+          path.startsWith('/loyalty')
           ? 'modules'
           : path.startsWith('/billing')
           ? 'billing'
@@ -122,11 +121,6 @@
       : []),
     ...(canModules
       ? [{ href: '/modules', icon: 'modules', label: t('nav.modules'), active: section === 'modules' }]
-      : []),
-    // Counters ride the modules grant (loyalty's companion feature) but get a
-    // first-class entry of their own.
-    ...(canModules
-      ? [{ href: '/counters', icon: 'list', label: t('nav.counters'), active: section === 'counters' }]
       : []),
     ...(canBilling
       ? [{ href: '/billing', icon: 'card', label: t('nav.billing'), active: section === 'billing' }]

--- a/console/dashboard/src/routes/(app)/+page.server.ts
+++ b/console/dashboard/src/routes/(app)/+page.server.ts
@@ -179,13 +179,17 @@ function commandDigest(uid: string): Promise<CommandDigest> {
 
 function moduleDigest(uid: string): Promise<ModuleDigest> {
   const visibleCatalog = MODULE_CATALOG.filter((m) => !m.hidden);
-  const catalogIds = new Set(visibleCatalog.map((m) => m.id));
   return listModules(uid)
-    .then((rows) => ({
-      on: rows.filter((r) => catalogIds.has(r.name) && r.is_enabled).length,
-      total: visibleCatalog.length,
-      ok: true
-    }))
+    .then((rows) => {
+      const byName = new Map(rows.map((row) => [row.name, row]));
+      return {
+        on: visibleCatalog.filter((def) =>
+          def.toggleable === false ? true : (byName.get(def.id)?.is_enabled ?? def.defaultEnabled)
+        ).length,
+        total: visibleCatalog.length,
+        ok: true
+      };
+    })
     .catch(() => ({ on: 0, total: visibleCatalog.length, ok: false }));
 }
 

--- a/console/dashboard/src/routes/(app)/counters/+page.server.ts
+++ b/console/dashboard/src/routes/(app)/counters/+page.server.ts
@@ -13,10 +13,10 @@ function effectiveId(session: Session | null | undefined): string {
   return session?.delegate_of ?? session?.user_id ?? 'demo';
 }
 
-// Counters belong to the loyalty module even though they live on their own
-// page, so they share loyalty's delegate scope (see module-gate.ts).
+// Counters are a catalog-defined Modules tool, so the page and every action
+// derive delegate access from the same definition as its tile and route guard.
 function gate(session: Session | null | undefined): void {
-  gateModulePage(session, 'loyalty');
+  gateModulePage(session, 'counters');
 }
 
 function demoCounters(): CounterDef[] {

--- a/console/dashboard/src/routes/(app)/modules/+page.server.ts
+++ b/console/dashboard/src/routes/(app)/modules/+page.server.ts
@@ -41,7 +41,7 @@ function merge(rows: ModuleView[], session: Session | null | undefined): ModuleS
     const row = byName.get(def.id);
     return {
       def,
-      enabled: row ? row.is_enabled : def.defaultEnabled,
+      enabled: def.toggleable === false ? true : row ? row.is_enabled : def.defaultEnabled,
       config: asConfig(row?.configs)
     };
   });
@@ -71,7 +71,8 @@ export const actions: Actions = {
 
     const f = await request.formData();
     const name = String(f.get('name') ?? '');
-    if (!moduleDef(name)) return fail(400, { ok: false, error: 'Unknown module.' });
+    const def = moduleDef(name);
+    if (!def || def.toggleable === false) return fail(400, { ok: false, error: 'Unknown module.' });
     const enabled = f.get('is_enabled') === 'on';
 
     if (env.DEMO === '1') return { ok: true, name, enabled };

--- a/console/dashboard/src/routes/(app)/modules/+page.svelte
+++ b/console/dashboard/src/routes/(app)/modules/+page.svelte
@@ -193,17 +193,19 @@
                 <div class="tile-foot">
                   <a class="configure" href={m.def.href ?? `/modules/${m.def.id}`}><Icon name="settings" size={13} /> {t('modules.configure')}</a>
                   <span class="grow"></span>
-                  <SaveStatus state={modStatus[m.def.id] ?? 'idle'} />
-                  <form method="POST" action="?/toggle" use:enhance={toggleSubmit(m)}>
-                    <input type="hidden" name="name" value={m.def.id} />
-                    <input type="hidden" name="is_enabled" value={m.enabled ? '' : 'on'} />
-                    <Switch
-                      type="submit"
-                      checked={m.enabled}
-                      label={m.enabled ? t('modules.disableAria', { label: m.def.label }) : t('modules.enableAria', { label: m.def.label })}
-                      pending={(modStatus[m.def.id] ?? 'idle') === 'saving'}
-                    />
-                  </form>
+                  {#if m.def.toggleable !== false}
+                    <SaveStatus state={modStatus[m.def.id] ?? 'idle'} />
+                    <form method="POST" action="?/toggle" use:enhance={toggleSubmit(m)}>
+                      <input type="hidden" name="name" value={m.def.id} />
+                      <input type="hidden" name="is_enabled" value={m.enabled ? '' : 'on'} />
+                      <Switch
+                        type="submit"
+                        checked={m.enabled}
+                        label={m.enabled ? t('modules.disableAria', { label: m.def.label }) : t('modules.enableAria', { label: m.def.label })}
+                        pending={(modStatus[m.def.id] ?? 'idle') === 'saving'}
+                      />
+                    </form>
+                  {/if}
                 </div>
               </div>
             {/each}
@@ -438,4 +440,3 @@
   .configure:hover { color: var(--bb-tan-pale); border-color: var(--bb-border-strong, rgba(201, 168, 124, 0.35)); background: rgba(201, 168, 124, 0.08); }
   .configure :global(svg) { stroke: currentColor; fill: none; }
 </style>
-

--- a/console/dashboard/src/routes/(app)/settings/+page.server.ts
+++ b/console/dashboard/src/routes/(app)/settings/+page.server.ts
@@ -22,8 +22,9 @@ import { isLocale, DEFAULT_LOCALE } from '@bagel/shared/i18n';
 import { env } from '$env/dynamic/private';
 
 // Dashboard sections an owner can delegate. Billing is view-only for a delegate
-// (the money actions stay owner-only — see billing/+page.server.ts). Timers has
-// no standalone scope: it rides under 'commands' (see guard.ts + timers gate).
+// (the money actions stay owner-only — see billing/+page.server.ts). Counters
+// ride under 'modules'; timers also ride under 'commands' (see the catalog's
+// delegateSections and module-gate.ts).
 const SECTIONS = ['commands', 'modules', 'channelpoints', 'billing'] as const;
 
 function tokenLabel(token: string): string {

--- a/console/dashboard/src/routes/user/[userId]/+page.server.ts
+++ b/console/dashboard/src/routes/user/[userId]/+page.server.ts
@@ -117,7 +117,7 @@ function publicCommands(rows: CommandView[]): PublicCommand[] {
 function publicModules(rows: ModuleView[]): PublicModule[] {
   const byName = new Map(rows.map((row) => [row.name, row]));
 
-  const catalogModules = MODULE_CATALOG.filter((def) => !def.hidden).flatMap((def): PublicModule[] => {
+  const catalogModules = MODULE_CATALOG.filter((def) => !def.hidden && def.toggleable !== false).flatMap((def): PublicModule[] => {
     const row = byName.get(def.id);
     const active = row ? row.is_enabled : def.defaultEnabled;
     if (!active) return [];

--- a/console/shared/lib/module-catalog.test.ts
+++ b/console/shared/lib/module-catalog.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from 'bun:test';
+import { MODULE_CATALOG, moduleDef, moduleDelegateSections } from './types';
+
+describe('module catalog', () => {
+  test('has unique ids', () => {
+    const ids = MODULE_CATALOG.map((def) => def.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  test('folds counters into Modules delegation without an enable switch', () => {
+    const counters = moduleDef('counters');
+    expect(counters).toBeDefined();
+    expect(counters?.href).toBe('/counters');
+    expect(counters?.toggleable).toBe(false);
+    expect(moduleDelegateSections(counters!)).toEqual(['modules']);
+  });
+});

--- a/console/shared/lib/types.ts
+++ b/console/shared/lib/types.ts
@@ -331,7 +331,8 @@ export interface ModuleCommandInfo {
 }
 
 export interface ModuleDef {
-  // id is the ModuleView.name key in the modules service.
+  // id is normally the ModuleView.name key in the modules service. Catalog
+  // tools with toggleable=false use it only as their stable UI key.
   id: string;
   label: string;
   tagline: string; // one-liner for the tile
@@ -339,6 +340,10 @@ export interface ModuleDef {
   icon: IconName;
   category: string;
   defaultEnabled: boolean;
+  // False for catalog tools that live under Modules but are always available
+  // rather than backed by an enableable row in the modules service. They keep
+  // the shared tile/delegation model without presenting a meaningless switch.
+  toggleable?: boolean;
   // If true, the module is hidden from the dashboard and unreachable.
   hidden?: boolean;
   // The module's configurable chat lines (the "commands" of the module page).
@@ -498,6 +503,21 @@ export const MODULE_CATALOG: readonly ModuleDef[] = [
     category: 'Community',
     defaultEnabled: false,
     href: '/loyalty',
+    replies: []
+  },
+  {
+    id: 'counters',
+    label: 'Counters',
+    tagline: 'Track wins, deaths, hugs, redeems — anything your chat can count.',
+    description:
+      'Create channel-wide, per-command, or per-viewer tallies. Adjust them from the dashboard or chat, and bump them from command responses and channel-point rewards.',
+    icon: 'list',
+    category: 'Community',
+    defaultEnabled: true,
+    toggleable: false,
+    href: '/counters',
+    // The default Modules delegation scope gives delegates access to the full
+    // counter book; commands-only delegates retain picker access separately.
     replies: []
   },
   {


### PR DESCRIPTION
## Summary

- move Counters discovery from a standalone navigation item into the Modules catalog
- model Counters as an always-available, non-toggleable catalog tool
- derive full counter management access from the existing Modules delegation scope
- preserve read-only counter-picker access for commands-only delegates
- keep module counts and public module output consistent with catalog-only tools

## Why

Counters is a secondary configuration surface rather than a primary dashboard section. Folding it into Modules reduces top-level navigation clutter and makes delegated access follow the same catalog metadata as the tile and page gate.

## Validation

- `bun test shared/lib/module-catalog.test.ts`
- `bun run check` (0 errors; one pre-existing CSS compatibility warning)
- `bun run --filter dashboard build`
- locale catalog parity check

The broader shared test suite reached 83 passing tests; the existing NATS failback test cannot bind Bun's ephemeral port in this environment (`EADDRINUSE` on port 0).
