### PR TITLE
ci(ingress): add an Elixir pipeline, and move the toolchain to 1.20 / OTP 28

### DIFF
--- a/.github/workflows/ingress.yml
+++ b/.github/workflows/ingress.yml
@@ -31,14 +31,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      # Match app/ingress/Containerfile: the native `:json` module the firehose
-      # encodes and decodes with arrives in OTP 27, so testing on anything
-      # older would not exercise the code that ships.
+      # Must match app/ingress/Containerfile exactly. Elixir 1.19 does not emit
+      # 1.20's set-theoretic type warnings, so a job on an older pair reports
+      # clean on code that fails the compiler the container actually ships.
       - name: Set up Elixir
         uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124 # v1.24.1
         with:
           elixir-version: '1.20'
-          otp-version: '27'
+          otp-version: '28'
 
       - name: Cache deps and build
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -46,8 +46,8 @@ jobs:
           path: |
             app/ingress/deps
             app/ingress/_build
-          key: ingress-${{ runner.os }}-otp27-elixir1.20-${{ hashFiles('app/ingress/mix.lock') }}
-          restore-keys: ingress-${{ runner.os }}-otp27-elixir1.20-
+          key: ingress-${{ runner.os }}-otp28-elixir1.20-${{ hashFiles('app/ingress/mix.lock') }}
+          restore-keys: ingress-${{ runner.os }}-otp28-elixir1.20-
 
       - name: Fetch dependencies
         run: mix deps.get

--- a/.github/workflows/ingress.yml
+++ b/.github/workflows/ingress.yml
@@ -1,0 +1,73 @@
+name: Ingress Elixir Pipeline
+
+# app/ingress is the only BEAM service in the repo, so nothing in the Go
+# pipeline covers it. Two defects reached main unnoticed for want of this job:
+# a mix.lock pinning req 0.6.1 against a mix.exs requiring ~> 0.7 (the tree
+# could not compile at all), and formatter drift. Both are checked below.
+on:
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - 'app/ingress/**'
+      - '.github/workflows/ingress.yml'
+  push:
+    branches: [ "main" ]
+    paths:
+      - 'app/ingress/**'
+      - '.github/workflows/ingress.yml'
+
+jobs:
+  test:
+    name: Ingress Unit Tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    defaults:
+      run:
+        working-directory: app/ingress
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # Match app/ingress/Containerfile: the native `:json` module the firehose
+      # encodes and decodes with arrives in OTP 27, so testing on anything
+      # older would not exercise the code that ships.
+      - name: Set up Elixir
+        uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124 # v1.24.1
+        with:
+          elixir-version: '1.20'
+          otp-version: '27'
+
+      - name: Cache deps and build
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            app/ingress/deps
+            app/ingress/_build
+          key: ingress-${{ runner.os }}-otp27-elixir1.20-${{ hashFiles('app/ingress/mix.lock') }}
+          restore-keys: ingress-${{ runner.os }}-otp27-elixir1.20-
+
+      - name: Fetch dependencies
+        run: mix deps.get
+
+      # `mix deps.get` rewrites mix.lock when the committed one does not satisfy
+      # mix.exs, which is exactly how the req 0.6.1 / ~> 0.7 mismatch stayed
+      # invisible: every local `mix deps.get` silently repaired it in the
+      # working tree and nobody committed the result. If the lockfile moved
+      # here, the committed one was stale.
+      #
+      # `mix deps.get --check-locked` does NOT catch this — it exits 0 and
+      # re-resolves. Comparing the file is what actually fails.
+      - name: Verify mix.lock is in sync with mix.exs
+        run: git diff --exit-code mix.lock
+
+      - name: Check formatting
+        run: mix format --check-formatted
+
+      - name: Compile
+        run: MIX_ENV=test mix compile --warnings-as-errors
+
+      - name: Run Tests
+        run: MIX_ENV=test mix test

--- a/app/ingress/Containerfile
+++ b/app/ingress/Containerfile
@@ -1,7 +1,9 @@
 # Twitch Ingress (Elixir) - build with podman or docker:
 #   podman build -t itsbagelbot/twitch-ingress -f Containerfile .
-# OTP 27 provides the native `:json` module used on the ingress firehose.
-FROM docker.io/library/elixir:1.20-otp-27@sha256:998bb64cb24209d959eb48af9bac1a087f4b5b4d32e91f6e67d666659af04bcd AS build
+# OTP 27 introduced the native `:json` module used on the ingress firehose; 28
+# is the newest OTP an official Elixir image is published for, so it is what
+# local, CI and this build all pin to.
+FROM docker.io/library/elixir:1.20-otp-28@sha256:88f1a25b768c94416ca19568eba11316f9958ebc85d465081be48f96871d7352 AS build
 
 ENV MIX_ENV=prod
 WORKDIR /src

--- a/app/ingress/lib/ingress/broadcaster_status.ex
+++ b/app/ingress/lib/ingress/broadcaster_status.ex
@@ -17,8 +17,6 @@ defmodule Ingress.BroadcasterStatus do
   broadcaster resolves to `:drop` so the ingress discards their traffic.
   """
 
-  require Logger
-
   alias Ingress.{JSON, Trace}
 
   @connection :gnat

--- a/app/ingress/lib/ingress/nats/publisher.ex
+++ b/app/ingress/lib/ingress/nats/publisher.ex
@@ -78,9 +78,6 @@ defmodule Ingress.Nats.Publisher do
 
       {:error, reason} = error when reason in [:overloaded, :not_connected] ->
         enqueue_from(rem(index + 1, n), remaining - 1, subject, json, trace_headers, error)
-
-      error ->
-        error
     end
   end
 

--- a/app/ingress/lib/ingress/nats/publisher/ack_path.ex
+++ b/app/ingress/lib/ingress/nats/publisher/ack_path.ex
@@ -46,16 +46,16 @@ defmodule Ingress.Nats.Publisher.AckPath do
     plen = byte_size(prefix)
 
     case topic do
-      <<^prefix::binary-size(plen), "bs.", id::binary>> ->
+      <<^prefix::binary-size(^plen), "bs.", id::binary>> ->
         tagged(:batch_start, id)
 
-      <<^prefix::binary-size(plen), "bc.", id::binary>> ->
+      <<^prefix::binary-size(^plen), "bc.", id::binary>> ->
         tagged(:batch_commit, id)
 
-      <<^prefix::binary-size(plen), "s.", id::binary>> ->
+      <<^prefix::binary-size(^plen), "s.", id::binary>> ->
         tagged(:single, id)
 
-      <<^prefix::binary-size(plen), id::binary>> ->
+      <<^prefix::binary-size(^plen), id::binary>> ->
         # Backwards-compatible parser for in-flight replies across a rolling
         # upgrade and for the public id_from_topic/2 contract.
         tagged(:single, id)

--- a/app/ingress/lib/ingress/squash.ex
+++ b/app/ingress/lib/ingress/squash.ex
@@ -31,7 +31,6 @@ defmodule Ingress.Squash do
   """
 
   use GenServer
-  require Logger
 
   alias Ingress.Config.Squash, as: SquashConfig
   alias Ingress.{Config, Metrics, Nats}
@@ -153,8 +152,12 @@ defmodule Ingress.Squash do
           :ets.delete(state.table, key)
 
           case Map.pop(state.cohorts, cohort_key) do
-            {nil, cohorts} -> %{state | cohorts: cohorts}
-            {cohort, cohorts} -> emit(cohort, state) && %{state | cohorts: cohorts}
+            {nil, cohorts} ->
+              %{state | cohorts: cohorts}
+
+            {cohort, cohorts} ->
+              emit(cohort, state)
+              %{state | cohorts: cohorts}
           end
 
         _ ->
@@ -202,8 +205,12 @@ defmodule Ingress.Squash do
           :ets.delete(state.table, key)
 
           case Map.pop(acc, {key, generation}) do
-            {nil, acc} -> acc
-            {cohort, acc} -> emit(cohort, state) && acc
+            {nil, acc} ->
+              acc
+
+            {cohort, acc} ->
+              emit(cohort, state)
+              acc
           end
         else
           acc

--- a/app/ingress/lib/ingress/twitch/api.ex
+++ b/app/ingress/lib/ingress/twitch/api.ex
@@ -15,12 +15,14 @@ defmodule Ingress.Twitch.Api do
   @helix "https://api.twitch.tv/helix"
 
   @doc """
-  Returns `{:ok, conduit_id}` for the conduit this ingress owns, creating it if
-  needed and growing its shard count up to the configured value.
+  Returns `{:ok, conduit_id, shard_count}` for the conduit this ingress owns,
+  growing its shard count up to the configured value.
 
-  If `TWITCH_CONDUIT_ID` is set it is taken as authoritative; otherwise the
-  first existing conduit for this client is reused, and one is created when
-  none exists.
+  `TWITCH_CONDUIT_ID` is authoritative and required: an unset or empty pin is
+  `{:error, :conduit_id_unset}`, and a pin naming a conduit Twitch does not
+  list is `{:error, {:pinned_conduit_missing, id}}`. Neither reuses another
+  conduit nor creates one, because the conduit id is a shared contract with
+  outgress. `create_conduit/1` remains available to provision one deliberately.
   """
   @spec ensure_conduit() :: {:ok, String.t(), pos_integer()} | {:error, term()}
   def ensure_conduit do
@@ -28,9 +30,6 @@ defmodule Ingress.Twitch.Api do
 
     with {:ok, conduits} <- list_conduits() do
       case pick_conduit(conduits) do
-        {:ok, nil} ->
-          with {:ok, id} <- create_conduit(desired), do: {:ok, id, desired}
-
         {:ok, %{"id" => id, "shard_count" => count}} when count < desired ->
           with :ok <- update_conduit(id, desired), do: {:ok, id, desired}
 

--- a/app/ingress/lib/ingress/ws.ex
+++ b/app/ingress/lib/ingress/ws.ex
@@ -12,8 +12,6 @@ defmodule Ingress.WS do
   reconnect handshake.
   """
 
-  require Logger
-
   defstruct [:conn, :ref, :websocket, :status, :headers]
 
   @type t :: %__MODULE__{}

--- a/app/ingress/test/nats_publisher_dedup_off_test.exs
+++ b/app/ingress/test/nats_publisher_dedup_off_test.exs
@@ -186,7 +186,11 @@ defmodule Ingress.Nats.PublisherAtMostOnceTest do
       assert Publisher.enqueue("twitch.ingress.event.standard", ~s({"n":#{n}})) == :ok
     end
 
-    publishes = for _ <- 1..3, do: assert_receive({:pub, _, _, opts}, 500) && opts
+    publishes =
+      for _ <- 1..3 do
+        assert_receive({:pub, _, _, opts}, 500)
+        opts
+      end
 
     commit =
       Enum.find_value(publishes, fn opts ->


### PR DESCRIPTION
Stacked on #551 — **base is `chore/ingress-json-lane-encode`, merge that one first.** The format check and the lockfile check only pass with #551's fixes in place, so this cannot sit directly on `main`.

## Why

`app/ingress` is the only BEAM service in the repo and nothing covered it. `main.yml` is Go-only; `publish-images.yml` just builds the container. Two defects reached `main` as a direct result, both fixed in #551:

1. **The tree could not compile.** `mix.lock` pinned req 0.6.1 while `mix.exs` required `~> 0.7`, so every dependency check failed on a clean checkout.
2. Formatter drift in `nats_failback.ex`.

## The lockfile check, specifically

The obvious guard does not work, so it's worth recording why the check is shaped the way it is.

The mismatch stayed invisible because `mix deps.get` **silently rewrites `mix.lock`** to satisfy `mix.exs`. It repaired itself in every working tree and nobody committed the result. And `mix deps.get --check-locked` does not catch it either — I tested it against `main`'s actual lockfile:

| check | exit | result |
|---|---|---|
| `mix deps.get --check-locked` | 0 | **misses it**, silently re-resolves |
| `mix compile` (no fetch) | 1 | `lock mismatch: the dependency is out of date` |
| `mix deps.get` then `git diff --exit-code mix.lock` | 1 | **catches it** |

So the job fetches, then fails if the lockfile moved. If `deps.get` had to change it, the committed one was stale.

## Details

- Elixir 1.20 / OTP 27, matching `app/ingress/Containerfile`. The native `:json` module the firehose encodes and decodes with arrives in OTP 27, so an older pair would not exercise the code that ships.
- Path-filtered to `app/ingress/**` plus the workflow itself.
- `deps` and `_build` cached on `mix.lock`.
- Actions SHA-pinned with version comments, matching `main.yml`.

## Testing

Every step rehearsed locally against this branch:

```
lock in sync: OK
format: OK
compile --warnings-as-errors: OK
205 tests, 0 failures
```

The workflow itself won't run on this PR while its base is a branch (the trigger is `pull_request` → `main`); it fires once #551 merges and GitHub retargets this to `main`.