### PR TITLE
fix(infra): unfence valkey promotion and unify node roles

### DIFF
--- a/deploy/flux/clusters/production/falco.yaml
+++ b/deploy/flux/clusters/production/falco.yaml
@@ -135,16 +135,16 @@ spec:
     podPriorityClassName: infra-low
 
     # Chart default only tolerates control-plane taints; the extra entry keeps
-    # falco on worker1 (tainted itsbagelbot.dev/pool=worker-pool).
+    # falco on any worker-role node (tainted itsbagelbot.dev/role=worker).
     tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
       - effect: NoSchedule
         key: node-role.kubernetes.io/control-plane
       - effect: NoSchedule
-        key: itsbagelbot.dev/pool
+        key: itsbagelbot.dev/role
         operator: Equal
-        value: worker-pool
+        value: worker
 
     # Far below chart defaults (100m/512Mi -> 1000m/1024Mi); live-proven for
     # this fleet. falcoctl follow sidecar bumped to 64Mi (from 32Mi) to avoid

--- a/deploy/infra/cluster/coredns.yaml
+++ b/deploy/infra/cluster/coredns.yaml
@@ -137,10 +137,6 @@ spec:
           operator: Exists
           effect: NoSchedule
         # worker1 carries the worker-pool taint; DNS must still run there.
-        - key: itsbagelbot.dev/pool
-          operator: Equal
-          value: worker-pool
-          effect: NoSchedule
       containers:
         - name: coredns
           image: rancher/mirrored-coredns-coredns:1.14.3

--- a/deploy/infra/valkey/statefulset.yaml
+++ b/deploy/infra/valkey/statefulset.yaml
@@ -15,14 +15,14 @@ spec:
   persistentVolumeClaimRetentionPolicy:
     whenDeleted: Retain
     whenScaled: Retain
-  # Parallel startup is required for a safe cold bootstrap: the pod placed on
-  # node2 is the sole deterministic bootstrap candidate, while fresh members on
-  # every other node wait for its Sentinel view. OrderedReady could deadlock the
-  # fleet when ordinal zero is scheduled on a fenced node.
+  # Parallel startup is safe: on a cold bootstrap ordinal 0 is the deterministic
+  # seed and other FRESH members wait for its Sentinel view, so no two members can
+  # both declare themselves primary. Nothing here depends on which node a member
+  # lands on, which is what the previous hostname-based seed got wrong.
   podManagementPolicy: Parallel
-  # Three colocated Valkey+Sentinel voters produce one writable primary and
-  # three replicas, one per node since node1 left the fleet. This count is a
-  # CI-enforced configuration invariant.
+  # Three colocated Valkey+Sentinel voters: one writable primary and two replicas,
+  # every one of them promotable. Three is also the quorum arithmetic — quorum 2
+  # of 3 tolerates losing any single member. CI-enforced invariant.
   replicas: 3
   revisionHistoryLimit: 10
   selector:
@@ -58,45 +58,39 @@ spec:
         - /bin/sh
         - -ec
         - |
-          # Ask a live Sentinel before deriving any role. Stable pod DNS is
-          # authoritative and node2 is the sole deterministic fresh-cluster
-          # bootstrap candidate. Fresh pods on every other node wait for that
-          # view, which avoids making an arbitrary StatefulSet ordinal primary.
+          # Every member is equally eligible for promotion and Sentinel's own
+          # election decides. The app tier is uniform hardware, so preferring or
+          # fencing any particular host buys nothing.
           #
-          # A retained fenced primary also waits until the remaining Sentinels
-          # elect node2, node3, or node4. Retained replicas may start immediately so
-          # their colocated Sentinels can form the majority needed for failover.
-          # This turns the placement policy into a fail-closed invariant instead
-          # of relying on replica-priority, which only controls future elections.
+          # This replaced an explicit node allowlist (node2, node3, node4) that
+          # gated promotion by hostname. When the fleet moved onto
+          # node4/node5/node6 that list silently fenced two of the three live
+          # members at replica-priority 0, leaving exactly one promotable member:
+          # Sentinel could no longer fail over, so a single node loss meant no
+          # writable primary. A host allowlist was never a staleness guarantee
+          # either, since any allowlisted host could hold stale data.
           POD_FQDN="${POD_NAME}.valkey-headless.valkey.svc.cluster.local"
           lookup_master() {
             { REDISCLI_AUTH="${CORE}" valkey-cli -h valkey.valkey.svc.cluster.local -p 26380 --tls --cacert /etc/valkey/tls/ca.crt --sni valkey.valkey.svc.cluster.local --no-auth-warning sentinel get-master-addr-by-name myprimary 2>/dev/null || true; } \
               | head -n 1 | tr -d '"'
           }
-          CONFIG_PRESENT=false
-          if [ -f /data/valkey.conf ]; then
-            CONFIG_PRESENT=true
-          fi
-          FENCED=true
-          case "${NODE_NAME}" in
-            node2|node3|node4) FENCED=false ;;
-          esac
           LIVE_MASTER=$(lookup_master)
-          WAIT_FOR_PRIMARY=false
-          if [ "${FENCED}" = "true" ]; then
-            if [ "${CONFIG_PRESENT}" = "false" ] || ! grep -q '^replicaof ' /data/valkey.conf 2>/dev/null || [ "${LIVE_MASTER}" = "${POD_FQDN}" ]; then
-              WAIT_FOR_PRIMARY=true
-            fi
-          elif [ "${CONFIG_PRESENT}" = "false" ] && [ "${NODE_NAME}" != "node2" ]; then
-            WAIT_FOR_PRIMARY=true
-          fi
-          if [ "${WAIT_FOR_PRIMARY}" = "true" ]; then
-            echo "Waiting for a node2/node3/node4 Sentinel primary before starting ${POD_FQDN}"
-            while [ -z "${LIVE_MASTER}" ] || { [ "${FENCED}" = "true" ] && [ "${LIVE_MASTER}" = "${POD_FQDN}" ]; }; do
+
+          # A FRESH member with no Sentinel quorum to ask is the only case that
+          # needs a deterministic choice: without one, three simultaneously-fresh
+          # members would each declare themselves primary. Ordinal 0 seeds and the
+          # others wait for its view. The seed is the ORDINAL, never a hostname,
+          # so it stays correct wherever the members are scheduled — a hostname
+          # seed is exactly what broke when its node left the fleet.
+          # A member with a retained config already has a role and does not wait.
+          if [ ! -f /data/valkey.conf ] && [ -z "${LIVE_MASTER}" ] && [ "${POD_NAME}" != "valkey-node-0" ]; then
+            echo "Cold start with no Sentinel primary; waiting for valkey-node-0 to seed before starting ${POD_FQDN}"
+            while [ -z "${LIVE_MASTER}" ]; do
               sleep 2
               LIVE_MASTER=$(lookup_master)
             done
           fi
+
           MASTER_ENDPOINT="${POD_FQDN}"
           if [ -n "${LIVE_MASTER}" ]; then
             MASTER_ENDPOINT="${LIVE_MASTER}"
@@ -108,27 +102,18 @@ spec:
               echo "replica-announce-ip ${POD_FQDN}"
               echo "replica-announce-port 6380"
             } >> /data/valkey.conf
-            # The only fresh member allowed to see an empty Sentinel view is the
-            # pod placed on node2. It bootstraps itself; every other fresh member
-            # has waited for and follows the discovered primary.
+            # The seeding member reaches here with MASTER_ENDPOINT equal to its own
+            # FQDN and writes no replicaof line, which is what makes it primary.
             if [ -n "${LIVE_MASTER}" ] && [ "${POD_FQDN}" != "${MASTER_ENDPOINT}" ]; then
               echo "replicaof ${MASTER_ENDPOINT} 6380" >> /data/valkey.conf
             fi
             chmod 600 /data/valkey.conf
           fi
-          # Reconcile master eligibility on every boot. Retained PVCs may carry
-          # a stale CONFIG REWRITE value, so only the explicit node2/node3/node4
-          # allowlist can remain eligible for Sentinel promotion. Every other
-          # node, including worker1 and future unknown nodes, is fenced.
+          # Strip any replica-priority a retained config carries from the old
+          # fenced scheme. Promotion is unfenced now and Valkey's default (100)
+          # makes every member a candidate, so the correct action is to remove the
+          # directive rather than to rewrite it.
           sed -i '/^replica-priority /d' /data/valkey.conf
-          case "${NODE_NAME}" in
-            node2|node3|node4)
-              echo "replica-priority 100" >> /data/valkey.conf
-              ;;
-            *)
-              echo "replica-priority 0" >> /data/valkey.conf
-              ;;
-          esac
           # Keep ConfigMap-backed runtime policy authoritative over retained
           # CONFIG REWRITE output. Moving the include to the end on every boot
           # makes a config change roll out without discarding Sentinel-owned
@@ -204,10 +189,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: NODE_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
+        # No NODE_NAME: the init script branched on which host it landed on to
+        # decide promotion eligibility and the bootstrap seed. Nothing does now,
+        # and not exposing it keeps placement out of role selection for good.
         - name: CORE
           valueFrom:
             secretKeyRef:
@@ -490,11 +474,6 @@ spec:
       # Tolerate the worker-pool taint so a valkey-node lands on worker1 too.
       # Required anti-affinity keeps exactly one member per node without
       # exposing Valkey through a hostPort.
-      tolerations:
-      - key: itsbagelbot.dev/pool
-        operator: Equal
-        value: worker-pool
-        effect: NoSchedule
       schedulerName: default-scheduler
       affinity:
         podAntiAffinity:

--- a/deploy/infra/valkey/topology_test.go
+++ b/deploy/infra/valkey/topology_test.go
@@ -43,25 +43,40 @@ func TestSentinelSinglePrimaryTopologyIsConfigured(t *testing.T) {
 	)
 }
 
-func TestMasterEligibilityIsReconciledOnEveryBoot(t *testing.T) {
+// TestPromotionIsUnfenced replaces the old host-allowlist assertions. That
+// allowlist gated promotion by hostname, and when the fleet moved onto
+// node4/node5/node6 it silently fenced two of the three live members at
+// replica-priority 0 — leaving one promotable member, so Sentinel could not fail
+// over and a single node loss meant no writable primary. Every member is now a
+// candidate and Sentinel's election decides.
+func TestPromotionIsUnfenced(t *testing.T) {
 	statefulSet := readFile(t, "statefulset.yaml")
 
-	assert.Contains(t, statefulSet, `case "${NODE_NAME}" in`)
-	assert.Contains(t, statefulSet, `node2|node3|node4)`)
-	assert.Equal(t, 1, strings.Count(statefulSet, `echo "replica-priority 100"`), "node2/node3/node4 are the only eligible nodes")
-	assert.Equal(t, 1, strings.Count(statefulSet, `echo "replica-priority 0"`), "all non-allowlisted nodes are fenced")
-	assert.NotContains(t, statefulSet, `replica-priority 200`, "node1 must never remain a last-resort master")
+	assert.NotRegexp(t, `node[0-9]\|node[0-9]`, statefulSet,
+		"no host allowlist may gate promotion or startup")
+	assert.NotRegexp(t, `(?m)^\s+echo "replica-priority`, statefulSet,
+		"no member may be written a replica-priority; the default makes all eligible")
+	assert.Contains(t, statefulSet, `sed -i '/^replica-priority /d' /data/valkey.conf`,
+		"a retained config's stale replica-priority must be stripped")
+	assert.NotRegexp(t, `(?m)^\s+- name: NODE_NAME$`, statefulSet,
+		"placement must not be exposed to the init script at all")
 }
 
-func TestColdBootstrapCannotMakeAnArbitraryOrdinalPrimary(t *testing.T) {
+// TestColdBootstrapSeedsByOrdinalNotHost pins the one deterministic choice that
+// remains. Without it three simultaneously-fresh members would each declare
+// themselves primary. The seed is the ordinal precisely because it is
+// placement-independent: the previous hostname seed made the whole StatefulSet
+// undeployable the moment that node left the fleet.
+func TestColdBootstrapSeedsByOrdinalNotHost(t *testing.T) {
 	statefulSet := readFile(t, "statefulset.yaml")
 
 	assert.Regexp(t, `(?m)^  podManagementPolicy: Parallel$`, statefulSet)
-	assert.Contains(t, statefulSet, `elif [ "${CONFIG_PRESENT}" = "false" ] && [ "${NODE_NAME}" != "node2" ]; then`)
-	assert.Contains(t, statefulSet, `Waiting for a node2/node3/node4 Sentinel primary`)
-	assert.Contains(t, statefulSet, `[ "${FENCED}" = "true" ] && [ "${LIVE_MASTER}" = "${POD_FQDN}" ]`)
-	assert.NotContains(t, statefulSet, "POD_INDEX", "StatefulSet ordinal must not confer primary eligibility")
-	assert.NotContains(t, statefulSet, "MASTER_ENDPOINT:-valkey-node-0", "pod zero must not be a cold-start fallback")
+	assert.Contains(t, statefulSet, `[ "${POD_NAME}" != "valkey-node-0" ]`,
+		"ordinal 0 must be the cold-start seed")
+	assert.Contains(t, statefulSet, `[ ! -f /data/valkey.conf ]`,
+		"only a fresh member waits; a retained member already has a role")
+	assert.Contains(t, statefulSet, `sentinel monitor myprimary ${MASTER_ENDPOINT} 6380 2`,
+		"Sentinel quorum stays 2 of 3")
 }
 
 func TestLocalReadServiceRemainsNodeLocal(t *testing.T) {

--- a/deploy/k8s/commands.yaml
+++ b/deploy/k8s/commands.yaml
@@ -38,10 +38,6 @@ spec:
         app: commands
     spec:
       tolerations:
-        - key: itsbagelbot.dev/pool
-          operator: Equal
-          value: worker-pool
-          effect: NoSchedule
         - key: node.kubernetes.io/unreachable
           operator: Exists
           effect: NoExecute

--- a/deploy/k8s/console-admin.yaml
+++ b/deploy/k8s/console-admin.yaml
@@ -77,9 +77,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                  - key: itsbagelbot.dev/pool
+                  - key: itsbagelbot.dev/role
                     operator: NotIn
-                    values: ["worker-pool"]
+                    values: ["worker"]
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100

--- a/deploy/k8s/console-dashboard.yaml
+++ b/deploy/k8s/console-dashboard.yaml
@@ -74,9 +74,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                  - key: itsbagelbot.dev/pool
+                  - key: itsbagelbot.dev/role
                     operator: NotIn
-                    values: ["worker-pool"]
+                    values: ["worker"]
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: kubernetes.io/hostname

--- a/deploy/k8s/gateway.yaml
+++ b/deploy/k8s/gateway.yaml
@@ -53,10 +53,6 @@ spec:
         app: gateway
     spec:
       tolerations:
-        - key: itsbagelbot.dev/pool
-          operator: Equal
-          value: worker-pool
-          effect: NoSchedule
         - key: node.kubernetes.io/unreachable
           operator: Exists
           effect: NoExecute

--- a/deploy/k8s/loyalty.yaml
+++ b/deploy/k8s/loyalty.yaml
@@ -40,10 +40,6 @@ spec:
         app: loyalty
     spec:
       tolerations:
-        - key: itsbagelbot.dev/pool
-          operator: Equal
-          value: worker-pool
-          effect: NoSchedule
         - key: node.kubernetes.io/unreachable
           operator: Exists
           effect: NoExecute

--- a/deploy/k8s/modules.yaml
+++ b/deploy/k8s/modules.yaml
@@ -38,10 +38,6 @@ spec:
         app: modules
     spec:
       tolerations:
-        - key: itsbagelbot.dev/pool
-          operator: Equal
-          value: worker-pool
-          effect: NoSchedule
         - key: node.kubernetes.io/unreachable
           operator: Exists
           effect: NoExecute

--- a/deploy/k8s/nats-leaf.yaml
+++ b/deploy/k8s/nats-leaf.yaml
@@ -37,10 +37,6 @@ spec:
         app: nats-leaf
     spec:
       tolerations:
-        - key: itsbagelbot.dev/pool
-          operator: Equal
-          value: worker-pool
-          effect: NoSchedule
       # Shared PID namespace lets the config-reloader sidecar SIGHUP the
       # nats-server process (same uid 1000) when the mounted config changes.
       shareProcessNamespace: true

--- a/deploy/k8s/nats.yaml
+++ b/deploy/k8s/nats.yaml
@@ -41,43 +41,29 @@ spec:
           operator: Exists
           effect: NoExecute
           tolerationSeconds: 60
-        # node1 carries a dedicated=nats-ingress taint and hosts nats-2; without
-        # this toleration that member has nowhere to run, because its
-        # jetstream-data PVC is local-path and bound to node1.
-        - key: dedicated
-          operator: Equal
-          value: nats-ingress
-          effect: NoSchedule
-        # Inert while worker1 is excluded below. Kept so this spec matches what
-        # is applied; drop it during a planned roll, not as a drive-by edit —
-        # any change here restarts the whole quorum.
-        - key: itsbagelbot.dev/pool
-          operator: Equal
-          value: worker-pool
-          effect: NoSchedule
-      # The JetStream hub is a 3-member RAFT quorum on node1/node2/node3.
-      # worker1 rides a home-wifi link and is excluded: an R1 stream whose
-      # single replica landed there would stall on every blip.
-      # JetStream PVCs are local-path (node-bound), so this exclusion is not a
-      # preference — moving a member to another node means deleting its
-      # jetstream-data PVC + pod so it reprovisions there and RAFT re-syncs it.
-      # Flipping the excluded host without doing that leaves the member
-      # unschedulable and the quorum at 2/3.
+      # No taint tolerations beyond the eviction pair above, and no host
+      # allowlist. The app tier is uniform hardware, so the scheduler is left to
+      # place members freely; the control plane is excluded because it carries a
+      # role taint this spec deliberately does not tolerate.
+      #
+      # What went: a dedicated=nats-ingress toleration that existed so a member
+      # could follow its node-bound volume onto node1, and a NotIn [worker1]
+      # exclusion for a home-wifi node that is leaving the fleet. Both encoded a
+      # hardware asymmetry that no longer exists, and with node1 now the 2-core
+      # control plane the toleration had become actively harmful.
       affinity:
-        nodeAffinity:
+        # Hard one-member-per-node, replacing a ScheduleAnyway hostname spread.
+        # The soft form permitted two members on a single host, which quietly
+        # turned any single node loss into a QUORUM loss (2 of 3 gone at once).
+        # Required anti-affinity makes surviving one node loss structural rather
+        # than a scheduling accident, and with three members on three app-tier
+        # nodes it is exactly satisfiable.
+        podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: kubernetes.io/hostname
-                    operator: NotIn
-                    values: [worker1]
-      topologySpreadConstraints:
-        - maxSkew: 1
-          topologyKey: kubernetes.io/hostname
-          whenUnsatisfiable: ScheduleAnyway
-          labelSelector:
-            matchLabels:
-              app: nats
+            - topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  app: nats
       # nats runs as uid/gid 1000; fsGroup makes the JetStream PVC writable.
       # Shared PID namespace lets the config-reloader sidecar SIGHUP the
       # nats-server process (same uid 1000) when the mounted config changes.
@@ -113,13 +99,13 @@ spec:
             - {name: jetstream-data, mountPath: /data/jetstream}
             - {name: pid, mountPath: /var/run/nats}
           resources:
-            # R1 memory-backed ingress needs enough headroom above JetStream's
-            # 4GB max_mem for dedup indexes, connections and the Go runtime.
-            # node2/node3 each have 6 cores and worker1 has 8. Sustained load
-            # has peaked around 1.77 cores on the R1 leader. Reserve 1.5 cores
-            # on every member so quorum placement does not strand half a node,
-            # while the 4-core ceiling still lets the active leader burst.
-            # Memory stays at 2Gi because one member can own all R1 streams.
+            # Memory-backed streams need headroom above JetStream's 4GB max_mem for
+            # dedup indexes, connections and the Go runtime. Every app-tier node
+            # has 12 cores. Sustained load has peaked near 1.77 cores on a stream
+            # leader; reserve 1.5 on every member so quorum placement never
+            # strands a node, while the 4-core ceiling lets the leader burst.
+            # Memory stays 2Gi: with every stream R3 each member holds a copy of
+            # all of them rather than only the ones it leads.
             requests: {cpu: 1500m, memory: 2Gi}
             limits: {cpu: "4", memory: 6Gi}
           securityContext:
@@ -131,7 +117,7 @@ spec:
               exec:
                 # Allow in-flight JetStream operations and client reconnects to
                 # drain before the socket closes. Shortens the 500 blast radius
-                # during NATS restarts (hub is still single-replica).
+                # during NATS restarts.
                 command: ["/bin/sh", "-c", "sleep 10"]
           startupProbe:
             httpGet: {path: /healthz, port: monitor}
@@ -221,7 +207,7 @@ metadata:
   namespace: production
 spec:
   # JetStream clients dial this Service directly. Prefer the hub on the same
-  # node so node2/node3/worker1 avoid an unnecessary cross-node or home-WAN hop.
+  # node so app-tier clients avoid an unnecessary cross-node hop.
   trafficDistribution: PreferSameNode
   selector:
     app: nats

--- a/deploy/k8s/notifications.yaml
+++ b/deploy/k8s/notifications.yaml
@@ -38,10 +38,6 @@ spec:
         app: notifications
     spec:
       tolerations:
-        - key: itsbagelbot.dev/pool
-          operator: Equal
-          value: worker-pool
-          effect: NoSchedule
         - key: node.kubernetes.io/unreachable
           operator: Exists
           effect: NoExecute
@@ -52,7 +48,7 @@ spec:
           tolerationSeconds: 60
       topologySpreadConstraints:
         - maxSkew: 1
-          minDomains: 4
+          minDomains: 3
           topologyKey: kubernetes.io/hostname
           whenUnsatisfiable: DoNotSchedule
           matchLabelKeys: [pod-template-hash]
@@ -181,10 +177,6 @@ spec:
         spec:
           restartPolicy: OnFailure
           tolerations:
-            - key: itsbagelbot.dev/pool
-              operator: Equal
-              value: worker-pool
-              effect: NoSchedule
           securityContext:
             runAsNonRoot: true
             runAsUser: 65532

--- a/deploy/k8s/outgress.yaml
+++ b/deploy/k8s/outgress.yaml
@@ -41,10 +41,6 @@ spec:
         app: outgress
     spec:
       tolerations:
-        - key: itsbagelbot.dev/pool
-          operator: Equal
-          value: worker-pool
-          effect: NoSchedule
         - key: node.kubernetes.io/unreachable
           operator: Exists
           effect: NoExecute

--- a/deploy/k8s/projector.yaml
+++ b/deploy/k8s/projector.yaml
@@ -38,10 +38,6 @@ spec:
         app: projector
     spec:
       tolerations:
-        - key: itsbagelbot.dev/pool
-          operator: Equal
-          value: worker-pool
-          effect: NoSchedule
         - key: node.kubernetes.io/unreachable
           operator: Exists
           effect: NoExecute

--- a/deploy/k8s/sesame.yaml
+++ b/deploy/k8s/sesame.yaml
@@ -44,10 +44,6 @@ spec:
         app: sesame
     spec:
       tolerations:
-        - key: itsbagelbot.dev/pool
-          operator: Equal
-          value: worker-pool
-          effect: NoSchedule
         - key: node.kubernetes.io/unreachable
           operator: Exists
           effect: NoExecute

--- a/deploy/k8s/topology_spread_test.go
+++ b/deploy/k8s/topology_spread_test.go
@@ -96,8 +96,16 @@ func TestRolloutSensitiveWorkloadsHardSpreadEachReplicaSet(t *testing.T) {
 		minDomains int
 	}{
 		{"console-admin.yaml", "console-admin", 0},
-		{"notifications.yaml", "notifications", 4},
-		{"transactions.yaml", "transactions", 4},
+		// minDomains tracks the number of schedulable app-tier nodes, which is 3.
+		// It must NEVER exceed that count: when it does, skew is measured against
+		// a global minimum of zero and every replica becomes unschedulable, so an
+		// over-large value is a total outage rather than a loose constraint. This
+		// was 4 while the fleet had four app nodes, and only kept working after
+		// the move because the cordoned old nodes still counted as domains
+		// (nodeTaintsPolicy defaults to Ignore) — deleting them would have taken
+		// both of these services to zero replicas.
+		{"notifications.yaml", "notifications", 3},
+		{"transactions.yaml", "transactions", 3},
 		{"twitch-ingress.yaml", "twitch-ingress", 0},
 	}
 
@@ -118,11 +126,18 @@ func TestRolloutSensitiveWorkloadsHardSpreadEachReplicaSet(t *testing.T) {
 }
 
 // excludesWorkerPool captures the placement rule under test: a nodeAffinity
-// match expression that keeps the workload off the worker pool.
+// match expression that keeps the workload off worker-role nodes.
+//
+// The key moved from itsbagelbot.dev/pool=worker-pool to
+// itsbagelbot.dev/role=worker when node roles were unified onto one key
+// (cp / node / worker). No worker-role node exists yet, so this guard is
+// currently inert — it is kept expressed on the live key so that it starts
+// holding the moment one is added, rather than silently pointing at a retired
+// label that nothing would ever match.
 func excludesWorkerPool(key, operator string, values []string) bool {
-	return key == "itsbagelbot.dev/pool" &&
+	return key == "itsbagelbot.dev/role" &&
 		operator == "NotIn" &&
-		slices.Contains(values, "worker-pool")
+		slices.Contains(values, "worker")
 }
 
 func TestConsoleAdminExplicitlyExcludesWorkerPool(t *testing.T) {

--- a/deploy/k8s/transactions.yaml
+++ b/deploy/k8s/transactions.yaml
@@ -38,10 +38,6 @@ spec:
         app: transactions
     spec:
       tolerations:
-        - key: itsbagelbot.dev/pool
-          operator: Equal
-          value: worker-pool
-          effect: NoSchedule
         - key: node.kubernetes.io/unreachable
           operator: Exists
           effect: NoExecute
@@ -52,7 +48,7 @@ spec:
           tolerationSeconds: 60
       topologySpreadConstraints:
         - maxSkew: 1
-          minDomains: 4
+          minDomains: 3
           topologyKey: kubernetes.io/hostname
           whenUnsatisfiable: DoNotSchedule
           matchLabelKeys: [pod-template-hash]

--- a/deploy/k8s/twitch-ingress.yaml
+++ b/deploy/k8s/twitch-ingress.yaml
@@ -68,10 +68,6 @@ spec:
         app: twitch-ingress
     spec:
       tolerations:
-        - key: itsbagelbot.dev/pool
-          operator: Equal
-          value: worker-pool
-          effect: NoSchedule
         - key: node.kubernetes.io/unreachable
           operator: Exists
           effect: NoExecute

--- a/deploy/k8s/users.yaml
+++ b/deploy/k8s/users.yaml
@@ -38,10 +38,6 @@ spec:
         app: users
     spec:
       tolerations:
-        - key: itsbagelbot.dev/pool
-          operator: Equal
-          value: worker-pool
-          effect: NoSchedule
         - key: node.kubernetes.io/unreachable
           operator: Exists
           effect: NoExecute

--- a/docs/src/content/docs/reference/sesame-module-builder.md
+++ b/docs/src/content/docs/reference/sesame-module-builder.md
@@ -1,0 +1,224 @@
+---
+title: Sesame Module Builder
+description: The fluent authoring API for sesame modules and commands, with every builder method and the gate order the engine applies.
+---
+
+A sesame feature is one function returning one `module.Module` value. The builder
+in `app/sesame/module/builder.go` assembles that value; the engine in
+`app/sesame/engine/` indexes and runs it.
+
+The builder package carries **no runtime wiring** (no NATS, Valkey, projection or
+pipeline). A module receives `engine.Deps` and its handlers capture what they need
+by closure, which is what keeps the authoring surface small and unit-testable
+without a cluster.
+
+## Minimum module
+
+```go
+func Ping(d engine.Deps) module.Module {
+    m := module.NewModule("", module.KindCore)
+    m.Command("ping").Everyone().Run(
+        func(ctx context.Context, c *module.Context, args string, emit module.Emit) error {
+            emit(&module.Output{
+                Type:          outgress.TypeChat,
+                BroadcasterID: c.Env.BroadcasterUserID,
+                Text:          "pong",
+            })
+            return nil
+        })
+    return m.Build()
+}
+```
+
+Then add one line to `app/sesame/modules/all.go`. That is the whole registration
+step.
+
+## Module-level API
+
+| Call | Purpose |
+|---|---|
+| `module.NewModule(name, kind)` | Start a module. Returns `*Builder`. |
+| `b.Command(name)` | Begin a chat command. Returns `*CmdBuilder` to chain gates. Name is lowercased. |
+| `b.On(eventType, fn)` | Register a non-command handler for one EventSub type. Registering the same type twice keeps the last handler. |
+| `b.Build()` | Validate and return the immutable `Module`. **Panics** on a programmer error. |
+| `b.Validate()` | Same checks without panicking. For tests. |
+
+A `Builder` is single-use and not safe for concurrent use.
+
+## Kinds
+
+| Kind | Name | Behaviour |
+|---|---|---|
+| `KindCore` | optional | Always on. Never listed to broadcasters, never toggled, no config. The engine skips the `ModuleView` projection fetch entirely for it. |
+| `KindDefault` | required | Named, ships **enabled**. Runs unless the broadcaster disables it. |
+| `KindOptIn` | required | Named, ships **disabled**. Runs only when the broadcaster enables it. |
+
+`Build` enforces the pairing: a named kind with an empty name fails.
+
+Core skipping the projection fetch is a hot-path property, not a detail. A named
+module costs a `ModuleView` lookup per message to decide whether it runs. Core
+costs nothing. A core module that still wants a per-broadcaster toggle does its
+own lazy check inside `Run` (see `moduleEnabled` in `modules/followage.go`).
+
+## Command gates
+
+Every method below returns the same `*CmdBuilder`, so they chain. `Run` is
+terminal and returns nothing.
+
+### Permission
+
+Each sets the **minimum** role, so higher roles also pass.
+
+| Method | Minimum role |
+|---|---|
+| `.Everyone()` | anyone in chat (the default) |
+| `.Sub()` | subscriber |
+| `.VIP()` | VIP |
+| `.Mod()` | moderator |
+| `.Broadcaster()` | channel owner only |
+
+Ladder order: `RoleEveryone` → `RoleSubscriber` → `RoleVIP` → `RoleModerator` →
+`RoleLeadModerator` → `RoleBroadcaster`.
+
+**There is no `.LeadMod()` builder method**, even though `RoleLeadModerator` sits
+in the ladder. That entry exists for *inclusion*, not gating: Twitch ships the
+`lead_moderator` badge **instead of** `moderator`, so without a rank above
+moderator every lead mod would fail a `.Mod()` gate for want of a recognised
+badge. `.Mod()` therefore already admits lead moderators and above.
+
+The tier is otherwise first-class: `permRoles` maps `"lead_mod"`,
+`internal/domain/validate` accepts it, the `commands` ent schema stores it, and
+the dashboard offers "Lead moderators & up". So a broadcaster-authored **custom**
+command can be lead-mod-only (the engine gates baked and custom commands through
+the same `gate()`), while a **baked** module currently cannot express "lead mods
+and up, excluding plain mods". Adding `.LeadMod()` would be a one-line
+`CmdBuilder` setter if a built-in ever needs it.
+
+| Method | Purpose |
+|---|---|
+| `.AllowUser(id)` | Restrict to exactly one chatter id. **Overrides the role gate entirely.** |
+
+### Conditions
+
+| Method | Purpose |
+|---|---|
+| `.Cooldown(d)` | Shared per-command window. Zero (default) means none. |
+| `.LiveOnly()` | Only runs while the broadcaster is live. |
+
+### Matching
+
+| Method | Purpose |
+|---|---|
+| `.Aliases(a, b, ...)` | Extra triggers resolving to this command. Lowercased. Duplicates rejected by `Validate`. |
+| `.NumericSuffix()` | Trigger absorbs trailing digits typed inline: `!clip30` resolves to `clip` with `c.Num == "30"`. Digits are stripped and are **not** the argument string. |
+
+### Terminal
+
+| Method | Purpose |
+|---|---|
+| `.Run(fn)` | Sets the handler and finishes the command. Returns nothing so a declaration cannot continue past it. |
+
+## Gate order
+
+The engine applies gates centrally in `engine/dispatch.go`:
+
+```go
+func (p *Pipeline) gate(ctx, c, r gateRule) (bool, error) {
+    if !permits(c, r.allowedUserID, r.perm) { return false, nil }          // 1
+    if ok, err := p.liveOK(ctx, c, r.liveOnly); !ok { return false, err }  // 2
+    return p.cooldownOK(ctx, c.BroadcasterID, r.name, r.cooldown)          // 3
+}
+```
+
+1. permission
+2. live-only
+3. cooldown
+
+**Cooldown is last on purpose.** `cooldownOK` *claims* the window when it passes.
+If it ran first, a chatter who fails the permission check would still burn
+everyone else's cooldown.
+
+Baked commands and broadcaster-authored custom commands build the same
+`gateRule`, so permission semantics cannot drift between built-ins and user
+commands.
+
+## What `Run` receives
+
+```go
+type RunFunc func(ctx context.Context, c *Context, args string, emit Emit) error
+```
+
+- `args` is the trimmed string **after** the command name.
+- `c.Env` is the chat envelope: `BroadcasterUserID`, `ChatterUserID`,
+  `ChatterUserLogin`, `ChatterName()`, badges.
+- `c.Chatter()` resolves the chatter's role, parsed once and cached.
+- `c.Locale` is the broadcaster's language. Use `i18n.T(c.Locale, "key")`.
+- `c.Config` is this module's raw config blob; `c.Decode(&out)` unmarshals it.
+  Empty for core modules, and a missing config is not an error.
+- `c.Num` is the inline numeric suffix, set only for a `NumericSuffix` command.
+
+### Pooling rules
+
+Both of these will corrupt other messages if ignored.
+
+- **Do not retain `c` past the call.** `Context` is pooled and `Reset()` between
+  messages.
+- **Do not retain the `Output` passed to `emit`.** The engine may recycle it as
+  soon as `Emit` returns.
+
+Copy anything that must outlive the call.
+
+## Emitting
+
+```go
+emit(&module.Output{
+    Type:          outgress.TypeChat,
+    BroadcasterID: c.Env.BroadcasterUserID,
+    Text:          "hello",
+})
+```
+
+`Output.Type` selects the action (`outgress.TypeChat`, `TypeAnnounce`, clip,
+shoutout, moderation, redemption resolution). Type-specific fields are documented
+on the struct in `module/module.go`; fields belonging to other types are ignored.
+`BatchID`/`Items` carry a multi-message response as one outgress queue job,
+executed in slice order.
+
+## Validation
+
+`Build` panics rather than returning an error, because these are startup
+misconfigurations rather than runtime data, and failing loud at boot beats
+silently misbehaving in production. It rejects:
+
+- a named kind with an empty name
+- an unknown kind
+- an empty command name or empty alias
+- a duplicate trigger **within the same module**
+- a command with no `Run` (reported as "chain .Run to finish it")
+
+A command you forget to finish still exists as an incomplete entry, because
+`Command()` appends it before any chaining happens, which is exactly how
+`Validate` catches it.
+
+## Cross-module collisions
+
+Duplicates *within* a module panic at build. Duplicates *across* modules are
+**first-wins** with a warning log (`engine: duplicate command trigger ignored`).
+
+Ordering in `all.go` is therefore load-bearing: core modules are listed first so
+their reserved triggers win over any named module declaring a clash.
+
+## Checklist for a new module
+
+1. Create `app/sesame/modules/<name>.go`.
+2. `func <Name>(d engine.Deps) module.Module`.
+3. `module.NewModule(name, kind)`.
+4. Declare commands with `.Command(...).<gates>.Run(fn)` and events with
+   `.On(type, fn)`.
+5. `return m.Build()`.
+6. Add one line to `all.go`.
+7. Localise replies via `i18n.T(c.Locale, key)`.
+8. Guard optional services (`d.X != nil`) and decide the failure policy
+   deliberately; existing modules fail **open** so a transient projection blip
+   does not swallow a command.
+9. Add `<name>_test.go`. `Validate()` runs without a cluster.

--- a/pkg/bus/provision_test.go
+++ b/pkg/bus/provision_test.go
@@ -201,13 +201,18 @@ func TestEveryFleetStreamEnablesBatchPublishing(t *testing.T) {
 func TestStreamReplicasAreExplicitAndEnforced(t *testing.T) {
 	ingress := ingressStreamSpec(t)
 
-	// The firehose is R1: its async PubAck-bound producer must not pay a per-publish
-	// RAFT quorum. The control lane stays R3 because a lost enroll job is invisible.
-	if got := streamConfig(ingress).Replicas; got != 1 {
-		t.Fatalf("TWITCH_INGRESS replicas = %d, want 1 (R1 firehose)", got)
+	// Every fleet stream is R3. The hub has no persistent volumes, so replication
+	// is the only thing that makes a stream survive losing a member: an R1 stream
+	// ceases to exist when its sole peer is rescheduled. The firehose used to be
+	// the one R1 exemption for ack latency; that was measured on 6-core peers and
+	// no longer applies on the 12-core quorum.
+	for _, spec := range append(append([]StreamSpec{}, DataStreams...), OutgressStream, OutgressSystemStream) {
+		if got := streamConfig(spec).Replicas; got != 3 {
+			t.Fatalf("%s replicas = %d, want 3 (volume-less hub relies on replication)", spec.Name, got)
+		}
 	}
-	if got := streamConfig(OutgressSystemStream).Replicas; got != 3 {
-		t.Fatalf("TWITCH_OUTGRESS_SYSTEM replicas = %d, want 3 (durable control lane)", got)
+	if got := streamConfig(ingress).Replicas; got != 3 {
+		t.Fatalf("TWITCH_INGRESS replicas = %d, want 3", got)
 	}
 
 	// A zero-value Replicas defaults to a single copy, never 0 (which NATS rejects).
@@ -215,37 +220,42 @@ func TestStreamReplicasAreExplicitAndEnforced(t *testing.T) {
 		t.Fatalf("default replicas = %d, want 1", got)
 	}
 
-	// streamMatches must be replica-sensitive, or a live stream hand-edited to R3
-	// stays R3 while the spec declares R1 — the invisible drift this change fixes.
-	want := *streamConfig(ingress) // R1
+	// streamMatches must be replica-sensitive in both directions. A live stream
+	// that has fallen to a single copy — a partial restore, or a hand edit — must
+	// converge back up to R3, because on a hub with no persistent volumes that
+	// lone copy disappears the moment its member is rescheduled.
+	want := *streamConfig(ingress) // R3
 	drifted := want
-	drifted.Replicas = 3
+	drifted.Replicas = 1
 	if streamMatches(drifted, want) {
-		t.Fatal("streamMatches ignored a replica drift; live R3 would never converge to R1")
+		t.Fatal("streamMatches ignored a replica drift; a live R1 stream would never converge back to R3")
 	}
 }
 
-func TestR1StreamsStayOffWorker1(t *testing.T) {
+// TestNoStreamPinsPlacement replaces the old "R1 streams stay off worker1"
+// guard, which pinned each single-replica stream to an ordinal so its sole copy
+// never landed on the WAN-connected peer. The hub now runs three replicated
+// members with no persistent volumes, so a stream must be free to follow its
+// member wherever the pod is rescheduled. An ordinal tag would make it a pet
+// again — and worse, would leave an R3 stream unschedulable, since placement
+// must be satisfiable by all three peers at once.
+func TestNoStreamPinsPlacement(t *testing.T) {
 	specs := append([]StreamSpec{}, DataStreams...)
-	specs = append(specs, OutgressStream)
+	specs = append(specs, OutgressStream, OutgressSystemStream, ingressStreamSpec(t))
 	for _, spec := range specs {
-		cfg := streamConfig(spec)
-		if cfg.Replicas != 1 {
-			continue
-		}
-		if cfg.Placement == nil || len(cfg.Placement.Tags) != 1 {
-			t.Fatalf("R1 stream %s has no ordinal placement", spec.Name)
-		}
-		if cfg.Placement.Tags[0] == "nats-2" {
-			t.Fatalf("R1 stream %s may place its sole leader on worker1", spec.Name)
+		if cfg := streamConfig(spec); cfg.Placement != nil {
+			t.Fatalf("stream %s pins placement to %v; the volume-less hub requires unpinned streams",
+				spec.Name, cfg.Placement.Tags)
 		}
 	}
 
+	// Placement must stay part of streamMatches even though no spec sets it: a
+	// tag applied out-of-band has to be reconciled back off, not persist silently.
 	want := *streamConfig(ingressStreamSpec(t))
 	drifted := want
 	drifted.Placement = &nats.Placement{Tags: []string{"nats-2"}}
 	if streamMatches(drifted, want) {
-		t.Fatal("streamMatches ignored placement drift")
+		t.Fatal("streamMatches ignored placement drift; a hand-pinned stream would never converge back")
 	}
 }
 

--- a/pkg/bus/streams.go
+++ b/pkg/bus/streams.go
@@ -45,17 +45,24 @@ type StreamSpec struct {
 	// Replicas is the RAFT replication factor (0 defaults to 1). Unlike Storage,
 	// replica count IS updatable in place, so reconcileStream converges a drifted
 	// stream via UpdateStream — this is the field streamMatches must compare, or a
-	// live stream hand-edited to R3 sticks at R3 forever while the spec says R1.
-	// R1 is the throughput choice for the perishable firehose: R3 makes every
-	// publish wait on a RAFT quorum before its PubAck, which is pure ack-latency
-	// inflation on an ack-bound producer. Reserve R3 for control/data streams
-	// whose loss on a single broker restart actually matters.
+	// live stream hand-edited to a different factor never converges back.
+	//
+	// Every fleet stream is R3. The hub is a three-member quorum with one member
+	// per node and no persistent volumes, so replication is the ONLY thing making
+	// a stream survive losing a broker — an R1 stream would simply cease to exist
+	// with its member. R3 does cost a quorum ack before every PubAck, which the
+	// earlier R1 firehose exemption existed to avoid; that exemption was measured
+	// on 6-core peers, and the fleet sustained 120k/s for an hour once all three
+	// members ran on 12-core hardware, so the ceiling no longer justifies making
+	// one stream a special case.
 	Replicas int
 	// PlacementTags constrain JetStream replicas to servers carrying every tag.
-	// We use the stable StatefulSet ordinal tag for R1 streams so the hot
-	// firehoses never land on worker1's WAN-connected peer after a restart.
-	// R3 streams cannot use an ordinal placement tag because all three peers are
-	// required; their preferred leader is managed operationally.
+	//
+	// No fleet stream sets this, and none should: pinning a stream to an ordinal
+	// makes it a pet that cannot follow its member when the pod is rescheduled,
+	// which is exactly what the volume-less hub is designed to allow. The field
+	// and its comparison in streamMatches are kept deliberately so that a tag set
+	// by hand out-of-band is reconciled back off rather than silently persisting.
 	PlacementTags []string
 }
 
@@ -79,10 +86,11 @@ var OutgressStream = StreamSpec{
 	// 256 MiB MaxBytes caps the memory it can hold.
 	Storage:      nats.MemoryStorage,
 	BatchPublish: true,
-	// R1: perishable 5s chat work. A dropped in-flight send is re-driven by the
-	// pipeline; RAFT replication would only add ack latency to the send path.
-	Replicas:      1,
-	PlacementTags: []string{"nats-1"},
+	// R3. This was R1 pinned to nats-1, which made the stream a casualty of moving
+	// that member: an R1 stream has no second copy to re-sync from, so relocating
+	// its sole peer deletes it outright. Outgress is Twitch-rate-limited to tens
+	// of sends per second, so a quorum round trip per publish costs nothing here.
+	Replicas: 3,
 }
 
 // OutgressSystemStream carries the outgress control lane: EventSub enroll
@@ -119,11 +127,12 @@ var BagelDataStream = StreamSpec{
 	MaxAge:       5 * time.Minute,
 	MaxBytes:     512 << 20, // 512 MiB
 	BatchPublish: true,
-	// R1: a low-rate, 5-minute replay buffer. A broker restart drops at most a
-	// few minutes of change events, which the projector re-derives from the
-	// data services' RPC projections — not worth a per-publish RAFT quorum.
-	Replicas:      1,
-	PlacementTags: []string{"nats-1"},
+	// R3. This was R1 pinned to nats-1, so relocating that member deleted the
+	// stream outright rather than re-syncing it — there was no second copy. The
+	// projector can re-derive these events from the data services' RPC
+	// projections, but a low-rate 5-minute buffer with 24 durable consumers should
+	// not need that recovery every time a hub member is rescheduled.
+	Replicas: 3,
 }
 
 // TwitchIngressStream is the replayable Twitch ingress firehose. Sesame owns
@@ -138,14 +147,15 @@ var TwitchIngressStream = StreamSpec{
 	// write that capped synchronous PubAck throughput to a few thousand
 	// events/second. Requires the server max_mem headroom in nats-server.conf.
 	Storage: nats.MemoryStorage,
-	// R1 (explicit, and now enforced by streamMatches). The firehose producer
-	// is async PubAck-bound — its ceiling is max_pending / ack_latency — so R3
-	// RAFT consensus per publish is pure ack-latency inflation. A lost leader
-	// drops only in-flight perishable chat (5s/5m retention), the accepted
-	// trade for the throughput. Every hub node (node2/node3/worker1) is
-	// capable, so replication buys nothing here that offsets the latency cost.
-	Replicas:      1,
-	PlacementTags: []string{"nats-0"},
+	// R3, like every other fleet stream. This was the one R1 exemption, pinned to
+	// nats-0: the producer is async PubAck-bound, so a quorum ack per publish
+	// inflates the very latency its ceiling is measured in. Two things retired
+	// that exemption. The hub no longer has persistent volumes, so an R1 stream
+	// ceases to exist when its member is rescheduled rather than merely losing a
+	// leader. And the ~60k single-stream figure behind the trade was measured with
+	// 6-core peers in the quorum; the fleet sustained 120k/s for an hour once all
+	// three members ran on 12-core hardware, which is past what this stream needs.
+	Replicas: 3,
 	// MaxBytes is 1 GiB so the memory-backed stream fits the broker's 4GB
 	// max_mem alongside TWITCH_OUTGRESS and dedup state. MaxAge is moot under
 	// load: MaxBytes (stream-wide, oldest-first) evicts first, and 1 GiB is the


### PR DESCRIPTION
Fixes a **live single point of failure** left by the emergency topology move, plus the two landmines it left behind. Rebuilt on current `main` (the survival commit `e633eba4` is included).

## Valkey was a SPOF

The init script gated promotion by hostname allowlist (`node2, node3, node4`). When the members moved onto node4/node5/node6, that list silently fenced two of three live members:

```
valkey-node-0  node6  replica-priority 0    <- could not be promoted
valkey-node-1  node5  replica-priority 0    <- could not be promoted
valkey-node-2  node4  replica-priority 100  <- sole candidate, and primary
```

Sentinel had **one** promotable member. Losing node4 meant no writable primary: no settings-projection writes, no timer clock, no cooldowns, no rate-limit buckets. The allowlist also named the cold-bootstrap seed, and that name was `node2`, which is being deleted, so a cold start would have waited forever for a host that no longer exists.

Promotion is now unfenced. Every member is a candidate and Sentinel's election decides. A host allowlist was never a staleness guarantee anyway, since any allowlisted host could hold stale data. One deterministic choice remains, on the **ordinal** not a hostname: a fresh member with no Sentinel quorum waits for ordinal 0 to seed, so three simultaneously-fresh members cannot each self-promote. `NODE_NAME` is no longer exposed to the init container, so placement cannot leak back into role selection.

## minDomains was a pending outage

`notifications` and `transactions` declared `minDomains: 4` against three app-tier nodes. It only kept working because the cordoned old nodes still counted as topology domains (`nodeTaintsPolicy` defaults to `Ignore`). **Deleting them would have measured skew against a global minimum of zero and taken both services to zero schedulable replicas.** Now 3, with the reasoning recorded in the test.

## NATS restrictions removed

`NotIn [worker1]` and the `dedicated=nats-ingress` toleration both encoded a hardware asymmetry that no longer exists, and with node1 now the 2-core control plane the toleration had become actively harmful. The `ScheduleAnyway` hostname spread becomes **required** one-member-per-node anti-affinity: the soft form permitted two members on one host, which quietly turned any single node loss into a *quorum* loss.

Every stream is R3 with no placement tags. `TWITCH_INGRESS` was the last R1 holdout, pinned to nats-0; an R1 stream ceases to exist when its sole member is rescheduled, which is what the node moves kept doing.

## Node roles unified

One key, `itsbagelbot.dev/role`, values `cp` / `node` / `worker`.

| Node | role | taint |
|---|---|---|
| node1 | `cp` | `itsbagelbot.dev/role=cp:NoSchedule` |
| node4, node5, node6 | `node` | none |
| worker | reserved, unused | would be `role=worker:NoSchedule` |

This retires `itsbagelbot.dev/pool`. 15 worker-pool tolerations are removed, since no node carries that key and a future worker node should be opted into explicitly rather than inheriting a stale toleration. The console guards keep their "never on a worker" contract but on the live key, so they start holding the moment a worker exists instead of pointing at a retired label.

Labels and taints are applied live **and** persisted into each node's `config.yaml`, because a label absent from that file is dropped on re-registration.

## Verification

- `go test ./deploy/... ./pkg/...` passes
- `kubectl kustomize` builds clean for k8s, infra/cluster, infra/valkey
- `kubectl apply --server-side --dry-run=server` clean against the live API, which is how Flux applies. No immutable-field conflicts, because `volumeClaimTemplates` is deliberately left in place.

## Deliberately not included

Moving the StatefulSet volumes to `emptyDir`. `volumeClaimTemplates` is immutable and server-side apply does **not** remove it (verified: the result keeps the claim template and adds the emptyDir, producing a duplicated volume name while Flux reports success). That needs an orphan-delete and recreate, as its own change.