### PR TITLE
fix(bus): replicate the lane durable and rebuild it when it is gone

### DIFF
--- a/app/sesame/main.go
+++ b/app/sesame/main.go
@@ -129,7 +129,7 @@ func main() {
 		log.Fatal("failed to subscribe rpc health", zap.Error(err))
 	}
 
-	health.Serve(cfg.ListenAddr, nc.IsConnected)
+	health.Serve(cfg.ListenAddr, func() bool { return nc.IsConnected() && bus.SubscriberHealthy(sub) })
 	logReady(cfg, deps.Special.Len(), log)
 
 	<-ctx.Done()

--- a/pkg/bus/bus.go
+++ b/pkg/bus/bus.go
@@ -490,6 +490,43 @@ func (s *fleetSubscriber) logger() *zap.Logger {
 	return s.log
 }
 
+// LaneHealth is implemented by a lane binding that can say whether its own fetch
+// loop is making progress.
+type LaneHealth interface{ Healthy() bool }
+
+// SubscriberHealthy reports whether every lane binding sub owns is making
+// progress, for a service's readiness probe.
+//
+// It exists because a NATS connection check is not a consumption check. The
+// lane durables are fleet-wide and deletable, and a pod that has lost its
+// durable holds an entirely healthy connection while consuming nothing — which
+// is exactly how sesame stayed green through seven hours of silence on
+// 2026-08-16. A subscriber with nothing to report is healthy: this must never
+// make a service that does not consume lanes look sick.
+func SubscriberHealthy(sub Subscriber) bool {
+	reporter, ok := sub.(LaneHealth)
+	return !ok || reporter.Healthy()
+}
+
+// Healthy reports whether every lane this subscriber has bound is making
+// progress. Bindings that cannot report — the push and broadcast paths — are
+// not counted: they have no fetch loop to wedge.
+func (s *fleetSubscriber) Healthy() bool {
+	s.mu.Lock()
+	lanes := make([]Subscriber, 0, len(s.flowLanes))
+	for _, lane := range s.flowLanes {
+		lanes = append(lanes, lane.sub)
+	}
+	s.mu.Unlock()
+
+	for _, lane := range lanes {
+		if reporter, ok := lane.(LaneHealth); ok && !reporter.Healthy() {
+			return false
+		}
+	}
+	return true
+}
+
 // broadcastSubscriber uses an ephemeral consumer with DeliverNew to avoid
 // replay storms: every instance gets every message (cache invalidation). The
 // explicit stream binding avoids an account-wide stream-name lookup.

--- a/pkg/bus/pull_consumer.go
+++ b/pkg/bus/pull_consumer.go
@@ -73,6 +73,17 @@ const (
 	// set — which every other pod is drawing from — shrinks by that much.
 	defaultPullAckEvery = 250 * time.Millisecond
 
+	// defaultPullReplicas matches the lane streams' own replica count. The durable
+	// has to survive exactly what the stream survives, and a consumer cannot ask
+	// for more replicas than the stream it reads has.
+	defaultPullReplicas = 3
+
+	// laneUnhealthyAfter is how long the fetch loop may stay in its error path
+	// before the lane reports itself unready. It has to clear an ordinary consumer
+	// leader election and a client reconnect — both error for a few seconds — and
+	// stay far under the time anyone would take to notice the silence by hand.
+	laneUnhealthyAfter = 30 * time.Second
+
 	pullProvisionTimeout = 5 * time.Second
 )
 
@@ -105,13 +116,21 @@ func pullConsumerConfig(subject, name string) jsapi.ConsumerConfig {
 		// fleet has stopped fetching from it. It is the same window the flow lane
 		// gives a pod to reconnect inside without losing its position.
 		InactiveThreshold: flowInactiveThreshold,
-		// R1 consumer state on an R3 stream, per NATS maintainer guidance for
-		// high-rate consumers: replicating per-consumer ack state is leader RAFT
-		// work on the hot path, and this design does not need it. Losing the state
-		// means the fleet re-provisions and resumes from the last replicated floor;
-		// the idempotency guard absorbs the redelivered window and the stream's own
-		// durability is untouched.
-		Replicas:      1,
+		// Consumer state is replicated with the stream it reads.
+		//
+		// This was R1, on the reasoning that per-consumer ack state is leader RAFT
+		// work on the hot path and that the fleet would simply re-provision after
+		// losing it. The second half was never true: nothing rebuilt a lane durable,
+		// so a single peer owned the whole fleet's ability to consume. On 2026-08-16
+		// one member lost peer routing for 23 minutes, the meta layer moved these
+		// durables eleven times while it churned and then lost them, and every pod
+		// spun on a name that no longer resolved for the next seven hours.
+		// Quorum-replicated state survives one member, which is the failure that
+		// actually happens; rebuildConsumer covers losing all of them at once.
+		//
+		// Memory storage stays. The lane streams are memory-backed themselves, so
+		// persisting ack state to disk cannot outlive the messages it describes.
+		Replicas:      pullReplicas(),
 		MemoryStorage: true,
 		Metadata:      map[string]string{managedConsumerMetadata: "true"},
 	}
@@ -144,6 +163,14 @@ func pullMaxAckPending() int {
 
 func pullFetchBatch() int {
 	return positiveInt(env.GetInt("NATS_PULL_FETCH_BATCH", defaultPullFetchBatch), defaultPullFetchBatch)
+}
+
+// pullReplicas exists as a knob only so a single-node broker (local runs, the
+// acceptance rigs) can bind the lane at all: asking three replicas of a
+// one-member cluster is a creation the server refuses, and the lane binding is
+// a boot-fatal step. Production never sets it.
+func pullReplicas() int {
+	return positiveInt(env.GetInt("NATS_PULL_REPLICAS", defaultPullReplicas), defaultPullReplicas)
 }
 
 // positiveDuration and positiveInt refuse a zero or negative override. Every
@@ -343,12 +370,21 @@ type pullDelivery struct {
 // one out, so a slow handler pool is backpressure onto the server's pending set
 // rather than a queue this process has to size against a flow-control window.
 type pullSubscriber struct {
-	nc       *nats.Conn
+	nc *nats.Conn
+	// consumer is read and replaced only by the pump goroutine, which is why
+	// rebuildConsumer needs no lock to swap it.
 	consumer jsapi.Consumer
-	stream   string
-	subject  string
-	name     string
-	log      *zap.Logger
+	// desired is the shape rebuildConsumer re-provisions, kept so a rebuild can
+	// never drift from the binding this loop was started with.
+	desired jsapi.ConsumerConfig
+	// rebind provisions a replacement durable. It is a field rather than a direct
+	// call so the rebuild decision is testable without a broker; the constructor
+	// always fills it with the real API path.
+	rebind  func() (jsapi.Consumer, error)
+	stream  string
+	subject string
+	name    string
+	log     *zap.Logger
 
 	batch    int
 	maxWait  time.Duration
@@ -358,7 +394,13 @@ type pullSubscriber struct {
 	dropped   atomic.Int64
 	fetchErrs atomic.Int64
 	ackErrs   atomic.Int64
+	rebuilt   atomic.Int64
 	closed    atomic.Bool
+
+	// errSince is the unix-nano instant the fetch loop entered its error path, or
+	// zero while it is healthy. An idle lane never sets it — Next simply blocks —
+	// so silence and sickness stay distinguishable to Healthy.
+	errSince atomic.Int64
 
 	// ackMu guards the newest delivery the floor has not yet covered. Both the
 	// fetch loop and the ack timer publish the floor, and two acks racing would
@@ -410,8 +452,9 @@ func newPullSubscriber(cfg flowLaneConfig, nc *nats.Conn, consumer jsapi.Consume
 		log = zap.NewNop()
 	}
 	ctx, cancel := context.WithCancel(context.Background())
-	return &pullSubscriber{
-		nc: nc, consumer: consumer, stream: cfg.stream, subject: cfg.subject,
+	s := &pullSubscriber{
+		nc: nc, consumer: consumer, desired: pullConsumerConfig(cfg.subject, name),
+		stream: cfg.stream, subject: cfg.subject,
 		name: name, log: log,
 		batch: pullFetchBatch(), maxWait: pullFetchMaxWait(), ackEvery: pullAckEvery(),
 		output:  make(chan *Message),
@@ -419,6 +462,8 @@ func newPullSubscriber(cfg flowLaneConfig, nc *nats.Conn, consumer jsapi.Consume
 		ctx:     ctx,
 		cancel:  cancel,
 	}
+	s.rebind = func() (jsapi.Consumer, error) { return ensurePullConsumer(s.nc, s.stream, s.desired) }
+	return s
 }
 
 func (s *pullSubscriber) start() {
@@ -473,6 +518,7 @@ func (s *pullSubscriber) pumpIterator() bool {
 			}
 			return s.noteFetchError(err)
 		}
+		s.noteFetchProgress()
 		if !s.deliver(wire) {
 			return false
 		}
@@ -669,6 +715,7 @@ func (s *pullSubscriber) noteFetchError(err error) bool {
 	if s.closed.Load() {
 		return false
 	}
+	s.errSince.CompareAndSwap(0, time.Now().UnixNano())
 	if count := s.fetchErrs.Add(1); count == 1 || count%1_000 == 0 {
 		s.log.Warn("lane fetch failed",
 			zap.String("stream", s.stream),
@@ -677,7 +724,71 @@ func (s *pullSubscriber) noteFetchError(err error) bool {
 			zap.Int64("fetch_errors", count),
 			zap.Error(err))
 	}
+	if consumerGone(err) {
+		s.rebuildConsumer()
+	}
 	return s.pause(s.maxWait)
+}
+
+// noteFetchProgress clears the error clock the moment the loop reads a message
+// again. It is a relaxed load per delivery on the hot path and a store only on
+// the edge, so a healthy lane pays a comparison and nothing else.
+func (s *pullSubscriber) noteFetchProgress() {
+	if s.errSince.Load() != 0 {
+		s.errSince.Store(0)
+	}
+}
+
+// consumerGone separates "the durable this binding names no longer exists" from
+// every other fetch failure. A leadership change, a timeout or a dropped
+// connection is the lane working through something and the next fetch may well
+// succeed; these two mean the name resolves to nothing and every later fetch
+// fails identically until something recreates it.
+func consumerGone(err error) bool {
+	return errors.Is(err, jsapi.ErrConsumerNotFound) || errors.Is(err, jsapi.ErrConsumerDeleted)
+}
+
+// rebuildConsumer re-provisions the shared durable after the server has lost it.
+//
+// The lane durable is fleet-wide and genuinely deletable: InactiveThreshold
+// expires it once the whole fleet stops fetching, and losing every replica of
+// its state takes it with them. The original design accepted that and assumed
+// "the fleet re-provisions" — but no code did, so a deleted durable meant every
+// pod asking a name that no longer resolved, five times a second, until someone
+// restarted the deployment by hand. This is that missing half.
+//
+// It runs on the pump goroutine, the only reader of s.consumer, so the swap
+// needs no lock. A failed rebuild is simply left to the next fetch error: the
+// pump loop already is the retry.
+func (s *pullSubscriber) rebuildConsumer() {
+	// The old consumer's receipt can never be acked against a new one, and
+	// holding it would spend the next floor ack on a guaranteed failure.
+	s.takePending()
+
+	consumer, err := s.rebind()
+	if err != nil {
+		s.log.Warn("lane consumer rebuild failed",
+			zap.String("stream", s.stream),
+			zap.String("subject", s.subject),
+			zap.String("consumer", s.name),
+			zap.Error(err))
+		return
+	}
+	s.consumer = consumer
+	s.log.Warn("lane consumer was missing and has been rebuilt",
+		zap.String("stream", s.stream),
+		zap.String("subject", s.subject),
+		zap.String("consumer", s.name),
+		zap.Int64("rebuilds", s.rebuilt.Add(1)))
+}
+
+// Healthy reports whether this lane's fetch loop is making progress, which is
+// the readiness signal a NATS connection check cannot give: a lane whose durable
+// has been deleted keeps a perfectly healthy connection while consuming nothing.
+// An idle lane is healthy — only sustained failure is not.
+func (s *pullSubscriber) Healthy() bool {
+	since := s.errSince.Load()
+	return since == 0 || time.Since(time.Unix(0, since)) < laneUnhealthyAfter
 }
 
 func (s *pullSubscriber) pause(wait time.Duration) bool {

--- a/pkg/bus/pull_consumer_test.go
+++ b/pkg/bus/pull_consumer_test.go
@@ -49,10 +49,11 @@ func TestPullConsumerConfigIsCheapFloorAcknowledgement(t *testing.T) {
 			fmt.Sprintf("pull consumer was given push delivery: %#v", cfg)},
 		contractClause{cfg.DeliverPolicy == jsapi.DeliverNewPolicy,
 			fmt.Sprintf("deliver policy = %v, want DeliverNew on a first creation", cfg.DeliverPolicy)},
-		// R1 memory consumer state on an R3 stream: replicating per-consumer ack
-		// state is leader RAFT work on the hot path this design does not need.
-		contractClause{cfg.Replicas == 1 && cfg.MemoryStorage,
-			fmt.Sprintf("consumer state must be R1 in memory: %#v", cfg)},
+		// Quorum-replicated consumer state, in memory. R1 put the whole fleet's
+		// ability to consume on one peer: on 2026-08-16 that peer churned, the
+		// durable was lost, and every pod spun on a name that no longer resolved.
+		contractClause{cfg.Replicas == defaultPullReplicas && cfg.MemoryStorage,
+			fmt.Sprintf("consumer state must be replicated in memory: %#v", cfg)},
 		contractClause{cfg.InactiveThreshold == flowInactiveThreshold,
 			fmt.Sprintf("inactive threshold = %v, want %v", cfg.InactiveThreshold, flowInactiveThreshold)},
 		contractClause{cfg.AckWait == defaultPullAckWait && cfg.MaxAckPending == defaultPullMaxAckPending,

--- a/pkg/bus/pull_rebuild_test.go
+++ b/pkg/bus/pull_rebuild_test.go
@@ -1,0 +1,140 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package bus
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	jsapi "github.com/nats-io/nats.go/jetstream"
+	"go.uber.org/zap"
+)
+
+// The lane durable is fleet-wide and the server is allowed to delete it, so the
+// binding that names it has to be able to put it back. Before this existed, a
+// deleted durable meant every pod asking a name that no longer resolved, five
+// times a second, until someone restarted the deployment by hand.
+func TestFetchErrorRebuildsALostDurable(t *testing.T) {
+	replacement := &pullConsumerHandle{info: &jsapi.ConsumerInfo{}}
+	s, rebuilds := subscriberWithRebind(replacement, nil)
+
+	if !s.noteFetchError(jsapi.ErrConsumerNotFound) {
+		t.Fatal("a fetch error on a live binding must keep the pump loop running")
+	}
+	if *rebuilds != 1 {
+		t.Fatalf("rebuild attempts = %d, want 1 after the durable went missing", *rebuilds)
+	}
+	if s.consumer != jsapi.Consumer(replacement) {
+		t.Fatal("the pump loop is still bound to the consumer the server has deleted")
+	}
+}
+
+// Only a lost durable justifies re-provisioning. Everything else is the lane
+// working through something the next fetch may well survive, and rebuilding on
+// it would delete and recreate a healthy fleet-wide consumer under load.
+func TestOnlyALostDurableTriggersARebuild(t *testing.T) {
+	transient := []error{
+		jsapi.ErrConsumerLeadershipChanged,
+		jsapi.ErrNoHeartbeat,
+		errors.New("nats: timeout"),
+	}
+	for _, err := range transient {
+		if consumerGone(err) {
+			t.Fatalf("consumerGone(%v) = true, want false: this is not a missing durable", err)
+		}
+	}
+	for _, err := range []error{jsapi.ErrConsumerNotFound, jsapi.ErrConsumerDeleted} {
+		if !consumerGone(err) {
+			t.Fatalf("consumerGone(%v) = false, want true", err)
+		}
+	}
+}
+
+// A rebuild that fails is left to the next fetch error — the pump loop already
+// is the retry — but it must not leave the binding pointing at nothing.
+func TestAFailedRebuildKeepsTheLoopRunning(t *testing.T) {
+	original := &pullConsumerHandle{info: &jsapi.ConsumerInfo{}}
+	s, rebuilds := subscriberWithRebind(nil, errors.New("nats: no responders"))
+	s.consumer = original
+
+	if !s.noteFetchError(jsapi.ErrConsumerDeleted) {
+		t.Fatal("a failed rebuild must not stop the pump loop")
+	}
+	if *rebuilds != 1 {
+		t.Fatalf("rebuild attempts = %d, want 1", *rebuilds)
+	}
+	if s.consumer != jsapi.Consumer(original) {
+		t.Fatal("a failed rebuild replaced the binding with a consumer it never got")
+	}
+}
+
+// Readiness has to separate an idle lane from a wedged one. A NATS connection
+// check cannot: a pod that has lost its durable stays connected and consumes
+// nothing, which is how sesame reported green through seven hours of silence.
+func TestLaneHealthSeparatesSilenceFromFailure(t *testing.T) {
+	s, _ := subscriberWithRebind(nil, errors.New("nats: no responders"))
+
+	if !s.Healthy() {
+		t.Fatal("a lane that has never failed is healthy, however long it has been idle")
+	}
+
+	// Inside the grace window an election or a reconnect must not flap readiness.
+	s.errSince.Store(time.Now().Add(-laneUnhealthyAfter / 2).UnixNano())
+	if !s.Healthy() {
+		t.Fatal("a lane erroring for less than the grace window must still report ready")
+	}
+
+	s.errSince.Store(time.Now().Add(-2 * laneUnhealthyAfter).UnixNano())
+	if s.Healthy() {
+		t.Fatal("a lane stuck in its error path past the grace window must report unready")
+	}
+
+	// One good read clears it: the loop is consuming again.
+	s.noteFetchProgress()
+	if !s.Healthy() {
+		t.Fatal("a lane that read a message again must report ready")
+	}
+}
+
+// The fleet subscriber is what a service's /readyz actually holds, so the lane
+// verdict has to survive the trip through it.
+func TestSubscriberHealthyAggregatesTheLanes(t *testing.T) {
+	sick, _ := subscriberWithRebind(nil, nil)
+	sick.errSince.Store(time.Now().Add(-2 * laneUnhealthyAfter).UnixNano())
+	well, _ := subscriberWithRebind(nil, nil)
+
+	fleet := &fleetSubscriber{flowLanes: map[string]*sharedFlowLane{
+		"well": {sub: well},
+	}}
+	if !SubscriberHealthy(fleet) {
+		t.Fatal("a fleet whose only lane is healthy must report ready")
+	}
+
+	fleet.flowLanes["sick"] = &sharedFlowLane{sub: sick}
+	if SubscriberHealthy(fleet) {
+		t.Fatal("one wedged lane must take the whole pod out of readiness")
+	}
+
+	// A subscriber with no lane to report on must never look sick: services that
+	// do not consume lanes share this probe.
+	if !SubscriberHealthy(&fleetSubscriber{}) {
+		t.Fatal("a subscriber with no lanes must report ready")
+	}
+}
+
+// subscriberWithRebind builds a pullSubscriber whose provisioning is a counter
+// rather than a broker, and returns the attempt count alongside it.
+func subscriberWithRebind(replacement jsapi.Consumer, failure error) (*pullSubscriber, *int) {
+	attempts := 0
+	s := &pullSubscriber{subject: "twitch.ingress.event.premium", log: zap.NewNop()}
+	s.rebind = func() (jsapi.Consumer, error) {
+		attempts++
+		if failure != nil {
+			return nil, failure
+		}
+		return replacement, nil
+	}
+	return s, &attempts
+}

--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -16,8 +16,12 @@ import (
 // alive and should not be restarted just because a dependency is reconnecting.
 //
 // /readyz is traffic readiness. ready reports whether the service can do work
-// right now (typically the NATS connection status); /readyz returns 503 until
-// it does. A nil ready always reports ok.
+// right now; /readyz returns 503 until it does. A nil ready always reports ok.
+//
+// For a service that consumes, "can do work" has to mean more than a live NATS
+// connection. A pod whose lane durable has been deleted stays connected and
+// consumes nothing, so a connection-only check reports green through a total
+// outage — see bus.SubscriberHealthy.
 //
 // The returned error channel yields at most one listener error.
 func Serve(addr string, ready func() bool) <-chan error {


### PR DESCRIPTION
## What broke

The shared pull-lane durable was `Replicas: 1` + `MemoryStorage: true`, on the reasoning that replicating per-consumer ack state is leader RAFT work the hot path does not need, and that the fleet would re-provision after losing it. The second half was never written, so one peer owned the whole fleet's ability to consume.

On 2026-08-16 a member lost peer routing for 23 minutes. Broker logs show the meta layer moving both lane durables eleven times while the cluster churned, the last move at 16:26:45, and then nothing — both were gone and stayed gone. Every sesame pod kept a healthy NATS connection, kept answering `/healthz` and `/readyz`, and asked a consumer name that no longer resolved five times a second for the next seven hours. Both durables carry a `created` timestamp of 23:52:33, the manual restart; every non-pull consumer in the account dates from 2026-07-28 and survived untouched.

## What changed

Three changes, one per link in that chain.

**Replicas follow the lane streams' own count.** The durable now survives losing a member, which is the failure that actually happens. Memory storage stays: the lane streams are memory-backed themselves, so persisting ack state to disk cannot outlive the messages it describes. `NATS_PULL_REPLICAS` exists only so a single-node broker (local runs, the acceptance rigs) can bind at all, since the lane binding is a boot-fatal step.

**`noteFetchError` re-provisions a missing durable.** `consumerGone` matches `ErrConsumerNotFound` and `ErrConsumerDeleted` only; a leadership change, a heartbeat gap or a timeout is the lane working through something the next fetch may survive, and rebuilding on those would delete and recreate a healthy fleet-wide consumer under load. R3 makes elections routine, so that line matters more than it did. The rebuild runs on the pump goroutine, the only reader of the binding, so the swap needs no lock; a failed rebuild is left to the next fetch error because the pump loop already is the retry.

**Readiness holds the lane verdict, not just the connection status.** A lane reports unhealthy only after sustained failure, so an idle lane and an election stay ready and a wedged one does not. `/healthz` keeps answering process liveness on purpose: restarting a pod cannot rebuild a durable a new pod also cannot reach, and gating liveness on broker reachability turns one outage into a fleet-wide crash loop. The recovery is the rebuild; readiness is the alarm.

## Rollout

No migration. `num_replicas` is updatable in place on 2.14; if the server refuses, `bindPullConsumer`'s existing replace path deletes and recreates against the carried ack floor. Converges on the first pod that boots the new image. Probe timing needs no manifest change: `/readyz` at `periodSeconds: 10` x `failureThreshold: 3` plus the 30s window surfaces a wedged lane in about a minute.

`InactiveThreshold` stays at 5m. It is still a real deletion vector, but now a survivable one.

## Verification

`go test -race -count=1 ./pkg/bus/... ./app/sesame/...` passes. Five new tests cover the rebuild, the transient-versus-gone split, a failed rebuild leaving the binding intact, the idle-versus-wedged distinction, and aggregation through the fleet subscriber. The R1 contract clause in `pull_consumer_test.go` is updated rather than deleted.