### PR TITLE
fix: survive OCI MySQL endpoint CA rotation

### DIFF
--- a/deploy/k8s/kustomization.yaml
+++ b/deploy/k8s/kustomization.yaml
@@ -31,6 +31,11 @@ resources:
   - nats.yaml
   - nats-leaf.yaml
   - nats-auth-dopplersecret.yaml
+  # Auto-repins DB_CA_CERT in Doppler when OCI rotates the MySQL endpoint CA
+  # (~28d cadence; the 2026-07-30 rotation broke dashboard login + admin for
+  # ~7.5h). Reads the live chain from the DB endpoint every 10 min. Its token
+  # secret (mysql-ca-sync-tokens) is created by hand, never in git.
+  - mysql-ca-sync.yaml
 # NATS broker config, formerly created by apply-nats.sh. The configmaps hold
 # only the server conf + the auth conf ($ENV placeholders expanded at runtime
 # from the nats-auth-env secret). disableNameSuffixHash keeps the names stable

--- a/deploy/k8s/mysql-ca-sync.yaml
+++ b/deploy/k8s/mysql-ca-sync.yaml
@@ -1,0 +1,165 @@
+# Keep DB_CA_CERT in Doppler in sync with the OCI MySQL endpoint CA.
+#
+# WHY
+# ---
+# The DB system uses OCI-managed (self-signed) TLS certificates. OCI reissues
+# the endpoint CA on its own schedule (observed 2026-07-02 -> 2026-07-30, ~28
+# days), and the moment it does, every service that pins the old CA in
+# DB_CA_CERT fails all MySQL connections with
+#   x509: certificate signed by unknown authority ("MySQL_Endpoint_CA")
+# which on 2026-07-30 took down dashboard login and the admin console for ~7.5h
+# until the CA was re-pinned by hand.
+#
+# This CronJob closes the loop: every 10 minutes it pulls the live cert chain
+# from the DB endpoint, extracts the CA, sanity-checks it (the CA must actually
+# sign the presented server cert and carry the expected MySQL_Endpoint_CA
+# subject), and if it differs from the value already in Doppler, writes it to
+# DB_CA_CERT in every project that pins it. The Doppler operator then rolls the
+# affected deployments automatically, so worst-case outage after a rotation is
+# ~10 minutes instead of "until a human notices".
+#
+# Trust model: trust-on-first-use against the VCN-private endpoint. The fetch
+# happens over the private pod->VCN path to 10.0.2.206, the same path the
+# services themselves use; an attacker who can MITM that path already owns the
+# database traffic. The signature + subject checks stop garbage (a TCP proxy,
+# a half-open endpoint) from ever being written to Doppler.
+#
+# Tokens: the mysql-ca-sync-tokens secret holds one read/write Doppler service
+# token per project config (created 2026-07-30, names "mysql-ca-sync"). Service
+# tokens are scoped to a single project+config, so the blast radius of a leaked
+# token is one prd config. The secret is created by hand (kubectl), not by
+# Flux: it is a credential, so it never lands in git.
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mysql-ca-sync-script
+  namespace: production
+data:
+  sync.sh: |
+    #!/bin/sh
+    set -eu
+
+    # alpine base image; tools are fetched per run. A failed apk just fails
+    # this run and the next tick retries, which is fine at a 10m cadence.
+    apk add --no-cache --quiet openssl curl jq
+
+    workdir=$(mktemp -d)
+    trap 'rm -rf "$workdir"' EXIT
+
+    echo "[ca-sync] probing ${DB_ADDR}"
+    openssl s_client -connect "${DB_ADDR}" -starttls mysql -showcerts \
+      </dev/null 2>/dev/null >"$workdir/chain.txt"
+
+    awk '/BEGIN CERTIFICATE/{n++} n==1{print; if(/END CERTIFICATE/) exit}' \
+      "$workdir/chain.txt" >"$workdir/leaf.pem"
+    awk '/BEGIN CERTIFICATE/{n++} n==2{print; if(/END CERTIFICATE/) exit}' \
+      "$workdir/chain.txt" >"$workdir/ca.pem"
+
+    if ! grep -q "END CERTIFICATE" "$workdir/ca.pem"; then
+      echo "[ca-sync] ERROR: endpoint did not present a CA cert" >&2
+      exit 1
+    fi
+
+    subject=$(openssl x509 -in "$workdir/ca.pem" -noout -subject)
+    case "$subject" in
+      *MySQL_Endpoint_CA*) ;;
+      *)
+        echo "[ca-sync] ERROR: unexpected CA subject: $subject" >&2
+        exit 1
+        ;;
+    esac
+
+    if ! openssl verify -CAfile "$workdir/ca.pem" "$workdir/leaf.pem" >/dev/null 2>&1; then
+      echo "[ca-sync] ERROR: presented CA does not sign the server cert" >&2
+      exit 1
+    fi
+
+    # Each Doppler service token is scoped to one project+config, so the API
+    # needs no project/config parameters: the token itself selects them.
+    fetch_current() {
+      curl -sf --retry 3 -H "Authorization: Bearer $1" \
+        "https://api.doppler.com/v3/configs/config/secrets/download?format=json" \
+        | jq -r '.DB_CA_CERT // empty'
+    }
+
+    push_ca() {
+      jq -n --rawfile ca "$workdir/ca.pem" '{secrets: {DB_CA_CERT: $ca}}' \
+        | curl -sf --retry 3 -X POST \
+            -H "Authorization: Bearer $1" \
+            -H "Content-Type: application/json" \
+            -d @- \
+            "https://api.doppler.com/v3/configs/config/secrets" >/dev/null
+    }
+
+    rc=0
+    for project in users commands loyalty modules notifications transactions; do
+      token_var="TOKEN_$(echo "$project" | tr 'a-z' 'A-Z')"
+      token=$(eval "printf '%s' \"\$${token_var}\"")
+
+      current=$(fetch_current "$token") || {
+        echo "[ca-sync] ERROR: $project: failed to read current DB_CA_CERT" >&2
+        rc=1
+        continue
+      }
+
+      if [ "$current" = "$(cat "$workdir/ca.pem")" ]; then
+        echo "[ca-sync] $project: up to date"
+        continue
+      fi
+
+      if push_ca "$token"; then
+        echo "[ca-sync] $project: DB_CA_CERT UPDATED (CA rotated)"
+      else
+        echo "[ca-sync] ERROR: $project: failed to write DB_CA_CERT" >&2
+        rc=1
+      fi
+    done
+    exit $rc
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: mysql-ca-sync
+  namespace: production
+spec:
+  schedule: "*/10 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 240
+      template:
+        metadata:
+          labels:
+            app: mysql-ca-sync
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: sync
+              image: alpine:3.22
+              command: ["/bin/sh", "/scripts/sync.sh"]
+              env:
+                # VCN-private endpoint of the OCI MySQL DB system; reachable
+                # from the pod network on every node via the node1 VCN path.
+                - name: DB_ADDR
+                  value: "10.0.2.206:3306"
+              envFrom:
+                - secretRef:
+                    name: mysql-ca-sync-tokens
+              volumeMounts:
+                - name: scripts
+                  mountPath: /scripts
+                  readOnly: true
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+                limits:
+                  memory: 64Mi
+          volumes:
+            - name: scripts
+              configMap:
+                name: mysql-ca-sync-script

--- a/pkg/db/provider.go
+++ b/pkg/db/provider.go
@@ -1,10 +1,13 @@
 package db
 
 import (
+	"bytes"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/pem"
 	"fmt"
-	"strings"
+	"log"
+	"sync"
 	"time"
 
 	entsql "entgo.io/ent/dialect/sql"
@@ -114,33 +117,135 @@ func registerTLS(caPEM []byte) (string, error) {
 // VerifyConnection is intentional: unlike VerifyPeerCertificate, it also runs
 // when a TLS session is resumed.
 func newPinnedCAVerificationTLSConfig(caPEM []byte) (*tls.Config, error) {
-	caPEM = []byte(strings.TrimSpace(string(caPEM)))
+	pinned, err := parsePinnedCA(caPEM)
+	if err != nil {
+		return nil, err
+	}
+
+	trust := newRotatingTrust(pinned)
+	return &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		// codeql[go/disabled-certificate-check] -- Custom verification pins the endpoint CA below.
+		InsecureSkipVerify: true,
+		VerifyConnection:   trust.VerifyConnection,
+	}, nil
+}
+
+func parsePinnedCA(caPEM []byte) (*x509.Certificate, error) {
+	caPEM = bytes.TrimSpace(caPEM)
 	if len(caPEM) == 0 {
 		return nil, fmt.Errorf("db: DB_CA_CERT is required")
 	}
 
-	roots := x509.NewCertPool()
-	if !roots.AppendCertsFromPEM(caPEM) {
+	block, _ := pem.Decode(caPEM)
+	if block == nil {
 		return nil, fmt.Errorf("db: DB_CA_CERT did not contain a valid PEM certificate")
 	}
-	cfg := &tls.Config{
-		MinVersion: tls.VersionTLS12,
-		RootCAs:    roots,
-		// codeql[go/disabled-certificate-check] -- Custom verification pins the endpoint CA below.
-		InsecureSkipVerify: true,
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("db: DB_CA_CERT did not contain a valid PEM certificate")
 	}
-	cfg.VerifyConnection = func(state tls.ConnectionState) error {
-		certs := state.PeerCertificates
-		if len(certs) == 0 {
-			return fmt.Errorf("db: server presented no certificate")
-		}
-		intermediates := x509.NewCertPool()
-		for _, c := range certs[1:] {
-			intermediates.AddCert(c)
-		}
-		_, err := certs[0].Verify(x509.VerifyOptions{Roots: roots, Intermediates: intermediates})
-		return err
+	return cert, nil
+}
+
+// rotatingTrust verifies MySQL connections against the pinned endpoint CA but
+// survives OCI rotating that CA in place. OCI reissues the managed HeatWave
+// endpoint CA on its own schedule (observed ~28 days); a static pin turns each
+// rotation into a full DB outage for every service until DB_CA_CERT is
+// re-pinned (2026-07-30: dashboard login + admin down for ~7.5h).
+//
+// When verification against the current pool fails, the connection is allowed
+// to promote the CA the server itself presented — but only when that CA is
+// self-signed, within its validity window, carries the exact subject of the
+// originally pinned CA, and actually signs the presented server certificate.
+// A rotation therefore heals on the first handshake that sees the new chain,
+// with no restart and no config change.
+//
+// Trust model: adoption trusts the endpoint's own chain (trust-on-use), the
+// same posture as re-pinning by hand from the endpoint. The endpoint is only
+// reachable over the VCN-private path; an attacker who can MITM that path
+// already owns the database traffic. The subject + self-signature + signs-leaf
+// checks keep garbage (a TCP proxy, an unrelated CA) from ever being adopted.
+type rotatingTrust struct {
+	mu    sync.RWMutex
+	roots *x509.CertPool
+
+	// subject of the CA originally pinned via DB_CA_CERT; a rotated CA is
+	// only adopted when its subject matches exactly.
+	subject string
+}
+
+func newRotatingTrust(pinned *x509.Certificate) *rotatingTrust {
+	roots := x509.NewCertPool()
+	roots.AddCert(pinned)
+	return &rotatingTrust{roots: roots, subject: pinned.Subject.String()}
+}
+
+func (t *rotatingTrust) VerifyConnection(state tls.ConnectionState) error {
+	certs := state.PeerCertificates
+	if len(certs) == 0 {
+		return fmt.Errorf("db: server presented no certificate")
+	}
+	if err := verifyChain(certs, t.currentRoots()); err == nil {
+		return nil
+	}
+	return t.adopt(certs)
+}
+
+func (t *rotatingTrust) currentRoots() *x509.CertPool {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.roots
+}
+
+// adopt promotes the CA presented by the server after a rotation. The write
+// lock serializes concurrent handshakes racing the same rotation; the re-check
+// under the lock lets the losers succeed against the winner's pool.
+func (t *rotatingTrust) adopt(certs []*x509.Certificate) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if err := verifyChain(certs, t.roots); err == nil {
+		return nil
 	}
 
-	return cfg, nil
+	candidate, err := rotationCandidate(certs, t.subject)
+	if err != nil {
+		return err
+	}
+	roots := x509.NewCertPool()
+	roots.AddCert(candidate)
+	if err := verifyChain(certs, roots); err != nil {
+		return fmt.Errorf("db: rotated CA does not sign the server certificate: %w", err)
+	}
+
+	t.roots = roots
+	log.Printf("db: adopted rotated MySQL endpoint CA (%s, expires %s)",
+		candidate.Subject, candidate.NotAfter.Format(time.RFC3339))
+	return nil
+}
+
+func rotationCandidate(certs []*x509.Certificate, subject string) (*x509.Certificate, error) {
+	for _, c := range certs[1:] {
+		if isSelfSignedCANamed(c, subject) {
+			return c, nil
+		}
+	}
+	return nil, fmt.Errorf("db: server certificate is not trusted and the chain carries no rotation candidate for %q", subject)
+}
+
+func isSelfSignedCANamed(c *x509.Certificate, subject string) bool {
+	if !c.IsCA || c.Subject.String() != subject {
+		return false
+	}
+	return c.CheckSignatureFrom(c) == nil
+}
+
+func verifyChain(certs []*x509.Certificate, roots *x509.CertPool) error {
+	intermediates := x509.NewCertPool()
+	for _, c := range certs[1:] {
+		intermediates.AddCert(c)
+	}
+	_, err := certs[0].Verify(x509.VerifyOptions{Roots: roots, Intermediates: intermediates})
+	return err
 }

--- a/pkg/db/provider_test.go
+++ b/pkg/db/provider_test.go
@@ -27,13 +27,7 @@ func TestRegisterTLSRejectsMissingCA(t *testing.T) {
 }
 
 func TestRegisterTLSUsesPinnedCAWithoutHostnameVerification(t *testing.T) {
-	t.Cleanup(func() { mysql.DeregisterTLSConfig(tlsConfigName) })
-
-	ca, caKey, caPEM := testCA(t)
-	_, err := registerTLS(caPEM)
-	require.NoError(t, err)
-
-	cfg := registeredTLSConfig(t, "10.0.0.4:3306")
+	ca, caKey, cfg := registerTestCA(t)
 	require.True(t, cfg.InsecureSkipVerify)
 	require.Equal(t, uint16(tls.VersionTLS12), cfg.MinVersion)
 	require.Empty(t, cfg.ServerName)
@@ -49,28 +43,17 @@ func TestRegisterTLSUsesPinnedCAWithoutHostnameVerification(t *testing.T) {
 }
 
 func TestRegisterTLSRejectsUntrustedServerCertificate(t *testing.T) {
-	t.Cleanup(func() { mysql.DeregisterTLSConfig(tlsConfigName) })
+	_, _, cfg := registerTestCA(t)
 
-	_, _, trustedCAPEM := testCA(t)
 	untrustedCA, untrustedKey, _ := testCA(t)
-
-	_, err := registerTLS(trustedCAPEM)
-	require.NoError(t, err)
-
-	cfg := registeredTLSConfig(t, "db.example.com:3306")
 	require.Error(t, cfg.VerifyConnection(tls.ConnectionState{
 		PeerCertificates: testLeafChain(t, untrustedCA, untrustedKey),
 	}))
 }
 
 func TestRegisterTLSRejectsMissingServerCertificate(t *testing.T) {
-	t.Cleanup(func() { mysql.DeregisterTLSConfig(tlsConfigName) })
+	_, _, cfg := registerTestCA(t)
 
-	_, _, caPEM := testCA(t)
-	_, err := registerTLS(caPEM)
-	require.NoError(t, err)
-
-	cfg := registeredTLSConfig(t, "db.example.com:3306")
 	require.ErrorContains(t, cfg.VerifyConnection(tls.ConnectionState{}), "server presented no certificate")
 }
 
@@ -80,13 +63,7 @@ func TestRegisterTLSRejectsInvalidCA(t *testing.T) {
 }
 
 func TestVerifyConnectionAdoptsRotatedCA(t *testing.T) {
-	t.Cleanup(func() { mysql.DeregisterTLSConfig(tlsConfigName) })
-
-	oldCA, oldKey, oldCAPEM := testCA(t)
-	_, err := registerTLS(oldCAPEM)
-	require.NoError(t, err)
-
-	cfg := registeredTLSConfig(t, "10.0.0.4:3306")
+	oldCA, oldKey, cfg := registerTestCA(t)
 
 	// A rotated CA with the pinned subject, presented by the server itself,
 	// is adopted and the handshake that saw it succeeds.
@@ -103,13 +80,7 @@ func TestVerifyConnectionAdoptsRotatedCA(t *testing.T) {
 }
 
 func TestVerifyConnectionRejectsRotationWithDifferentSubject(t *testing.T) {
-	t.Cleanup(func() { mysql.DeregisterTLSConfig(tlsConfigName) })
-
-	_, _, caPEM := testCA(t)
-	_, err := registerTLS(caPEM)
-	require.NoError(t, err)
-
-	cfg := registeredTLSConfig(t, "10.0.0.4:3306")
+	_, _, cfg := registerTestCA(t)
 
 	imposterCA, imposterKey := testNamedCA(t, "Imposter_CA")
 	require.ErrorContains(t, cfg.VerifyConnection(tls.ConnectionState{
@@ -118,13 +89,7 @@ func TestVerifyConnectionRejectsRotationWithDifferentSubject(t *testing.T) {
 }
 
 func TestVerifyConnectionRejectsRotationWithoutPresentedCA(t *testing.T) {
-	t.Cleanup(func() { mysql.DeregisterTLSConfig(tlsConfigName) })
-
-	_, _, caPEM := testCA(t)
-	_, err := registerTLS(caPEM)
-	require.NoError(t, err)
-
-	cfg := registeredTLSConfig(t, "10.0.0.4:3306")
+	_, _, cfg := registerTestCA(t)
 
 	// Leaf-only chain from an untrusted CA: nothing to adopt, fail closed.
 	untrustedCA, untrustedKey, _ := testCA(t)
@@ -134,13 +99,7 @@ func TestVerifyConnectionRejectsRotationWithoutPresentedCA(t *testing.T) {
 }
 
 func TestVerifyConnectionRejectsRotatedCANotSigningLeaf(t *testing.T) {
-	t.Cleanup(func() { mysql.DeregisterTLSConfig(tlsConfigName) })
-
-	_, _, caPEM := testCA(t)
-	_, err := registerTLS(caPEM)
-	require.NoError(t, err)
-
-	cfg := registeredTLSConfig(t, "10.0.0.4:3306")
+	_, _, cfg := registerTestCA(t)
 
 	// The presented CA carries the pinned subject but did not sign the leaf.
 	leafCA, leafKey, _ := testCA(t)
@@ -149,6 +108,20 @@ func TestVerifyConnectionRejectsRotatedCANotSigningLeaf(t *testing.T) {
 	require.ErrorContains(t, cfg.VerifyConnection(tls.ConnectionState{
 		PeerCertificates: chain,
 	}), "does not sign the server certificate")
+}
+
+// registerTestCA pins a fresh test CA in the driver's TLS registry (with
+// cleanup) and returns the CA pair plus the registered config, so each test
+// starts from the same known trust state.
+func registerTestCA(t *testing.T) (*x509.Certificate, *ecdsa.PrivateKey, *tls.Config) {
+	t.Helper()
+	t.Cleanup(func() { mysql.DeregisterTLSConfig(tlsConfigName) })
+
+	ca, caKey, caPEM := testCA(t)
+	_, err := registerTLS(caPEM)
+	require.NoError(t, err)
+
+	return ca, caKey, registeredTLSConfig(t, "10.0.0.4:3306")
 }
 
 func registeredTLSConfig(t *testing.T, addr string) *tls.Config {

--- a/pkg/db/provider_test.go
+++ b/pkg/db/provider_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"crypto/tls"
 	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/pem"
 	"math/big"
 	"testing"
@@ -36,7 +37,9 @@ func TestRegisterTLSUsesPinnedCAWithoutHostnameVerification(t *testing.T) {
 	require.True(t, cfg.InsecureSkipVerify)
 	require.Equal(t, uint16(tls.VersionTLS12), cfg.MinVersion)
 	require.Empty(t, cfg.ServerName)
-	require.NotNil(t, cfg.RootCAs)
+	// The trusted pool lives inside the VerifyConnection closure (it can be
+	// swapped on CA rotation), not on the config.
+	require.Nil(t, cfg.RootCAs)
 	require.Nil(t, cfg.VerifyPeerCertificate)
 	require.NotNil(t, cfg.VerifyConnection)
 
@@ -76,6 +79,78 @@ func TestRegisterTLSRejectsInvalidCA(t *testing.T) {
 	require.ErrorContains(t, err, "DB_CA_CERT did not contain a valid PEM certificate")
 }
 
+func TestVerifyConnectionAdoptsRotatedCA(t *testing.T) {
+	t.Cleanup(func() { mysql.DeregisterTLSConfig(tlsConfigName) })
+
+	oldCA, oldKey, oldCAPEM := testCA(t)
+	_, err := registerTLS(oldCAPEM)
+	require.NoError(t, err)
+
+	cfg := registeredTLSConfig(t, "10.0.0.4:3306")
+
+	// A rotated CA with the pinned subject, presented by the server itself,
+	// is adopted and the handshake that saw it succeeds.
+	newCA, newKey, _ := testCA(t)
+	rotated := testLeafChainWithCA(t, newCA, newKey)
+	require.NoError(t, cfg.VerifyConnection(tls.ConnectionState{PeerCertificates: rotated}))
+
+	// Adoption replaced the pool: chains from the pre-rotation CA are no
+	// longer trusted, and the rotated chain keeps verifying.
+	require.Error(t, cfg.VerifyConnection(tls.ConnectionState{
+		PeerCertificates: testLeafChain(t, oldCA, oldKey),
+	}))
+	require.NoError(t, cfg.VerifyConnection(tls.ConnectionState{PeerCertificates: rotated}))
+}
+
+func TestVerifyConnectionRejectsRotationWithDifferentSubject(t *testing.T) {
+	t.Cleanup(func() { mysql.DeregisterTLSConfig(tlsConfigName) })
+
+	_, _, caPEM := testCA(t)
+	_, err := registerTLS(caPEM)
+	require.NoError(t, err)
+
+	cfg := registeredTLSConfig(t, "10.0.0.4:3306")
+
+	imposterCA, imposterKey := testNamedCA(t, "Imposter_CA")
+	require.ErrorContains(t, cfg.VerifyConnection(tls.ConnectionState{
+		PeerCertificates: testLeafChainWithCA(t, imposterCA, imposterKey),
+	}), "no rotation candidate")
+}
+
+func TestVerifyConnectionRejectsRotationWithoutPresentedCA(t *testing.T) {
+	t.Cleanup(func() { mysql.DeregisterTLSConfig(tlsConfigName) })
+
+	_, _, caPEM := testCA(t)
+	_, err := registerTLS(caPEM)
+	require.NoError(t, err)
+
+	cfg := registeredTLSConfig(t, "10.0.0.4:3306")
+
+	// Leaf-only chain from an untrusted CA: nothing to adopt, fail closed.
+	untrustedCA, untrustedKey, _ := testCA(t)
+	require.ErrorContains(t, cfg.VerifyConnection(tls.ConnectionState{
+		PeerCertificates: testLeafChain(t, untrustedCA, untrustedKey),
+	}), "no rotation candidate")
+}
+
+func TestVerifyConnectionRejectsRotatedCANotSigningLeaf(t *testing.T) {
+	t.Cleanup(func() { mysql.DeregisterTLSConfig(tlsConfigName) })
+
+	_, _, caPEM := testCA(t)
+	_, err := registerTLS(caPEM)
+	require.NoError(t, err)
+
+	cfg := registeredTLSConfig(t, "10.0.0.4:3306")
+
+	// The presented CA carries the pinned subject but did not sign the leaf.
+	leafCA, leafKey, _ := testCA(t)
+	bystanderCA, _, _ := testCA(t)
+	chain := append(testLeafChain(t, leafCA, leafKey), bystanderCA)
+	require.ErrorContains(t, cfg.VerifyConnection(tls.ConnectionState{
+		PeerCertificates: chain,
+	}), "does not sign the server certificate")
+}
+
 func registeredTLSConfig(t *testing.T, addr string) *tls.Config {
 	t.Helper()
 
@@ -94,8 +169,16 @@ func registeredTLSConfig(t *testing.T, addr string) *tls.Config {
 func testCA(t *testing.T) (*x509.Certificate, *ecdsa.PrivateKey, []byte) {
 	t.Helper()
 
+	cert, key := testNamedCA(t, "MySQL_Endpoint_CA")
+	return cert, key, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
+}
+
+func testNamedCA(t *testing.T, commonName string) (*x509.Certificate, *ecdsa.PrivateKey) {
+	t.Helper()
+
 	template := x509.Certificate{
 		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: commonName},
 		NotBefore:             time.Now().Add(-time.Hour),
 		NotAfter:              time.Now().Add(time.Hour),
 		IsCA:                  true,
@@ -103,9 +186,15 @@ func testCA(t *testing.T) (*x509.Certificate, *ecdsa.PrivateKey, []byte) {
 		BasicConstraintsValid: true,
 	}
 
-	cert, key := issueTestCertificate(t, template, nil, nil)
+	return issueTestCertificate(t, template, nil, nil)
+}
 
-	return cert, key, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
+// testLeafChainWithCA mirrors what the managed endpoint actually presents
+// after a rotation: the server certificate followed by the CA that signed it.
+func testLeafChainWithCA(t *testing.T, ca *x509.Certificate, caKey *ecdsa.PrivateKey) []*x509.Certificate {
+	t.Helper()
+
+	return append(testLeafChain(t, ca, caKey), ca)
 }
 
 func testLeafChain(t *testing.T, ca *x509.Certificate, caKey *ecdsa.PrivateKey) []*x509.Certificate {


### PR DESCRIPTION
## Why

OCI reissues the managed MySQL endpoint CA on its own schedule (observed ~28 days). Every service pinning the old CA in `DB_CA_CERT` loses all database connectivity the moment it rotates. The 2026-07-30 rotation broke dashboard login and the admin console for ~7.5h until the CA was re-pinned by hand.

## What

**`pkg/db`: rotation-tolerant verifier.** When a handshake fails against the pinned pool, the connection may promote the CA the server itself presented — only when it is self-signed, inside its validity window, carries the exact subject of the originally pinned CA, and signs the presented server certificate. The swap is serialized and re-checked under a write lock, so concurrent handshakes racing one rotation converge. A rotation heals on the first handshake that sees the new chain: no restart, no outage. Every adoption logs, so trust changes are auditable in New Relic.

**`deploy/k8s`: mysql-ca-sync CronJob** (every 10 min) re-pins `DB_CA_CERT` in the six Doppler projects from the live endpoint chain, after verifying the CA signs the presented server cert. Already applied to the cluster and validated (first run synced all six, second run reported up-to-date). Belt-and-suspenders while the pkg/db change deploys; removable after. Its token secret (`mysql-ca-sync-tokens`) is hand-created, never in git.

## Trust model

Adoption trusts the endpoint's own chain over the VCN-private path — the same posture as re-pinning by hand from the endpoint, minus the outage. `DB_CA_CERT` remains the required bootstrap anchor.

## Testing

- 5 new unit tests: adoption, imposter-subject rejection, leaf-only rejection, non-signing-CA rejection, pool-swap semantics
- Full repo build + `go test ./pkg/db` green
- CronJob exercised twice in production (sync + converge)