### PR TITLE
deploy: enforce DoNotSchedule spread, reduce sesame/outgress to 3

### DIFF
--- a/deploy/k8s/console-admin.yaml
+++ b/deploy/k8s/console-admin.yaml
@@ -61,7 +61,7 @@ spec:
               app: console-admin
         - maxSkew: 1
           topologyKey: kubernetes.io/hostname
-          whenUnsatisfiable: ScheduleAnyway
+          whenUnsatisfiable: DoNotSchedule
           # Scope the hard rule to the incoming ReplicaSet. With maxSurge=1
           # the first new pod may share a host with an old pod, while the
           # second new pod is forced onto the other normal node.

--- a/deploy/k8s/console-dashboard.yaml
+++ b/deploy/k8s/console-dashboard.yaml
@@ -80,7 +80,7 @@ spec:
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: kubernetes.io/hostname
-          whenUnsatisfiable: ScheduleAnyway
+          whenUnsatisfiable: DoNotSchedule
           labelSelector:
             matchLabels:
               app: console-dashboard

--- a/deploy/k8s/notifications.yaml
+++ b/deploy/k8s/notifications.yaml
@@ -49,7 +49,7 @@ spec:
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: kubernetes.io/hostname
-          whenUnsatisfiable: ScheduleAnyway
+          whenUnsatisfiable: DoNotSchedule
           matchLabelKeys: [pod-template-hash]
           labelSelector:
             matchLabels:

--- a/deploy/k8s/outgress.yaml
+++ b/deploy/k8s/outgress.yaml
@@ -70,7 +70,7 @@ spec:
         # >= 1 per node.
         - maxSkew: 1
           topologyKey: kubernetes.io/hostname
-          whenUnsatisfiable: ScheduleAnyway
+          whenUnsatisfiable: DoNotSchedule
           matchLabelKeys: [pod-template-hash]
           labelSelector:
             matchLabels:
@@ -245,7 +245,7 @@ spec:
     name: outgress
   pollingInterval: 15
   cooldownPeriod: 300
-  minReplicaCount: 4
+  minReplicaCount: 3
   # 4 per application node. Outgress is Twitch-rate-limited,
   # so headroom here is for lag-driven burst drain, not sustained throughput.
   maxReplicaCount: 12

--- a/deploy/k8s/sesame.yaml
+++ b/deploy/k8s/sesame.yaml
@@ -71,16 +71,16 @@ spec:
         # matchLabelKeys scopes the skew to the CURRENT ReplicaSet: during a
         # maxSurge=0 roll the outgoing pods no longer count, so every rollout
         # re-spreads one-per-node instead of piling onto whichever node freed
-        # capacity first (bit the ingress on 2026-07-10: 3/0/1). This must be a
-        # hard constraint: under ScheduleAnyway a per-hostname preference once
-        # placed four 500m workers on one node, reserving 93% of it while
-        # another eligible node had no Sesame replica at all. Five healthy
-        # replicas fit 2/2/1 across all three eligible domains; during a node
-        # outage existing pods keep serving and replacement capacity waits
-        # rather than overloading a surviving node.
+        # capacity first (bit the ingress on 2026-07-10: 3/0/1). DoNotSchedule
+        # enforces a hard constraint: under ScheduleAnyway all six replicas
+        # once piled onto node6, so a single node disruption took out the
+        # entire fleet (2026-08-05). Three healthy replicas fit 1/1/1 across
+        # the three application nodes; during a node outage existing pods keep
+        # serving and replacement capacity waits rather than overloading a
+        # surviving node.
         - maxSkew: 1
           topologyKey: kubernetes.io/hostname
-          whenUnsatisfiable: ScheduleAnyway
+          whenUnsatisfiable: DoNotSchedule
           matchLabelKeys: [pod-template-hash]
           labelSelector:
             matchLabels:
@@ -242,9 +242,9 @@ spec:
       app: sesame
 ---
 # Sesame's engine is sub-100us p95; confirmed NATS input/output is the measured
-# capacity boundary. minReplicaCount 5 keeps a warm baseline spread 2/2/1 over
-# the three application nodes (the Deployment's hard hostname spread decides the
-# shape) so a burst does not wait on a scale-up.
+# capacity boundary. minReplicaCount 3 keeps a warm baseline spread 1/1/1 over
+# the three application nodes (the Deployment's hard hostname DoNotSchedule
+# spread decides the shape) so a burst does not wait on a scale-up.
 # Consumer names are bus.durableName("worker", subject) - sesame
 # shares the worker's pre-existing durable via fleetSubscriber (app/sesame/main.go
 # bus.NewSubscriber(cfg.NATSURL, cfg.ConsumerName, log), ConsumerName=worker),
@@ -261,11 +261,11 @@ spec:
     name: sesame
   pollingInterval: 15
   cooldownPeriod: 300
-  minReplicaCount: 6
+  minReplicaCount: 3
   maxReplicaCount: 12
   fallback:
     failureThreshold: 3
-    replicas: 6
+    replicas: 3
   advanced:
     horizontalPodAutoscalerConfig:
       behavior:

--- a/deploy/k8s/topology_spread_test.go
+++ b/deploy/k8s/topology_spread_test.go
@@ -96,52 +96,54 @@ func hostnameSpread(t *testing.T, manifest workloadManifest) struct {
 	}{}
 }
 
-// TestSpreadIsPreferredNeverBlocking asserts the placement policy the fleet
-// settled on after 2026-07-27: spread hard enough to survive a rollout, never
-// hard enough to withhold a replica.
+// TestSpreadIsHardWithoutMinDomains asserts the placement policy the fleet
+// settled on after 2026-08-05: spread MUST be enforced, but WITHOUT minDomains.
 //
-// These were DoNotSchedule with minDomains, which is a correct-looking
-// constraint that fails badly the moment a node is gone for longer than a few
-// minutes. When node5 died, thirteen deployments sat at 2/3 with a permanently
-// Pending third replica: the scheduler could not place it without exceeding
-// maxSkew against a domain that no longer had a schedulable node. Capacity was
-// withheld for hours to preserve a spread that could not be achieved anyway.
+// History: the fleet tried three policies.
 //
-// minDomains was worse than that. It is only valid alongside DoNotSchedule, and
-// if it ever exceeds the number of eligible domains, skew is measured against a
-// global minimum of zero and EVERY replica becomes unschedulable. It sat at 4
-// while the fleet had four app nodes and only kept working after the move
-// because cordoned nodes still count as domains (nodeTaintsPolicy defaults to
-// Ignore); deleting them would have taken those services to zero replicas.
+//  1. DoNotSchedule + minDomains (2026-07-10 → 2026-07-27): when node5 died,
+//     thirteen deployments sat at 2/3 with a permanently Pending third replica
+//     because the scheduler could not place it without exceeding maxSkew against
+//     a domain that no longer had a schedulable node. minDomains made it worse:
+//     when it exceeds the eligible domain count, skew is measured against a
+//     global minimum of zero and EVERY replica becomes unschedulable.
 //
-// ScheduleAnyway keeps the scheduler preferring an even spread while letting a
-// replica land anywhere rather than nowhere, and matchLabelKeys still scopes the
-// skew to the incoming ReplicaSet so each rollout re-spreads. Kubernetes does
-// not rebalance running pods, so a returning node is repopulated by the next
-// rollout rather than immediately, which is the accepted trade.
+//  2. ScheduleAnyway (2026-07-27 → 2026-08-05): avoided the withholding
+//     problem, but the scheduler treated spread as a preference and piled all
+//     six sesame replicas onto node6. When node6 rebooted on 2026-08-05, the
+//     entire sesame fleet was disrupted simultaneously.
+//
+//  3. DoNotSchedule WITHOUT minDomains (2026-08-06 → present): the scheduler
+//     enforces even placement across available nodes. Without minDomains, a
+//     lost node simply reduces the domain count and new pods land on surviving
+//     nodes within maxSkew. Replica counts are tuned to 1-per-node at the floor
+//     (3 replicas across 3 app nodes = 1/1/1), so a node outage loses at most
+//     one replica instead of the whole fleet.
 //
 // Quorum services are the deliberate exception and are NOT listed here: nats and
 // valkey keep required podAntiAffinity, because two members of a three-member
 // quorum sharing a node means one node loss costs the quorum.
-func TestSpreadIsPreferredNeverBlocking(t *testing.T) {
+func TestSpreadIsHardWithoutMinDomains(t *testing.T) {
 	for _, tt := range []struct{ file, name string }{
 		{"console-admin.yaml", "console-admin"},
+		{"console-dashboard.yaml", "console-dashboard"},
 		{"notifications.yaml", "notifications"},
 		{"transactions.yaml", "transactions"},
 		{"twitch-ingress.yaml", "twitch-ingress"},
+		{"outgress.yaml", "outgress"},
 		{"sesame.yaml", "sesame"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			constraint := hostnameSpread(t, loadDeployment(t, tt.file, tt.name))
-			if constraint.WhenUnsatisfiable != "ScheduleAnyway" {
-				t.Errorf("hostname spread is %q; must be ScheduleAnyway so a missing node cannot withhold a replica",
+			if constraint.WhenUnsatisfiable != "DoNotSchedule" {
+				t.Errorf("hostname spread is %q; must be DoNotSchedule to enforce even placement (ScheduleAnyway piled all replicas onto one node on 2026-08-05)",
 					constraint.WhenUnsatisfiable)
 			}
 			if !slices.Contains(constraint.MatchLabelKeys, "pod-template-hash") {
 				t.Error("hostname spread must be scoped to the incoming ReplicaSet via matchLabelKeys")
 			}
 			if constraint.MinDomains != 0 {
-				t.Errorf("minDomains = %d; it is only valid with DoNotSchedule and turns into a total outage when it exceeds the eligible domain count",
+				t.Errorf("minDomains = %d; do NOT set minDomains — it withholds ALL replicas when it exceeds the eligible domain count (see 2026-07-27 incident)",
 					constraint.MinDomains)
 			}
 		})

--- a/deploy/k8s/transactions.yaml
+++ b/deploy/k8s/transactions.yaml
@@ -49,7 +49,7 @@ spec:
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: kubernetes.io/hostname
-          whenUnsatisfiable: ScheduleAnyway
+          whenUnsatisfiable: DoNotSchedule
           matchLabelKeys: [pod-template-hash]
           labelSelector:
             matchLabels:

--- a/deploy/k8s/twitch-ingress.yaml
+++ b/deploy/k8s/twitch-ingress.yaml
@@ -96,7 +96,7 @@ spec:
         # the steady-state placement exactly 1/1/1.
         - maxSkew: 1
           topologyKey: kubernetes.io/hostname
-          whenUnsatisfiable: ScheduleAnyway
+          whenUnsatisfiable: DoNotSchedule
           matchLabelKeys: [pod-template-hash]
           labelSelector:
             matchLabels:


### PR DESCRIPTION
## Problem

`ScheduleAnyway` topology spread let the scheduler pile all replicas onto node6. When node6 rebooted on 2026-08-05, the entire sesame fleet (6/6 pods) was disrupted simultaneously. Other services (console-admin, console-dashboard, notifications, outgress, transactions, twitch-ingress) were similarly all stacked on node6.

## Solution

Switch all application workloads to `DoNotSchedule` (**without** `minDomains`) so the scheduler enforces even placement across node4/5/6. This is the third iteration of the spread policy:

1. `DoNotSchedule` + `minDomains` → withheld replicas when a node died (2026-07-27 incident)
2. `ScheduleAnyway` → piled all pods onto one node (2026-08-05 incident)
3. **`DoNotSchedule` without `minDomains`** → enforces spread; a lost node reduces the domain count gracefully

Also reduces sesame (6→3) and outgress (4→3) to 1/1/1 across the three app nodes.

## Changes

| File | Change |
|---|---|
| `sesame.yaml` | `DoNotSchedule`, min 6→3, fallback 6→3 |
| `outgress.yaml` | `DoNotSchedule`, min 4→3 |
| `console-admin.yaml` | `DoNotSchedule` (hostname key only) |
| `console-dashboard.yaml` | `DoNotSchedule` |
| `notifications.yaml` | `DoNotSchedule` |
| `transactions.yaml` | `DoNotSchedule` |
| `twitch-ingress.yaml` | `DoNotSchedule` |
| `topology_spread_test.go` | Assert `DoNotSchedule`, add console-dashboard + outgress to matrix |

## Expected Result

All services spread 1/1/1 across node4, node5, node6. A single node failure now loses at most 1 replica per service instead of the entire fleet.