### PR TITLE
fix(falco): bump falcoctl-artifact-follow memory 32Mi→64Mi

### DIFF
--- a/deploy/flux/clusters/production/falco.yaml
+++ b/deploy/flux/clusters/production/falco.yaml
@@ -147,7 +147,8 @@ spec:
         value: worker-pool
 
     # Far below chart defaults (100m/512Mi -> 1000m/1024Mi); live-proven for
-    # this fleet.
+    # this fleet. falcoctl follow sidecar bumped to 64Mi (from 32Mi) to avoid
+    # sustained >90% memory utilization from Go runtime baseline RSS.
     resources:
       requests:
         cpu: 10m
@@ -171,16 +172,22 @@ spec:
           # P and kills the sustained throttling WITHOUT raising the limit (tune
           # before room). Same mechanism automaxprocs implements for low-limit
           # Go sidecars. If throttling persists after this, THEN bump limits.
+          #
+          # Memory: Go's idle RSS (GC heap, stacks, runtime metadata) sits
+          # ~25Mi, which against a 32Mi limit kept utilization >90% for 5m+ and
+          # fired "Container high memory utilization" (CRITICAL). Bumped to
+          # 64Mi so the baseline floats at ~40% instead. Request raised to 32Mi
+          # to match (request ≈ actual idle RSS).
           env:
             - name: GOMAXPROCS
               value: "1"
           resources:
             requests:
               cpu: 5m
-              memory: 16Mi
+              memory: 32Mi
             limits:
               cpu: 25m
-              memory: 32Mi
+              memory: 64Mi
 
     customRules:
       bagelbot-exceptions.yaml: |-


### PR DESCRIPTION
## Problem

New Relic CRITICAL alert firing:

> **falcoctl-artifact-follow** query result is > 90.0 for 5 minutes — *Container high memory utilization*
> Policy: Kubernetes alert policy

## Root cause

The `falcoctl-artifact-follow` sidecar is a Go binary (falcoctl 0.12.2) that wakes every 168h to poll for artifact updates. The Go runtime's idle RSS (GC heap, stacks, runtime metadata) sits around **~25Mi**. Against a **32Mi** limit, the container perpetually sits above 90% memory utilization.

This is the memory analog of the GOMAXPROCS=1 CPU-throttle fix already in place — the resource envelope was too tight for what the Go runtime consumes at rest, not for what the workload itself does.

## Fix

| | Before | After |
|---|---|---|
| Memory request | 16Mi | **32Mi** (≈ actual idle RSS) |
| Memory limit | 32Mi | **64Mi** (~40% utilization at idle) |

The alert should clear within ~5 minutes of the DaemonSet rolling.