### PR TITLE
feat(stats): answer the stats page at stats.itsbagelbot.com

### DIFF
--- a/console/dashboard/src/hooks.ts
+++ b/console/dashboard/src/hooks.ts
@@ -1,0 +1,15 @@
+import type { Reroute } from '@sveltejs/kit';
+
+// stats.itsbagelbot.com is this same app answering under a second hostname:
+// its root serves the public stats page. This hook is universal — it runs on
+// the server and in the client router alike, so a client-side navigation to
+// '/' on the stats host (the language switch, for one) resolves to the same
+// route the server rendered. Every other path falls through to the normal
+// route table: /stats/* endpoints keep working, and authed routes on the
+// stats host simply bounce to /login as they would anywhere.
+//
+// Matching the first label rather than a full hostname keeps local testing
+// honest (stats.localhost) without a config knob.
+export const reroute: Reroute = ({ url }) => {
+  if (url.hostname.split('.')[0] === 'stats' && url.pathname === '/') return '/stats';
+};

--- a/console/dashboard/src/lib/server/config-sanity.ts
+++ b/console/dashboard/src/lib/server/config-sanity.ts
@@ -23,7 +23,12 @@ export function dashboardL1CacheCapacity(env: Env): number {
 // Validate at boot (from the init hook), reading the injected env rather than
 // process.env so all runtime config flows through $env/dynamic/private.
 export function assertConfigSane(env: Env): void {
-  const origin = assertOrigin('ORIGIN', env.ORIGIN);
+  // ORIGIN is optional in production: the app answers under two hostnames
+  // (dashboard. and stats.itsbagelbot.com), so the deployment derives each
+  // request's origin from traefik's forwarded headers (HOST_HEADER /
+  // PROTOCOL_HEADER) instead of pinning one. When ORIGIN is set (dev, DEMO),
+  // it must still be a bare origin and must agree with the callback.
+  const origin = env.ORIGIN ? assertOrigin('ORIGIN', env.ORIGIN) : undefined;
   assertCallback('TWITCH_REDIRECT_URI', env.TWITCH_REDIRECT_URI, {
     origin,
     callbackPath: '/auth/callback'

--- a/console/dashboard/src/routes/(public)/stats/+page.svelte
+++ b/console/dashboard/src/routes/(public)/stats/+page.svelte
@@ -268,6 +268,11 @@
 <svelte:head>
   <title>{t('stats.title')}</title>
   <meta name="description" content={t('stats.metaDescription')} />
+  <!-- The page answers on two hosts (stats.itsbagelbot.com root and
+       dashboard.itsbagelbot.com/stats); the subdomain is the one search
+       engines and shares should converge on. -->
+  <link rel="canonical" href="https://stats.itsbagelbot.com/" />
+  <meta property="og:url" content="https://stats.itsbagelbot.com/" />
   <meta property="og:title" content={t('stats.title')} />
   <meta property="og:description" content={t('stats.metaDescription')} />
   <meta name="twitter:title" content={t('stats.title')} />

--- a/deploy/k8s/console-dashboard.yaml
+++ b/deploy/k8s/console-dashboard.yaml
@@ -119,10 +119,17 @@ spec:
               value: /etc/console/tls/tls.key
             - name: NODE_ENV
               value: production
-            # adapter-node sits behind cloudflared+traefik; ORIGIN lets SvelteKit
-            # validate form POSTs (origin-checked CSRF) against the public URL.
-            - name: ORIGIN
-              value: https://dashboard.itsbagelbot.com
+            # adapter-node sits behind cloudflared+traefik. The app answers
+            # under two public hostnames (dashboard. and stats.itsbagelbot.com),
+            # so instead of pinning one ORIGIN it derives each request's origin
+            # from traefik's forwarded headers — traefik always sets both, and
+            # overwrites client-supplied values, so the origin-checked CSRF on
+            # form POSTs stays sound. The stats host reroutes '/' to the public
+            # stats page in the app (src/hooks.ts).
+            - name: PROTOCOL_HEADER
+              value: x-forwarded-proto
+            - name: HOST_HEADER
+              value: x-forwarded-host
             # Pin the in-cluster NATS endpoint. The Doppler secret's NATS_HOST is
             # a stale cross-namespace FQDN (nats.bagelbot...) that does not
             # resolve here; NATS_URL overrides it. Auth (NATS_USER/PASSWORD) still
@@ -290,7 +297,7 @@ metadata:
 spec:
   entryPoints: [websecure]
   routes:
-    - match: Host(`dashboard.itsbagelbot.com`)
+    - match: Host(`dashboard.itsbagelbot.com`) || Host(`stats.itsbagelbot.com`)
       kind: Rule
       services:
         - name: console-dashboard


### PR DESCRIPTION
## What

The public stats page now answers at https://stats.itsbagelbot.com (root), while the code keeps living in the dashboard console. dashboard.itsbagelbot.com/stats keeps working; the subdomain is canonical.

## How

- Universal `reroute` hook: any `stats.*` host serving `/` resolves to the `/stats` route. Server and client router agree, so client-side navigations (language switch) resolve identically. All other paths fall through: `/stats/data` + `/stats/stream` unchanged, authed routes on the stats host bounce to /login as anywhere.
- adapter-node's pinned `ORIGIN` forces one origin for every request, which would blind the app to the second host. The deployment now derives per-request origin from traefik's forwarded headers (`PROTOCOL_HEADER`/`HOST_HEADER` = x-forwarded-proto/host; traefik sets and overwrites both, so origin-checked CSRF on form POSTs stays sound). Boot sanity treats ORIGIN as optional and still validates it against the Twitch callback when present (dev/DEMO).
- Traefik IngressRoute matches both hostnames onto the same service. Tunnel side needs nothing: the cloudflared config's `*.itsbagelbot.com` wildcard already lands on traefik.
- Canonical + og:url point at the subdomain.

## Testing

- Local: `stats.localhost:5199/` serves the stats page (EN/FR), `localhost:5199/` serves the dashboard unchanged, `/stats/data` 200 on the stats host. Dashboard check 0 errors.

## Deploy notes

Requires the CNAME `stats` → tunnel (already added). Until this deploys, stats.itsbagelbot.com 404s at traefik — expected.