### PR TITLE
fix(deploy): point nats placement back at the topology that runs

### DIFF
--- a/deploy/k8s/nats.yaml
+++ b/deploy/k8s/nats.yaml
@@ -41,22 +41,28 @@ spec:
           operator: Exists
           effect: NoExecute
           tolerationSeconds: 60
-        # Tolerate worker1's worker-pool taint so the hub can run there (see the
-        # affinity note): worker1 is the 8-core/15GiB third quorum member.
+        # node1 carries a dedicated=nats-ingress taint and hosts nats-2; without
+        # this toleration that member has nowhere to run, because its
+        # jetstream-data PVC is local-path and bound to node1.
+        - key: dedicated
+          operator: Equal
+          value: nats-ingress
+          effect: NoSchedule
+        # Inert while worker1 is excluded below. Kept so this spec matches what
+        # is applied; drop it during a planned roll, not as a drive-by edit —
+        # any change here restarts the whole quorum.
         - key: itsbagelbot.dev/pool
           operator: Equal
           value: worker-pool
           effect: NoSchedule
-      # The JetStream hub is a 3-member RAFT quorum on node2/node3/worker1.
-      # worker1 rides a home-wifi link, but with three voters a worker1
-      # blip still leaves node2+node3 as a 2/3 quorum. Trade-off: an R1 stream
-      # whose single replica lands on worker1 stalls while that link blips, so the
-      # hot firehose must stay replicated or have its placement watched — validate
-      # on the prod topology test before bumping resources (see the runbook).
-      # JetStream PVCs are local-path (node-bound): moving a member to another
-      # node means deleting its jetstream-data PVC + pod so it reprovisions
-      # there and RAFT re-syncs it. The node1 exclusion below is inert since
-      # node1 left the fleet; kept so the applied spec is unchanged.
+      # The JetStream hub is a 3-member RAFT quorum on node1/node2/node3.
+      # worker1 rides a home-wifi link and is excluded: an R1 stream whose
+      # single replica landed there would stall on every blip.
+      # JetStream PVCs are local-path (node-bound), so this exclusion is not a
+      # preference — moving a member to another node means deleting its
+      # jetstream-data PVC + pod so it reprovisions there and RAFT re-syncs it.
+      # Flipping the excluded host without doing that leaves the member
+      # unschedulable and the quorum at 2/3.
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -64,7 +70,7 @@ spec:
               - matchExpressions:
                   - key: kubernetes.io/hostname
                     operator: NotIn
-                    values: [node1]
+                    values: [worker1]
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: kubernetes.io/hostname


### PR DESCRIPTION
## What broke

`nats` StatefulSet carried `kustomize.toolkit.fluxcd.io/reconcile: disabled`, hiding a drift between the manifest and the cluster. Removing the pin let flux apply the manifest, and `nats-2` went `Pending`:

```
0/4 nodes are available: 1 node(s) had untolerated taint(s),
3 node(s) didn't match PersistentVolume's node affinity.
```

The quorum ran at 2/3 for ~6 minutes until the live spec was patched back by hand.

## Why

The manifest describes a quorum on node2/node3/worker1:

- tolerates `itsbagelbot.dev/pool=worker-pool` (worker1's taint)
- excludes **node1** via node affinity, with a comment saying node1 had left the fleet

Reality: node1 is in the fleet, carries a `dedicated=nats-ingress:NoSchedule` taint, and hosts `nats-2`. That member's `jetstream-data` PVC is local-path, so it is *bound* to node1 — excluding node1 leaves it nowhere to run, and no toleration for that taint means it cannot land there anyway.

## Change

Describe what actually runs:

- tolerate `dedicated=nats-ingress`
- exclude `worker1` instead of `node1`
- rewrite the comment so the next reader knows the exclusion is a consequence of node-bound local-path PVCs, not a preference — flipping the excluded host without migrating the PVC is exactly what caused the outage above

The now-inert `worker-pool` toleration is kept deliberately: removing it changes the pod spec and would restart all three members for no functional gain.

## Verification

`kubectl diff -f deploy/k8s/nats.yaml -n production` is empty against the live cluster, so flux applies this as a no-op — the quorum does not roll again. All three members are currently `3/3 Running` at revision `nats-7d855668fd`, `nats-2` back on node1.

## Follow-up, not in this PR

If the node2/node3/worker1 topology is still the intent, it needs the real migration: delete `nats-2`'s `jetstream-data` PVC and pod so local-path reprovisions on worker1 and RAFT re-syncs. That is a deliberate operation with quorum risk, not a manifest edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)