### PR TITLE
fix(console): make the chat rehearsal match the bot, and share it with the site

### DIFF
--- a/app/outgress/internal/worker/clip.go
+++ b/app/outgress/internal/worker/clip.go
@@ -201,11 +201,43 @@ func clipReplyText(meta clipMeta, clipURL string) string {
 // the same palette applies; {clipper}/{title} read more naturally for a clip.
 func clipExpand(meta clipMeta, clipURL string) string {
 	title := strings.TrimSpace(meta.Title)
-	return strings.NewReplacer(
-		"{clip}", clipURL,
-		"{user}", meta.Clipper,
-		"{clipper}", meta.Clipper,
-		"{target}", title,
-		"{title}", title,
-	).Replace(strings.TrimSpace(meta.Reply))
+	tokens := map[string]string{
+		"clip":    clipURL,
+		"user":    meta.Clipper,
+		"clipper": meta.Clipper,
+		"target":  title,
+		"title":   title,
+	}
+	return expandTokens(strings.TrimSpace(meta.Reply), tokens)
+}
+
+// expandTokens is a single-pass {key} substitution mirroring sesame's
+// module.Expand semantics (outgress does not import sesame packages): token
+// names are case-insensitive, an unknown token stays literal (braces and
+// all), and a '{' with no closing brace is copied through to the end.
+func expandTokens(tmpl string, tokens map[string]string) string {
+	var b strings.Builder
+	b.Grow(len(tmpl))
+	for i := 0; i < len(tmpl); {
+		open := strings.IndexByte(tmpl[i:], '{')
+		if open < 0 {
+			b.WriteString(tmpl[i:])
+			break
+		}
+		open += i
+		end := strings.IndexByte(tmpl[open:], '}')
+		if end < 0 {
+			b.WriteString(tmpl[i:])
+			break
+		}
+		end += open
+		b.WriteString(tmpl[i:open])
+		if val, ok := tokens[strings.ToLower(tmpl[open+1:end])]; ok {
+			b.WriteString(val)
+		} else {
+			b.WriteString(tmpl[open : end+1])
+		}
+		i = end + 1
+	}
+	return b.String()
 }

--- a/app/outgress/internal/worker/clip.go
+++ b/app/outgress/internal/worker/clip.go
@@ -164,11 +164,13 @@ func clipID(body io.Reader) (string, error) {
 }
 
 // sendClipReply posts the chat line announcing a freshly created clip through
-// the normal chat action (registry route, rate buckets, sender-id injection).
-// Its error is only for the caller to log; the clip already exists, so the
-// caller must not redeliver on a reply failure.
+// the normal actions (registry route, rate buckets, sender-id injection). The
+// reply goes through sendBotLine, so a custom template leading with a
+// slash-verb (/announce, /pin, …) becomes that native action, exactly like
+// every sesame-emitted reply. Its error is only for the caller to log; the
+// clip already exists, so the caller must not redeliver on a reply failure.
 func (w *Worker) sendClipReply(ctx context.Context, broadcasterID string, meta clipMeta, clipURL string) error {
-	return w.sendBotChat(ctx, broadcasterID, clipReplyText(meta, clipURL))
+	return w.sendBotLine(ctx, broadcasterID, clipReplyText(meta, clipURL))
 }
 
 // clipReplyText composes the chat line for a new clip. When the broadcaster set
@@ -200,7 +202,11 @@ func clipReplyText(meta clipMeta, clipURL string) string {
 // them). The {user} and {target} aliases match the standard command tokens so
 // the same palette applies; {clipper}/{title} read more naturally for a clip.
 func clipExpand(meta clipMeta, clipURL string) string {
-	title := strings.TrimSpace(meta.Title)
+	// The title is viewer-typed (!clip <title>). The reply now routes leading
+	// slash-verbs, so a template starting with {title}/{target} must not let
+	// a viewer mint /announce as the bot: strip a leading slash/space run,
+	// mirroring sesame's sanitizeVar for command {args}.
+	title := strings.TrimLeft(strings.TrimSpace(meta.Title), " /")
 	tokens := map[string]string{
 		"clip":    clipURL,
 		"user":    meta.Clipper,

--- a/app/outgress/internal/worker/clip_reply_test.go
+++ b/app/outgress/internal/worker/clip_reply_test.go
@@ -76,3 +76,18 @@ func TestClipExpandCaseInsensitive(t *testing.T) {
 		t.Errorf("clipExpand case-insensitive = %q, want %q", got, want)
 	}
 }
+
+// The viewer-typed title cannot mint a slash-verb through a template that
+// leads with {title}/{target}: leading slashes/spaces are stripped, while
+// non-leading slashes (URLs) survive.
+func TestClipExpandSanitizesLeadingSlashTitle(t *testing.T) {
+	got := clipExpand(clipMeta{
+		Clipper: "viewer",
+		Title:   " /announce pwned",
+		Reply:   "{title} clipped by {clipper}",
+	}, testClipURL)
+	want := "announce pwned clipped by viewer"
+	if got != want {
+		t.Errorf("clipExpand sanitized = %q, want %q", got, want)
+	}
+}

--- a/app/outgress/internal/worker/clip_reply_test.go
+++ b/app/outgress/internal/worker/clip_reply_test.go
@@ -64,3 +64,15 @@ func TestClipExpand(t *testing.T) {
 		t.Errorf("clipExpand = %q, want %q", got, want)
 	}
 }
+
+func TestClipExpandCaseInsensitive(t *testing.T) {
+	got := clipExpand(clipMeta{
+		Clipper: "viewer",
+		Title:   "sick play",
+		Reply:   "{Clipper} clipped {TITLE} → {Clip} {broken",
+	}, testClipURL)
+	want := "viewer clipped sick play → " + testClipURL + " {broken"
+	if got != want {
+		t.Errorf("clipExpand case-insensitive = %q, want %q", got, want)
+	}
+}

--- a/app/outgress/internal/worker/dispatch.go
+++ b/app/outgress/internal/worker/dispatch.go
@@ -62,6 +62,64 @@ func (w *Worker) processPayload(ctx context.Context, payload *outgress.Message) 
 	return act.Run(ctx, payload)
 }
 
+// sendBotLine routes one synthetic bot line, honoring a leading slash-verb
+// the same way sesame's pipeline does for module outputs: outgress.CutSlash
+// owns the grammar, so "/announce hi" becomes a native announcement, "/pin"
+// a pin, "/shoutout <target>" a shoutout, and anything else (including /me,
+// which Twitch chat renders itself) a plain chat line. A routed action with
+// no usable payload (empty announce/pin message, shoutout without a target)
+// is dropped rather than sent for Twitch to reject.
+func (w *Worker) sendBotLine(ctx context.Context, broadcasterID, text string) error {
+	sc, ok := outgress.CutSlash(text)
+	if !ok {
+		return w.sendBotChat(ctx, broadcasterID, text)
+	}
+	switch sc.Type {
+	case outgress.TypeShoutout:
+		if sc.To == "" {
+			return nil
+		}
+		return w.processPayload(ctx, &outgress.Message{
+			Type:          outgress.TypeShoutout,
+			BroadcasterID: broadcasterID,
+			To:            sc.To,
+			Payload:       []byte("{}"),
+		})
+	case outgress.TypeAnnounce:
+		if sc.Text == "" {
+			return nil
+		}
+		body, err := sonic.Marshal(struct {
+			Message string `json:"message"`
+		}{sc.Text})
+		if err != nil {
+			return err
+		}
+		return w.processPayload(ctx, &outgress.Message{
+			Type:          outgress.TypeAnnounce,
+			BroadcasterID: broadcasterID,
+			Color:         sc.Color,
+			Payload:       body,
+		})
+	default: // TypePin: the pin action sends the message first, then pins it.
+		if sc.Text == "" {
+			return nil
+		}
+		body, err := sonic.Marshal(struct {
+			BroadcasterID string `json:"broadcaster_id"`
+			Message       string `json:"message"`
+		}{broadcasterID, sc.Text})
+		if err != nil {
+			return err
+		}
+		return w.processPayload(ctx, &outgress.Message{
+			Type:          outgress.TypePin,
+			BroadcasterID: broadcasterID,
+			Payload:       body,
+		})
+	}
+}
+
 // sendBotChat routes one synthetic bot chat line (a clip reply, the reauth
 // beacon) through the ordinary chat action — registry route defaults, bot
 // sender injection, per-channel chat rate bucket — exactly as if a lane job

--- a/app/outgress/internal/worker/dispatch.go
+++ b/app/outgress/internal/worker/dispatch.go
@@ -74,50 +74,78 @@ func (w *Worker) sendBotLine(ctx context.Context, broadcasterID, text string) er
 	if !ok {
 		return w.sendBotChat(ctx, broadcasterID, text)
 	}
+	msg, err := slashMessage(broadcasterID, sc)
+	if err != nil || msg == nil {
+		return err
+	}
+	return w.processPayload(ctx, msg)
+}
+
+// slashMessage builds the outgress message for a routed slash action. It
+// returns a nil message (and nil error) when the action carries no usable
+// payload — an /announce or /pin with no text, a /shoutout with no target —
+// so the caller drops it instead of sending a call Twitch would reject.
+func slashMessage(broadcasterID string, sc outgress.SlashCommand) (*outgress.Message, error) {
 	switch sc.Type {
 	case outgress.TypeShoutout:
-		if sc.To == "" {
-			return nil
-		}
-		return w.processPayload(ctx, &outgress.Message{
-			Type:          outgress.TypeShoutout,
-			BroadcasterID: broadcasterID,
-			To:            sc.To,
-			Payload:       []byte("{}"),
-		})
+		return shoutoutMessage(broadcasterID, sc), nil
 	case outgress.TypeAnnounce:
-		if sc.Text == "" {
-			return nil
-		}
-		body, err := sonic.Marshal(struct {
-			Message string `json:"message"`
-		}{sc.Text})
-		if err != nil {
-			return err
-		}
-		return w.processPayload(ctx, &outgress.Message{
-			Type:          outgress.TypeAnnounce,
-			BroadcasterID: broadcasterID,
-			Color:         sc.Color,
-			Payload:       body,
-		})
-	default: // TypePin: the pin action sends the message first, then pins it.
-		if sc.Text == "" {
-			return nil
-		}
-		body, err := sonic.Marshal(struct {
-			BroadcasterID string `json:"broadcaster_id"`
-			Message       string `json:"message"`
-		}{broadcasterID, sc.Text})
-		if err != nil {
-			return err
-		}
-		return w.processPayload(ctx, &outgress.Message{
-			Type:          outgress.TypePin,
-			BroadcasterID: broadcasterID,
-			Payload:       body,
-		})
+		return announceMessage(broadcasterID, sc)
+	default:
+		return pinMessage(broadcasterID, sc)
 	}
+}
+
+// shoutoutMessage builds the Send a Shoutout job: the target rides a dedicated
+// field, so the body is empty.
+func shoutoutMessage(broadcasterID string, sc outgress.SlashCommand) *outgress.Message {
+	if sc.To == "" {
+		return nil
+	}
+	return &outgress.Message{
+		Type:          outgress.TypeShoutout,
+		BroadcasterID: broadcasterID,
+		To:            sc.To,
+		Payload:       []byte("{}"),
+	}
+}
+
+func announceMessage(broadcasterID string, sc outgress.SlashCommand) (*outgress.Message, error) {
+	if sc.Text == "" {
+		return nil, nil
+	}
+	body, err := sonic.Marshal(struct {
+		Message string `json:"message"`
+	}{sc.Text})
+	if err != nil {
+		return nil, err
+	}
+	return &outgress.Message{
+		Type:          outgress.TypeAnnounce,
+		BroadcasterID: broadcasterID,
+		Color:         sc.Color,
+		Payload:       body,
+	}, nil
+}
+
+// pinMessage builds the pin job, whose action sends the message first and then
+// pins it until the current stream ends.
+func pinMessage(broadcasterID string, sc outgress.SlashCommand) (*outgress.Message, error) {
+	if sc.Text == "" {
+		return nil, nil
+	}
+	body, err := sonic.Marshal(struct {
+		BroadcasterID string `json:"broadcaster_id"`
+		Message       string `json:"message"`
+	}{broadcasterID, sc.Text})
+	if err != nil {
+		return nil, err
+	}
+	return &outgress.Message{
+		Type:          outgress.TypePin,
+		BroadcasterID: broadcasterID,
+		Payload:       body,
+	}, nil
 }
 
 // sendBotChat routes one synthetic bot chat line (a clip reply, the reauth

--- a/app/outgress/internal/worker/dispatch.go
+++ b/app/outgress/internal/worker/dispatch.go
@@ -86,14 +86,10 @@ func (w *Worker) sendBotLine(ctx context.Context, broadcasterID, text string) er
 // payload — an /announce or /pin with no text, a /shoutout with no target —
 // so the caller drops it instead of sending a call Twitch would reject.
 func slashMessage(broadcasterID string, sc outgress.SlashCommand) (*outgress.Message, error) {
-	switch sc.Type {
-	case outgress.TypeShoutout:
+	if sc.Type == outgress.TypeShoutout {
 		return shoutoutMessage(broadcasterID, sc), nil
-	case outgress.TypeAnnounce:
-		return announceMessage(broadcasterID, sc)
-	default:
-		return pinMessage(broadcasterID, sc)
 	}
+	return textActionMessage(broadcasterID, sc)
 }
 
 // shoutoutMessage builds the Send a Shoutout job: the target rides a dedicated
@@ -110,42 +106,38 @@ func shoutoutMessage(broadcasterID string, sc outgress.SlashCommand) *outgress.M
 	}
 }
 
-func announceMessage(broadcasterID string, sc outgress.SlashCommand) (*outgress.Message, error) {
+// textActionMessage builds the /announce and /pin jobs, which share everything
+// but their body. Color is empty for a pin (CutSlash sets it only on an
+// announce), so it can be assigned unconditionally.
+func textActionMessage(broadcasterID string, sc outgress.SlashCommand) (*outgress.Message, error) {
 	if sc.Text == "" {
 		return nil, nil
 	}
-	body, err := sonic.Marshal(struct {
-		Message string `json:"message"`
-	}{sc.Text})
+	body, err := textActionBody(broadcasterID, sc)
 	if err != nil {
 		return nil, err
 	}
 	return &outgress.Message{
-		Type:          outgress.TypeAnnounce,
+		Type:          sc.Type,
 		BroadcasterID: broadcasterID,
 		Color:         sc.Color,
 		Payload:       body,
 	}, nil
 }
 
-// pinMessage builds the pin job, whose action sends the message first and then
-// pins it until the current stream ends.
-func pinMessage(broadcasterID string, sc outgress.SlashCommand) (*outgress.Message, error) {
-	if sc.Text == "" {
-		return nil, nil
+// textActionBody marshals the body Twitch wants: an announcement carries only
+// the message, while a pin reuses the Send Chat Message body because the pin
+// action posts the line first and then pins it for the current stream.
+func textActionBody(broadcasterID string, sc outgress.SlashCommand) ([]byte, error) {
+	if sc.Type == outgress.TypeAnnounce {
+		return sonic.Marshal(struct {
+			Message string `json:"message"`
+		}{sc.Text})
 	}
-	body, err := sonic.Marshal(struct {
+	return sonic.Marshal(struct {
 		BroadcasterID string `json:"broadcaster_id"`
 		Message       string `json:"message"`
 	}{broadcasterID, sc.Text})
-	if err != nil {
-		return nil, err
-	}
-	return &outgress.Message{
-		Type:          outgress.TypePin,
-		BroadcasterID: broadcasterID,
-		Payload:       body,
-	}, nil
 }
 
 // sendBotChat routes one synthetic bot chat line (a clip reply, the reauth

--- a/app/sesame/engine/pipeline.go
+++ b/app/sesame/engine/pipeline.go
@@ -261,6 +261,17 @@ func (p *Pipeline) newEmit(ctx context.Context, partition string, state *emitSta
 		if o == nil || o.Type == "" {
 			return
 		}
+		// Slash-verbs route on EVERY path, not just custom commands: a module
+		// reply (alert, trigger word, reward, gateway) leading with /announce,
+		// /shoutout or /pin becomes that native action here. Translate is a
+		// no-op on non-chat outputs, so the command path's per-line translation
+		// is never re-parsed. A translated action with no usable payload (an
+		// /announce with no message, a /shoutout with no target, an empty chat
+		// line) is dropped instead of sending a call Twitch would reject.
+		Translate(o)
+		if isEmptyAction(o) {
+			return
+		}
 		if p.floorSuppressed(o) {
 			return
 		}

--- a/app/sesame/engine/pipeline_test.go
+++ b/app/sesame/engine/pipeline_test.go
@@ -260,3 +260,41 @@ func TestProcessPublishErrorNacks(t *testing.T) {
 	err := p.Process(chatMsg(t, "standard", "hi"))
 	assert.Error(t, err) // publish failure DOES nack
 }
+
+// The emit path translates a leading slash-verb for EVERY module output — a
+// module reply "/announcegreen …" leaves the pipeline as a native announce
+// action, not a chat line carrying the verb as text.
+func TestEmitTranslatesSlashVerbOnModulePath(t *testing.T) {
+	pub := &fakePublisher{}
+	p := newPipelineWith(pub, fakeReader{}, emitModule("", module.KindCore, "/announcegreen big news"))
+	require.NoError(t, p.Process(chatMsg(t, "standard", "hi")))
+	require.Len(t, pub.got, 1)
+	assert.Equal(t, outgress.TypeAnnounce, pub.got[0].msg.Type)
+	assert.Equal(t, "green", pub.got[0].msg.Color)
+
+	var inner struct {
+		Message string `json:"message"`
+	}
+	require.NoError(t, sonic.Unmarshal(pub.got[0].msg.Payload, &inner))
+	assert.Equal(t, "big news", inner.Message)
+}
+
+// A translated action with no usable payload (here a /shoutout without a
+// target) is dropped at emit instead of being sent for Twitch to reject.
+func TestEmitDropsEmptySlashAction(t *testing.T) {
+	pub := &fakePublisher{}
+	p := newPipelineWith(pub, fakeReader{}, emitModule("", module.KindCore, "/shoutout"))
+	require.NoError(t, p.Process(chatMsg(t, "standard", "hi")))
+	assert.Empty(t, pub.got)
+}
+
+// /me stays a plain chat line with the verb kept in the text: Twitch chat
+// itself renders the action, so the pipeline must not strip it.
+func TestEmitLeavesMePassthrough(t *testing.T) {
+	pub := &fakePublisher{}
+	p := newPipelineWith(pub, fakeReader{}, emitModule("", module.KindCore, "/me waves"))
+	require.NoError(t, p.Process(chatMsg(t, "standard", "hi")))
+	require.Len(t, pub.got, 1)
+	assert.Equal(t, outgress.TypeChat, pub.got[0].msg.Type)
+	assert.Equal(t, "/me waves", chatMessageText(t, pub.got[0].msg))
+}

--- a/app/sesame/engine/slash.go
+++ b/app/sesame/engine/slash.go
@@ -1,61 +1,38 @@
 package engine
 
 import (
-	"strings"
-
 	"ItsBagelBot/app/sesame/module"
 	"ItsBagelBot/internal/domain/outgress"
 )
 
 // Translate inspects out.Text for a leading slash-verb and, when it finds a
 // known one, rewrites the Output in place: it sets the outgress Type (and Color
-// or To where the verb carries one) and strips the verb prefix from Text. A
-// command author writes the verb the same way they would in chat (e.g.
+// or To where the verb carries one) and strips the verb prefix from Text. An
+// author writes the verb the same way they would in chat (e.g.
 // "/announce hello"), and the engine turns it into the right outgress action.
 //
-// Recognized verbs:
+// The verb grammar lives in outgress.CutSlash — the single owner shared with
+// outgress's own synthetic sends — see its doc for the recognized verbs. /me
+// is a plain passthrough: Twitch chat interprets the leading "/me" itself, so
+// the verb is NOT stripped and the output stays chat.
 //
-//   - /announce[blue|green|orange|purple] -> TypeAnnounce, that color (plain
-//     /announce is "primary"); the verb is stripped from Text.
-//   - /shoutout <target> -> TypeShoutout; the first token (leading '@' stripped)
-//     becomes To and is removed from Text.
-//   - /pin <message> -> TypePin; the verb is stripped from Text. Outgress sends
-//     the message first, then pins it until the current stream ends.
-//   - /me -> left as a plain chat line; the verb is NOT stripped (Twitch chat
-//     interprets the leading "/me" itself).
-//
-// Anything else is left unchanged.
+// Only a chat output is translated. That makes the call idempotent — an
+// already-routed action (announce/shoutout/pin) is never re-parsed — so it is
+// safe both in the custom-command path (which translates per line before
+// batching) and centrally in the pipeline's emit, where EVERY module output
+// passes through it.
 func Translate(out *module.Output) {
-	text := out.Text
-
-	// /announce family. Order matters: the colored variants are prefixes of the
-	// bare verb's namespace, so check the longer forms first.
-	if color, rest, ok := matchAnnounce(text); ok {
-		out.Type = outgress.TypeAnnounce
-		out.Color = color
-		out.Text = rest
+	if out.Type != outgress.TypeChat {
 		return
 	}
-
-	// /shoutout <target>
-	if rest, ok := cutVerb(text, "/shoutout"); ok {
-		rest = strings.TrimLeft(rest, " ")
-		target, remainder, _ := strings.Cut(rest, " ")
-		target = strings.TrimPrefix(target, "@")
-		out.Type = outgress.TypeShoutout
-		out.To = target
-		out.Text = strings.TrimLeft(remainder, " ")
+	sc, ok := outgress.CutSlash(out.Text)
+	if !ok {
 		return
 	}
-
-	// /pin <message>
-	if rest, ok := cutVerb(text, "/pin"); ok {
-		out.Type = outgress.TypePin
-		out.Text = rest
-		return
-	}
-
-	// /me is a plain passthrough: leave Type=chat and keep the verb in Text.
+	out.Type = sc.Type
+	out.Color = sc.Color
+	out.To = sc.To
+	out.Text = sc.Text
 }
 
 // isEmptyAction reports whether a translated output carries no usable payload, so
@@ -70,41 +47,4 @@ func isEmptyAction(out *module.Output) bool {
 	default:
 		return false
 	}
-}
-
-// matchAnnounce reports whether text leads with an /announce verb. It returns
-// the announce color and the text with the verb (and one following space)
-// stripped.
-func matchAnnounce(text string) (color, rest string, ok bool) {
-	type variant struct {
-		verb  string
-		color string
-	}
-	// Longest verbs first so "/announceblue" is not mistaken for "/announce".
-	for _, v := range []variant{
-		{"/announceblue", "blue"},
-		{"/announcegreen", "green"},
-		{"/announceorange", "orange"},
-		{"/announcepurple", "purple"},
-		{"/announce", "primary"},
-	} {
-		if r, matched := cutVerb(text, v.verb); matched {
-			return v.color, r, true
-		}
-	}
-	return "", "", false
-}
-
-// cutVerb matches verb either as the whole string or as a "verb " prefix. On a
-// match it returns the remainder with the single separating space removed (empty
-// when the text was exactly the verb). A "verb" followed by a non-space (e.g.
-// "/announceblue" when matching "/announce") is not a match.
-func cutVerb(text, verb string) (rest string, ok bool) {
-	if text == verb {
-		return "", true
-	}
-	if strings.HasPrefix(text, verb+" ") {
-		return text[len(verb)+1:], true
-	}
-	return "", false
 }

--- a/app/sesame/module/vars.go
+++ b/app/sesame/module/vars.go
@@ -16,6 +16,11 @@ import (
 // "{key}" (braces included) is preserved, so an unknown token is left untouched
 // rather than silently dropped. A '{' with no matching '}' is copied literally
 // through to the end.
+//
+// Token names are case-insensitive: the key's name — everything before the
+// first ':' — is lowercased before repl sees it, so {User} and {USER} resolve
+// like {user}. A payload after the ':' keeps its case ({choice:Hi,Yo} offers
+// "Hi"), so every repl matches against lowercase names only.
 func Expand(dst []byte, tmpl string, repl func(key string) (val string, ok bool)) []byte {
 	for i := 0; i < len(tmpl); {
 		if tmpl[i] != '{' {
@@ -47,10 +52,20 @@ func closeBrace(s string, from int) int {
 // appendToken resolves the "{key}" span tmpl[open:end+1] and appends either its
 // value or, for an unknown key, the literal span (braces and all).
 func appendToken(dst []byte, tmpl string, open, end int, repl func(key string) (val string, ok bool)) []byte {
-	if val, ok := repl(tmpl[open+1 : end]); ok {
+	if val, ok := repl(normalizeKey(tmpl[open+1 : end])); ok {
 		return append(dst, val...)
 	}
 	return append(dst, tmpl[open:end+1]...)
+}
+
+// normalizeKey lowercases a token's name — the part before the first ':' —
+// leaving any payload untouched, so {Random:1-6} normalizes to random:1-6 but
+// {choice:Hi,Yo} keeps its option casing.
+func normalizeKey(key string) string {
+	if name, payload, found := strings.Cut(key, ":"); found {
+		return strings.ToLower(name) + ":" + payload
+	}
+	return strings.ToLower(key)
 }
 
 

--- a/app/sesame/module/vars_test.go
+++ b/app/sesame/module/vars_test.go
@@ -35,3 +35,27 @@ func TestExpandString(t *testing.T) {
 	got := ExpandString("{raider} raided with {viewers}! {unknown}", repl)
 	assert.Equal(t, "CoolStreamer raided with 42! {unknown}", got)
 }
+
+func TestExpandKeyCaseInsensitive(t *testing.T) {
+	repl := func(key string) (string, bool) {
+		// Keys arrive with the name lowercased; the payload keeps its case.
+		switch {
+		case key == "user":
+			return "sam", true
+		case key == "choice:Hi,Yo":
+			return "Hi", true
+		default:
+			return "", false
+		}
+	}
+	got := ExpandString("{User} says {CHOICE:Hi,Yo} to {USER}", repl)
+	assert.Equal(t, "sam says Hi to sam", got)
+}
+
+func TestParseDynamicCaseInsensitiveViaExpand(t *testing.T) {
+	// {Random:5-5} normalizes to random:5-5 before ParseDynamic sees it.
+	got := ExpandString("{Random:5-5}", func(key string) (string, bool) {
+		return ParseDynamic(key)
+	})
+	assert.Equal(t, "5", got)
+}

--- a/app/sesame/modules/channelpoints.go
+++ b/app/sesame/modules/channelpoints.go
@@ -247,7 +247,12 @@ func expandReward(tmpl string, ev redemptionEvent, counterValue string, points i
 		case "user":
 			return strings.TrimPrefix(displayName(ev.UserName, ev.UserLogin), "@"), true
 		case "input":
-			return ev.UserInput, true
+			// {input} is viewer-typed text. With slash-verbs now routed on
+			// every emit path, a template leading with {input} must not let a
+			// redeemer mint /announce (or any verb) as the bot: strip a
+			// leading slash/space run, mirroring the engine's sanitizeVar for
+			// command {args}. Non-leading slashes (URLs) are untouched.
+			return strings.TrimLeft(ev.UserInput, " /"), true
 		case "reward":
 			return ev.Reward.Title, true
 		case "cost":

--- a/app/sesame/modules/govee.go
+++ b/app/sesame/modules/govee.go
@@ -184,12 +184,23 @@ const defaultGoveeReply = "@{user} set the lights to {color}!"
 
 // renderGoveeReply fills the reply template's {user} and {color} tokens for one
 // redemption, falling back to defaultGoveeReply when the template is blank.
+// Expansion goes through module.ExpandString so token names are
+// case-insensitive; anything else stays literal (no dynamic tokens here).
 func renderGoveeReply(tmpl string, ev redemptionEvent, color string) string {
 	if strings.TrimSpace(tmpl) == "" {
 		tmpl = defaultGoveeReply
 	}
 	user := strings.TrimPrefix(displayName(ev.UserName, ev.UserLogin), "@")
-	return strings.NewReplacer("{user}", user, "{color}", color).Replace(tmpl)
+	return module.ExpandString(tmpl, func(key string) (string, bool) {
+		switch key {
+		case "user":
+			return user, true
+		case "color":
+			return color, true
+		default:
+			return "", false
+		}
+	})
 }
 
 // decodeGoveeRedemption decodes the module config and the redemption event, and

--- a/console/dashboard/src/lib/components/channelpoints/RewardEditor.svelte
+++ b/console/dashboard/src/lib/components/channelpoints/RewardEditor.svelte
@@ -50,13 +50,15 @@
     { token: '{points}', label: t('channelpoints.tokPoints') }
   ];
 
-  // Rehearsal samples: substitute ONLY the reward tokens (samplesOnly) with the
-  // draft's own values so the preview shows the real reply, not placeholders.
+  // Rehearsal samples: the reward tokens expandReward resolves (see
+  // app/sesame/modules/channelpoints.go), with the draft's own values so the
+  // preview shows the real reply, not placeholders.
   const samples = $derived<Record<string, string>>({
     user: 'sesame_sam',
     input: draft.isUserInputRequired ? 'good luck!' : '',
     reward: draft.title || t('channelpoints.fieldTitle'),
     cost: String(draft.cost || 0),
+    channel: 'bagel_bakery',
     counter: '42',
     points: String(draft.points || 0)
   });
@@ -121,11 +123,13 @@
       <span>{t('channelpoints.fieldMessage')}</span>
       <ResponseEditor bind:value={draft.message} tokens={TOKENS} placeholder={DEFAULT_MESSAGE} />
     </label>
+    <!-- kind="reply": expandReward substitutes the reward tokens plus the
+         dynamic set ({random}/{choice:…}); nothing else. -->
     <ChatPreview
+      kind="reply"
       response={draft.message || DEFAULT_MESSAGE}
       showViewer={false}
       tag={t('channelpoints.previewTag')}
-      samplesOnly
       {samples}
     />
   {/if}

--- a/console/dashboard/src/lib/components/commands/BuiltinInspector.svelte
+++ b/console/dashboard/src/lib/components/commands/BuiltinInspector.svelte
@@ -107,7 +107,7 @@
       </div>
       <!-- kind="reply": built-in replies are expanded by a bare token replacer
            (e.g. clipExpand) — only def.previewSamples substitute, no dynamic
-           tokens, no slash-verb routing. -->
+           tokens. Leading slash-verbs still route (outgress sendBotLine). -->
       <ChatPreview
         kind="reply"
         dynamic={false}

--- a/console/dashboard/src/lib/components/commands/BuiltinInspector.svelte
+++ b/console/dashboard/src/lib/components/commands/BuiltinInspector.svelte
@@ -105,7 +105,12 @@
         <ResponseEditor name="reply" bind:value={message} tokens={palette} placeholder={def.preview} />
         <small class="hint">{t('builtinInspector.replyHint')}</small>
       </div>
+      <!-- kind="reply": built-in replies are expanded by a bare token replacer
+           (e.g. clipExpand) — only def.previewSamples substitute, no dynamic
+           tokens, no slash-verb routing. -->
       <ChatPreview
+        kind="reply"
+        dynamic={false}
         name={def.id}
         args={def.previewArgs ?? ''}
         response={effectiveMessage}
@@ -121,7 +126,7 @@
   {:else}
     <div class="field">
       <span>{t('builtinInspector.preview')}</span>
-      <ChatPreview name={def.id} args={def.previewArgs ?? ''} response={def.preview} samples={def.previewSamples} />
+      <ChatPreview kind="reply" dynamic={false} name={def.id} args={def.previewArgs ?? ''} response={def.preview} samples={def.previewSamples} />
     </div>
   {/if}
 

--- a/console/dashboard/src/lib/components/commands/ChatPreview.svelte
+++ b/console/dashboard/src/lib/components/commands/ChatPreview.svelte
@@ -15,9 +15,8 @@
   //
   //   kind="reply" — module replies (alerts, triggers, rewards, built-ins,
   //   gateway commands): ONLY the tokens in `samples` (plus the dynamic set
-  //   unless dynamic={false}), one plain message, no slash-verb actions —
-  //   those surfaces never run Translate, so "/announce hi" is sent, and
-  //   shown, as literal text.
+  //   unless dynamic={false}), one message. A leading slash-verb routes the
+  //   same as a command line — the pipeline translates every emitted output.
   import {
     rehearseCommand,
     rehearseReply,

--- a/console/dashboard/src/lib/components/commands/ChatPreview.svelte
+++ b/console/dashboard/src/lib/components/commands/ChatPreview.svelte
@@ -1,93 +1,69 @@
 <script lang="ts">
-  // Live chat rehearsal: acts out the command as it will look in Twitch chat —
+  // Live chat rehearsal: acts out a response as it will look in Twitch chat —
   // a viewer types the trigger, the bot "types" for a beat, then replies with
   // sample values substituted into the tokens. Re-runs (debounced) as the
   // response is edited, so authors see the real thing, not a template string.
   //
-  // When the response leads with a Twitch slash-verb (/announce…, /shoutout, /pin,
-  // /me) the worker turns it into that native action instead of a plain chat
-  // line (see app/sesame/engine/slash.go). The rehearsal mirrors that parse so
-  // authors can see they're driving a Twitch command — an announcement callout,
-  // a shoutout card, a stream-long pin, or an italic /me action — with a badge
-  // naming the verb.
-  // A multi-line response (newline-delimited, up to 5 lines) is acted out as
-  // the bot sending one chat message per line, in order — the same fan-out the
-  // worker performs — so authors see exactly how many messages they're minting.
-  import { normName, responseLines, RESPONSE_MAX_LINES, getI18n } from '@bagel/shared';
+  // This component only RENDERS. What the bot would actually send — which
+  // tokens expand, whether a leading /announce, /shoutout, /pin or /me becomes
+  // a native Twitch action, how many messages a multi-line response mints —
+  // is computed by the shared rehearsal core (@bagel/shared rehearsal.ts),
+  // which mirrors the Go engine line by line. `kind` picks the surface:
+  //
+  //   kind="command" — custom "!command" responses: full command tokens,
+  //   slash-verb routing per line, up to 5 messages (one per line).
+  //
+  //   kind="reply" — module replies (alerts, triggers, rewards, built-ins,
+  //   gateway commands): ONLY the tokens in `samples` (plus the dynamic set
+  //   unless dynamic={false}), one plain message, no slash-verb actions —
+  //   those surfaces never run Translate, so "/announce hi" is sent, and
+  //   shown, as literal text.
+  import {
+    rehearseCommand,
+    rehearseReply,
+    COMMAND_SAMPLES,
+    normName,
+    getI18n,
+    type RehearsedLine,
+    type Seg
+  } from '@bagel/shared';
 
   const { t } = getI18n();
 
-  // Reused beyond custom commands: built-in commands pass `args` (the text a
-  // viewer types after the trigger, e.g. "!clip That is amazing") and sample
-  // overrides; event-driven module replies pass showViewer=false + a `tag` (the
-  // firing event, e.g. "on follow") so only the bot line renders.
   let {
     name = '',
     response = '',
     args = '',
+    kind = 'command',
     showViewer = true,
     viewerText = undefined as string | undefined,
     tag = undefined as string | undefined,
     samples = undefined as Record<string, string> | undefined,
-    samplesOnly = false
+    dynamic = true
   }: {
     name?: string;
     response?: string;
     args?: string;
+    // Which bot expansion path this surface rehearses (see header comment).
+    kind?: 'command' | 'reply';
     showViewer?: boolean;
     // viewerText renders the viewer line verbatim (a plain chat message, no "!"
     // trigger) — used by trigger-word rehearsals where a normal message fires the
     // reply. When unset the viewer types the "!command" trigger.
     viewerText?: string;
     tag?: string;
+    // kind="command": overrides merged over the standard command samples.
+    // kind="reply": the surface's OWN token map — nothing else substitutes.
     samples?: Record<string, string>;
-    // samplesOnly drops the default command samples entirely: gateway module
-    // replies substitute ONLY their own tokens ({player}, {wins}, ...) — the
-    // bot never expands {user}/{random} there, so previewing those as values
-    // would rehearse a reply the bot cannot produce. Unknown tokens stay
-    // marked, exactly like a typo in a custom command.
-    samplesOnly?: boolean;
+    // kind="reply" only: false for surfaces whose bot path is a bare string
+    // replacer with no {random}/{choice:…} fallback (govee, clip).
+    dynamic?: boolean;
   } = $props();
 
-  // Keys mirror what sesame actually expands (custom commands: expandCommand in
-  // app/sesame/engine/vars.go; the rest are alert-module tokens).
-  const DEFAULT_SAMPLES: Record<string, string> = {
-    user: 'sesame_sam',
-    sender: 'sesame_sam',
-    args: 'aaaa',
-    target: 'ferret_king',
-    touser: 'ferret_king',
-    channel: 'bagel_bakery',
-    random: '57',
-    tier: '1000',
-    bits: '500',
-    raider: 'CrustyCrumbs',
-    raider_login: 'crustycrumbs',
-    viewers: '42',
-    count: '5',
-    duration: '90'
-  };
-  // Caller overrides win (e.g. a raid alert where {user} is the raiding channel).
-  const SAMPLES = $derived<Record<string, string>>(
-    samplesOnly ? (samples ?? {}) : { ...DEFAULT_SAMPLES, ...(samples ?? {}) }
-  );
-  // The sample viewer typing the trigger; module replies carry no {user} sample.
-  const viewerName = $derived(SAMPLES.user ?? DEFAULT_SAMPLES.user);
+  // The sample viewer typing the trigger; reply surfaces may carry no {user}.
+  const viewerName = $derived(samples?.user ?? COMMAND_SAMPLES.user);
 
   const trigger = $derived('!' + (normName(name) || 'command') + (args ? ' ' + args : ''));
-
-  // --- Slash-verb parse, mirrored from app/worker/module/slash.go ---------
-  // Sesame recognizes a leading verb, rewrites the outgress Type, and
-  // strips the verb from the text. We reproduce the same matching (whole-verb
-  // or "verb " prefix) so the rehearsal renders the same action the bot sends.
-  type Mode = 'chat' | 'announce' | 'shoutout' | 'pin' | 'me';
-  type Parsed = {
-    mode: Mode;
-    body: string; // text with the verb stripped (what actually gets shown)
-    verb?: string; // the matched verb, e.g. "/announcegreen"
-    color?: string; // announce color key
-    target?: string; // shoutout target (leading @ removed)
-  };
 
   // Twitch announcement accent colors. "primary" is the channel accent.
   const ACCENT: Record<string, string> = {
@@ -98,117 +74,17 @@
     purple: '#c77dff'
   };
 
-  // Longest verbs first so "/announceblue" isn't mistaken for "/announce".
-  const ANNOUNCE: [string, string][] = [
-    ['/announceblue', 'blue'],
-    ['/announcegreen', 'green'],
-    ['/announceorange', 'orange'],
-    ['/announcepurple', 'purple'],
-    ['/announce', 'primary']
-  ];
-
-  // cutVerb: match verb as the whole string or as a "verb " prefix; returns the
-  // remainder with the single separating space removed (null when no match).
-  function cutVerb(text: string, verb: string): string | null {
-    if (text === verb) return '';
-    if (text.startsWith(verb + ' ')) return text.slice(verb.length + 1);
-    return null;
-  }
-
-  function parseLine(text: string): Parsed {
-    for (const [verb, color] of ANNOUNCE) {
-      const rest = cutVerb(text, verb);
-      if (rest !== null) return { mode: 'announce', body: rest, verb, color };
-    }
-    const so = cutVerb(text, '/shoutout');
-    if (so !== null) {
-      const trimmed = so.replace(/^ +/, '');
-      const sp = trimmed.indexOf(' ');
-      const rawTarget = sp === -1 ? trimmed : trimmed.slice(0, sp);
-      const remainder = sp === -1 ? '' : trimmed.slice(sp + 1).replace(/^ +/, '');
-      return { mode: 'shoutout', body: remainder, verb: '/shoutout', target: rawTarget.replace(/^@/, '') };
-    }
-    const pin = cutVerb(text, '/pin');
-    if (pin !== null) return { mode: 'pin', body: pin, verb: '/pin' };
-    // /me is a plain passthrough on the wire (verb kept in Text), but Twitch
-    // renders it as an italic action — strip the verb for display.
-    const me = cutVerb(text, '/me');
-    if (me !== null) return { mode: 'me', body: me, verb: '/me' };
-    return { mode: 'chat', body: text };
-  }
+  const views = $derived.by<RehearsedLine[]>(() =>
+    kind === 'command' ? rehearseCommand(response, samples) : rehearseReply(response, samples, { dynamic })
+  );
 
   // Human label for the "uses Twitch command" badge.
-  function verbLabelOf(p: Parsed): string {
-    if (p.mode === 'announce') {
-      return p.color === 'primary' ? '/announce' : `/announce (${p.color})`;
+  function verbLabelOf(v: RehearsedLine): string {
+    if (v.mode === 'announce') {
+      return v.color === 'primary' ? '/announce' : `/announce (${v.color})`;
     }
-    return p.verb ?? '';
+    return v.verb ?? '';
   }
-
-  // Substituted segments over the *stripped* body: known tokens become
-  // highlighted sample values, unknown {tokens} stay marked so typos are visible.
-  type Seg = { text: string; kind: 'plain' | 'sample' | 'unknown' };
-
-  // Deterministic stand-ins for the dynamic tokens sesame resolves at run time
-  // ({counter:x} via the loyalty bump, {random:min-max}/{choice:a,b,c} via
-  // module.ParseDynamic). Prefix matching is case-sensitive like the bot's;
-  // null = the bot would leave the token literal.
-  function dynamicSample(raw: string): string | null {
-    // Bot counters are admin-only: runtime leaves the token visible, so the
-    // rehearsal does too.
-    if (raw.startsWith('counter:bot:')) return null;
-    if (raw.startsWith('counter:')) return raw.length > 'counter:'.length ? '42' : null;
-    if (raw.startsWith('random:')) return randomSample(raw.slice('random:'.length));
-    if (raw.startsWith('choice:')) return raw.slice('choice:'.length).split(',')[0];
-    return null;
-  }
-
-  // Midpoint of a valid {random:min-max} range, so the rehearsal shows a value
-  // the bot could roll without re-rolling on every keystroke.
-  function randomSample(range: string): string | null {
-    const m = range.match(/^(\d+)-(\d+)$/);
-    if (!m) return null;
-    const min = Number(m[1]);
-    const max = Number(m[2]);
-    return max >= min ? String(Math.floor((min + max) / 2)) : null;
-  }
-
-  // One token's segment. dynamic=false (samplesOnly callers) skips the dynamic
-  // forms and leaves colon tokens plain: gateway replies never resolve them.
-  function tokenSeg(span: string, raw: string, samples: Record<string, string>, dynamic: boolean): Seg {
-    const key = raw.toLowerCase();
-    if (key in samples) return { text: samples[key], kind: 'sample' };
-    const dyn = dynamic ? dynamicSample(raw) : null;
-    if (dyn !== null) return { text: dyn, kind: 'sample' };
-    if (raw.includes(':') && !dynamic) return { text: span, kind: 'plain' };
-    return { text: span, kind: 'unknown' };
-  }
-
-  function segmentsOf(body: string, samples: Record<string, string>, dynamic: boolean): Seg[] {
-    const out: Seg[] = [];
-    const re = /\{([a-z_]+(?::[^{}]*)?)\}/gi;
-    let last = 0;
-    for (const m of body.matchAll(re)) {
-      if (m.index > last) out.push({ text: body.slice(last, m.index), kind: 'plain' });
-      out.push(tokenSeg(m[0], m[1], samples, dynamic));
-      last = m.index + m[0].length;
-    }
-    if (last < body.length) out.push({ text: body.slice(last), kind: 'plain' });
-    return out;
-  }
-
-  // One rehearsed bot message per response line, mirroring the worker's
-  // fan-out: every line is parsed for its own slash-verb and substituted
-  // independently, capped at the same ceiling the service enforces.
-  type LineView = Parsed & { segments: Seg[] };
-  const views = $derived.by<LineView[]>(() =>
-    responseLines(response)
-      .slice(0, RESPONSE_MAX_LINES)
-      .map((line) => {
-        const p = parseLine(line);
-        return { ...p, segments: segmentsOf(p.body, SAMPLES, !samplesOnly) };
-      })
-  );
 
   // Typing beat: edits flip to the dots, settle back to the reply. Debounced so
   // the bot doesn't stutter on every keystroke.
@@ -228,6 +104,14 @@
     return () => clearTimeout(settle);
   });
 </script>
+
+{#snippet segs(list: Seg[])}
+  {#each list as seg, i (i)}
+    {#if seg.kind === 'sample'}<mark>{seg.text}</mark>
+    {:else if seg.kind === 'unknown'}<mark class="unknown" title={t('chatPreview.unknownVar')}>{seg.text}</mark>
+    {:else}{seg.text}{/if}
+  {/each}
+{/snippet}
 
 <div class="chat" aria-label={t('chatPreview.ariaPreview')}>
   <span class="chat-tag">{tag ?? t('chatPreview.rehearsal')}</span>
@@ -256,7 +140,7 @@
       <span class="msg empty">{t('chatPreview.nothingToSay')}</span>
     </div>
   {:else}
-    <!-- One bot message per response line, staggered like the worker's send order. -->
+    <!-- One bot message per rehearsed line, staggered like the worker's send order. -->
     {#each views as v, li (li)}
       <div
         class="line bot"
@@ -275,13 +159,7 @@
               {t('chatPreview.announcement')}
             </span>
             {#if v.segments.length}
-              <span class="msg reply">
-                {#each v.segments as seg, i (i)}
-                  {#if seg.kind === 'sample'}<mark>{seg.text}</mark>
-                  {:else if seg.kind === 'unknown'}<mark class="unknown" title={t('chatPreview.unknownVar')}>{seg.text}</mark>
-                  {:else}{seg.text}{/if}
-                {/each}
-              </span>
+              <span class="msg reply">{@render segs(v.segments)}</span>
             {:else}
               <span class="msg empty">{t('chatPreview.addMessageAfter', { verb: v.verb ?? '' })}</span>
             {/if}
@@ -298,13 +176,7 @@
         {:else if v.mode === 'me'}
           <span class="via inline" title={t('chatPreview.runsVerb', { verb: '/me' })}>Twitch /me</span>
           {#if v.segments.length}
-            <span class="msg reply action">
-              {#each v.segments as seg, i (i)}
-                {#if seg.kind === 'sample'}<mark>{seg.text}</mark>
-                {:else if seg.kind === 'unknown'}<mark class="unknown" title={t('chatPreview.unknownVar')}>{seg.text}</mark>
-                {:else}{seg.text}{/if}
-              {/each}
-            </span>
+            <span class="msg reply action">{@render segs(v.segments)}</span>
           {:else}
             <span class="msg empty">{t('chatPreview.addActionAfterMe')}</span>
           {/if}
@@ -315,25 +187,13 @@
               {t('chatPreview.pinnedForStream')}
             </span>
             {#if v.segments.length}
-              <span class="msg reply">
-                {#each v.segments as seg, i (i)}
-                  {#if seg.kind === 'sample'}<mark>{seg.text}</mark>
-                  {:else if seg.kind === 'unknown'}<mark class="unknown" title={t('chatPreview.unknownVar')}>{seg.text}</mark>
-                  {:else}{seg.text}{/if}
-                {/each}
-              </span>
+              <span class="msg reply">{@render segs(v.segments)}</span>
             {:else}
               <span class="msg empty">{t('chatPreview.addMessageAfter', { verb: '/pin' })}</span>
             {/if}
           </div>
         {:else}
-          <span class="msg reply">
-            {#each v.segments as seg, i (i)}
-              {#if seg.kind === 'sample'}<mark>{seg.text}</mark>
-              {:else if seg.kind === 'unknown'}<mark class="unknown" title={t('chatPreview.unknownVar')}>{seg.text}</mark>
-              {:else}{seg.text}{/if}
-            {/each}
-          </span>
+          <span class="msg reply">{@render segs(v.segments)}</span>
         {/if}
       </div>
     {/each}

--- a/console/dashboard/src/lib/components/govee/GoveeRewardEditor.svelte
+++ b/console/dashboard/src/lib/components/govee/GoveeRewardEditor.svelte
@@ -131,7 +131,9 @@
   <Field label={t('govee.fieldReply')} tag={t('common.optional')}>
     <ResponseEditor bind:value={replyMessage} name="replyMessage" tokens={REPLY_TOKENS} placeholder={DEFAULT_REPLY} />
   </Field>
-  <ChatPreview response={replyMessage || DEFAULT_REPLY} showViewer={false} tag={t('govee.previewTag')} samplesOnly samples={replySamples} />
+  <!-- kind="reply" + dynamic={false}: the govee reply is a bare {user}/{color}
+       string replacer (renderGoveeReply) — nothing else ever expands. -->
+  <ChatPreview kind="reply" dynamic={false} response={replyMessage || DEFAULT_REPLY} showViewer={false} tag={t('govee.previewTag')} samples={replySamples} />
 
   <Field label={t('govee.afterTitle')}>
     <select class="input" name="onRedeem" bind:value={onRedeem}>

--- a/console/dashboard/src/lib/components/modules/ReplyEditor.svelte
+++ b/console/dashboard/src/lib/components/modules/ReplyEditor.svelte
@@ -5,12 +5,12 @@
   //
   // Two reply shapes:
   //  - event replies (shoutout, alerts): framed by the firing event (`tag`),
-  //    bot line only, default samples.
-  //  - command replies (gateway modules: reply.command set): rehearsed exactly
-  //    like a custom command — "Chat rehearsal" border, a sample viewer typing
-  //    the trigger, the bot answering with THIS reply's own sample values
-  //    substituted (samplesOnly, so foreign tokens stay marked as unknown) —
-  //    and the token palette swaps to the reply's supported variables.
+  //    bot line only.
+  //  - command replies (gateway modules: reply.command set): same surface as a
+  //    custom command — "Chat rehearsal" border, a sample viewer typing the
+  //    trigger — and the token palette swaps to the reply's supported variables.
+  // Both rehearse with kind="reply": ONLY this reply's previewSamples (plus the
+  //    dynamic tokens) substitute, so foreign tokens stay marked as unknown.
   //
   // Save/Cancel are handled by the page so the whole-module config persists in
   // one place.
@@ -59,17 +59,25 @@
   </label>
 
   {#if isCommand}
-    <!-- Same rehearsal as the commands page: viewer types the trigger, the bot
-         answers with the reply's sample values substituted. -->
+    <!-- Same surface as the commands page: viewer types the trigger, the bot
+         answers. kind="reply" because sesame expands only this reply's own
+         tokens (plus {random}/{choice:…}) — never the command set. -->
     <ChatPreview
+      kind="reply"
       name={reply.command}
       args={reply.previewArgs ?? ''}
       samples={reply.previewSamples}
-      samplesOnly
       response={effectiveMessage}
     />
   {:else}
-    <ChatPreview name="" showViewer={false} tag={reply.event} response={effectiveMessage} />
+    <ChatPreview
+      kind="reply"
+      name=""
+      showViewer={false}
+      tag={reply.event}
+      samples={reply.previewSamples}
+      response={effectiveMessage}
+    />
   {/if}
 
   <div class="actions">

--- a/console/dashboard/src/lib/components/modules/TriggerRuleEditor.svelte
+++ b/console/dashboard/src/lib/components/modules/TriggerRuleEditor.svelte
@@ -91,11 +91,14 @@
     <ResponseEditor bind:value={message} placeholder={DEFAULT_RESPONSE} tokens={TOKENS} />
   </div>
 
+  <!-- kind="reply": trigger replies expand only {user} plus the dynamic
+       tokens (see app/sesame/modules/triggers.go firstReply). -->
   <ChatPreview
+    kind="reply"
     name=""
     viewerText={sampleMessage}
     tag={`on "${phrase.trim() || 'hello'}"`}
-    samples={{ user: 'sesame_sam', random: '42' }}
+    samples={{ user: 'sesame_sam' }}
     response={effectiveMessage}
   />
 

--- a/console/shared/lib/index.ts
+++ b/console/shared/lib/index.ts
@@ -70,4 +70,5 @@ export * from './connection-state';
 export * from './overlay-stack';
 export * from './inspector-machine';
 export * from './commands-validate';
+export * from './rehearsal';
 export * from './validation';

--- a/console/shared/lib/rehearsal.test.ts
+++ b/console/shared/lib/rehearsal.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from 'bun:test';
+import { expandSegments, rehearseCommand, rehearseReply, type Seg } from './rehearsal';
+
+/** The rehearsed chat text of a line: what the bot would actually send. */
+function textOf(segments: Seg[]): string {
+  return segments.map((s) => s.text).join('');
+}
+
+describe('token expansion (module/vars.go Expand mirror)', () => {
+  const resolve = (key: string) => (key === 'user' ? 'sam' : null);
+
+  test('substitutes known tokens and marks them as samples', () => {
+    expect(expandSegments('hi {user}!', resolve)).toEqual([
+      { text: 'hi ', kind: 'plain' },
+      { text: 'sam', kind: 'sample' },
+      { text: '!', kind: 'plain' }
+    ]);
+  });
+
+  test('keys are case-sensitive, exactly like the engine', () => {
+    // expandCommand matches "user", not "User": the bot leaves {User} literal.
+    expect(expandSegments('{User}', resolve)).toEqual([{ text: '{User}', kind: 'unknown' }]);
+  });
+
+  test('any brace span is a token — unknown ones stay literal but marked', () => {
+    expect(expandSegments('{touser2} {foo bar}', resolve)).toEqual([
+      { text: '{touser2}', kind: 'unknown' },
+      { text: ' ', kind: 'plain' },
+      { text: '{foo bar}', kind: 'unknown' }
+    ]);
+  });
+
+  test('a "{" with no closing brace is copied literally', () => {
+    expect(expandSegments('oops {user', resolve)).toEqual([{ text: 'oops {user', kind: 'plain' }]);
+  });
+
+  test('an empty-string resolution drops the token from the output', () => {
+    // Mirrors e.g. a reward's {input} with no input: ok=true, value "".
+    expect(textOf(expandSegments('[{gone}]', () => ''))).toBe('[]');
+  });
+});
+
+describe('rehearseCommand', () => {
+  test('substitutes exactly the expandCommand token set', () => {
+    const [line] = rehearseCommand('{user} {target} {args} {channel}');
+    expect(textOf(line.segments)).toBe('sesame_sam ferret_king aaaa bagel_bakery');
+    expect(line.segments.filter((s) => s.kind === 'sample')).toHaveLength(4);
+  });
+
+  test('alert-only tokens do NOT expand in a command (the bot leaves them literal)', () => {
+    const [line] = rehearseCommand('{bits} {viewers} {raider}');
+    expect(line.segments.every((s) => s.kind === 'unknown' || s.text === ' ')).toBe(true);
+  });
+
+  test('resolves dynamic tokens deterministically', () => {
+    const [line] = rehearseCommand('{random} {random:10-20} {choice:a,b,c}');
+    expect(textOf(line.segments)).toBe('57 15 a');
+  });
+
+  test('invalid random ranges stay literal, like ParseDynamic ok=false', () => {
+    const [line] = rehearseCommand('{random:5-1} {random:x-y}');
+    expect(textOf(line.segments)).toBe('{random:5-1} {random:x-y}');
+  });
+
+  test('counters resolve with engine normalization; bot counters stay literal', () => {
+    const [line] = rehearseCommand('{counter:Deaths} {counter:bot:feeds} {counter:}');
+    expect(line.segments.map((s) => s.kind)).toEqual(['sample', 'plain', 'unknown', 'plain', 'unknown']);
+    expect(textOf(line.segments)).toBe('42 {counter:bot:feeds} {counter:}');
+  });
+
+  test('caps at 5 messages, one per line, like emitResponse', () => {
+    expect(rehearseCommand('a\nb\nc\nd\ne\nf')).toHaveLength(5);
+  });
+
+  test('routes each line its own slash verb', () => {
+    const [a, b] = rehearseCommand('/announcegreen go {user}!\n/me waves');
+    expect(a.mode).toBe('announce');
+    expect(a.color).toBe('green');
+    expect(textOf(a.segments)).toBe('go sesame_sam!');
+    expect(b.mode).toBe('me');
+    expect(textOf(b.segments)).toBe('waves');
+  });
+
+  test('longest announce verb wins ("/announceblue" is not "/announce")', () => {
+    const [line] = rehearseCommand('/announceblue hi');
+    expect(line.verb).toBe('/announceblue');
+    expect(line.color).toBe('blue');
+  });
+
+  test('shoutout consumes the target (leading @ dropped)', () => {
+    const [line] = rehearseCommand('/shoutout @{target} go watch');
+    expect(line.mode).toBe('shoutout');
+    expect(line.target).toBe('ferret_king');
+    expect(textOf(line.segments)).toBe('go watch');
+  });
+
+  test('verbs route AFTER expansion, matching the engine order', () => {
+    // emitResponse expands first, then translates: a verb minted by a token
+    // still becomes the native action.
+    const [line] = rehearseCommand('{choice:/pin read the rules,/announce hi}');
+    expect(line.mode).toBe('pin');
+    expect(textOf(line.segments)).toBe('read the rules');
+  });
+});
+
+describe('rehearseReply', () => {
+  test('substitutes only the given samples; command tokens stay unknown', () => {
+    const [line] = rehearseReply('{user} {args}', { user: 'sam' });
+    expect(line.segments).toEqual([
+      { text: 'sam', kind: 'sample' },
+      { text: ' ', kind: 'plain' },
+      { text: '{args}', kind: 'unknown' }
+    ]);
+  });
+
+  test('resolves dynamic tokens by default (module ExpandString fallback)', () => {
+    const [line] = rehearseReply('{choice:hey,yo} {random}', {});
+    expect(textOf(line.segments)).toBe('hey 57');
+  });
+
+  test('dynamic=false mirrors bare replacers (govee, clip): nothing but samples', () => {
+    const [line] = rehearseReply('{user} {random}', { user: 'sam' }, { dynamic: false });
+    expect(textOf(line.segments)).toBe('sam {random}');
+    expect(line.segments.at(-1)?.kind).toBe('unknown');
+  });
+
+  test('never routes slash verbs — reply surfaces skip Translate', () => {
+    const [line] = rehearseReply('/announce big news', {});
+    expect(line.mode).toBe('chat');
+    expect(textOf(line.segments)).toBe('/announce big news');
+  });
+
+  test('is a single message: no multi-line fan-out', () => {
+    expect(rehearseReply('a\nb', {})).toHaveLength(1);
+  });
+
+  test('an empty template rehearses nothing', () => {
+    expect(rehearseReply('  \n ', {})).toHaveLength(0);
+  });
+
+  test('matches dotted token names like {raider.login}', () => {
+    const [line] = rehearseReply('twitch.tv/{raider.login}', { 'raider.login': 'crustycrumbs' });
+    expect(textOf(line.segments)).toBe('twitch.tv/crustycrumbs');
+  });
+});

--- a/console/shared/lib/rehearsal.test.ts
+++ b/console/shared/lib/rehearsal.test.ts
@@ -126,10 +126,17 @@ describe('rehearseReply', () => {
     expect(line.segments.at(-1)?.kind).toBe('unknown');
   });
 
-  test('never routes slash verbs — reply surfaces skip Translate', () => {
+  test('routes slash verbs like any emitted output', () => {
     const [line] = rehearseReply('/announce big news', {});
-    expect(line.mode).toBe('chat');
-    expect(textOf(line.segments)).toBe('/announce big news');
+    expect(line.mode).toBe('announce');
+    expect(line.color).toBe('primary');
+    expect(textOf(line.segments)).toBe('big news');
+  });
+
+  test('routes verbs after expansion, matching the emit order', () => {
+    const [line] = rehearseReply('{opener} everyone', { opener: '/pin welcome' });
+    expect(line.mode).toBe('pin');
+    expect(textOf(line.segments)).toBe('welcome everyone');
   });
 
   test('is a single message: no multi-line fan-out', () => {

--- a/console/shared/lib/rehearsal.test.ts
+++ b/console/shared/lib/rehearsal.test.ts
@@ -17,9 +17,11 @@ describe('token expansion (module/vars.go Expand mirror)', () => {
     ]);
   });
 
-  test('keys are case-sensitive, exactly like the engine', () => {
-    // expandCommand matches "user", not "User": the bot leaves {User} literal.
-    expect(expandSegments('{User}', resolve)).toEqual([{ text: '{User}', kind: 'unknown' }]);
+  test('token names are case-insensitive, payloads keep their case', () => {
+    // module.Expand lowercases the name before the resolver sees it.
+    expect(expandSegments('{User}', resolve)).toEqual([{ text: 'sam', kind: 'sample' }]);
+    const choice = expandSegments('{CHOICE:Hi,Yo}', (k) => (k === 'choice:Hi,Yo' ? 'Hi' : null));
+    expect(choice).toEqual([{ text: 'Hi', kind: 'sample' }]);
   });
 
   test('any brace span is a token — unknown ones stay literal but marked', () => {

--- a/console/shared/lib/rehearsal.test.ts
+++ b/console/shared/lib/rehearsal.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { expandSegments, rehearseCommand, rehearseReply, type Seg } from './rehearsal';
+import { expandSegments, rehearseCommand, rehearseReply, type Seg, type Token } from './rehearsal';
 
 /** The rehearsed chat text of a line: what the bot would actually send. */
 function textOf(segments: Seg[]): string {
@@ -7,7 +7,7 @@ function textOf(segments: Seg[]): string {
 }
 
 describe('token expansion (module/vars.go Expand mirror)', () => {
-  const resolve = (key: string) => (key === 'user' ? 'sam' : null);
+  const resolve = (token: Token) => (token.name === 'user' ? 'sam' : null);
 
   test('substitutes known tokens and marks them as samples', () => {
     expect(expandSegments('hi {user}!', resolve)).toEqual([
@@ -20,7 +20,7 @@ describe('token expansion (module/vars.go Expand mirror)', () => {
   test('token names are case-insensitive, payloads keep their case', () => {
     // module.Expand lowercases the name before the resolver sees it.
     expect(expandSegments('{User}', resolve)).toEqual([{ text: 'sam', kind: 'sample' }]);
-    const choice = expandSegments('{CHOICE:Hi,Yo}', (k) => (k === 'choice:Hi,Yo' ? 'Hi' : null));
+    const choice = expandSegments('{CHOICE:Hi,Yo}', (t) => (t.key === 'choice:Hi,Yo' ? 'Hi' : null));
     expect(choice).toEqual([{ text: 'Hi', kind: 'sample' }]);
   });
 

--- a/console/shared/lib/rehearsal.test.ts
+++ b/console/shared/lib/rehearsal.test.ts
@@ -49,6 +49,11 @@ describe('rehearseCommand', () => {
     expect(line.segments.filter((s) => s.kind === 'sample')).toHaveLength(4);
   });
 
+  test('{sender}/{target} are aliases; an override of the canonical covers them', () => {
+    const [line] = rehearseCommand('{sender} waves at {target}', { user: 'maya_live', touser: 'alex' });
+    expect(textOf(line.segments)).toBe('maya_live waves at alex');
+  });
+
   test('alert-only tokens do NOT expand in a command (the bot leaves them literal)', () => {
     const [line] = rehearseCommand('{bits} {viewers} {raider}');
     expect(line.segments.every((s) => s.kind === 'unknown' || s.text === ' ')).toBe(true);
@@ -137,6 +142,14 @@ describe('rehearseReply', () => {
     const [line] = rehearseReply('{opener} everyone', { opener: '/pin welcome' });
     expect(line.mode).toBe('pin');
     expect(textOf(line.segments)).toBe('welcome everyone');
+  });
+
+  test('/me renders as an italic action on reply surfaces too', () => {
+    // The bot sends "/me …" as plain chat (Twitch renders the action itself);
+    // the rehearsal shows the rendered form: me mode, verb stripped.
+    const [line] = rehearseReply('/me thanks {user} warmly', { user: 'sam' });
+    expect(line.mode).toBe('me');
+    expect(textOf(line.segments)).toBe('thanks sam warmly');
   });
 
   test('is a single message: no multi-line fan-out', () => {

--- a/console/shared/lib/rehearsal.ts
+++ b/console/shared/lib/rehearsal.ts
@@ -5,8 +5,12 @@
 //   - token expansion:       app/sesame/module/vars.go (Expand, ParseDynamic)
 //   - command tokens:        app/sesame/engine/vars.go (expandCommand)
 //   - counter normalization: app/sesame/engine/loyalty_valkey.go (NormalizeCounterName)
-//   - slash-verb routing:    app/sesame/engine/slash.go (Translate)
+//   - slash-verb routing:    internal/domain/outgress/slash.go (CutSlash)
 //   - emit order + line cap: app/sesame/engine/dispatch.go (emitResponse)
+//
+// The marketing site's command builder imports this module too (aliased
+// @bagel/rehearsal), so it stays pure: plain data in, plain data out, no DOM
+// and no framework. Each surface renders the RehearsedLine[] its own way.
 //
 // The bot has exactly two expansion behaviors, so there are exactly two
 // rehearsals. Slash-verbs route on EVERY path — the pipeline's emit (and
@@ -40,7 +44,7 @@ export type RehearsalMode = 'chat' | 'announce' | 'shoutout' | 'pin' | 'me';
 /** One chat message as the bot would send it. */
 export interface RehearsedLine {
   mode: RehearsalMode;
-  /** The matched slash verb, e.g. "/announcegreen" (command rehearsal only). */
+  /** The matched slash verb, e.g. "/announcegreen". */
   verb?: string;
   /** Announce accent color key ("primary" for the bare verb). */
   color?: string;
@@ -49,27 +53,61 @@ export interface RehearsedLine {
   segments: Seg[];
 }
 
+/** Sample values, keyed the way Token.key is built. */
+export type Samples = Readonly<Record<string, string>>;
+
+/**
+ * One "{…}" span, split the way module.Expand reads it. The name is
+ * lower-cased (token names are case-insensitive) while the payload after the
+ * first ':' keeps its case, so {CHOICE:Hi,Yo} still offers "Hi".
+ *
+ * payload is null when the span carries no ':' at all — the engine draws a
+ * real distinction there: {choice} is unknown and stays literal, while
+ * {choice:} is an (empty) option list that resolves.
+ */
+export interface Token {
+  /** The span exactly as written, braces included. */
+  span: string;
+  name: string;
+  payload: string | null;
+  /** "name", or "name:payload" — what a sample map is keyed by. */
+  key: string;
+}
+
+/** Resolve one token to its rehearsed value; null leaves it literal. */
+export type Resolve = (token: Token) => string | null;
+
 /** Sample values for the canonical tokens expandCommand resolves — nothing
  * more, so the rehearsal never substitutes a token the bot would leave
- * literal. {sender} and {target} are engine aliases (resolveCommandToken maps
- * them to {user}/{touser}), so they are intentionally absent: an override of
- * the canonical token covers its alias too. */
-export const COMMAND_SAMPLES: Record<string, string> = {
+ * literal. {sender} and {target} are absent on purpose: they are aliases
+ * (see COMMAND_ALIASES), so overriding the canonical token covers both. */
+export const COMMAND_SAMPLES: Samples = {
   user: 'sesame_sam',
   args: 'aaaa',
   touser: 'ferret_king',
   channel: 'bagel_bakery'
 };
 
+/** expandCommand resolves each pair to one value ({user}/{sender} are both the
+ * chatter, {touser}/{target} both the mentioned name), so the alias
+ * canonicalizes before lookup and a single override covers its partner. */
+const COMMAND_ALIASES: Samples = { sender: 'user', target: 'touser' };
+
+/** Deterministic stand-ins for values the bot rolls at run time, so the
+ * rehearsal shows something the bot could produce without re-rolling on
+ * every keystroke. */
+const RANDOM_SAMPLE = '57';
+const COUNTER_SAMPLE = '42';
+
 /** Rehearse a custom command response: expand, split into messages, then
  * route each line's leading slash-verb — the same order as emitResponse.
  * (Expansion per line equals whole-template expansion: no token value can
  * carry a newline, so line boundaries never move.) */
-export function rehearseCommand(response: string, overrides?: Record<string, string>): RehearsedLine[] {
-  const samples = { ...COMMAND_SAMPLES, ...(overrides ?? {}) };
+export function rehearseCommand(response: string, overrides?: Samples): RehearsedLine[] {
+  const samples: Samples = { ...COMMAND_SAMPLES, ...(overrides ?? {}) };
   return responseLines(response)
     .slice(0, RESPONSE_MAX_LINES)
-    .map((line) => rehearseLine(line, (key) => resolveCommandToken(key, samples)));
+    .map((line) => rehearseLine(line, (token) => resolveCommandToken(token, samples)));
 }
 
 /** Rehearse a module reply: one message, the module's own tokens plus
@@ -78,15 +116,13 @@ export function rehearseCommand(response: string, overrides?: Record<string, str
  * line: the pipeline translates every emitted output. */
 export function rehearseReply(
   response: string,
-  samples: Record<string, string> = {},
+  samples: Samples = {},
   opts: { dynamic?: boolean } = {}
 ): RehearsedLine[] {
   const dynamic = opts.dynamic ?? true;
   const text = responseLines(response).join(' ');
   if (text === '') return [];
-  const resolve = (key: string) =>
-    key in samples ? samples[key] : dynamic ? resolveDynamic(key) : null;
-  return [rehearseLine(text, resolve)];
+  return [rehearseLine(text, (token) => resolveReplyToken(token, samples, dynamic))];
 }
 
 /** One chat message: expand tokens, then route the leading slash-verb over
@@ -94,8 +130,7 @@ export function rehearseReply(
  * {choice:/pin a,/pin b}) still routes. */
 function rehearseLine(line: string, resolve: Resolve): RehearsedLine {
   const segments = expandSegments(line, resolve);
-  const expanded = segments.map((s) => s.text).join('');
-  const action = parseSlash(expanded);
+  const action = parseSlash(segments.map((seg) => seg.text).join(''));
   return {
     mode: action.mode,
     verb: action.verb,
@@ -107,15 +142,10 @@ function rehearseLine(line: string, resolve: Resolve): RehearsedLine {
 
 // --- token expansion (module/vars.go Expand) ------------------------------
 
-type Resolve = (key: string) => string | null;
-
 /** Single-pass {key} scan mirroring Go's Expand: any text up to the next '}'
- * is the key, a '{' with no closing brace is copied literally through to the
- * end. Token names are case-insensitive like the engine — the name (before
- * the first ':') is lowercased before resolution, payloads keep their case —
- * so every resolver matches lowercase names only. A resolved key becomes a
- * highlighted sample; an unresolved one stays literal (braces and all),
- * marked unknown. */
+ * is the token, and a '{' with no closing brace is copied literally through
+ * to the end. A resolved token becomes a highlighted sample; an unresolved
+ * one stays literal (braces and all), marked unknown. */
 export function expandSegments(text: string, resolve: Resolve): Seg[] {
   const out: Seg[] = [];
   let plainFrom = 0;
@@ -128,49 +158,70 @@ export function expandSegments(text: string, resolve: Resolve): Seg[] {
     const end = text.indexOf('}', i + 1);
     if (end < 0) break; // no closing brace: the rest is literal
     pushPlain(out, text.slice(plainFrom, i));
-    out.push(tokenSeg(text.slice(i, end + 1), resolve(normalizeKey(text.slice(i + 1, end)))));
+    out.push(segFor(parseToken(text.slice(i, end + 1)), resolve));
     plainFrom = i = end + 1;
   }
   pushPlain(out, text.slice(plainFrom));
-  return out.filter((s) => s.text !== '');
-}
-
-/** module.Expand's normalizeKey mirror: lowercase the token name (before the
- * first ':'), keep any payload's case ({CHOICE:Hi,Yo} → choice:Hi,Yo). */
-function normalizeKey(key: string): string {
-  const colon = key.indexOf(':');
-  if (colon < 0) return key.toLowerCase();
-  return key.slice(0, colon).toLowerCase() + key.slice(colon);
+  return out.filter((seg) => seg.text !== '');
 }
 
 function pushPlain(out: Seg[], text: string): void {
   if (text !== '') out.push({ text, kind: 'plain' });
 }
 
-function tokenSeg(span: string, value: string | null): Seg {
-  if (value === null) return { text: span, kind: 'unknown' };
+function segFor(token: Token, resolve: Resolve): Seg {
+  const value = resolve(token);
+  if (value === null) return { text: token.span, kind: 'unknown' };
   return { text: value, kind: 'sample' };
 }
 
-/** expandCommand's lookup order: named tokens, then {counter:…}, then the
- * dynamic set. null = the bot leaves the token literal. {sender} and {target}
- * are aliases of {user}/{touser} — expandCommand resolves each pair to the
- * same value — so they canonicalize before lookup, letting a single override
- * of {user}/{touser} cover its alias. */
-function resolveCommandToken(key: string, samples: Record<string, string>): string | null {
-  const canonical = key === 'sender' ? 'user' : key === 'target' ? 'touser' : key;
-  if (canonical in samples) return samples[canonical];
-  if (key.startsWith('counter:')) return resolveCounter(key.slice('counter:'.length));
-  return resolveDynamic(key);
+/** Split a "{…}" span into its case-folded name and case-preserved payload. */
+function parseToken(span: string): Token {
+  const body = span.slice(1, -1);
+  const colon = body.indexOf(':');
+  if (colon < 0) {
+    const name = body.toLowerCase();
+    return { span, name, payload: null, key: name };
+  }
+  const name = body.slice(0, colon).toLowerCase();
+  const payload = body.slice(colon + 1);
+  return { span, name, payload, key: `${name}:${payload}` };
 }
 
-/** {counter:<name>} bumps and renders the counter — a deterministic '42'
- * here. Bot-scope counters (bot:…) are admin-only and an empty name never
- * resolves, so both stay literal, exactly like the engine. */
-function resolveCounter(rawName: string): string | null {
-  const name = normalizeCounterName(rawName);
+// --- resolvers ------------------------------------------------------------
+
+/** expandCommand's lookup order: named tokens (aliases folded in), then
+ * {counter:…}, then the dynamic set. */
+function resolveCommandToken(token: Token, samples: Samples): string | null {
+  const sample = lookupSample(token, samples, COMMAND_ALIASES);
+  if (sample !== null) return sample;
+  // A bare {counter} is not the counter form; it falls through like any
+  // other unknown name, exactly as CutPrefix does in the engine.
+  if (token.name === 'counter' && token.payload !== null) return resolveCounter(token);
+  return resolveDynamic(token);
+}
+
+/** A module reply resolves only its own token map, plus the dynamic set when
+ * that module falls back to ParseDynamic. */
+function resolveReplyToken(token: Token, samples: Samples, dynamic: boolean): string | null {
+  const sample = lookupSample(token, samples);
+  if (sample !== null) return sample;
+  return dynamic ? resolveDynamic(token) : null;
+}
+
+function lookupSample(token: Token, samples: Samples, aliases: Samples = {}): string | null {
+  const name = aliases[token.name] ?? token.name;
+  const key = token.payload === null ? name : `${name}:${token.payload}`;
+  return key in samples ? samples[key] : null;
+}
+
+/** {counter:<name>} bumps and renders the counter. Bot-scope counters
+ * (bot:…) are admin-only and an empty name never resolves, so both stay
+ * literal, exactly like the engine. */
+function resolveCounter(token: Token): string | null {
+  const name = normalizeCounterName(token.payload ?? '');
   if (name === '' || name.startsWith('bot:')) return null;
-  return '42';
+  return COUNTER_SAMPLE;
 }
 
 /** NormalizeCounterName mirror: trim, drop one leading '!', trim, lowercase. */
@@ -178,26 +229,30 @@ function normalizeCounterName(name: string): string {
   return name.trim().replace(/^!/, '').trim().toLowerCase();
 }
 
-/** ParseDynamic mirror with deterministic stand-ins so the rehearsal does not
- * re-roll on every keystroke: {random} → 57, {random:min-max} → the range
- * midpoint (invalid ranges stay literal), {choice:a,b,c} → the first option. */
-function resolveDynamic(key: string): string | null {
-  if (key === 'random') return '57';
-  if (key.startsWith('random:')) return randomMidpoint(key.slice('random:'.length));
-  if (key.startsWith('choice:')) return key.slice('choice:'.length).split(',')[0];
-  return null;
+/** ParseDynamic mirror: {random} → a fixed stand-in, {random:min-max} → the
+ * range midpoint (invalid ranges stay literal), {choice:a,b,c} → the first
+ * option. */
+function resolveDynamic(token: Token): string | null {
+  switch (token.name) {
+    case 'random':
+      return token.payload === null ? RANDOM_SAMPLE : randomMidpoint(token.payload);
+    case 'choice':
+      return token.payload === null ? null : token.payload.split(',')[0];
+    default:
+      return null;
+  }
 }
 
 function randomMidpoint(range: string): string | null {
-  const m = range.match(/^(\d+)-(\d+)$/);
-  if (!m) return null;
-  const min = Number(m[1]);
-  const max = Number(m[2]);
+  const bounds = range.match(/^(\d+)-(\d+)$/);
+  if (!bounds) return null;
+  const min = Number(bounds[1]);
+  const max = Number(bounds[2]);
   if (max < min) return null;
   return String(Math.floor((min + max) / 2));
 }
 
-// --- slash-verb routing (engine/slash.go Translate) -----------------------
+// --- slash-verb routing (outgress/slash.go CutSlash) ----------------------
 
 interface SlashAction {
   mode: RehearsalMode;
@@ -209,28 +264,33 @@ interface SlashAction {
   bodyStart: number;
 }
 
+interface AnnounceVerb {
+  verb: string;
+  color: string;
+}
+
 // Longest verbs first so "/announceblue" is not mistaken for "/announce".
-const ANNOUNCE_VERBS: ReadonlyArray<readonly [string, string]> = [
-  ['/announceblue', 'blue'],
-  ['/announcegreen', 'green'],
-  ['/announceorange', 'orange'],
-  ['/announcepurple', 'purple'],
-  ['/announce', 'primary']
+const ANNOUNCE_VERBS: readonly AnnounceVerb[] = [
+  { verb: '/announceblue', color: 'blue' },
+  { verb: '/announcegreen', color: 'green' },
+  { verb: '/announceorange', color: 'orange' },
+  { verb: '/announcepurple', color: 'purple' },
+  { verb: '/announce', color: 'primary' }
 ];
 
-/** Translate mirror over the EXPANDED text — the engine expands first, so a
- * verb produced by a token (e.g. {choice:/pin a,/pin b}) still routes. */
+/** CutSlash mirror over the EXPANDED text — the engine expands first, so a
+ * verb produced by a token still routes. /me is a wire passthrough (the verb
+ * stays in the text), but Twitch renders it as an italic action, so it is
+ * displayed that way with the verb stripped. */
 function parseSlash(text: string): SlashAction {
-  for (const [verb, color] of ANNOUNCE_VERBS) {
-    const at = verbEnd(text, verb);
-    if (at !== null) return { mode: 'announce', verb, color, bodyStart: at };
+  for (const entry of ANNOUNCE_VERBS) {
+    const at = verbEnd(text, entry.verb);
+    if (at !== null) return { mode: 'announce', verb: entry.verb, color: entry.color, bodyStart: at };
   }
   const shoutoutAt = verbEnd(text, '/shoutout');
   if (shoutoutAt !== null) return parseShoutout(text, shoutoutAt);
   const pinAt = verbEnd(text, '/pin');
   if (pinAt !== null) return { mode: 'pin', verb: '/pin', bodyStart: pinAt };
-  // /me is a wire passthrough (the verb stays in the text), but Twitch renders
-  // it as an italic action — display it that way, verb stripped.
   const meAt = verbEnd(text, '/me');
   if (meAt !== null) return { mode: 'me', verb: '/me', bodyStart: meAt };
   return { mode: 'chat', bodyStart: 0 };

--- a/console/shared/lib/rehearsal.ts
+++ b/console/shared/lib/rehearsal.ts
@@ -104,10 +104,13 @@ function rehearseCommandLine(line: string, samples: Record<string, string>): Reh
 
 type Resolve = (key: string) => string | null;
 
-/** Single-pass {key} scan mirroring Go's Expand: case-SENSITIVE keys, any
- * text up to the next '}' is the key, a '{' with no closing brace is copied
- * literally through to the end. A resolved key becomes a highlighted sample;
- * an unresolved one stays literal (braces and all), marked unknown. */
+/** Single-pass {key} scan mirroring Go's Expand: any text up to the next '}'
+ * is the key, a '{' with no closing brace is copied literally through to the
+ * end. Token names are case-insensitive like the engine — the name (before
+ * the first ':') is lowercased before resolution, payloads keep their case —
+ * so every resolver matches lowercase names only. A resolved key becomes a
+ * highlighted sample; an unresolved one stays literal (braces and all),
+ * marked unknown. */
 export function expandSegments(text: string, resolve: Resolve): Seg[] {
   const out: Seg[] = [];
   let plainFrom = 0;
@@ -120,11 +123,19 @@ export function expandSegments(text: string, resolve: Resolve): Seg[] {
     const end = text.indexOf('}', i + 1);
     if (end < 0) break; // no closing brace: the rest is literal
     pushPlain(out, text.slice(plainFrom, i));
-    out.push(tokenSeg(text.slice(i, end + 1), resolve(text.slice(i + 1, end))));
+    out.push(tokenSeg(text.slice(i, end + 1), resolve(normalizeKey(text.slice(i + 1, end)))));
     plainFrom = i = end + 1;
   }
   pushPlain(out, text.slice(plainFrom));
   return out.filter((s) => s.text !== '');
+}
+
+/** module.Expand's normalizeKey mirror: lowercase the token name (before the
+ * first ':'), keep any payload's case ({CHOICE:Hi,Yo} → choice:Hi,Yo). */
+function normalizeKey(key: string): string {
+  const colon = key.indexOf(':');
+  if (colon < 0) return key.toLowerCase();
+  return key.slice(0, colon).toLowerCase() + key.slice(colon);
 }
 
 function pushPlain(out: Seg[], text: string): void {

--- a/console/shared/lib/rehearsal.ts
+++ b/console/shared/lib/rehearsal.ts
@@ -1,0 +1,255 @@
+// Chat-rehearsal core: the dashboard-side mirror of how the bot expands and
+// routes a response template. Every rule here corresponds to one place in the
+// Go engine — keep them in lockstep:
+//
+//   - token expansion:       app/sesame/module/vars.go (Expand, ParseDynamic)
+//   - command tokens:        app/sesame/engine/vars.go (expandCommand)
+//   - counter normalization: app/sesame/engine/loyalty_valkey.go (NormalizeCounterName)
+//   - slash-verb routing:    app/sesame/engine/slash.go (Translate)
+//   - emit order + line cap: app/sesame/engine/dispatch.go (emitResponse)
+//
+// The bot has exactly two expansion behaviors, so there are exactly two
+// rehearsals:
+//
+//   rehearseCommand — custom "!command" responses. The engine expands the
+//   whole template first, then splits it into lines (cap 5, one chat message
+//   each), then translates a leading slash-verb per line into a native Twitch
+//   action (/announce, /shoutout, /pin, /me).
+//
+//   rehearseReply — module replies (alerts, trigger words, channel-point
+//   rewards, built-ins, gateway commands). Each module expands ONLY its own
+//   token map — most fall back to the shared dynamic tokens ({random},
+//   {choice:…}), a few (govee, clip) do not — and emits one plain chat
+//   message. Reply surfaces never run Translate: a literal "/announce hi"
+//   is sent as plain text, and the rehearsal shows it that way.
+
+import { RESPONSE_MAX_LINES, responseLines } from './commands-validate';
+
+export type SegKind = 'plain' | 'sample' | 'unknown';
+
+/** One run of rehearsed text: literal, a substituted sample, or a token the
+ * bot would leave untouched (kept literal so typos stay visible). */
+export interface Seg {
+  text: string;
+  kind: SegKind;
+}
+
+export type RehearsalMode = 'chat' | 'announce' | 'shoutout' | 'pin' | 'me';
+
+/** One chat message as the bot would send it. */
+export interface RehearsedLine {
+  mode: RehearsalMode;
+  /** The matched slash verb, e.g. "/announcegreen" (command rehearsal only). */
+  verb?: string;
+  /** Announce accent color key ("primary" for the bare verb). */
+  color?: string;
+  /** Shoutout target with the leading '@' removed. */
+  target?: string;
+  segments: Seg[];
+}
+
+/** Sample values for exactly the tokens expandCommand resolves — nothing
+ * more, so the rehearsal never substitutes a token the bot would leave
+ * literal. {target} is the dashboard-facing alias of {touser}. */
+export const COMMAND_SAMPLES: Record<string, string> = {
+  user: 'sesame_sam',
+  sender: 'sesame_sam',
+  args: 'aaaa',
+  touser: 'ferret_king',
+  target: 'ferret_king',
+  channel: 'bagel_bakery'
+};
+
+/** Rehearse a custom command response: expand, split into messages, then
+ * route each line's leading slash-verb — the same order as emitResponse.
+ * (Expansion per line equals whole-template expansion: no token value can
+ * carry a newline, so line boundaries never move.) */
+export function rehearseCommand(response: string, overrides?: Record<string, string>): RehearsedLine[] {
+  const samples = { ...COMMAND_SAMPLES, ...(overrides ?? {}) };
+  return responseLines(response)
+    .slice(0, RESPONSE_MAX_LINES)
+    .map((line) => rehearseCommandLine(line, samples));
+}
+
+/** Rehearse a module reply: one plain chat message, the module's own tokens
+ * plus (unless dynamic=false — govee and clip use a bare string replacer)
+ * the shared dynamic tokens. No slash-verb routing, ever. */
+export function rehearseReply(
+  response: string,
+  samples: Record<string, string> = {},
+  opts: { dynamic?: boolean } = {}
+): RehearsedLine[] {
+  const dynamic = opts.dynamic ?? true;
+  const text = responseLines(response).join(' ');
+  if (text === '') return [];
+  const resolve = (key: string) =>
+    key in samples ? samples[key] : dynamic ? resolveDynamic(key) : null;
+  return [{ mode: 'chat', segments: expandSegments(text, resolve) }];
+}
+
+function rehearseCommandLine(line: string, samples: Record<string, string>): RehearsedLine {
+  const segments = expandSegments(line, (key) => resolveCommandToken(key, samples));
+  const expanded = segments.map((s) => s.text).join('');
+  const action = parseSlash(expanded);
+  return {
+    mode: action.mode,
+    verb: action.verb,
+    color: action.color,
+    target: action.target,
+    segments: sliceSegments(segments, action.bodyStart)
+  };
+}
+
+// --- token expansion (module/vars.go Expand) ------------------------------
+
+type Resolve = (key: string) => string | null;
+
+/** Single-pass {key} scan mirroring Go's Expand: case-SENSITIVE keys, any
+ * text up to the next '}' is the key, a '{' with no closing brace is copied
+ * literally through to the end. A resolved key becomes a highlighted sample;
+ * an unresolved one stays literal (braces and all), marked unknown. */
+export function expandSegments(text: string, resolve: Resolve): Seg[] {
+  const out: Seg[] = [];
+  let plainFrom = 0;
+  let i = 0;
+  while (i < text.length) {
+    if (text[i] !== '{') {
+      i++;
+      continue;
+    }
+    const end = text.indexOf('}', i + 1);
+    if (end < 0) break; // no closing brace: the rest is literal
+    pushPlain(out, text.slice(plainFrom, i));
+    out.push(tokenSeg(text.slice(i, end + 1), resolve(text.slice(i + 1, end))));
+    plainFrom = i = end + 1;
+  }
+  pushPlain(out, text.slice(plainFrom));
+  return out.filter((s) => s.text !== '');
+}
+
+function pushPlain(out: Seg[], text: string): void {
+  if (text !== '') out.push({ text, kind: 'plain' });
+}
+
+function tokenSeg(span: string, value: string | null): Seg {
+  if (value === null) return { text: span, kind: 'unknown' };
+  return { text: value, kind: 'sample' };
+}
+
+/** expandCommand's lookup order: named tokens, then {counter:…}, then the
+ * dynamic set. null = the bot leaves the token literal. */
+function resolveCommandToken(key: string, samples: Record<string, string>): string | null {
+  if (key in samples) return samples[key];
+  if (key.startsWith('counter:')) return resolveCounter(key.slice('counter:'.length));
+  return resolveDynamic(key);
+}
+
+/** {counter:<name>} bumps and renders the counter — a deterministic '42'
+ * here. Bot-scope counters (bot:…) are admin-only and an empty name never
+ * resolves, so both stay literal, exactly like the engine. */
+function resolveCounter(rawName: string): string | null {
+  const name = normalizeCounterName(rawName);
+  if (name === '' || name.startsWith('bot:')) return null;
+  return '42';
+}
+
+/** NormalizeCounterName mirror: trim, drop one leading '!', trim, lowercase. */
+function normalizeCounterName(name: string): string {
+  return name.trim().replace(/^!/, '').trim().toLowerCase();
+}
+
+/** ParseDynamic mirror with deterministic stand-ins so the rehearsal does not
+ * re-roll on every keystroke: {random} → 57, {random:min-max} → the range
+ * midpoint (invalid ranges stay literal), {choice:a,b,c} → the first option. */
+function resolveDynamic(key: string): string | null {
+  if (key === 'random') return '57';
+  if (key.startsWith('random:')) return randomMidpoint(key.slice('random:'.length));
+  if (key.startsWith('choice:')) return key.slice('choice:'.length).split(',')[0];
+  return null;
+}
+
+function randomMidpoint(range: string): string | null {
+  const m = range.match(/^(\d+)-(\d+)$/);
+  if (!m) return null;
+  const min = Number(m[1]);
+  const max = Number(m[2]);
+  if (max < min) return null;
+  return String(Math.floor((min + max) / 2));
+}
+
+// --- slash-verb routing (engine/slash.go Translate) -----------------------
+
+interface SlashAction {
+  mode: RehearsalMode;
+  verb?: string;
+  color?: string;
+  target?: string;
+  /** Index into the expanded text where the message body starts (the verb —
+   * and, for shoutout, the target — is consumed by the action). */
+  bodyStart: number;
+}
+
+// Longest verbs first so "/announceblue" is not mistaken for "/announce".
+const ANNOUNCE_VERBS: ReadonlyArray<readonly [string, string]> = [
+  ['/announceblue', 'blue'],
+  ['/announcegreen', 'green'],
+  ['/announceorange', 'orange'],
+  ['/announcepurple', 'purple'],
+  ['/announce', 'primary']
+];
+
+/** Translate mirror over the EXPANDED text — the engine expands first, so a
+ * verb produced by a token (e.g. {choice:/pin a,/pin b}) still routes. */
+function parseSlash(text: string): SlashAction {
+  for (const [verb, color] of ANNOUNCE_VERBS) {
+    const at = verbEnd(text, verb);
+    if (at !== null) return { mode: 'announce', verb, color, bodyStart: at };
+  }
+  const shoutoutAt = verbEnd(text, '/shoutout');
+  if (shoutoutAt !== null) return parseShoutout(text, shoutoutAt);
+  const pinAt = verbEnd(text, '/pin');
+  if (pinAt !== null) return { mode: 'pin', verb: '/pin', bodyStart: pinAt };
+  // /me is a wire passthrough (the verb stays in the text), but Twitch renders
+  // it as an italic action — display it that way, verb stripped.
+  const meAt = verbEnd(text, '/me');
+  if (meAt !== null) return { mode: 'me', verb: '/me', bodyStart: meAt };
+  return { mode: 'chat', bodyStart: 0 };
+}
+
+/** cutVerb mirror: the verb matches as the whole string or as a "verb "
+ * prefix; returns the index just past the verb and its one separating space,
+ * or null when the verb does not lead the text. */
+function verbEnd(text: string, verb: string): number | null {
+  if (text === verb) return verb.length;
+  if (text.startsWith(verb + ' ')) return verb.length + 1;
+  return null;
+}
+
+/** /shoutout <target> — the first token (leading '@' dropped) becomes the
+ * target; the body is what follows, left-trimmed, like the engine's Cut. */
+function parseShoutout(text: string, from: number): SlashAction {
+  let i = from;
+  while (text[i] === ' ') i++;
+  let j = i;
+  while (j < text.length && text[j] !== ' ') j++;
+  const target = text.slice(i, j).replace(/^@/, '');
+  while (text[j] === ' ') j++;
+  return { mode: 'shoutout', verb: '/shoutout', target, bodyStart: j };
+}
+
+/** Drop the first `from` characters from a segment list, preserving the
+ * sample/unknown marks of whatever remains. */
+function sliceSegments(segments: Seg[], from: number): Seg[] {
+  if (from <= 0) return segments;
+  const out: Seg[] = [];
+  let skip = from;
+  for (const seg of segments) {
+    if (skip >= seg.text.length) {
+      skip -= seg.text.length;
+      continue;
+    }
+    out.push(skip > 0 ? { ...seg, text: seg.text.slice(skip) } : seg);
+    skip = 0;
+  }
+  return out;
+}

--- a/console/shared/lib/rehearsal.ts
+++ b/console/shared/lib/rehearsal.ts
@@ -49,15 +49,15 @@ export interface RehearsedLine {
   segments: Seg[];
 }
 
-/** Sample values for exactly the tokens expandCommand resolves — nothing
+/** Sample values for the canonical tokens expandCommand resolves — nothing
  * more, so the rehearsal never substitutes a token the bot would leave
- * literal. {target} is the dashboard-facing alias of {touser}. */
+ * literal. {sender} and {target} are engine aliases (resolveCommandToken maps
+ * them to {user}/{touser}), so they are intentionally absent: an override of
+ * the canonical token covers its alias too. */
 export const COMMAND_SAMPLES: Record<string, string> = {
   user: 'sesame_sam',
-  sender: 'sesame_sam',
   args: 'aaaa',
   touser: 'ferret_king',
-  target: 'ferret_king',
   channel: 'bagel_bakery'
 };
 
@@ -153,9 +153,13 @@ function tokenSeg(span: string, value: string | null): Seg {
 }
 
 /** expandCommand's lookup order: named tokens, then {counter:…}, then the
- * dynamic set. null = the bot leaves the token literal. */
+ * dynamic set. null = the bot leaves the token literal. {sender} and {target}
+ * are aliases of {user}/{touser} — expandCommand resolves each pair to the
+ * same value — so they canonicalize before lookup, letting a single override
+ * of {user}/{touser} cover its alias. */
 function resolveCommandToken(key: string, samples: Record<string, string>): string | null {
-  if (key in samples) return samples[key];
+  const canonical = key === 'sender' ? 'user' : key === 'target' ? 'touser' : key;
+  if (canonical in samples) return samples[canonical];
   if (key.startsWith('counter:')) return resolveCounter(key.slice('counter:'.length));
   return resolveDynamic(key);
 }

--- a/console/shared/lib/rehearsal.ts
+++ b/console/shared/lib/rehearsal.ts
@@ -9,19 +9,20 @@
 //   - emit order + line cap: app/sesame/engine/dispatch.go (emitResponse)
 //
 // The bot has exactly two expansion behaviors, so there are exactly two
-// rehearsals:
+// rehearsals. Slash-verbs route on EVERY path — the pipeline's emit (and
+// outgress's sendBotLine for the clip reply) translates a leading /announce,
+// /shoutout, /pin after expansion — so both rehearsals render the native
+// action; they differ only in tokens and fan-out:
 //
 //   rehearseCommand — custom "!command" responses. The engine expands the
 //   whole template first, then splits it into lines (cap 5, one chat message
-//   each), then translates a leading slash-verb per line into a native Twitch
-//   action (/announce, /shoutout, /pin, /me).
+//   each), then translates each line's leading slash-verb.
 //
 //   rehearseReply — module replies (alerts, trigger words, channel-point
 //   rewards, built-ins, gateway commands). Each module expands ONLY its own
 //   token map — most fall back to the shared dynamic tokens ({random},
-//   {choice:…}), a few (govee, clip) do not — and emits one plain chat
-//   message. Reply surfaces never run Translate: a literal "/announce hi"
-//   is sent as plain text, and the rehearsal shows it that way.
+//   {choice:…}), a few (govee, clip) do not — and emits one message, whose
+//   leading slash-verb routes the same way.
 
 import { RESPONSE_MAX_LINES, responseLines } from './commands-validate';
 
@@ -68,12 +69,13 @@ export function rehearseCommand(response: string, overrides?: Record<string, str
   const samples = { ...COMMAND_SAMPLES, ...(overrides ?? {}) };
   return responseLines(response)
     .slice(0, RESPONSE_MAX_LINES)
-    .map((line) => rehearseCommandLine(line, samples));
+    .map((line) => rehearseLine(line, (key) => resolveCommandToken(key, samples)));
 }
 
-/** Rehearse a module reply: one plain chat message, the module's own tokens
- * plus (unless dynamic=false — govee and clip use a bare string replacer)
- * the shared dynamic tokens. No slash-verb routing, ever. */
+/** Rehearse a module reply: one message, the module's own tokens plus
+ * (unless dynamic=false — govee and clip use a bare string replacer) the
+ * shared dynamic tokens. A leading slash-verb routes exactly like a command
+ * line: the pipeline translates every emitted output. */
 export function rehearseReply(
   response: string,
   samples: Record<string, string> = {},
@@ -84,11 +86,14 @@ export function rehearseReply(
   if (text === '') return [];
   const resolve = (key: string) =>
     key in samples ? samples[key] : dynamic ? resolveDynamic(key) : null;
-  return [{ mode: 'chat', segments: expandSegments(text, resolve) }];
+  return [rehearseLine(text, resolve)];
 }
 
-function rehearseCommandLine(line: string, samples: Record<string, string>): RehearsedLine {
-  const segments = expandSegments(line, (key) => resolveCommandToken(key, samples));
+/** One chat message: expand tokens, then route the leading slash-verb over
+ * the EXPANDED text — the engine's order, so a verb minted by a token (e.g.
+ * {choice:/pin a,/pin b}) still routes. */
+function rehearseLine(line: string, resolve: Resolve): RehearsedLine {
+  const segments = expandSegments(line, resolve);
   const expanded = segments.map((s) => s.text).join('');
   const action = parseSlash(expanded);
   return {

--- a/console/shared/lib/rehearsal.ts
+++ b/console/shared/lib/rehearsal.ts
@@ -104,10 +104,10 @@ const COUNTER_SAMPLE = '42';
  * (Expansion per line equals whole-template expansion: no token value can
  * carry a newline, so line boundaries never move.) */
 export function rehearseCommand(response: string, overrides?: Samples): RehearsedLine[] {
-  const samples: Samples = { ...COMMAND_SAMPLES, ...(overrides ?? {}) };
+  const resolve = commandResolver({ ...COMMAND_SAMPLES, ...(overrides ?? {}) });
   return responseLines(response)
     .slice(0, RESPONSE_MAX_LINES)
-    .map((line) => rehearseLine(line, (token) => resolveCommandToken(token, samples)));
+    .map((line) => rehearseLine(line, resolve));
 }
 
 /** Rehearse a module reply: one message, the module's own tokens plus
@@ -119,10 +119,9 @@ export function rehearseReply(
   samples: Samples = {},
   opts: { dynamic?: boolean } = {}
 ): RehearsedLine[] {
-  const dynamic = opts.dynamic ?? true;
   const text = responseLines(response).join(' ');
   if (text === '') return [];
-  return [rehearseLine(text, (token) => resolveReplyToken(token, samples, dynamic))];
+  return [rehearseLine(text, replyResolver(samples, opts.dynamic ?? true))];
 }
 
 /** One chat message: expand tokens, then route the leading slash-verb over
@@ -192,64 +191,51 @@ function parseToken(span: string): Token {
 
 /** expandCommand's lookup order: named tokens (aliases folded in), then
  * {counter:…}, then the dynamic set. */
-function resolveCommandToken(token: Token, samples: Samples): string | null {
-  const sample = lookupSample(token, samples, COMMAND_ALIASES);
-  if (sample !== null) return sample;
-  // A bare {counter} is not the counter form; it falls through like any
-  // other unknown name, exactly as CutPrefix does in the engine.
-  if (token.name === 'counter' && token.payload !== null) return resolveCounter(token);
-  return resolveDynamic(token);
+function commandResolver(samples: Samples): Resolve {
+  return (token) => {
+    const name = COMMAND_ALIASES[token.name] ?? token.name;
+    const key = token.payload === null ? name : `${name}:${token.payload}`;
+    if (key in samples) return samples[key];
+    // A bare {counter} is not the counter form: it falls through like any
+    // other unknown name, exactly as CutPrefix does in the engine.
+    if (token.name === 'counter' && token.payload !== null) return counterSample(token);
+    return dynamicSample(token);
+  };
 }
 
 /** A module reply resolves only its own token map, plus the dynamic set when
  * that module falls back to ParseDynamic. */
-function resolveReplyToken(token: Token, samples: Samples, dynamic: boolean): string | null {
-  const sample = lookupSample(token, samples);
-  if (sample !== null) return sample;
-  return dynamic ? resolveDynamic(token) : null;
+function replyResolver(samples: Samples, dynamic: boolean): Resolve {
+  return (token) => {
+    if (token.key in samples) return samples[token.key];
+    return dynamic ? dynamicSample(token) : null;
+  };
 }
 
-function lookupSample(token: Token, samples: Samples, aliases: Samples = {}): string | null {
-  const name = aliases[token.name] ?? token.name;
-  const key = token.payload === null ? name : `${name}:${token.payload}`;
-  return key in samples ? samples[key] : null;
-}
-
-/** {counter:<name>} bumps and renders the counter. Bot-scope counters
- * (bot:…) are admin-only and an empty name never resolves, so both stay
- * literal, exactly like the engine. */
-function resolveCounter(token: Token): string | null {
-  const name = normalizeCounterName(token.payload ?? '');
+/** {counter:<name>} bumps and renders the counter. The name normalizes like
+ * NormalizeCounterName (trim, drop one leading '!', trim, lower-case).
+ * Bot-scope counters (bot:…) are admin-only and an empty name never resolves,
+ * so both stay literal, exactly like the engine. */
+function counterSample(token: Token): string | null {
+  const name = (token.payload ?? '').trim().replace(/^!/, '').trim().toLowerCase();
   if (name === '' || name.startsWith('bot:')) return null;
   return COUNTER_SAMPLE;
 }
 
-/** NormalizeCounterName mirror: trim, drop one leading '!', trim, lowercase. */
-function normalizeCounterName(name: string): string {
-  return name.trim().replace(/^!/, '').trim().toLowerCase();
-}
-
 /** ParseDynamic mirror: {random} → a fixed stand-in, {random:min-max} → the
- * range midpoint (invalid ranges stay literal), {choice:a,b,c} → the first
+ * range midpoint (an invalid range stays literal), {choice:a,b,c} → the first
  * option. */
-function resolveDynamic(token: Token): string | null {
-  switch (token.name) {
-    case 'random':
-      return token.payload === null ? RANDOM_SAMPLE : randomMidpoint(token.payload);
-    case 'choice':
-      return token.payload === null ? null : token.payload.split(',')[0];
-    default:
-      return null;
+function dynamicSample(token: Token): string | null {
+  if (token.name === 'choice') {
+    return token.payload === null ? null : token.payload.split(',')[0];
   }
-}
-
-function randomMidpoint(range: string): string | null {
-  const bounds = range.match(/^(\d+)-(\d+)$/);
+  if (token.name !== 'random') return null;
+  if (token.payload === null) return RANDOM_SAMPLE;
+  const bounds = token.payload.match(/^(\d+)-(\d+)$/);
   if (!bounds) return null;
   const min = Number(bounds[1]);
   const max = Number(bounds[2]);
-  if (max < min) return null;
-  return String(Math.floor((min + max) / 2));
+  return max < min ? null : String(Math.floor((min + max) / 2));
 }
 
 // --- slash-verb routing (outgress/slash.go CutSlash) ----------------------
@@ -264,18 +250,23 @@ interface SlashAction {
   bodyStart: number;
 }
 
-interface AnnounceVerb {
+interface VerbSpec {
   verb: string;
-  color: string;
+  mode: RehearsalMode;
+  /** Announce accent color; absent for the verbs that carry none. */
+  color?: string;
 }
 
 // Longest verbs first so "/announceblue" is not mistaken for "/announce".
-const ANNOUNCE_VERBS: readonly AnnounceVerb[] = [
-  { verb: '/announceblue', color: 'blue' },
-  { verb: '/announcegreen', color: 'green' },
-  { verb: '/announceorange', color: 'orange' },
-  { verb: '/announcepurple', color: 'purple' },
-  { verb: '/announce', color: 'primary' }
+const VERBS: readonly VerbSpec[] = [
+  { verb: '/announceblue', mode: 'announce', color: 'blue' },
+  { verb: '/announcegreen', mode: 'announce', color: 'green' },
+  { verb: '/announceorange', mode: 'announce', color: 'orange' },
+  { verb: '/announcepurple', mode: 'announce', color: 'purple' },
+  { verb: '/announce', mode: 'announce', color: 'primary' },
+  { verb: '/shoutout', mode: 'shoutout' },
+  { verb: '/pin', mode: 'pin' },
+  { verb: '/me', mode: 'me' }
 ];
 
 /** CutSlash mirror over the EXPANDED text — the engine expands first, so a
@@ -283,25 +274,21 @@ const ANNOUNCE_VERBS: readonly AnnounceVerb[] = [
  * stays in the text), but Twitch renders it as an italic action, so it is
  * displayed that way with the verb stripped. */
 function parseSlash(text: string): SlashAction {
-  for (const entry of ANNOUNCE_VERBS) {
-    const at = verbEnd(text, entry.verb);
-    if (at !== null) return { mode: 'announce', verb: entry.verb, color: entry.color, bodyStart: at };
+  for (const spec of VERBS) {
+    const at = verbEnd(text, spec);
+    if (at === null) continue;
+    if (spec.mode === 'shoutout') return parseShoutout(text, at);
+    return { mode: spec.mode, verb: spec.verb, color: spec.color, bodyStart: at };
   }
-  const shoutoutAt = verbEnd(text, '/shoutout');
-  if (shoutoutAt !== null) return parseShoutout(text, shoutoutAt);
-  const pinAt = verbEnd(text, '/pin');
-  if (pinAt !== null) return { mode: 'pin', verb: '/pin', bodyStart: pinAt };
-  const meAt = verbEnd(text, '/me');
-  if (meAt !== null) return { mode: 'me', verb: '/me', bodyStart: meAt };
   return { mode: 'chat', bodyStart: 0 };
 }
 
 /** cutVerb mirror: the verb matches as the whole string or as a "verb "
  * prefix; returns the index just past the verb and its one separating space,
  * or null when the verb does not lead the text. */
-function verbEnd(text: string, verb: string): number | null {
-  if (text === verb) return verb.length;
-  if (text.startsWith(verb + ' ')) return verb.length + 1;
+function verbEnd(text: string, spec: VerbSpec): number | null {
+  if (text === spec.verb) return spec.verb.length;
+  if (text.startsWith(spec.verb + ' ')) return spec.verb.length + 1;
   return null;
 }
 

--- a/console/shared/lib/types.ts
+++ b/console/shared/lib/types.ts
@@ -56,10 +56,10 @@ export interface BuiltinCommandDef {
   description: string; // longer copy for the inspector
   // usage lists example invocations shown in the inspector.
   usage: string[];
-  // preview is the bot REPLY template, rendered through ChatPreview so the
-  // inspector shows the same rehearsal as a custom command (viewer line + the
-  // ItsBagelBot name/logo). previewArgs is what the viewer types after the
-  // trigger; previewSamples fills tokens ChatPreview does not know by default.
+  // preview is the bot REPLY template, rendered through ChatPreview (as a
+  // reply rehearsal: only previewSamples substitute — built-in replies are
+  // bare token replacers with no dynamic tokens or slash-verb routing).
+  // previewArgs is what the viewer types after the trigger.
   preview: string;
   previewArgs?: string;
   previewSamples?: Record<string, string>;
@@ -126,7 +126,7 @@ export const BUILTIN_COMMANDS: readonly BuiltinCommandDef[] = [
     // = the title argument (standard command token).
     preview: '{user} clipped: {target} → {clip}',
     previewArgs: 'That is amazing',
-    previewSamples: { target: 'That is amazing', clip: 'clips.twitch.tv/AbCdEf' },
+    previewSamples: { user: 'sesame_sam', target: 'That is amazing', clip: 'clips.twitch.tv/AbCdEf' },
     defaultActive: true,
     defaultPerm: 'everyone',
     defaultCooldown: 15,
@@ -308,10 +308,10 @@ export interface ModuleReply {
   command?: string;
   // previewArgs is what the sample viewer types after the trigger.
   previewArgs?: string;
-  // previewSamples maps this reply's tokens to sample values. When command is
-  // set the preview substitutes ONLY these (samplesOnly): sesame expands only
-  // the module's own tokens here, so the generic {user}/{random} samples would
-  // preview values the bot will never produce.
+  // previewSamples maps this reply's tokens to sample values. The rehearsal
+  // (kind="reply") substitutes ONLY these plus the shared dynamic tokens:
+  // sesame expands only the module's own token map here, so the generic
+  // command samples would preview values the bot will never produce.
   previewSamples?: Record<string, string>;
   // tokens is the editor's insert palette (without braces), replacing the
   // default command tokens with the ones this reply actually supports.
@@ -679,7 +679,10 @@ export const MODULE_CATALOG: readonly ModuleDef[] = [
         event: 'on raid',
         messageKey: 'message',
         defaultMessage:
-          'Massive shoutout to {raider} for the raid with {viewers} viewers! Check them out at twitch.tv/{raider.login}'
+          'Massive shoutout to {raider} for the raid with {viewers} viewers! Check them out at twitch.tv/{raider.login}',
+        // Tokens the shoutout module resolves (app/sesame/modules/shoutout.go).
+        tokens: ['raider', 'raider.login', 'viewers'],
+        previewSamples: { raider: 'CrustyCrumbs', 'raider.login': 'crustycrumbs', viewers: '42' }
       }
     ],
     settings: [
@@ -708,7 +711,10 @@ export const MODULE_CATALOG: readonly ModuleDef[] = [
         event: 'on follow',
         enableKey: 'followEnabled',
         messageKey: 'followMessage',
-        defaultMessage: 'Thank you for following the channel, {user}!'
+        defaultMessage: 'Thank you for following the channel, {user}!',
+        // Per-alert tokens/samples mirror the maps in app/sesame/modules/alerts.go.
+        tokens: ['user'],
+        previewSamples: { user: 'sesame_sam' }
       },
       {
         key: 'sub',
@@ -717,7 +723,9 @@ export const MODULE_CATALOG: readonly ModuleDef[] = [
         event: 'on subscribe',
         enableKey: 'subEnabled',
         messageKey: 'subMessage',
-        defaultMessage: 'Welcome to the community, {user}! Thank you for subscribing!'
+        defaultMessage: 'Welcome to the community, {user}! Thank you for subscribing!',
+        tokens: ['user', 'tier'],
+        previewSamples: { user: 'sesame_sam', tier: '1000' }
       },
       {
         key: 'gift',
@@ -737,7 +745,9 @@ export const MODULE_CATALOG: readonly ModuleDef[] = [
         event: 'on cheer',
         enableKey: 'cheerEnabled',
         messageKey: 'cheerMessage',
-        defaultMessage: 'Thank you for the {bits} bits, {user}!'
+        defaultMessage: 'Thank you for the {bits} bits, {user}!',
+        tokens: ['user', 'bits'],
+        previewSamples: { user: 'sesame_sam', bits: '500' }
       },
       {
         key: 'raid',
@@ -746,7 +756,9 @@ export const MODULE_CATALOG: readonly ModuleDef[] = [
         event: 'on raid',
         enableKey: 'raidEnabled',
         messageKey: 'raidMessage',
-        defaultMessage: '{user} is raiding the channel with {viewers} viewers! Welcome everyone!'
+        defaultMessage: '{user} is raiding the channel with {viewers} viewers! Welcome everyone!',
+        tokens: ['user', 'viewers'],
+        previewSamples: { user: 'CrustyCrumbs', viewers: '42' }
       },
       {
         key: 'ads',
@@ -756,7 +768,9 @@ export const MODULE_CATALOG: readonly ModuleDef[] = [
         enableKey: 'adsEnabled',
         messageKey: 'adsMessage',
         defaultOff: true,
-        defaultMessage: "Ads are rolling for {duration} seconds. Hang tight, we'll be right back!"
+        defaultMessage: "Ads are rolling for {duration} seconds. Hang tight, we'll be right back!",
+        tokens: ['duration'],
+        previewSamples: { duration: '90' }
       }
     ]
   },

--- a/internal/domain/outgress/slash.go
+++ b/internal/domain/outgress/slash.go
@@ -1,0 +1,89 @@
+package outgress
+
+import "strings"
+
+// SlashCommand is the routed form of a leading chat slash-verb in authored
+// response text: the outgress action it becomes plus the fields that action
+// carries. It is produced by CutSlash, the single owner of the verb grammar —
+// sesame's engine translates module outputs through it and outgress routes
+// its own synthetic sends (the clip reply) through it, so every path
+// recognizes exactly the same verbs.
+type SlashCommand struct {
+	// Type is the outgress action: TypeAnnounce, TypeShoutout or TypePin.
+	Type string
+	// Color is the announce color (primary, blue, green, orange, purple);
+	// empty for non-announce.
+	Color string
+	// To is the shoutout target with the leading '@' removed; empty otherwise.
+	To string
+	// Text is the message with the verb (and, for shoutout, the target)
+	// consumed.
+	Text string
+}
+
+// CutSlash inspects text for a leading slash-verb and returns its routed
+// form. ok=false means the text is plain chat: no verb, an unknown verb, or
+// /me — which Twitch chat renders itself, so the verb must stay in the text.
+//
+// Recognized verbs:
+//
+//   - /announce[blue|green|orange|purple] <message> -> TypeAnnounce + Color
+//     (plain /announce is "primary"); the verb is stripped from Text.
+//   - /shoutout <target> [message] -> TypeShoutout; the first token (leading
+//     '@' stripped) becomes To and is removed from Text.
+//   - /pin <message> -> TypePin; the verb is stripped from Text.
+func CutSlash(text string) (SlashCommand, bool) {
+	if color, rest, ok := cutAnnounce(text); ok {
+		return SlashCommand{Type: TypeAnnounce, Color: color, Text: rest}, true
+	}
+	if rest, ok := cutVerb(text, "/shoutout"); ok {
+		rest = strings.TrimLeft(rest, " ")
+		target, remainder, _ := strings.Cut(rest, " ")
+		return SlashCommand{
+			Type: TypeShoutout,
+			To:   strings.TrimPrefix(target, "@"),
+			Text: strings.TrimLeft(remainder, " "),
+		}, true
+	}
+	if rest, ok := cutVerb(text, "/pin"); ok {
+		return SlashCommand{Type: TypePin, Text: rest}, true
+	}
+	return SlashCommand{}, false
+}
+
+// cutAnnounce reports whether text leads with an /announce verb. It returns
+// the announce color and the text with the verb (and one following space)
+// stripped.
+func cutAnnounce(text string) (color, rest string, ok bool) {
+	type variant struct {
+		verb  string
+		color string
+	}
+	// Longest verbs first so "/announceblue" is not mistaken for "/announce".
+	for _, v := range []variant{
+		{"/announceblue", "blue"},
+		{"/announcegreen", "green"},
+		{"/announceorange", "orange"},
+		{"/announcepurple", "purple"},
+		{"/announce", "primary"},
+	} {
+		if r, matched := cutVerb(text, v.verb); matched {
+			return v.color, r, true
+		}
+	}
+	return "", "", false
+}
+
+// cutVerb matches verb either as the whole string or as a "verb " prefix. On a
+// match it returns the remainder with the single separating space removed (empty
+// when the text was exactly the verb). A "verb" followed by a non-space (e.g.
+// "/announceblue" when matching "/announce") is not a match.
+func cutVerb(text, verb string) (rest string, ok bool) {
+	if text == verb {
+		return "", true
+	}
+	if strings.HasPrefix(text, verb+" ") {
+		return text[len(verb)+1:], true
+	}
+	return "", false
+}

--- a/web/astro.config.mjs
+++ b/web/astro.config.mjs
@@ -4,6 +4,19 @@ import sitemap from '@astrojs/sitemap';
 import { readdirSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 
+// The chat rehearsal (command builder) shares ONE source of truth with the
+// dashboard: the pure, framework-free engine mirror in console/shared. The
+// builder imports it as `@bagel/rehearsal` and renders the returned data with
+// its own DOM, so the slash-verb grammar and token expansion can never drift
+// from the bot the way a hand-copied version would. The file is pure TS with
+// no runtime deps (it pulls only two helpers from commands-validate.ts), so
+// Vite bundles a few KB of logic into the client chunk — no server code, no
+// @bagel/shared install. The catalog (sample values, bilingual copy) stays
+// local in src/i18n/builder.ts; only the logic is shared.
+const rehearsalCore = fileURLToPath(new URL('../console/shared/lib/rehearsal.ts', import.meta.url));
+// Repo root, so Vite's dev server may read the shared file that lives outside web/.
+const repoRoot = fileURLToPath(new URL('..', import.meta.url));
+
 // Locales are discovered from the catalog files: one src/i18n/locales/<code>.json
 // per language. Dropping in a new JSON adds the language to Astro's i18n config
 // (and, via the same folder, to the runtime catalog in src/i18n/ui.ts) with no
@@ -37,8 +50,14 @@ export default defineConfig({
   },
 
   vite: {
+    resolve: {
+      // Single source of truth for the rehearsal logic (see rehearsalCore above).
+      alias: { '@bagel/rehearsal': rehearsalCore },
+    },
     server: {
       allowedHosts: true, // Bypass Vite 6's network host blocking for external devices
+      // Let the dev server serve the shared rehearsal file from the repo root.
+      fs: { allow: [repoRoot] },
     },
     build: {
       // The production CSP only permits scripts loaded from this origin.

--- a/web/src/components/builder/CommandBuilder.astro
+++ b/web/src/components/builder/CommandBuilder.astro
@@ -12,8 +12,11 @@
  * the rehearsal and a single action card — one primary CTA, the chat-paste
  * path secondary beneath it.
  *
- * The rehearsal is a straight port of the dashboard inspector's ChatPreview
- * (console/dashboard/src/lib/components/commands/ChatPreview.svelte): same
+ * The rehearsal SHARES the dashboard's logic rather than copying it: the
+ * client script imports the engine mirror from console/shared/lib/rehearsal.ts
+ * (aliased as `@bagel/rehearsal` in astro.config.mjs) — the same module the
+ * dashboard inspector's ChatPreview uses — so the slash-verb grammar and token
+ * expansion here always match the bot. Only the rendering is local: same
  * typing beat, same staggered reply-in animation, same announcement /
  * shoutout / pin / me styling and sample-value highlights — the builder is
  * meant to feel like the dashboard reaching out onto the marketing site.
@@ -186,11 +189,16 @@ for (const surface of data.surfaces) {
         ui: Record<string, string> & { recipes: { label: string; text: string }[] };
     };
 
-    // --- Slash-verb parse, same tables as the dashboard's ChatPreview (which
-    // itself mirrors app/sesame/engine/slash.go). ---------------------------
-    type Mode = 'chat' | 'announce' | 'shoutout' | 'pin' | 'me';
-    type Parsed = { mode: Mode; body: string; verb?: string; color?: string; target?: string };
+    // The rehearsal logic is NOT reimplemented here. `@bagel/rehearsal` is the
+    // dashboard's own engine mirror (console/shared/lib/rehearsal.ts, aliased
+    // in astro.config.mjs): it owns the slash-verb grammar and token expansion,
+    // so the builder can never drift from the bot. This file only turns the
+    // RehearsedLine[] it returns into DOM. The sample values stay local, in
+    // src/i18n/builder.ts, and ride in as the `samples` argument.
+    import { rehearseCommand, rehearseReply, type RehearsedLine, type Seg } from '@bagel/rehearsal';
 
+    // Announcement accent colors — presentation only, keyed by the color the
+    // shared parse reports.
     const ACCENT: Record<string, string> = {
         primary: 'var(--tan-light)',
         blue: '#4a9eff',
@@ -199,43 +207,9 @@ for (const surface of data.surfaces) {
         purple: '#c77dff',
     };
 
-    const ANNOUNCE: [string, string][] = [
-        ['/announceblue', 'blue'],
-        ['/announcegreen', 'green'],
-        ['/announceorange', 'orange'],
-        ['/announcepurple', 'purple'],
-        ['/announce', 'primary'],
-    ];
-
-    function cutVerb(text: string, verb: string): string | null {
-        if (text === verb) return '';
-        if (text.startsWith(verb + ' ')) return text.slice(verb.length + 1);
-        return null;
-    }
-
-    function parseLine(text: string): Parsed {
-        for (const [verb, color] of ANNOUNCE) {
-            const rest = cutVerb(text, verb);
-            if (rest !== null) return { mode: 'announce', body: rest, verb, color };
-        }
-        const so = cutVerb(text, '/shoutout');
-        if (so !== null) {
-            const trimmed = so.replace(/^ +/, '');
-            const sp = trimmed.indexOf(' ');
-            const rawTarget = sp === -1 ? trimmed : trimmed.slice(0, sp);
-            const remainder = sp === -1 ? '' : trimmed.slice(sp + 1).replace(/^ +/, '');
-            return { mode: 'shoutout', body: remainder, verb: '/shoutout', target: rawTarget.replace(/^@/, '') };
-        }
-        const pin = cutVerb(text, '/pin');
-        if (pin !== null) return { mode: 'pin', body: pin, verb: '/pin' };
-        const me = cutVerb(text, '/me');
-        if (me !== null) return { mode: 'me', body: me, verb: '/me' };
-        return { mode: 'chat', body: text };
-    }
-
-    function verbLabelOf(p: Parsed): string {
-        if (p.mode === 'announce') return p.color === 'primary' ? '/announce' : `/announce (${p.color})`;
-        return p.verb ?? '';
+    function verbLabelOf(view: RehearsedLine): string {
+        if (view.mode === 'announce') return view.color === 'primary' ? '/announce' : `/announce (${view.color})`;
+        return view.verb ?? '';
     }
 
     function initBuilder(root: HTMLElement) {
@@ -313,46 +287,36 @@ for (const surface of data.surfaces) {
             return raw;
         };
 
-        // --- Token substitution: known tokens become highlighted samples,
-        // unknown {tokens} stay marked, exactly like the dashboard rehearsal.
-        type Seg = { text: string; kind: 'plain' | 'sample' | 'unknown' };
-        const rint = (lo: number, hi: number) => String(lo + Math.floor(Math.random() * (hi - lo + 1)));
+        // --- Sample values handed to the shared rehearsal ---------------------
+        // The catalog's own tokens, keyed without braces. Dynamic and
+        // {counter:…} forms are deliberately left out: the shared logic
+        // resolves those itself (deterministically, so the preview doesn't
+        // re-roll on every keystroke), exactly as the dashboard does.
+        const RESOLVED_BY_CORE = /^(random(:|$)|choice:|counter:)/;
 
-        function resolveToken(body: string): string | null {
-            const samples = new Map(current().vars.map((x) => [x.token.slice(1, -1), x.sample]));
-            if (samples.has(body)) return samples.get(body)!;
-            // Aliases the bot honors but the palette hides for clarity.
-            if (body === 'sender' && samples.has('user')) return samples.get('user')!;
-            if (body === 'target' && samples.has('touser')) return samples.get('touser')!;
-            if (body === 'touser' && samples.has('target')) return samples.get('target')!;
-            if (body === 'random') return rint(1, 100);
-            const rand = body.match(/^random:(-?\d+)-(-?\d+)$/);
-            if (rand) {
-                const lo = parseInt(rand[1], 10);
-                const hi = parseInt(rand[2], 10);
-                return hi >= lo ? rint(lo, hi) : null;
+        function sampleMap(): Record<string, string> {
+            const samples: Record<string, string> = {};
+            for (const item of current().vars) {
+                const key = item.token.slice(1, -1);
+                if (!RESOLVED_BY_CORE.test(key)) samples[key] = item.sample;
             }
-            if (body.startsWith('choice:')) {
-                const options = body.slice(7).split(',').map((o) => o.trim()).filter(Boolean);
-                return options.length ? options[Math.floor(Math.random() * options.length)] : null;
-            }
-            if (mode === 'custom' && body.startsWith('counter:') && body.length > 'counter:'.length) return '128';
-            return null;
+            return samples;
         }
 
-        function segmentsOf(body: string): Seg[] {
-            const out: Seg[] = [];
-            const re = /\{([a-z_]+(?:\.[a-z_]+)?(?::[^{}]*)?)\}/gi;
-            let last = 0;
-            for (const m of body.matchAll(re)) {
-                if (m.index! > last) out.push({ text: body.slice(last, m.index), kind: 'plain' });
-                const value = resolveToken(m[1]);
-                if (value !== null) out.push({ text: value, kind: 'sample' });
-                else out.push({ text: m[0], kind: 'unknown' });
-                last = m.index! + m[0].length;
-            }
-            if (last < body.length) out.push({ text: body.slice(last), kind: 'plain' });
-            return out;
+        // A surface resolves the dynamic tokens when its module falls back to
+        // module.ParseDynamic — which the catalog encodes by offering them in
+        // the palette. The odd one out is the !clip reply: outgress expands it
+        // with a bare token replacer, so {random} there stays literal.
+        const surfaceIsDynamic = () => current().vars.some((x) => /^\{(random|choice)/.test(x.token));
+
+        // Custom commands fan out to one message per line (cap 5) and route a
+        // slash-verb per line; a module reply is a single message. Both share
+        // the same expansion and verb grammar.
+        function rehearse(): RehearsedLine[] {
+            const source = lines().join('\n');
+            return mode === 'custom'
+                ? rehearseCommand(source, sampleMap())
+                : rehearseReply(source, sampleMap(), { dynamic: surfaceIsDynamic() });
         }
 
         // --- Rehearsal DOM (ported ChatPreview markup, textContent only) -----
@@ -394,7 +358,7 @@ for (const surface of data.surfaces) {
             return el('span', inline ? 'via inline' : 'via', `Twitch ${label}`);
         }
 
-        function botLine(view: Parsed & { segments: Seg[] }, index: number): HTMLElement {
+        function botLine(view: RehearsedLine, index: number): HTMLElement {
             const line = el('div', 'line bot');
             line.style.setProperty('--reply-delay', `${index * 140}ms`);
             if (view.mode !== 'chat') line.classList.add('special');
@@ -478,17 +442,14 @@ for (const surface of data.surfaces) {
             const viewer = viewerLine();
             if (viewer) chat.append(viewer);
 
-            const out = lines().slice(0, data.limits.linesMax);
-            if (out.length === 0) {
+            const views = rehearse();
+            if (views.length === 0) {
                 const line = el('div', 'line bot');
                 line.append(botName(), el('span', 'msg empty', ui.nothingToSay));
                 chat.append(line);
                 return;
             }
-            out.forEach((raw, i) => {
-                const parsed = parseLine(raw);
-                chat.append(botLine({ ...parsed, segments: segmentsOf(parsed.body) }, i));
-            });
+            views.forEach((view, i) => chat.append(botLine(view, i)));
         }
 
         function renderTyping() {

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,9 +1,16 @@
 {
   "extends": "astro/tsconfigs/strict",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@bagel/rehearsal": ["../console/shared/lib/rehearsal.ts"]
+    }
+  },
   "include": [
     ".astro/types.d.ts",
     "**/*",
-    "./worker-configuration.d.ts"
+    "./worker-configuration.d.ts",
+    "../console/shared/lib/rehearsal.ts"
   ],
   "exclude": [
     "dist"


### PR DESCRIPTION
The chat rehearsal (dashboard inspector + marketing-site command builder) was hand-mirroring the Go engine in two separate places. Both copies had drifted, so the preview showed things the bot would never send. This centralizes the logic, fixes the divergences it exposed, and makes the site share the same core.

## The drift, and what it showed wrong

| Divergence | Preview showed | The bot actually |
|---|---|---|
| Case sensitivity | `{User}` marked as a typo | expanded it |
| Slash verbs on reply surfaces | announcement cards on alerts/triggers/rewards | only routed them for custom commands |
| Verb parsed before expansion | `{choice:/pin a,/pin b}` as plain chat | expands first, then routes → a real pin |
| Alert tokens in custom commands | `{bits}`/`{raider}` substituted | leaves them literal |
| Dynamic tokens on module replies | marked as typos | resolves them (`ParseDynamic` fallback) |
| Token name charset | `{raider.login}` unmatchable | expands it |

## What changed

**One shared core.** `console/shared/lib/rehearsal.ts` is a pure, framework-free mirror of the engine, annotated function-by-function with the Go file it tracks (`module.Expand`, `expandCommand`, `Translate`, `NormalizeCounterName`, `emitResponse`). It exposes exactly two entry points, matching the bot's two expansion paths:

- `rehearseCommand` — expand → split (cap 5) → route a verb per line
- `rehearseReply` — the surface's own token map, one message

`ChatPreview.svelte` is now rendering-only; a `kind` prop replaced the `samplesOnly` flag soup, and four duplicated markup blocks collapsed into one snippet.

**Slash verbs route on every path.** The grammar moved to `internal/domain/outgress/CutSlash`, one owner shared by both services. `engine.Translate` is a thin adapter over it, guarded to chat outputs so it is idempotent, and the pipeline's emit now translates *every* module output — alerts, trigger words, rewards, gateway replies — then drops empty actions. Outgress routes its own synthetic clip reply through the same grammar, so a custom clip template leading with `/announce` becomes the native action too.

Because verbs now route after expansion, viewer-controlled tokens that can lead a template are sanitized the way command `{args}` already was: channel-point `{input}` and clip `{title}`/`{target}`. A redeemer or clipper cannot mint a verb as the bot.

**Token names are case-insensitive.** `module.Expand` lowercases a token's name (before the first `:`) centrally, so `{User}`, `{RANDOM}` and `{Counter:Deaths}` work while payloads keep their case (`{choice:Hi,Yo}` still offers `Hi`). Covers every `ExpandString` surface; govee moved off its bare replacer, and outgress's `clipExpand` got a local equivalent since outgress must not import sesame packages.

**The site shares the core instead of copying it.** `web/src/components/builder/CommandBuilder.astro` had its own slash tables, `parseLine`, and token regex — the copy with the raw-line and case-sensitivity bugs above. It now imports the same module (aliased `@bagel/rehearsal`), which is pure TS returning plain data, so Vite bundles a few KB into the client chunk with no `@bagel/shared` install and no server code. Only rendering stays local: sample values and bilingual copy remain in `i18n/builder.ts` and ride in as the `samples` argument, so the site keeps its own voice while the logic can no longer drift.

## Verification

- Go: `go test ./app/... ./internal/...` clean, incl. new pipeline tests (announce routes from a module output, empty shoutout dropped, `/me` stays passthrough) and clip sanitize/case tests.
- Console: 113 shared tests pass; `svelte-check` 0 errors.
- Web: production build succeeds with the cross-package import; shared grammar confirmed present in the client bundle and no server deps leaked; `astro check` adds no new errors; all builder E2E tests pass.
- Browser: verified in both surfaces — a cheer alert with `/announcepurple` renders the native announcement card, and on the site `{USER}`/`{Target}` resolve, `{choice:/pin …}` routes to a pin, and `{random}` correctly stays literal on the `!clip` surface.

Two pre-existing web E2E failures (home-page gates, guides hub expecting 3 cards when 4 guides now exist) are unrelated — confirmed identical on a clean tree.