### PR TITLE
feat(web): credit Hypixel API account in notice

### DIFF
--- a/web/src/components/home/Games.astro
+++ b/web/src/components/home/Games.astro
@@ -10,6 +10,13 @@ import { getLangFromUrl, useTranslations } from '../../i18n/ui';
 
 const lang = getLangFromUrl(Astro.url);
 const t = useTranslations(lang);
+
+// The affiliation note names the Minecraft account the Hypixel API key belongs
+// to. `{ign}` marks where the linked handle sits so each locale keeps it in its
+// own prose order; the profile link is the public proof of that ownership.
+const IGN = 'ItsMavey';
+const IGN_PROFILE = `https://namemc.com/profile/${IGN}`;
+const [legalBefore, legalAfter = ''] = t('games.legal').split('{ign}');
 ---
 
 <section class="games" id="integrations">
@@ -98,7 +105,12 @@ const t = useTranslations(lang);
         </Card>
     </div>
 
-    <p class="games__legal">{t('games.legal')}</p>
+    <p class="games__legal">{legalBefore}<a
+        class="games__legal-link"
+        href={IGN_PROFILE}
+        target="_blank"
+        rel="noopener noreferrer"
+    >{IGN}</a>{legalAfter}</p>
 </section>
 
 <style>
@@ -340,6 +352,19 @@ const t = useTranslations(lang);
         line-height: 1.7;
         color: var(--muted, #888077);
         opacity: 0.75;
+    }
+
+    .games__legal-link {
+        color: var(--tan-light, #e0c49a);
+        text-decoration: underline;
+        text-decoration-color: rgba(224, 196, 154, 0.4);
+        text-underline-offset: 2px;
+        transition: color 180ms ease, text-decoration-color 180ms ease;
+    }
+
+    .games__legal-link:is(:hover, :focus-visible) {
+        color: var(--white, #f0ece4);
+        text-decoration-color: rgba(240, 236, 228, 0.7);
     }
 
     @media (prefers-reduced-motion: reduce) {

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -98,7 +98,7 @@
   "games.fnDesc": "Lifetime and season stats, plus the daily item shop, one command away.",
   "games.reqTitle": "Want another game?",
   "games.reqDesc": "We are adding more. Open an issue on GitHub and tell us what you play.",
-  "games.legal": "ItsBagelBot is not an official Minecraft service and is not approved by or associated with Mojang or Microsoft. Not affiliated with or endorsed by Hypixel Inc. or MCSR Ranked. Portions of the materials used are trademarks and/or copyrighted works of Epic Games, Inc. Not endorsed by Epic Games.",
+  "games.legal": "ItsBagelBot is not an official Minecraft service and is not approved by or associated with Mojang or Microsoft. Not affiliated with or endorsed by Hypixel Inc. or MCSR Ranked. Hypixel data is retrieved through the official Hypixel API, using a developer key linked to the Minecraft account {ign}, the developer and owner of ItsBagelBot. Portions of the materials used are trademarks and/or copyrighted works of Epic Games, Inc. Not endorsed by Epic Games.",
   "qw.eyebrow": "The quiet work",
   "qw.title": "While you play, it sweeps the floor.",
   "qw.goveeReward": "moth_lamp redeemed · sunset",

--- a/web/src/i18n/locales/fr.json
+++ b/web/src/i18n/locales/fr.json
@@ -98,7 +98,7 @@
   "games.fnDesc": "Stats de saison et à vie, plus la boutique du jour, en une seule commande.",
   "games.reqTitle": "Vous voulez un autre jeu ?",
   "games.reqDesc": "Nous en ajoutons d'autres. Ouvrez une issue sur GitHub et dites-nous à quoi vous jouez.",
-  "games.legal": "ItsBagelBot n'est pas un service Minecraft officiel et n'est ni approuvé par ni associé à Mojang ou Microsoft. Non affilié à ni approuvé par Hypixel Inc. ou MCSR Ranked. Certains éléments utilisés sont des marques et/ou des œuvres protégées d'Epic Games, Inc. Non approuvé par Epic Games.",
+  "games.legal": "ItsBagelBot n'est pas un service Minecraft officiel et n'est ni approuvé par ni associé à Mojang ou Microsoft. Non affilié à ni approuvé par Hypixel Inc. ou MCSR Ranked. Les données Hypixel sont récupérées via l'API officielle Hypixel, avec une clé développeur liée au compte Minecraft {ign}, développeur et propriétaire d'ItsBagelBot. Certains éléments utilisés sont des marques et/ou des œuvres protégées d'Epic Games, Inc. Non approuvé par Epic Games.",
   "qw.eyebrow": "Le travail discret",
   "qw.title": "Pendant que vous jouez, il balaie le sol.",
   "qw.goveeReward": "moth_lamp a échangé · coucher de soleil",


### PR DESCRIPTION
## Why

The Hypixel API application was rejected:

> We are unable to verify that you are the creator of this project. Can you please update your site to contain information to verify you are the owner, such as creating an about section that refers to your Minecraft account as the developer.

## What

The affiliation note under the Game Integrations section now names the Minecraft account behind the Hypixel API key and links it to the public NameMC profile.

> ...Not affiliated with or endorsed by Hypixel Inc. or MCSR Ranked. **Hypixel data is retrieved through the official Hypixel API, using a developer key linked to the Minecraft account [ItsMavey](https://namemc.com/profile/ItsMavey), the developer and owner of ItsBagelBot.** Portions of the materials...

- `games.legal` carries an `{ign}` placeholder so each locale keeps the handle in its own prose order; `Games.astro` splits on it and renders the anchor.
- EN and FR both updated.

Verification link for the re-application: https://itsbagelbot.com/#integrations

## Verified

Dev server, both locales: link text, `href`, `rel="noopener noreferrer"`, `target="_blank"`, no leftover placeholder, no console errors.