### PR TITLE
infra(node4): add valkey replica, full workload topology, move sesame preference

### DIFF
--- a/deploy/ansible/valkey-host-tuning.yml
+++ b/deploy/ansible/valkey-host-tuning.yml
@@ -11,6 +11,7 @@
       - node1
       - node2
       - node3
+      - node4
       - worker1
   tasks:
     - name: Refuse an empty or partial cluster target

--- a/deploy/ansible/valkey-rollout-preflight.yml
+++ b/deploy/ansible/valkey-rollout-preflight.yml
@@ -91,7 +91,7 @@
     - name: Refuse rollout with a primary outside node2 and node3
       ansible.builtin.assert:
         that:
-          - valkey_primary_node.stdout in ['node2', 'node3']
+          - valkey_primary_node.stdout in ['node2', 'node3', 'node4']
         fail_msg: >-
           Refusing rollout: Sentinel primary {{ valkey_primary_pod }} is on
-          {{ valkey_primary_node.stdout | default('an unknown node') }}, not node2/node3.
+          {{ valkey_primary_node.stdout | default('an unknown node') }}, not node2/node3/node4.

--- a/deploy/infra/cluster/cloudflared.yaml
+++ b/deploy/infra/cluster/cloudflared.yaml
@@ -1,7 +1,7 @@
 # Cloudflare Tunnel connector. Public ingress enters here: Cloudflare's edge
 # dials these outbound connectors and forwards to traefik.kube-system:443.
 #
-# Replicas hard-spread one per non-worker host (node2/node3). worker1 is
+# Replicas hard-spread one per non-worker host (node2/node3/node4). worker1 is
 # excluded explicitly: it is a burst worker, not part of the ingress failure
 # domain. A single tunnel ID supports many connector replicas (Cloudflare's
 # native HA model). Both outbound paths are already encrypted (443 to traefik
@@ -18,7 +18,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cloudflared
 spec:
-  replicas: 2 # one per non-worker node (node2, node3); node1 decommissioned
+  replicas: 3 # one per non-worker node (node2, node3, node4); node1 decommissioned
   revisionHistoryLimit: 3
   strategy:
     type: RollingUpdate

--- a/deploy/infra/tailscale/proxies.yaml
+++ b/deploy/infra/tailscale/proxies.yaml
@@ -3,8 +3,8 @@
 #
 # The ingress ProxyGroup runs one proxy per node. The Tailscale operator
 # currently realizes ProxyGroups as StatefulSets, not DaemonSets, so this uses
-# the supported API shape while keeping DaemonSet-like placement: two replicas
-# with strict hostname anti-affinity (node3 decommissioned, worker1 not
+# the supported API shape while keeping DaemonSet-like placement: three replicas
+# with strict hostname anti-affinity (worker1 not
 # included). Ingresses opt in via the tailscale.com/proxy-group annotation.
 apiVersion: tailscale.com/v1alpha1
 kind: ProxyClass
@@ -44,5 +44,5 @@ metadata:
   name: ts-ingress
 spec:
   type: ingress
-  replicas: 2
+  replicas: 3
   proxyClass: ha-spread

--- a/deploy/infra/valkey/pdb.yaml
+++ b/deploy/infra/valkey/pdb.yaml
@@ -4,7 +4,7 @@ metadata:
   name: valkey
   namespace: valkey
 spec:
-  # Quorum protection: three in-cluster Sentinels require two votes to
+  # Quorum protection: four in-cluster Sentinels require two votes to
   # authorize a failover. Allowing only ONE voluntary disruption at a time
   # keeps that majority reachable.
   maxUnavailable: 1

--- a/deploy/infra/valkey/statefulset.yaml
+++ b/deploy/infra/valkey/statefulset.yaml
@@ -21,9 +21,9 @@ spec:
   # fleet when ordinal zero is scheduled on a fenced node.
   podManagementPolicy: Parallel
   # Three colocated Valkey+Sentinel voters produce one writable primary and
-  # two replicas, one per node since node1 left the fleet. This count is a
+  # three replicas, one per node since node1 left the fleet. This count is a
   # CI-enforced configuration invariant.
-  replicas: 3
+  replicas: 4
   revisionHistoryLimit: 10
   selector:
     matchLabels:
@@ -64,7 +64,7 @@ spec:
           # view, which avoids making an arbitrary StatefulSet ordinal primary.
           #
           # A retained fenced primary also waits until the remaining Sentinels
-          # elect node2 or node3. Retained replicas may start immediately so
+          # elect node2, node3, or node4. Retained replicas may start immediately so
           # their colocated Sentinels can form the majority needed for failover.
           # This turns the placement policy into a fail-closed invariant instead
           # of relying on replica-priority, which only controls future elections.
@@ -79,7 +79,7 @@ spec:
           fi
           FENCED=true
           case "${NODE_NAME}" in
-            node2|node3) FENCED=false ;;
+            node2|node3|node4) FENCED=false ;;
           esac
           LIVE_MASTER=$(lookup_master)
           WAIT_FOR_PRIMARY=false
@@ -91,7 +91,7 @@ spec:
             WAIT_FOR_PRIMARY=true
           fi
           if [ "${WAIT_FOR_PRIMARY}" = "true" ]; then
-            echo "Waiting for a node2/node3 Sentinel primary before starting ${POD_FQDN}"
+            echo "Waiting for a node2/node3/node4 Sentinel primary before starting ${POD_FQDN}"
             while [ -z "${LIVE_MASTER}" ] || { [ "${FENCED}" = "true" ] && [ "${LIVE_MASTER}" = "${POD_FQDN}" ]; }; do
               sleep 2
               LIVE_MASTER=$(lookup_master)
@@ -117,12 +117,12 @@ spec:
             chmod 600 /data/valkey.conf
           fi
           # Reconcile master eligibility on every boot. Retained PVCs may carry
-          # a stale CONFIG REWRITE value, so only the explicit node2/node3
+          # a stale CONFIG REWRITE value, so only the explicit node2/node3/node4
           # allowlist can remain eligible for Sentinel promotion. Every other
           # node, including worker1 and future unknown nodes, is fenced.
           sed -i '/^replica-priority /d' /data/valkey.conf
           case "${NODE_NAME}" in
-            node2|node3)
+            node2|node3|node4)
               echo "replica-priority 100" >> /data/valkey.conf
               ;;
             *)

--- a/deploy/infra/valkey/topology_test.go
+++ b/deploy/infra/valkey/topology_test.go
@@ -19,7 +19,7 @@ func TestSentinelSinglePrimaryTopologyIsConfigured(t *testing.T) {
 	statefulSet := readFile(t, "statefulset.yaml")
 	valkeyConfig := readFile(t, "config/valkey.conf")
 
-	assert.Regexp(t, `(?m)^  replicas: 3$`, statefulSet, "three Valkey+Sentinel pods")
+	assert.Regexp(t, `(?m)^  replicas: 4$`, statefulSet, "four Valkey+Sentinel pods")
 	assert.Contains(t, statefulSet, topologyMarker)
 	assert.Contains(t, statefulSet, partitioningGuard)
 	assert.Contains(t, statefulSet, "- --sentinel")
@@ -47,8 +47,8 @@ func TestMasterEligibilityIsReconciledOnEveryBoot(t *testing.T) {
 	statefulSet := readFile(t, "statefulset.yaml")
 
 	assert.Contains(t, statefulSet, `case "${NODE_NAME}" in`)
-	assert.Contains(t, statefulSet, `node2|node3)`)
-	assert.Equal(t, 1, strings.Count(statefulSet, `echo "replica-priority 100"`), "node2/node3 are the only eligible nodes")
+	assert.Contains(t, statefulSet, `node2|node3|node4)`)
+	assert.Equal(t, 1, strings.Count(statefulSet, `echo "replica-priority 100"`), "node2/node3/node4 are the only eligible nodes")
 	assert.Equal(t, 1, strings.Count(statefulSet, `echo "replica-priority 0"`), "all non-allowlisted nodes are fenced")
 	assert.NotContains(t, statefulSet, `replica-priority 200`, "node1 must never remain a last-resort master")
 }
@@ -58,7 +58,7 @@ func TestColdBootstrapCannotMakeAnArbitraryOrdinalPrimary(t *testing.T) {
 
 	assert.Regexp(t, `(?m)^  podManagementPolicy: Parallel$`, statefulSet)
 	assert.Contains(t, statefulSet, `elif [ "${CONFIG_PRESENT}" = "false" ] && [ "${NODE_NAME}" != "node2" ]; then`)
-	assert.Contains(t, statefulSet, `Waiting for a node2/node3 Sentinel primary`)
+	assert.Contains(t, statefulSet, `Waiting for a node2/node3/node4 Sentinel primary`)
 	assert.Contains(t, statefulSet, `[ "${FENCED}" = "true" ] && [ "${LIVE_MASTER}" = "${POD_FQDN}" ]`)
 	assert.NotContains(t, statefulSet, "POD_INDEX", "StatefulSet ordinal must not confer primary eligibility")
 	assert.NotContains(t, statefulSet, "MASTER_ENDPOINT:-valkey-node-0", "pod zero must not be a cold-start fallback")

--- a/deploy/k8s/commands.yaml
+++ b/deploy/k8s/commands.yaml
@@ -21,7 +21,7 @@ metadata:
   annotations:
     secrets.doppler.com/reload: "true"
 spec:
-  replicas: 3 # one per hot-path node: node2, node3, worker1
+  replicas: 4 # one per hot-path node: node2, node3, node4, worker1
   revisionHistoryLimit: 3
   minReadySeconds: 10
   strategy:

--- a/deploy/k8s/console-admin.yaml
+++ b/deploy/k8s/console-admin.yaml
@@ -36,7 +36,7 @@ metadata:
   annotations:
     secrets.doppler.com/reload: "true"
 spec:
-  replicas: 2 # no worker toleration: one per normal node (node2, node3), never worker1; node1 decommissioned
+  replicas: 3 # no worker toleration: one per normal node (node2, node3, node4), never worker1; node1 decommissioned
   revisionHistoryLimit: 3
   minReadySeconds: 10
   strategy:

--- a/deploy/k8s/console-dashboard.yaml
+++ b/deploy/k8s/console-dashboard.yaml
@@ -50,7 +50,7 @@ metadata:
   annotations:
     secrets.doppler.com/reload: "true"
 spec:
-  replicas: 2 # one per schedulable node (node2, node3; no worker toleration)
+  replicas: 3 # one per schedulable node (node2, node3, node4; no worker toleration)
   revisionHistoryLimit: 3
   minReadySeconds: 10
   strategy:

--- a/deploy/k8s/gateway.yaml
+++ b/deploy/k8s/gateway.yaml
@@ -36,7 +36,7 @@ metadata:
 spec:
   # Stateless and cache-backed: keep one local RPC responder beside Sesame on
   # each hot-path node; the working set is one HTTP client and Valkey connection.
-  replicas: 3
+  replicas: 4
   revisionHistoryLimit: 3
   minReadySeconds: 10
   strategy:

--- a/deploy/k8s/loyalty.yaml
+++ b/deploy/k8s/loyalty.yaml
@@ -23,7 +23,7 @@ metadata:
 spec:
   # Keep one local loyalty RPC responder beside Sesame on every hot-path node.
   # Event folds remain queue-grouped across the three replicas.
-  replicas: 3
+  replicas: 4
   revisionHistoryLimit: 3
   minReadySeconds: 10
   strategy:

--- a/deploy/k8s/modules.yaml
+++ b/deploy/k8s/modules.yaml
@@ -21,7 +21,7 @@ metadata:
   annotations:
     secrets.doppler.com/reload: "true"
 spec:
-  replicas: 3 # one per hot-path node: node2, node3, worker1
+  replicas: 4 # one per hot-path node: node2, node3, node4, worker1
   revisionHistoryLimit: 3
   minReadySeconds: 10
   strategy:

--- a/deploy/k8s/notifications.yaml
+++ b/deploy/k8s/notifications.yaml
@@ -21,7 +21,7 @@ metadata:
   annotations:
     secrets.doppler.com/reload: "true"
 spec:
-  replicas: 3 # one per schedulable node incl worker1 (tolerates worker-pool)
+  replicas: 4 # one per schedulable node incl worker1 (tolerates worker-pool)
   revisionHistoryLimit: 3
   minReadySeconds: 10
   strategy:
@@ -52,7 +52,7 @@ spec:
           tolerationSeconds: 60
       topologySpreadConstraints:
         - maxSkew: 1
-          minDomains: 3
+          minDomains: 4
           topologyKey: kubernetes.io/hostname
           whenUnsatisfiable: DoNotSchedule
           matchLabelKeys: [pod-template-hash]

--- a/deploy/k8s/outgress.yaml
+++ b/deploy/k8s/outgress.yaml
@@ -249,13 +249,13 @@ spec:
     name: outgress
   pollingInterval: 15
   cooldownPeriod: 300
-  minReplicaCount: 3
-  # 3 per hot-path node (node2/node3/worker1). Outgress is Twitch-rate-limited,
+  minReplicaCount: 4
+  # 3 per hot-path node (node2/node3/node4/worker1). Outgress is Twitch-rate-limited,
   # so headroom here is for lag-driven burst drain, not sustained throughput.
-  maxReplicaCount: 9
+  maxReplicaCount: 12
   fallback:
     failureThreshold: 3
-    replicas: 3
+    replicas: 4
   advanced:
     horizontalPodAutoscalerConfig:
       behavior:

--- a/deploy/k8s/projector.yaml
+++ b/deploy/k8s/projector.yaml
@@ -21,7 +21,7 @@ metadata:
   annotations:
     secrets.doppler.com/reload: "true"
 spec:
-  replicas: 3 # one per hot-path node: node2, node3, worker1
+  replicas: 4 # one per hot-path node: node2, node3, node4, worker1
   revisionHistoryLimit: 3
   minReadySeconds: 10
   strategy:

--- a/deploy/k8s/sesame.yaml
+++ b/deploy/k8s/sesame.yaml
@@ -59,9 +59,9 @@ spec:
       # The node1 exclusion below is inert since node1 left the fleet; kept so
       # the applied spec is unchanged. KEDA (see the ScaledObject below) scales
       # onto node2/node3/worker1.
-      # Baseline shape at the KEDA floor of 5: node3=2, worker1=2, node2=1.
-      # node2 already carries the control plane + valkey master, so the doubles
-      # belong on the big-CPU pair; the graded preferences below pick which
+      # Baseline shape at the KEDA floor of 6: node4=2, worker1=2, node2=1, node3=1.
+      # node2 already carries the control plane + valkey master, so the double
+      # belongs on the big-CPU node4; the graded preferences below pick which
       # nodes take them (node3 first, worker1 second). The required hostname
       # spread below is authoritative: preferences choose which nodes receive
       # the two extra replicas, but can never stack four workers on one node.
@@ -79,7 +79,7 @@ spec:
                 matchExpressions:
                   - key: kubernetes.io/hostname
                     operator: In
-                    values: [node3]
+                    values: [node4]
             - weight: 20
               preference:
                 matchExpressions:
@@ -262,7 +262,7 @@ spec:
 ---
 # Sesame's engine is sub-100us p95; confirmed NATS input/output is the measured
 # capacity boundary. minReplicaCount 5 keeps the baseline shape
-# node3=2, worker1=2, node2=1 (see the Deployment's graded node preferences)
+# node4=2, worker1=2, node2=1, node3=1 (see the Deployment's graded node preferences)
 # without waiting on a scale-up; node2 stays light on purpose.
 # Consumer names are bus.durableName("worker", subject) - sesame
 # shares the worker's pre-existing durable via fleetSubscriber (app/sesame/main.go
@@ -280,11 +280,11 @@ spec:
     name: sesame
   pollingInterval: 15
   cooldownPeriod: 300
-  minReplicaCount: 5
-  maxReplicaCount: 10
+  minReplicaCount: 6
+  maxReplicaCount: 12
   fallback:
     failureThreshold: 3
-    replicas: 5
+    replicas: 6
   advanced:
     horizontalPodAutoscalerConfig:
       behavior:

--- a/deploy/k8s/topology_spread_test.go
+++ b/deploy/k8s/topology_spread_test.go
@@ -96,8 +96,8 @@ func TestRolloutSensitiveWorkloadsHardSpreadEachReplicaSet(t *testing.T) {
 		minDomains int
 	}{
 		{"console-admin.yaml", "console-admin", 0},
-		{"notifications.yaml", "notifications", 3},
-		{"transactions.yaml", "transactions", 3},
+		{"notifications.yaml", "notifications", 4},
+		{"transactions.yaml", "transactions", 4},
 		{"twitch-ingress.yaml", "twitch-ingress", 0},
 	}
 

--- a/deploy/k8s/transactions.yaml
+++ b/deploy/k8s/transactions.yaml
@@ -21,7 +21,7 @@ metadata:
   annotations:
     secrets.doppler.com/reload: "true"
 spec:
-  replicas: 3 # one per hot-path node: node2, node3, worker1
+  replicas: 4 # one per hot-path node: node2, node3, node4, worker1
   revisionHistoryLimit: 3
   minReadySeconds: 10
   strategy:
@@ -52,7 +52,7 @@ spec:
           tolerationSeconds: 60
       topologySpreadConstraints:
         - maxSkew: 1
-          minDomains: 3
+          minDomains: 4
           topologyKey: kubernetes.io/hostname
           whenUnsatisfiable: DoNotSchedule
           matchLabelKeys: [pod-template-hash]

--- a/deploy/k8s/twitch-ingress.yaml
+++ b/deploy/k8s/twitch-ingress.yaml
@@ -43,7 +43,7 @@ metadata:
   annotations:
     secrets.doppler.com/reload: "true"
 spec:
-  replicas: 3 # one per eligible hot-path node: node2, node3, worker1
+  replicas: 4 # one per eligible hot-path node: node2, node3, node4, worker1
   revisionHistoryLimit: 3
   # On SIGTERM each pod hands its conduit shards off make-before-break
   # (Ingress.Drain): the successor binds on a peer before the local socket

--- a/deploy/k8s/users.yaml
+++ b/deploy/k8s/users.yaml
@@ -21,7 +21,7 @@ metadata:
   annotations:
     secrets.doppler.com/reload: "true"
 spec:
-  replicas: 3 # one per hot-path node: node2, node3, worker1
+  replicas: 4 # one per hot-path node: node2, node3, node4, worker1
   revisionHistoryLimit: 3
   minReadySeconds: 10
   strategy:


### PR DESCRIPTION
## Summary

Add node4 as a full fleet member across all workloads, valkey, infra, and ansible.

### Valkey
- Replicas 3→4, node4 added to master-eligible allowlist (`replica-priority 100`)
- PDB comment updated, sentinel quorum stays at 2

### Sesame
- Scheduling preference moved from node3 → node4
- KEDA floor bumped: min 5→6, max 10→12, fallback 5→6

### Hot-path workloads (replicas 3→4)
commands, gateway, loyalty, modules, projector, transactions, users, twitch-ingress, notifications

### Non-worker workloads (replicas 2→3)
console-admin, console-dashboard, cloudflared

### Tailscale
- ProxyGroup ts-ingress: replicas 2→3

### Outgress KEDA
- min 3→4, max 9→12, fallback 3→4

### Tests
- Valkey topology test + k8s topology spread test assertions updated
- All tests pass

### Ansible
- valkey-rollout-preflight: node4 accepted as primary location
- valkey-host-tuning: node4 added to required nodes

### No change needed
- Traefik (DaemonSet), CoreDNS (DaemonSet) — auto-schedule on node4