### PR TITLE
fix(alerts): dedupe follow alerts over a 72h window

### DIFF
--- a/app/sesame/modules/alerts.go
+++ b/app/sesame/modules/alerts.go
@@ -228,29 +228,80 @@ func Alerts(d engine.Deps) module.Module {
 	subAlert := onAlert(
 		func(cfg alertsConfig) (bool, string) { return alertOn(cfg.SubEnabled), cfg.SubMessage },
 		defaultSubTemplate,
-		subLine)
+		func(_ context.Context, ev subscribeEvent) (alertLine, bool) {
+			// A gifted recipient is announced through the gift alert on
+			// channel.subscription.gift (one line per gifter, not one per
+			// recipient), so a gift bomb cannot flood chat with welcome lines.
+			if ev.UserLogin == "" || ev.IsGift {
+				return alertLine{}, false
+			}
+			return alertLine{ev.BroadcasterUserID, map[string]string{
+				"user": chatName(ev.UserName, ev.UserLogin),
+				"tier": ev.Tier,
+			}}, true
+		})
 	m.On("channel.subscribe", subAlert)
 	m.On("channel.subscription.message", subAlert)
 
 	m.On("channel.subscription.gift", onAlert(
 		func(cfg alertsConfig) (bool, string) { return alertOn(cfg.GiftEnabled), cfg.GiftMessage },
 		defaultGiftTemplate,
-		giftLine))
+		func(_ context.Context, ev giftEvent) (alertLine, bool) {
+			if ev.BroadcasterUserID == "" || ev.Total <= 0 {
+				return alertLine{}, false
+			}
+			gifter := "An anonymous gifter"
+			if !ev.IsAnonymous {
+				gifter = displayName(ev.UserName, ev.UserLogin)
+			}
+			return alertLine{ev.BroadcasterUserID, map[string]string{
+				"user":  strings.TrimPrefix(gifter, "@"),
+				"count": strconv.Itoa(ev.Total),
+				"tier":  ev.Tier,
+			}}, true
+		}))
 
 	m.On("channel.cheer", onAlert(
 		func(cfg alertsConfig) (bool, string) { return alertOn(cfg.CheerEnabled), cfg.CheerMessage },
 		defaultCheerTemplate,
-		cheerLine))
+		func(_ context.Context, ev cheerEvent) (alertLine, bool) {
+			if ev.BroadcasterUserID == "" {
+				return alertLine{}, false
+			}
+			cheerer := "An anonymous cheerer"
+			if !ev.IsAnonymous {
+				cheerer = displayName(ev.UserName, ev.UserLogin)
+			}
+			return alertLine{ev.BroadcasterUserID, map[string]string{
+				"user": strings.TrimPrefix(cheerer, "@"),
+				"bits": strconv.Itoa(ev.Bits),
+			}}, true
+		}))
 
 	m.On("channel.raid", onAlert(
 		func(cfg alertsConfig) (bool, string) { return alertOn(cfg.RaidEnabled), cfg.RaidMessage },
 		defaultRaidTemplate,
-		raidLine))
+		func(_ context.Context, ev raidEvent) (alertLine, bool) {
+			if ev.FromBroadcasterUserLogin == "" {
+				return alertLine{}, false
+			}
+			return alertLine{ev.ToBroadcasterUserID, map[string]string{
+				"user":    chatName(ev.FromBroadcasterUserName, ev.FromBroadcasterUserLogin),
+				"viewers": strconv.Itoa(ev.Viewers),
+			}}, true
+		}))
 
 	m.On("channel.ad_break.begin", onAlert(
 		func(cfg alertsConfig) (bool, string) { return adAlertOn(cfg.AdsEnabled), cfg.AdsMessage },
 		defaultAdsTemplate,
-		adBreakLine))
+		func(_ context.Context, ev adBreakEvent) (alertLine, bool) {
+			if ev.BroadcasterUserID == "" {
+				return alertLine{}, false
+			}
+			return alertLine{ev.BroadcasterUserID, map[string]string{
+				"duration": strconv.Itoa(ev.DurationSeconds),
+			}}, true
+		}))
 
 	return m.Build()
 }
@@ -267,86 +318,6 @@ func followLine(cd engine.CooldownStore, log *zap.Logger) func(context.Context, 
 			"user": chatName(ev.UserName, ev.UserLogin),
 		}}, true
 	}
-}
-
-// subLine renders the welcome line for a new sub or a resub.
-func subLine(_ context.Context, ev subscribeEvent) (alertLine, bool) {
-	// A gifted recipient is announced through the gift alert on
-	// channel.subscription.gift (one line per gifter, not one per recipient),
-	// so a gift bomb cannot flood chat with welcome lines.
-	if ev.UserLogin == "" || ev.IsGift {
-		return alertLine{}, false
-	}
-	return alertLine{ev.BroadcasterUserID, map[string]string{
-		"user": chatName(ev.UserName, ev.UserLogin),
-		"tier": ev.Tier,
-	}}, true
-}
-
-// anonymousSender is the identity of an alert whose sender is allowed to stay
-// anonymous (a gift, a cheer). Twitch omits the name and login entirely in that
-// case, so each such alert carries its own stand-in label.
-type anonymousSender struct {
-	isAnonymous bool
-	name        string
-	login       string
-	anonLabel   string
-}
-
-// userToken renders the {user} token for a sender who may be anonymous: the
-// stand-in label when they are, otherwise the display name with any leading @
-// stripped so a template can write "@{user}" without doubling it.
-func (s anonymousSender) userToken() string {
-	if s.isAnonymous {
-		return s.anonLabel
-	}
-	return chatName(s.name, s.login)
-}
-
-// giftLine renders the one line a gifter gets for a whole gift batch.
-func giftLine(_ context.Context, ev giftEvent) (alertLine, bool) {
-	if ev.BroadcasterUserID == "" || ev.Total <= 0 {
-		return alertLine{}, false
-	}
-	gifter := anonymousSender{ev.IsAnonymous, ev.UserName, ev.UserLogin, "An anonymous gifter"}
-	return alertLine{ev.BroadcasterUserID, map[string]string{
-		"user":  gifter.userToken(),
-		"count": strconv.Itoa(ev.Total),
-		"tier":  ev.Tier,
-	}}, true
-}
-
-// cheerLine renders the cheer thank-you.
-func cheerLine(_ context.Context, ev cheerEvent) (alertLine, bool) {
-	if ev.BroadcasterUserID == "" {
-		return alertLine{}, false
-	}
-	cheerer := anonymousSender{ev.IsAnonymous, ev.UserName, ev.UserLogin, "An anonymous cheerer"}
-	return alertLine{ev.BroadcasterUserID, map[string]string{
-		"user": cheerer.userToken(),
-		"bits": strconv.Itoa(ev.Bits),
-	}}, true
-}
-
-// raidLine announces an incoming raid to the raided channel.
-func raidLine(_ context.Context, ev raidEvent) (alertLine, bool) {
-	if ev.FromBroadcasterUserLogin == "" {
-		return alertLine{}, false
-	}
-	return alertLine{ev.ToBroadcasterUserID, map[string]string{
-		"user":    chatName(ev.FromBroadcasterUserName, ev.FromBroadcasterUserLogin),
-		"viewers": strconv.Itoa(ev.Viewers),
-	}}, true
-}
-
-// adBreakLine warns chat that an ad break started.
-func adBreakLine(_ context.Context, ev adBreakEvent) (alertLine, bool) {
-	if ev.BroadcasterUserID == "" {
-		return alertLine{}, false
-	}
-	return alertLine{ev.BroadcasterUserID, map[string]string{
-		"duration": strconv.Itoa(ev.DurationSeconds),
-	}}, true
 }
 
 // displayName prefers the EventSub display name, falling back to the login

--- a/app/sesame/modules/alerts.go
+++ b/app/sesame/modules/alerts.go
@@ -283,17 +283,34 @@ func subLine(_ context.Context, ev subscribeEvent) (alertLine, bool) {
 	}}, true
 }
 
+// anonymousSender is the identity of an alert whose sender is allowed to stay
+// anonymous (a gift, a cheer). Twitch omits the name and login entirely in that
+// case, so each such alert carries its own stand-in label.
+type anonymousSender struct {
+	isAnonymous bool
+	name        string
+	login       string
+	anonLabel   string
+}
+
+// userToken renders the {user} token for a sender who may be anonymous: the
+// stand-in label when they are, otherwise the display name with any leading @
+// stripped so a template can write "@{user}" without doubling it.
+func (s anonymousSender) userToken() string {
+	if s.isAnonymous {
+		return s.anonLabel
+	}
+	return chatName(s.name, s.login)
+}
+
 // giftLine renders the one line a gifter gets for a whole gift batch.
 func giftLine(_ context.Context, ev giftEvent) (alertLine, bool) {
 	if ev.BroadcasterUserID == "" || ev.Total <= 0 {
 		return alertLine{}, false
 	}
-	gifter := "An anonymous gifter"
-	if !ev.IsAnonymous {
-		gifter = displayName(ev.UserName, ev.UserLogin)
-	}
+	gifter := anonymousSender{ev.IsAnonymous, ev.UserName, ev.UserLogin, "An anonymous gifter"}
 	return alertLine{ev.BroadcasterUserID, map[string]string{
-		"user":  strings.TrimPrefix(gifter, "@"),
+		"user":  gifter.userToken(),
 		"count": strconv.Itoa(ev.Total),
 		"tier":  ev.Tier,
 	}}, true
@@ -304,12 +321,9 @@ func cheerLine(_ context.Context, ev cheerEvent) (alertLine, bool) {
 	if ev.BroadcasterUserID == "" {
 		return alertLine{}, false
 	}
-	cheerer := "An anonymous cheerer"
-	if !ev.IsAnonymous {
-		cheerer = displayName(ev.UserName, ev.UserLogin)
-	}
+	cheerer := anonymousSender{ev.IsAnonymous, ev.UserName, ev.UserLogin, "An anonymous cheerer"}
 	return alertLine{ev.BroadcasterUserID, map[string]string{
-		"user": strings.TrimPrefix(cheerer, "@"),
+		"user": cheerer.userToken(),
 		"bits": strconv.Itoa(ev.Bits),
 	}}, true
 }

--- a/app/sesame/modules/alerts.go
+++ b/app/sesame/modules/alerts.go
@@ -5,10 +5,13 @@ import (
 	"encoding/json"
 	"strconv"
 	"strings"
+	"time"
 
 	"ItsBagelBot/app/sesame/engine"
 	"ItsBagelBot/app/sesame/module"
 	"ItsBagelBot/internal/domain/outgress"
+
+	"go.uber.org/zap"
 )
 
 // Default chat templates for each alert. Tokens are documented per handler below.
@@ -52,11 +55,57 @@ func alertOn(v string) bool { return v != "off" }
 // the broadcaster explicitly turns it on, so only "on" fires.
 func adAlertOn(v string) bool { return v == "on" }
 
+// followAlertWindow is how long a channel remembers that it already thanked a
+// follower. Twitch re-sends channel.follow on every re-follow, so without this
+// a viewer can unfollow/refollow in a loop and drive the alert line as fast as
+// they can click. Three days is well past the timescale that baiting is fun on,
+// and it also swallows the duplicate a JetStream redelivery would otherwise
+// turn into a second thank-you.
+//
+// The window is deliberately per (channel, follower): a genuine follower who
+// leaves and comes back later in the week is still thanked, and one channel's
+// alerts never suppress another's. See followAlertKey for the Valkey key, and
+// docs/src/content/docs/microservices/sesame.md ("Follow-alert dedupe") for why
+// a multi-day window is safe to hold in the keyspace.
+const followAlertWindow = 72 * time.Hour
+
 // followEvent is the subset of the channel.follow EventSub payload we use.
 type followEvent struct {
+	UserID            string `json:"user_id"`
 	UserName          string `json:"user_name"`
 	UserLogin         string `json:"user_login"`
 	BroadcasterUserID string `json:"broadcaster_user_id"`
+}
+
+// followAlertKey is the per-channel, per-follower claim the alert takes for
+// followAlertWindow. Both ids are Twitch's numeric user ids, so a rename never
+// re-opens the window the way a login-keyed claim would.
+func followAlertKey(ev followEvent) string {
+	return "alert:follow:" + ev.BroadcasterUserID + ":" + ev.UserID
+}
+
+// firstFollowAlert claims this follower's window and reports whether the alert
+// should fire. It runs only once the alert is known to be enabled, so a channel
+// with follow alerts off never burns a window it would want later.
+//
+// It fails open: with no cooldown store wired, no user id on the payload, or
+// Valkey unreachable, the alert still posts. A missed thank-you is a worse
+// outcome than the duplicate an outage can let through, and the abuse this gate
+// exists for cannot cause the outage.
+func firstFollowAlert(ctx context.Context, cd engine.CooldownStore, log *zap.Logger, ev followEvent) bool {
+	if cd == nil || ev.UserID == "" {
+		return true
+	}
+	ok, err := cd.Allow(ctx, followAlertKey(ev), followAlertWindow)
+	if err != nil {
+		log.Warn("alerts: follow cooldown unavailable, alerting anyway",
+			zap.String("broadcaster_id", ev.BroadcasterUserID),
+			zap.String("user_id", ev.UserID),
+			zap.Error(err),
+		)
+		return true
+	}
+	return ok
 }
 
 // subscribeEvent is the subset of the channel.subscribe EventSub payload we
@@ -111,9 +160,12 @@ type alertLine struct {
 // render for the destination and token values, and emit the expanded line.
 // pick returns the alert's enable state and custom template; fallback is the
 // default template used when the broadcaster has not set one. render's false
-// return drops the event (missing identity, or an alert another handler owns).
-func onAlert[T any](pick func(alertsConfig) (bool, string), fallback string, render func(ev T) (alertLine, bool)) module.EventHandler {
-	return func(_ context.Context, c *module.Context, emit module.Emit) error {
+// return drops the event (missing identity, an alert another handler owns, or a
+// dedupe window this event lost); it receives the message context so a render
+// that has to claim shared state does so only for an alert that is enabled and
+// otherwise ready to fire.
+func onAlert[T any](pick func(alertsConfig) (bool, string), fallback string, render func(ctx context.Context, ev T) (alertLine, bool)) module.EventHandler {
+	return func(ctx context.Context, c *module.Context, emit module.Emit) error {
 		var cfg alertsConfig
 		_ = c.Decode(&cfg)
 		enabled, tmpl := pick(cfg)
@@ -124,7 +176,7 @@ func onAlert[T any](pick func(alertsConfig) (bool, string), fallback string, ren
 		if err := json.Unmarshal(c.Env.Event, &ev); err != nil {
 			return err
 		}
-		line, ok := render(ev)
+		line, ok := render(ctx, ev)
 		if !ok {
 			return nil
 		}
@@ -155,14 +207,20 @@ func onAlert[T any](pick func(alertsConfig) (bool, string), fallback string, ren
 // from the module config the pipeline sets on the Context. Raid is a separate
 // alert from the Shoutout module: Shoutout points chat at the raider's channel,
 // this just announces the raid happened.
-func Alerts(_ engine.Deps) module.Module {
+//
+// Only the follow alert is deduplicated (followAlertWindow): it is the one
+// event a viewer can re-trigger at will. Subs, gifts, cheers and raids each
+// cost the sender something, and ad breaks are the channel's own, so those are
+// announced every time.
+func Alerts(d engine.Deps) module.Module {
 	m := module.NewModule("alerts", module.KindDefault)
+	log := moduleLog(d)
 
 	m.On("channel.follow", onAlert(
 		func(cfg alertsConfig) (bool, string) { return alertOn(cfg.FollowEnabled), cfg.FollowMessage },
 		defaultFollowTemplate,
-		func(ev followEvent) (alertLine, bool) {
-			if ev.UserLogin == "" {
+		func(ctx context.Context, ev followEvent) (alertLine, bool) {
+			if ev.UserLogin == "" || !firstFollowAlert(ctx, d.Cooldown, log, ev) {
 				return alertLine{}, false
 			}
 			return alertLine{ev.BroadcasterUserID, map[string]string{
@@ -178,7 +236,7 @@ func Alerts(_ engine.Deps) module.Module {
 	subAlert := onAlert(
 		func(cfg alertsConfig) (bool, string) { return alertOn(cfg.SubEnabled), cfg.SubMessage },
 		defaultSubTemplate,
-		func(ev subscribeEvent) (alertLine, bool) {
+		func(_ context.Context, ev subscribeEvent) (alertLine, bool) {
 			// A gifted recipient is announced through the gift alert on
 			// channel.subscription.gift (one line per gifter, not one per
 			// recipient), so a gift bomb cannot flood chat with welcome lines.
@@ -196,7 +254,7 @@ func Alerts(_ engine.Deps) module.Module {
 	m.On("channel.subscription.gift", onAlert(
 		func(cfg alertsConfig) (bool, string) { return alertOn(cfg.GiftEnabled), cfg.GiftMessage },
 		defaultGiftTemplate,
-		func(ev giftEvent) (alertLine, bool) {
+		func(_ context.Context, ev giftEvent) (alertLine, bool) {
 			if ev.BroadcasterUserID == "" || ev.Total <= 0 {
 				return alertLine{}, false
 			}
@@ -214,7 +272,7 @@ func Alerts(_ engine.Deps) module.Module {
 	m.On("channel.cheer", onAlert(
 		func(cfg alertsConfig) (bool, string) { return alertOn(cfg.CheerEnabled), cfg.CheerMessage },
 		defaultCheerTemplate,
-		func(ev cheerEvent) (alertLine, bool) {
+		func(_ context.Context, ev cheerEvent) (alertLine, bool) {
 			if ev.BroadcasterUserID == "" {
 				return alertLine{}, false
 			}
@@ -231,7 +289,7 @@ func Alerts(_ engine.Deps) module.Module {
 	m.On("channel.raid", onAlert(
 		func(cfg alertsConfig) (bool, string) { return alertOn(cfg.RaidEnabled), cfg.RaidMessage },
 		defaultRaidTemplate,
-		func(ev raidEvent) (alertLine, bool) {
+		func(_ context.Context, ev raidEvent) (alertLine, bool) {
 			if ev.FromBroadcasterUserLogin == "" {
 				return alertLine{}, false
 			}
@@ -244,7 +302,7 @@ func Alerts(_ engine.Deps) module.Module {
 	m.On("channel.ad_break.begin", onAlert(
 		func(cfg alertsConfig) (bool, string) { return adAlertOn(cfg.AdsEnabled), cfg.AdsMessage },
 		defaultAdsTemplate,
-		func(ev adBreakEvent) (alertLine, bool) {
+		func(_ context.Context, ev adBreakEvent) (alertLine, bool) {
 			if ev.BroadcasterUserID == "" {
 				return alertLine{}, false
 			}

--- a/app/sesame/modules/alerts.go
+++ b/app/sesame/modules/alerts.go
@@ -214,19 +214,11 @@ func onAlert[T any](pick func(alertsConfig) (bool, string), fallback string, ren
 // announced every time.
 func Alerts(d engine.Deps) module.Module {
 	m := module.NewModule("alerts", module.KindDefault)
-	log := moduleLog(d)
 
 	m.On("channel.follow", onAlert(
 		func(cfg alertsConfig) (bool, string) { return alertOn(cfg.FollowEnabled), cfg.FollowMessage },
 		defaultFollowTemplate,
-		func(ctx context.Context, ev followEvent) (alertLine, bool) {
-			if ev.UserLogin == "" || !firstFollowAlert(ctx, d.Cooldown, log, ev) {
-				return alertLine{}, false
-			}
-			return alertLine{ev.BroadcasterUserID, map[string]string{
-				"user": chatName(ev.UserName, ev.UserLogin),
-			}}, true
-		}))
+		followLine(d.Cooldown, moduleLog(d))))
 
 	// The sub alert serves both channel.subscribe (new subs) and
 	// channel.subscription.message (resubs shared in chat), so a renewing sub
@@ -236,82 +228,111 @@ func Alerts(d engine.Deps) module.Module {
 	subAlert := onAlert(
 		func(cfg alertsConfig) (bool, string) { return alertOn(cfg.SubEnabled), cfg.SubMessage },
 		defaultSubTemplate,
-		func(_ context.Context, ev subscribeEvent) (alertLine, bool) {
-			// A gifted recipient is announced through the gift alert on
-			// channel.subscription.gift (one line per gifter, not one per
-			// recipient), so a gift bomb cannot flood chat with welcome lines.
-			if ev.UserLogin == "" || ev.IsGift {
-				return alertLine{}, false
-			}
-			return alertLine{ev.BroadcasterUserID, map[string]string{
-				"user": chatName(ev.UserName, ev.UserLogin),
-				"tier": ev.Tier,
-			}}, true
-		})
+		subLine)
 	m.On("channel.subscribe", subAlert)
 	m.On("channel.subscription.message", subAlert)
 
 	m.On("channel.subscription.gift", onAlert(
 		func(cfg alertsConfig) (bool, string) { return alertOn(cfg.GiftEnabled), cfg.GiftMessage },
 		defaultGiftTemplate,
-		func(_ context.Context, ev giftEvent) (alertLine, bool) {
-			if ev.BroadcasterUserID == "" || ev.Total <= 0 {
-				return alertLine{}, false
-			}
-			gifter := "An anonymous gifter"
-			if !ev.IsAnonymous {
-				gifter = displayName(ev.UserName, ev.UserLogin)
-			}
-			return alertLine{ev.BroadcasterUserID, map[string]string{
-				"user":  strings.TrimPrefix(gifter, "@"),
-				"count": strconv.Itoa(ev.Total),
-				"tier":  ev.Tier,
-			}}, true
-		}))
+		giftLine))
 
 	m.On("channel.cheer", onAlert(
 		func(cfg alertsConfig) (bool, string) { return alertOn(cfg.CheerEnabled), cfg.CheerMessage },
 		defaultCheerTemplate,
-		func(_ context.Context, ev cheerEvent) (alertLine, bool) {
-			if ev.BroadcasterUserID == "" {
-				return alertLine{}, false
-			}
-			cheerer := "An anonymous cheerer"
-			if !ev.IsAnonymous {
-				cheerer = displayName(ev.UserName, ev.UserLogin)
-			}
-			return alertLine{ev.BroadcasterUserID, map[string]string{
-				"user": strings.TrimPrefix(cheerer, "@"),
-				"bits": strconv.Itoa(ev.Bits),
-			}}, true
-		}))
+		cheerLine))
 
 	m.On("channel.raid", onAlert(
 		func(cfg alertsConfig) (bool, string) { return alertOn(cfg.RaidEnabled), cfg.RaidMessage },
 		defaultRaidTemplate,
-		func(_ context.Context, ev raidEvent) (alertLine, bool) {
-			if ev.FromBroadcasterUserLogin == "" {
-				return alertLine{}, false
-			}
-			return alertLine{ev.ToBroadcasterUserID, map[string]string{
-				"user":    chatName(ev.FromBroadcasterUserName, ev.FromBroadcasterUserLogin),
-				"viewers": strconv.Itoa(ev.Viewers),
-			}}, true
-		}))
+		raidLine))
 
 	m.On("channel.ad_break.begin", onAlert(
 		func(cfg alertsConfig) (bool, string) { return adAlertOn(cfg.AdsEnabled), cfg.AdsMessage },
 		defaultAdsTemplate,
-		func(_ context.Context, ev adBreakEvent) (alertLine, bool) {
-			if ev.BroadcasterUserID == "" {
-				return alertLine{}, false
-			}
-			return alertLine{ev.BroadcasterUserID, map[string]string{
-				"duration": strconv.Itoa(ev.DurationSeconds),
-			}}, true
-		}))
+		adBreakLine))
 
 	return m.Build()
+}
+
+// followLine renders the follow alert. It is the one render that needs runtime
+// deps: the dedupe window is claimed here, inside the render, so it is taken
+// only for a channel whose follow alert is actually enabled.
+func followLine(cd engine.CooldownStore, log *zap.Logger) func(context.Context, followEvent) (alertLine, bool) {
+	return func(ctx context.Context, ev followEvent) (alertLine, bool) {
+		if ev.UserLogin == "" || !firstFollowAlert(ctx, cd, log, ev) {
+			return alertLine{}, false
+		}
+		return alertLine{ev.BroadcasterUserID, map[string]string{
+			"user": chatName(ev.UserName, ev.UserLogin),
+		}}, true
+	}
+}
+
+// subLine renders the welcome line for a new sub or a resub.
+func subLine(_ context.Context, ev subscribeEvent) (alertLine, bool) {
+	// A gifted recipient is announced through the gift alert on
+	// channel.subscription.gift (one line per gifter, not one per recipient),
+	// so a gift bomb cannot flood chat with welcome lines.
+	if ev.UserLogin == "" || ev.IsGift {
+		return alertLine{}, false
+	}
+	return alertLine{ev.BroadcasterUserID, map[string]string{
+		"user": chatName(ev.UserName, ev.UserLogin),
+		"tier": ev.Tier,
+	}}, true
+}
+
+// giftLine renders the one line a gifter gets for a whole gift batch.
+func giftLine(_ context.Context, ev giftEvent) (alertLine, bool) {
+	if ev.BroadcasterUserID == "" || ev.Total <= 0 {
+		return alertLine{}, false
+	}
+	gifter := "An anonymous gifter"
+	if !ev.IsAnonymous {
+		gifter = displayName(ev.UserName, ev.UserLogin)
+	}
+	return alertLine{ev.BroadcasterUserID, map[string]string{
+		"user":  strings.TrimPrefix(gifter, "@"),
+		"count": strconv.Itoa(ev.Total),
+		"tier":  ev.Tier,
+	}}, true
+}
+
+// cheerLine renders the cheer thank-you.
+func cheerLine(_ context.Context, ev cheerEvent) (alertLine, bool) {
+	if ev.BroadcasterUserID == "" {
+		return alertLine{}, false
+	}
+	cheerer := "An anonymous cheerer"
+	if !ev.IsAnonymous {
+		cheerer = displayName(ev.UserName, ev.UserLogin)
+	}
+	return alertLine{ev.BroadcasterUserID, map[string]string{
+		"user": strings.TrimPrefix(cheerer, "@"),
+		"bits": strconv.Itoa(ev.Bits),
+	}}, true
+}
+
+// raidLine announces an incoming raid to the raided channel.
+func raidLine(_ context.Context, ev raidEvent) (alertLine, bool) {
+	if ev.FromBroadcasterUserLogin == "" {
+		return alertLine{}, false
+	}
+	return alertLine{ev.ToBroadcasterUserID, map[string]string{
+		"user":    chatName(ev.FromBroadcasterUserName, ev.FromBroadcasterUserLogin),
+		"viewers": strconv.Itoa(ev.Viewers),
+	}}, true
+}
+
+// adBreakLine warns chat that an ad break started.
+func adBreakLine(_ context.Context, ev adBreakEvent) (alertLine, bool) {
+	if ev.BroadcasterUserID == "" {
+		return alertLine{}, false
+	}
+	return alertLine{ev.BroadcasterUserID, map[string]string{
+		"duration": strconv.Itoa(ev.DurationSeconds),
+	}}, true
 }
 
 // displayName prefers the EventSub display name, falling back to the login

--- a/app/sesame/modules/alerts_test.go
+++ b/app/sesame/modules/alerts_test.go
@@ -2,7 +2,9 @@ package modules
 
 import (
 	"context"
+	"errors"
 	"testing"
+	"time"
 
 	"ItsBagelBot/app/sesame/engine"
 	"ItsBagelBot/app/sesame/module"
@@ -15,15 +17,19 @@ import (
 )
 
 const (
-	followJSON    = `{"user_name":"CoolViewer","user_login":"coolviewer","broadcaster_user_id":"2"}`
-	subscribeJSON = `{"user_name":"CoolViewer","user_login":"coolviewer","broadcaster_user_id":"2","tier":"1000"}`
-	giftedSubJSON = `{"user_name":"CoolViewer","user_login":"coolviewer","broadcaster_user_id":"2","tier":"1000","is_gift":true}`
-	resubJSON     = `{"user_name":"CoolViewer","user_login":"coolviewer","broadcaster_user_id":"2","tier":"1000","cumulative_months":7,"streak_months":7,"message":{"text":"7 months!"}}`
-	giftJSON      = `{"is_anonymous":false,"user_name":"GenerousViewer","user_login":"generousviewer","broadcaster_user_id":"2","total":5,"tier":"1000"}`
-	anonGiftJSON  = `{"is_anonymous":true,"broadcaster_user_id":"2","total":3,"tier":"1000"}`
-	cheerJSON     = `{"is_anonymous":false,"user_name":"CoolViewer","user_login":"coolviewer","broadcaster_user_id":"2","bits":100}`
-	anonCheerJSON = `{"is_anonymous":true,"broadcaster_user_id":"2","bits":50}`
-	adBreakJSON   = `{"broadcaster_user_id":"2","duration_seconds":90,"is_automatic":true}`
+	followJSON = `{"user_id":"7","user_name":"CoolViewer","user_login":"coolviewer","broadcaster_user_id":"2"}`
+	// A follow payload with no user id: the dedupe has nothing to key on.
+	followNoIDJSON = `{"user_name":"CoolViewer","user_login":"coolviewer","broadcaster_user_id":"2"}`
+	// The same follower on a different channel.
+	followOtherChannelJSON = `{"user_id":"7","user_name":"CoolViewer","user_login":"coolviewer","broadcaster_user_id":"9"}`
+	subscribeJSON          = `{"user_name":"CoolViewer","user_login":"coolviewer","broadcaster_user_id":"2","tier":"1000"}`
+	giftedSubJSON          = `{"user_name":"CoolViewer","user_login":"coolviewer","broadcaster_user_id":"2","tier":"1000","is_gift":true}`
+	resubJSON              = `{"user_name":"CoolViewer","user_login":"coolviewer","broadcaster_user_id":"2","tier":"1000","cumulative_months":7,"streak_months":7,"message":{"text":"7 months!"}}`
+	giftJSON               = `{"is_anonymous":false,"user_name":"GenerousViewer","user_login":"generousviewer","broadcaster_user_id":"2","total":5,"tier":"1000"}`
+	anonGiftJSON           = `{"is_anonymous":true,"broadcaster_user_id":"2","total":3,"tier":"1000"}`
+	cheerJSON              = `{"is_anonymous":false,"user_name":"CoolViewer","user_login":"coolviewer","broadcaster_user_id":"2","bits":100}`
+	anonCheerJSON          = `{"is_anonymous":true,"broadcaster_user_id":"2","bits":50}`
+	adBreakJSON            = `{"broadcaster_user_id":"2","duration_seconds":90,"is_automatic":true}`
 )
 
 func alertsCtx(eventType, payload, config string) *module.Context {
@@ -40,12 +46,24 @@ func alertsCtx(eventType, payload, config string) *module.Context {
 
 func alertsHandler(t *testing.T, eventType string) module.EventHandler {
 	t.Helper()
-	m := Alerts(engine.Deps{Log: zap.NewNop()})
+	return alertsHandlerWith(t, eventType, engine.Deps{Log: zap.NewNop()})
+}
+
+// alertsHandlerWith builds the module from a caller-supplied Deps, for the
+// tests that need a cooldown store wired in.
+func alertsHandlerWith(t *testing.T, eventType string, d engine.Deps) module.EventHandler {
+	t.Helper()
+	m := Alerts(d)
 	assert.Equal(t, "alerts", m.Name)
 	assert.Equal(t, module.KindDefault, m.Kind)
 	h := m.Events[eventType]
 	require.NotNil(t, h, "alerts must handle %s", eventType)
 	return h
+}
+
+// alertsDeps wires a scripted cooldown into an otherwise bare Deps.
+func alertsDeps(cd engine.CooldownStore) engine.Deps {
+	return engine.Deps{Log: zap.NewNop(), Cooldown: cd}
 }
 
 // alertInput is one event fired at the alerts module: the EventSub type, its
@@ -63,6 +81,91 @@ func runAlert(t *testing.T, in alertInput) []module.Output {
 	var col collector
 	require.NoError(t, alertsHandler(t, in.event)(context.Background(), alertsCtx(in.event, in.payload, in.cfg), col.emit))
 	return col.out
+}
+
+// runAlertOn fires one event through a handler the caller already built, so a
+// dedupe test can send several events at the same module instance.
+func runAlertOn(t *testing.T, h module.EventHandler, in alertInput) []module.Output {
+	t.Helper()
+	var col collector
+	require.NoError(t, h(context.Background(), alertsCtx(in.event, in.payload, in.cfg), col.emit))
+	return col.out
+}
+
+// The first follow claims the per-channel, per-follower window; a re-follow
+// inside it is silent, so unfollow/refollow cannot drive the alert line.
+func TestAlertsFollowDedupeSuppressesRefollow(t *testing.T) {
+	cd := &fakeCooldown{allow: []bool{true, false}}
+	h := alertsHandlerWith(t, "channel.follow", alertsDeps(cd))
+	in := alertInput{event: "channel.follow", payload: followJSON}
+
+	require.Len(t, runAlertOn(t, h, in), 1)
+	assert.Empty(t, runAlertOn(t, h, in), "re-follow inside the window must stay silent")
+
+	assert.Equal(t, []string{"alert:follow:2:7", "alert:follow:2:7"}, cd.keys)
+	assert.Equal(t, []time.Duration{followAlertWindow, followAlertWindow}, cd.ttls)
+	assert.Equal(t, 72*time.Hour, followAlertWindow, "follow dedupe window must stay multi-day")
+}
+
+// The same follower on another channel must still be thanked: the key carries
+// the broadcaster id.
+func TestAlertsFollowDedupeIsPerChannel(t *testing.T) {
+	cd := &fakeCooldown{}
+	h := alertsHandlerWith(t, "channel.follow", alertsDeps(cd))
+
+	require.Len(t, runAlertOn(t, h, alertInput{event: "channel.follow", payload: followJSON}), 1)
+	require.Len(t, runAlertOn(t, h, alertInput{event: "channel.follow", payload: followOtherChannelJSON}), 1)
+
+	assert.Equal(t, []string{"alert:follow:2:7", "alert:follow:9:7"}, cd.keys)
+}
+
+// Valkey unreachable must not swallow thank-yous: the gate fails open.
+func TestAlertsFollowDedupeFailsOpen(t *testing.T) {
+	cd := &fakeCooldown{err: errors.New("valkey down")}
+	h := alertsHandlerWith(t, "channel.follow", alertsDeps(cd))
+
+	assert.Len(t, runAlertOn(t, h, alertInput{event: "channel.follow", payload: followJSON}), 1)
+}
+
+// No user id on the payload means nothing stable to key on, so the alert fires
+// rather than claiming a window every follower would share.
+func TestAlertsFollowWithoutUserIDSkipsDedupe(t *testing.T) {
+	cd := &fakeCooldown{allow: []bool{false}}
+	h := alertsHandlerWith(t, "channel.follow", alertsDeps(cd))
+
+	assert.Len(t, runAlertOn(t, h, alertInput{event: "channel.follow", payload: followNoIDJSON}), 1)
+	assert.Empty(t, cd.keys)
+}
+
+// A channel with follow alerts off must not burn a window it would want the
+// moment the broadcaster turns them back on.
+func TestAlertsFollowDisabledClaimsNoWindow(t *testing.T) {
+	cd := &fakeCooldown{}
+	h := alertsHandlerWith(t, "channel.follow", alertsDeps(cd))
+
+	in := alertInput{event: "channel.follow", payload: followJSON, cfg: `{"followEnabled":"off"}`}
+	assert.Empty(t, runAlertOn(t, h, in))
+	assert.Empty(t, cd.keys)
+}
+
+// Every alert other than follow costs its sender something (or is the
+// channel's own ad break), so none of them are deduplicated.
+func TestAlertsNonFollowAlertsAreNotDeduped(t *testing.T) {
+	cd := &fakeCooldown{}
+	d := alertsDeps(cd)
+
+	for _, in := range []alertInput{
+		{event: "channel.subscribe", payload: subscribeJSON},
+		{event: "channel.subscription.message", payload: resubJSON},
+		{event: "channel.subscription.gift", payload: giftJSON},
+		{event: "channel.cheer", payload: cheerJSON},
+		{event: "channel.raid", payload: raidJSON},
+		{event: "channel.ad_break.begin", payload: adBreakJSON, cfg: `{"adsEnabled":"on"}`},
+	} {
+		h := alertsHandlerWith(t, in.event, d)
+		assert.Len(t, runAlertOn(t, h, in), 1, in.event)
+	}
+	assert.Empty(t, cd.keys)
 }
 
 // Every alert with its default template: one chat line to the broadcaster's

--- a/app/sesame/modules/queue_test.go
+++ b/app/sesame/modules/queue_test.go
@@ -338,14 +338,22 @@ func TestQueueJoinAndListViaSubcommand(t *testing.T) {
 }
 
 // fakeCooldown scripts CooldownStore.Allow: it records the claimed keys and
-// answers from the allow queue (defaulting to true when exhausted).
+// their windows, and answers from the allow queue (defaulting to true when
+// exhausted). A non-nil err makes every claim fail, which is how the callers'
+// fail-open/fail-closed behavior is exercised.
 type fakeCooldown struct {
 	keys  []string
+	ttls  []time.Duration
 	allow []bool
+	err   error
 }
 
-func (f *fakeCooldown) Allow(_ context.Context, key string, _ time.Duration) (bool, error) {
+func (f *fakeCooldown) Allow(_ context.Context, key string, ttl time.Duration) (bool, error) {
 	f.keys = append(f.keys, key)
+	f.ttls = append(f.ttls, ttl)
+	if f.err != nil {
+		return false, f.err
+	}
 	if len(f.allow) == 0 {
 		return true, nil
 	}

--- a/console/shared/lib/types.ts
+++ b/console/shared/lib/types.ts
@@ -699,7 +699,7 @@ export const MODULE_CATALOG: readonly ModuleDef[] = [
     label: 'Chat Alerts',
     tagline: 'Announce follows, subs, cheers, raids and ad breaks in chat.',
     description:
-      'The bot posts a chat line when someone follows, subscribes, cheers, or raids, and can announce ad breaks. Turn each alert on or off and customize its message. New alerts default on, except the ad-break alert which stays off until you enable it.',
+      'The bot posts a chat line when someone follows, subscribes, cheers, or raids, and can announce ad breaks. Turn each alert on or off and customize its message. New alerts default on, except the ad-break alert which stays off until you enable it. A follow alert fires at most once per viewer every three days, so unfollowing and refollowing cannot spam your chat.',
     icon: 'bell',
     category: 'Community',
     defaultEnabled: true,
@@ -707,7 +707,7 @@ export const MODULE_CATALOG: readonly ModuleDef[] = [
       {
         key: 'follow',
         label: 'Follow alert',
-        tagline: 'When someone follows your channel.',
+        tagline: 'When someone follows your channel. Fires once per viewer every three days.',
         event: 'on follow',
         enableKey: 'followEnabled',
         messageKey: 'followMessage',

--- a/docs/src/content/docs/microservices/sesame.md
+++ b/docs/src/content/docs/microservices/sesame.md
@@ -85,3 +85,33 @@ Sesame maintains high throughput by avoiding database reads on the hot path:
 - **Live Store**: `ValkeyLiveStore` checks if a broadcaster is currently live. It caches locally, falls back to Valkey, and can trigger a system outgress lane check to Twitch if the key is cold.
 - **Domain State**: Cooldowns, timers, loyalty live views, greeting windows, and
   reputation state are backed by Valkey. Transport replay is not.
+
+### Follow-alert dedupe
+
+Twitch re-sends `channel.follow` on every re-follow, so an unfollow/refollow loop would otherwise drive the chat
+alert as fast as a viewer can click. The alerts module claims `alert:follow:<broadcaster>:<follower>` for 72 hours
+using the same `SET key 1 NX PX` idiom as a command cooldown, and posts the thank-you only when it wins the claim.
+Both halves of the key are Twitch numeric IDs, so a rename cannot reopen the window, and one channel's claim never
+suppresses another's. The claim is taken after the enable toggle is read, so a channel with follow alerts off never
+burns a window it would want the moment it turns them back on.
+
+Only follows are gated. Subs, gifts, cheers and raids each cost the sender something, and ad breaks are the
+channel's own event.
+
+Three properties of the fleet make a multi-day window safe to hold in Valkey:
+
+- **The claim always lands on the primary.** `SET ... NX` is a write, so replica lag cannot let two replicas both
+  believe they won the window.
+- **The window survives restarts.** The keyspace runs AOF with `appendfsync everysec` on a persistent volume
+  (`save ""`, no RDB snapshots). The AOF records expirations as absolute timestamps, so a pod restart or a full
+  fleet restart restores each claim with its *remaining* time, not a refreshed 72 hours. The only loss window is
+  the sub-second of writes an unclean kill can drop, plus the few milliseconds of unreplicated writes a Sentinel
+  failover discards. Both cost at most a duplicate alert.
+- **The key set stays small.** At 5,000 follows/day a channel holds roughly 15,000 claims of about 120 bytes each:
+  under 2 MiB against the 512 MiB `maxmemory` budget. The window could be raised to a week at the same order of
+  cost. The pressure to watch is not size but policy: `maxmemory-policy volatile-lru` evicts TTL-carrying keys
+  first, and these claims are written once and rarely read, making them the coldest keys in the keyspace.
+  Sustained memory pressure would evict them and reopen alerts.
+
+The gate fails open. With Valkey unreachable the alert still posts and the miss is logged, because a lost
+thank-you is a worse outcome than a duplicate, and the abuse the gate exists for cannot cause the outage.


### PR DESCRIPTION
Closes #518

Twitch re-sends `channel.follow` on every re-follow, so a viewer could unfollow/refollow in a loop and drive the chat alert as fast as they could click.

## What changed

The follow alert claims `alert:follow:<broadcaster>:<follower>` for **72 hours** through the existing `CooldownStore` (`SET key 1 NX PX`, same idiom as a command cooldown) and posts only when it wins the claim.

- Both halves of the key are Twitch numeric IDs, so a rename cannot reopen the window, and one channel's claim never suppresses another's.
- The claim is taken **after** the enable toggle is read, so a channel with follow alerts off never burns a window it would want the moment it turns them back on.
- Only follows are gated. Subs, gifts, cheers and raids each cost the sender something, and ad breaks are the channel's own event.
- `onAlert` now hands the message context to `render`, so a render that claims shared state does it at the right point in the shared shell. Mechanical `_ context.Context` param on the other five renders.
- The gate **fails open**: no store wired, no `user_id` on the payload, or Valkey unreachable, and the alert still posts with the miss logged. A lost thank-you is a worse outcome than a duplicate, and the abuse this guards against cannot cause the outage.

## Why 72h is safe to hold in Valkey

The issue asked for research on the window length. Three properties of the fleet:

- **The claim always lands on the primary.** `SET ... NX` is a write, so replica lag cannot let two replicas both believe they won.
- **The window survives restarts.** The keyspace runs AOF with `appendfsync everysec` on a PVC (`save ""`, no RDB). AOF records expirations as absolute timestamps, so a pod restart or full fleet restart restores each claim with its *remaining* time, not a refreshed 72h. Loss window: the sub-second an unclean kill drops, plus the few ms of unreplicated writes a Sentinel failover discards. Both cost at most a duplicate alert.
- **The key set stays small.** A channel taking 5,000 follows/day holds roughly 15,000 claims of about 120 bytes: under 2 MiB against the 512 MiB `maxmemory` budget. A week-long window costs the same order. The pressure to watch is not size but policy: `maxmemory-policy volatile-lru` evicts TTL-carrying keys first, and these claims are written once and rarely read, making them the coldest keys in the keyspace.

Raising the window to 7d is a one-constant change if the three-day hole turns out to be worth closing.

## Tests

Refollow suppressed, per-channel isolation, fail-open on Valkey error, no-`user_id` path, disabled-alert claims nothing, and all six non-follow alerts ungated. `fakeCooldown` extended to record TTLs and script errors.

## Also

- `docs/microservices/sesame.md`: new "Follow-alert dedupe" section with the durability and sizing argument.
- `console/shared/lib/types.ts`: dashboard copy tells broadcasters the alert fires once per viewer every three days.