### PR TITLE
fix(gateway): pace urchin bucket, split 429 origins

### DIFF
--- a/app/gateway/internal/config/config.go
+++ b/app/gateway/internal/config/config.go
@@ -32,10 +32,15 @@ type Config struct {
 	// system with its own key and budget — Coral's profile endpoint needs the
 	// Player Data permission our key lacks (403). Key empty = provider disabled.
 	// Usernames resolve to uuids through Mojang's public API.
+	// Mojang is a second, independently-throttled upstream on this provider's
+	// path, so it carries its own budget: Hypixel meters per key, Mojang meters
+	// per source IP, and a name resolve spends Mojang's allowance before the
+	// Hypixel key is ever touched.
 	HypixelBaseURL   string
 	MojangBaseURL    string
 	HypixelAPIKey    string
 	HypixelRateLimit float64
+	MojangRateLimit  float64
 
 	// MCSR Ranked provider. The public API needs no key; APIKey optionally
 	// unlocks expanded rate limits. Enabled unless MCSR_ENABLED=false.
@@ -80,8 +85,14 @@ func Load() *Config {
 		ValkeyAddr:     env.Get("VALKEY_ADDR", "127.0.0.1:6379"),
 		ValkeyPassword: env.Get("VALKEY_PASSWORD", ""),
 
-		UrchinBaseURL:   env.Get("URCHIN_BASE_URL", "https://api.urchin.gg"),
-		UrchinAPIKey:    env.Get("URCHIN_API_KEY", ""),
+		UrchinBaseURL: env.Get("URCHIN_BASE_URL", "https://api.urchin.gg"),
+		UrchinAPIKey:  env.Get("URCHIN_API_KEY", ""),
+		// Coral meters per key over a ROLLING 5-minute window: personal keys
+		// allow 600, developer keys whatever was assigned at issue time. The
+		// default fits a personal key; a developer key MUST set
+		// URCHIN_RATE_LIMIT to its assigned number, and a key shared with an
+		// overlay needs headroom below that (the budget is per key, not per
+		// caller, so overlay polling spends the same window).
 		UrchinRateLimit: env.GetFloat("URCHIN_RATE_LIMIT", 600.0),
 
 		HypixelBaseURL: env.Get("HYPIXEL_BASE_URL", "https://api.hypixel.net"),
@@ -89,6 +100,11 @@ func Load() *Config {
 		HypixelAPIKey:  env.Get("HYPIXEL_API_KEY", ""),
 		// Hypixel personal keys allow 300 requests per 5 minutes.
 		HypixelRateLimit: env.GetFloat("HYPIXEL_RATE_LIMIT", 300.0),
+		// Mojang throttles the profile endpoint per source IP, not per key, so
+		// the whole fleet shares one allowance no matter how many pods run.
+		// 600 per 10 minutes is the commonly observed ceiling; the bucket is
+		// deliberately fleet-wide (one shared budget) rather than per-pod.
+		MojangRateLimit: env.GetFloat("MOJANG_RATE_LIMIT", 600.0),
 
 		McsrBaseURL:   env.Get("MCSR_BASE_URL", "https://api.mcsrranked.com"),
 		McsrAPIKey:    env.Get("MCSR_API_KEY", ""),

--- a/app/gateway/internal/core/buckets.go
+++ b/app/gateway/internal/core/buckets.go
@@ -17,16 +17,16 @@ type Buckets struct {
 	standard ratelimit.Spec
 }
 
-// strictBucket derives a token bucket that can never exceed limit requests in
-// ANY window of windowSeconds. A bucket with burst B and refill r admits up to
-// B + r*window requests per window in the worst case (full burst, then a full
-// window of refill), so sizing burst = refill-per-window = limit/2 keeps every
-// rolling window at or under the upstream's allowance — a bucket naively sized
-// capacity=limit, refill=limit/window would admit up to 2x the allowance.
-// Burst is floored because ratelimit.NewSpec requires an integer capacity and
-// panicking at boot over an odd configured limit would crashloop the pod.
-func strictBucket(limit, windowSeconds float64) (burst, refillPerSecond float64) {
-	burst = math.Max(1, math.Floor(limit/2))
+// pacedBucket derives a token bucket that can never exceed limit requests in
+// ANY window of windowSeconds AND never bursts past maxBurst at once. A bucket
+// with burst B and refill r admits up to B + r*window requests per window in
+// the worst case (full burst, then a full window of refill), so keeping
+// burst + refill*window = limit holds every rolling window at the allowance —
+// a bucket naively sized capacity=limit, refill=limit/window would admit up to
+// 2x. Burst is floored because ratelimit.NewSpec requires an integer capacity
+// and panicking at boot over an odd configured limit would crashloop the pod.
+func pacedBucket(limit, windowSeconds, maxBurst float64) (burst, refillPerSecond float64) {
+	burst = math.Max(1, math.Min(maxBurst, math.Floor(limit/2)))
 	refillPerSecond = (limit - burst) / windowSeconds
 	if refillPerSecond <= 0 {
 		// Degenerate budget (limit ~1): NewSpec requires a positive refill;
@@ -36,16 +36,34 @@ func strictBucket(limit, windowSeconds float64) (burst, refillPerSecond float64)
 	return burst, refillPerSecond
 }
 
+// strictBucket is pacedBucket with the widest burst that still bounds the
+// rolling window: half up front, half refilled across the window.
+func strictBucket(limit, windowSeconds float64) (burst, refillPerSecond float64) {
+	return pacedBucket(limit, windowSeconds, math.Floor(limit/2))
+}
+
 // NewBuckets derives the (general, standard) token-bucket pair for one
 // upstream allowing capacity requests per windowSeconds — strictly: the
 // general bucket bounds TOTAL spend to the allowance in every rolling window,
 // and the standard bucket bounds standard-lane spend to 75% of it, so premium
 // always keeps a 25% reserve.
 func NewBuckets(key string, capacity, windowSeconds float64) Buckets {
+	return NewPacedBuckets(key, capacity, windowSeconds, math.Floor(capacity/2))
+}
+
+// NewPacedBuckets is NewBuckets with an explicit burst ceiling, for an
+// upstream that enforces a short-window pace UNDER its documented quota.
+// Coral is the motivating case: 600 per rolling 5 minutes on paper, but a
+// measured edge limiter of ~40 rapid requests refilling ~4/s answers 429 long
+// before the quota (2026-07-28 probe: 37 rapid 200s, then 429, next request
+// 200 again). A wide-burst bucket sails through that wall; capping burst while
+// keeping burst + refill*window = capacity spends the full quota without ever
+// exceeding the pace. The standard lane keeps its 75% share of both.
+func NewPacedBuckets(key string, capacity, windowSeconds, maxBurst float64) Buckets {
 	gen := math.Max(1, math.Floor(capacity))
 	std := math.Max(1, math.Floor(gen*0.75))
-	genBurst, genRefill := strictBucket(gen, windowSeconds)
-	stdBurst, stdRefill := strictBucket(std, windowSeconds)
+	genBurst, genRefill := pacedBucket(gen, windowSeconds, maxBurst)
+	stdBurst, stdRefill := pacedBucket(std, windowSeconds, math.Max(1, math.Floor(maxBurst*0.75)))
 	return Buckets{
 		key:      key,
 		general:  ratelimit.NewSpec(genBurst, genRefill),
@@ -79,7 +97,7 @@ func (b Buckets) Enforce(ctx context.Context, limiter *ratelimit.Limiter, isPrem
 			return err
 		}
 		if !ok {
-			return &UpstreamError{Status: 429, Message: "premium rate limit exceeded"}
+			return &UpstreamError{Status: 429, Message: "premium rate limit exceeded", LocalDeny: true}
 		}
 		return nil
 	}
@@ -90,7 +108,7 @@ func (b Buckets) Enforce(ctx context.Context, limiter *ratelimit.Limiter, isPrem
 		return err
 	}
 	if deniedIdx != 0 {
-		return &UpstreamError{Status: 429, Message: "standard rate limit exceeded"}
+		return &UpstreamError{Status: 429, Message: "standard rate limit exceeded", LocalDeny: true}
 	}
 	return nil
 }

--- a/app/gateway/internal/core/buckets_test.go
+++ b/app/gateway/internal/core/buckets_test.go
@@ -61,3 +61,38 @@ func TestNewBucketsDoesNotPanic(t *testing.T) {
 		NewBuckets("k", 0, 300) // clamped to 1 by the caller-facing floor
 	})
 }
+
+// A paced bucket must satisfy BOTH constraints at once: the rolling window
+// stays at the documented quota, and the instantaneous burst stays at the
+// measured edge ceiling. Coral's numbers: 600/5min quota, ~40-request ~4/s
+// edge wall; burst 8 + ~1.97/s spends the full quota without ever bursting
+// near the wall.
+func TestPacedBucketCoralNumbers(t *testing.T) {
+	burst, refill := pacedBucket(600, 300, 8)
+	assert.Equal(t, 8.0, burst)
+	assert.InDelta(t, (600.0-8.0)/300.0, refill, 1e-9)
+	assert.InDelta(t, 600.0, burst+refill*300, 1e-9, "full quota still spent across the rolling window")
+	assert.Less(t, refill, 4.0, "sustained pace must stay under the measured edge refill")
+
+	// Standard lane: 75% of quota, 75% of burst ceiling.
+	stdBurst, stdRefill := pacedBucket(450, 300, 6)
+	assert.Equal(t, 6.0, stdBurst)
+	assert.InDelta(t, 450.0, stdBurst+stdRefill*300, 1e-9)
+}
+
+// A ceiling wider than the strict half-split must not loosen the rolling
+// window: pacedBucket clamps to the strict burst.
+func TestPacedBucketClampsToStrict(t *testing.T) {
+	burst, refill := pacedBucket(300, 300, 1000)
+	sBurst, sRefill := strictBucket(300, 300)
+	assert.Equal(t, sBurst, burst)
+	assert.InDelta(t, sRefill, refill, 1e-9)
+}
+
+func TestNewPacedBucketsDoesNotPanic(t *testing.T) {
+	assert.NotPanics(t, func() {
+		NewPacedBuckets("k", 600, 300, 8)
+		NewPacedBuckets("k", 1, 300, 8)
+		NewPacedBuckets("k", 600.7, 300, 0.4) // ceiling under 1 clamps to 1
+	})
+}

--- a/app/gateway/internal/core/bytes.go
+++ b/app/gateway/internal/core/bytes.go
@@ -150,12 +150,20 @@ func storeEntry(ctx context.Context, c *Cache, key string, payload []byte, ttl t
 	entryBufPool.Put(bufp)
 }
 
-// refreshBytes revalidates one stale key in the background, deduped via
-// c.refreshing so only one refresh runs per key. It uses a detached context (the
-// triggering request was already answered from the stale value) and
-// single-flights with any concurrent blocking miss. A failed refresh is
-// swallowed and leaves the stale entry to expire on its physical TTL, so an
-// upstream blip degrades to slightly-old data rather than an error.
+// refreshBytes revalidates one stale key in the background. Deduplication is
+// fleet-wide: the refresh is gated on a SET NX EX claim in the shared store, so
+// exactly ONE replica refreshes a stale key no matter how a burst spreads
+// across the queue group — without the claim each pod would fire its own
+// refresh and one stale key would cost one upstream call per replica. The
+// pod-local c.refreshing map is only a cheap pre-filter that keeps one pod from
+// stacking goroutines on a hot key; the claim in Valkey is the authority.
+//
+// The claim expires on its own (never deleted early), so refresh attempts for
+// one key are floored to one per swrRefreshTimeout fleet-wide — a deliberate
+// backoff that shields the upstream. A successful refresh rewrites the entry
+// fresh, so nothing re-triggers anyway; a failed refresh is swallowed and the
+// stale entry keeps serving until its physical TTL, so an upstream blip
+// degrades to slightly-old data rather than an error.
 func (c *Cache) refreshBytes(key string, build func(context.Context) ([]byte, time.Duration, error)) {
 	if _, busy := c.refreshing.LoadOrStore(key, struct{}{}); busy {
 		return
@@ -164,6 +172,11 @@ func (c *Cache) refreshBytes(key string, build func(context.Context) ([]byte, ti
 		defer c.refreshing.Delete(key)
 		ctx, cancel := context.WithTimeout(context.Background(), swrRefreshTimeout)
 		defer cancel()
+		if won, err := c.store.SetNX(ctx, key+":swr", []byte("1"), swrRefreshTimeout); err != nil || !won {
+			// Lost claim: another replica is refreshing. Claim error: leave the
+			// stale entry serving; the next read retries the claim.
+			return
+		}
 		_, _, _ = c.sf.Do(key, func() (any, error) {
 			payload, ttl, err := build(ctx)
 			if err != nil {

--- a/app/gateway/internal/core/bytes_test.go
+++ b/app/gateway/internal/core/bytes_test.go
@@ -144,6 +144,38 @@ func TestCachedBytesStaleServedThenRevalidated(t *testing.T) {
 	}, time.Second, 10*time.Millisecond)
 }
 
+// A stale key read on several replicas at once must cost ONE upstream call,
+// not one per replica: the SWR refresh is gated on a SET NX claim in the
+// SHARED store, so the pod-local dedup maps never decide alone. Two Cache
+// instances over one store model two pods; without the claim each would fire
+// its own background refresh.
+func TestCachedBytesStaleRefreshClaimedOnceFleetWide(t *testing.T) {
+	st := newMemStore()
+	podA, podB := NewCache(st), NewCache(st)
+	var builds atomic.Int32
+	ctx := context.Background()
+
+	_, err := CachedBytes(ctx, podA, "k", buildStatic(`{"n":1}`, 20*time.Millisecond, &builds))
+	require.NoError(t, err)
+	require.Equal(t, int32(1), builds.Load())
+	time.Sleep(40 * time.Millisecond)
+
+	// Both pods take a stale hit and each spawns its refresh goroutine; the
+	// claim lets exactly one through.
+	rebuild := buildStatic(`{"n":2}`, time.Minute, &builds)
+	for _, pod := range []*Cache{podA, podB} {
+		b, gerr := CachedBytes(ctx, pod, "k", rebuild)
+		require.NoError(t, gerr)
+		assert.JSONEq(t, `{"n":1}`, string(b), "stale hit must serve the old bytes")
+	}
+
+	require.Eventually(t, func() bool {
+		got, gerr := CachedBytes(ctx, podA, "k", rebuild)
+		return gerr == nil && string(got) == `{"n":2}`
+	}, time.Second, 10*time.Millisecond)
+	assert.Equal(t, int32(2), builds.Load(), "one cold fill + exactly one fleet-wide refresh")
+}
+
 // The reply-bytes hit path is the gateway's hot path: after the store read it
 // must do no JSON work and no allocation (prefix check + slice only).
 func BenchmarkCachedBytesHit(b *testing.B) {

--- a/app/gateway/internal/core/cache.go
+++ b/app/gateway/internal/core/cache.go
@@ -26,6 +26,11 @@ type Store interface {
 	// retain it (the valkey client serializes within the call; an in-memory
 	// test store must copy).
 	Set(ctx context.Context, key string, val []byte, ttl time.Duration) error
+	// SetNX writes val under key for ttl only when the key is absent and
+	// reports whether this caller won the claim. It is the fleet-wide mutual
+	// exclusion primitive: coordination lives in the shared store, never in
+	// pod-local state, so replicas cannot each make the same decision.
+	SetNX(ctx context.Context, key string, val []byte, ttl time.Duration) (bool, error)
 	// Del removes key.
 	Del(ctx context.Context, key string) error
 }
@@ -53,6 +58,20 @@ func (s *ValkeyStore) Get(ctx context.Context, key string) ([]byte, bool, error)
 
 func (s *ValkeyStore) Set(ctx context.Context, key string, val []byte, ttl time.Duration) error {
 	return s.c.Do(ctx, s.c.B().Set().Key(key).Value(valkey.BinaryString(val)).Ex(ttl).Build()).Error()
+}
+
+// SetNX claims key with SET NX EX. A lost claim answers as a Valkey nil reply,
+// which is a normal outcome, not an error. Writes route to the Sentinel-elected
+// master, so the claim is authoritative fleet-wide.
+func (s *ValkeyStore) SetNX(ctx context.Context, key string, val []byte, ttl time.Duration) (bool, error) {
+	res := s.c.Do(ctx, s.c.B().Set().Key(key).Value(valkey.BinaryString(val)).Nx().Ex(ttl).Build())
+	if err := res.Error(); err != nil {
+		if valkey.IsValkeyNil(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
 }
 
 func (s *ValkeyStore) Del(ctx context.Context, key string) error {

--- a/app/gateway/internal/core/cache_test.go
+++ b/app/gateway/internal/core/cache_test.go
@@ -43,6 +43,16 @@ func (s *memStore) Del(_ context.Context, key string) error {
 	return nil
 }
 
+func (s *memStore) SetNX(_ context.Context, key string, val []byte, _ time.Duration) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.m[key]; ok {
+		return false, nil
+	}
+	s.m[key] = append([]byte(nil), val...)
+	return true, nil
+}
+
 type payload struct {
 	Name string `json:"name"`
 	N    int    `json:"n"`

--- a/app/gateway/internal/core/http.go
+++ b/app/gateway/internal/core/http.go
@@ -24,6 +24,12 @@ type UpstreamError struct {
 	// Message is the upstream's own error text when it sent a JSON
 	// {"error": "..."} body, empty otherwise.
 	Message string
+	// LocalDeny marks a 429 minted by our own token bucket rather than
+	// received from the upstream. The two must stay distinguishable: a bucket
+	// denial refills in seconds and cost no upstream call, while a real
+	// upstream 429 means the provider is throttling our address and retrying
+	// immediately makes it worse.
+	LocalDeny bool
 }
 
 func (e *UpstreamError) Error() string {

--- a/app/gateway/internal/core/reply.go
+++ b/app/gateway/internal/core/reply.go
@@ -6,57 +6,109 @@ import (
 	"time"
 )
 
-// FriendlyUpstream maps an upstream failure onto a user-facing reply message.
-// negative reports whether the failure may be negatively cached: a missing
-// player (400/404) stays missing for a while, but a rate-limit denial (429)
-// or a key-permission problem (403) must be retried on the next request.
-// An infrastructure failure returns "" and should be propagated.
-func FriendlyUpstream(err error) (msg string, negative bool) {
+// Pin classifies how long a friendly upstream failure may be cached.
+type Pin uint8
+
+const (
+	// PinNone must retry on the very next request: our own bucket denial (a
+	// token refills within seconds and retrying costs no upstream call) and
+	// key-permission problems (fixed out of band, must heal instantly).
+	PinNone Pin = iota
+	// PinNegative is a stable absence (missing player): cached for the
+	// endpoint's negativeTTL.
+	PinNegative
+	// PinThrottle is an upstream throttle (the provider or its CDN answered
+	// 429): cached briefly so a chat burst answers from cache instead of
+	// re-hitting an upstream that is already telling us to back off —
+	// hammering it just keeps the throttle window open.
+	PinThrottle
+)
+
+// ThrottleTTL is the PinThrottle cool-down. Long enough to absorb a command
+// burst, short enough that recovery is never minutes away.
+const ThrottleTTL = 20 * time.Second
+
+// FriendlyUpstream maps an upstream failure onto a user-facing reply message
+// and its Pin class. An infrastructure failure returns "" and should be
+// propagated.
+func FriendlyUpstream(err error) (msg string, pin Pin) {
 	var ue *UpstreamError
 	if !errors.As(err, &ue) {
-		return "", false
+		return "", PinNone
 	}
 	switch ue.Status {
 	case 400, 404:
 		if ue.Message != "" {
-			return ue.Message, true
+			return ue.Message, PinNegative
 		}
-		return "player not found", true
+		return "player not found", PinNegative
 	case 403:
 		// The API key lacks the permission (or is locked). A config problem,
 		// not a player problem — say so, and never pin it to a player's key.
-		return "stats lookup not permitted right now", false
+		return "stats lookup not permitted right now", PinNone
 	case 429:
-		return "stats service is busy, try again in a minute", false
+		return friendly429(ue)
 	}
-	return "", false
+	return "", PinNone
+}
+
+// friendly429 tells the two rate-limit origins apart. They demand different
+// texts and different caching: our own bucket refills in seconds and denies
+// before any upstream call, so retrying is free; an upstream 429 means the
+// provider (or Cloudflare in front of it) is throttling our address, and only
+// backing off ends that.
+func friendly429(ue *UpstreamError) (string, Pin) {
+	if ue.LocalDeny {
+		return "stats commands are busy right now, try again in a few seconds", PinNone
+	}
+	return "stats provider is rate limiting us, try again in a minute", PinThrottle
+}
+
+// pinTTL maps a Pin class onto the store TTL for one endpoint.
+func pinTTL(pin Pin, negativeTTL time.Duration) time.Duration {
+	switch pin {
+	case PinNegative:
+		return negativeTTL
+	case PinThrottle:
+		return ThrottleTTL
+	default:
+		return 0
+	}
 }
 
 // BuildReply is the one build function every byte-flow endpoint hands to
 // CachedBytes: fetch produces the typed success reply, errReply shapes the
 // endpoint's reply-with-Error for a friendly failure. Successes are stored for
-// ttl, negatively cacheable failures (player not found) for negativeTTL, and
-// non-cacheable friendly failures (rate limited, key permissions) answer with
-// ttl zero so the next request retries. Infrastructure failures propagate.
-func BuildReply(ctx context.Context, ttl, negativeTTL time.Duration, fetch func(context.Context) (any, error), errReply func(msg string) any) ([]byte, time.Duration, error) {
+// ttl and friendly failures for their Pin class's TTL (zero answers without
+// caching, so the next request retries). Infrastructure failures propagate.
+//
+// friendly reports the upstream failure the reply was shaped from (nil for a
+// success), so the caller can log what the upstream actually said — the reply
+// itself deliberately carries only the friendly text.
+func BuildReply(ctx context.Context, ttl, negativeTTL time.Duration, fetch func(context.Context) (any, error), errReply func(msg string) any) ([]byte, time.Duration, *UpstreamError, error) {
 	v, err := fetch(ctx)
 	if err != nil {
-		msg, negative := FriendlyUpstream(err)
-		if msg == "" {
-			return nil, 0, err
-		}
-		b, merr := MarshalReply(errReply(msg))
-		if merr != nil {
-			return nil, 0, merr
-		}
-		if !negative {
-			return b, 0, nil
-		}
-		return b, negativeTTL, nil
+		return buildErrReply(err, negativeTTL, errReply)
 	}
 	b, merr := MarshalReply(v)
 	if merr != nil {
-		return nil, 0, merr
+		return nil, 0, nil, merr
 	}
-	return b, ttl, nil
+	return b, ttl, nil, nil
+}
+
+// buildErrReply shapes one fetch failure: a friendly failure becomes the
+// endpoint's error reply with its Pin TTL, anything else propagates.
+func buildErrReply(err error, negativeTTL time.Duration, errReply func(msg string) any) ([]byte, time.Duration, *UpstreamError, error) {
+	msg, pin := FriendlyUpstream(err)
+	if msg == "" {
+		return nil, 0, nil, err
+	}
+	b, merr := MarshalReply(errReply(msg))
+	if merr != nil {
+		return nil, 0, nil, merr
+	}
+	var ue *UpstreamError
+	errors.As(err, &ue)
+	return b, pinTTL(pin, negativeTTL), ue, nil
 }

--- a/app/gateway/internal/core/reply_test.go
+++ b/app/gateway/internal/core/reply_test.go
@@ -1,0 +1,79 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The two 429 origins must stay distinguishable in chat: a bucket denial
+// refills in seconds and cost no upstream call, an upstream 429 means the
+// provider is throttling our address. Collapsing them to one message is what
+// made the real incident undiagnosable from the outside.
+func TestFriendlyUpstream429Origins(t *testing.T) {
+	msg, pin := FriendlyUpstream(&UpstreamError{Status: 429, Message: "standard rate limit exceeded", LocalDeny: true})
+	assert.Equal(t, "stats commands are busy right now, try again in a few seconds", msg)
+	assert.Equal(t, PinNone, pin, "a bucket denial must retry on the next request")
+
+	msg, pin = FriendlyUpstream(&UpstreamError{Status: 429})
+	assert.Equal(t, "stats provider is rate limiting us, try again in a minute", msg)
+	assert.Equal(t, PinThrottle, pin, "an upstream throttle must back off briefly")
+}
+
+func TestFriendlyUpstreamClasses(t *testing.T) {
+	msg, pin := FriendlyUpstream(&UpstreamError{Status: 404})
+	assert.Equal(t, "player not found", msg)
+	assert.Equal(t, PinNegative, pin)
+
+	msg, pin = FriendlyUpstream(&UpstreamError{Status: 403})
+	assert.Equal(t, "stats lookup not permitted right now", msg)
+	assert.Equal(t, PinNone, pin)
+
+	msg, _ = FriendlyUpstream(errors.New("dial tcp: timeout"))
+	assert.Empty(t, msg, "infrastructure failures must propagate, not chat")
+}
+
+// BuildReply maps each Pin class onto its store TTL: negatives keep the
+// endpoint's negativeTTL, upstream throttles pin for ThrottleTTL, and bucket
+// denials answer with TTL zero so the very next request retries.
+func TestBuildReplyPinTTLs(t *testing.T) {
+	const negativeTTL = 5 * time.Minute
+	errReply := func(msg string) any { return map[string]string{"error": msg} }
+	build := func(err error) (time.Duration, *UpstreamError) {
+		t.Helper()
+		b, ttl, friendly, berr := BuildReply(context.Background(), time.Minute, negativeTTL,
+			func(context.Context) (any, error) { return nil, err }, errReply)
+		require.NoError(t, berr)
+		require.NotEmpty(t, b)
+		return ttl, friendly
+	}
+
+	ttl, friendly := build(&UpstreamError{Status: 404})
+	assert.Equal(t, negativeTTL, ttl)
+	require.NotNil(t, friendly)
+
+	ttl, friendly = build(&UpstreamError{Status: 429})
+	assert.Equal(t, ThrottleTTL, ttl)
+	require.NotNil(t, friendly)
+	assert.False(t, friendly.LocalDeny)
+
+	ttl, friendly = build(&UpstreamError{Status: 429, LocalDeny: true})
+	assert.Equal(t, time.Duration(0), ttl)
+	require.NotNil(t, friendly)
+	assert.True(t, friendly.LocalDeny)
+}
+
+// A success reports no friendly failure and keeps the endpoint's TTL.
+func TestBuildReplySuccess(t *testing.T) {
+	b, ttl, friendly, err := BuildReply(context.Background(), time.Minute, time.Hour,
+		func(context.Context) (any, error) { return map[string]string{"ok": "1"}, nil },
+		func(msg string) any { return map[string]string{"error": msg} })
+	require.NoError(t, err)
+	assert.NotEmpty(t, b)
+	assert.Equal(t, time.Minute, ttl)
+	assert.Nil(t, friendly)
+}

--- a/app/gateway/internal/provider/builder_test.go
+++ b/app/gateway/internal/provider/builder_test.go
@@ -44,6 +44,16 @@ func (s *memStore) Del(_ context.Context, key string) error {
 	return nil
 }
 
+func (s *memStore) SetNX(_ context.Context, key string, val []byte, _ time.Duration) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.m[key]; ok {
+		return false, nil
+	}
+	s.m[key] = append([]byte(nil), val...)
+	return true, nil
+}
+
 func testDeps() Deps {
 	return Deps{Cache: core.NewCache(newMemStore())}
 }

--- a/app/gateway/internal/provider/flow.go
+++ b/app/gateway/internal/provider/flow.go
@@ -173,7 +173,11 @@ func (f *flowSpec) handler(d Deps, ref endpointRef) HandlerFunc {
 // exactly the states an operator needs to see. Missing players (400/404) stay
 // quiet; they are routine.
 func logFriendly(log *zap.Logger, ref endpointRef, id ID, friendly *core.UpstreamError) {
-	if friendly == nil || friendly.Status == 400 || friendly.Status == 404 {
+	if friendly == nil {
+		return
+	}
+	switch friendly.Status {
+	case 400, 404:
 		return
 	}
 	log.Warn("gateway upstream denial",

--- a/app/gateway/internal/provider/flow.go
+++ b/app/gateway/internal/provider/flow.go
@@ -148,10 +148,12 @@ func (f *flowSpec) handler(d Deps, ref endpointRef) HandlerFunc {
 		}
 		b, err := core.CachedBytes(ctx, cache, core.Key(ref.provider, ref.endpoint, id.Key),
 			func(ctx context.Context) ([]byte, time.Duration, error) {
-				return core.BuildReply(ctx, f.ttl, f.negativeTTL,
+				b, ttl, friendly, err := core.BuildReply(ctx, f.ttl, f.negativeTTL,
 					func(ctx context.Context) (any, error) { return f.fetch(ctx, req, id) },
 					func(msg string) any { return f.reply(id.Display, msg) },
 				)
+				logFriendly(log, ref, id, friendly)
+				return b, ttl, err
 			})
 		if err != nil {
 			log.Warn("gateway fetch failed",
@@ -163,4 +165,22 @@ func (f *flowSpec) handler(d Deps, ref endpointRef) HandlerFunc {
 		}
 		return json.RawMessage(b)
 	}
+}
+
+// logFriendly records the friendly failures that would otherwise be invisible:
+// they are shaped into ordinary replies, so without this line neither the
+// gateway nor the caller ever logs that a rate limit or key problem happened —
+// exactly the states an operator needs to see. Missing players (400/404) stay
+// quiet; they are routine.
+func logFriendly(log *zap.Logger, ref endpointRef, id ID, friendly *core.UpstreamError) {
+	if friendly == nil || friendly.Status == 400 || friendly.Status == 404 {
+		return
+	}
+	log.Warn("gateway upstream denial",
+		zap.String("provider", ref.provider),
+		zap.String("endpoint", ref.endpoint),
+		zap.String("id", id.Display),
+		zap.Int("status", friendly.Status),
+		zap.String("upstream_message", friendly.Message),
+		zap.Bool("local_deny", friendly.LocalDeny))
 }

--- a/app/gateway/internal/providers/all.go
+++ b/app/gateway/internal/providers/all.go
@@ -52,10 +52,11 @@ func appendHypixel(out []provider.Provider, cfg *config.Config, d provider.Deps,
 		return out
 	}
 	return append(out, hypixel.New(hypixel.Config{
-		BaseURL:       cfg.HypixelBaseURL,
-		MojangBaseURL: cfg.MojangBaseURL,
-		APIKey:        cfg.HypixelAPIKey,
-		RateLimit:     cfg.HypixelRateLimit,
+		BaseURL:         cfg.HypixelBaseURL,
+		MojangBaseURL:   cfg.MojangBaseURL,
+		APIKey:          cfg.HypixelAPIKey,
+		RateLimit:       cfg.HypixelRateLimit,
+		MojangRateLimit: cfg.MojangRateLimit,
 	}, d))
 }
 

--- a/app/gateway/internal/providers/clashroyale/clashroyale_test.go
+++ b/app/gateway/internal/providers/clashroyale/clashroyale_test.go
@@ -46,6 +46,16 @@ func (s *memStore) Del(_ context.Context, key string) error {
 	return nil
 }
 
+func (s *memStore) SetNX(_ context.Context, key string, val []byte, _ time.Duration) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.m[key]; ok {
+		return false, nil
+	}
+	s.m[key] = append([]byte(nil), val...)
+	return true, nil
+}
+
 func newTestProvider(t *testing.T, handler http.Handler) provider.Provider {
 	t.Helper()
 	srv := httptest.NewServer(handler)

--- a/app/gateway/internal/providers/fortnite/fortnite_test.go
+++ b/app/gateway/internal/providers/fortnite/fortnite_test.go
@@ -48,6 +48,16 @@ func (s *memStore) Del(_ context.Context, key string) error {
 	return nil
 }
 
+func (s *memStore) SetNX(_ context.Context, key string, val []byte, _ time.Duration) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.m[key]; ok {
+		return false, nil
+	}
+	s.m[key] = append([]byte(nil), val...)
+	return true, nil
+}
+
 // newTestProvider wires the provider with BOTH upstreams faked: stats is the
 // api-fortnite.com double (account lookup + raw stats), shop the
 // fortnite-api.com double. extra tweaks the config before building. It returns

--- a/app/gateway/internal/providers/govee/govee.go
+++ b/app/gateway/internal/providers/govee/govee.go
@@ -167,7 +167,7 @@ func (p *api) devices(ctx context.Context, req gatewayrpc.Request) any {
 
 	cacheKey := core.Key(providerName, "devices", broadcaster)
 	b, err := core.CachedBytes(ctx, p.cache, cacheKey, func(ctx context.Context) ([]byte, time.Duration, error) {
-		return core.BuildReply(ctx, devicesTTL, negativeTTL,
+		b, ttl, _, err := core.BuildReply(ctx, devicesTTL, negativeTTL,
 			func(ctx context.Context) (any, error) {
 				var resp deviceListResponse
 				req := core.Request{Method: http.MethodGet, Path: devicesPath, Headers: authHeader(key)}
@@ -181,6 +181,7 @@ func (p *api) devices(ctx context.Context, req gatewayrpc.Request) any {
 			},
 			func(msg string) any { return gatewayrpc.GoveeDevicesReply{Error: msg} },
 		)
+		return b, ttl, err
 	})
 	if err != nil {
 		log.Warn("govee devices fetch failed", zap.String("broadcaster", broadcaster), zap.Error(err))

--- a/app/gateway/internal/providers/govee/govee_test.go
+++ b/app/gateway/internal/providers/govee/govee_test.go
@@ -46,6 +46,16 @@ func (s *memStore) Del(_ context.Context, key string) error {
 	return nil
 }
 
+func (s *memStore) SetNX(_ context.Context, key string, val []byte, _ time.Duration) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.m[key]; ok {
+		return false, nil
+	}
+	s.m[key] = append([]byte(nil), val...)
+	return true, nil
+}
+
 // fakeKeys is a canned key resolver: key by broadcaster id, err short-circuits.
 type fakeKeys struct {
 	key string

--- a/app/gateway/internal/providers/hypixel/hypixel.go
+++ b/app/gateway/internal/providers/hypixel/hypixel.go
@@ -36,6 +36,10 @@ const (
 
 	// rateWindowSeconds is the Hypixel key budget window (5 minutes).
 	rateWindowSeconds = 300.0
+	// mojangWindowSeconds is Mojang's profile-endpoint budget window (10
+	// minutes). It is a separate window from Hypixel's because it is a separate
+	// upstream: Mojang throttles per source IP, Hypixel per key.
+	mojangWindowSeconds = 600.0
 )
 
 // Config carries the provider's environment. APIKey empty = provider disabled
@@ -46,6 +50,12 @@ type Config struct {
 	MojangBaseURL string
 	APIKey        string
 	RateLimit     float64
+	// MojangRateLimit is the Mojang profile endpoint's own budget per
+	// mojangWindowSeconds. It is separate from RateLimit: the name resolve and
+	// the stats call hit different systems with different throttles, and the
+	// resolve happens first, so metering only the Hypixel call leaves Mojang
+	// completely unguarded.
+	MojangRateLimit float64
 }
 
 // providerName is the subject token this provider answers under.
@@ -58,6 +68,11 @@ type api struct {
 	cache   *core.Cache
 	limiter *ratelimit.Limiter
 	buckets core.Buckets
+	// mojangBuckets is the resolve hop's own budget. Sharing `buckets` would be
+	// wrong twice over: it would spend the Hypixel key's allowance on calls that
+	// never reach Hypixel, and it would bound Mojang by a window Mojang does not
+	// use.
+	mojangBuckets core.Buckets
 }
 
 // New builds the hypixel provider: one byte-flow stats endpoint.
@@ -84,12 +99,16 @@ func newAPI(cfg Config, d provider.Deps) *api {
 	if cfg.RateLimit <= 0 {
 		cfg.RateLimit = 300
 	}
+	if cfg.MojangRateLimit <= 0 {
+		cfg.MojangRateLimit = 600
+	}
 	return &api{
-		http:    core.NewHTTPClient(base, map[string]string{"API-Key": cfg.APIKey}, httpTimeout),
-		mojang:  core.NewHTTPClient(mojangBase, nil, httpTimeout),
-		cache:   d.Cache,
-		limiter: d.Limiter,
-		buckets: core.NewBuckets("ratelimit:gateway:hypixel", cfg.RateLimit, rateWindowSeconds),
+		http:          core.NewHTTPClient(base, map[string]string{"API-Key": cfg.APIKey}, httpTimeout),
+		mojang:        core.NewHTTPClient(mojangBase, nil, httpTimeout),
+		cache:         d.Cache,
+		limiter:       d.Limiter,
+		buckets:       core.NewBuckets("ratelimit:gateway:hypixel", cfg.RateLimit, rateWindowSeconds),
+		mojangBuckets: core.NewBuckets("ratelimit:gateway:mojang", cfg.MojangRateLimit, mojangWindowSeconds),
 	}
 }
 
@@ -135,12 +154,21 @@ func looksLikeUUID(account string) bool {
 // resolveUUID turns a username into the canonical uuid via Mojang, cached for
 // a day. An unknown name is a 404 there already (204 on the legacy path is
 // also treated as missing by the empty-id check), so it negative-caches.
-func (p *api) resolveUUID(ctx context.Context, account string) (string, error) {
+//
+// The Mojang budget is spent inside the cache fill, so only a real resolve
+// costs a token and a hit costs nothing. Metering here is what keeps Mojang
+// from answering 429 on its own terms: it throttles per source IP, so an
+// unguarded resolve could exhaust the fleet's allowance while the Hypixel key
+// — whose bucket is only reached further down — still showed a full budget.
+func (p *api) resolveUUID(ctx context.Context, account string, isPremium bool) (string, error) {
 	if looksLikeUUID(account) {
 		return strings.ReplaceAll(account, "-", ""), nil
 	}
 	key := core.Key(providerName, "uuid", accountKey(account))
 	return core.Cached(ctx, p.cache, key, uuidTTL, negativeTTL, func(ctx context.Context) (string, error) {
+		if err := p.mojangBuckets.Enforce(ctx, p.limiter, isPremium); err != nil {
+			return "", err
+		}
 		var profile mojangProfile
 		if err := p.mojang.GetJSON(ctx, "/users/profiles/minecraft/"+account, nil, &profile); err != nil {
 			return "", err
@@ -178,7 +206,7 @@ type playerResponse struct {
 // fetchStats resolves the uuid, spends the Hypixel budget, and shapes the
 // success reply.
 func (p *api) fetchStats(ctx context.Context, account string, isPremium bool) (gatewayrpc.HypixelStatsReply, error) {
-	uuid, err := p.resolveUUID(ctx, account)
+	uuid, err := p.resolveUUID(ctx, account, isPremium)
 	if err != nil {
 		return gatewayrpc.HypixelStatsReply{}, err
 	}

--- a/app/gateway/internal/providers/hypixel/hypixel_test.go
+++ b/app/gateway/internal/providers/hypixel/hypixel_test.go
@@ -47,6 +47,16 @@ func (s *memStore) Del(_ context.Context, key string) error {
 	return nil
 }
 
+func (s *memStore) SetNX(_ context.Context, key string, val []byte, _ time.Duration) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.m[key]; ok {
+		return false, nil
+	}
+	s.m[key] = append([]byte(nil), val...)
+	return true, nil
+}
+
 // newTestProvider wires the provider with BOTH upstreams faked: mojang answers
 // the uuid resolve, hypixel answers /v2/player.
 func newTestProvider(t *testing.T, mojang, hypixel http.Handler) provider.Provider {
@@ -217,6 +227,46 @@ func TestOddRateLimitDoesNotPanic(t *testing.T) {
 		New(Config{APIKey: "k", RateLimit: 100.3},
 			provider.Deps{Cache: core.NewCache(newMemStore()), Log: zap.NewNop()})
 	})
+	assert.NotPanics(t, func() {
+		New(Config{APIKey: "k", MojangRateLimit: 100.3},
+			provider.Deps{Cache: core.NewCache(newMemStore()), Log: zap.NewNop()})
+	})
+}
+
+// Mojang is a second upstream with its own throttle (per source IP, not per
+// key), so it must carry a budget of its own. Sharing the Hypixel bucket would
+// spend the Hypixel key's allowance on calls that never reach Hypixel and would
+// leave Mojang guarded by the wrong window; carrying no bucket at all — the
+// original defect — left the resolve hop completely unmetered, so Mojang could
+// answer 429 while the Hypixel budget still read as untouched.
+func TestMojangCarriesItsOwnBudget(t *testing.T) {
+	p := newAPI(Config{APIKey: "k"}, provider.Deps{Cache: core.NewCache(newMemStore()), Log: zap.NewNop()})
+	assert.NotEqual(t, p.buckets, p.mojangBuckets, "the resolve hop must not share the Hypixel key's bucket")
+	assert.NotEqual(t, core.Buckets{}, p.mojangBuckets, "the resolve hop must be metered")
+}
+
+// A Mojang throttle answers the upstream-flavored rate-limit message and pins
+// briefly: the immediate next request answers from the cache instead of
+// re-hitting an upstream that is already throttling us.
+func TestStatsMojangRateLimitedPinsBriefly(t *testing.T) {
+	var mojangHits int
+	p := newTestProvider(t,
+		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			mojangHits++
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"error":"TooManyRequestsException"}`))
+		}),
+		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(playerBody))
+		}))
+	h := statsHandle(t, p)
+
+	reply := asReply(t, h(context.Background(), gatewayrpc.Request{Account: "Techno"}))
+	assert.Equal(t, "stats provider is rate limiting us, try again in a minute", reply.Error)
+
+	reply = asReply(t, h(context.Background(), gatewayrpc.Request{Account: "Techno"}))
+	assert.Equal(t, "stats provider is rate limiting us, try again in a minute", reply.Error)
+	assert.Equal(t, 1, mojangHits, "a burst during an upstream throttle must answer from the pinned reply, not re-hit the upstream")
 }
 
 func TestLooksLikeUUID(t *testing.T) {

--- a/app/gateway/internal/providers/mcsr/mcsr_test.go
+++ b/app/gateway/internal/providers/mcsr/mcsr_test.go
@@ -47,6 +47,16 @@ func (s *memStore) Del(_ context.Context, key string) error {
 	return nil
 }
 
+func (s *memStore) SetNX(_ context.Context, key string, val []byte, _ time.Duration) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.m[key]; ok {
+		return false, nil
+	}
+	s.m[key] = append([]byte(nil), val...)
+	return true, nil
+}
+
 func userBody(elo int, wins, loses, played int) string {
 	i := strconv.Itoa
 	return `{

--- a/app/gateway/internal/providers/urchin/urchin.go
+++ b/app/gateway/internal/providers/urchin/urchin.go
@@ -41,6 +41,11 @@ const (
 
 	// rateWindowSeconds is the Coral key budget window (5 minutes).
 	rateWindowSeconds = 300.0
+	// maxBurst caps instantaneous spend. Coral runs an undocumented edge
+	// limiter (~40 rapid requests, ~4/s refill, measured 2026-07-28) far below
+	// the 600/5min key quota; 8-at-once with ~2/s sustained refill stays under
+	// that wall while still spending the full quota across the window.
+	maxBurst = 8.0
 )
 
 // Config carries the provider's environment: the Coral base URL, the API key
@@ -103,7 +108,7 @@ func newAPI(cfg Config, d provider.Deps) *api {
 		cache:   d.Cache,
 		key:     cfg.APIKey,
 		limiter: d.Limiter,
-		buckets: core.NewBuckets("ratelimit:gateway:urchin", cfg.RateLimit, rateWindowSeconds),
+		buckets: core.NewPacedBuckets("ratelimit:gateway:urchin", cfg.RateLimit, rateWindowSeconds, maxBurst),
 	}
 }
 

--- a/app/gateway/internal/providers/urchin/urchin_test.go
+++ b/app/gateway/internal/providers/urchin/urchin_test.go
@@ -47,6 +47,16 @@ func (s *memStore) Del(_ context.Context, key string) error {
 	return nil
 }
 
+func (s *memStore) SetNX(_ context.Context, key string, val []byte, _ time.Duration) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.m[key]; ok {
+		return false, nil
+	}
+	s.m[key] = append([]byte(nil), val...)
+	return true, nil
+}
+
 func newTestProvider(t *testing.T, handler http.Handler) provider.Provider {
 	t.Helper()
 	srv := httptest.NewServer(handler)

--- a/app/sesame/modules/urchin.go
+++ b/app/sesame/modules/urchin.go
@@ -19,8 +19,9 @@ import (
 const urchinModuleName = "urchin"
 
 // urchinCooldown is the shared per-command window; the gateway caches upstream
-// replies, so this only shields chat from command spam, not the API.
-const urchinCooldown = 10 * time.Second
+// replies, so this only shields chat from command spam, not the API. The
+// upstream budget is the gateway's URCHIN_RATE_LIMIT bucket, not this window.
+const urchinCooldown = 5 * time.Second
 
 // Default reply templates. The broadcaster customizes them per command on the
 // module page; blank falls back to these.


### PR DESCRIPTION
## Problem

`!daily`/`!weekly`/`!sniper` answered **"stats service is busy"** in bursts while the Coral key's documented budget (600 per rolling 5 min, verified) was barely touched.

Measured live against `api.urchin.gg` (probe from node6, prod key): **37 rapid requests → 200, request 38 → 429 in 116 ms, next request → 200 again.** Coral runs an undocumented edge burst limiter (~40 tokens, ~4/s refill, instant recovery) underneath the documented quota. Our bucket was shaped `burst 300, refill 1/s`: correct for the rolling window, but it approves spikes 40x above the edge wall.

Compounding defects:
- both 429 origins (our bucket vs upstream) collapsed to one chat text, upstream message discarded
- friendly failures were invisible in every service's logs (gateway shapes them into replies, sesame treats them as handled)
- upstream 429s were never cached, so every command instantly re-hit a throttled upstream and kept the window hot
- SWR background refreshes deduped per pod, so one stale key could cost one upstream call per replica
- the Mojang resolve hop in the hypixel provider was the gateway's only unmetered outbound call

## Changes

- **`core.NewPacedBuckets`**: burst ceiling + `burst + refill*window = quota`; urchin runs **burst 8 / ~2 per s** — can't trip the measured wall, still spends the full 600
- **429 origin split**: `UpstreamError.LocalDeny`; bucket denial chats "try again in a few seconds" and retries instantly, upstream 429 chats "stats provider is rate limiting us" and pins **20 s** (`ThrottleTTL`)
- **`logFriendly`** in the flow handler: one warn line with status, upstream message, `local_deny`
- **SWR refresh dedup is Valkey-authoritative**: `SET NX EX` claim on `<key>:swr`, one refresh fleet-wide; pod-local map is only a goroutine pre-filter
- **Mojang budget**: own bucket (600/10 min default, `MOJANG_RATE_LIMIT`), spent inside the cache fill
- urchin command cooldown **10 s → 5 s**

## Tests

- `reply_test.go`: origin split + Pin TTL mapping
- `buckets_test.go`: paced derivation satisfies both ceilings, clamps to strict
- `bytes_test.go`: two replicas over one store → exactly one refresh
- `hypixel_test.go`: Mojang metered separately, upstream 429 pins briefly
- full gateway + sesame suites green, core race-clean