### PR TITLE
refactor(web): extract site-wide ReadingProgress component

### DIFF
--- a/web/src/components/guides/GuideShell.astro
+++ b/web/src/components/guides/GuideShell.astro
@@ -1,7 +1,7 @@
 ---
 /**
  * GuideShell — long-form visual guides that respect the reader. Same reading
- * contract as LegalShell (thin progress bar, sticky scrollspy TOC) with a
+ * contract as LegalShell (sticky scrollspy TOC) with a
  * guide-specific vocabulary: numbered sections, an optional "at a glance"
  * note per section, a breadcrumb back to the hub, and a prev/next pager so a
  * reader can walk the whole handbook without returning to the hub.
@@ -45,10 +45,6 @@ const hubHref = localizePath('/guides', lang);
 ---
 
 <div class="gshell" data-guide>
-    <div class="gshell__progress" aria-hidden="true">
-        <span class="gshell__progress-fill" data-guide-progress></span>
-    </div>
-
     <div class="gshell__grid">
         <nav class="gshell__toc" aria-label={labels.toc}>
             <TextLink class="gshell__hub" href={hubHref} label={`← ${labels.hub}`} size="0.7rem" />
@@ -109,28 +105,6 @@ const hubHref = localizePath('/guides', lang);
         max-width: var(--content-max, 1200px);
         margin: 0 auto;
         padding: 0 24px 96px;
-    }
-
-    /* ── Reading progress ── */
-
-    .gshell__progress {
-        position: fixed;
-        top: 0;
-        left: 0;
-        right: 0;
-        height: 2px;
-        z-index: 90;
-        pointer-events: none;
-    }
-
-    .gshell__progress-fill {
-        display: block;
-        height: 100%;
-        width: 100%;
-        background: linear-gradient(90deg, var(--green-glow, #52b788), var(--tan, #c9a87c));
-        transform: scaleX(var(--read, 0));
-        transform-origin: left;
-        box-shadow: 0 0 12px rgba(201, 168, 124, 0.5);
     }
 
     /* ── Layout ── */
@@ -493,13 +467,11 @@ const hubHref = localizePath('/guides', lang);
 </style>
 
 <script>
-    /* Reading progress + TOC scrollspy — same contract as LegalShell. */
+    /* TOC scrollspy — same contract as LegalShell. */
     function setupGuide(root: HTMLElement) {
         if (root.dataset.guideReady === 'true') return;
         root.dataset.guideReady = 'true';
 
-        const fill = root.querySelector<HTMLElement>('[data-guide-progress]');
-        const article = root.querySelector<HTMLElement>('.gshell__content');
         const sections = Array.from(root.querySelectorAll<HTMLElement>('[data-guide-section]'));
         const links = new Map(
             Array.from(root.querySelectorAll<HTMLAnchorElement>('[data-guide-link]'))
@@ -510,12 +482,6 @@ const hubHref = localizePath('/guides', lang);
 
         function update() {
             ticking = false;
-            if (article && fill) {
-                const rect = article.getBoundingClientRect();
-                const total = rect.height - window.innerHeight;
-                const read = total > 0 ? Math.min(1, Math.max(0, -rect.top / total)) : 1;
-                fill.style.setProperty('--read', read.toFixed(4));
-            }
 
             let currentId = sections[0]?.id;
             for (const section of sections) {

--- a/web/src/components/legal/LegalShell.astro
+++ b/web/src/components/legal/LegalShell.astro
@@ -1,8 +1,9 @@
 ---
 /**
- * LegalShell — legal pages that respect the reader. A thin reading-progress
- * bar, a sticky scrollspy table of contents (desktop), and a "plain words"
- * one-liner on every section so nobody has to parse legalese to get the gist.
+ * LegalShell — legal pages that respect the reader. A sticky scrollspy table
+ * of contents (desktop) and a "plain words" one-liner on every section so
+ * nobody has to parse legalese to get the gist. (The reading-progress bar is
+ * site-wide now: ui/ReadingProgress, mounted in Layout.)
  * Pages pass sections (id, heading, plain) and the rendered body of each
  * section as a Content component (from a markdown content collection).
  */
@@ -28,10 +29,6 @@ const labels = { toc: t('legal.toc'), updated: t('legal.updated'), plain: t('leg
 ---
 
 <div class="lshell" data-legal>
-    <div class="lshell__progress" aria-hidden="true">
-        <span class="lshell__progress-fill" data-legal-progress></span>
-    </div>
-
     <div class="lshell__grid">
         <nav class="lshell__toc" aria-label={labels.toc}>
             <span class="lshell__toc-label">{labels.toc}</span>
@@ -69,29 +66,6 @@ const labels = { toc: t('legal.toc'), updated: t('legal.updated'), plain: t('leg
         max-width: var(--content-max, 1200px);
         margin: 0 auto;
         padding: 0 24px 96px;
-    }
-
-    /* ── Reading progress ── */
-
-    .lshell__progress {
-        position: fixed;
-        top: 0;
-        left: 0;
-        right: 0;
-        height: 2px;
-        z-index: 90;
-        background: transparent;
-        pointer-events: none;
-    }
-
-    .lshell__progress-fill {
-        display: block;
-        height: 100%;
-        width: 100%;
-        background: linear-gradient(90deg, var(--green-glow, #52b788), var(--tan, #c9a87c));
-        transform: scaleX(var(--read, 0));
-        transform-origin: left;
-        box-shadow: 0 0 12px rgba(201, 168, 124, 0.5);
     }
 
     /* ── Layout ── */
@@ -258,13 +232,11 @@ const labels = { toc: t('legal.toc'), updated: t('legal.updated'), plain: t('leg
 </style>
 
 <script>
-    /* Reading progress + TOC scrollspy. One shared scroll listener per page. */
+    /* TOC scrollspy. One shared scroll listener per page. */
     function setupLegal(root: HTMLElement) {
         if (root.dataset.legalReady === 'true') return;
         root.dataset.legalReady = 'true';
 
-        const fill = root.querySelector<HTMLElement>('[data-legal-progress]');
-        const article = root.querySelector<HTMLElement>('.lshell__content');
         const sections = Array.from(root.querySelectorAll<HTMLElement>('[data-legal-section]'));
         const links = new Map(
             Array.from(root.querySelectorAll<HTMLAnchorElement>('[data-legal-link]'))
@@ -275,12 +247,6 @@ const labels = { toc: t('legal.toc'), updated: t('legal.updated'), plain: t('leg
 
         function update() {
             ticking = false;
-            if (article && fill) {
-                const rect = article.getBoundingClientRect();
-                const total = rect.height - window.innerHeight;
-                const read = total > 0 ? Math.min(1, Math.max(0, -rect.top / total)) : 1;
-                fill.style.setProperty('--read', read.toFixed(4));
-            }
 
             /* Current section: the last one whose top passed the upper third */
             let currentId = sections[0]?.id;

--- a/web/src/components/ui/ReadingProgress.astro
+++ b/web/src/components/ui/ReadingProgress.astro
@@ -1,0 +1,66 @@
+---
+/**
+ * ReadingProgress — the thin gradient bar fixed to the top of the viewport
+ * showing how far down the page the reader is. Mounted once in Layout so
+ * every page gets it; measures whole-document scroll (unlike the old
+ * per-shell bars, which measured only their article).
+ */
+---
+
+<div class="rprogress" aria-hidden="true">
+    <span class="rprogress__fill" data-reading-progress></span>
+</div>
+
+<style>
+    .rprogress {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        height: 2px;
+        z-index: 90;
+        pointer-events: none;
+    }
+
+    .rprogress__fill {
+        display: block;
+        height: 100%;
+        width: 100%;
+        background: linear-gradient(90deg, var(--green-glow, #52b788), var(--tan, #c9a87c));
+        transform: scaleX(var(--read, 0));
+        transform-origin: left;
+        box-shadow: 0 0 12px rgba(201, 168, 124, 0.5);
+    }
+</style>
+
+<script>
+    /* One shared scroll listener for the lifetime of the tab; the fill element
+       is re-queried on astro:page-load because the router swaps the DOM. */
+    let fill: HTMLElement | null = null;
+    let ticking = false;
+
+    function update() {
+        ticking = false;
+        if (!fill) return;
+        const doc = document.documentElement;
+        const total = doc.scrollHeight - window.innerHeight;
+        const read = total > 0 ? Math.min(1, Math.max(0, window.scrollY / total)) : 0;
+        fill.style.setProperty('--read', read.toFixed(4));
+    }
+
+    function onScroll() {
+        if (ticking) return;
+        ticking = true;
+        requestAnimationFrame(update);
+    }
+
+    function setup() {
+        fill = document.querySelector<HTMLElement>('[data-reading-progress]');
+        update();
+    }
+
+    window.addEventListener('scroll', onScroll, { passive: true });
+    window.addEventListener('resize', onScroll, { passive: true });
+    setup();
+    document.addEventListener('astro:page-load', setup);
+</script>

--- a/web/src/layouts/Layout.astro
+++ b/web/src/layouts/Layout.astro
@@ -6,6 +6,7 @@ import Cursor from '../components/ui/Cursor.astro'
 import Footer from '../components/layout/Footer.astro'
 import Nav from "../components/layout/Nav.astro";
 import Brackets from '../components/ui/Brackets.astro'
+import ReadingProgress from '../components/ui/ReadingProgress.astro'
 import { getLangFromUrl, LOCALIZED_PATHS, locales, defaultLang, splitLocale, localizePath, useTranslations } from '../i18n/ui';
 
 interface Props {
@@ -224,6 +225,7 @@ const contentSecurityPolicy = [
         <slot/>
     </main>
     <Nav/>
+    <ReadingProgress/>
     <Brackets/>
     <Footer/>
     <Cursor/>


### PR DESCRIPTION
The thin reading-progress bar previously lived duplicated inside LegalShell and GuideShell, each instance measuring only its own article.

- New `web/src/components/ui/ReadingProgress.astro`: same visual (gradient fill, fixed 2px bar at viewport top), measures whole-document scroll, re-binds on `astro:page-load` for view transitions.
- Mounted once in `Layout.astro`, so every page site-wide shows it.
- Removed duplicate markup/CSS/fill JS from LegalShell and GuideShell; their TOC scrollspy is untouched.

Verified in dev preview on /privacy, /guides/modules, and the homepage: exactly one bar, no leftovers, fill updates on scroll. Production build passes (26 pages).