### PR TITLE
feat(net): retire the VLAN subnet route; node1 rides WireGuard roaming

### DIFF
--- a/deploy/ansible/group_vars/all.yml
+++ b/deploy/ansible/group_vars/all.yml
@@ -45,21 +45,18 @@ tailscale_direct_peers:
 # private networks, and the fleet already depends on it: node1 advertises OCI's
 # 10.0.0.0/16 so in-cluster pods can reach the database.
 #
-# Exactly ONE ServaRICA node advertises the private VLAN (10.10.0.0/24), for the
-# same reason in reverse. Once flannel on those nodes peers over their VLAN
-# addresses, node1 has no physical path to 10.10.0.x, and this route is what
-# gives it one. App-tier traffic still goes DIRECT over the VLAN at
-# sub-millisecond latency; only the control plane's small share (~0.05 GB/day)
-# takes the tailnet hop, and measured 2026-07-27 that hop is 2ms versus the
-# 2.8-4.0ms it already pays on the public path, so it costs nothing.
+# NO node advertises the private VLAN (10.10.0.0/24), and none may. The pod
+# mesh does not need it: node1 keeps a public flannel endpoint, the app nodes
+# keepalive to it every 25s, and kernel WireGuard roaming teaches node1 their
+# public endpoints, so node1's pod traffic rides the public path with no route
+# (verified 2026-07-28, wg show on node1 lists only public endpoints). A VLAN
+# subnet route existed briefly and was measured to carry no pod traffic.
 #
-# Do NOT add the second and third node as advertisers for failover. Measured
-# 2026-07-27: a node that advertises a subnet but loses the primary election
-# installs the primary's "10.10.0.0/24 dev tailscale0" into table 52, and rule
-# 5270 outranks main's 32766, so it shadows that node's own direct eth1 path and
-# routes VLAN peers through the primary. See the long note in
-# inventory.cluster.ini.example for the measurement and for how the resulting
-# single-advertiser risk is contained (control-plane pinning, by role).
+# Do NOT re-add an advertiser, and NEVER two: a node that advertises the subnet
+# but loses the primary election installs the primary's "10.10.0.0/24 dev
+# tailscale0" into table 52, and rule 5270 outranks main's 32766, so it shadows
+# that node's own direct eth1 path (measured 2026-07-27). See the long note in
+# inventory.cluster.ini.example.
 #
 # EMPTY MEANS "DO NOT TOUCH", deliberately. `tailscale set --advertise-routes=`
 # with an empty value CLEARS every advertised route, so a run against a partial

--- a/deploy/ansible/inventory.cluster.ini.example
+++ b/deploy/ansible/inventory.cluster.ini.example
@@ -18,65 +18,54 @@
 #
 # PRIVATE VLAN (node4/5/6 only)
 # -----------------------------
-# vlan_address is this node's address on the ServaRICA private VLAN, and
-# tailscale_advertise_routes publishes that subnet to the tailnet so hosts with no
-# physical path to it (node1 at OCI) can still reach it.
-#
-# EXACTLY ONE NODE ADVERTISES 10.10.0.0/24. This is not the obvious choice, so
-# it is worth stating why the obvious one is wrong. Advertising from all three
-# for HA failover was tried and MEASURED on 2026-07-27: it breaks the VLAN.
-# A node that advertises a subnet becomes a member of that route, and a member
-# that is NOT the elected primary installs the primary's route locally:
-#
-#   node4 (primary):     PrimaryRoutes=[10.10.0.0/24]   table 52: empty      OK
-#   node5/6 (secondary): PrimaryRoutes=None             table 52: 10.10.0.0/24
-#
-# That entry is "10.10.0.0/24 dev tailscale0" in table 52, and rule 5270
-# (table 52) outranks 32766 (main), so it SHADOWS the node's own direct eth1
-# path: node5 would reach node6 by tunnelling through node4 instead of crossing
-# the switch. Splitting tag:cp from tag:nodes does not save you here. The ACL
-# grant controls whether a node may reach the subnet, not whether a node that
-# advertises it installs it.
-#
-# The single-advertiser risk is real but is handled at the other end instead:
-# everything the apiserver calls synchronously (cert-manager + trust-manager
-# webhooks, metrics-server, KEDA's metricsServer and webhooks) is pinned to the
-# control plane by role, so losing the advertiser costs cross-node pod routing
-# and KEDA's operator hop, not cluster admission. See deploy/infra/keda/release.yaml.
-#
-# node1 keeps advertising OCI's 10.0.0.0/16, which is how in-cluster pods reach
-# the database. It is declared here rather than left implicit so a playbook run
-# reconciles it instead of drifting; see the destructive-empty warning in
-# group_vars/all.yml.
+# vlan_address is this node's address on the ServaRICA private VLAN.
 #
 # THE POD MESH IS ON THE VLAN as of 2026-07-27. node4/5/6 set flannel_iface=eth1
 # and node_external_ip=10.10.0.x, so flannel's wireguard-native endpoint for each
 # is its VLAN address and inter-node pod traffic crosses the switch instead of the
 # public internet (measured after the switch: eth1 ~5x the byte rate of eth0).
 #
-# node1 deliberately KEEPS its public endpoint. flannel publishes exactly one
-# endpoint per node, so this is asymmetric on purpose: node4/5/6 dial node1 over
-# the public internet, and node1 dials them at 10.10.0.x through the tailscale
-# subnet route. Both directions resolve, which is all WireGuard needs.
+# NO TAILSCALE SUBNET ROUTE FOR 10.10.0.0/24 EXISTS, and none is needed. This is
+# the part that is easy to get wrong, because it looks like node1 (OCI, no
+# physical path to the VLAN) could never reach flannel endpoints at 10.10.0.x:
 #
-# Consequence worth knowing before adding a node: any host WITHOUT a route to
-# 10.10.0.0/24 loses pod-network reachability to node4/5/6. That is why node2 was
-# removed from the cluster outright and node3 carries a NoExecute standby taint.
-# Both are tag:nodes, which the ACL does not grant the VLAN, so they could not
-# reach the app tier's flannel endpoints; they kept working only on a stale
-# WireGuard endpoint that would have died at the next rekey. A retired node left
-# in the cluster is not inert, it stays in kube-dns and Service endpoints and
-# black-holes the traffic it is handed.
+#   node1 deliberately keeps its PUBLIC flannel endpoint, so node4/5/6 initiate
+#   WireGuard to node1 over the public internet, and flannel's net-conf sets
+#   PersistentKeepaliveInterval 25 for every peer. Kernel WireGuard ROAMS: it
+#   updates a peer's endpoint to the outer source address of the latest
+#   authenticated inbound packet. The app nodes' keepalives arrive at node1 from
+#   their PUBLIC addresses, so node1's flannel-wg learns those and sends pod
+#   traffic back over the public path. Verified 2026-07-28 on node1:
+#     wg show flannel-wg endpoints -> 38.49.x.x public IPs, never 10.10.0.x
+#   A tailscale subnet route for the VLAN previously existed and was measured to
+#   carry no pod traffic at all; it was removed, along with its ACL grant and
+#   auto-approver. Worst case after a node1 flannel restart: the configured
+#   10.10.0.x endpoints are unreachable for up to ~25s until the first keepalive
+#   arrives and roaming re-learns the public endpoints.
 #
-# MTU: flannel-wg is 1420 and tailscale0 is 1350, so node1's packets to the VLAN
-# exceed the tunnel budget and are IP-fragmented rather than dropped (verified:
-# 1400-byte pings and a 3400-byte TCP body both succeed node1 pod -> node6 pod).
-# That path carries only KEDA's metrics gRPC now that everything the apiserver
-# calls synchronously is pinned to node1, so the fragmentation cost is immaterial.
-# net.ipv4.tcp_mtu_probing=1 is the blackhole backstop if it ever is not.
+# NEVER advertise 10.10.0.0/24 from any node, and never from more than one:
+# a member that loses the primary election installs the primary's route into
+# table 52 (rule 5270 outranks main's 32766), shadowing its own direct eth1 path
+# (measured 2026-07-27: node5/6 as secondaries got "10.10.0.0/24 dev tailscale0"
+# and VLAN connectivity broke). The ACL tag split does not prevent this; the
+# grant controls reachability, not whether an advertiser installs the route.
+#
+# Everything the apiserver calls synchronously (cert-manager + trust-manager
+# webhooks, metrics-server, all of KEDA) is pinned to the control plane by role,
+# so no admission or aggregated-API path ever crosses nodes. KEDA's operator
+# polls NATS over the pod mesh described above. See deploy/infra/keda/release.yaml.
+#
+# node1 keeps advertising OCI's 10.0.0.0/16, which is how in-cluster pods reach
+# the database. It is declared here rather than left implicit so a playbook run
+# reconciles it instead of drifting; see the destructive-empty warning in
+# group_vars/all.yml.
+#
+# Retired nodes are not inert while they remain cluster members: they stay in
+# kube-dns and Service endpoints and black-hole whatever they are handed. That is
+# why node2 was removed outright and node3 carries a NoExecute standby taint.
 [cluster]
 node1 ansible_host=node1 ansible_user=opc k3s_role=server flannel_iface=enp0s6 node_external_ip={{ NODE1_PUBLIC_IP }} wireguard_endpoint={{ NODE1_PUBLIC_IP }} api_advertise_address={{ NODE1_TAILNET_IP }} node_role=cp tailscale_advertise_routes=10.0.0.0/16
-node4 ansible_host=node4 ansible_user=almalinux k3s_role=agent flannel_iface=eth1 node_external_ip=10.10.0.4 wireguard_endpoint=10.10.0.4 node_role=node vlan_address=10.10.0.4/24 tailscale_advertise_routes=10.10.0.0/24
+node4 ansible_host=node4 ansible_user=almalinux k3s_role=agent flannel_iface=eth1 node_external_ip=10.10.0.4 wireguard_endpoint=10.10.0.4 node_role=node vlan_address=10.10.0.4/24
 node5 ansible_host=node5 ansible_user=almalinux k3s_role=agent flannel_iface=eth1 node_external_ip=10.10.0.5 wireguard_endpoint=10.10.0.5 node_role=node vlan_address=10.10.0.5/24
 node6 ansible_host=node6 ansible_user=almalinux k3s_role=agent flannel_iface=eth1 node_external_ip=10.10.0.6 wireguard_endpoint=10.10.0.6 node_role=node vlan_address=10.10.0.6/24
 

--- a/deploy/infra/keda/release.yaml
+++ b/deploy/infra/keda/release.yaml
@@ -105,18 +105,21 @@ spec:
     # unreachable aggregated APIService is worse than an unreachable backend: it
     # stalls API discovery cluster-wide, not just KEDA.
     #
-    # The operator has to follow them, because metricsServer queries it over gRPC
-    # :9666. Split across tiers, that gRPC hop was the LAST piece of cross-node
-    # pod traffic leaving node1, and node1 is at OCI with no path to the private
-    # VLAN. Serving it would have meant a tailscale SUBNET ROUTE, which puts a
-    # single route advertiser in the failure path of autoscaling. Co-locating all
-    # three makes both internal hops node-local instead.
+    # The operator follows them so the metricsServer -> operator gRPC hop (:9666)
+    # is node-local too. The operator's own NATS polling goes over the pod mesh
+    # to the app tier, and that works from node1 WITHOUT any tailscale subnet
+    # route: node1 keeps a public flannel endpoint, the app nodes keepalive to it
+    # every 25s, and kernel WireGuard roaming teaches node1 their public
+    # endpoints (verified 2026-07-28: wg show on node1 lists only public IPs).
+    # Worst case after a node1 flannel restart is ~25s of unreachable app-tier
+    # pods until the first keepalive roams the endpoints back, during which KEDA
+    # serves each ScaledObject's fallback replicas.
     #
-    # What the operator still needs off-node is NATS monitoring, and that now
-    # arrives as a Tailscale Service (nats-monitoring.tail451e6d.ts.net, see the
-    # Ingress in deploy/k8s/nats.yaml) which node1 dials over HOST networking by
-    # tailnet name. No pod route, no subnet route. The ts-ingress ProxyGroup runs
-    # 3 ha-spread replicas, so no single proxy or node carries it.
+    # Do NOT point the nats-jetstream triggers at the nats-monitoring Tailscale
+    # Service instead. It was tried: the scaler fetches /jsz fine, but in
+    # clustered mode it then follows the stream to the consumer leader and dials
+    # that member at the address NATS advertises, which is a POD IP, so a single
+    # fronting Service cannot satisfy it. The tailnet Service is kept for humans.
     #
     # Required, not preferred: a preference lets the scheduler rebalance a
     # component onto the app tier and silently reintroduce the cross-node hop.

--- a/deploy/k8s/outgress.yaml
+++ b/deploy/k8s/outgress.yaml
@@ -270,8 +270,11 @@ spec:
         value: "75"
     - type: nats-jetstream
       metadata:
-        natsServerMonitoringEndpoint: nats-monitoring.tail451e6d.ts.net
-        useHttps: "true"
+        # ClusterIP, not the tailnet Service. See the long note in sesame.yaml:
+        # KEDA's clustered scaler follows the cluster to the leader's advertised
+        # POD IP, so a single tailnet Service does not remove the pod-network
+        # dependency.
+        natsServerMonitoringEndpoint: nats.production.svc.cluster.local:8222
         account: BUS
         stream: TWITCH_OUTGRESS
         consumer: outgress-premium_twitch_outgress_premium
@@ -279,8 +282,7 @@ spec:
         activationLagThreshold: "5"
     - type: nats-jetstream
       metadata:
-        natsServerMonitoringEndpoint: nats-monitoring.tail451e6d.ts.net
-        useHttps: "true"
+        natsServerMonitoringEndpoint: nats.production.svc.cluster.local:8222
         account: BUS
         stream: TWITCH_OUTGRESS
         consumer: outgress-standard_twitch_outgress_standard
@@ -288,8 +290,7 @@ spec:
         activationLagThreshold: "20"
     - type: nats-jetstream
       metadata:
-        natsServerMonitoringEndpoint: nats-monitoring.tail451e6d.ts.net
-        useHttps: "true"
+        natsServerMonitoringEndpoint: nats.production.svc.cluster.local:8222
         account: BUS
         stream: TWITCH_OUTGRESS_SYSTEM
         consumer: outgress-system_twitch_outgress_system

--- a/deploy/k8s/sesame.yaml
+++ b/deploy/k8s/sesame.yaml
@@ -288,8 +288,25 @@ spec:
         value: "300m"
     - type: nats-jetstream
       metadata:
-        natsServerMonitoringEndpoint: nats-monitoring.tail451e6d.ts.net
-        useHttps: "true"
+        # Still the in-cluster ClusterIP, NOT the tailnet Service, and that is a
+        # known limitation rather than an oversight.
+        #
+        # Moving this to nats-monitoring.tail451e6d.ts.net was tried on
+        # 2026-07-27 so the control plane would need no VLAN subnet route. The
+        # /jsz fetch works over the tailnet, but KEDA's clustered-JetStream
+        # scaler then follows the cluster to the consumer's leader and dials that
+        # member's monitoring endpoint by its ADVERTISED POD IP:
+        #   Get "https://10.42.3.205/varz": dial tcp 10.42.3.205:443: refused
+        # A pod IP is only reachable over the pod network, so exposing one
+        # Service does not remove the dependency; every NATS member would have to
+        # be individually reachable under the address NATS itself advertises.
+        #
+        # Two further traps if this is retried. Tailnet names need a TRAILING DOT
+        # here: the pod resolver runs ndots:5, this name has 4 dots, so the search
+        # list is walked first and resolution fails outright. And KEDA does not
+        # fail loudly, it suppresses the error and serves the static `fallback`
+        # replicas below, so autoscaling stops while the HPA still reads healthy.
+        natsServerMonitoringEndpoint: nats.production.svc.cluster.local:8222
         account: BUS
         stream: TWITCH_INGRESS
         consumer: worker_twitch_ingress_event_premium
@@ -299,8 +316,7 @@ spec:
         activationLagThreshold: "500"
     - type: nats-jetstream
       metadata:
-        natsServerMonitoringEndpoint: nats-monitoring.tail451e6d.ts.net
-        useHttps: "true"
+        natsServerMonitoringEndpoint: nats.production.svc.cluster.local:8222
         account: BUS
         stream: TWITCH_INGRESS
         consumer: worker_twitch_ingress_event_standard

--- a/deploy/k8s/sesame.yaml
+++ b/deploy/k8s/sesame.yaml
@@ -288,24 +288,25 @@ spec:
         value: "300m"
     - type: nats-jetstream
       metadata:
-        # Still the in-cluster ClusterIP, NOT the tailnet Service, and that is a
-        # known limitation rather than an oversight.
+        # In-cluster ClusterIP, on purpose, and it needs NO tailscale subnet
+        # route even though the operator runs on the control plane: node1's
+        # flannel reaches the app tier over kernel WireGuard's roamed PUBLIC
+        # endpoints (see deploy/infra/keda/release.yaml and the inventory notes).
         #
-        # Moving this to nats-monitoring.tail451e6d.ts.net was tried on
-        # 2026-07-27 so the control plane would need no VLAN subnet route. The
-        # /jsz fetch works over the tailnet, but KEDA's clustered-JetStream
+        # Do not move this to the nats-monitoring tailnet Service. It was tried
+        # on 2026-07-27: the /jsz fetch works, but KEDA's clustered-JetStream
         # scaler then follows the cluster to the consumer's leader and dials that
         # member's monitoring endpoint by its ADVERTISED POD IP:
         #   Get "https://10.42.3.205/varz": dial tcp 10.42.3.205:443: refused
-        # A pod IP is only reachable over the pod network, so exposing one
-        # Service does not remove the dependency; every NATS member would have to
-        # be individually reachable under the address NATS itself advertises.
+        # so a single fronting Service cannot satisfy it; every NATS member would
+        # have to be reachable under the address NATS itself advertises.
         #
-        # Two further traps if this is retried. Tailnet names need a TRAILING DOT
-        # here: the pod resolver runs ndots:5, this name has 4 dots, so the search
-        # list is walked first and resolution fails outright. And KEDA does not
-        # fail loudly, it suppresses the error and serves the static `fallback`
-        # replicas below, so autoscaling stops while the HPA still reads healthy.
+        # Two further traps if this is ever retried. Tailnet names need a
+        # TRAILING DOT here: the pod resolver runs ndots:5, this name has 4 dots,
+        # so the search list is walked first and resolution fails outright. And
+        # KEDA does not fail loudly, it suppresses the error and serves the
+        # static `fallback` replicas below, so autoscaling stops while the HPA
+        # still reads healthy.
         natsServerMonitoringEndpoint: nats.production.svc.cluster.local:8222
         account: BUS
         stream: TWITCH_INGRESS


### PR DESCRIPTION
Removes the 10.10.0.0/24 tailscale subnet route, its ACL grant, and its auto-approver, and syncs the docs to how the pod mesh actually works.

Proof gathered before and after removal:
- `wg show flannel-wg` on node1 listed only public peer endpoints, never 10.10.0.x, so the route carried no pod traffic
- Removing it produced zero blip: node1 pod to NATS ClusterIP stayed HTTP 200 at unchanged latency, KEDA logged zero scaler errors, JetStream RAFT held throughout
- App-tier VLAN mesh unaffected, sub-millisecond direct over eth1

Also corrects two earlier claims in the docs (route usage, node2/3 rekey risk) that the measurements disproved.

Follows #504, #506, #507, #508.