### PR TITLE
fix(ingress): stop NatsFailback from recycling healthy local NATS connections

### DIFF
--- a/app/ingress/lib/ingress/nats_failback.ex
+++ b/app/ingress/lib/ingress/nats_failback.ex
@@ -8,6 +8,7 @@ defmodule Ingress.NatsFailback do
   """
 
   use GenServer
+  require Logger
 
   # Only the RPC plane (:gnat) is failed back to the node-local leaf. The BUS
   # plane (:gnat_bus) dials the hub directly (hub-direct firehose), whose
@@ -48,14 +49,27 @@ defmodule Ingress.NatsFailback do
 
     {successes, candidate} =
       Enum.reduce(@connections, {state.successes, nil}, fn name, {counts, candidate} ->
+        locality = local_connection?(name, state.node)
+
         cond do
-          local_connection?(name, state.node) ->
+          locality == true ->
+            # Already on the node-local leaf — nothing to do.
             {Map.put(counts, name, 0), candidate}
+
+          locality == :unknown ->
+            # Connection is reconnecting or between states (process absent,
+            # server_info unavailable). Don't count this toward displacement;
+            # leave the counter unchanged so a transient reconnect window
+            # (e.g. after Gnat's own backoff) doesn't accumulate false
+            # displacement evidence.
+            {counts, candidate}
 
           !local_ready ->
             {Map.put(counts, name, 0), candidate}
 
           true ->
+            # Connection is confirmed on a remote leaf and the local leaf is
+            # healthy — count toward failback.
             count = Map.get(counts, name, 0) + 1
             next = if is_nil(candidate) and count >= state.required, do: name, else: candidate
             {Map.put(counts, name, count), next}
@@ -66,6 +80,17 @@ defmodule Ingress.NatsFailback do
     # lets subscriptions settle before the other account is re-homed.
     successes =
       if candidate do
+        server =
+          try do
+            Gnat.server_info(candidate).server_name
+          catch
+            :exit, _ -> "(unavailable)"
+          end
+
+        Logger.info(
+          "NatsFailback: recycling #{candidate} from #{server} back to node-local leaf"
+        )
+
         stop_connection(candidate)
         Map.put(successes, candidate, 0)
       else
@@ -80,16 +105,23 @@ defmodule Ingress.NatsFailback do
     {:noreply, state}
   end
 
+  # Returns `true` when connected to the node-local leaf, `false` when
+  # confirmed on a remote server, or `:unknown` when the connection process
+  # is absent or between states (backoff reconnect window). The three-way
+  # return lets the caller distinguish "definitely displaced" from "can't
+  # tell yet", preventing transient reconnect windows from accumulating
+  # false displacement evidence that triggers unnecessary connection kills.
+  @spec local_connection?(atom(), String.t()) :: boolean() | :unknown
   defp local_connection?(name, node) do
     case Process.whereis(name) do
       nil ->
-        false
+        :unknown
 
       _pid ->
         try do
           Gnat.server_info(name).server_name |> String.starts_with?(node <> "--")
         catch
-          :exit, _ -> false
+          :exit, _ -> :unknown
         end
     end
   end


### PR DESCRIPTION
## Problem

Every `twitch-ingress` pod logs `connection failed :normal` from `Gnat.ConnectionSupervisor` every ~90 seconds, flooding New Relic and burning CPU on reconnection churn across all three worker nodes.

## Root Cause

`Ingress.NatsFailback` runs a 30-second health check loop. When the `:gnat` process is absent during Gnat's 4-second backoff reconnect window (after the *previous* kill), `local_connection?/2` returned `false` — the same value as "confirmed on a remote server". Three such cycles (90 seconds) accumulated false displacement evidence and triggered another `Gnat.stop(:gnat)`, creating an infinite kill loop on healthy connections.

## Fix

`local_connection?/2` now returns a **three-way** value:
- `true` → confirmed on the node-local leaf (reset counter)
- `false` → confirmed on a remote leaf (count toward failback)
- `:unknown` → process absent or between states (**skip**, leave counter unchanged)

This breaks the kill loop because transient reconnect windows no longer count as displacement evidence. Genuine failback still works as before.

Also adds explicit `Logger.info` when a connection is intentionally recycled for failback visibility.

## Testing

- `mix test` — **159 tests, 0 failures** ✅
- Compilation clean, no warnings

## Expected Impact

- `connection failed :normal` error log stops appearing every 90 seconds
- CPU usage on node5 drops closer to node4/node6 levels
- Erlang VM memory alarm churn eliminated