### PR TITLE
perf(fortnite): stop re-resolving an account binding that cannot change

### DIFF
--- a/app/gossip/internal/providers/fortnite/fortnite.go
+++ b/app/gossip/internal/providers/fortnite/fortnite.go
@@ -47,9 +47,32 @@ const (
 	// statsTTL matches the other stats providers' staleness budget.
 	statsTTL    = 10 * time.Minute
 	negativeTTL = 5 * time.Minute
-	// accountTTL: an Epic display-name -> account-id binding only changes on a
-	// rename.
-	accountTTL = 24 * time.Hour
+	// accountTTL is how long a display-name -> account-id binding is trusted.
+	// It is the single most expensive TTL in this provider, because the binding
+	// sits in front of the stats call rather than beside it: fetchStats cannot
+	// build the /api/v2/stats/{id} URL until the resolve has answered, so a
+	// cold binding turns one upstream round trip into two SEQUENTIAL ones
+	// against prod.api-fortnite.com — measured at ~700ms a call from this
+	// fleet, the slowest upstream any provider here talks to. That is the whole
+	// distance between the two !fnstats timings production shows: 871ms with
+	// the binding warm, 1.44s with it cold.
+	//
+	// A day was a round number, not a sized one. Size it against what the
+	// binding actually tracks and 24h is far too short: an Epic account id is
+	// immutable, so this mapping can only break on a display-name change, and
+	// Epic rate-limits renames to one every two weeks. Two weeks is therefore
+	// the shortest interval at which a fresh answer can differ from a stale
+	// one, and at 24h the provider was re-resolving an unchanged binding
+	// roughly fourteen times for every time it could possibly have moved,
+	// paying a 700ms serial call for each.
+	//
+	// Serving a stale binding through a rename is also the mild failure, not
+	// the severe one: the id keeps resolving to the same account, so the stats
+	// stay correct and only the canonically-cased Player name in the reply
+	// lags. And it self-heals without waiting out the window — a renamed player
+	// is looked up under the NEW display name, which is a different cache key
+	// and resolves fresh.
+	accountTTL = 14 * 24 * time.Hour
 	// seasonTTL bounds how stale the auto-fetched season start may run; a
 	// season rollover (4x a year) is picked up within the hour.
 	seasonTTL = time.Hour

--- a/app/gossip/internal/providers/fortnite/fortnite_test.go
+++ b/app/gossip/internal/providers/fortnite/fortnite_test.go
@@ -66,6 +66,14 @@ func (s *memStore) SetNX(_ context.Context, key string, val []byte, _ time.Durat
 // directly; endpoint handlers come from build() via handle.
 func newTestProvider(t *testing.T, stats, shop http.Handler, extra func(*Config)) *api {
 	t.Helper()
+	p, _ := newTestProviderWithStore(t, stats, shop, extra)
+	return p
+}
+
+// newTestProviderWithStore is newTestProvider plus the backing store, for the
+// tests that need to age one cache entry out from under the provider.
+func newTestProviderWithStore(t *testing.T, stats, shop http.Handler, extra func(*Config)) (*api, *memStore) {
+	t.Helper()
 	statsSrv := httptest.NewServer(stats)
 	t.Cleanup(statsSrv.Close)
 	shopSrv := httptest.NewServer(shop)
@@ -74,7 +82,8 @@ func newTestProvider(t *testing.T, stats, shop http.Handler, extra func(*Config)
 	if extra != nil {
 		extra(&cfg)
 	}
-	return newAPI(cfg, provider.Deps{Cache: core.NewCache(newMemStore()), Log: zap.NewNop()})
+	store := newMemStore()
+	return newAPI(cfg, provider.Deps{Cache: core.NewCache(store), Log: zap.NewNop()}), store
 }
 
 func noUpstream(t *testing.T, name string) http.Handler {

--- a/app/gossip/internal/providers/fortnite/sharing_test.go
+++ b/app/gossip/internal/providers/fortnite/sharing_test.go
@@ -39,6 +39,37 @@ func TestStatsAndSessionShareOneUpstreamFetch(t *testing.T) {
 		"a warm !fnstats must make the session path cost no upstream call at all")
 }
 
+// The account binding sits IN FRONT of the stats call, not beside it: the
+// /api/v2/stats/{id} URL cannot be built until the resolve has answered, so the
+// two run in series against the same ~700ms upstream. That makes the binding's
+// lifetime the difference between a one-call refill and a two-call one, which is
+// the whole gap between the 871ms and 1.44s !fnstats timings production shows.
+// A stats entry aging out is the routine event — statsTTL is ten minutes — so it
+// must never drag the resolve back onto the critical path with it.
+func TestStatsEntryExpiryDoesNotRedoTheAccountResolve(t *testing.T) {
+	var reqs []*http.Request
+	p, store := newTestProviderWithStore(t, statsUpstream(t, "Ninja", syntheticBlob, &reqs), noUpstream(t, "shop"), nil)
+	ctx := context.Background()
+
+	require.Empty(t, asStats(t, handle(t, p, "stats")(ctx, gossiprpc.Request{Account: "Ninja"})).Error)
+	require.Equal(t, []string{
+		"/api/v1/account/displayName/Ninja",
+		"/api/v2/stats/deadbeef",
+	}, requestPaths(reqs), "a cold lookup pays both upstream calls, in series")
+
+	// Age out ONLY the stats entry, the way production does: accountTTL is two
+	// weeks against statsTTL's ten minutes, so the binding outlives roughly two
+	// thousand stats entries.
+	require.NoError(t, store.Del(ctx, lifetimeStatsKey("Ninja")))
+
+	require.Empty(t, asStats(t, handle(t, p, "stats")(ctx, gossiprpc.Request{Account: "Ninja"})).Error)
+	assert.Equal(t, []string{
+		"/api/v1/account/displayName/Ninja",
+		"/api/v2/stats/deadbeef",
+		"/api/v2/stats/deadbeef",
+	}, requestPaths(reqs), "the refill must cost the stats call alone")
+}
+
 // The shared entry holds friendly failures as ordinary replies, so a session
 // read can decode to a reply carrying Error and zero counters. Diffing that
 // against a snapshot would report a clean session for a player the upstream has


### PR DESCRIPTION
Stacked on #554.

## The measurement

`bagel.rpc.gossip.fortnite.stats` shows two distinct timings in production, not a spread:

- `871.028523ms`
- `1.444816929s`

That is not variance. `prod.api-fortnite.com` answers in ~700ms from this fleet — the slowest upstream any gossip provider talks to — and the two timings are one call and two calls to it.

The reason there are ever two is that the display-name resolve sits **in front of** the stats call rather than beside it. `fetchStats` cannot build the `/api/v2/stats/{id}` URL until the resolve has answered, so the two cannot overlap. Every cold binding costs a second serial 700ms leg.

## The change

`accountTTL` 24h to 14 days.

A day was a round number, not a sized one. An Epic account id is immutable, so this mapping can only break on a display-name change, and Epic rate-limits renames to one every two weeks. Two weeks is the shortest interval at which a fresh answer can differ from a stale one. At 24h the provider re-resolved an unchanged binding roughly fourteen times for every time it could possibly have moved.

Serving a stale binding through a rename is the mild failure, not the severe one: the id still resolves to the same account, so the stats stay correct and only the canonically-cased `Player` name in the reply lags. It also self-heals without waiting the window out, because a renamed player is looked up under the new display name, which is a different cache key.

Combined with #554, which put stale-while-revalidate on the envelope cache this binding lives in, the resolve now leaves the critical path in both directions: it is fresh for two weeks, and its expiry is served stale while a background refresh replaces it.

## Test

`TestStatsEntryExpiryDoesNotRedoTheAccountResolve` pins the property the constant protects, not the constant: a stats entry aged out of the store must cost exactly one upstream call on refill, not two. It passes at either TTL — the test is the regression guard against the resolve ever becoming uncached, and the new value is what makes the property hold at production timescales (the binding now outlives roughly two thousand stats entries instead of a hundred and forty).

`newTestProvider` gained a `newTestProviderWithStore` variant so a test can age one entry out from under the provider; existing callers are unchanged.

## Not included

`shopTTL` is 15 minutes against a payload that rotates once a day at 00:00 UTC, and `fortnite.shop` was measured at 584ms. Since retention is twice the fresh window, the shop entry is gone 30 minutes after the last `!store`, which for a once-in-a-while command means nearly every call is a full cold download (422ms upstream, 247ms of it payload transfer). Fixing it properly needs a TTL that expires at the rotation rather than on a fixed interval, which the declared-flow builder cannot express today — a static TTL long enough to survive the day would also serve yesterday's shop for that long. Left alone rather than traded for staleness on a user-facing command.

## Verification

`go build ./...`, `go vet ./...`, `go test -race` across `app/gossip`, gofmt clean.
