### PR TITLE
fix(sesame): make alloc ceiling race-detector-aware

### DIFF
--- a/app/sesame/engine/alloc_ceiling_race_test.go
+++ b/app/sesame/engine/alloc_ceiling_race_test.go
@@ -1,0 +1,10 @@
+//go:build race
+
+package engine
+
+// allocCeiling is the per-Process allocation limit used by
+// TestProcessNoOutputAllocCeiling.  The race detector instruments sync.Pool and
+// context operations, adding 2-3 allocations that do not exist in production
+// builds.  The wider ceiling keeps the test useful as a structural regression
+// guard without flaking under -race.
+const allocCeiling = 16.0

--- a/app/sesame/engine/alloc_ceiling_test.go
+++ b/app/sesame/engine/alloc_ceiling_test.go
@@ -1,0 +1,9 @@
+//go:build !race
+
+package engine
+
+// allocCeiling is the per-Process allocation limit used by
+// TestProcessNoOutputAllocCeiling.  Without the race detector the hot path sits
+// at 12 allocs (the JSON decoder floor); keep the ceiling tight so any
+// structural regression (un-pooling Context/Envelope) is caught immediately.
+const allocCeiling = 12.0

--- a/app/sesame/engine/pipeline_bench_test.go
+++ b/app/sesame/engine/pipeline_bench_test.go
@@ -78,8 +78,7 @@ func TestProcessNoOutputAllocCeiling(t *testing.T) {
 		_ = p.Process(msg)
 	})
 
-	const ceiling = 12.0
-	if avg > ceiling {
-		t.Fatalf("no-output hot path allocates %.1f allocs/op, ceiling %.0f: pooling likely regressed", avg, ceiling)
+	if avg > allocCeiling {
+		t.Fatalf("no-output hot path allocates %.1f allocs/op, ceiling %.0f: pooling likely regressed", avg, allocCeiling)
 	}
 }


### PR DESCRIPTION
## Problem

`TestProcessNoOutputAllocCeiling` has been failing on every CI run (Renovate PRs, Flux image-update pushes to main) because the allocation ceiling of 12 was calibrated without `-race`, but CI runs `go test -v -race ./...`.

The race detector instruments `sync.Pool` and `context.WithValue` operations, adding 2-3 allocations per `Process` call that don't exist in production builds. This pushed the count from 12 → 14-15, exceeding the ceiling.

## Fix

Split the ceiling into two build-tag-guarded constants:

| File | Build tag | Ceiling | Rationale |
|------|-----------|---------|-----------|
| `alloc_ceiling_test.go` | `!race` | **12** | Tight — catches real pooling regressions |
| `alloc_ceiling_race_test.go` | `race` | **16** | Allows for race detector overhead |

The test in `pipeline_bench_test.go` now references the `allocCeiling` constant instead of a hardcoded value.

## Verification

- ✅ `go test -race -run TestProcessNoOutputAllocCeiling -count=5` — **PASS** (14 allocs, ceiling 16)
- ✅ `go test -run TestProcessNoOutputAllocCeiling -count=3` — **PASS** (12 allocs, ceiling 12)
- ✅ `go test -race ./...` — all 49 packages **PASS**