### PR TITLE
perf(gossip): stale-while-revalidate the envelope cache and instrument upstream calls

### DIFF
--- a/app/gossip/internal/core/cache.go
+++ b/app/gossip/internal/core/cache.go
@@ -105,7 +105,26 @@ func Key(provider, endpoint, id string) string {
 type cacheEnvelope[T any] struct {
 	Value T              `json:"v"`
 	Error *UpstreamError `json:"e,omitempty"`
+	// Fresh is the unix-millisecond instant this entry stops being fresh. The
+	// record is retained for twice its fresh window, so the span between the two
+	// is the stale tail Cached serves from while it revalidates behind the
+	// caller. An entry written before this field existed decodes it as zero,
+	// which reads as "already stale": that entry is served once and refreshed,
+	// so the format rolls forward on its own rather than needing a flush.
+	Fresh int64 `json:"f,omitempty"`
 }
+
+// envelope is one decoded entry: the value, the negative it stands in for, and
+// when it stops being fresh.
+type envelope[T any] struct {
+	value    T
+	negative *UpstreamError
+	fresh    int64
+}
+
+// stale reports whether the entry has passed its fresh window and should be
+// revalidated behind the caller it is about to be served to.
+func (e envelope[T]) stale() bool { return time.Now().UnixMilli() >= e.fresh }
 
 // decodeEnvelope reads one cached entry. ok is false for anything that is not a
 // well-formed envelope — including a legacy/foreign-format entry that happens to
@@ -113,25 +132,27 @@ type cacheEnvelope[T any] struct {
 // reply into the envelope would silently succeed with a zero Value, and the caller
 // would serve an empty reply (blank player, all-zero stats) until the entry
 // expired. That exact bug shipped once; the marker check is its regression guard.
-func decodeEnvelope[T any](b []byte) (v T, negative *UpstreamError, ok bool) {
+func decodeEnvelope[T any](b []byte) (out envelope[T], ok bool) {
 	var probe struct {
 		Value codec.RawMessage `json:"v"`
 		Error *UpstreamError   `json:"e"`
+		Fresh int64            `json:"f"`
 	}
 	if err := codec.Unmarshal(b, &probe); err != nil {
-		return v, nil, false
+		return out, false
 	}
+	out.fresh = probe.Fresh
 	if probe.Error != nil && probe.Error.Status != 0 {
-		return v, probe.Error, true
+		out.negative = probe.Error
+		return out, true
 	}
 	if len(probe.Value) == 0 {
-		return v, nil, false // no marker: legacy or foreign format
+		return out, false // no marker: legacy or foreign format
 	}
-	if err := codec.Unmarshal(probe.Value, &v); err != nil {
-		var zero T
-		return zero, nil, false
+	if err := codec.Unmarshal(probe.Value, &out.value); err != nil {
+		return envelope[T]{}, false
 	}
-	return v, nil, true
+	return out, true
 }
 
 // Cached returns the cached T under key, or runs fetch to fill it for ttl.
@@ -150,60 +171,31 @@ func decodeEnvelope[T any](b []byte) (v T, negative *UpstreamError, ok bool) {
 // its denial to premium callers entitled to the 25% reserve. Admission runs after
 // the hit check because a hit costs no upstream call and so must cost no budget.
 // A nil admit means the lookup spends none.
+// A fresh hit returns as-is. A hit past its fresh window returns the stored value
+// IMMEDIATELY and revalidates behind the caller, so the slow upstream leaves the
+// critical path after the first cold fetch. That matters most on the dependent
+// leg of a lookup: a fortnite display-name resolve runs BEFORE the stats call and
+// the stats call needs its answer, so without this an expired account entry put a
+// whole upstream round trip in front of a command that was otherwise warm.
+//
+// A negative is never revalidated in the background. It stands for an absence, so
+// refreshing it would spend upstream budget to re-learn nothing; it simply expires.
 func Cached[T any](ctx context.Context, c *Cache, key string, ttl, negativeTTL time.Duration, admit func(context.Context) error, fetch func(context.Context) (T, error)) (T, error) {
+	f := envelopeFlight[T]{cache: c, key: key, ttl: ttl, negativeTTL: negativeTTL, admit: admit, fetch: fetch}
 	var zero T
-	if b, ok, err := c.store.Get(ctx, key); err == nil && ok {
-		if v, negative, decoded := decodeEnvelope[T](b); decoded {
-			if negative != nil {
-				return zero, negative
-			}
-			return v, nil
+
+	if entry, ok := f.read(ctx); ok {
+		if entry.negative == nil && entry.stale() {
+			f.refresh()
 		}
-		// Poison entry (shape drift after a deploy): drop it and refetch.
-		_ = c.store.Del(ctx, key)
+		return entry.answer()
 	}
 
 	if err := spend(ctx, admit); err != nil {
 		return zero, err
 	}
 
-	res, err, _ := c.sf.Do(key, func() (any, error) {
-		// A previous flight may have filled the key while we queued.
-		if b, ok, gerr := c.store.Get(ctx, key); gerr == nil && ok {
-			if v, negative, decoded := decodeEnvelope[T](b); decoded {
-				if negative != nil {
-					return zero, negative
-				}
-				return v, nil
-			}
-		}
-		v, ferr := fetch(ctx)
-		var ue *UpstreamError
-		var env cacheEnvelope[T]
-		var cacheTTL time.Duration
-
-		if ferr != nil {
-			if errors.As(ferr, &ue) && (ue.Status == 404 || ue.Status == 400) {
-				// Negative cache hit
-				env.Error = ue
-				cacheTTL = negativeTTL
-			} else {
-				return nil, ferr
-			}
-		} else {
-			env.Value = v
-			cacheTTL = ttl
-		}
-
-		if b, merr := codec.Marshal(env); merr == nil {
-			_ = c.store.Set(ctx, key, b, cacheTTL)
-		}
-
-		if env.Error != nil {
-			return v, env.Error
-		}
-		return v, nil
-	})
+	res, err, _ := c.sf.Do(key, func() (any, error) { return f.fill(ctx) })
 	if err != nil {
 		return zero, err
 	}
@@ -211,6 +203,110 @@ func Cached[T any](ctx context.Context, c *Cache, key string, ttl, negativeTTL t
 		return v, nil
 	}
 	return zero, fmt.Errorf("cache %s: unexpected value type %T", key, res)
+}
+
+// envelopeFlight is one Cached lookup's parameters travelling together. They are
+// bundled because every step below needs most of them, and threading six
+// arguments through each would be its own kind of unreadable.
+type envelopeFlight[T any] struct {
+	cache       *Cache
+	key         string
+	ttl         time.Duration
+	negativeTTL time.Duration
+	admit       func(context.Context) error
+	fetch       func(context.Context) (T, error)
+}
+
+// read returns the stored entry, dropping one whose format does not parse so the
+// caller's refetch replaces it rather than serving a zero value out of a legacy
+// or foreign record.
+func (f envelopeFlight[T]) read(ctx context.Context) (envelope[T], bool) {
+	b, found, err := f.cache.store.Get(ctx, f.key)
+	if err != nil || !found {
+		return envelope[T]{}, false
+	}
+	entry, ok := decodeEnvelope[T](b)
+	if !ok {
+		_ = f.cache.store.Del(ctx, f.key)
+		return envelope[T]{}, false
+	}
+	return entry, true
+}
+
+// answer turns one decoded entry into the pair its caller receives.
+func (e envelope[T]) answer() (T, error) {
+	if e.negative != nil {
+		var zero T
+		return zero, e.negative
+	}
+	return e.value, nil
+}
+
+// fill is the foreground flight body: another flight may have filled the key
+// while this caller queued, so it re-reads before spending an upstream call.
+func (f envelopeFlight[T]) fill(ctx context.Context) (any, error) {
+	if entry, ok := f.read(ctx); ok {
+		return entry.answer()
+	}
+	return f.refetch(ctx)
+}
+
+// refetch runs the fetch unconditionally and stores what it returns. The
+// double-check read fill does is deliberately absent: a revalidation runs while
+// the stale entry is still present, so re-reading it would hand back that stale
+// value and skip the refresh this whole path exists to perform.
+func (f envelopeFlight[T]) refetch(ctx context.Context) (any, error) {
+	v, ferr := f.fetch(ctx)
+	env, cacheTTL, err := f.envelopeFor(v, ferr)
+	if err != nil {
+		return nil, err
+	}
+	if b, merr := codec.Marshal(env); merr == nil {
+		_ = f.cache.store.Set(ctx, f.key, b, cacheTTL)
+	}
+	if env.Error != nil {
+		return v, env.Error
+	}
+	return v, nil
+}
+
+// envelopeFor shapes one fetch outcome into the record to store and how long to
+// keep it. A success is retained for twice its fresh window, so the second half
+// is the stale tail; a 400/404 is the absence worth remembering for negativeTTL;
+// anything else is an infrastructure failure that must not be cached at all.
+func (f envelopeFlight[T]) envelopeFor(v T, ferr error) (cacheEnvelope[T], time.Duration, error) {
+	if ferr == nil {
+		return cacheEnvelope[T]{Value: v, Fresh: time.Now().Add(f.ttl).UnixMilli()}, 2 * f.ttl, nil
+	}
+	var ue *UpstreamError
+	if errors.As(ferr, &ue) && (ue.Status == 404 || ue.Status == 400) {
+		return cacheEnvelope[T]{Error: ue}, f.negativeTTL, nil
+	}
+	return cacheEnvelope[T]{}, 0, ferr
+}
+
+// refresh revalidates one stale key in the background under the same discipline
+// refreshBytes uses: the pod-local map is a cheap pre-filter, the SET NX claim in
+// the shared store is the authority, so a stale key costs ONE upstream call
+// fleet-wide rather than one per replica. It spends budget after winning the
+// claim, so only the replica that will actually call the upstream pays. A failure
+// is swallowed and the stale entry keeps serving until its physical TTL.
+func (f envelopeFlight[T]) refresh() {
+	if _, busy := f.cache.refreshing.LoadOrStore(f.key, struct{}{}); busy {
+		return
+	}
+	go func() {
+		defer f.cache.refreshing.Delete(f.key)
+		ctx, cancel := context.WithTimeout(context.Background(), swrRefreshTimeout)
+		defer cancel()
+		if won, err := f.cache.store.SetNX(ctx, f.key+":swr", []byte("1"), swrRefreshTimeout); err != nil || !won {
+			return
+		}
+		if err := spend(ctx, f.admit); err != nil {
+			return
+		}
+		_, _, _ = f.cache.sf.Do(f.key, func() (any, error) { return f.refetch(ctx) })
+	}()
 }
 
 // GetJSON reads a raw (non-fetching) entry, for provider-owned state like the

--- a/app/gossip/internal/core/cache_test.go
+++ b/app/gossip/internal/core/cache_test.go
@@ -328,3 +328,129 @@ func TestSnapshotRoundTrip(t *testing.T) {
 func TestKey(t *testing.T) {
 	assert.Equal(t, "gossip:urchin:daily:techno", Key("urchin", "daily", "techno"))
 }
+
+// A stale entry must be served IMMEDIATELY and revalidated behind the caller.
+// This is the property the fortnite account resolve depends on: it runs before
+// the stats call, so an expired entry that blocked would put a whole upstream
+// round trip in front of an otherwise warm command.
+func TestCachedStaleServedThenRevalidated(t *testing.T) {
+	c := NewCache(newMemStore())
+	ctx := context.Background()
+	var fetches atomic.Int32
+
+	fill := func(n int) func(context.Context) (payload, error) {
+		return func(context.Context) (payload, error) {
+			fetches.Add(1)
+			return payload{Name: "x", N: n}, nil
+		}
+	}
+
+	// Fresh for 20ms, retained for twice that.
+	got, err := Cached(ctx, c, "k", 20*time.Millisecond, time.Minute, nil, fill(1))
+	require.NoError(t, err)
+	require.Equal(t, 1, got.N)
+	time.Sleep(40 * time.Millisecond)
+
+	// Stale read: the OLD value comes back at once, and one refresh is kicked.
+	got, err = Cached(ctx, c, "k", time.Minute, time.Minute, nil, fill(2))
+	require.NoError(t, err)
+	assert.Equal(t, 1, got.N, "a stale read must serve the stored value, not block on the refetch")
+
+	require.Eventually(t, func() bool {
+		v, gerr := Cached(ctx, c, "k", time.Minute, time.Minute, nil, fill(2))
+		return gerr == nil && v.N == 2
+	}, time.Second, 10*time.Millisecond)
+	assert.Equal(t, int32(2), fetches.Load(), "one cold fill plus exactly one revalidation")
+}
+
+// The revalidation is claimed once across replicas, exactly as the byte path
+// does it: two Cache instances over one store model two pods, and without the
+// shared claim each would fire its own upstream call for one stale key.
+func TestCachedStaleRefreshClaimedOnceFleetWide(t *testing.T) {
+	st := newMemStore()
+	podA, podB := NewCache(st), NewCache(st)
+	ctx := context.Background()
+	var fetches atomic.Int32
+
+	_, err := Cached(ctx, podA, "k", 20*time.Millisecond, time.Minute, nil,
+		func(context.Context) (payload, error) {
+			fetches.Add(1)
+			return payload{Name: "x", N: 1}, nil
+		})
+	require.NoError(t, err)
+	time.Sleep(40 * time.Millisecond)
+
+	// The refetch parks until both pods have taken their stale read, so the
+	// winner's write cannot land in between and turn the second into a fresh hit.
+	release := make(chan struct{})
+	refetch := func(context.Context) (payload, error) {
+		<-release
+		fetches.Add(1)
+		return payload{Name: "x", N: 2}, nil
+	}
+	for _, pod := range []*Cache{podA, podB} {
+		got, gerr := Cached(ctx, pod, "k", time.Minute, time.Minute, nil, refetch)
+		require.NoError(t, gerr)
+		assert.Equal(t, 1, got.N, "stale read must serve the old value")
+	}
+	close(release)
+
+	require.Eventually(t, func() bool {
+		v, gerr := Cached(ctx, podA, "k", time.Minute, time.Minute, nil, refetch)
+		return gerr == nil && v.N == 2
+	}, time.Second, 10*time.Millisecond)
+	assert.Equal(t, int32(2), fetches.Load(), "one cold fill plus exactly one fleet-wide refresh")
+}
+
+// A negative stands for an absence, so revalidating it in the background would
+// spend upstream budget to re-learn nothing. It expires instead.
+func TestCachedNegativeIsNotRevalidated(t *testing.T) {
+	c := NewCache(newMemStore())
+	ctx := context.Background()
+	missing := &UpstreamError{Status: 404, Message: "player not found"}
+	var fetches atomic.Int32
+
+	fetch := func(context.Context) (payload, error) {
+		fetches.Add(1)
+		return payload{}, missing
+	}
+
+	// The first answer is the fetch's own error; the next two are decoded back
+	// out of the entry, so they are equal by value and NOT the same pointer.
+	for range 3 {
+		_, err := Cached(ctx, c, "k", time.Minute, time.Minute, nil, fetch)
+		var ue *UpstreamError
+		require.ErrorAs(t, err, &ue)
+		assert.Equal(t, 404, ue.Status)
+		assert.Equal(t, "player not found", ue.Message)
+	}
+	// Give any (incorrect) background refresh a chance to run before asserting.
+	time.Sleep(50 * time.Millisecond)
+	assert.Equal(t, int32(1), fetches.Load(), "a cached negative must not be refetched")
+}
+
+// An entry written before the fresh stamp existed decodes it as zero, which
+// reads as already stale. It is served once and refreshed, so the format rolls
+// forward on its own instead of needing a cache flush at deploy.
+func TestCachedLegacyEntryWithoutStampRefreshes(t *testing.T) {
+	st := newMemStore()
+	ctx := context.Background()
+	require.NoError(t, st.Set(ctx, "k", []byte(`{"v":{"name":"old","n":1}}`), time.Minute))
+	c := NewCache(st)
+	var fetches atomic.Int32
+
+	got, err := Cached(ctx, c, "k", time.Minute, time.Minute, nil,
+		func(context.Context) (payload, error) {
+			fetches.Add(1)
+			return payload{Name: "new", N: 2}, nil
+		})
+	require.NoError(t, err)
+	assert.Equal(t, "old", got.Name, "the legacy value is still served, not discarded")
+
+	require.Eventually(t, func() bool {
+		v, gerr := Cached(ctx, c, "k", time.Minute, time.Minute, nil,
+			func(context.Context) (payload, error) { return payload{Name: "new", N: 2}, nil })
+		return gerr == nil && v.Name == "new"
+	}, time.Second, 10*time.Millisecond)
+	assert.Equal(t, int32(1), fetches.Load())
+}

--- a/app/gossip/internal/core/http.go
+++ b/app/gossip/internal/core/http.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"net/url"
 	"time"
+
+	"github.com/newrelic/go-agent/v3/newrelic"
 )
 
 // maxBody bounds an upstream response read. The largest legitimate payload the
@@ -190,7 +192,19 @@ func (c *HTTPClient) Do(ctx context.Context, r Request, out any) error {
 	if err != nil {
 		return err
 	}
+
+	// Report the call to New Relic as an external segment. Without this a
+	// handler's transaction is one opaque block, so "the provider is slow" and
+	// "we are slow" are indistinguishable in the only place that has the whole
+	// picture — which is exactly the question a slow !fnstats raises, and one
+	// that cost a manual round of curl-from-a-probe-pod to answer once. The
+	// segment ends before the body is read, so it measures the upstream's time
+	// to first byte and not our decode; decodeJSON's read and unmarshal stay in
+	// the surrounding transaction, which is where they belong.
+	segment := newrelic.StartExternalSegment(newrelic.FromContext(ctx), req)
 	resp, err := c.hc.Do(req)
+	segment.Response = resp
+	segment.End()
 	if err != nil {
 		return err
 	}

--- a/app/gossip/internal/providers/mcsr/mcsr.go
+++ b/app/gossip/internal/providers/mcsr/mcsr.go
@@ -25,9 +25,14 @@ import (
 )
 
 const (
-	// userTTL keeps chat spam off the MCSR API (500 req / 10 min fleet-wide)
-	// while staying fresh enough that a finished match shows within a minute.
-	userTTL = time.Minute
+	// userTTL keeps chat spam off the MCSR API (500 req / 10 min fleet-wide).
+	// Sized against the game, not against a round number: the world record sits
+	// around 6:35, so no run can start and finish inside this window, and a
+	// viewer asking twice about the same player is asking about the same run.
+	// At one minute the entry expired faster than the upstream answered on a
+	// cold call, so essentially every !mcsr paid a full round trip to an API
+	// that returns the same numbers.
+	userTTL = 6 * time.Minute
 	// snapshotTTL outlives any plausible single stream; Twitch caps broadcasts
 	// at 48h.
 	snapshotTTL = 49 * time.Hour


### PR DESCRIPTION
Follow-up to #547, from measuring production rather than guessing.

## What the measurements said

Gossip is not CPU bound (4-6m against a 250m limit), Valkey is 0.26ms average over 387 samples, and there were zero rate-limit denials and zero RPC timeouts across 40 minutes. Upstream latency dominates, measured from inside the cluster on the real endpoints:

| endpoint | total |
|---|---|
| fn-account | 163ms |
| fn-season | 270ms |
| mcsr-user | 296ms, then 50ms (server-side cached) |
| urchin-tags | ~200ms |
| fn-shop | 422ms (247ms of it payload transfer) |

Against that, `!fnstats` spent 871ms-1.44s in-handler. The reason is structural: the display-name resolve runs before the stats call and the stats call needs its answer, so the two cannot overlap, and both go to the slowest upstream in the set.

## Changes

**Stale-while-revalidate on the envelope cache.** The byte-flow cache already did this; the envelope cache did not, so every expiry put a full round trip back in front of a command. Entries now carry a fresh-until stamp and are retained for twice their fresh window. The refresh uses the same SET NX claim `refreshBytes` uses, so a stale key costs one upstream call fleet-wide rather than one per replica, and it spends budget only after winning the claim.

Negatives are never revalidated: an absence refetched in the background spends budget to re-learn nothing.

Old entries decode the stamp as zero, read as already stale, and are served once then refreshed, so the format rolls forward without a cache flush.

**mcsr user TTL 1min to 6min.** Sized against the game: the world record is around 6:35, so no run can begin and end inside the window. At one minute the entry expired faster than the upstream answered, so nearly every `!mcsr` paid a full round trip for unchanged numbers.

**Upstream calls become New Relic external segments.** A handler's transaction was one opaque block, so "provider slow" and "we are slow" were indistinguishable in the one place that has the whole picture. Answering it once cost a round of curl from a probe pod. The segment ends before the body read, so it measures the upstream's time to first byte; the read and unmarshal stay in the surrounding transaction.

## Tests

Four new cases on the envelope cache: stale is served immediately and revalidated once, the refresh is claimed once across two Cache instances sharing one store, a negative is not revalidated, and a legacy entry without the stamp is served then refreshed.

One worth noting: a cached negative is decoded into a new `*UpstreamError`, so it is equal by value and not the same pointer. The test asserts on status and message rather than identity.

## Verification

`go build ./...`, `go vet ./...`, `go test -race` across `app/gossip` and `pkg/bus`, gofmt clean.

## Not included

Trace headers still do not propagate from sesame into gossip's RPC engine, so gossip spans remain orphaned from the sesame spans that cause them. The external segments make gossip's own breakdown readable; linking the two ends is still open.
