### PR TITLE
fix(nats): suppress hub route gossip under hostNetwork

### DIFF
--- a/deploy/k8s/nats-server.conf
+++ b/deploy/k8s/nats-server.conf
@@ -74,6 +74,11 @@ cluster {
     "nats-route://nats-1.nats-headless.production.svc.cluster.local:6222"
     "nats-route://nats-2.nats-headless.production.svc.cluster.local:6222"
   ]
+  # Gossip advertises bare IP literals (node addresses in the host netns), and
+  # an IP dial can never pass verify:true hostname verification against the
+  # DNS-only cert, so every gossiped route is a guaranteed TLS failure loop.
+  # The three explicit DNS routes above already form the full mesh.
+  no_advertise: true
 }
 
 # JetStream configuration. `domain: hub` makes this the authoritative


### PR DESCRIPTION
Follow-up to #514. Hub members now gossip node-IP route literals; `verify: true` can never hostname-verify an IP dial against the DNS-only hub certificate, so every gossiped route became a permanent TLS retry loop (~75 errors/min in hub logs). `no_advertise: true` stops the gossip; the three explicit DNS routes already form the full mesh, and the leaf cluster has carried the same setting since the de-mesh. Config hash change rolls the hub one member at a time.