### PR TITLE
feat(deploy): serve web/'s error pages from the traefik edge

### DIFF
--- a/deploy/infra/cluster/traefik-config.yaml
+++ b/deploy/infra/cluster/traefik-config.yaml
@@ -26,6 +26,12 @@ spec:
   valuesContent: |-
     deployment:
       kind: DaemonSet
+    providers:
+      kubernetesCRD:
+        # The web-error-pages fallback (deploy/k8s/web-error-pages.yaml) proxies
+        # unrouted hosts / dead-backend errors to the marketing site through an
+        # ExternalName Service, which the CRD provider refuses by default.
+        allowExternalNameServices: true
     service:
       type: ClusterIP
       spec:

--- a/deploy/k8s/console-dashboard.yaml
+++ b/deploy/k8s/console-dashboard.yaml
@@ -299,6 +299,11 @@ spec:
   routes:
     - match: Host(`dashboard.itsbagelbot.com`) || Host(`stats.itsbagelbot.com`)
       kind: Rule
+      middlewares:
+        # Dead-backend 502-504 render web/'s coded 500 page instead of
+        # traefik's plain text (deploy/k8s/web-error-pages.yaml). App-rendered
+        # errors pass through untouched.
+        - name: web-error-pages
       services:
         - name: console-dashboard
           port: 80

--- a/deploy/k8s/kustomization.yaml
+++ b/deploy/k8s/kustomization.yaml
@@ -28,6 +28,9 @@ resources:
   - sesame.yaml
   - twitch-ingress.yaml
   - network-policies.yaml
+  # Edge error pages: unrouted hosts + dead-backend 5xx get web/'s coded
+  # 404/500 instead of traefik's plain-text defaults.
+  - web-error-pages.yaml
   - nats.yaml
   - nats-leaf.yaml
   - nats-auth-dopplersecret.yaml

--- a/deploy/k8s/web-error-pages.yaml
+++ b/deploy/k8s/web-error-pages.yaml
@@ -1,0 +1,97 @@
+# Pretty edge errors, served from the marketing site (web/, Cloudflare-hosted).
+# Two failure classes swap traefik's plain-text defaults for web/'s coded error
+# pages:
+#
+#   1. A hostname the tunnel wildcard admits but no router claims (a stray
+#      *.itsbagelbot.com subdomain): the lowest-priority catch-all router below
+#      proxies the request to the marketing origin with the path forced to one
+#      that cannot exist, so Cloudflare answers with web/'s 404 page AND a real
+#      404 status.
+#   2. A routed backend that cannot answer (all pods gone -> traefik's own
+#      502-504): the errors middleware fetches web/'s /500 page and serves it
+#      under the original status code. App-rendered errors (SvelteKit's own
+#      404/500 pages) pass through untouched — the middleware watches only the
+#      status range traefik itself generates.
+#
+# The marketing apex resolves to Cloudflare's static hosting directly (NOT back
+# through the tunnel — verified: the apex serves with no tunnel route present),
+# so proxying to it cannot loop into cloudflared.
+#
+# Requires providers.kubernetesCRD.allowExternalNameServices=true in the
+# traefik HelmChartConfig (deploy/infra/cluster/traefik-config.yaml).
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-origin
+  namespace: production
+spec:
+  type: ExternalName
+  externalName: itsbagelbot.com
+  ports:
+    - name: https
+      port: 443
+---
+apiVersion: traefik.io/v1alpha1
+kind: ServersTransport
+metadata:
+  name: web-origin-transport
+  namespace: production
+spec:
+  # Public Cloudflare certificate, verified against the system trust pool (no
+  # rootCAsSecrets). SNI pinned to the site: the ExternalName dial would
+  # otherwise present the cluster-internal name.
+  serverName: itsbagelbot.com
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: web-error-pages
+  namespace: production
+spec:
+  errors:
+    # Only the codes traefik generates when a backend is unreachable. The apps'
+    # own 404/500 renders must never be swallowed.
+    status: ["502-504"]
+    service:
+      name: web-origin
+      port: 443
+      scheme: https
+      serversTransport: web-origin-transport
+      # Host must be the marketing site for Cloudflare to route it.
+      passHostHeader: false
+    query: "/500"
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: web-not-found
+  namespace: production
+spec:
+  # A path that cannot exist on the marketing site: Cloudflare then returns
+  # web/'s 404 page with a genuine 404 status, which is exactly what an
+  # unrouted hostname deserves.
+  replacePath:
+    path: /edge-unrouted-host
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: unrouted-host-fallback
+  namespace: production
+spec:
+  entryPoints: [websecure]
+  routes:
+    # Explicit rock-bottom priority so every real router (all of which carry
+    # longer, auto-prioritized rules) wins first.
+    - match: HostRegexp(`^.+$`)
+      kind: Rule
+      priority: 1
+      middlewares:
+        - name: web-not-found
+      services:
+        - name: web-origin
+          port: 443
+          scheme: https
+          serversTransport: web-origin-transport
+          passHostHeader: false
+  tls: {}


### PR DESCRIPTION
## What

Traefik's plain-text defaults are replaced by the coded error pages from web/ for the two edge failure classes the apps can't render themselves.

## How

- **Unrouted hostname** (tunnel wildcard admits it, no router claims it): a priority-1 catch-all IngressRoute proxies to the Cloudflare-hosted marketing origin with the path forced to `/edge-unrouted-host`, so Cloudflare answers with web/'s 404 page and a genuine 404 status.
- **Dead backend** (traefik-generated 502-504 on the dashboard router): `errors` middleware serves web/'s `/500` page under the original status code. App-rendered 404/500 pass through untouched — the watched range is only what traefik itself generates.
- Plumbing: ExternalName Service → apex + ServersTransport (system trust, SNI pinned). The apex resolves to Cloudflare's static hosting directly, not back through the tunnel — no loop (verified live). `allowExternalNameServices` enabled on the CRD provider in the traefik HelmChartConfig; helm-controller rolls the DaemonSet one node at a time.

## Testing

- All five manifests validate against the live API server (`kubectl apply --dry-run=server`).
- `https://itsbagelbot.com/500` → 200 coded page; unknown path → 404 status + coded 404 page (the exact responses the middleware will relay).