### PR TITLE
Reorganize Doppler inheritance and integration scope

### DIFF
--- a/deploy/ansible/README.md
+++ b/deploy/ansible/README.md
@@ -8,8 +8,9 @@ Any RHEL-family distro works — **Rocky, Alma, Oracle, RHEL, CentOS Stream**. P
 whatever you run your own stack on; the playbook checks `os_family == RedHat` and
 uses the family's generic repos (`dnf`, `rhel/$releasever` Tailscale repo, etc).
 
-Secrets never touch the repo. The run is wrapped with **Doppler**; the k3s token and
-the Tailscale pre-auth key come from the environment.
+Secrets never touch the repo. The run is wrapped with the least-privilege Doppler
+config `infra-bootstrap/prd`; the k3s token and Tailscale pre-auth key come from
+the environment.
 
 ## Debian → Red Hat is a reinstall, not an in-place convert
 
@@ -76,7 +77,7 @@ When adding a node, update `tailscale_direct_peers` in `group_vars/all.yml`
 
 ## Secrets (Doppler)
 
-Put these in the Doppler config you run with:
+Put these in Doppler config `infra-bootstrap/prd`:
 
 | Key | What |
 |-----|------|
@@ -103,7 +104,7 @@ ansible-galaxy collection install -r requirements.yml
 ./provision.sh 51.x.x.x opc node4
 
 # dry run first:
-NODE_NAME=node4 doppler run -- ansible-playbook site.yml \
+NODE_NAME=node4 doppler run --project infra-bootstrap --config prd -- ansible-playbook site.yml \
   -e target_host=51.x.x.x -e target_user=opc --check --diff
 ```
 
@@ -173,7 +174,8 @@ The play asserts that node1, node2, node3, and worker1 are all present before it
 changes a host. Running it against the default single-node provisioning
 inventory fails loudly instead of reporting a successful no-op.
 
-`provision.sh` is just a thin `doppler run -- ansible-playbook …` wrapper.
+`provision.sh` is a thin `doppler run --project infra-bootstrap --config prd --
+ansible-playbook …` wrapper.
 
 ### Compute-only nodes (taint + label)
 

--- a/deploy/ansible/group_vars/all.yml
+++ b/deploy/ansible/group_vars/all.yml
@@ -1,6 +1,6 @@
 # ─────────────────────────────────────────────────────────────────────────────
 # Fleet-wide config. NO secrets committed.
-# Secrets come from the environment, injected by `doppler run`:
+# Secrets come from infra-bootstrap/prd, injected by `doppler run`:
 #   K3S_TOKEN   — node1 join token
 #   TS_AUTHKEY  — Tailscale PRE-AUTHORIZED key, ephemeral=false, tagged tag:itsbagelbot
 # Optional:

--- a/deploy/ansible/inventory.ini
+++ b/deploy/ansible/inventory.ini
@@ -4,7 +4,7 @@
 # the end, after Tailscale + firewall are up. Afterwards reach it via Tailscale SSH.
 #
 # Pass the target at runtime (no host data committed):
-#   doppler run -- ansible-playbook site.yml -e target_host=1.2.3.4 -e target_user=opc
+#   doppler run -p infra-bootstrap -c prd -- ansible-playbook site.yml -e target_host=1.2.3.4 -e target_user=opc
 #
 # target_user defaults to 'opc' (Oracle Linux on OVH/OCI). Rocky/Alma = rocky/almalinux.
 

--- a/deploy/ansible/k3s-server-tuning.yml
+++ b/deploy/ansible/k3s-server-tuning.yml
@@ -1,7 +1,7 @@
 ---
 # Pin the k3s server's Go runtime memory guard.
 #
-#   doppler run -- ansible-playbook -i inventory.cluster.ini k3s-server-tuning.yml
+#   doppler run -p infra-bootstrap -c prd -- ansible-playbook -i inventory.cluster.ini k3s-server-tuning.yml
 #
 # node2 is the SINGLE k3s server (sqlite/kine — no HA, see the control-plane
 # migration notes). Its Go heap is capped with GOMEMLIMIT + GOGC, delivered via

--- a/deploy/ansible/provision.sh
+++ b/deploy/ansible/provision.sh
@@ -8,7 +8,8 @@
 #   ./provision.sh 51.x.x.x                 # auto-generated new node name, user=opc
 #   ./provision.sh 51.x.x.x opc node4       # explicit incremental name
 #
-# Doppler must hold:  K3S_TOKEN, TS_AUTHKEY   (TS_AUTHKEY = preauth key, tag:itsbagelbot)
+# Doppler project infra-bootstrap/prd must hold: K3S_TOKEN, TS_AUTHKEY
+# (TS_AUTHKEY = preauth key, tag:itsbagelbot).
 # Optional in Doppler/env:  NODE_ZONE
 #   NODE_POOL=worker-pool  -> taint+label the node so only tolerating pods land on it
 set -euo pipefail
@@ -26,4 +27,5 @@ EXTRA=(-e "target_host=${HOST}" -e "target_user=${USER_}")
 # NODE_NAME / NODE_POOL flow through the environment (lookup('env',...) in group_vars)
 export NODE_NAME NODE_POOL="${NODE_POOL:-}"
 
-exec doppler run -- ansible-playbook site.yml "${EXTRA[@]}" "${@:4}"
+exec doppler run --project infra-bootstrap --config prd -- \
+  ansible-playbook site.yml "${EXTRA[@]}" "${@:4}"

--- a/deploy/ansible/site.yml
+++ b/deploy/ansible/site.yml
@@ -2,7 +2,7 @@
 # Provision ONE fresh RHEL-family box into the fleet as a new node.
 #
 # Run wrapped with Doppler so secrets never touch the repo or process args:
-#   doppler run -- ansible-playbook site.yml -e target_host=<ip> -e target_user=opc
+#   doppler run -p infra-bootstrap -c prd -- ansible-playbook site.yml -e target_host=<ip> -e target_user=opc
 #
 # Order is load-bearing:
 #   base → selinux → firewall → tailscale → k3s_agent → ssh_removal (LAST).
@@ -29,14 +29,14 @@
           - tailscale_authkey | length > 0
         fail_msg: >-
           K3S_TOKEN and TS_AUTHKEY must be set in the environment.
-          Run via:  doppler run -- ansible-playbook site.yml ...
+          Run via: doppler run -p infra-bootstrap -c prd -- ansible-playbook site.yml ...
 
   roles:
     - role: base
     - role: selinux
     # Tagged so the firewall policy can be re-applied to an already-provisioned
     # node in isolation (e.g. to roll out the CNI trusted-zone binder):
-    #   doppler run -- ansible-playbook site.yml --tags firewall -e target_host=<tailnet-ip>
+    #   doppler run -p infra-bootstrap -c prd -- ansible-playbook site.yml --tags firewall -e target_host=<tailnet-ip>
     - role: firewall
       tags: [firewall]
     - role: tailscale

--- a/deploy/doppler/README.md
+++ b/deploy/doppler/README.md
@@ -1,0 +1,33 @@
+# Doppler topology
+
+`topology.json` is the names-only contract for Doppler projects, config
+inheritance, and parent-owned entries. It intentionally contains no values.
+
+Runtime workloads always use a token scoped to their service project. Projects
+prefixed with `shared-` are inheritance-only and must not have workload tokens or
+direct deployment integrations.
+
+Infrastructure integrations use single-purpose projects. Their tokens cannot
+read the broad legacy `infra/prd` root or unrelated branch-config entries.
+
+The graph is flat: a service may inherit several capability parents, but parents
+do not inherit other parents. Parent name sets are disjoint, so correctness never
+depends on Doppler inheritance precedence.
+
+Run the offline contract tests with:
+
+```sh
+go test ./deploy/doppler
+```
+
+With an authenticated Doppler CLI, compare the live names and inheritance graph
+without fetching values:
+
+```sh
+deploy/doppler/check-live.sh
+```
+
+`shared` and `worker` are retained temporarily as inactive rollback sources.
+Legacy `infra` remains until its Flux webhook and any out-of-band CLI consumers
+are inventoried. Archive these projects only after the production observation
+window and a service-token/integration review in the Doppler UI.

--- a/deploy/doppler/check-live.sh
+++ b/deploy/doppler/check-live.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+topology="$root_dir/topology.json"
+
+command -v doppler >/dev/null
+command -v jq >/dev/null
+
+failed=0
+
+while IFS=$'\t' read -r project config expected_names; do
+  metadata="$(doppler configs get --project "$project" --config "$config" --json --no-check-version)"
+  if [[ "$(jq -r '.inheritable' <<<"$metadata")" != "true" ]]; then
+    echo "$project/$config: not inheritable"
+    failed=1
+  fi
+
+  actual_names="$({ doppler secrets --only-names --project "$project" --config "$config" --json --no-check-version; } \
+    | jq -cS '[keys[] | select(startswith("DOPPLER_") | not)]')"
+  if [[ "$actual_names" != "$expected_names" ]]; then
+    echo "$project/$config: name set differs"
+    failed=1
+  else
+    echo "$project/$config: PASS"
+  fi
+done < <(jq -r '
+  .parents | to_entries[] as $project |
+  $project.value.configs | to_entries[] |
+  [$project.key, .key, (.value | sort | tojson)] | @tsv
+' "$topology")
+
+while IFS=$'\t' read -r project config expected_names; do
+  actual_names="$({ doppler secrets --only-names --project "$project" --config "$config" --json --no-check-version; } \
+    | jq -cS '[keys[] | select(startswith("DOPPLER_") | not)]')"
+  if [[ "$actual_names" != "$expected_names" ]]; then
+    echo "$project/$config: integration name set differs"
+    failed=1
+  else
+    echo "$project/$config: PASS"
+  fi
+done < <(jq -r '
+  .integrations | to_entries[] |
+  [.key, .value.config, (.value.names | sort | tojson)] | @tsv
+' "$topology")
+
+while IFS=$'\t' read -r project config expected_refs; do
+  actual_refs="$(doppler configs get --project "$project" --config "$config" --json --no-check-version \
+    | jq -c '[.inherits[]? | .project + "." + .config] | sort')"
+  if [[ "$actual_refs" != "$expected_refs" ]]; then
+    echo "$project/$config: inheritance differs"
+    failed=1
+  else
+    echo "$project/$config: PASS"
+  fi
+done < <(jq -r '
+  . as $top |
+  .services | to_entries[] as $service |
+  $top.profiles[$service.value.inheritProfile] | to_entries[] |
+  [$service.key, .key, (.value | sort | tojson)] | @tsv
+' "$topology")
+
+exit "$failed"

--- a/deploy/doppler/topology.json
+++ b/deploy/doppler/topology.json
@@ -1,0 +1,141 @@
+{
+  "schemaVersion": 1,
+  "parents": {
+    "shared-runtime-defaults": {
+      "directConsumersAllowed": false,
+      "configs": {
+        "dev": ["LOG_LEVEL"],
+        "stg": ["LOG_LEVEL"],
+        "prd": ["LOG_LEVEL"]
+      }
+    },
+    "shared-observability": {
+      "directConsumersAllowed": false,
+      "configs": {
+        "dev": ["NEW_RELIC_LICENSE_KEY"],
+        "stg": ["NEW_RELIC_LICENSE_KEY"],
+        "prd": ["NEW_RELIC_LICENSE_KEY"]
+      }
+    },
+    "shared-nats-client": {
+      "directConsumersAllowed": false,
+      "configs": {
+        "dev": [
+          "NATS_BROADCASTER_STATUS_SUBJECT",
+          "NATS_CACHE_INVALIDATION_SUBJECT",
+          "NATS_HOST",
+          "NATS_PORT"
+        ],
+        "stg": [
+          "NATS_BROADCASTER_STATUS_SUBJECT",
+          "NATS_CACHE_INVALIDATION_SUBJECT",
+          "NATS_HOST",
+          "NATS_PORT"
+        ],
+        "prd": [
+          "NATS_BROADCASTER_STATUS_SUBJECT",
+          "NATS_CACHE_INVALIDATION_SUBJECT",
+          "NATS_HOST",
+          "NATS_PORT"
+        ]
+      }
+    },
+    "shared-valkey-client": {
+      "directConsumersAllowed": false,
+      "configs": {
+        "dev": [],
+        "stg": [],
+        "prd": ["VALKEY_ADDR"]
+      }
+    }
+  },
+  "services": {
+    "admin": {"inheritProfile": "full"},
+    "broadcaster-data": {"inheritProfile": "full"},
+    "dashboard": {"inheritProfile": "full"},
+    "lane-premium": {"inheritProfile": "full"},
+    "lane-standard": {"inheritProfile": "full"},
+    "lane-stream": {"inheritProfile": "full"},
+    "twitch-ingress": {"inheritProfile": "full"},
+    "gateway": {"inheritProfile": "production-full"},
+    "outgress": {"inheritProfile": "production-full"},
+    "commands": {"inheritProfile": "production-observability"},
+    "loyalty": {"inheritProfile": "production-observability"},
+    "modules": {"inheritProfile": "production-observability"},
+    "notifications": {"inheritProfile": "production-observability"},
+    "projector": {"inheritProfile": "production-observability"},
+    "transactions": {"inheritProfile": "production-observability"},
+    "users": {"inheritProfile": "production-observability"},
+    "sesame": {"inheritProfile": "production-observability"}
+  },
+  "profiles": {
+    "full": {
+      "dev": [
+        "shared-runtime-defaults.dev",
+        "shared-observability.dev",
+        "shared-nats-client.dev",
+        "shared-valkey-client.dev"
+      ],
+      "stg": [
+        "shared-runtime-defaults.stg",
+        "shared-observability.stg",
+        "shared-nats-client.stg",
+        "shared-valkey-client.stg"
+      ],
+      "prd": [
+        "shared-runtime-defaults.prd",
+        "shared-observability.prd",
+        "shared-nats-client.prd",
+        "shared-valkey-client.prd"
+      ],
+      "dev_personal": [
+        "shared-runtime-defaults.dev",
+        "shared-observability.dev",
+        "shared-nats-client.dev",
+        "shared-valkey-client.dev"
+      ]
+    },
+    "production-full": {
+      "prd": [
+        "shared-runtime-defaults.prd",
+        "shared-observability.prd",
+        "shared-nats-client.prd",
+        "shared-valkey-client.prd"
+      ]
+    },
+    "production-observability": {
+      "prd": ["shared-observability.prd"]
+    }
+  },
+  "integrations": {
+    "infra-bootstrap": {
+      "config": "prd",
+      "names": ["ANSIBLE_VAULT_PASSWORD", "K3S_TOKEN", "TS_AUTHKEY"],
+      "cliConsumers": ["deploy/ansible/provision.sh"]
+    },
+    "infra-crowdsec": {
+      "config": "prd",
+      "names": ["CROWDSEC_LAPI_SECRET", "CROWDSEC_REGISTRATION_TOKEN"],
+      "kubernetesTokenSecrets": ["crowdsec/infra-crowdsec-doppler-token"]
+    },
+    "infra-newrelic": {
+      "config": "prd",
+      "names": ["NEW_RELIC_LICENSE_KEY"],
+      "kubernetesTokenSecrets": ["newrelic/infra-newrelic-doppler-token"]
+    },
+    "infra-valkey-core": {
+      "config": "prd",
+      "names": ["VALKEY_CORE_PASSWORD"],
+      "kubernetesTokenSecrets": [
+        "newrelic/infra-valkey-core-doppler-token",
+        "valkey/infra-valkey-core-doppler-token"
+      ]
+    },
+    "infra-valkey-users": {
+      "config": "prd",
+      "names": ["VALKEY_USERS_ACL"],
+      "kubernetesTokenSecrets": ["valkey/infra-valkey-users-doppler-token"]
+    }
+  },
+  "rollbackProjects": ["infra", "shared", "worker"]
+}

--- a/deploy/doppler/topology_test.go
+++ b/deploy/doppler/topology_test.go
@@ -1,0 +1,328 @@
+package doppler_test
+
+import (
+	"encoding/json"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+)
+
+type topology struct {
+	SchemaVersion int                    `json:"schemaVersion"`
+	Parents       map[string]parent      `json:"parents"`
+	Services      map[string]service     `json:"services"`
+	Profiles      map[string]profile     `json:"profiles"`
+	Integrations  map[string]integration `json:"integrations"`
+	Rollback      []string               `json:"rollbackProjects"`
+}
+
+type parent struct {
+	DirectConsumersAllowed bool                `json:"directConsumersAllowed"`
+	Configs                map[string][]string `json:"configs"`
+}
+
+type service struct {
+	InheritProfile string `json:"inheritProfile"`
+}
+
+type profile map[string][]string
+
+type integration struct {
+	Config                 string   `json:"config"`
+	Names                  []string `json:"names"`
+	KubernetesTokenSecrets []string `json:"kubernetesTokenSecrets"`
+	CLIConsumers           []string `json:"cliConsumers"`
+}
+
+func loadTopology(t *testing.T) topology {
+	t.Helper()
+	b, err := os.ReadFile("topology.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got topology
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatal(err)
+	}
+	return got
+}
+
+func TestSchemaVersion(t *testing.T) {
+	top := loadTopology(t)
+	if top.SchemaVersion != 1 {
+		t.Fatalf("unsupported schema version %d", top.SchemaVersion)
+	}
+}
+
+func TestParentsAreInheritanceOnly(t *testing.T) {
+	top := loadTopology(t)
+	for project, parent := range top.Parents {
+		if !strings.HasPrefix(project, "shared-") {
+			t.Errorf("parent project %q must use the shared- prefix", project)
+		}
+		if parent.DirectConsumersAllowed {
+			t.Errorf("parent project %q must not allow direct runtime consumers", project)
+		}
+	}
+}
+
+type parentConfigEntry struct {
+	project string
+	config  string
+	names   []string
+}
+
+var rootConfigs = map[string]bool{
+	"dev": true,
+	"stg": true,
+	"prd": true,
+}
+
+func parentConfigs(top topology) []parentConfigEntry {
+	var entries []parentConfigEntry
+	for project, parent := range top.Parents {
+		for config, names := range parent.Configs {
+			entries = append(entries, parentConfigEntry{project: project, config: config, names: names})
+		}
+	}
+	return entries
+}
+
+func TestParentConfigsAreRootConfigsWithSortedNames(t *testing.T) {
+	top := loadTopology(t)
+	for _, entry := range parentConfigs(top) {
+		if !rootConfigs[entry.config] {
+			t.Errorf("parent %s has non-root config %q", entry.project, entry.config)
+		}
+		if !sort.StringsAreSorted(entry.names) {
+			t.Errorf("%s/%s names must be sorted", entry.project, entry.config)
+		}
+	}
+}
+
+type ownedName struct {
+	project string
+	config  string
+	name    string
+}
+
+func parentOwnedNames(top topology) []ownedName {
+	var entries []ownedName
+	for _, parentConfig := range parentConfigs(top) {
+		for _, name := range parentConfig.names {
+			entries = append(entries, ownedName{
+				project: parentConfig.project,
+				config:  parentConfig.config,
+				name:    name,
+			})
+		}
+	}
+	return entries
+}
+
+func TestParentNameOwnershipIsDisjoint(t *testing.T) {
+	top := loadTopology(t)
+	owners := map[string]string{}
+	for _, entry := range parentOwnedNames(top) {
+		key := entry.config + "/" + entry.name
+		if previous, ok := owners[key]; ok {
+			t.Errorf("%s is owned by both %s and %s in %s", entry.name, previous, entry.project, entry.config)
+		}
+		owners[key] = entry.project
+	}
+}
+
+func TestServicesUseDeclaredProfiles(t *testing.T) {
+	top := loadTopology(t)
+	for project, svc := range top.Services {
+		if strings.HasPrefix(project, "shared") {
+			t.Errorf("runtime service %q cannot be a shared parent", project)
+		}
+		if _, ok := top.Profiles[svc.InheritProfile]; !ok {
+			t.Errorf("service %s uses missing profile %q", project, svc.InheritProfile)
+		}
+	}
+}
+
+type profileConfigEntry struct {
+	profileName string
+	childConfig string
+	refs        []string
+}
+
+func profileConfigs(top topology) []profileConfigEntry {
+	var entries []profileConfigEntry
+	for profileName, configs := range top.Profiles {
+		for childConfig, refs := range configs {
+			entries = append(entries, profileConfigEntry{
+				profileName: profileName,
+				childConfig: childConfig,
+				refs:        refs,
+			})
+		}
+	}
+	return entries
+}
+
+type profileReferenceEntry struct {
+	profileName string
+	childConfig string
+	ref         string
+}
+
+func profileReferences(top topology) []profileReferenceEntry {
+	var entries []profileReferenceEntry
+	for _, config := range profileConfigs(top) {
+		for _, ref := range config.refs {
+			entries = append(entries, profileReferenceEntry{
+				profileName: config.profileName,
+				childConfig: config.childConfig,
+				ref:         ref,
+			})
+		}
+	}
+	return entries
+}
+
+func parseProfileReference(raw string) (project string, config string, ok bool) {
+	project, config, ok = strings.Cut(raw, ".")
+	if strings.Contains(config, ".") {
+		ok = false
+	}
+	return project, config, ok
+}
+
+func TestProfileReferencesAreWellFormed(t *testing.T) {
+	for _, entry := range profileReferences(loadTopology(t)) {
+		_, _, ok := parseProfileReference(entry.ref)
+		if !ok {
+			t.Errorf("profile %s has invalid inheritance reference %q", entry.profileName, entry.ref)
+		}
+	}
+}
+
+func TestProfileReferencesUseDeclaredParents(t *testing.T) {
+	top := loadTopology(t)
+	for _, entry := range profileReferences(top) {
+		project, _, ok := parseProfileReference(entry.ref)
+		if ok && top.Parents[project].Configs == nil {
+			t.Errorf("profile %s references undeclared parent %q", entry.profileName, project)
+		}
+	}
+}
+
+func TestProfileReferencesUseDeclaredConfigs(t *testing.T) {
+	top := loadTopology(t)
+	for _, entry := range profileReferences(top) {
+		project, config, ok := parseProfileReference(entry.ref)
+		if ok && top.Parents[project].Configs[config] == nil {
+			t.Errorf("profile %s references undeclared config %s", entry.profileName, entry.ref)
+		}
+	}
+}
+
+func expectedParentEnvironment(childConfig string) string {
+	if childConfig == "dev_personal" {
+		return "dev"
+	}
+	return childConfig
+}
+
+func TestProfileReferencesMatchChildEnvironments(t *testing.T) {
+	for _, entry := range profileReferences(loadTopology(t)) {
+		_, config, ok := parseProfileReference(entry.ref)
+		if ok && config != expectedParentEnvironment(entry.childConfig) {
+			t.Errorf("profile %s maps %s to %s", entry.profileName, entry.childConfig, entry.ref)
+		}
+	}
+}
+
+func TestProfileConfigsInheritEachParentOnce(t *testing.T) {
+	for _, entry := range profileConfigs(loadTopology(t)) {
+		assertUniqueParentReferences(t, entry)
+	}
+}
+
+func assertUniqueParentReferences(t *testing.T, entry profileConfigEntry) {
+	t.Helper()
+	seen := map[string]bool{}
+	for _, raw := range entry.refs {
+		project, _, ok := parseProfileReference(raw)
+		if ok && seen[project] {
+			t.Errorf("profile %s/%s inherits parent %s twice", entry.profileName, entry.childConfig, project)
+		}
+		seen[project] = true
+	}
+}
+
+func TestRollbackSourcesAreNotRuntimeServices(t *testing.T) {
+	top := loadTopology(t)
+	for _, project := range top.Rollback {
+		if _, ok := top.Services[project]; ok {
+			t.Errorf("rollback source %q is still declared as a runtime service", project)
+		}
+	}
+}
+
+func TestIntegrationsUseProductionRootConfigs(t *testing.T) {
+	for project, integration := range loadTopology(t).Integrations {
+		if integration.Config != "prd" {
+			t.Errorf("integration %s must target a production root config", project)
+		}
+	}
+}
+
+func TestIntegrationsDeclareNames(t *testing.T) {
+	for project, integration := range loadTopology(t).Integrations {
+		if len(integration.Names) == 0 {
+			t.Errorf("integration %s declares no names", project)
+		}
+	}
+}
+
+func TestIntegrationNamesAreSorted(t *testing.T) {
+	for project, integration := range loadTopology(t).Integrations {
+		if !sort.StringsAreSorted(integration.Names) {
+			t.Errorf("integration %s names must be sorted", project)
+		}
+	}
+}
+
+func TestIntegrationsDeclareConsumers(t *testing.T) {
+	for project, integration := range loadTopology(t).Integrations {
+		if !hasIntegrationConsumer(integration) {
+			t.Errorf("integration %s has no declared consumer", project)
+		}
+	}
+}
+
+func hasIntegrationConsumer(integration integration) bool {
+	if len(integration.KubernetesTokenSecrets) != 0 {
+		return true
+	}
+	return len(integration.CLIConsumers) != 0
+}
+
+type kubernetesBinding struct {
+	project string
+	value   string
+}
+
+func kubernetesBindings(top topology) []kubernetesBinding {
+	var bindings []kubernetesBinding
+	for project, integration := range top.Integrations {
+		for _, value := range integration.KubernetesTokenSecrets {
+			bindings = append(bindings, kubernetesBinding{project: project, value: value})
+		}
+	}
+	return bindings
+}
+
+func TestIntegrationKubernetesBindingsAreNamespaced(t *testing.T) {
+	for _, binding := range kubernetesBindings(loadTopology(t)) {
+		if len(strings.Split(binding.value, "/")) != 2 {
+			t.Errorf("integration %s has invalid Kubernetes binding %q", binding.project, binding.value)
+		}
+	}
+}

--- a/deploy/infra/cluster/crowdsec-dopplersecret.yaml
+++ b/deploy/infra/cluster/crowdsec-dopplersecret.yaml
@@ -1,0 +1,24 @@
+# CrowdSec receives only its two LAPI entries from a dedicated Doppler project.
+# The token cannot read cluster bootstrap or Flux entries from legacy infra/prd.
+apiVersion: secrets.doppler.com/v1alpha1
+kind: DopplerSecret
+metadata:
+  name: doppler-crowdsec-lapi-secrets
+  namespace: crowdsec
+spec:
+  host: https://api.doppler.com
+  tokenSecret:
+    name: infra-crowdsec-doppler-token
+  managedSecret:
+    name: crowdsec-lapi-secrets
+    namespace: crowdsec
+    type: Opaque
+  processors:
+    CROWDSEC_LAPI_SECRET:
+      asName: csLapiSecret
+      type: plain
+    CROWDSEC_REGISTRATION_TOKEN:
+      asName: registrationToken
+      type: plain
+  resyncSeconds: 60
+  verifyTLS: true

--- a/deploy/infra/cluster/kustomization.yaml
+++ b/deploy/infra/cluster/kustomization.yaml
@@ -8,6 +8,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - cloudflared.yaml
+  - crowdsec-dopplersecret.yaml
   # coredns replaces the skipped k3s addon (coredns.yaml.skip on node2);
   # DaemonSet on node2/node3/worker1 + PreferSameNode kube-dns.
   - coredns.yaml

--- a/deploy/infra/cluster/newrelic-dopplersecrets.yaml
+++ b/deploy/infra/cluster/newrelic-dopplersecrets.yaml
@@ -1,14 +1,12 @@
 # Doppler -> Kubernetes secret sync for the New Relic stack (ns newrelic).
 #
-# These DopplerSecrets already exist LIVE but were applied out-of-band (each
-# carries a kubectl last-applied-configuration and is NOT Flux-managed). This
-# file pulls them into the repo so the `cluster` Kustomization owns them, mirror-
-# ing their live specs EXACTLY (managedSecret name + processor asName), so Flux
-# adoption is a no-op rather than a rewrite. The Doppler operator reconciles the
-# managed Secrets from project infra / config prd_newrelic.
+# The `cluster` Flux Kustomization owns these DopplerSecrets. The operator
+# reconciles their managed Secrets from least-privilege infra-newrelic and
+# infra-valkey-core projects; neither token can read the broad legacy infra/prd
+# root. Processor output names preserve the keys expected by each subchart.
 #
 # WHY THESE EXACT asName VALUES: each nri-bundle subchart reads its license from
-# a DIFFERENT key, so the single Doppler var NEWRELIC_LICENSE_KEY is projected
+# a DIFFERENT key, so the single Doppler var NEW_RELIC_LICENSE_KEY is projected
 # under the key each subchart expects. The HelmRelease (newrelic.yaml) points
 # customSecretName/customSecretLicenseKey at these:
 #   nri-bundle-newrelic-infrastructure-license  key licenseKey  (infra agents)
@@ -37,13 +35,13 @@ metadata:
 spec:
   host: https://api.doppler.com
   tokenSecret:
-    name: doppler-token-secret
+    name: infra-newrelic-doppler-token
   managedSecret:
     name: nri-bundle-newrelic-infrastructure-license
     namespace: newrelic
     type: Opaque
   processors:
-    NEWRELIC_LICENSE_KEY:
+    NEW_RELIC_LICENSE_KEY:
       asName: licenseKey
       type: plain
   resyncSeconds: 60
@@ -57,13 +55,13 @@ metadata:
 spec:
   host: https://api.doppler.com
   tokenSecret:
-    name: doppler-token-secret
+    name: infra-newrelic-doppler-token
   managedSecret:
     name: nri-bundle-newrelic-logging-config
     namespace: newrelic
     type: Opaque
   processors:
-    NEWRELIC_LICENSE_KEY:
+    NEW_RELIC_LICENSE_KEY:
       asName: license
       type: plain
   resyncSeconds: 60
@@ -77,13 +75,13 @@ metadata:
 spec:
   host: https://api.doppler.com
   tokenSecret:
-    name: doppler-token-secret
+    name: infra-newrelic-doppler-token
   managedSecret:
     name: nri-bundle-newrelic-prometheus-agent-license
     namespace: newrelic
     type: Opaque
   processors:
-    NEWRELIC_LICENSE_KEY:
+    NEW_RELIC_LICENSE_KEY:
       asName: licenseKey
       type: plain
   resyncSeconds: 60
@@ -97,13 +95,13 @@ metadata:
 spec:
   host: https://api.doppler.com
   tokenSecret:
-    name: doppler-token-secret
+    name: infra-newrelic-doppler-token
   managedSecret:
     name: newrelic-key-secret
     namespace: newrelic
     type: Opaque
   processors:
-    NEWRELIC_LICENSE_KEY:
+    NEW_RELIC_LICENSE_KEY:
       asName: new_relic_license_key
       type: plain
   resyncSeconds: 60
@@ -120,7 +118,7 @@ metadata:
 spec:
   host: https://api.doppler.com
   tokenSecret:
-    name: doppler-token-secret
+    name: infra-valkey-core-doppler-token
   managedSecret:
     name: valkey-core-secret
     namespace: newrelic

--- a/deploy/infra/valkey/dopplersecrets.yaml
+++ b/deploy/infra/valkey/dopplersecrets.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   host: https://api.doppler.com
   tokenSecret:
-    name: doppler-token-secret
+    name: infra-valkey-core-doppler-token
   managedSecret:
     name: valkey-core-secret
     namespace: valkey
@@ -29,7 +29,7 @@ metadata:
 spec:
   host: https://api.doppler.com
   tokenSecret:
-    name: doppler-token-secret
+    name: infra-valkey-users-doppler-token
   managedSecret:
     name: valkey-users-secret
     namespace: valkey

--- a/deploy/k8s/sesame.yaml
+++ b/deploy/k8s/sesame.yaml
@@ -1,8 +1,6 @@
-# sesame replaces the worker: same lanes, same pkg/bus consumer group ("worker"),
-# same Doppler secret values. It reuses the worker's Doppler service token
-# (worker-doppler-token, created out-of-band and never pruned), so sesame-env
-# holds the identical secrets the worker read (VALKEY_*, NATS_CACHE_INVALIDATION_PREFIX,
-# TWITCH_SPECIAL_USER_IDS). Only the k8s secret name differs.
+# Sesame keeps the established pkg/bus consumer group ("worker"), but owns its
+# Doppler project and read-only service token. The old worker token is retained
+# out-of-band only as a short-lived rollback path during the project cutover.
 apiVersion: secrets.doppler.com/v1alpha1
 kind: DopplerSecret
 metadata:
@@ -11,7 +9,7 @@ metadata:
 spec:
   host: https://api.doppler.com
   tokenSecret:
-    name: worker-doppler-token
+    name: sesame-doppler-token
   managedSecret:
     name: sesame-env
     namespace: production


### PR DESCRIPTION
## What changed

- Replaces direct inheritance from the generic `shared` project with flat capability parents for runtime defaults, observability, NATS client settings, and Valkey client settings.
- Gives Sesame its own Doppler project and Kubernetes token reference instead of reusing Worker.
- Moves New Relic, Valkey core, Valkey ACL, CrowdSec, and fleet bootstrap into least-privilege projects.
- Adds a names-only topology contract, offline Go tests, and a live validator that uses `doppler secrets --only-names`.
- Updates GitOps manifests and Ansible commands to use the new project/token names.

## Why

The previous `shared` rollout was partial and `infra/prd_*` branch configs inherited unrelated entries from the broad `infra/prd` root. This caused inconsistent inheritance and exposed unrelated configuration names to scoped integrations.

## Validation

- Full `go test ./...` passed.
- Doppler live topology validation passed for every declared parent, integration, service, and config.
- All copied payloads were compared in memory with PASS/FAIL-only output.
- Kubernetes managed Secret key-name sets match their least-privilege contracts.
- Every DopplerSecret reports sync-ready.
- All production Deployments, the Valkey StatefulSet, New Relic pods, and CrowdSec pods are ready.
- Kustomize builds, shell syntax, and Ansible syntax checks passed.

No secret value is included in this change or its logs. Legacy `infra`, `shared`, Worker tokens, and generic Kubernetes token Secrets remain available for rollback during the observation window.
