### PR TITLE
fix(ingress): wait for name release before starting rebalance successor

### DIFF
--- a/app/ingress/lib/ingress/conduit_manager.ex
+++ b/app/ingress/lib/ingress/conduit_manager.ex
@@ -40,6 +40,10 @@ defmodule Ingress.ConduitManager do
   @rebalance_stable_ticks 9
   @rebalance_handoff_timeout_ms 20_000
   @rebalance_poll_interval_ms 300
+  # The released name has to reach the registry replica on the node Horde
+  # places the successor on before that start can register. Delta sync is
+  # sub-second; this bounds the wait well above it without stalling the tick.
+  @rebalance_name_release_timeout_ms 5_000
 
   def start_link(_opts) do
     GenServer.start_link(__MODULE__, [], name: via())
@@ -361,7 +365,7 @@ defmodule Ingress.ConduitManager do
     Logger.info("rebalancing shard #{shard_id} #{node(pid)} → #{target} after stable membership")
 
     with :ok <- release_shard_name(pid),
-         {:started, successor} <- start_shard(conduit_id, shard_id),
+         {:started, successor} <- start_successor(conduit_id, shard_id),
          :ok <- await_bound(successor, rebalance_deadline()) do
       GenServer.stop(pid, :normal, @orphan_stop_timeout_ms)
       Metrics.count("Conduit/ShardRebalances")
@@ -382,6 +386,41 @@ defmodule Ingress.ConduitManager do
   catch
     :exit, reason -> {:error, {:release_failed, reason}}
   end
+
+  # `release_shard_name` unregisters on the node the old copy runs on, but the
+  # successor registers on whichever node Horde places it on, and that node's
+  # registry replica only learns of the release at the next delta sync. Starting
+  # the instant the release returns therefore races that sync and gets
+  # `{:already_started, _}` for the very copy just unregistered — a rebalance
+  # that rolls back on every tick, forever. Retry until the release has
+  # propagated to the placing node, then give up and roll back.
+  defp start_successor(conduit_id, shard_id) do
+    start_until_free(
+      fn -> start_shard(conduit_id, shard_id) end,
+      name_release_deadline()
+    )
+  end
+
+  @doc false
+  # Retry policy for a blocked start. Public so it can be exercised without a
+  # running Horde cluster.
+  def start_until_free(start_fun, deadline, poll_ms \\ @rebalance_poll_interval_ms) do
+    case start_fun.() do
+      {:started, pid} ->
+        {:started, pid}
+
+      :blocked ->
+        if System.monotonic_time(:millisecond) >= deadline do
+          {:error, :name_release_timeout}
+        else
+          Process.sleep(poll_ms)
+          start_until_free(start_fun, deadline, poll_ms)
+        end
+    end
+  end
+
+  defp name_release_deadline,
+    do: System.monotonic_time(:millisecond) + @rebalance_name_release_timeout_ms
 
   defp rebalance_deadline,
     do: System.monotonic_time(:millisecond) + @rebalance_handoff_timeout_ms

--- a/app/ingress/test/conduit_manager_test.exs
+++ b/app/ingress/test/conduit_manager_test.exs
@@ -1,0 +1,46 @@
+defmodule Ingress.ConduitManagerTest do
+  use ExUnit.Case, async: true
+
+  alias Ingress.ConduitManager
+
+  describe "start_until_free/3" do
+    test "takes the successor from the first start that succeeds" do
+      pid = self()
+
+      assert {:started, ^pid} =
+               ConduitManager.start_until_free(fn -> {:started, pid} end, deadline(1_000), 5)
+    end
+
+    test "retries a blocked start until the released name has propagated" do
+      pid = self()
+      calls = :counters.new(1, [])
+
+      start_fun = fn ->
+        :counters.add(calls, 1, 1)
+
+        # The placing node's registry replica still carries the old
+        # registration for the first two attempts.
+        if :counters.get(calls, 1) < 3, do: :blocked, else: {:started, pid}
+      end
+
+      assert {:started, ^pid} = ConduitManager.start_until_free(start_fun, deadline(1_000), 5)
+      assert :counters.get(calls, 1) == 3
+    end
+
+    test "gives up once the propagation window closes, so the caller can roll back" do
+      calls = :counters.new(1, [])
+
+      start_fun = fn ->
+        :counters.add(calls, 1, 1)
+        :blocked
+      end
+
+      assert {:error, :name_release_timeout} =
+               ConduitManager.start_until_free(start_fun, deadline(30), 5)
+
+      assert :counters.get(calls, 1) > 1
+    end
+  end
+
+  defp deadline(ms), do: System.monotonic_time(:millisecond) + ms
+end


### PR DESCRIPTION
## Problem

Shard 1 has been failing to rebalance every reconcile tick since the pod-spread rebalance shipped:

```
rebalancing shard 1 ingress@10.42.1.219 → ingress@10.42.2.179 after stable membership
shard 1 rebalance failed: :blocked; rolling back
```

The two log lines are 3 ms apart. `rebalance_shard/4` released the shard's registry name on the node the old copy runs on, then called `start_shard/2` immediately. The successor registers on whichever node Horde places it on, and that node's registry replica only learns about the release at the next delta sync — so the start read a stale replica and came back `{:error, {:already_started, old_pid}}`, pointing at the copy that was just unregistered. `start_shard/2` maps that to `:blocked`, the `with` chain fell through to rollback, and the shard never moved. Deterministic: it can never converge, and every rollback also spends a Twitch `assign_shard` call re-asserting the old binding.

`:blocked` is overloaded. On the heal path it means the registration is wedged on a pid nothing can remove (escalate to a rescue) — correct there. On the rebalance path, right after a voluntary release, it just means the release has not propagated yet. `Ingress.Drain` does the same make-before-break handoff and already tolerates this, treating `{:already_started, pid}` as success and retrying around the sync interval.

## Fix

Rebalance now starts the successor through `start_until_free/3`, which retries the blocked start every 300 ms until the release has propagated, bounded at 5 s (well above sub-second delta sync), then falls through to the existing rollback with `{:error, :name_release_timeout}`.

`start_shard/2` semantics are unchanged, so the heal/restart path still escalates `:blocked` to a rescue session.

## Testing

- New `test/conduit_manager_test.exs` covers the retry policy without a running Horde cluster: immediate success, blocked-twice-then-started, and window-closes-then-timeout.
- Full ingress suite: 159 tests, 0 failures. `mix format --check-formatted` clean, no new compile warnings.

## Deploy note

`twitch-ingress` currently carries `kustomize.toolkit.fluxcd.io/reconcile: disabled`, so this will not roll out until that annotation is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)