### PR TITLE
Fix reconnect control latency and dashboard feedback

### DIFF
--- a/app/outgress/internal/worker/buckets.go
+++ b/app/outgress/internal/worker/buckets.go
@@ -41,6 +41,15 @@ const (
 	helixUserCapacity    = 800.0
 )
 
+const (
+	// A lease epoch deliberately closes both generations around its boundary.
+	// System work is asynchronous and rare, so it can cheaply bridge that gap
+	// instead of reporting a false quota exhaustion. Chat/API calls stay on the
+	// non-blocking path.
+	systemGuardRetryMax        = 750 * time.Millisecond
+	systemGuardActivationSlack = 25 * time.Millisecond
+)
+
 // Stable bucket parameters are formatted once at process initialization. Chat
 // keys remain per-broadcaster, but their numeric Lua arguments do not.
 var (
@@ -111,11 +120,50 @@ func (w *Worker) takeGeneralHelix(ctx context.Context, payload *outgress.Message
 // general partition would have spent anyway, so the fleet stays within the
 // real 800/min Helix limit.
 func (w *Worker) takeSystemHelix(ctx context.Context) error {
-	err := w.take(ctx, helixSystemSpec.ForKey("ratelimit:helix:system"))
+	err := w.takeSystem(ctx, helixSystemSpec.ForKey("ratelimit:helix:system"))
 	if !errors.Is(err, errRateLimitShared) {
 		return err
 	}
-	return w.take(ctx, helixGeneralSpec.ForKey("ratelimit:helix:app"))
+	return w.takeSystem(ctx, helixGeneralSpec.ForKey("ratelimit:helix:app"))
+}
+
+func (w *Worker) takeSystem(ctx context.Context, req ratelimit.Request) error {
+	started := time.Now()
+	defer recordStageDuration(ctx, "outgress.limiter_ms", started)
+
+	allowed, err := w.limiter.Allow(ctx, req)
+	if err != nil {
+		return err
+	}
+	if allowed {
+		return nil
+	}
+
+	wait := ratelimit.GuardRetryAfter(w.limiter)
+	if wait <= 0 || wait > systemGuardRetryMax {
+		return errRateLimitShared
+	}
+	wait += systemGuardActivationSlack
+	if wait > systemGuardRetryMax {
+		wait = systemGuardRetryMax
+	}
+
+	timer := time.NewTimer(wait)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+	}
+
+	allowed, err = w.limiter.Allow(ctx, req)
+	if err != nil {
+		return err
+	}
+	if !allowed {
+		return errRateLimitShared
+	}
+	return nil
 }
 
 // take consumes one token or returns an error that nacks the message, so the

--- a/app/outgress/internal/worker/buckets.go
+++ b/app/outgress/internal/worker/buckets.go
@@ -128,15 +128,9 @@ func (w *Worker) takeSystemHelix(ctx context.Context) error {
 }
 
 func (w *Worker) takeSystem(ctx context.Context, req ratelimit.Request) error {
-	started := time.Now()
-	defer recordStageDuration(ctx, "outgress.limiter_ms", started)
-
-	allowed, err := w.limiter.Allow(ctx, req)
-	if err != nil {
+	err := w.take(ctx, req)
+	if !errors.Is(err, errRateLimitShared) {
 		return err
-	}
-	if allowed {
-		return nil
 	}
 	return w.retrySystemAfterGuard(ctx, req)
 }
@@ -149,8 +143,7 @@ func (w *Worker) retrySystemAfterGuard(ctx context.Context, req ratelimit.Reques
 	if err := waitForSystemGuard(ctx, wait); err != nil {
 		return err
 	}
-	allowed, err := w.limiter.Allow(ctx, req)
-	return systemLimitResult(allowed, err)
+	return w.take(ctx, req)
 }
 
 func systemGuardRetryDelay(manager ratelimit.Manager) (time.Duration, bool) {
@@ -174,16 +167,6 @@ func waitForSystemGuard(ctx context.Context, wait time.Duration) error {
 	case <-timer.C:
 		return nil
 	}
-}
-
-func systemLimitResult(allowed bool, err error) error {
-	if err != nil {
-		return err
-	}
-	if !allowed {
-		return errRateLimitShared
-	}
-	return nil
 }
 
 // take consumes one token or returns an error that nacks the message, so the

--- a/app/outgress/internal/worker/buckets.go
+++ b/app/outgress/internal/worker/buckets.go
@@ -138,25 +138,45 @@ func (w *Worker) takeSystem(ctx context.Context, req ratelimit.Request) error {
 	if allowed {
 		return nil
 	}
+	return w.retrySystemAfterGuard(ctx, req)
+}
 
-	wait := ratelimit.GuardRetryAfter(w.limiter)
-	if wait <= 0 || wait > systemGuardRetryMax {
+func (w *Worker) retrySystemAfterGuard(ctx context.Context, req ratelimit.Request) error {
+	wait, ok := systemGuardRetryDelay(w.limiter)
+	if !ok {
 		return errRateLimitShared
+	}
+	if err := waitForSystemGuard(ctx, wait); err != nil {
+		return err
+	}
+	allowed, err := w.limiter.Allow(ctx, req)
+	return systemLimitResult(allowed, err)
+}
+
+func systemGuardRetryDelay(manager ratelimit.Manager) (time.Duration, bool) {
+	wait := ratelimit.GuardRetryAfter(manager)
+	if wait <= 0 || wait > systemGuardRetryMax {
+		return 0, false
 	}
 	wait += systemGuardActivationSlack
 	if wait > systemGuardRetryMax {
 		wait = systemGuardRetryMax
 	}
+	return wait, true
+}
 
+func waitForSystemGuard(ctx context.Context, wait time.Duration) error {
 	timer := time.NewTimer(wait)
 	defer timer.Stop()
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
 	case <-timer.C:
+		return nil
 	}
+}
 
-	allowed, err = w.limiter.Allow(ctx, req)
+func systemLimitResult(allowed bool, err error) error {
 	if err != nil {
 		return err
 	}

--- a/app/outgress/internal/worker/buckets_test.go
+++ b/app/outgress/internal/worker/buckets_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"slices"
 	"testing"
+	"time"
 
 	"ItsBagelBot/pkg/ratelimit"
 
@@ -19,6 +20,22 @@ type scriptedLimiter struct {
 	errs   map[string]error
 	calls  []string
 }
+
+type guardOnceLimiter struct {
+	calls int
+	wait  time.Duration
+}
+
+func (g *guardOnceLimiter) Allow(context.Context, ratelimit.Request) (bool, error) {
+	g.calls++
+	return g.calls > 1, nil
+}
+
+func (g *guardOnceLimiter) AllowOrdered(context.Context, ratelimit.Request, ratelimit.Request) (uint8, error) {
+	return 0, nil
+}
+
+func (g *guardOnceLimiter) GuardRetryAfter() time.Duration { return g.wait }
 
 func (s *scriptedLimiter) Allow(_ context.Context, req ratelimit.Request) (bool, error) {
 	s.calls = append(s.calls, req.Key)
@@ -83,5 +100,17 @@ func TestTakeSystemHelixInfraErrorDoesNotSpill(t *testing.T) {
 	}
 	if len(limiter.calls) != 1 {
 		t.Fatalf("calls = %v, want no spillover on infra error", limiter.calls)
+	}
+}
+
+func TestTakeSystemHelixRetriesLeaseGuardBeforeSpillover(t *testing.T) {
+	limiter := &guardOnceLimiter{wait: time.Millisecond}
+	w := systemLaneWorker(limiter)
+
+	if err := w.takeSystemHelix(context.Background()); err != nil {
+		t.Fatalf("takeSystemHelix() = %v, want nil after guard retry", err)
+	}
+	if limiter.calls != 2 {
+		t.Fatalf("calls = %d, want one guard retry", limiter.calls)
 	}
 }

--- a/app/outgress/internal/worker/eventsub.go
+++ b/app/outgress/internal/worker/eventsub.go
@@ -25,6 +25,14 @@ import (
 // "ok", so a failing, pending, or cleared channel always gets its enroll.
 const enrollCooldownTTL = 2 * time.Minute
 
+const (
+	// A dashboard disconnect followed by enable commonly overlaps for less than
+	// a second. Keep the newer intent in-process briefly instead of paying the
+	// system lane's 15-second transient-failure redelivery delay.
+	enrollLockWaitTimeout  = 3 * time.Second
+	enrollLockPollInterval = 100 * time.Millisecond
+)
+
 // Enrollment states persisted in the channel registry (sub_state). The
 // console's connection model mirrors these exact strings.
 const (
@@ -108,9 +116,9 @@ func effectiveMode(job outgress.EventSubJob) string {
 	return outgress.ModeDisable
 }
 
-// errEnrollLockBusy naks a job that lost the enroll-lock race so paced
-// redelivery re-applies it after the holder finishes.
-var errEnrollLockBusy = errors.New("enroll lock busy: another operation in progress for this channel")
+// errEnrollLockBusy naks a job whose lock stayed busy beyond the short local
+// wait. It is expected backpressure, not an application failure.
+const errEnrollLockBusy expectedNackError = "enroll lock busy: another operation in progress for this channel"
 
 // underEnrollLock runs fn only when this replica wins the channel's enroll
 // lock, so exactly one replica works an enable/disable/reconnect at a time.
@@ -127,13 +135,49 @@ func (w *Worker) underEnrollLock(ctx context.Context, op string, e enrollment, f
 		return err // transient valkey error: nak, let paced redelivery retry
 	}
 	if !got {
-		w.log.Info(op+" waiting on enroll lock, nak for paced redelivery",
+		w.log.Info(op+" waiting on enroll lock",
 			zap.String("broadcaster_id", e.broadcasterID))
-		return errEnrollLockBusy
+		got, err = waitForEnrollLock(ctx, enrollLockWaitTimeout, enrollLockPollInterval, func() (bool, error) {
+			return w.registry.AcquireEnrollLock(ctx, e.broadcasterID, w.owner, 60*time.Second)
+		})
+		if err != nil {
+			return err
+		}
+		if !got {
+			return errEnrollLockBusy
+		}
+		w.log.Info(op+" acquired enroll lock after waiting",
+			zap.String("broadcaster_id", e.broadcasterID))
 	}
 	defer func() { _ = w.registry.ReleaseEnrollLock(ctx, e.broadcasterID, w.owner) }()
 
 	return fn()
+}
+
+func waitForEnrollLock(
+	ctx context.Context,
+	timeout time.Duration,
+	pollInterval time.Duration,
+	acquire func() (bool, error),
+) (bool, error) {
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return false, ctx.Err()
+		case <-timer.C:
+			return false, nil
+		case <-ticker.C:
+			got, err := acquire()
+			if err != nil || got {
+				return got, err
+			}
+		}
+	}
 }
 
 // skipRevokedEnroll acknowledges an enable/reconnect for a channel whose

--- a/app/outgress/internal/worker/eventsub_test.go
+++ b/app/outgress/internal/worker/eventsub_test.go
@@ -1,7 +1,10 @@
 package worker
 
 import (
+	"context"
+	"errors"
 	"testing"
+	"time"
 
 	"ItsBagelBot/internal/domain/rpc/manage"
 )
@@ -25,5 +28,38 @@ func TestRedundantEnrollRequiresHealthyState(t *testing.T) {
 		if got := redundantEnroll(tc.ch, tc.found); got != tc.want {
 			t.Errorf("%s: redundantEnroll = %v, want %v", tc.name, got, tc.want)
 		}
+	}
+}
+
+func TestWaitForEnrollLockAcquiresAfterHolderFinishes(t *testing.T) {
+	attempts := 0
+	got, err := waitForEnrollLock(context.Background(), 100*time.Millisecond, time.Millisecond, func() (bool, error) {
+		attempts++
+		return attempts == 2, nil
+	})
+	if err != nil || !got {
+		t.Fatalf("waitForEnrollLock() = %v, %v; want acquired", got, err)
+	}
+	if attempts != 2 {
+		t.Fatalf("attempts = %d, want 2", attempts)
+	}
+}
+
+func TestWaitForEnrollLockTimesOut(t *testing.T) {
+	got, err := waitForEnrollLock(context.Background(), 5*time.Millisecond, time.Millisecond, func() (bool, error) {
+		return false, nil
+	})
+	if err != nil || got {
+		t.Fatalf("waitForEnrollLock() = %v, %v; want clean timeout", got, err)
+	}
+}
+
+func TestWaitForEnrollLockReturnsAcquireError(t *testing.T) {
+	boom := errors.New("valkey unavailable")
+	got, err := waitForEnrollLock(context.Background(), 100*time.Millisecond, time.Millisecond, func() (bool, error) {
+		return false, boom
+	})
+	if got || !errors.Is(err, boom) {
+		t.Fatalf("waitForEnrollLock() = %v, %v; want acquire error", got, err)
 	}
 }

--- a/console/dashboard/src/lib/components/overview/BotStatusPanel.svelte
+++ b/console/dashboard/src/lib/components/overview/BotStatusPanel.svelte
@@ -21,6 +21,7 @@
     loading = false,
     ui,
     checkingText,
+    busy = false,
     isDelegate = false,
     isPremium = false,
     logoSrc,
@@ -32,6 +33,7 @@
     loading?: boolean;
     ui?: ConnUi;
     checkingText: string;
+    busy?: boolean;
     isDelegate?: boolean;
     isPremium?: boolean;
     logoSrc: string;
@@ -134,12 +136,13 @@
           icon="activity"
           type="button"
           class="ov-cta"
+          disabled={busy}
           onclick={() => onRestart?.()}
         >{kind === 'degraded' ? t('common.reconnect') : t('overview.restart')}</Button>
-        <Button variant="ghost" icon="power" type="button" class="ov-cta" onclick={() => onDisconnect?.()}>{t('overview.disconnect')}</Button>
+        <Button variant="ghost" icon="power" type="button" class="ov-cta" disabled={busy} onclick={() => onDisconnect?.()}>{t('overview.disconnect')}</Button>
       {:else if ui.showEnable}
         <form method="POST" action="?/enable" use:enhance={enableSubmit}>
-          <Button variant="primary" icon="power" type="submit" class="ov-cta">{t('overview.enable')}</Button>
+          <Button variant="primary" icon="power" type="submit" class="ov-cta" loading={busy}>{t('overview.enable')}</Button>
         </form>
       {:else if ui.showConnect}
         <!-- reauth_required: the grant died server-side, only a fresh Twitch

--- a/console/dashboard/src/lib/connection-poll.test.ts
+++ b/console/dashboard/src/lib/connection-poll.test.ts
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import {
+  CONNECTION_POLL_FAST_MS,
+  connectionPollDelay,
+  connectionPollSettled
+} from './connection-poll';
+
+describe('connection polling', () => {
+  test('polls quickly through the ordinary reconnect window, then backs off', () => {
+    assert.equal(connectionPollDelay(0), CONNECTION_POLL_FAST_MS);
+    assert.equal(connectionPollDelay(4999), CONNECTION_POLL_FAST_MS);
+    assert.equal(connectionPollDelay(5000), 2500);
+  });
+
+  test('connect waits for a transition or a short old-state grace period', () => {
+    assert.equal(connectionPollSettled('connected', 'ok', 500, false), false);
+    assert.equal(connectionPollSettled('connected', 'ok', 500, true), true);
+    assert.equal(connectionPollSettled('connected', 'ok', 1500, false), true);
+    assert.equal(connectionPollSettled('connected', 'pending', 5000, true), false);
+  });
+
+  test('disconnect waits for an inactive subscription state', () => {
+    assert.equal(connectionPollSettled('disconnected', 'ok', 5000, true), false);
+    assert.equal(connectionPollSettled('disconnected', 'unenrolled', 500, false), true);
+    assert.equal(connectionPollSettled('disconnected', 'failing', 500, false), true);
+    assert.equal(connectionPollSettled('disconnected', 'revoked', 500, false), true);
+  });
+});

--- a/console/dashboard/src/lib/connection-poll.ts
+++ b/console/dashboard/src/lib/connection-poll.ts
@@ -1,0 +1,31 @@
+export type ConnectionPollGoal = 'connected' | 'disconnected';
+
+export const CONNECTION_POLL_FAST_MS = 500;
+export const CONNECTION_POLL_TIMEOUT_MS = 30_000;
+
+const CONNECTION_POLL_SLOW_MS = 2500;
+const CONNECTION_POLL_FAST_WINDOW_MS = 5000;
+const CONNECTION_SETTLE_GRACE_MS = 1500;
+
+export function connectionPollDelay(elapsedMs: number): number {
+  return elapsedMs < CONNECTION_POLL_FAST_WINDOW_MS
+    ? CONNECTION_POLL_FAST_MS
+    : CONNECTION_POLL_SLOW_MS;
+}
+
+export function connectionPollSettled(
+  goal: ConnectionPollGoal,
+  state: string,
+  elapsedMs: number,
+  sawUnsettled: boolean
+): boolean {
+  if (goal === 'disconnected') {
+    return state === 'unenrolled' || state === 'failing' || state === 'revoked';
+  }
+  return (
+    state !== 'pending' &&
+    state !== 'unenrolled' &&
+    state !== 'unknown' &&
+    (sawUnsettled || elapsedMs >= CONNECTION_SETTLE_GRACE_MS)
+  );
+}

--- a/console/dashboard/src/routes/(app)/+page.svelte
+++ b/console/dashboard/src/routes/(app)/+page.svelte
@@ -12,6 +12,13 @@
   import LinkedSummary from '$lib/components/overview/LinkedSummary.svelte';
   import TopCommands from '$lib/components/overview/TopCommands.svelte';
   import SetupProgress from '$lib/components/overview/SetupProgress.svelte';
+  import {
+    CONNECTION_POLL_FAST_MS,
+    CONNECTION_POLL_TIMEOUT_MS,
+    connectionPollDelay,
+    connectionPollSettled,
+    type ConnectionPollGoal
+  } from '$lib/connection-poll';
   let { data } = $props();
 
   const { t } = getI18n();
@@ -92,11 +99,13 @@
   let actionError = $state('');
 
   function openModal(action: PendingAction) {
+    if (actionBusy) return;
     actionError = '';
     pending = action;
   }
 
-  function closeModal() {
+  function closeModal(force = false) {
+    if (actionBusy && !force) return;
     actionError = '';
     pending = null;
   }
@@ -106,13 +115,17 @@
   // from "reconnecting" to ok/failing without a manual refresh. `sub` (when set)
   // overrides the server snapshot.
   let sub = $state<{ state: string; error: string } | null>(null);
-  let pollTimer: ReturnType<typeof setInterval> | null = null;
+  let actionBusy = $state(false);
+  let pollTimer: ReturnType<typeof setTimeout> | null = null;
+  let pollRun = 0;
 
-  function stopPolling() {
+  function stopPolling(clearBusy = true) {
+    pollRun += 1;
     if (pollTimer) {
-      clearInterval(pollTimer);
+      clearTimeout(pollTimer);
       pollTimer = null;
     }
+    if (clearBusy) actionBusy = false;
   }
 
   async function refreshSub(): Promise<string> {
@@ -128,33 +141,49 @@
     return 'unknown';
   }
 
-  // Poll while the enroll is unsettled, backstopped at ~30s so a stuck job
-  // stops spinning. 'unenrolled' counts as unsettled here: a just-published
-  // enroll job reads as 'unenrolled' until outgress picks it up and writes
-  // 'pending', and stopping in that gap would freeze the pill mid-flight.
-  function startPolling() {
-    stopPolling();
-    let ticks = 0;
-    pollTimer = setInterval(async () => {
-      ticks += 1;
+  // Poll quickly while the ordinary 1-2s operation finishes, then back off.
+  // Disconnect has its own terminal state: the action response only proves the
+  // job was queued, so Enable stays locked until Outgress reports unenrolled.
+  function startPolling(goal: ConnectionPollGoal) {
+    stopPolling(false);
+    actionBusy = true;
+    const run = ++pollRun;
+    const started = Date.now();
+    let sawUnsettled = false;
+
+    const tick = async () => {
       const state = await refreshSub();
-      if ((state !== 'pending' && state !== 'unenrolled') || ticks >= 12) stopPolling();
-    }, 2500);
+      if (run !== pollRun) return;
+
+      const elapsed = Date.now() - started;
+      if (state === 'pending' || state === 'unenrolled') sawUnsettled = true;
+      if (
+        connectionPollSettled(goal, state, elapsed, sawUnsettled) ||
+        elapsed >= CONNECTION_POLL_TIMEOUT_MS
+      ) {
+        pollTimer = null;
+        actionBusy = false;
+        return;
+      }
+      pollTimer = setTimeout(tick, connectionPollDelay(elapsed));
+    };
+
+    pollTimer = setTimeout(tick, CONNECTION_POLL_FAST_MS);
   }
 
   // Mark reconnecting immediately on user action, then poll to the outcome.
   function trackReconnect() {
     sub = { state: 'pending', error: '' };
-    startPolling();
+    startPolling('connected');
   }
 
   onMount(() => {
     refreshSub().then(async (state) => {
-      if (state === 'pending') return startPolling();
+      if (state === 'pending') return startPolling('connected');
       // The load-time self-heal reports 'pending' before outgress has written
       // anything, so a fresh poll can still read 'unenrolled'. Poll through
       // that gap only when the server said an enroll is actually in flight.
-      if (state === 'unenrolled' && (await data.conn).signals.sub === 'pending') startPolling();
+      if (state === 'unenrolled' && (await data.conn).signals.sub === 'pending') startPolling('connected');
     });
     return stopPolling;
   });
@@ -168,27 +197,31 @@
   };
 
   function closeAfterSubmit() {
-    const wasRestart = pending === 'restart';
+    const action = pending;
+    actionBusy = true;
     return async ({ result, update }: Enhanced) => {
       if (result.type === 'success') {
         await update();
-        closeModal();
-        // Only a restart re-enrolls; disconnect just tears down.
-        if (wasRestart) trackReconnect();
+        closeModal(true);
+        if (action === 'restart') trackReconnect();
+        else startPolling('disconnected');
       } else {
         await update({ reset: false });
+        actionBusy = false;
         actionError = t('overview.actionFailed');
       }
     };
   }
 
   function enableSubmit() {
+    actionBusy = true;
     return async ({ result, update }: Enhanced) => {
       if (result.type === 'success') {
         await update();
         trackReconnect();
       } else {
         await update({ reset: false });
+        actionBusy = false;
         toast('err', t('overview.actionFailed'));
       }
     };
@@ -213,6 +246,7 @@
     <BotStatusPanel
       ui={u}
       checkingText={t('overview.checking')}
+      busy={actionBusy}
       {isDelegate}
       isPremium={data.isPremium}
       logoSrc={logo}
@@ -306,10 +340,11 @@
     <p class="modal-body">{modalBody}</p>
     {#if actionError}<p class="modal-error" role="alert">{actionError}</p>{/if}
     <form method="POST" action={modalAction} use:enhance={closeAfterSubmit} class="modal-actions">
-      <Button variant="ghost" type="button" onclick={closeModal}>{t('common.cancel')}</Button>
+      <Button variant="ghost" type="button" disabled={actionBusy} onclick={() => closeModal()}>{t('common.cancel')}</Button>
       <Button
         variant={pending === 'disconnect' ? 'tan' : 'primary'}
         type="submit"
+        loading={actionBusy}
       >
         {pending === 'restart' ? t('overview.restart') : t('overview.disconnect')}
       </Button>

--- a/console/shared/lib/connection-state.test.ts
+++ b/console/shared/lib/connection-state.test.ts
@@ -69,6 +69,11 @@ describe('connectionUiState', () => {
 		}
 	});
 
+	test('management actions are unavailable while an enrollment is in flight', () => {
+		expect(connectionUiState({ ...base, sub: 'pending' }).canManage).toBe(false);
+		expect(connectionUiState({ ...base, sub: 'unenrolled' }).canManage).toBe(false);
+	});
+
 	test('every signal permutation resolves to exactly one kind', () => {
 		const grants: (boolean | 'unknown')[] = [true, false, 'unknown'];
 		const actives: (boolean | 'unknown')[] = [true, false, 'unknown'];

--- a/console/shared/lib/connection-state.ts
+++ b/console/shared/lib/connection-state.ts
@@ -77,7 +77,10 @@ function activeKind(sub: SubState): ConnKind {
 
 // Per-kind action sets. Membership lists keep each ConnUi flag a single
 // readable predicate instead of a growing boolean chain.
-const MANAGEABLE: readonly ConnKind[] = ['online', 'degraded', 'sub_unknown', 'connecting'];
+// A connecting channel already has a control operation in flight. Hiding its
+// management actions prevents restart/disconnect/enable sequences from racing
+// each other while Outgress is still converging the previous intent.
+const MANAGEABLE: readonly ConnKind[] = ['online', 'degraded', 'sub_unknown'];
 const CONNECTABLE: readonly ConnKind[] = ['auth_required', 'reauth_required'];
 const RETRYABLE: readonly ConnKind[] = ['unavailable', 'sub_unknown'];
 

--- a/pkg/ratelimit/lease_manager.go
+++ b/pkg/ratelimit/lease_manager.go
@@ -34,10 +34,14 @@ type activePlan struct {
 	validFromMS int64
 	notBefore   time.Time
 	notAfter    time.Time
-	members     []Member
-	selfIndex   int
-	selfPodID   string
-	shares      [profileHelixUser + 1]selfShare
+	// nextNotBefore is the earliest safe admission time for the following
+	// generation. Between notAfter and this deadline both generations are
+	// deliberately closed, preventing their leased shares from overlapping.
+	nextNotBefore time.Time
+	members       []Member
+	selfIndex     int
+	selfPodID     string
+	shares        [profileHelixUser + 1]selfShare
 }
 
 // coversNow reports whether now falls inside the plan's guarded admission
@@ -117,13 +121,15 @@ func (m *LeaseManager) ActivatePlan(plan Plan, serverNow, localNow time.Time, gu
 
 	notBefore := localNow.Add(time.UnixMilli(canonical.ValidFromMS).Sub(serverNow) + guard)
 	notAfter := localNow.Add(time.UnixMilli(canonical.ValidUntilMS).Sub(serverNow) - guard)
+	nextNotBefore := localNow.Add(time.UnixMilli(canonical.ValidUntilMS).Sub(serverNow) + guard)
 	if !notBefore.Before(notAfter) {
 		return errors.New("ratelimit: lease guard consumes plan interval")
 	}
 	ap := &activePlan{
 		epoch: canonical.Epoch, generation: canonical.Generation,
 		validFromMS: canonical.ValidFromMS, notBefore: notBefore, notAfter: notAfter,
-		members: canonical.Members, selfIndex: selfIndex,
+		nextNotBefore: nextNotBefore,
+		members:       canonical.Members, selfIndex: selfIndex,
 	}
 	if selfIndex >= 0 {
 		ap.selfPodID = canonical.Members[selfIndex].PodID
@@ -208,6 +214,29 @@ func (m *LeaseManager) primeFixedBuckets(now time.Time, plan *activePlan) {
 
 func (m *LeaseManager) Allow(ctx context.Context, req Request) (bool, error) {
 	return m.allowAt(ctx, &req, time.Now())
+}
+
+// GuardRetryAfter distinguishes the intentional lease-generation guard from a
+// genuinely empty token bucket. The old plan knows the next generation's safe
+// opening boundary, so a system caller that lands in the gap can wait a few
+// milliseconds and retry without weakening the no-overlap invariant.
+func (m *LeaseManager) GuardRetryAfter() time.Duration {
+	return m.guardRetryAfterAt(time.Now())
+}
+
+func (m *LeaseManager) guardRetryAfterAt(now time.Time) time.Duration {
+	plan := m.plan.Load()
+	if plan == nil {
+		return 0
+	}
+	switch {
+	case now.Before(plan.notBefore):
+		return plan.notBefore.Sub(now)
+	case !now.Before(plan.notAfter) && now.Before(plan.nextNotBefore):
+		return plan.nextNotBefore.Sub(now)
+	default:
+		return 0
+	}
 }
 
 // allowAt is the admission core with an explicit clock so deterministic tests

--- a/pkg/ratelimit/lease_manager_test.go
+++ b/pkg/ratelimit/lease_manager_test.go
@@ -245,6 +245,38 @@ func TestExpiredPlanFailsClosed(t *testing.T) {
 	}
 }
 
+func TestGuardRetryAfterCoversBothSidesOfEpochBoundary(t *testing.T) {
+	manager := NewLeaseManager(nil, NewBucketStore(16), nil, WithLeaseIdentity("local", "pod-a"))
+	serverNow := time.Now()
+	localNow := serverNow
+	guard := 250 * time.Millisecond
+	plan := Plan{
+		Version: planVersion, Epoch: 1, Generation: 16,
+		ValidFromMS:  serverNow.Add(time.Second).UnixMilli(),
+		ValidUntilMS: serverNow.Add(31 * time.Second).UnixMilli(),
+		Members:      []Member{{PodID: "pod-a", Region: "local"}},
+	}
+	if err := plan.ComputeDigest(); err != nil {
+		t.Fatal(err)
+	}
+	if err := manager.ActivatePlan(plan, serverNow, localNow, guard); err != nil {
+		t.Fatal(err)
+	}
+
+	active := manager.plan.Load()
+	beforeOpening := active.notBefore.Add(-40 * time.Millisecond)
+	if got := manager.guardRetryAfterAt(beforeOpening); got != 40*time.Millisecond {
+		t.Fatalf("opening guard retry = %v, want 40ms", got)
+	}
+	beforeNextGeneration := active.nextNotBefore.Add(-40 * time.Millisecond)
+	if got := manager.guardRetryAfterAt(beforeNextGeneration); got != 40*time.Millisecond {
+		t.Fatalf("closing guard retry = %v, want 40ms", got)
+	}
+	if got := manager.guardRetryAfterAt(active.notBefore.Add(time.Second)); got != 0 {
+		t.Fatalf("active plan retry = %v, want zero", got)
+	}
+}
+
 func TestLocalFastPathAllocatesNothing(t *testing.T) {
 	store := NewBucketStore(16)
 	manager := NewLeaseManager(nil, store, nil, WithLeaseIdentity("local", "pod-a"))

--- a/pkg/ratelimit/manager.go
+++ b/pkg/ratelimit/manager.go
@@ -2,6 +2,7 @@ package ratelimit
 
 import (
 	"context"
+	"time"
 )
 
 // Manager abstracts the rate limit decisions so the worker can remain
@@ -9,6 +10,22 @@ import (
 type Manager interface {
 	Allow(ctx context.Context, req Request) (bool, error)
 	AllowOrdered(ctx context.Context, first, second Request) (uint8, error)
+}
+
+// GuardRetryAfter reports how long a manager expects its current lease
+// generation guard to remain closed. Most managers have no lease guard and
+// return zero through this helper. Control-plane callers may use the bounded
+// hint to bridge the deliberately tiny epoch gap without mistaking it for real
+// quota exhaustion.
+func GuardRetryAfter(manager Manager) time.Duration {
+	type guardReporter interface {
+		GuardRetryAfter() time.Duration
+	}
+	reporter, ok := manager.(guardReporter)
+	if !ok {
+		return 0
+	}
+	return reporter.GuardRetryAfter()
 }
 
 // Ensure the existing Limiter implements the interface.


### PR DESCRIPTION
## What changed

- distinguish the intentional lease epoch guard from genuine Helix quota exhaustion, then let rare system-lane work wait through the bounded guard and retry once
- briefly wait for a per-channel enrollment lock before falling back to the system lane 15-second redelivery delay
- keep dashboard connection controls locked while an operation is converging
- poll quickly through the normal reconnect window, then back off, with separate connected/disconnected completion states
- extract and test the dashboard polling policy

## Why

The reported reconnect did not consume the 800-action quota. It landed in the 500 ms protected gap around a lease epoch boundary, where both the 100-action system reserve and 700-action fallback intentionally fail closed. A later overlapping restart/disconnect/enable sequence then lost the channel lock and paid the system lane 15-second NAK delay. The dashboard made this easier to trigger by leaving controls available and refreshing only every 2.5 seconds.

## Validation

- go test ./...
- bun test shared (113 passed, 1 integration-only test skipped by its existing environment guard)
- bun test dashboard/src/lib/connection-poll.test.ts shared/lib/connection-state.test.ts
- bun run check (0 errors; one pre-existing unrelated CSS compatibility warning)
- git diff --check