### PR TITLE
chore(web): update dev badge from Alpha to Beta

### DIFF
--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -35,7 +35,7 @@
   "hero.lede": "ItsBagelBot is the all-in-one Twitch companion, baked for independence. One setup, every tool. No corporate tracking, no monthly fees, nothing held back.",
   "hero.devTitle": "ItsBagelBot is still in the oven",
   "hero.devBody": "Early access is on the way. Join the Discord and we will keep you posted.",
-  "hero.devBadge": "Alpha",
+  "hero.devBadge": "Beta",
   "hero.badge1": "Privacy-First",
   "hero.badge2": "One-Time Setup",
   "hero.badge3": "Eco-Friendly",

--- a/web/src/i18n/locales/fr.json
+++ b/web/src/i18n/locales/fr.json
@@ -35,7 +35,7 @@
   "hero.lede": "ItsBagelBot est le compagnon Twitch tout-en-un, conçu pour l'indépendance. Une seule configuration, tous les outils. Aucun pistage, aucun frais mensuel, rien qui reste au placard.",
   "hero.devTitle": "ItsBagelBot est encore au four",
   "hero.devBody": "L'accès anticipé arrive bientôt. Rejoignez le Discord, on vous tient au courant.",
-  "hero.devBadge": "Alpha",
+  "hero.devBadge": "Beta",
   "hero.badge1": "Priorité à la vie privée",
   "hero.badge2": "Configuration unique",
   "hero.badge3": "Écoresponsable",


### PR DESCRIPTION
Updates the marketing website hero badge text from "Alpha" to "Beta" across English and French locale catalogs (`web/src/i18n/locales/en.json` and `web/src/i18n/locales/fr.json`).

## Verification
- Built site locally (`bun run build` in `web/`) and verified static HTML output renders the `Beta` badge.