### PR TITLE
feat(personality): fact fires only on @mention

### DIFF
--- a/app/sesame/modules/personality.go
+++ b/app/sesame/modules/personality.go
@@ -27,7 +27,7 @@ var (
 
 // Personality is the bot's built-in voice: a fixed set of phrase reactions on
 // the non-command chat path (praise, insults, pets, feeds, flips, a per-stream
-// mood) plus a rotating bagel fun fact whenever the bot itself is mentioned.
+// mood) plus a rotating bagel fun fact whenever chat @-mentions the bot.
 // It is a named core module: always on, never listed on the dashboard, no
 // config, not removable. The entire script lives in personality_lines.go.
 //
@@ -47,7 +47,8 @@ type personalityReply func(ctx context.Context, d engine.Deps, c *module.Context
 // per-channel cooldown that keeps it charming instead of spammy, an optional
 // 1-in-N chance gate for ambient reactions, and the reply renderer. matchRaw
 // rows match against the raw lowercased message instead of the normalized one
-// (needed for the 🥯 emoji, which normalization would strip).
+// (needed for the 🥯 emoji and the "@" of a mention, both of which
+// normalization would strip).
 type reaction struct {
 	name     string
 	phrases  []string
@@ -59,12 +60,13 @@ type reaction struct {
 
 // botNames are every way chat addresses the bot, bare "bagel" included; a
 // directed reaction ("good {name}", "feed the {name}") accepts any of them.
-// botHandles is the strict subset that unambiguously means the bot itself,
-// used by the mention→fact row so a lone "bagel" (the food) never triggers it.
-var (
-	botNames   = []string{"bagel", "bagelbot", "bagel bot", "itsbagelbot", "its bagel bot"}
-	botHandles = []string{"bagelbot", "bagel bot", "itsbagelbot", "its bagel bot"}
-)
+var botNames = []string{"bagel", "bagelbot", "bagel bot", "itsbagelbot", "its bagel bot"}
+
+// botMention is the literal Twitch @-mention of the bot, and the only thing
+// that serves a fun fact. Written out in chat ("bagelbot", "bagel fact") it is
+// just a word about a breakfast food; the "@" is the part that means someone is
+// talking to the bot, so the fact row matches the raw text to keep it.
+const botMention = "@itsbagelbot"
 
 // withNames expands "{name}" in each pattern across the given name list, so a
 // reaction declares its shape once ("feed the {name}") and every way of
@@ -81,11 +83,11 @@ func withNames(names []string, patterns ...string) []string {
 
 // personalityReactions is scanned in order and the first match wins, so the
 // specific interactions sit above the generic mention→fact row: "good night
-// @itsbagelbot" lands on the goodnight, "good bagel bot" on praise, and only
-// an undirected mention falls through to a fun fact. gn sits above good so an
+// @itsbagelbot" lands on the goodnight, "good bagel bot" on praise, and only a
+// bare "@itsbagelbot" falls through to a fun fact. gn sits above good so an
 // explicit goodnight always beats a praise phrase sharing the line. Phrases
 // are lowercase; matching is word-boundary via containsWord on normalized
-// text (see normalizeChat), except the raw-text emoji row.
+// text (see normalizeChat), except the raw-text emoji and fact rows.
 var personalityReactions = []reaction{
 	{name: "gn", phrases: withNames(botNames, "gn {name}", "goodnight {name}", "good night {name}", "night {name}", "bonne nuit {name}"), cooldown: 60 * time.Second, reply: packReply(personalityGnPack)},
 	{name: "good", phrases: append(withNames(botNames, "good {name}"), "good bot"), cooldown: 15 * time.Second, reply: packReply(personalityGoodPack)},
@@ -98,7 +100,7 @@ var personalityReactions = []reaction{
 	{name: "mood", phrases: withNames(botNames, "{name} mood", "mood of the {name}"), cooldown: 60 * time.Second, reply: moodReply},
 	{name: "give", phrases: []string{"give me a bagel", "i want a bagel", "gimme bagel", "gimme a bagel"}, cooldown: 30 * time.Second, reply: packReply(personalityGiveBagel)},
 	{name: "emoji", phrases: []string{"🥯"}, cooldown: 90 * time.Second, oneIn: 12, matchRaw: true, reply: packReply(personalityEmojiPack)},
-	{name: "fact", phrases: append(withNames(botHandles, "{name}"), "bagel fact", "bagel facts"), cooldown: 10 * time.Second, reply: factReply},
+	{name: "fact", phrases: []string{botMention}, cooldown: 10 * time.Second, matchRaw: true, reply: factReply},
 }
 
 // personalityOnChat is the chat handler: screen the line, find the first
@@ -129,7 +131,7 @@ func personalityOnChat(d engine.Deps) module.EventHandler {
 // matchReaction returns the first reaction one of whose phrases occurs in the
 // message at word boundaries. Most rows match the normalized text so "gn,
 // @ItsBagelBot!!" reads as "gn itsbagelbot"; raw rows see the lowercased
-// original.
+// original, "@" and emoji intact.
 func matchReaction(raw string) (reaction, bool) {
 	norm := normalizeChat(raw)
 	for _, r := range personalityReactions {

--- a/app/sesame/modules/personality_test.go
+++ b/app/sesame/modules/personality_test.go
@@ -134,7 +134,7 @@ func TestPersonalityMentionWalksFactCursor(t *testing.T) {
 func TestPersonalityFactFallsBackWithoutStore(t *testing.T) {
 	pinPersonalityRand(t)
 	var col collector
-	require.NoError(t, personalityHandler(t, engine.Deps{})(context.Background(), personalityCtx("bagel fact please"), col.emit))
+	require.NoError(t, personalityHandler(t, engine.Deps{})(context.Background(), personalityCtx("@ItsBagelBot tell me something"), col.emit))
 	require.Len(t, col.out, 1)
 	assert.Equal(t, personalityFacts[0], col.out[0].Text)
 }
@@ -261,20 +261,32 @@ func TestPersonalityNameVariantsReachDirectedReactions(t *testing.T) {
 	}
 }
 
-func TestPersonalityBareMentionStillFacts(t *testing.T) {
+func TestPersonalityFactOnlyOnAtMention(t *testing.T) {
 	pinPersonalityRand(t)
 	store := &fakePersonality{cursor: 1}
 	h := personalityHandler(t, engine.Deps{Personality: store})
-	for _, text := range []string{"@ItsBagelBot", "yo bagelbot", "its bagel bot is here"} {
+	for _, text := range []string{"@ItsBagelBot", "hey @itsbagelbot, listen", "@ItsBagelBot!"} {
 		var col collector
 		require.NoError(t, h(context.Background(), personalityCtx(text), col.emit))
 		require.Len(t, col.out, 1, text)
 		assert.Equal(t, personalityFacts[0], col.out[0].Text, text)
 	}
 
-	var col collector
-	require.NoError(t, h(context.Background(), personalityCtx("I love a warm bagel"), col.emit))
-	assert.Empty(t, col.out, "bare 'bagel' (the food) must not trigger the fact row")
+	// Everything short of an @-mention is silent: the written-out handles, the
+	// old "bagel fact" phrases, and the food itself.
+	for _, text := range []string{
+		"yo bagelbot",
+		"its bagel bot is here",
+		"itsbagelbot what is up",
+		"bagel fact",
+		"bagel facts please",
+		"I love a warm bagel",
+		"@itsbagelbotfake is a copy",
+	} {
+		var col collector
+		require.NoError(t, h(context.Background(), personalityCtx(text), col.emit))
+		assert.Empty(t, col.out, text)
+	}
 }
 
 func TestPersonalityNormalizeChat(t *testing.T) {


### PR DESCRIPTION
## What

The personality module's fun-fact row previously matched:

- the written-out handles `bagelbot`, `bagel bot`, `itsbagelbot`, `its bagel bot`
- the phrases `bagel fact` / `bagel facts`

All of those are gone. The row now fires on a literal `@itsbagelbot` and nothing else.

## Why

Those triggers matched ordinary chat about the breakfast food, so a fun fact landed on lines nobody addressed to the bot. The `@` is the part that means someone is talking to the bot.

## How

The row is now `matchRaw: true`. `normalizeChat` strips punctuation, which would make `@itsbagelbot` and a bare `itsbagelbot` indistinguishable, so the fact row matches the raw lowercased message instead. Word-boundary matching still applies, so `@itsbagelbotfake` does not trigger.

The now-unused `botHandles` var was removed; `botMention` replaces it.

## Not changed

Every other reaction (gn, good, bad, thanks, toast, pet, feed, boop, mood, give, emoji) still accepts all `botNames` variants including bare `bagel`. The fact row stays last in the table, so `gn @ItsBagelBot` still lands on the goodnight. Cooldown (10s) and the golden-bagel override are untouched.

## Testing

`TestPersonalityBareMentionStillFacts` became `TestPersonalityFactOnlyOnAtMention`, asserting the removed triggers are now silent. `go test ./app/sesame/...` passes, `go vet` clean.