### PR TITLE
feat(keda): reach NATS by tailnet name so node1 needs no subnet route

### DIFF
--- a/deploy/infra/keda/release.yaml
+++ b/deploy/infra/keda/release.yaml
@@ -96,40 +96,31 @@ spec:
     # Verify a change landed; do not trust that the key was read:
     #   kubectl -n keda get deploy keda-operator -o jsonpath='{.spec.template.spec.affinity}'
     #
-    # operator -> APPLICATION TIER (off cp).
-    # Every ScaledObject polls NATS directly:
-    #   natsServerMonitoringEndpoint: nats.production.svc.cluster.local:8222
-    # (six triggers at a 15s pollingInterval, see the outgress and sesame
-    # ScaledObjects). That ClusterIP resolves to NATS pods on the app tier, so the
-    # operator needs pod-network reachability to node4/5/6. Flannel
-    # wireguard-native publishes exactly ONE endpoint per node, so once the pod
-    # mesh moves onto the ServaRICA private VLAN, node1 (OCI, not on that VLAN)
-    # reaches it only over the tailscale subnet route.
+    # ALL THREE COMPONENTS -> CONTROL PLANE (on cp), required.
     #
-    # metricsServer and webhooks -> CONTROL PLANE (on cp), required.
-    # Both are called SYNCHRONOUSLY BY THE APISERVER: metricsServer backs the
-    # v1beta1.external.metrics.k8s.io aggregated APIService, webhooks back the
-    # keda-admission ValidatingWebhookConfiguration. Pinning them beside the
-    # apiserver keeps those calls node-local, so they survive any VLAN, subnet
-    # route, or advertiser failure. An unreachable aggregated APIService is worse
-    # than an unreachable backend: it stalls API discovery cluster-wide, not just
-    # KEDA. metricsServer still queries the operator over gRPC :9666 cross-node;
-    # if THAT hop breaks, scaling degrades to each ScaledObject's `fallback`
-    # replicas, which is the loud, bounded failure we want.
+    # metricsServer and webhooks are called SYNCHRONOUSLY BY THE APISERVER:
+    # metricsServer backs the v1beta1.external.metrics.k8s.io aggregated
+    # APIService, webhooks back the keda-admission ValidatingWebhookConfiguration.
+    # Pinning them beside the apiserver keeps those calls node-local. An
+    # unreachable aggregated APIService is worse than an unreachable backend: it
+    # stalls API discovery cluster-wide, not just KEDA.
     #
-    # Required, not preferred, on both sides: a preference lets the scheduler
-    # rebalance either half onto the wrong tier and reintroduce the problem.
+    # The operator has to follow them, because metricsServer queries it over gRPC
+    # :9666. Split across tiers, that gRPC hop was the LAST piece of cross-node
+    # pod traffic leaving node1, and node1 is at OCI with no path to the private
+    # VLAN. Serving it would have meant a tailscale SUBNET ROUTE, which puts a
+    # single route advertiser in the failure path of autoscaling. Co-locating all
+    # three makes both internal hops node-local instead.
+    #
+    # What the operator still needs off-node is NATS monitoring, and that now
+    # arrives as a Tailscale Service (nats-monitoring.tail451e6d.ts.net, see the
+    # Ingress in deploy/k8s/nats.yaml) which node1 dials over HOST networking by
+    # tailnet name. No pod route, no subnet route. The ts-ingress ProxyGroup runs
+    # 3 ha-spread replicas, so no single proxy or node carries it.
+    #
+    # Required, not preferred: a preference lets the scheduler rebalance a
+    # component onto the app tier and silently reintroduce the cross-node hop.
     operator:
-      tolerations: []
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: itsbagelbot.dev/role
-                    operator: NotIn
-                    values: [cp, worker]
-    metricsServer:
       tolerations: &cpToleration
         - key: itsbagelbot.dev/role
           operator: Equal
@@ -143,6 +134,9 @@ spec:
                   - key: itsbagelbot.dev/role
                     operator: In
                     values: [cp]
+    metricsServer:
+      tolerations: *cpToleration
+      affinity: *cpAffinity
     webhooks:
       tolerations: *cpToleration
       affinity: *cpAffinity

--- a/deploy/k8s/nats.yaml
+++ b/deploy/k8s/nats.yaml
@@ -256,3 +256,42 @@ spec:
     app: nats
   ports:
     - {name: cluster, port: 6222, targetPort: cluster}
+---
+# NATS monitoring (/jsz) published on the tailnet, so KEDA can poll consumer lag
+# from the control plane WITHOUT a pod-network path to the application tier.
+#
+# WHY THIS EXISTS
+# ---------------
+# KEDA's metricsServer backs an aggregated APIService, so it must sit beside the
+# apiserver on node1 (see deploy/infra/keda/release.yaml). It reaches the KEDA
+# operator over gRPC, so the operator has to live on node1 too, and the operator
+# is what polls NATS. That made the operator's poll the last piece of cross-node
+# POD traffic leaving node1, which is precisely what the private-VLAN topology
+# must not require: node1 is at OCI with no path to 10.10.0.0/24, and reaching it
+# through a tailscale SUBNET ROUTE puts every advertiser in the failure path.
+#
+# Routing it through the ts-ingress ProxyGroup instead means node1 dials a stable
+# tailnet name over HOST networking, which is exactly what node1 is allowed to do.
+# The ProxyGroup runs 3 ha-spread replicas, so no single proxy or node carries it,
+# unlike a NodePort pinned to one node's address.
+#
+# The ScaledObject triggers in outgress.yaml / sesame.yaml point at this name with
+# useHttps "true"; the cert is a real MagicDNS cert, so no custom CA is involved.
+# Reaching it needs a tag:cp -> tag:k8s grant in the tailnet policy.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: nats-monitoring
+  namespace: production
+  annotations:
+    tailscale.com/proxy-group: ts-ingress
+spec:
+  ingressClassName: tailscale
+  defaultBackend:
+    service:
+      name: nats
+      port:
+        number: 8222
+  tls:
+    - hosts:
+        - nats-monitoring

--- a/deploy/k8s/outgress.yaml
+++ b/deploy/k8s/outgress.yaml
@@ -270,7 +270,8 @@ spec:
         value: "75"
     - type: nats-jetstream
       metadata:
-        natsServerMonitoringEndpoint: nats.production.svc.cluster.local:8222
+        natsServerMonitoringEndpoint: nats-monitoring.tail451e6d.ts.net
+        useHttps: "true"
         account: BUS
         stream: TWITCH_OUTGRESS
         consumer: outgress-premium_twitch_outgress_premium
@@ -278,7 +279,8 @@ spec:
         activationLagThreshold: "5"
     - type: nats-jetstream
       metadata:
-        natsServerMonitoringEndpoint: nats.production.svc.cluster.local:8222
+        natsServerMonitoringEndpoint: nats-monitoring.tail451e6d.ts.net
+        useHttps: "true"
         account: BUS
         stream: TWITCH_OUTGRESS
         consumer: outgress-standard_twitch_outgress_standard
@@ -286,7 +288,8 @@ spec:
         activationLagThreshold: "20"
     - type: nats-jetstream
       metadata:
-        natsServerMonitoringEndpoint: nats.production.svc.cluster.local:8222
+        natsServerMonitoringEndpoint: nats-monitoring.tail451e6d.ts.net
+        useHttps: "true"
         account: BUS
         stream: TWITCH_OUTGRESS_SYSTEM
         consumer: outgress-system_twitch_outgress_system

--- a/deploy/k8s/sesame.yaml
+++ b/deploy/k8s/sesame.yaml
@@ -288,7 +288,8 @@ spec:
         value: "300m"
     - type: nats-jetstream
       metadata:
-        natsServerMonitoringEndpoint: nats.production.svc.cluster.local:8222
+        natsServerMonitoringEndpoint: nats-monitoring.tail451e6d.ts.net
+        useHttps: "true"
         account: BUS
         stream: TWITCH_INGRESS
         consumer: worker_twitch_ingress_event_premium
@@ -298,7 +299,8 @@ spec:
         activationLagThreshold: "500"
     - type: nats-jetstream
       metadata:
-        natsServerMonitoringEndpoint: nats.production.svc.cluster.local:8222
+        natsServerMonitoringEndpoint: nats-monitoring.tail451e6d.ts.net
+        useHttps: "true"
         account: BUS
         stream: TWITCH_INGRESS
         consumer: worker_twitch_ingress_event_standard


### PR DESCRIPTION
Removes the control plane's dependency on the VLAN subnet route.

All three KEDA components move to the control plane so both internal hops (apiserver to metricsServer, metricsServer to operator over gRPC 9666) are node-local. The operator's NATS polling moves to a Tailscale Service published through the existing ts-ingress ProxyGroup, dialed by tailnet name over host networking.

Verified before this PR: `https://nats-monitoring.tail451e6d.ts.net/jsz` returns live JetStream data, and the keda image is arm64-native and pre-pulled on node1.

Follows #504 and #506.