### PR TITLE
fix(ansible): bind the VLAN off trusted, pin Cilium egress source

### DIFF
--- a/deploy/ansible/roles/cilium_node_routes/defaults/main.yml
+++ b/deploy/ansible/roles/cilium_node_routes/defaults/main.yml
@@ -1,0 +1,32 @@
+---
+# Source-hint routes for a node whose Cilium node IP is NOT the address the
+# kernel would pick for outbound traffic on its primary interface.
+#
+# This is the OCI control plane's situation. Its VNIC holds the private VCN
+# address from DHCP (which owns the default route and is therefore the
+# preferred source) plus the public address added as a secondary /32, and that
+# public address is what Cilium advertises as the node IP. Without a per-peer
+# route carrying an explicit src, every packet Cilium sends to a peer leaves
+# with the private VCN source, the peer's WireGuard does not recognise it, and
+# pod traffic is silently dropped in one direction only.
+#
+# The failure is deceptive: WireGuard handshakes and return traffic on an
+# already-established flow still get through, so the tunnel reports fresh
+# handshakes and node-level health passes while pod-to-pod is dead. Diagnosed
+# 2026-08-14 after a rebuild dropped the routes: the control plane had sent
+# 859 KB to a worker that had received 10 KB of it.
+#
+# Empty means "this host does not need source hints" and the role ends early,
+# which is the case for every node whose node IP is its primary address.
+cilium_node_public_ip: "{{ lookup('env', 'NODE_PUBLIC_IP') | default('', true) }}"
+
+# Public addresses of the peers to pin a source for. Sourced from the
+# environment (Doppler) rather than committed: this repository is public and
+# these addresses identify the fleet. See inventory.cluster.ini.example.
+cilium_route_peers: []
+
+# Gateway and interface the hints are installed on. Defaults resolve from
+# discovered facts so a rebuilt image that enumerates the NIC differently does
+# not need an override.
+cilium_route_interface: "{{ ansible_default_ipv4.interface | default('') }}"
+cilium_route_gateway: "{{ ansible_default_ipv4.gateway | default('') }}"

--- a/deploy/ansible/roles/cilium_node_routes/tasks/main.yml
+++ b/deploy/ansible/roles/cilium_node_routes/tasks/main.yml
@@ -1,0 +1,92 @@
+---
+# Pin the source address Cilium's peer traffic leaves with. See defaults for
+# the failure this prevents and how it presented.
+
+- name: Skip hosts that do not need source hints
+  ansible.builtin.meta: end_host
+  when: >-
+    cilium_node_public_ip | length == 0
+    or cilium_route_peers | length == 0
+
+- name: Require a resolvable interface and gateway for the source hints
+  ansible.builtin.assert:
+    that:
+      - cilium_route_interface | length > 0
+      - cilium_route_gateway | length > 0
+    fail_msg: >-
+      Could not resolve the default interface/gateway on {{ inventory_hostname }}.
+      Set cilium_route_interface and cilium_route_gateway explicitly.
+
+# Only meaningful when the node IP is NOT already the preferred source. On a
+# host where it is, the kernel picks it anyway and these routes are noise.
+- name: Read the source the kernel currently picks for the first peer
+  ansible.builtin.command: "ip route get {{ cilium_route_peers[0] }}"
+  register: cilium_route_current
+  changed_when: false
+
+- name: Report that the node IP is already the preferred source
+  ansible.builtin.debug:
+    msg: >-
+      {{ inventory_hostname }} already egresses as {{ cilium_node_public_ip }};
+      source hints are not needed here.
+  when: "'src ' ~ cilium_node_public_ip in cilium_route_current.stdout"
+
+# NetworkManager owns the profile, so the routes go in the connection rather
+# than being added with `ip route`: a bare `ip route add` is lost on the next
+# reboot, which is exactly how this regressed. Written WITHOUT reactivating the
+# connection, because bouncing the interface on the control plane would cut the
+# apiserver; the live routes below cover the running system until then.
+- name: Find the NetworkManager profile for the primary interface
+  ansible.builtin.command: >-
+    nmcli -t -f UUID,DEVICE connection show --active
+  register: cilium_route_nm_conns
+  changed_when: false
+
+- name: Resolve the profile UUID
+  ansible.builtin.set_fact:
+    cilium_route_nm_uuid: >-
+      {{ cilium_route_nm_conns.stdout_lines
+         | select('search', ':' ~ cilium_route_interface ~ '$')
+         | first | split(':') | first }}
+
+- name: Fail clearly when the profile cannot be resolved
+  ansible.builtin.fail:
+    msg: >-
+      No active NetworkManager profile found for {{ cilium_route_interface }}.
+      Refusing to install source hints that would not persist.
+  when: cilium_route_nm_uuid | length == 0
+
+# Read what the profile already carries so the +ipv4.routes append below is
+# idempotent: repeating it would otherwise stack a duplicate entry per run.
+- name: Read the routes already stored on the profile
+  ansible.builtin.command: >-
+    nmcli -g ipv4.routes connection show {{ cilium_route_nm_uuid }}
+  register: cilium_route_stored
+  changed_when: false
+
+# Addressed by UUID, never by name: more than one profile can share a name
+# (the control plane has two called "Wired Connection"), and modifying the
+# wrong one persists the routes onto a profile that is never activated.
+- name: Persist the source hints on the connection profile
+  ansible.builtin.command: >-
+    nmcli connection modify {{ cilium_route_nm_uuid }}
+    +ipv4.routes "{{ item }}/32 {{ cilium_route_gateway }} src={{ cilium_node_public_ip }}"
+  loop: "{{ cilium_route_peers }}"
+  register: cilium_route_persist
+  changed_when: cilium_route_persist.rc == 0
+  when: item not in cilium_route_stored.stdout
+
+- name: Install the source hints on the running system
+  ansible.builtin.command: >-
+    ip route replace {{ item }}/32 via {{ cilium_route_gateway }}
+    dev {{ cilium_route_interface }} src {{ cilium_node_public_ip }}
+  loop: "{{ cilium_route_peers }}"
+  register: cilium_route_live
+  changed_when: cilium_route_live.rc == 0
+
+- name: Verify every peer now egresses as the node IP
+  ansible.builtin.command: "ip route get {{ item }}"
+  loop: "{{ cilium_route_peers }}"
+  register: cilium_route_verify
+  changed_when: false
+  failed_when: "'src ' ~ cilium_node_public_ip not in cilium_route_verify.stdout"

--- a/deploy/ansible/roles/private_vlan/defaults/main.yml
+++ b/deploy/ansible/roles/private_vlan/defaults/main.yml
@@ -4,5 +4,21 @@
 vlan_interface: eth1
 
 # Empty means "this host is not on the private VLAN" and the role ends early.
-# Set per host in inventory.cluster.ini (node4/5/6 only; node1 is at OCI).
+# Set per host in inventory.cluster.ini (the ServaRICA workers only; the OCI
+# control plane has no physical path to this segment).
 vlan_address: ""
+
+# firewalld zone the VLAN interface is bound to. NOT trusted: that zone is
+# target=ACCEPT, so binding the VLAN there accepted every port from any source
+# arriving on the segment, including kubelet (10250), Valkey (6380/26380) and
+# the NATS client, cluster and unauthenticated monitoring ports. Source zones
+# outrank interface zones, so the declared fleet peers already match the fleet
+# zone by source address and are unaffected by this; what changes is traffic
+# from a source NOT on that list, which now gets the fleet port allowlist
+# instead of blanket accept.
+#
+# This was found live on 2026-08-14: two of three workers had the interface in
+# trusted while the third had it in public, and all three had trusted in their
+# PERMANENT config, so the odd one out was a runtime-only override that a
+# firewall-cmd --reload would have silently undone.
+vlan_firewall_zone: fleet

--- a/deploy/ansible/roles/private_vlan/tasks/main.yml
+++ b/deploy/ansible/roles/private_vlan/tasks/main.yml
@@ -42,22 +42,53 @@
     method6: disabled
     autoconnect: true
     state: present
+    # NetworkManager owns this interface, so its connection profile is the
+    # authoritative zone binding: what firewalld's own permanent config says
+    # loses to this on reboot. Setting it here (rather than only via the
+    # firewalld module below) is what makes the zone survive a reboot.
+    zone: "{{ vlan_firewall_zone }}"
   notify: bring up private vlan
 
 # firewalld's default zone is public, which would drop node-to-node traffic on
-# this interface. The VLAN carries the pod mesh once flannel moves onto it, so it
-# belongs in the same trusted zone as tailscale0/cni0/flannel-wg.
-#
-# This is an explicit trust decision: it assumes the VLAN is genuinely private to
-# this account. If the provider ever shares that segment between customers, this
-# line is what would need revisiting first.
-- name: Trust the private VLAN interface
+# this interface, so the VLAN needs an explicit zone. It is deliberately NOT
+# trusted (target=ACCEPT); see the vlan_firewall_zone comment in defaults for
+# what that exposed and why the fleet allowlist is the right home for it.
+- name: Confirm the target firewalld zone exists
+  ansible.builtin.command: "firewall-cmd --permanent --get-zones"
+  register: vlan_zone_list
+  changed_when: false
+
+- name: Fail clearly when the target zone is not defined
+  ansible.builtin.fail:
+    msg: >-
+      firewalld zone "{{ vlan_firewall_zone }}" does not exist on
+      {{ inventory_hostname }}, so the VLAN interface cannot be bound to it.
+      Create the zone (with its port and source allowlist) before running this
+      role, or override vlan_firewall_zone.
+  when: vlan_firewall_zone not in vlan_zone_list.stdout.split()
+
+- name: Bind the private VLAN interface to its firewalld zone
   ansible.posix.firewalld:
-    zone: trusted
+    zone: "{{ vlan_firewall_zone }}"
     interface: "{{ vlan_interface }}"
     permanent: true
     immediate: true
     state: enabled
+
+# firewalld keeps its own permanent interface list per zone, separate from the
+# NM binding above. A zone change therefore leaves the interface listed under
+# BOTH the old and new zone, and the two race on reload. Observed live on all
+# three workers on 2026-08-14. Strip any stale binding so reload is
+# deterministic.
+- name: Remove the VLAN interface from every other zone
+  ansible.posix.firewalld:
+    zone: "{{ item }}"
+    interface: "{{ vlan_interface }}"
+    permanent: true
+    state: disabled
+  loop: "{{ vlan_zone_list.stdout.split() | difference([vlan_firewall_zone]) }}"
+  failed_when: false
+  changed_when: false
 
 - name: Read the VLAN interface state
   ansible.builtin.command: "cat /sys/class/net/{{ vlan_interface }}/statistics/rx_bytes"

--- a/deploy/ansible/site.yml
+++ b/deploy/ansible/site.yml
@@ -46,6 +46,14 @@
     #   doppler run -p infra-bootstrap -c prd -- ansible-playbook site.yml --tags vlan -i inventory.cluster.ini
     - role: private_vlan
       tags: [vlan]
+    # Only does anything on a node whose Cilium node IP is not the address the
+    # kernel would pick for egress (the OCI control plane, whose public IP is a
+    # secondary /32 while DHCP owns the default route). Ends early everywhere
+    # else. Tagged so the hints can be restored on a live node after a rebuild
+    # without touching anything else:
+    #   doppler run -p infra-bootstrap -c prd -- ansible-playbook site.yml --tags cilium-routes -i inventory.cluster.ini
+    - role: cilium_node_routes
+      tags: [cilium-routes]
     - role: tailscale
     - role: k3s_agent
     - role: ssh_removal


### PR DESCRIPTION
Codifies two node-level fixes that were applied live on 2026-08-14. Both regress on every rebuild today, because nothing in the repo sets them: the fleet rebuild earlier that day reintroduced both.

## 1. Private VLAN interface was bound to the `trusted` zone

`trusted` is `target=ACCEPT`. Binding the VLAN there accepted **every port** from any source arriving on that segment, including kubelet (10250), Valkey (6380/26380) and the NATS client, cluster and unauthenticated monitoring ports.

Source zones outrank interface zones, so the declared fleet peers already matched `fleet` by source address and were never affected. What changes is traffic from a source **not** on that list, which now gets the fleet port allowlist instead of blanket accept.

Live state when found: two of three workers had the interface in `trusted` and the third in `public` — but **all three had `trusted` in their permanent config**, so the odd one out was a runtime-only override that a `firewall-cmd --reload` would have silently undone.

The zone is now `vlan_firewall_zone` (default `fleet`) and is set on the **NetworkManager profile**, which is what actually survives a reboot: NM owns the interface, and its binding beats firewalld's own permanent config. The role also strips the interface from every other zone, because firewalld keeps a separate per-zone interface list and a zone change otherwise leaves it registered in both, where the two race on reload. That double-binding was observed on all three workers.

## 2. Cilium egress used the wrong source address on the control plane

A node whose Cilium node IP is not the address the kernel picks for egress loses pod traffic **in one direction only**. The OCI control plane holds the private VCN address from DHCP — which owns the default route and is therefore the preferred source — plus the public address as a secondary `/32`, and it is the public one Cilium advertises as the node IP. Without a per-peer route carrying an explicit `src`, peers receive packets from an address their WireGuard does not recognise and drop them.

The failure mode is deceptive and cost real time to find: WireGuard handshakes and return traffic on already-established flows still pass, so tunnels report **fresh handshakes** and node-level health passes while pod-to-pod is dead. The byte counters gave it away — the control plane had sent 859 KB to a worker that received 10 KB of it.

New `cilium_node_routes` role installs the hints on the NM connection profile:

- **Addressed by UUID, never by name.** The control plane has two profiles both called "Wired Connection"; modifying by name can persist routes onto a profile that is never activated.
- **Does not reactivate the connection.** Bouncing that interface on the control plane would cut the apiserver. Live routes cover the running system; the profile covers reboot.
- **Idempotent.** Reads the stored routes first, since `+ipv4.routes` would otherwise stack a duplicate per run.
- **Verifies.** Fails if any peer does not egress as the node IP afterwards.

Both roles no-op on hosts that do not need them (`meta: end_host`), so this is inert for every worker.

## Verification

`ansible-playbook --syntax-check site.yml` passes; all edited and new files parse as YAML. Nothing was executed against a host from this branch — the live fix was applied separately and is already in place and verified (pod-to-pod returns 200 in both directions across all four nodes).

Peer addresses and the node public IP come from the environment (Doppler), never committed — this repository is public. Confirmed no fleet addresses appear in any file in this diff.

## Not included

- The inventory template still uses the pre-rename host names (`node1`/`node4`/`node5`/`node6`), while the fleet is now `cp1`/`node1`/`node2`/`node3`. It also needs `cilium_node_public_ip` and `cilium_route_peers` declared. Left out deliberately rather than guessed at.
- The `fleet` zone itself is still created out-of-band; this branch only binds an interface to it and fails clearly if it is absent.