### PR TITLE
fix: security review findings (module authz, entitlement expiry, MySQL CA adoption)

### DIFF
--- a/app/transactions/web/server.go
+++ b/app/transactions/web/server.go
@@ -308,11 +308,16 @@ func (s *Server) applyBilling(ctx context.Context, event tebexEvent, payment rec
 		return fmt.Errorf("invalid webhook date: %w", err)
 	}
 	expiresAt := payment.ExpiresAt
-	if action == billingrpc.ActionActivate && expiresAt == nil {
+	if grantsPaid(action) && expiresAt == nil {
 		// One-time purchases (single-month buys, gifts) can arrive without any
-		// expiry on the payment subject, but a paid month must still run out —
-		// an activation without expiry would never be revoked by the safety
-		// net. Default to one month from the payment event.
+		// expiry on the payment subject, but every action that leaves the user
+		// paid must still run out. This is not just activation: a
+		// payment.dispute.won maps to ActionCancelAborted and follows a
+		// payment.dispute.opened that already cleared the stored expiry
+		// (ActionRevoke), so a nil expiry here would otherwise reinstate the
+		// user with no expiry at all, permanent premium, and no further Tebex
+		// event ever arrives for a settled one-time payment to correct it.
+		// Default to one month from the payment event.
 		fallback := occurredAt.AddDate(0, 1, 0)
 		expiresAt = &fallback
 	}

--- a/app/transactions/web/server_test.go
+++ b/app/transactions/web/server_test.go
@@ -117,6 +117,93 @@ func TestPaymentCompletedWithoutUserIDStoresFailedState(t *testing.T) {
 	assert.Contains(t, store.events[0].Error, "user id")
 }
 
+// A resolved chargeback (payment.dispute.won) maps to ActionCancelAborted and,
+// like a one-time payment.completed, can arrive with no expiry on the payment
+// subject. Without the fallback this reinstates the user with an open-ended
+// grant: the preceding payment.dispute.opened already cleared the stored
+// expiry via ActionRevoke, and no further Tebex event ever arrives for a
+// settled one-time payment to correct it. This is the regression the fix
+// covers.
+func TestDisputeWonOnOneTimePurchaseCarriesBoundedExpiry(t *testing.T) {
+
+	store := &fakeStore{}
+	app := newTestApp(store)
+
+	opened := `{"id":"evt-dispute-open","type":"payment.dispute.opened","date":"2026-07-02T00:00:00+00:00","subject":{"transaction_id":"tbx-1234","custom":{"user_id":"1001"}}}`
+	resp := doWebhook(t, app, opened, testSecret, true)
+	resp.Body.Close()
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+
+	won := `{"id":"evt-dispute-won","type":"payment.dispute.won","date":"2026-07-05T00:00:00+00:00","subject":{"transaction_id":"tbx-1234","custom":{"user_id":"1001"},"products":[]}}`
+	resp = doWebhook(t, app, won, testSecret, true)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.Len(t, store.changes, 2)
+	assert.Equal(t, billingrpc.ActionRevoke, store.changes[0].Action)
+	assert.Equal(t, billingrpc.ActionCancelAborted, store.changes[1].Action)
+	require.NotNil(t, store.changes[1].ExpiresAt,
+		"a settled one-time payment must not reinstate premium with no expiry")
+	assert.Equal(t, "2026-08-05", store.changes[1].ExpiresAt.UTC().Format("2006-01-02"))
+}
+
+// A cancellation-requested event keeps the user paid until the term ends, so
+// it needs the same fallback as activation when the recurring subject carries
+// no next_payment_at.
+func TestCancelRequestedWithoutNextPaymentCarriesBoundedExpiry(t *testing.T) {
+
+	store := &fakeStore{}
+	app := newTestApp(store)
+	body := `{
+		"id":"evt-cancel-requested",
+		"type":"recurring-payment.cancellation.requested",
+		"date":"2026-07-02T00:00:00+00:00",
+		"subject":{
+			"reference":"tbx-r-1234",
+			"initial_payment":{
+				"transaction_id":"tbx-init",
+				"custom":{"user_id":"1001"}
+			}
+		}
+	}`
+
+	resp := doWebhook(t, app, body, testSecret, true)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.Len(t, store.changes, 1)
+	assert.Equal(t, billingrpc.ActionCancelRequested, store.changes[0].Action)
+	require.NotNil(t, store.changes[0].ExpiresAt,
+		"a cancellation without a next payment date must still carry a bounded expiry")
+	assert.Equal(t, "2026-08-02", store.changes[0].ExpiresAt.UTC().Format("2006-01-02"))
+}
+
+// The fallback must never override an expiry Tebex actually sent.
+func TestPaymentCompletedWithExplicitExpiryIsNotOverridden(t *testing.T) {
+
+	store := &fakeStore{}
+	app := newTestApp(store)
+	body := `{
+		"id":"evt-payment-expiry",
+		"type":"payment.completed",
+		"date":"2026-07-02T00:00:00+00:00",
+		"subject":{
+			"transaction_id":"tbx-5678",
+			"custom":{"user_id":"1001"},
+			"products":[{"expires_at":"2027-01-01T00:00:00+00:00"}]
+		}
+	}`
+
+	resp := doWebhook(t, app, body, testSecret, true)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.Len(t, store.changes, 1)
+	assert.Equal(t, billingrpc.ActionActivate, store.changes[0].Action)
+	require.NotNil(t, store.changes[0].ExpiresAt)
+	assert.Equal(t, "2027-01-01", store.changes[0].ExpiresAt.UTC().Format("2006-01-02"))
+}
+
 func TestRefundRevokesEntitlementAndStoresProcessedState(t *testing.T) {
 
 	store := &fakeStore{}

--- a/app/transactions/web/tebexevent.go
+++ b/app/transactions/web/tebexevent.go
@@ -87,6 +87,20 @@ var billingEventActions = map[string]struct {
 	"payment.dispute.lost":                     {billingrpc.ActionRevoke, false},
 }
 
+// grantsPaid reports whether action leaves the user paid, as opposed to
+// ActionRevoke which does not. Activate, CancelRequested (cancellation
+// pending but still paid until the term ends) and CancelAborted (a reversed
+// cancellation, or a chargeback the merchant won) all route to
+// applyPaidUpdate in app/users/repository/billing.go and land the user in
+// user.StatusPaid. Every one of them needs a bounded expiry on the way in
+// (see the fallback in applyBilling below), so the paid-producing set is
+// defined once here instead of duplicated per call site.
+func grantsPaid(action billingrpc.Action) bool {
+	return action == billingrpc.ActionActivate ||
+		action == billingrpc.ActionCancelRequested ||
+		action == billingrpc.ActionCancelAborted
+}
+
 // trialAction picks the billing action a trial event drives, or false when the
 // event (ending-soon reminder, trial ended) changes nothing.
 func trialAction(eventType string) (billingrpc.Action, bool) {

--- a/app/users/repository/billing.go
+++ b/app/users/repository/billing.go
@@ -56,10 +56,10 @@ func (r *Users) ApplyBilling(ctx context.Context, req billingrpc.ApplyRequest) (
 		)
 		switch req.Action {
 		case billingrpc.ActionActivate, billingrpc.ActionCancelAborted:
-			applyPaidUpdate(q, req, false)
+			applyPaidUpdate(q, req, false, u.SubscriptionExpiresAt)
 
 		case billingrpc.ActionCancelRequested:
-			applyPaidUpdate(q, req, true)
+			applyPaidUpdate(q, req, true, u.SubscriptionExpiresAt)
 
 		case billingrpc.ActionRevoke:
 			q.SetStatus(user.StatusFree).
@@ -104,14 +104,38 @@ func (r *Users) countGiftForGifter(ctx context.Context, req billingrpc.ApplyRequ
 // applyPaidUpdate sets the paid-tier fields common to a Tebex activation and a
 // cancellation-requested event; the two differ only in whether the cancellation
 // is pending. One place, so the update chain is not duplicated per action.
-func applyPaidUpdate(q *ent.UserUpdate, req billingrpc.ApplyRequest, cancelPending bool) {
+//
+// storedExpiresAt is the row's expiry before this update runs. The caller
+// (transactions/web's applyBilling) already backfills a fallback expiry for
+// every action that reaches this function, but that is a second place trusted
+// to get it right, not a guarantee. A payment.dispute.won lands here as
+// ActionCancelAborted after the preceding payment.dispute.opened already
+// cleared subscription_expires_at via ActionRevoke; if req.ExpiresAt were
+// ever nil for that event (a one-time purchase carries no payment-subject
+// expiry), setting StatusPaid with no expiry at all would reinstate the user
+// with permanent premium; see the incident this function's fallback exists
+// for. This is the backstop that makes it structurally impossible from this
+// side too: when the request carries no expiry and the stored row has none
+// either, clamp to one month from the event instead of leaving it open. A
+// hard reject was considered and rejected: SetAdminStatus can afford to
+// reject because it is a synchronous, operator-driven call the caller retries
+// by hand, but this path is a Tebex webhook, and ApplyBilling's contract is
+// that a returned error makes Tebex retry the delivery (see its doc comment).
+// That retry path exists for transient NATS/users outages, not a condition
+// that Tebex redelivering the identical event can ever resolve, so rejecting
+// here would leave a legitimately paid customer (a won dispute) stuck in an
+// infinite retry loop instead of holding a bounded grant.
+func applyPaidUpdate(q *ent.UserUpdate, req billingrpc.ApplyRequest, cancelPending bool, storedExpiresAt *time.Time) {
 	q.SetStatus(user.StatusPaid).
 		SetSubscriptionSource("tebex").
 		SetSubscriptionCancelPending(cancelPending).
 		SetBillingEventAt(req.OccurredAt).
 		SetBillingEventID(req.EventID)
-	if req.ExpiresAt != nil {
+	switch {
+	case req.ExpiresAt != nil:
 		q.SetSubscriptionExpiresAt(*req.ExpiresAt)
+	case storedExpiresAt == nil:
+		q.SetSubscriptionExpiresAt(req.OccurredAt.AddDate(0, 1, 0))
 	}
 	if req.RecurringReference != "" {
 		q.SetSubscriptionRef(req.RecurringReference)

--- a/app/users/repository/users_test.go
+++ b/app/users/repository/users_test.go
@@ -288,6 +288,57 @@ func TestApplyBillingCancellationAndEnd(t *testing.T) {
 	assert.Empty(t, view.SubscriptionSource)
 }
 
+// A payment.dispute.won arrives as ActionCancelAborted after the preceding
+// payment.dispute.opened (ActionRevoke) already cleared the stored expiry.
+// If the transactions-side fallback were ever bypassed, ApplyBilling would
+// otherwise be asked to set StatusPaid with no expiry on a row that already
+// has none. The backstop in applyPaidUpdate must clamp this to a bounded
+// expiry rather than mint permanent premium: this is the invariant that
+// makes the bug structurally impossible from the users side, independent of
+// whether the transactions side got its fallback right.
+func TestApplyBillingBackstopClampsUnboundedPaidGrant(t *testing.T) {
+	_, _, repo := setup(t)
+	ctx := context.Background()
+	require.NoError(t, repo.Register(ctx, 5005, "Chargeback", "chargeback@example.com"))
+
+	started := time.Date(2026, 7, 2, 12, 0, 0, 0, time.UTC)
+	expires := started.AddDate(0, 1, 0)
+	_, err := repo.ApplyBilling(ctx, billingrpc.ApplyRequest{
+		UserID: 5005, EventID: "evt-start", Action: billingrpc.ActionActivate,
+		OccurredAt: started, ExpiresAt: &expires,
+	})
+	require.NoError(t, err)
+
+	// payment.dispute.opened: the revoke clears the stored expiry.
+	_, err = repo.ApplyBilling(ctx, billingrpc.ApplyRequest{
+		UserID: 5005, EventID: "evt-dispute-open", Action: billingrpc.ActionRevoke,
+		OccurredAt: started.Add(time.Hour),
+	})
+	require.NoError(t, err)
+	view, err := repo.Get(ctx, 5005)
+	require.NoError(t, err)
+	assert.Equal(t, "free", view.Status)
+	assert.Nil(t, view.SubscriptionExpiresAt)
+
+	// payment.dispute.won arrives as ActionCancelAborted with no expiry, the
+	// exact shape a one-time purchase produces without the transactions-side
+	// fallback.
+	won := started.Add(3 * 24 * time.Hour)
+	applied, err := repo.ApplyBilling(ctx, billingrpc.ApplyRequest{
+		UserID: 5005, EventID: "evt-dispute-won", Action: billingrpc.ActionCancelAborted,
+		OccurredAt: won,
+	})
+	require.NoError(t, err)
+	assert.True(t, applied)
+
+	view, err = repo.Get(ctx, 5005)
+	require.NoError(t, err)
+	assert.Equal(t, "paid", view.Status)
+	require.NotNil(t, view.SubscriptionExpiresAt,
+		"a nil-expiry paid update against a NULL stored expiry must not mint an unbounded grant")
+	assert.Equal(t, won.AddDate(0, 1, 0), *view.SubscriptionExpiresAt)
+}
+
 func TestExpireSubscriptionsHonorsTebexGrace(t *testing.T) {
 	client, _, repo := setup(t)
 	ctx := context.Background()

--- a/console/dashboard/src/lib/server/guard.ts
+++ b/console/dashboard/src/lib/server/guard.ts
@@ -50,6 +50,32 @@ function delegateAllowedPaths(sections: readonly string[]): string[] {
   return allowed;
 }
 
+// pathnameAllowed checks a request path against the delegate's allowed-path
+// list. An exact hit always passes; a prefix hit (a sub-route under a
+// granted section) usually does too, EXCEPT under '/modules': that prefix
+// covers the generic per-module reply page for every catalog module, but a
+// module can declare its own narrower delegateSections (channel points), so
+// admitting '/modules/<id>' on the strength of the bare 'modules' grant
+// would let it reach a module it was never granted. Recheck the specific
+// module's own scope in that one case; every other prefix (the counters
+// list, a bespoke href) carries no per-item scope of its own.
+function pathnameAllowed(pathname: string, allowed: string[], sections: readonly string[]): boolean {
+  if (allowed.includes(pathname)) return true;
+  const prefix = allowed.find((p) => pathname.startsWith(p + '/'));
+  if (!prefix) return false;
+  if (prefix !== '/modules') return true;
+  const id = pathname.slice(prefix.length + 1).split('/')[0];
+  return moduleSubpathAllowed(id, sections);
+}
+
+function moduleSubpathAllowed(id: string, sections: readonly string[]): boolean {
+  const def = MODULE_CATALOG.find((d) => d.id === id);
+  // An id the catalog has never heard of 404s at the route itself; let the
+  // request through rather than duplicating that check here.
+  if (!def) return true;
+  return moduleDelegateSections(def).some((sec) => sections.includes(sec));
+}
+
 // guardSession validates an already-opened session against authoritative
 // account state. Returns the session to keep in locals, or throws a redirect
 // (wiping the cookie when the session itself is dead). Anonymous requests
@@ -97,9 +123,11 @@ export async function guardSession(event: RequestEvent, s: Session): Promise<Ses
     // Section scope for everything under (app) — pages AND their actions
     // (the per-page gates remain as defense in depth).
     if (event.route.id?.startsWith('/(app)')) {
-      const allowed = delegateAllowedPaths(s.sections ?? []);
-      const ok = allowed.some((p) => event.url.pathname === p || event.url.pathname.startsWith(p + '/'));
-      if (!ok) throw redirect(303, allowed[0] ?? '/delegate/exit');
+      const sections = s.sections ?? [];
+      const allowed = delegateAllowedPaths(sections);
+      if (!pathnameAllowed(event.url.pathname, allowed, sections)) {
+        throw redirect(303, allowed[0] ?? '/delegate/exit');
+      }
     }
   }
 

--- a/console/dashboard/src/lib/server/module-gate.ts
+++ b/console/dashboard/src/lib/server/module-gate.ts
@@ -24,3 +24,13 @@ export function gateModulePage(session: Session | null | undefined, moduleId: st
   const def = moduleDef(moduleId);
   if (!def || !delegateCanOpen(def, session)) throw redirect(302, '/');
 }
+
+// assertModuleWritable reports whether a write action (toggle, save, patch)
+// may touch this module's stored row. It folds together the same two checks
+// the read paths already make (delegateCanOpen's scope check, and the
+// def.hidden rejection the [id] load performs) so a write gate can never end
+// up looser than its matching read gate: gateModules() alone only knows the
+// 'modules' section, not that a module like channel points is its own grant.
+export function assertModuleWritable(session: Session | null | undefined, def: ModuleDef): boolean {
+  return !def.hidden && delegateCanOpen(def, session);
+}

--- a/console/dashboard/src/routes/(app)/modules/+page.server.ts
+++ b/console/dashboard/src/routes/(app)/modules/+page.server.ts
@@ -4,7 +4,7 @@ import { MODULE_CATALOG, moduleDef } from '@bagel/shared';
 import { listModules, upsertModule, type ModuleView } from '$lib/server/commands-store';
 import { auditDashboardImpersonation } from '$lib/server/services';
 import { logger } from '@bagel/shared/server/logger';
-import { delegateCanOpen } from '$lib/server/module-gate';
+import { assertModuleWritable, delegateCanOpen } from '$lib/server/module-gate';
 import type { Session } from '$lib/server/session';
 import { env } from '$env/dynamic/private';
 import { fail, redirect } from '@sveltejs/kit';
@@ -73,6 +73,9 @@ export const actions: Actions = {
     const name = String(f.get('name') ?? '');
     const def = moduleDef(name);
     if (!def || def.toggleable === false) return fail(400, { ok: false, error: 'Unknown module.' });
+    // gateModules above only proves the 'modules' section; channel points is
+    // its own grant and would otherwise flip through this generic toggle.
+    if (!assertModuleWritable(locals.session, def)) return fail(403, { ok: false, error: 'Not allowed.' });
     const enabled = f.get('is_enabled') === 'on';
 
     if (env.DEMO === '1') return { ok: true, name, enabled };

--- a/console/dashboard/src/routes/(app)/modules/+page.server.ts
+++ b/console/dashboard/src/routes/(app)/modules/+page.server.ts
@@ -60,41 +60,60 @@ export const load: PageServerLoad = async ({ locals }) => {
   }
 };
 
+// resolveToggle gates the tile toggle against the module it actually names.
+// Rejections come back as `denied` for the action to hand straight back.
+// gateModules only proves the 'modules' section, so the per-module check
+// matters here: channel points is its own delegation grant and would
+// otherwise flip through this generic toggle.
+type ToggleTarget = { denied: ReturnType<typeof fail> } | { uid: string };
+
+function resolveToggle(name: string, session: Session | null | undefined): ToggleTarget {
+  const def = moduleDef(name);
+  if (!def || def.toggleable === false) return { denied: fail(400, { ok: false, error: 'Unknown module.' }) };
+  if (!assertModuleWritable(session, def)) return { denied: fail(403, { ok: false, error: 'Not allowed.' }) };
+  return { uid: effectiveId(session) };
+}
+
 export const actions: Actions = {
   // Quick tile on/off: flips enabled while preserving the stored config.
   toggle: async ({ request, locals }) => {
     gateModules(locals.session);
-    const uid = effectiveId(locals.session);
     if (env.DEMO !== '1' && !locals.session) {
       return fail(401, { ok: false, error: 'Not signed in.' });
     }
 
     const f = await request.formData();
     const name = String(f.get('name') ?? '');
-    const def = moduleDef(name);
-    if (!def || def.toggleable === false) return fail(400, { ok: false, error: 'Unknown module.' });
-    // gateModules above only proves the 'modules' section; channel points is
-    // its own grant and would otherwise flip through this generic toggle.
-    if (!assertModuleWritable(locals.session, def)) return fail(403, { ok: false, error: 'Not allowed.' });
+    const target = resolveToggle(name, locals.session);
+    if ('denied' in target) return target.denied;
     const enabled = f.get('is_enabled') === 'on';
 
     if (env.DEMO === '1') return { ok: true, name, enabled };
 
-    try {
-      // The tile only flips enabled: re-read the stored config and write it back
-      // untouched. Never rebuild it from the tile form — the page flattens every
-      // config value to a string for its reply inputs, which would corrupt the
-      // nested blobs some modules own (channel-points rewards, timers) into
-      // "[object Object]" and wipe them on a toggle.
-      const rows = await listModules(uid);
-      const config = rows.find((r) => r.name === name)?.configs;
-      await upsertModule(uid, name, enabled, config);
-    } catch (e) {
-      logger.error({ err: e }, `[modules] toggle ${name} failed`);
-      return fail(400, { ok: false });
-    }
-
-    auditDashboardImpersonation(locals.session, 'module:toggle', `${name}=${enabled}`);
-    return { ok: true, name, enabled };
+    return flipModule({ name, uid: target.uid, enabled }, locals.session);
   }
 };
+
+// flipModule writes the enable flag, preserving the stored config. The tile
+// only flips enabled: re-read the stored config and write it back untouched.
+// Never rebuild it from the tile form — the page flattens every config value
+// to a string for its reply inputs, which would corrupt the nested blobs some
+// modules own (channel-points rewards, timers) into "[object Object]" and wipe
+// them on a toggle.
+async function flipModule(
+  flip: { name: string; uid: string; enabled: boolean },
+  session: Session | null | undefined
+) {
+  const { name, uid, enabled } = flip;
+  try {
+    const rows = await listModules(uid);
+    const config = rows.find((r) => r.name === name)?.configs;
+    await upsertModule(uid, name, enabled, config);
+  } catch (e) {
+    logger.error({ err: e }, `[modules] toggle ${name} failed`);
+    return fail(400, { ok: false });
+  }
+
+  auditDashboardImpersonation(session, 'module:toggle', `${name}=${enabled}`);
+  return { ok: true, name, enabled };
+}

--- a/console/dashboard/src/routes/(app)/modules/[id]/+page.server.ts
+++ b/console/dashboard/src/routes/(app)/modules/[id]/+page.server.ts
@@ -3,6 +3,7 @@ import { moduleDef, type ModuleDef } from '@bagel/shared';
 import { listModules, upsertModule, patchModule } from '$lib/server/commands-store';
 import { auditDashboardImpersonation } from '$lib/server/services';
 import { logger } from '@bagel/shared/server/logger';
+import { assertModuleWritable } from '$lib/server/module-gate';
 import type { Session } from '$lib/server/session';
 import { env } from '$env/dynamic/private';
 import { error, fail, redirect } from '@sveltejs/kit';
@@ -85,6 +86,24 @@ function buildConfig(def: ModuleDef, f: FormData): Record<string, string> {
   return config;
 }
 
+// allowedConfigKeys names every key a module's own page can legitimately
+// write, mirroring buildConfig above key for key: each reply's message and
+// (if it has one) enable toggle, each plain setting, and triggers' own
+// "rules" blob. patch takes a client-authored JSON delta rather than a form
+// buildConfig can walk field by field, so without this a delegate (or a
+// forged request) could stash arbitrary keys into the stored config that no
+// UI ever reads back.
+function allowedConfigKeys(def: ModuleDef): Set<string> {
+  const keys = new Set<string>();
+  for (const reply of def.replies) {
+    keys.add(reply.messageKey);
+    if (reply.enableKey) keys.add(reply.enableKey);
+  }
+  for (const field of def.settings ?? []) keys.add(field.key);
+  if (def.id === 'triggers') keys.add('rules');
+  return keys;
+}
+
 export const actions: Actions = {
   // One save persists the whole module config (enable + every reply message and
   // per-reply toggle). The client always posts the full draft, so upsertModule's
@@ -92,7 +111,13 @@ export const actions: Actions = {
   save: async ({ request, params, locals }) => {
     gateModules(locals.session);
     const def = moduleDef(params.id);
-    if (!def) return fail(404, { ok: false, error: 'Unknown module.' });
+    // href modules own a bespoke page (see the load's redirect above) and
+    // are never editable through this generic reply inspector, so they read
+    // as not-found here the same as an id the catalog has never heard of.
+    if (!def || def.href) return fail(404, { ok: false, error: 'Unknown module.' });
+    // gateModules above only proves the 'modules' section; a module with its
+    // own delegation grant (channel points) needs its own scope checked too.
+    if (!assertModuleWritable(locals.session, def)) return fail(403, { ok: false, error: 'Not allowed.' });
     const uid = effectiveId(locals.session);
     if (env.DEMO !== '1' && !locals.session) {
       return fail(401, { ok: false, error: 'Not signed in.' });
@@ -123,7 +148,10 @@ export const actions: Actions = {
   patch: async ({ request, params, locals }) => {
     gateModules(locals.session);
     const def = moduleDef(params.id);
-    if (!def) return fail(404, { ok: false, error: 'Unknown module.' });
+    // See save above: href modules are never editable through this route,
+    // regardless of who is asking.
+    if (!def || def.href) return fail(404, { ok: false, error: 'Unknown module.' });
+    if (!assertModuleWritable(locals.session, def)) return fail(403, { ok: false, error: 'Not allowed.' });
     const uid = effectiveId(locals.session);
     if (env.DEMO !== '1' && !locals.session) {
       return fail(401, { ok: false, error: 'Not signed in.' });
@@ -132,7 +160,7 @@ export const actions: Actions = {
     const f = await request.formData();
     const enabled = f.get('is_enabled') === 'on';
     const expectedRev = Number(f.get('expected_rev') ?? '0') || 0;
-    const partial = parsePartial(f.get('partial'));
+    const partial = parsePartial(f.get('partial'), def);
     if (!partial) return fail(400, { ok: false, error: 'Invalid patch.' });
 
     if (env.DEMO === '1') return { ok: true, rev: expectedRev + 1, conflict: false };
@@ -149,17 +177,18 @@ export const actions: Actions = {
   }
 };
 
-// parsePartial coerces the posted patch JSON into a flat string map, or null when
-// it is not a valid object.
-function parsePartial(raw: FormDataEntryValue | null): Record<string, string> | null {
+// parsePartial coerces the posted patch JSON into a flat string map, dropping
+// any key the module def does not declare (allowedConfigKeys), or null when
+// the payload is not a valid object at all. The keys are the only thing that
+// makes it into the stored config, so an unknown key never has anywhere to
+// land, no matter what the request tries to smuggle in.
+function parsePartial(raw: FormDataEntryValue | null, def: ModuleDef): Record<string, string> | null {
   try {
     const obj = JSON.parse(String(raw ?? '{}'));
     if (!obj || typeof obj !== 'object') return {};
-    const partial: Record<string, string> = {};
-    for (const [k, v] of Object.entries(obj as Record<string, unknown>)) {
-      partial[k] = v == null ? '' : String(v);
-    }
-    return partial;
+    const allowed = allowedConfigKeys(def);
+    const entries = Object.entries(obj as Record<string, unknown>).filter(([k]) => allowed.has(k));
+    return Object.fromEntries(entries.map(([k, v]) => [k, v == null ? '' : String(v)]));
   } catch {
     return null;
   }

--- a/console/dashboard/src/routes/(app)/modules/[id]/+page.server.ts
+++ b/console/dashboard/src/routes/(app)/modules/[id]/+page.server.ts
@@ -104,24 +104,34 @@ function allowedConfigKeys(def: ModuleDef): Set<string> {
   return keys;
 }
 
+// resolveWrite gates a write action and resolves what it writes: the module
+// def and the id whose row it touches. Every rejection is returned as `denied`
+// for the action to hand straight back, so both actions read as a single gate
+// call instead of repeating the same four checks and drifting apart from each
+// other (and from the load) the way the read and write paths already did once.
+// href modules are refused here for the same reason the load redirects them:
+// their bespoke page owns the write.
+type WriteTarget = { denied: ReturnType<typeof fail> } | { def: ModuleDef; uid: string };
+
+function resolveWrite(id: string, session: Session | null | undefined): WriteTarget {
+  gateModules(session);
+  const def = moduleDef(id);
+  if (!def || def.href) return { denied: fail(404, { ok: false, error: 'Unknown module.' }) };
+  // gateModules above only proves the 'modules' section; a module with its
+  // own delegation grant (channel points) needs its own scope checked too.
+  if (!assertModuleWritable(session, def)) return { denied: fail(403, { ok: false, error: 'Not allowed.' }) };
+  if (env.DEMO !== '1' && !session) return { denied: fail(401, { ok: false, error: 'Not signed in.' }) };
+  return { def, uid: effectiveId(session) };
+}
+
 export const actions: Actions = {
   // One save persists the whole module config (enable + every reply message and
   // per-reply toggle). The client always posts the full draft, so upsertModule's
   // config replace is authoritative.
   save: async ({ request, params, locals }) => {
-    gateModules(locals.session);
-    const def = moduleDef(params.id);
-    // href modules own a bespoke page (see the load's redirect above) and
-    // are never editable through this generic reply inspector, so they read
-    // as not-found here the same as an id the catalog has never heard of.
-    if (!def || def.href) return fail(404, { ok: false, error: 'Unknown module.' });
-    // gateModules above only proves the 'modules' section; a module with its
-    // own delegation grant (channel points) needs its own scope checked too.
-    if (!assertModuleWritable(locals.session, def)) return fail(403, { ok: false, error: 'Not allowed.' });
-    const uid = effectiveId(locals.session);
-    if (env.DEMO !== '1' && !locals.session) {
-      return fail(401, { ok: false, error: 'Not signed in.' });
-    }
+    const target = resolveWrite(params.id, locals.session);
+    if ('denied' in target) return target.denied;
+    const { def, uid } = target;
 
     const f = await request.formData();
     const enabled = f.get('is_enabled') === 'on';
@@ -146,36 +156,47 @@ export const actions: Actions = {
   // last read. A conflict means another writer moved the revision on: the client
   // reloads and retries instead of clobbering it.
   patch: async ({ request, params, locals }) => {
-    gateModules(locals.session);
-    const def = moduleDef(params.id);
-    // See save above: href modules are never editable through this route,
-    // regardless of who is asking.
-    if (!def || def.href) return fail(404, { ok: false, error: 'Unknown module.' });
-    if (!assertModuleWritable(locals.session, def)) return fail(403, { ok: false, error: 'Not allowed.' });
-    const uid = effectiveId(locals.session);
-    if (env.DEMO !== '1' && !locals.session) {
-      return fail(401, { ok: false, error: 'Not signed in.' });
-    }
+    const target = resolveWrite(params.id, locals.session);
+    if ('denied' in target) return target.denied;
+    const { def, uid } = target;
 
     const f = await request.formData();
-    const enabled = f.get('is_enabled') === 'on';
-    const expectedRev = Number(f.get('expected_rev') ?? '0') || 0;
     const partial = parsePartial(f.get('partial'), def);
     if (!partial) return fail(400, { ok: false, error: 'Invalid patch.' });
+    const enabled = f.get('is_enabled') === 'on';
+    const expectedRev = Number(f.get('expected_rev') ?? '0') || 0;
 
     if (env.DEMO === '1') return { ok: true, rev: expectedRev + 1, conflict: false };
 
-    try {
-      const res = await patchModule({ userId: uid, name: def.id, isEnabled: enabled, partial, expectedRev });
-      if (res.conflict) return { ok: false, conflict: true, rev: res.rev };
-      auditDashboardImpersonation(locals.session, 'module:patch', `${def.id}=${enabled}`);
-      return { ok: true, rev: res.rev, conflict: false };
-    } catch (e) {
-      logger.error({ err: e }, `[modules] patch ${def.id} failed`);
-      return fail(400, { ok: false });
-    }
+    return applyPatch(def, uid, { enabled, expectedRev, partial }, locals.session);
   }
 };
+
+// applyPatch performs the optimistic-concurrency write itself, so the action
+// above stays a straight read of the request. A conflict is a normal outcome
+// the client retries after refetching, not a failure.
+async function applyPatch(
+  def: ModuleDef,
+  uid: string,
+  draft: { enabled: boolean; expectedRev: number; partial: Record<string, string> },
+  session: Session | null | undefined
+) {
+  try {
+    const res = await patchModule({
+      userId: uid,
+      name: def.id,
+      isEnabled: draft.enabled,
+      partial: draft.partial,
+      expectedRev: draft.expectedRev
+    });
+    if (res.conflict) return { ok: false, conflict: true, rev: res.rev };
+    auditDashboardImpersonation(session, 'module:patch', `${def.id}=${draft.enabled}`);
+    return { ok: true, rev: res.rev, conflict: false };
+  } catch (e) {
+    logger.error({ err: e }, `[modules] patch ${def.id} failed`);
+    return fail(400, { ok: false });
+  }
+}
 
 // parsePartial coerces the posted patch JSON into a flat string map, dropping
 // any key the module def does not declare (allowedConfigKeys), or null when

--- a/pkg/db/provider.go
+++ b/pkg/db/provider.go
@@ -6,8 +6,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"log"
-	"sync"
+	"net"
 	"time"
 
 	entsql "entgo.io/ent/dialect/sql"
@@ -17,6 +16,7 @@ import (
 	"ItsBagelBot/pkg/env"
 
 	"github.com/go-sql-driver/mysql"
+	"go.uber.org/zap"
 
 	// Registers the "nrmysql" driver: the MySQL driver wrapped with New
 	// Relic datastore instrumentation. Queries report as segments of the
@@ -70,7 +70,11 @@ func NewDriver(cfg Config) (*entsql.Driver, error) {
 		"time_zone":             "'+00:00'",
 	}
 
-	tlsName, err := registerTLS([]byte(env.Get("DB_CA_CERT", "")))
+	mode, err := resolveTLSMode()
+	if err != nil {
+		return nil, err
+	}
+	tlsName, err := registerTLS([]byte(env.Get("DB_CA_CERT", "")), mode, cfg.Address)
 	if err != nil {
 		return nil, err
 	}
@@ -90,18 +94,116 @@ func NewDriver(cfg Config) (*entsql.Driver, error) {
 // enough.
 const tlsConfigName = "bagel-mysql"
 
-// registerTLS builds and registers the TLS config used for every MySQL
-// connection so traffic to the managed HeatWave endpoint is always encrypted.
+// TLS trust model for the managed MySQL HeatWave endpoint.
 //
-// DB_CA_CERT must hold the endpoint CA (PEM); connections fail closed when it
-// is absent or invalid. The HeatWave endpoint certificate carries no SAN and
-// we dial it by private IP, so Go's default identity check cannot apply;
-// instead we pin the CA and verify the presented chain back to it ourselves,
-// which authenticates the server (MITM-resistant) without a hostname match.
-// The configured root must therefore be the dedicated HeatWave endpoint CA,
-// never a broad/shared trust bundle such as the internal fleet CA.
-func registerTLS(caPEM []byte) (string, error) {
-	cfg, err := newPinnedCAVerificationTLSConfig(caPEM)
+// History: on 2026-07-30 every DB-backed service lost connectivity for about
+// 7.5 hours when handshakes started failing with "certificate signed by
+// unknown authority" against the DB_CA_CERT pinned since 2026-07-02. That was
+// read at the time as evidence that OCI reissues the managed endpoint CA on a
+// roughly 28 day schedule (PR #517, "fix: survive OCI MySQL endpoint CA
+// rotation"), and this package grew an in-band mechanism that would adopt
+// whatever CA the server presented next, provided it reused the originally
+// pinned key (an interim tightening over the first version, which matched on
+// subject name alone).
+//
+// That belief does not hold up. It was a single data point (one observed
+// change, 28 days after the CA was first pinned), and the CA re-pinned by
+// hand right after the outage, still live today, has notBefore =
+// 2026-07-30T11:52:17Z (the exact hour of the incident) and notAfter =
+// 2029-07-29T11:52:17Z: a three year validity window. OCI does not mint a
+// three year CA it plans to discard in 28 days. What rotated on 2026-07-30
+// was almost certainly the server's LEAF certificate under a CA that had
+// just been (re)issued, conflated in the original fix with the CA itself. The
+// adoption mechanism this produced was also a genuine vulnerability: keyed on
+// subject name, it would trust any self-signed certificate an attacker minted
+// offline with the right CN; the SPKI based interim fix closed that specific
+// hole but kept the underlying design, trusting whatever the server hands
+// back on the wire, which is wrong regardless of how tightly the promotion
+// check is written. It has been removed entirely here, not hardened further.
+//
+// Current state, DB_TLS_MODE=VERIFY_CA (the default): the endpoint presents
+// OCI's service-defined, self-signed MySQL_Endpoint_CA. That certificate
+// carries no SAN, so hostname identity cannot be checked, only the chain.
+// DB_CA_CERT pins that CA. When OCI eventually reissues it for real, every
+// service fails closed until an operator re-fetches the CA from the OCI
+// console and updates DB_CA_CERT in Doppler, which restarts the consuming
+// deployments (the Doppler operator rolls on secret change). That manual
+// re-pin is the intended recovery path now, not an automatic one:
+// warnIfPinnedCANearExpiry logs at error level starting 30 days before
+// DB_CA_CERT's notAfter so the deadline surfaces before it becomes an outage.
+//
+// Target state, DB_TLS_MODE=VERIFY_IDENTITY: OCI MySQL HeatWave DB Systems
+// support bringing your own certificate (BYOC) through the OCI Certificates
+// Service, letting the DB System present a certificate signed by a CA the
+// operator controls, with a SAN for the DB System's endpoint. Once that
+// switch is made, VERIFY_IDENTITY turns on plain Go verification (RootCAs
+// plus ServerName, no custom hook, no InsecureSkipVerify): strictly stronger
+// than VERIFY_CA because it also binds the server's identity, not only the
+// chain.
+//
+// Cutover sequence (do this in order; associating a certificate restarts the
+// DB System, so a brief connection gap is expected regardless of ordering,
+// the goal is only to keep that gap short):
+//  1. In the OCI Certificates Service, create or reuse a CA and issue a leaf
+//     certificate for the DB System's endpoint. Give it a SAN matching
+//     whatever DB_ADDR's host portion will be after the switch: an IP SAN
+//     for the DB System's private IP, or a DNS SAN for its FQDN if DB_ADDR
+//     is also moving to that FQDN (ServerName is derived from DB_ADDR's
+//     host, see registerTLS). Export the CA certificate, not the leaf.
+//  2. Associate the certificate with the DB System (OCI console, or
+//     UpdateDbSystem with secureConnections set to the certificate OCID).
+//     This restarts the DB System.
+//  3. Update DB_CA_CERT in Doppler to the CA from step 1 and set
+//     DB_TLS_MODE=VERIFY_IDENTITY, for every project that pins it (users,
+//     commands, loyalty, modules, notifications, transactions). Do this
+//     immediately after step 2 so the window where the DB System's live
+//     certificate and a service's trust configuration disagree stays short.
+//  4. Confirm each service reconnects (dashboard login and the admin console
+//     are the fastest smoke test) before considering the migration done.
+//
+// Rotating the leaf afterward is steps 1 and 2 again over the same CA, with
+// no Doppler change and no service restart: the VERIFY_CA steady state
+// today, except the identity check now also applies.
+type tlsMode string
+
+const (
+	// tlsModeVerifyCA verifies the presented chain against the pinned CA but
+	// not the server's identity (no SAN match), matching MySQL's own
+	// VERIFY_CA ssl-mode.
+	tlsModeVerifyCA tlsMode = "VERIFY_CA"
+
+	// tlsModeVerifyIdentity verifies the presented chain against the pinned
+	// CA and that the certificate's SAN matches the server host, matching
+	// MySQL's own VERIFY_IDENTITY ssl-mode.
+	tlsModeVerifyIdentity tlsMode = "VERIFY_IDENTITY"
+
+	tlsModeEnvVar = "DB_TLS_MODE"
+)
+
+// resolveTLSMode reads DB_TLS_MODE, defaulting to VERIFY_CA: that is what
+// matches the endpoint's actual certificate today, so a service that never
+// sets the variable keeps behaving exactly as it does now, and a deploy of
+// this change is a no-op until an operator flips it. An unrecognised value
+// fails closed rather than silently picking a mode.
+func resolveTLSMode() (tlsMode, error) {
+	switch mode := tlsMode(env.Get(tlsModeEnvVar, string(tlsModeVerifyCA))); mode {
+	case tlsModeVerifyCA, tlsModeVerifyIdentity:
+		return mode, nil
+	default:
+		return "", fmt.Errorf("db: %s must be %q or %q, got %q",
+			tlsModeEnvVar, tlsModeVerifyCA, tlsModeVerifyIdentity, mode)
+	}
+}
+
+// registerTLS builds and registers the TLS config used for every MySQL
+// connection so traffic to the managed HeatWave endpoint is always encrypted
+// and authenticated. See the tlsMode doc comment above for what each mode
+// checks and the migration path between them.
+//
+// DB_CA_CERT must hold the trusted CA (PEM); connections fail closed when it
+// is absent or invalid, regardless of mode.
+func registerTLS(caPEM []byte, mode tlsMode, addr string) (string, error) {
+	cfg, err := newMySQLTLSConfig(caPEM, mode, addr)
 	if err != nil {
 		return "", err
 	}
@@ -112,22 +214,30 @@ func registerTLS(caPEM []byte) (string, error) {
 	return tlsConfigName, nil
 }
 
-// newPinnedCAVerificationTLSConfig uses the dedicated endpoint CA as the
-// server identity because the managed certificate has no SAN to match against.
-// VerifyConnection is intentional: unlike VerifyPeerCertificate, it also runs
-// when a TLS session is resumed.
-func newPinnedCAVerificationTLSConfig(caPEM []byte) (*tls.Config, error) {
+// newMySQLTLSConfig parses the pinned CA once and builds the tls.Config for
+// the requested mode. addr is only consulted for VERIFY_IDENTITY, to derive
+// the ServerName Go checks the presented certificate's SAN against.
+func newMySQLTLSConfig(caPEM []byte, mode tlsMode, addr string) (*tls.Config, error) {
 	pinned, err := parsePinnedCA(caPEM)
 	if err != nil {
 		return nil, err
 	}
+	warnIfPinnedCANearExpiry(pinned)
 
-	trust := newRotatingTrust(pinned)
+	if mode != tlsModeVerifyIdentity {
+		return verifyCATLSConfig(pinned), nil
+	}
+
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, fmt.Errorf("db: DB_ADDR must be host:port for VERIFY_IDENTITY, got %q: %w", addr, err)
+	}
+	roots := x509.NewCertPool()
+	roots.AddCert(pinned)
 	return &tls.Config{
 		MinVersion: tls.VersionTLS12,
-		// codeql[go/disabled-certificate-check] -- Custom verification pins the endpoint CA below.
-		InsecureSkipVerify: true,
-		VerifyConnection:   trust.VerifyConnection,
+		RootCAs:    roots,
+		ServerName: host,
 	}, nil
 }
 
@@ -148,97 +258,67 @@ func parsePinnedCA(caPEM []byte) (*x509.Certificate, error) {
 	return cert, nil
 }
 
-// rotatingTrust verifies MySQL connections against the pinned endpoint CA but
-// survives OCI rotating that CA in place. OCI reissues the managed HeatWave
-// endpoint CA on its own schedule (observed ~28 days); a static pin turns each
-// rotation into a full DB outage for every service until DB_CA_CERT is
-// re-pinned (2026-07-30: dashboard login + admin down for ~7.5h).
-//
-// When verification against the current pool fails, the connection is allowed
-// to promote the CA the server itself presented — but only when that CA is
-// self-signed, within its validity window, carries the exact subject of the
-// originally pinned CA, and actually signs the presented server certificate.
-// A rotation therefore heals on the first handshake that sees the new chain,
-// with no restart and no config change.
-//
-// Trust model: adoption trusts the endpoint's own chain (trust-on-use), the
-// same posture as re-pinning by hand from the endpoint. The endpoint is only
-// reachable over the VCN-private path; an attacker who can MITM that path
-// already owns the database traffic. The subject + self-signature + signs-leaf
-// checks keep garbage (a TCP proxy, an unrelated CA) from ever being adopted.
-type rotatingTrust struct {
-	mu    sync.RWMutex
-	roots *x509.CertPool
+// caExpiryWarningWindow is how far ahead of DB_CA_CERT's notAfter the pin
+// starts logging at error level. The pin governing this connection is now a
+// long-lived CA (see the tlsMode doc comment above), which is exactly the
+// kind of deadline that is easy to forget until it becomes an outage; 30 days
+// gives an operator time to re-fetch and re-pin before that happens.
+const caExpiryWarningWindow = 30 * 24 * time.Hour
 
-	// subject of the CA originally pinned via DB_CA_CERT; a rotated CA is
-	// only adopted when its subject matches exactly.
-	subject string
+// warnIfPinnedCANearExpiry logs at error level, not warn: an expiring pin is
+// a coming fleet-wide outage, and error level is what reaches Fluent Bit and
+// New Relic alerting without depending on anyone reading info logs.
+func warnIfPinnedCANearExpiry(pinned *x509.Certificate) {
+	remaining := time.Until(pinned.NotAfter)
+	if remaining > caExpiryWarningWindow {
+		return
+	}
+	zap.L().Error("db: pinned MySQL endpoint CA (DB_CA_CERT) is close to expiry, "+
+		"re-fetch the current CA (OCI console for the service-defined CA, or the "+
+		"OCI Certificates Service certificate for a BYOC CA) and update DB_CA_CERT in Doppler",
+		zap.Time("notAfter", pinned.NotAfter),
+		zap.Duration("remaining", remaining),
+	)
 }
 
-func newRotatingTrust(pinned *x509.Certificate) *rotatingTrust {
+// verifyCATLSConfig implements MySQL's VERIFY_CA semantics: the presented
+// chain must verify against the pinned CA, no hostname check. InsecureSkipVerify
+// paired with a custom VerifyConnection is what implements that combination
+// in Go's tls package; VerifyConnection, rather than VerifyPeerCertificate, is
+// used because it also runs when a TLS session is resumed.
+func verifyCATLSConfig(pinned *x509.Certificate) *tls.Config {
 	roots := x509.NewCertPool()
 	roots.AddCert(pinned)
-	return &rotatingTrust{roots: roots, subject: pinned.Subject.String()}
+
+	return &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		// codeql[go/disabled-certificate-check] -- VERIFY_CA mode: the OCI
+		// service-defined MySQL_Endpoint_CA signs a certificate with no SAN,
+		// so hostname identity cannot be checked. VerifyConnection below
+		// still requires the presented chain to verify against the pinned
+		// DB_CA_CERT and fails closed otherwise. Nothing the server presents
+		// is ever trusted beyond that single check: there is no fallback and
+		// no in-band promotion of an alternate CA.
+		InsecureSkipVerify: true,
+		VerifyConnection:   verifyAgainstPinned(roots),
+	}
 }
 
-func (t *rotatingTrust) VerifyConnection(state tls.ConnectionState) error {
-	certs := state.PeerCertificates
-	if len(certs) == 0 {
-		return fmt.Errorf("db: server presented no certificate")
-	}
-	if err := verifyChain(certs, t.currentRoots()); err == nil {
-		return nil
-	}
-	return t.adopt(certs)
-}
-
-func (t *rotatingTrust) currentRoots() *x509.CertPool {
-	t.mu.RLock()
-	defer t.mu.RUnlock()
-	return t.roots
-}
-
-// adopt promotes the CA presented by the server after a rotation. The write
-// lock serializes concurrent handshakes racing the same rotation; the re-check
-// under the lock lets the losers succeed against the winner's pool.
-func (t *rotatingTrust) adopt(certs []*x509.Certificate) error {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
-	if err := verifyChain(certs, t.roots); err == nil {
-		return nil
-	}
-
-	candidate, err := rotationCandidate(certs, t.subject)
-	if err != nil {
-		return err
-	}
-	roots := x509.NewCertPool()
-	roots.AddCert(candidate)
-	if err := verifyChain(certs, roots); err != nil {
-		return fmt.Errorf("db: rotated CA does not sign the server certificate: %w", err)
-	}
-
-	t.roots = roots
-	log.Printf("db: adopted rotated MySQL endpoint CA (%s, expires %s)",
-		candidate.Subject, candidate.NotAfter.Format(time.RFC3339))
-	return nil
-}
-
-func rotationCandidate(certs []*x509.Certificate, subject string) (*x509.Certificate, error) {
-	for _, c := range certs[1:] {
-		if isSelfSignedCANamed(c, subject) {
-			return c, nil
+// verifyAgainstPinned returns a VerifyConnection callback that checks the
+// presented chain against roots and nothing else.
+func verifyAgainstPinned(roots *x509.CertPool) func(tls.ConnectionState) error {
+	return func(state tls.ConnectionState) error {
+		certs := state.PeerCertificates
+		if len(certs) == 0 {
+			return fmt.Errorf("db: server presented no certificate")
 		}
+		if err := verifyChain(certs, roots); err != nil {
+			return fmt.Errorf("db: server certificate does not chain to the pinned "+
+				"DB_CA_CERT, re-fetch the endpoint CA from the OCI console and update "+
+				"DB_CA_CERT in Doppler: %w", err)
+		}
+		return nil
 	}
-	return nil, fmt.Errorf("db: server certificate is not trusted and the chain carries no rotation candidate for %q", subject)
-}
-
-func isSelfSignedCANamed(c *x509.Certificate, subject string) bool {
-	if !c.IsCA || c.Subject.String() != subject {
-		return false
-	}
-	return c.CheckSignatureFrom(c) == nil
 }
 
 func verifyChain(certs []*x509.Certificate, roots *x509.CertPool) error {

--- a/pkg/db/provider_test.go
+++ b/pkg/db/provider_test.go
@@ -14,114 +14,218 @@ import (
 
 	"github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 )
 
+const testDBAddr = "10.0.0.4:3306"
+
 func TestRegisterTLSRejectsMissingCA(t *testing.T) {
-	name, err := registerTLS(nil)
+	name, err := registerTLS(nil, tlsModeVerifyCA, testDBAddr)
 	require.Empty(t, name)
 	require.ErrorContains(t, err, "DB_CA_CERT is required")
 
-	name, err = registerTLS([]byte(" \n\t"))
+	name, err = registerTLS([]byte(" \n\t"), tlsModeVerifyCA, testDBAddr)
 	require.Empty(t, name)
 	require.ErrorContains(t, err, "DB_CA_CERT is required")
 }
 
+func TestRegisterTLSRejectsInvalidCA(t *testing.T) {
+	_, err := registerTLS([]byte("not pem"), tlsModeVerifyCA, testDBAddr)
+	require.ErrorContains(t, err, "DB_CA_CERT did not contain a valid PEM certificate")
+}
+
+func TestResolveTLSModeDefaultsToVerifyCA(t *testing.T) {
+	mode, err := resolveTLSMode()
+	require.NoError(t, err)
+	require.Equal(t, tlsModeVerifyCA, mode)
+}
+
+func TestResolveTLSModeAcceptsVerifyIdentity(t *testing.T) {
+	t.Setenv(tlsModeEnvVar, "VERIFY_IDENTITY")
+
+	mode, err := resolveTLSMode()
+	require.NoError(t, err)
+	require.Equal(t, tlsModeVerifyIdentity, mode)
+}
+
+func TestResolveTLSModeRejectsUnknownValue(t *testing.T) {
+	t.Setenv(tlsModeEnvVar, "TRUST_EVERYTHING")
+
+	_, err := resolveTLSMode()
+	require.ErrorContains(t, err, "DB_TLS_MODE")
+}
+
+// --- VERIFY_CA: the mode the fleet runs today against the OCI service-defined,
+// SAN-less MySQL_Endpoint_CA. ---
+
 func TestRegisterTLSUsesPinnedCAWithoutHostnameVerification(t *testing.T) {
-	ca, caKey, cfg := registerTestCA(t)
+	ca, caKey, cfg := registerTestCA(t, tlsModeVerifyCA, testDBAddr)
 	require.True(t, cfg.InsecureSkipVerify)
 	require.Equal(t, uint16(tls.VersionTLS12), cfg.MinVersion)
 	require.Empty(t, cfg.ServerName)
-	// The trusted pool lives inside the VerifyConnection closure (it can be
-	// swapped on CA rotation), not on the config.
+	// The trusted pool lives inside the VerifyConnection closure, not on the
+	// config: VERIFY_CA never sets RootCAs directly.
 	require.Nil(t, cfg.RootCAs)
 	require.Nil(t, cfg.VerifyPeerCertificate)
 	require.NotNil(t, cfg.VerifyConnection)
 
+	// Steady state: a chain actually signed by the pinned CA verifies.
 	require.NoError(t, cfg.VerifyConnection(tls.ConnectionState{
 		PeerCertificates: testLeafChain(t, ca, caKey),
 	}))
 }
 
-func TestRegisterTLSRejectsUntrustedServerCertificate(t *testing.T) {
-	_, _, cfg := registerTestCA(t)
+func TestVerifyCARejectsForgedCAWithCopiedSubjectDifferentKey(t *testing.T) {
+	_, _, cfg := registerTestCA(t, tlsModeVerifyCA, testDBAddr)
 
-	untrustedCA, untrustedKey, _ := testCA(t)
-	require.Error(t, cfg.VerifyConnection(tls.ConnectionState{
-		PeerCertificates: testLeafChain(t, untrustedCA, untrustedKey),
-	}))
+	// The bypass the old rotatingTrust/adopt machinery made possible: an
+	// attacker cannot know the pinned CA's private key, but the subject DN is
+	// public, so they mint their own CA carrying the identical subject and
+	// self-sign it for free. There is no adoption path left to fall into; the
+	// chain simply fails to verify against the one pinned root.
+	forgedCA, forgedKey := testNamedCA(t, "MySQL_Endpoint_CA")
+	err := cfg.VerifyConnection(tls.ConnectionState{
+		PeerCertificates: testLeafChainWithCA(t, forgedCA, forgedKey),
+	})
+	require.ErrorContains(t, err, "does not chain to the pinned DB_CA_CERT")
+	require.ErrorContains(t, err, "OCI console")
+	require.ErrorContains(t, err, "Doppler")
 }
 
-func TestRegisterTLSRejectsMissingServerCertificate(t *testing.T) {
-	_, _, cfg := registerTestCA(t)
+func TestVerifyCARejectsCAReusingPinnedKeyButNotSigningLeaf(t *testing.T) {
+	_, caKey, cfg := registerTestCA(t, tlsModeVerifyCA, testDBAddr)
 
+	// The presented chain carries a CA reusing the pinned key as its trailing
+	// entry, but the leaf was actually signed by an unrelated CA. With no
+	// promotion logic left, this is rejected the same way any other
+	// unrecognised chain is: there is nothing special-cased about the pinned
+	// key showing up somewhere in the chain.
+	leafCA, leafKey, _ := testCA(t)
+	bystanderCA := selfSignWithKey(t, "MySQL_Endpoint_CA", caKey, 3)
+	chain := append(testLeafChain(t, leafCA, leafKey), bystanderCA)
+	err := cfg.VerifyConnection(tls.ConnectionState{PeerCertificates: chain})
+	require.ErrorContains(t, err, "does not chain to the pinned DB_CA_CERT")
+}
+
+func TestVerifyCARejectsUnrelatedCA(t *testing.T) {
+	_, _, cfg := registerTestCA(t, tlsModeVerifyCA, testDBAddr)
+
+	untrustedCA, untrustedKey, _ := testCA(t)
+	err := cfg.VerifyConnection(tls.ConnectionState{
+		PeerCertificates: testLeafChain(t, untrustedCA, untrustedKey),
+	})
+	require.ErrorContains(t, err, "does not chain to the pinned DB_CA_CERT")
+}
+
+func TestVerifyCARejectsEmptyPeerChain(t *testing.T) {
+	_, _, cfg := registerTestCA(t, tlsModeVerifyCA, testDBAddr)
 	require.ErrorContains(t, cfg.VerifyConnection(tls.ConnectionState{}), "server presented no certificate")
 }
 
-func TestRegisterTLSRejectsInvalidCA(t *testing.T) {
-	_, err := registerTLS([]byte("not pem"))
-	require.ErrorContains(t, err, "DB_CA_CERT did not contain a valid PEM certificate")
+// --- VERIFY_IDENTITY: the target mode once the DB System is switched to a
+// BYOC certificate carrying a SAN for its endpoint. ---
+
+func TestRegisterTLSVerifyIdentityBuildsStandardConfig(t *testing.T) {
+	addr := "db.internal.example:3306"
+	_, _, cfg := registerTestCA(t, tlsModeVerifyIdentity, addr)
+
+	require.False(t, cfg.InsecureSkipVerify)
+	require.Equal(t, uint16(tls.VersionTLS12), cfg.MinVersion)
+	require.Equal(t, "db.internal.example", cfg.ServerName)
+	require.NotNil(t, cfg.RootCAs)
+	// No custom hook: verification is Go's standard RootCAs + ServerName check.
+	require.Nil(t, cfg.VerifyPeerCertificate)
+	require.Nil(t, cfg.VerifyConnection)
 }
 
-func TestVerifyConnectionAdoptsRotatedCA(t *testing.T) {
-	oldCA, oldKey, cfg := registerTestCA(t)
-
-	// A rotated CA with the pinned subject, presented by the server itself,
-	// is adopted and the handshake that saw it succeeds.
-	newCA, newKey, _ := testCA(t)
-	rotated := testLeafChainWithCA(t, newCA, newKey)
-	require.NoError(t, cfg.VerifyConnection(tls.ConnectionState{PeerCertificates: rotated}))
-
-	// Adoption replaced the pool: chains from the pre-rotation CA are no
-	// longer trusted, and the rotated chain keeps verifying.
-	require.Error(t, cfg.VerifyConnection(tls.ConnectionState{
-		PeerCertificates: testLeafChain(t, oldCA, oldKey),
-	}))
-	require.NoError(t, cfg.VerifyConnection(tls.ConnectionState{PeerCertificates: rotated}))
+func TestRegisterTLSVerifyIdentityRejectsAddrWithoutPort(t *testing.T) {
+	_, _, caPEM := testCA(t)
+	_, err := registerTLS(caPEM, tlsModeVerifyIdentity, "db.internal.example")
+	require.ErrorContains(t, err, "must be host:port")
 }
 
-func TestVerifyConnectionRejectsRotationWithDifferentSubject(t *testing.T) {
-	_, _, cfg := registerTestCA(t)
+func TestVerifyIdentityAcceptsChainAndHostnameTogether(t *testing.T) {
+	addr := "db.internal.example:3306"
+	ca, caKey, cfg := registerTestCA(t, tlsModeVerifyIdentity, addr)
 
-	imposterCA, imposterKey := testNamedCA(t, "Imposter_CA")
-	require.ErrorContains(t, cfg.VerifyConnection(tls.ConnectionState{
-		PeerCertificates: testLeafChainWithCA(t, imposterCA, imposterKey),
-	}), "no rotation candidate")
+	// registerTLS does not install a custom verifier for this mode; it relies
+	// on crypto/tls running the standard checks against RootCAs/ServerName at
+	// handshake time. Exercise those same primitives directly here to prove
+	// the config actually enables both the chain and the hostname check.
+	leaf := testLeafWithSAN(t, ca, caKey, "db.internal.example")
+	_, err := leaf.Verify(x509.VerifyOptions{Roots: cfg.RootCAs, DNSName: cfg.ServerName})
+	require.NoError(t, err)
 }
 
-func TestVerifyConnectionRejectsRotationWithoutPresentedCA(t *testing.T) {
-	_, _, cfg := registerTestCA(t)
+func TestVerifyIdentityRejectsHostnameMismatch(t *testing.T) {
+	addr := "db.internal.example:3306"
+	ca, caKey, cfg := registerTestCA(t, tlsModeVerifyIdentity, addr)
 
-	// Leaf-only chain from an untrusted CA: nothing to adopt, fail closed.
-	untrustedCA, untrustedKey, _ := testCA(t)
-	require.ErrorContains(t, cfg.VerifyConnection(tls.ConnectionState{
-		PeerCertificates: testLeafChain(t, untrustedCA, untrustedKey),
-	}), "no rotation candidate")
+	leaf := testLeafWithSAN(t, ca, caKey, "someone-else.example")
+	_, err := leaf.Verify(x509.VerifyOptions{Roots: cfg.RootCAs, DNSName: cfg.ServerName})
+	require.Error(t, err)
 }
 
-func TestVerifyConnectionRejectsRotatedCANotSigningLeaf(t *testing.T) {
-	_, _, cfg := registerTestCA(t)
+func TestVerifyIdentityRejectsUnrelatedCA(t *testing.T) {
+	addr := "db.internal.example:3306"
+	_, _, cfg := registerTestCA(t, tlsModeVerifyIdentity, addr)
 
-	// The presented CA carries the pinned subject but did not sign the leaf.
-	leafCA, leafKey, _ := testCA(t)
-	bystanderCA, _, _ := testCA(t)
-	chain := append(testLeafChain(t, leafCA, leafKey), bystanderCA)
-	require.ErrorContains(t, cfg.VerifyConnection(tls.ConnectionState{
-		PeerCertificates: chain,
-	}), "does not sign the server certificate")
+	untrustedCA, untrustedKey := testNamedCA(t, "Unrelated_CA")
+	leaf := testLeafWithSAN(t, untrustedCA, untrustedKey, "db.internal.example")
+	_, err := leaf.Verify(x509.VerifyOptions{Roots: cfg.RootCAs, DNSName: cfg.ServerName})
+	require.Error(t, err)
+}
+
+// --- Pinned CA expiry warning. ---
+
+func TestWarnIfPinnedCANearExpiryFiresInsideWindow(t *testing.T) {
+	logs := captureGlobalLogs(t)
+
+	cert, _ := testNamedCAWithValidity(t, "MySQL_Endpoint_CA", time.Now().Add(10*24*time.Hour))
+	warnIfPinnedCANearExpiry(cert)
+
+	require.Equal(t, 1, logs.Len())
+	entry := logs.All()[0]
+	require.Contains(t, entry.Message, "DB_CA_CERT")
+	require.Equal(t, zap.ErrorLevel, entry.Level)
+}
+
+func TestWarnIfPinnedCANearExpiryStaysQuietOutsideWindow(t *testing.T) {
+	logs := captureGlobalLogs(t)
+
+	cert, _ := testNamedCAWithValidity(t, "MySQL_Endpoint_CA", time.Now().Add(90*24*time.Hour))
+	warnIfPinnedCANearExpiry(cert)
+
+	require.Equal(t, 0, logs.Len())
+}
+
+// captureGlobalLogs swaps zap's global logger (what zap.L() resolves to, the
+// same global pkg/logger.New wires up via zap.ReplaceGlobals in every real
+// service) for an observed logger, and restores the previous global on
+// cleanup.
+func captureGlobalLogs(t *testing.T) *observer.ObservedLogs {
+	t.Helper()
+
+	core, logs := observer.New(zap.ErrorLevel)
+	restore := zap.ReplaceGlobals(zap.New(core))
+	t.Cleanup(restore)
+
+	return logs
 }
 
 // registerTestCA pins a fresh test CA in the driver's TLS registry (with
 // cleanup) and returns the CA pair plus the registered config, so each test
 // starts from the same known trust state.
-func registerTestCA(t *testing.T) (*x509.Certificate, *ecdsa.PrivateKey, *tls.Config) {
+func registerTestCA(t *testing.T, mode tlsMode, addr string) (*x509.Certificate, *ecdsa.PrivateKey, *tls.Config) {
 	t.Helper()
 	t.Cleanup(func() { mysql.DeregisterTLSConfig(tlsConfigName) })
 
 	ca, caKey, caPEM := testCA(t)
-	_, err := registerTLS(caPEM)
+	_, err := registerTLS(caPEM, mode, addr)
 	require.NoError(t, err)
 
-	return ca, caKey, registeredTLSConfig(t, "10.0.0.4:3306")
+	return ca, caKey, registeredTLSConfig(t, addr)
 }
 
 func registeredTLSConfig(t *testing.T, addr string) *tls.Config {
@@ -148,12 +252,19 @@ func testCA(t *testing.T) (*x509.Certificate, *ecdsa.PrivateKey, []byte) {
 
 func testNamedCA(t *testing.T, commonName string) (*x509.Certificate, *ecdsa.PrivateKey) {
 	t.Helper()
+	return testNamedCAWithValidity(t, commonName, time.Now().Add(time.Hour))
+}
+
+// testNamedCAWithValidity builds a self-signed CA with a caller-chosen
+// notAfter, used to drive the expiry warning across its threshold.
+func testNamedCAWithValidity(t *testing.T, commonName string, notAfter time.Time) (*x509.Certificate, *ecdsa.PrivateKey) {
+	t.Helper()
 
 	template := x509.Certificate{
 		SerialNumber:          big.NewInt(1),
 		Subject:               pkix.Name{CommonName: commonName},
 		NotBefore:             time.Now().Add(-time.Hour),
-		NotAfter:              time.Now().Add(time.Hour),
+		NotAfter:              notAfter,
 		IsCA:                  true,
 		KeyUsage:              x509.KeyUsageCertSign,
 		BasicConstraintsValid: true,
@@ -162,8 +273,31 @@ func testNamedCA(t *testing.T, commonName string) (*x509.Certificate, *ecdsa.Pri
 	return issueTestCertificate(t, template, nil, nil)
 }
 
-// testLeafChainWithCA mirrors what the managed endpoint actually presents
-// after a rotation: the server certificate followed by the CA that signed it.
+// selfSignWithKey mints a self-signed CA certificate over an EXISTING key
+// pair rather than a fresh one, standing in for a chain entry that reuses the
+// pinned CA's key without being the actual issuer of the presented leaf.
+func selfSignWithKey(t *testing.T, commonName string, key *ecdsa.PrivateKey, serial int64) *x509.Certificate {
+	t.Helper()
+
+	template := x509.Certificate{
+		SerialNumber:          big.NewInt(serial),
+		Subject:               pkix.Name{CommonName: commonName},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	require.NoError(t, err)
+	cert, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+	return cert
+}
+
+// testLeafChainWithCA mirrors what the managed endpoint actually presents:
+// the server certificate followed by the CA that signed it.
 func testLeafChainWithCA(t *testing.T, ca *x509.Certificate, caKey *ecdsa.PrivateKey) []*x509.Certificate {
 	t.Helper()
 
@@ -184,6 +318,26 @@ func testLeafChain(t *testing.T, ca *x509.Certificate, caKey *ecdsa.PrivateKey) 
 
 	cert, _ := issueTestCertificate(t, template, ca, caKey)
 	return []*x509.Certificate{cert}
+}
+
+// testLeafWithSAN mints a leaf certificate carrying a DNS SAN, standing in
+// for a BYOC certificate issued through the OCI Certificates Service: unlike
+// the service-defined certificate, it has a name VERIFY_IDENTITY can check.
+func testLeafWithSAN(t *testing.T, ca *x509.Certificate, caKey *ecdsa.PrivateKey, dnsName string) *x509.Certificate {
+	t.Helper()
+
+	template := x509.Certificate{
+		SerialNumber:          big.NewInt(2),
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		DNSNames:              []string{dnsName},
+	}
+
+	cert, _ := issueTestCertificate(t, template, ca, caKey)
+	return cert
 }
 
 func issueTestCertificate(


### PR DESCRIPTION
Fixes three vulnerabilities found in a security review of the dashboard, the transactions service and the shared DB library. Each was verified against the code before being fixed; the reasoning is in the individual commit messages.

## 1. Module write actions ignored per-module delegation scope

The read paths enforced scope, the write paths did not. A delegate holding only the blanket `modules` grant could toggle or rewrite `channelpoints`, which declares `delegateSections: ['channelpoints']` specifically so it is *not* covered by that grant. The route guard admitted `/modules/<id>` on the `/modules` prefix alone, and the modules service applies no allowlist, so the console was the only enforcement point.

Scope and `hidden` checks are now folded into one `assertModuleWritable` helper called from all three write actions after `moduleDef` resolves. `save`/`patch` reject `href` modules, mirroring the load's redirect. `parsePartial` is constrained to keys the module def declares. The guard rechecks the module's own scope for sub-paths.

## 2. Chargeback that resolved in our favour granted permanent premium

`applyBilling` backfilled a fallback expiry only for `ActionActivate`. `payment.dispute.won` maps to `ActionCancelAborted`, which also leaves the user paid but carried no expiry for one-time purchases, and the preceding `dispute.opened` had already cleared the stored expiry. `ExpireSubscriptions` skips NULL-expiry rows, so the grant was never reaped and no further Tebex event would ever correct it.

Fallback now applies to every paid-producing action, plus a backstop in `applyPaidUpdate` so no path can mint an unbounded paid row. Clamps rather than rejects, because a returned error makes Tebex redeliver and redelivery cannot resolve a structural violation.

## 3. MySQL TLS adopted attacker-generatable CAs

`rotatingTrust` promoted whatever CA the server presented on verification failure, gated only on it being self-signed with the pinned subject DN. All three properties are attacker generatable, and no hostname check offset it since the managed certificate has no SAN. `pkg/db` is shared, so this exposed every service's database traffic and credentials.

The mechanism is removed rather than hardened. Its premise was a single data point (one CA change 28 days after the initial pin) extrapolated into a monthly schedule; the CA re-pinned after that incident is valid 2026-07-30 to 2029-07-29, so what rotated was almost certainly the leaf.

`DB_TLS_MODE` selects `VERIFY_CA` (default, matching today's SAN-less certificate) or `VERIFY_IDENTITY` (plain `RootCAs` + `ServerName`, no `InsecureSkipVerify`, for once the DB System serves a BYOC certificate). **The default makes this deploy a no-op** until an operator flips it. Failures now name `DB_CA_CERT` and the remediation, and the pinned CA warns at error level 30 days before expiry.

## Verification

`go build ./...`, `go vet`, `go test ./app/transactions/... ./app/users/... ./pkg/db/...` and `gofmt -l` all clean; `bun run --filter dashboard check` reports 0 errors (1 pre-existing unrelated CSS warning). Regression tests added for the dispute-won path, nil-expiry cancel-requested, the forged-subject CA rejection and the CA expiry warning.

## Not included

Node-level firewall remediation (stale overlay grants for a decommissioned host, `eth1` in the ACCEPT-all zone on two workers, sshd drop-in ordering) is tracked separately. node1 could not be audited at all: its Tailscale node key has expired and port 22 is unreachable on both the tailnet and public addresses.