### PR TITLE
fix(ingress): post-rollout shard rebalance and hard pod spread

### DIFF
--- a/app/ingress/lib/ingress/conduit_manager.ex
+++ b/app/ingress/lib/ingress/conduit_manager.ex
@@ -22,6 +22,7 @@ defmodule Ingress.ConduitManager do
   require Logger
 
   alias Ingress.Metrics
+  alias Ingress.ShardDistribution
   alias Ingress.ShardHealth
   alias Ingress.ShardScaler
   alias Ingress.ShardSession
@@ -33,6 +34,12 @@ defmodule Ingress.ConduitManager do
   @retry_interval_ms 5_000
   # How long a direct stop of an unsupervised (orphan) shard may take.
   @orphan_stop_timeout_ms 5_000
+  # Passive Horde redistribution avoids stop-before-start gaps during a roll.
+  # Once the same membership has survived this many reconcile ticks (~2 min),
+  # move at most one shard per tick with an explicit make-before-break handoff.
+  @rebalance_stable_ticks 9
+  @rebalance_handoff_timeout_ms 20_000
+  @rebalance_poll_interval_ms 300
 
   def start_link(_opts) do
     GenServer.start_link(__MODULE__, [], name: via())
@@ -50,7 +57,9 @@ defmodule Ingress.ConduitManager do
        # shard_id => consecutive reconcile ticks observed unhealthy on Twitch
        unhealthy_counts: %{},
        # shard_id => {rescue pid, seen count when the rescue was spawned}
-       rescues: %{}
+       rescues: %{},
+       placement_nodes: [],
+       placement_stable_ticks: 0
      }, {:continue, :reconcile}}
   end
 
@@ -99,6 +108,7 @@ defmodule Ingress.ConduitManager do
         snapshot = shard_snapshot(state.conduit_id)
         applied = converge_shards(state.conduit_id, desired, state.applied_shard_count, snapshot)
         state = run_health_pass(%{state | applied_shard_count: applied}, desired, snapshot)
+        state = rebalance_shards(state, desired, snapshot)
         Process.send_after(self(), :reconcile, @reconcile_interval_ms)
         state
 
@@ -258,9 +268,9 @@ defmodule Ingress.ConduitManager do
     spec = {Ingress.ShardSession, shard_id: shard_id, conduit_id: conduit_id}
 
     case Horde.DynamicSupervisor.start_child(Ingress.ShardSupervisor, spec) do
-      {:ok, _pid} ->
+      {:ok, pid} ->
         Logger.info("started shard #{shard_id}")
-        :started
+        {:started, pid}
 
       {:error, {:already_started, _pid}} ->
         :blocked
@@ -272,6 +282,159 @@ defmodule Ingress.ConduitManager do
         Logger.warning("shard #{shard_id} start failed: #{inspect(reason)}")
         :blocked
     end
+  end
+
+  # Horde stays in passive redistribution mode because its active mode moves a
+  # shard stop-before-start on every membership change. A rolling deployment
+  # therefore finishes safely but can leave the final pod to join with no
+  # shards. After membership has remained unchanged for roughly two minutes,
+  # repair only a real count imbalance, one shard per reconcile tick.
+  defp rebalance_shards(state, desired, snapshot) do
+    nodes = placement_nodes()
+    state = track_placement_membership(state, nodes)
+
+    if rebalance_ready?(state, desired, snapshot, nodes) do
+      case rebalance_candidate(desired, nodes) do
+        nil ->
+          state
+
+        {shard_id, pid, target} ->
+          rebalance_shard(state.conduit_id, shard_id, pid, target)
+          state
+      end
+    else
+      state
+    end
+  end
+
+  defp placement_nodes do
+    visible = MapSet.new([node() | Node.list()])
+
+    Horde.Cluster.members(Ingress.ShardSupervisor)
+    |> Enum.map(fn
+      {_supervisor, member_node} -> member_node
+      member_node when is_atom(member_node) -> member_node
+    end)
+    |> Enum.filter(&MapSet.member?(visible, &1))
+    |> Enum.reject(&ShardDistribution.draining_node?/1)
+    |> Enum.uniq()
+    |> Enum.sort()
+  catch
+    :exit, _ -> []
+  end
+
+  defp track_placement_membership(%{placement_nodes: nodes} = state, nodes) do
+    %{state | placement_stable_ticks: state.placement_stable_ticks + 1}
+  end
+
+  defp track_placement_membership(state, nodes) do
+    %{state | placement_nodes: nodes, placement_stable_ticks: 1}
+  end
+
+  defp rebalance_ready?(state, desired, {:ok, shards}, nodes) do
+    state.placement_stable_ticks >= @rebalance_stable_ticks and
+      length(nodes) > 1 and
+      desired >= length(nodes) and
+      state.rescues == %{} and
+      ShardHealth.unhealthy_ids(shards, desired) == []
+  end
+
+  defp rebalance_ready?(_state, _desired, _snapshot, _nodes), do: false
+
+  defp rebalance_candidate(desired, nodes) do
+    placements =
+      0..(desired - 1)
+      |> Enum.reduce_while([], fn shard_id, acc ->
+        case Horde.Registry.lookup(Ingress.Registry, {:shard, shard_id}) do
+          [{pid, _}] -> {:cont, [{shard_id, pid} | acc]}
+          [] -> {:halt, :incomplete}
+        end
+      end)
+
+    case placements do
+      :incomplete -> nil
+      complete -> ShardDistribution.rebalance_candidate(complete, nodes)
+    end
+  end
+
+  defp rebalance_shard(conduit_id, shard_id, pid, target) do
+    Logger.info("rebalancing shard #{shard_id} #{node(pid)} → #{target} after stable membership")
+
+    with :ok <- release_shard_name(pid),
+         {:started, successor} <- start_shard(conduit_id, shard_id),
+         :ok <- await_bound(successor, rebalance_deadline()) do
+      GenServer.stop(pid, :normal, @orphan_stop_timeout_ms)
+      Metrics.count("Conduit/ShardRebalances")
+      :ok
+    else
+      failure ->
+        Logger.warning("shard #{shard_id} rebalance failed: #{inspect(failure)}; rolling back")
+        rollback_rebalance(shard_id, pid)
+    end
+  catch
+    :exit, reason ->
+      Logger.warning("shard #{shard_id} rebalance exited: #{inspect(reason)}; rolling back")
+      rollback_rebalance(shard_id, pid)
+  end
+
+  defp release_shard_name(pid) do
+    GenServer.call(pid, :release_name, @orphan_stop_timeout_ms)
+  catch
+    :exit, reason -> {:error, {:release_failed, reason}}
+  end
+
+  defp rebalance_deadline,
+    do: System.monotonic_time(:millisecond) + @rebalance_handoff_timeout_ms
+
+  defp await_bound(pid, deadline) do
+    cond do
+      match?(%{bound: true}, probe_shard(pid)) ->
+        :ok
+
+      System.monotonic_time(:millisecond) >= deadline ->
+        {:error, :bind_timeout}
+
+      true ->
+        Process.sleep(@rebalance_poll_interval_ms)
+        await_bound(pid, deadline)
+    end
+  end
+
+  defp rollback_rebalance(shard_id, old_pid) do
+    case Horde.Registry.lookup(Ingress.Registry, {:shard, shard_id}) do
+      [{successor, _}] when successor != old_pid ->
+        case Horde.DynamicSupervisor.terminate_child(Ingress.ShardSupervisor, successor) do
+          :ok -> :ok
+          {:error, :not_found} -> GenServer.stop(successor, :normal, @orphan_stop_timeout_ms)
+          {:error, _reason} -> :ok
+        end
+
+      _ ->
+        :ok
+    end
+
+    reclaim_old_shard(old_pid, 5)
+    GenServer.cast(old_pid, :reassert_binding)
+  catch
+    :exit, _ -> :ok
+  end
+
+  defp reclaim_old_shard(_pid, 0), do: :error
+
+  defp reclaim_old_shard(pid, attempts) do
+    case GenServer.call(pid, :reclaim_name, @orphan_stop_timeout_ms) do
+      {:ok, _owner} ->
+        :ok
+
+      {:error, {:already_registered, ^pid}} ->
+        :ok
+
+      {:error, {:already_registered, _other}} ->
+        Process.sleep(@rebalance_poll_interval_ms)
+        reclaim_old_shard(pid, attempts - 1)
+    end
+  catch
+    :exit, _ -> :error
   end
 
   # Twitch silently drops events routed to a shard slot whose transport is not
@@ -346,7 +509,7 @@ defmodule Ingress.ConduitManager do
     Metrics.count("Conduit/ShardRestarts")
 
     case restart_shard(slot, pid) do
-      :started -> {0, rescues}
+      {:started, _pid} -> {0, rescues}
       :blocked -> ensure_rescue(slot, seen, rescues)
     end
   end

--- a/app/ingress/lib/ingress/shard_distribution.ex
+++ b/app/ingress/lib/ingress/shard_distribution.ex
@@ -5,8 +5,10 @@ defmodule Ingress.ShardDistribution do
   Conduit on two nodes always splits 3/2 instead of wherever the default
   hash ring happens to land (4/1 in practice).
 
-  Placement is deterministic given the same membership, so restarts and
-  scale-ups land in a balanced shape without any rebalancing moves.
+  Placement is deterministic given the same membership. New shards land in a
+  balanced shape immediately; `Ingress.ConduitManager` uses the same target
+  calculation for a delayed make-before-break rebalance after membership has
+  settled following a rollout.
 
   Nodes carrying a `{:draining, node}` marker (registered by `Ingress.Drain`
   during a planned shutdown) are excluded from every placement — a handoff
@@ -29,12 +31,14 @@ defmodule Ingress.ShardDistribution do
         Horde.UniformDistribution.choose_node(child_spec, members)
 
       shard_id ->
-        members
-        |> Enum.filter(&match?(%{status: :alive}, &1))
-        |> Enum.sort_by(fn %{name: {_sup, node}} -> node end)
-        |> case do
-          [] -> {:error, :no_alive_nodes}
-          alive -> {:ok, Enum.at(alive, rem(shard_id, length(alive)))}
+        alive =
+          members
+          |> Enum.filter(&match?(%{status: :alive}, &1))
+          |> Enum.map(fn %{name: {_sup, node}} -> node end)
+
+        case target_node(shard_id, alive) do
+          nil -> {:error, :no_alive_nodes}
+          target -> {:ok, Enum.find(members, fn %{name: {_sup, node}} -> node == target end)}
         end
     end
   end
@@ -42,7 +46,65 @@ defmodule Ingress.ShardDistribution do
   @impl true
   def has_quorum?(_members), do: true
 
-  defp draining?(%{name: {_sup, node}}) do
+  @doc """
+  Returns the deterministic node for a shard under the supplied membership.
+  """
+  def target_node(_shard_id, []), do: nil
+
+  def target_node(shard_id, nodes) do
+    nodes = Enum.sort(nodes)
+    Enum.at(nodes, rem(shard_id, length(nodes)))
+  end
+
+  @doc """
+  Picks one move that strictly improves an imbalanced fleet.
+
+  Placements are `{shard_id, pid}` pairs. A balanced fleet (node counts differ
+  by at most one) is left alone even when shard ids do not sit on their
+  deterministic target, avoiding needless WebSocket rebinds.
+  """
+  def rebalance_candidate(placements, nodes),
+    do: rebalance_candidate(placements, nodes, &node/1)
+
+  @doc false
+  def rebalance_candidate(placements, nodes, owner_node) do
+    nodes = Enum.sort(nodes)
+    counts = Enum.frequencies_by(placements, fn {_shard_id, owner} -> owner_node.(owner) end)
+
+    if balanced?(nodes, counts) do
+      nil
+    else
+      placements
+      |> Enum.map(fn {shard_id, owner} ->
+        source = owner_node.(owner)
+        target = target_node(shard_id, nodes)
+        {shard_id, owner, target, Map.get(counts, source, 0), Map.get(counts, target, 0)}
+      end)
+      |> Enum.filter(fn {_shard_id, _owner, target, source_load, target_load} ->
+        target != nil and source_load > target_load
+      end)
+      |> Enum.sort_by(fn {shard_id, _owner, _target, source_load, target_load} ->
+        {target_load, -source_load, shard_id}
+      end)
+      |> List.first()
+      |> case do
+        nil -> nil
+        {shard_id, owner, target, _source_load, _target_load} -> {shard_id, owner, target}
+      end
+    end
+  end
+
+  # A fleet with no nodes needs no move. Otherwise it is balanced when the
+  # per-node shard counts differ by at most one; empty placements collapse to
+  # all-zero loads, which reads as balanced.
+  defp balanced?([], _counts), do: true
+
+  defp balanced?(nodes, counts) do
+    loads = Enum.map(nodes, &Map.get(counts, &1, 0))
+    Enum.max(loads) - Enum.min(loads) <= 1
+  end
+
+  def draining_node?(node) do
     case Horde.Registry.lookup(Ingress.Registry, {:draining, node}) do
       [{pid, _}] -> node(pid) in [node() | Node.list()]
       [] -> false
@@ -52,6 +114,8 @@ defmodule Ingress.ShardDistribution do
     # markers can exist either.
     ArgumentError -> false
   end
+
+  defp draining?(%{name: {_sup, node}}), do: draining_node?(node)
 
   defp shard_id(%{start: {Ingress.ShardSession, :start_link, [opts]}}) when is_list(opts),
     do: Keyword.get(opts, :shard_id)

--- a/app/ingress/lib/ingress/shard_session.ex
+++ b/app/ingress/lib/ingress/shard_session.ex
@@ -142,6 +142,16 @@ defmodule Ingress.ShardSession do
     {:reply, :ok, state}
   end
 
+  # A steady-state rebalance uses the same make-before-break handoff as a
+  # planned drain, but unlike a drain it can roll back when the successor does
+  # not bind. Registration must happen inside this process because Horde
+  # associates the name with the caller.
+  @impl true
+  def handle_call(:reclaim_name, _from, state) do
+    result = Horde.Registry.register(Ingress.Registry, {:shard, state.shard_id}, nil)
+    {:reply, result, state}
+  end
+
   # The other copy of this shard is bound but lost the registry merge; it is
   # taking the registration over and asks us to stand down. If we bound
   # concurrently (race between the merge and this message), keep serving:

--- a/app/ingress/test/shard_distribution_test.exs
+++ b/app/ingress/test/shard_distribution_test.exs
@@ -63,4 +63,36 @@ defmodule Ingress.ShardDistributionTest do
     assert {:ok, %{name: {_sup, node}}} = ShardDistribution.choose_node(spec, members)
     assert node in [:ingress@node1, :ingress@node2]
   end
+
+  test "selects a shard that moves from an overloaded node to an empty node" do
+    placements = [{0, :node1}, {1, :node1}, {2, :node2}]
+    owner_node = & &1
+
+    assert {2, :node2, :node3} =
+             ShardDistribution.rebalance_candidate(
+               placements,
+               [:node1, :node2, :node3],
+               owner_node
+             )
+  end
+
+  test "does not move shards when node counts are already balanced" do
+    placements = [{0, :node2}, {1, :node1}, {2, :node3}]
+
+    assert ShardDistribution.rebalance_candidate(
+             placements,
+             [:node1, :node2, :node3],
+             & &1
+           ) == nil
+  end
+
+  test "four shards across three nodes accepts the unavoidable 2/1/1 shape" do
+    placements = [{0, :node1}, {1, :node1}, {2, :node2}, {3, :node3}]
+
+    assert ShardDistribution.rebalance_candidate(
+             placements,
+             [:node1, :node2, :node3],
+             & &1
+           ) == nil
+  end
 end

--- a/deploy/k8s/console-admin.yaml
+++ b/deploy/k8s/console-admin.yaml
@@ -61,11 +61,25 @@ spec:
               app: console-admin
         - maxSkew: 1
           topologyKey: kubernetes.io/hostname
-          whenUnsatisfiable: ScheduleAnyway
+          whenUnsatisfiable: DoNotSchedule
+          # Scope the hard rule to the incoming ReplicaSet. With maxSurge=1
+          # the first new pod may share a host with an old pod, while the
+          # second new pod is forced onto the other normal node.
+          matchLabelKeys: [pod-template-hash]
           labelSelector:
             matchLabels:
               app: console-admin
       affinity:
+        # Admin has no worker-pool toleration today; make that placement
+        # contract explicit so a future broad toleration cannot move both
+        # operator replicas away from node2/node3.
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: itsbagelbot.dev/pool
+                    operator: NotIn
+                    values: ["worker-pool"]
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100

--- a/deploy/k8s/notifications.yaml
+++ b/deploy/k8s/notifications.yaml
@@ -52,12 +52,15 @@ spec:
           tolerationSeconds: 60
       topologySpreadConstraints:
         - maxSkew: 1
+          minDomains: 3
           topologyKey: kubernetes.io/hostname
-          whenUnsatisfiable: ScheduleAnyway
+          whenUnsatisfiable: DoNotSchedule
+          matchLabelKeys: [pod-template-hash]
           labelSelector:
             matchLabels:
               app: notifications
-      # DaemonSet placement keeps one notifications pod per schedulable node.
+      # Three replicas and three eligible domains keep one notifications pod
+      # per hot-path node after every ReplicaSet rollout.
       # Resolve external hosts without the cluster search-domain fan-out
       # (ndots:1) and serialize A/AAAA to dodge the conntrack race; cap any
       # DNS stall well under a few seconds.

--- a/deploy/k8s/topology_spread_test.go
+++ b/deploy/k8s/topology_spread_test.go
@@ -1,0 +1,141 @@
+package k8s
+
+import (
+	"io"
+	"os"
+	"slices"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+type workloadManifest struct {
+	Kind     string `yaml:"kind"`
+	Metadata struct {
+		Name string `yaml:"name"`
+	} `yaml:"metadata"`
+	Spec struct {
+		Template struct {
+			Spec struct {
+				TopologySpreadConstraints []struct {
+					MinDomains        int      `yaml:"minDomains"`
+					TopologyKey       string   `yaml:"topologyKey"`
+					WhenUnsatisfiable string   `yaml:"whenUnsatisfiable"`
+					MatchLabelKeys    []string `yaml:"matchLabelKeys"`
+				} `yaml:"topologySpreadConstraints"`
+				Affinity struct {
+					NodeAffinity struct {
+						Required struct {
+							NodeSelectorTerms []struct {
+								MatchExpressions []struct {
+									Key      string   `yaml:"key"`
+									Operator string   `yaml:"operator"`
+									Values   []string `yaml:"values"`
+								} `yaml:"matchExpressions"`
+							} `yaml:"nodeSelectorTerms"`
+						} `yaml:"requiredDuringSchedulingIgnoredDuringExecution"`
+					} `yaml:"nodeAffinity"`
+				} `yaml:"affinity"`
+			} `yaml:"spec"`
+		} `yaml:"template"`
+	} `yaml:"spec"`
+}
+
+func loadDeployment(t *testing.T, filename, name string) workloadManifest {
+	t.Helper()
+
+	f, err := os.Open(filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	decoder := yaml.NewDecoder(f)
+	for {
+		var manifest workloadManifest
+		if err := decoder.Decode(&manifest); err != nil {
+			if err == io.EOF {
+				break
+			}
+			t.Fatal(err)
+		}
+		if manifest.Kind == "Deployment" && manifest.Metadata.Name == name {
+			return manifest
+		}
+	}
+
+	t.Fatalf("%s Deployment is missing from %s", name, filename)
+	return workloadManifest{}
+}
+
+func hostnameSpread(t *testing.T, manifest workloadManifest) struct {
+	MinDomains        int      `yaml:"minDomains"`
+	TopologyKey       string   `yaml:"topologyKey"`
+	WhenUnsatisfiable string   `yaml:"whenUnsatisfiable"`
+	MatchLabelKeys    []string `yaml:"matchLabelKeys"`
+} {
+	t.Helper()
+	for _, constraint := range manifest.Spec.Template.Spec.TopologySpreadConstraints {
+		if constraint.TopologyKey == "kubernetes.io/hostname" {
+			return constraint
+		}
+	}
+	t.Fatalf("%s has no hostname topology spread constraint", manifest.Metadata.Name)
+	return struct {
+		MinDomains        int      `yaml:"minDomains"`
+		TopologyKey       string   `yaml:"topologyKey"`
+		WhenUnsatisfiable string   `yaml:"whenUnsatisfiable"`
+		MatchLabelKeys    []string `yaml:"matchLabelKeys"`
+	}{}
+}
+
+func TestRolloutSensitiveWorkloadsHardSpreadEachReplicaSet(t *testing.T) {
+	tests := []struct {
+		file       string
+		name       string
+		minDomains int
+	}{
+		{"console-admin.yaml", "console-admin", 0},
+		{"notifications.yaml", "notifications", 3},
+		{"transactions.yaml", "transactions", 3},
+		{"twitch-ingress.yaml", "twitch-ingress", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			constraint := hostnameSpread(t, loadDeployment(t, tt.file, tt.name))
+			if constraint.WhenUnsatisfiable != "DoNotSchedule" {
+				t.Fatalf("hostname spread is %q, want DoNotSchedule", constraint.WhenUnsatisfiable)
+			}
+			if !slices.Contains(constraint.MatchLabelKeys, "pod-template-hash") {
+				t.Fatal("hostname spread must be scoped to the incoming ReplicaSet")
+			}
+			if constraint.MinDomains != tt.minDomains {
+				t.Fatalf("minDomains = %d, want %d", constraint.MinDomains, tt.minDomains)
+			}
+		})
+	}
+}
+
+// excludesWorkerPool captures the placement rule under test: a nodeAffinity
+// match expression that keeps the workload off the worker pool.
+func excludesWorkerPool(key, operator string, values []string) bool {
+	return key == "itsbagelbot.dev/pool" &&
+		operator == "NotIn" &&
+		slices.Contains(values, "worker-pool")
+}
+
+func TestConsoleAdminExplicitlyExcludesWorkerPool(t *testing.T) {
+	admin := loadDeployment(t, "console-admin.yaml", "console-admin")
+	terms := admin.Spec.Template.Spec.Affinity.NodeAffinity.Required.NodeSelectorTerms
+
+	for _, term := range terms {
+		for _, expression := range term.MatchExpressions {
+			if excludesWorkerPool(expression.Key, expression.Operator, expression.Values) {
+				return
+			}
+		}
+	}
+
+	t.Fatal("console-admin must explicitly exclude the worker pool")
+}

--- a/deploy/k8s/transactions.yaml
+++ b/deploy/k8s/transactions.yaml
@@ -21,7 +21,7 @@ metadata:
   annotations:
     secrets.doppler.com/reload: "true"
 spec:
-  replicas: 3 # one per node; 3 schedulable nodes incl worker1 (tolerates worker-pool); node3 decommissioned
+  replicas: 3 # one per hot-path node: node2, node3, worker1
   revisionHistoryLimit: 3
   minReadySeconds: 10
   strategy:
@@ -52,12 +52,15 @@ spec:
           tolerationSeconds: 60
       topologySpreadConstraints:
         - maxSkew: 1
+          minDomains: 3
           topologyKey: kubernetes.io/hostname
-          whenUnsatisfiable: ScheduleAnyway
+          whenUnsatisfiable: DoNotSchedule
+          matchLabelKeys: [pod-template-hash]
           labelSelector:
             matchLabels:
               app: transactions
-      # DaemonSet placement keeps one transactions pod per schedulable node.
+      # Three replicas and three eligible domains keep one transactions pod
+      # per hot-path node after every ReplicaSet rollout.
       securityContext:
         runAsNonRoot: true
         runAsUser: 65532

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	golang.org/x/sync v0.22.0
 	golang.org/x/text v0.40.0
 	golang.org/x/time v0.15.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -68,5 +69,4 @@ require (
 	google.golang.org/grpc v1.82.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )


### PR DESCRIPTION
## What

Two placement gaps surface after a rolling deploy, plus the same soft-spread pattern in two more services.

### Ingress shard rebalance
Horde stays in **passive** redistribution so a roll never stops a shard before its successor starts. The safe side effect: shards stay wherever a drain moved them, so a replacement node can rejoin and sit empty with nothing to correct it.

`ConduitManager` now runs a delayed **make-before-break** rebalance, gated on:
- membership stable for ~2 min (9 reconcile ticks at 15s),
- every shard healthy on Twitch,
- no active rescue, and at least 2 non-draining nodes.

It moves **one shard per tick** toward the same deterministic target `ShardDistribution` already computes: release the old registry name, start the successor on its target node, wait for it to bind, then stop the old copy. If the successor never binds it rolls back and the old copy reclaims its name (the socket never stopped serving, so no slot goes dark). This reuses the proven planned-drain handoff and adds the rollback that a drain does not need.

`ShardDistribution.rebalance_candidate/3` is pure and unit-tested: it only fires on a real count imbalance (node loads differ by >1) and leaves an unavoidable 2/1/1 shape alone, so no needless WebSocket rebinds.

### Hard pod spread for rollout-sensitive workloads
`console-admin`, `notifications`, and `transactions` used `whenUnsatisfiable: ScheduleAnyway`, so a surge rollout could settle both/all new replicas on one node (Kubernetes never evicts a running pod to improve spread).

- `DoNotSchedule` scoped to the incoming ReplicaSet via `matchLabelKeys: [pod-template-hash]`, so the hard rule constrains the new RS without wedging on old pods during the roll.
- `minDomains: 3` on `notifications`/`transactions` (3 replicas, 3 eligible domains incl. worker1, which they tolerate). Omitted on `console-admin`, which has only 2 eligible domains.
- `console-admin` nodeAffinity makes its no-worker-pool contract explicit so a future broad toleration cannot move both operator replicas off node2/node3.

`deploy/k8s/topology_spread_test.go` pins `DoNotSchedule` + `matchLabelKeys` + expected `minDomains` across all four rollout-sensitive workloads (incl. the already-correct `twitch-ingress` reference).

## Tradeoffs
Hard spread reduces replica count during a node outage by design: with worker1 down, `notifications`/`transactions` run 2/3 (3rd Pending) until it returns; `console-admin` degrades to 1/2 during a node2/node3 outage. This is the intended consequence of correct spread over packing.

## Verification
- `go test ./deploy/k8s/` ok; `go mod tidy` clean (yaml.v3 promoted to direct).
- `mix test` (ingress): 151 tests, 0 failures; `mix compile --warnings-as-errors` clean.
- k3s v1.35.5 supports `matchLabelKeys` (GA 1.32) and `minDomains` (GA 1.30).