### PR TITLE
fix(ingress): tolerate transient DNS errors to prevent Horde split

### DIFF
--- a/app/ingress/config/runtime.exs
+++ b/app/ingress/config/runtime.exs
@@ -27,7 +27,13 @@ topologies =
           strategy: Cluster.Strategy.Kubernetes.DNS,
           config: [
             service: headless,
-            application_name: System.get_env("BAGELBOT_K8S_APP_NAME", "ingress")
+            application_name: System.get_env("BAGELBOT_K8S_APP_NAME", "ingress"),
+            # Error-tolerant resolver: on a transient DNS failure it replays the
+            # last good pod-IP set as a synthetic success, so a resolver error
+            # never disconnects live peers (which would split the Horde cluster).
+            # A genuine membership change is a successful lookup with a different
+            # set and passes through untouched. See Ingress.ClusterResolver.
+            resolver: &Ingress.ClusterResolver.resolve/1
           ]
         ]
       ]

--- a/app/ingress/lib/ingress/cluster_resolver.ex
+++ b/app/ingress/lib/ingress/cluster_resolver.ex
@@ -1,0 +1,84 @@
+defmodule Ingress.ClusterResolver do
+  @moduledoc """
+  Error-tolerant resolver shim for the libcluster `Cluster.Strategy.Kubernetes.DNS`
+  strategy.
+
+  libcluster polls the headless service every 5s and, on ANY resolver error,
+  treats the answer as an empty node list and then actively disconnects every
+  peer BEAM node (`Cluster.Strategy.Kubernetes.DNS.load/1`). A single node-local
+  CoreDNS hiccup therefore partitions the whole cluster, and the Horde CRDT merge
+  on recovery produces duplicate `{:shard, id}` registrations that flap the Twitch
+  conduit binding (last-PATCH-wins) and drop a shard to `websocket_disconnected`.
+
+  Wired in as the strategy's `:resolver`, this shim remembers the last successful
+  NON-EMPTY address set and, on a resolver error, replays it as a synthetic
+  `{:ok, hostent}` so the strategy sees "nothing changed" (`removed = ∅`) instead
+  of "everyone left". A genuine membership change is a SUCCESSFUL lookup returning
+  a different set, which passes through untouched, so real scale-downs and pod
+  removals are still honored.
+
+  Safety invariant: this shim can only ever make the strategy CONNECT to an
+  address that was real at some point, never DISCONNECT a peer because DNS failed.
+  Connecting to an address whose pod has since died is a no-op (the dist handshake
+  fails, so the node never joins `nodes()` and never becomes a Horde member).
+  `net_ticktime` plus Horde's `:dead` handoff remain the path that retires a peer
+  that genuinely left, and that path is driven only by successful, honored lookups.
+
+  State lives in `:persistent_term` (the same primitive `Ingress.Config` uses for
+  the boot-time hot path), written on change only: a `:persistent_term.put`
+  triggers a global literal GC, so it must never run on every poll, only when the
+  membership set actually differs. No supervised child or ETS table is needed; a
+  read before the first success returns `:none` and falls through to the raw
+  error, which the strategy maps to `[]` against an empty membership: still a
+  no-op.
+  """
+
+  @key {__MODULE__, :addresses}
+
+  @doc """
+  Resolver entrypoint handed to `Cluster.Strategy.Kubernetes.DNS` via the
+  topology `:resolver` config. `inner` defaults to the same lookup libcluster
+  uses by default and is injectable for tests.
+  """
+  def resolve(name, inner \\ &default_lookup/1) do
+    handle(inner.(name), name)
+  end
+
+  # Successful lookup with at least one address: remember it, pass it through.
+  defp handle(
+         {:ok, {:hostent, _fqdn, _aliases, :inet, _len, [_ | _] = addresses}} = result,
+         _name
+       ) do
+    remember(addresses)
+    result
+  end
+
+  # Successful lookup with zero addresses: a genuine, honored shrink. Do not cache
+  # an empty set over a good one; pass it through so the strategy removes the
+  # departed peers.
+  defp handle({:ok, {:hostent, _fqdn, _aliases, :inet, _len, []}} = result, _name), do: result
+
+  # Resolver error: replay the last good set if we have one, turning a mass
+  # disconnect into a no-op.
+  defp handle({:error, _reason} = result, name), do: substitute(result, name)
+
+  # Any other shape (for example a non-:inet hostent): leave it untouched.
+  defp handle(result, _name), do: result
+
+  defp substitute(error_result, name) do
+    case :persistent_term.get(@key, :none) do
+      :none -> error_result
+      addresses -> {:ok, {:hostent, name, [], :inet, 4, addresses}}
+    end
+  end
+
+  # Write-on-change only: a persistent_term put triggers a global literal GC, so
+  # it runs solely when the membership set actually differs from the stored one.
+  defp remember(addresses) do
+    if :persistent_term.get(@key, :none) != addresses do
+      :persistent_term.put(@key, addresses)
+    end
+  end
+
+  defp default_lookup(name), do: :inet_res.getbyname(name, :a)
+end

--- a/app/ingress/test/cluster_resolver_test.exs
+++ b/app/ingress/test/cluster_resolver_test.exs
@@ -1,0 +1,66 @@
+defmodule Ingress.ClusterResolverTest do
+  # async: false — the module keeps its last-known-good set in global
+  # persistent_term, so tests must not run concurrently and each clears the slot.
+  use ExUnit.Case, async: false
+
+  alias Ingress.ClusterResolver
+
+  @service ~c"twitch-ingress-headless"
+  @key {Ingress.ClusterResolver, :addresses}
+
+  defp hostent(addresses), do: {:ok, {:hostent, @service, [], :inet, 4, addresses}}
+
+  setup do
+    :persistent_term.erase(@key)
+    on_exit(fn -> :persistent_term.erase(@key) end)
+    :ok
+  end
+
+  test "successful non-empty lookup passes through unchanged and is remembered" do
+    good = hostent([{10, 0, 0, 1}, {10, 0, 0, 2}])
+    assert ^good = ClusterResolver.resolve(@service, fn _ -> good end)
+
+    # Remembered: a later error replays the same addresses as a synthetic success.
+    assert {:ok, {:hostent, _fqdn, [], :inet, _len, [{10, 0, 0, 1}, {10, 0, 0, 2}]}} =
+             ClusterResolver.resolve(@service, fn _ -> {:error, :timeout} end)
+  end
+
+  test "successful empty lookup is honored (genuine shrink) and not cached" do
+    empty = hostent([])
+    assert ^empty = ClusterResolver.resolve(@service, fn _ -> empty end)
+
+    # Nothing cached, so a following error stays an error (nothing to resurrect).
+    assert {:error, :nxdomain} =
+             ClusterResolver.resolve(@service, fn _ -> {:error, :nxdomain} end)
+  end
+
+  test "error with a prior good set substitutes the last known addresses" do
+    _ = ClusterResolver.resolve(@service, fn _ -> hostent([{10, 0, 0, 5}]) end)
+
+    result = ClusterResolver.resolve(@service, fn _ -> {:error, :timeout} end)
+
+    # The substituted tuple satisfies the dep's own success match, and carries
+    # exactly the remembered addresses (the load-bearing shape claim).
+    assert {:ok, {:hostent, _fqdn, [], :inet, _len, addresses}} = result
+    assert addresses == [{10, 0, 0, 5}]
+  end
+
+  test "error with no prior good returns the error unchanged (first boot)" do
+    assert {:error, :nxdomain} =
+             ClusterResolver.resolve(@service, fn _ -> {:error, :nxdomain} end)
+  end
+
+  test "a fresh non-empty success overwrites the remembered set (post scale-down)" do
+    _ =
+      ClusterResolver.resolve(@service, fn _ ->
+        hostent([{10, 0, 0, 1}, {10, 0, 0, 2}, {10, 0, 0, 3}])
+      end)
+
+    _ = ClusterResolver.resolve(@service, fn _ -> hostent([{10, 0, 0, 1}, {10, 0, 0, 2}]) end)
+
+    # After the shrink was observed, an error replays only the surviving two:
+    # the departed node is never resurrected.
+    assert {:ok, {:hostent, _fqdn, [], :inet, _len, [{10, 0, 0, 1}, {10, 0, 0, 2}]}} =
+             ClusterResolver.resolve(@service, fn _ -> {:error, :timeout} end)
+  end
+end


### PR DESCRIPTION
## Problem

libcluster's `Cluster.Strategy.Kubernetes.DNS` polls the headless service every 5s to discover peer pod IPs. On any resolver error (timeout, SERVFAIL, NXDOMAIN), `get_nodes/1` returns an empty list and `load/1` then actively disconnects every peer BEAM node. A single node-local CoreDNS blip therefore partitions the whole cluster.

Horde membership (`members: :auto`) is driven purely by BEAM node connectivity, so the partition looks like nodes dying. Each partition independently re-supervises the "dead" nodes' shards (`process_redistribution: :passive` still respawns on node-down). On DNS recovery the CRDT merge produces duplicate `{:shard, id}` registrations, the conduit binding flaps (last-PATCH-wins), and a shard drops to `websocket_disconnected`.

This is the dominant, uniquely catastrophic split trigger: it drops all peers at once, unlike net_kernel-path drops that lose a single node and are absorbed by Horde `:passive`.

## Fix

Inject an error-tolerant `:resolver` (`Ingress.ClusterResolver`) into the Kubernetes.DNS topology. It remembers the last successful non-empty pod-IP set in `persistent_term` and, on a resolver error, replays it as a synthetic `{:ok, hostent}` so the strategy sees no removed nodes and disconnects no one.

A genuine membership change is a successful lookup returning a different set, which passes through untouched, so real scale-downs and pod removals stay honored. Stored write-on-change, so no global literal GC runs on the 5s poll.

Safety invariant: the shim can only ever CONNECT to an address that was real at some point, never DISCONNECT a peer because DNS failed. Connecting to a since-dead IP is a no-op (the dist handshake fails, so it never joins Horde).

Scope: fixes the DNS-error trigger only. net_ticktime tick-loss, WireGuard data-plane flaps, and GC pauses drop single nodes that Horde `:passive` already absorbs, and are out of scope by design. No Horde quorum gate added, keeping the deliberate availability-over-consistency posture.

## Test

`mix test`: 156 tests, 0 failures. New `cluster_resolver_test.exs` covers success-remembered, success-empty-honored, error-substitutes-last-good, first-boot-passthrough, and post-scale-down no-resurrection. `mix format` clean.
