### PR TITLE
fix(keda): move the operator to the app tier so it can follow the leader

### DIFF
--- a/deploy/infra/keda/release.yaml
+++ b/deploy/infra/keda/release.yaml
@@ -99,7 +99,7 @@ spec:
     # Verify a change landed; do not trust that the key was read:
     #   kubectl -n keda get deploy keda-operator -o jsonpath='{.spec.template.spec.affinity}'
     #
-    # ALL THREE COMPONENTS -> CONTROL PLANE (on cp), required.
+    # metricsServer and webhooks -> CONTROL PLANE. operator -> APP TIER.
     #
     # metricsServer and webhooks are called SYNCHRONOUSLY BY THE APISERVER:
     # metricsServer backs the v1beta1.external.metrics.k8s.io aggregated
@@ -108,25 +108,66 @@ spec:
     # unreachable aggregated APIService is worse than an unreachable backend: it
     # stalls API discovery cluster-wide, not just KEDA.
     #
-    # The operator follows them so the metricsServer -> operator gRPC hop (:9666)
-    # is node-local too. The operator's own NATS polling goes over the pod mesh
-    # to the app tier, and that works from node1 WITHOUT any tailscale subnet
-    # route: node1 keeps a public flannel endpoint, the app nodes keepalive to it
-    # every 25s, and kernel WireGuard roaming teaches node1 their public
-    # endpoints (verified 2026-07-28: wg show on node1 lists only public IPs).
-    # Worst case after a node1 flannel restart is ~25s of unreachable app-tier
-    # pods until the first keepalive roams the endpoints back, during which KEDA
-    # serves each ScaledObject's fallback replicas.
+    # The operator used to follow them onto the control plane so the
+    # metricsServer -> operator gRPC hop (:9666) stayed node-local. The
+    # configured endpoint is fine from there — measured 2026-08-17 from a pod on
+    # the control plane, nats.production.svc.cluster.local:8222/jsz returns 72455
+    # bytes in 8ms, TCP 10/10 to the ClusterIP and 5/5 to each member. The
+    # configured endpoint is not the hop that fails.
+    #
+    # The SECOND hop is. In clustered mode the scaler reads /jsz, finds the
+    # stream's leader, then dials that member directly for /varz, choosing from
+    # the addresses NATS gossips in connect_urls. A hostNetwork member listening
+    # on 0.0.0.0 gossips EVERY local interface, so the set is:
+    #
+    #   38.49.213.227   public
+    #   10.10.0.4       provider VLAN
+    #   100.72.196.29   tailnet (plus its IPv6)
+    #   10.44.2.100     cilium host address
+    #
+    # Only the fleet can route all four. From the control plane the VLAN is not
+    # routed at all and never will be — advertising 10.10.0.0/24 off the fleet is
+    # a standing no — so whenever the scaler picks it the fetch dies:
+    #
+    #   Get "http://10.10.0.4:8222/varz": context deadline exceeded
+    #
+    # It is intermittent because the choice is, which is why both ScaledObjects
+    # flap between real metrics and Fallback=True on static replicas rather than
+    # failing outright. During the 2026-08-16 lane outage they were pinned in
+    # fallback, so nothing scaled up, and a fresh pod is what would have
+    # re-provisioned the deleted lane durables: the deletion that killed the
+    # lanes also blinded the autoscaler that would have healed them.
+    #
+    # On the app tier every gossiped address is on-link or local, so the
+    # leader-follow always resolves whichever one it picks. The cost is that the
+    # metricsServer -> operator gRPC hop becomes cross-node: one pod-mesh round
+    # trip per HPA metric fetch, roughly every 15s per ScaledObject. That is a
+    # rounding error against a scaler that cannot read its own broker's leader.
+    #
+    # The other way to fix this is client_advertise on the NATS side, so members
+    # stop gossiping VLAN, tailnet and pod addresses to everyone. That is a
+    # fleet-wide change to how every client discovers the cluster; this one moves
+    # a single deployment. Do the narrow one first.
     #
     # Do NOT point the nats-jetstream triggers at the nats-monitoring Tailscale
-    # Service instead. It was tried: the scaler fetches /jsz fine, but in
-    # clustered mode it then follows the stream to the consumer leader and dials
-    # that member at the address NATS advertises, which is a POD IP, so a single
-    # fronting Service cannot satisfy it. The tailnet Service is kept for humans.
+    # Service instead. Same second hop, same outcome: the scaler fetches /jsz
+    # fine and then dials the leader at a gossiped address the tailnet Service
+    # cannot front. The tailnet Service is kept for humans.
     #
-    # Required, not preferred: a preference lets the scheduler rebalance a
-    # component onto the app tier and silently reintroduce the cross-node hop.
+    # Required, not preferred, on both tiers: a preference lets the scheduler
+    # rebalance a component across the boundary and silently restore the failure.
     operator:
+      # No control-plane toleration: the app nodes carry no taint, and leaving it
+      # here would let the scheduler put the operator back where it cannot scrape.
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: itsbagelbot.dev/role
+                    operator: In
+                    values: [node]
+    metricsServer:
       tolerations: &cpToleration
         - key: itsbagelbot.dev/role
           operator: Equal
@@ -140,9 +181,6 @@ spec:
                   - key: itsbagelbot.dev/role
                     operator: In
                     values: [cp]
-    metricsServer:
-      tolerations: *cpToleration
-      affinity: *cpAffinity
     webhooks:
       tolerations: *cpToleration
       affinity: *cpAffinity


### PR DESCRIPTION
> **Correction to the first revision of this PR.** It claimed the control plane could not reach NATS on 8222 at all. That measurement was taken from `cilium-agent`, which is `hostNetwork` — the wrong namespace. From the pod network, where KEDA actually runs, the configured endpoint is fine. The change is still right; the reason was not. Rewritten below.

## Why

Both `sesame` and `outgress` ScaledObjects flap between real metrics and `Fallback=True` on static replicas.

The configured trigger endpoint is not the problem. Measured from a pod on the control plane:

```
nats.production.svc.cluster.local:8222/jsz  ->  72455 bytes in 8ms
ClusterIP 10.43.87.21:8222                  ->  TCP ok=10 fail=0
38.49.213.227 / .218.104 / .214.55 :8222    ->  TCP ok=5 fail=0 each
```

The **second hop** is. In clustered mode the scaler reads `/jsz`, finds the stream's leader, then dials that member directly for `/varz`, choosing from the addresses NATS gossips in `connect_urls`. A hostNetwork member listening on `0.0.0.0` gossips every local interface, so `nats-0` alone offers:

```
38.49.213.227:4222   public
10.10.0.5:4222       provider VLAN
100.100.144.49:4222  tailnet  (+ fd7a:115c:a1e0::… )
10.44.2.100:4222     cilium host address
```

Only the fleet can route all four. From the control plane the VLAN is not routed and never will be — advertising `10.10.0.0/24` off the fleet is a standing no — so whenever the scaler picks it:

```
ERROR nats_jetstream_scaler unable to access NATS JetStream monitoring server endpoint
  natsServerMonitoringURL: "http://10.10.0.4:8222/varz"
  error: Get "http://10.10.0.4:8222/varz": context deadline exceeded
```

Note `monitoring **server** endpoint` — a different message from the `/jsz` fetch, and it is the one that fires. It is intermittent because the address choice is, which is why the ScaledObjects flap rather than fail outright.

This is also why nothing self-healed during the 2026-08-16 lane outage: both were pinned in fallback, so KEDA never scaled sesame up, and a fresh pod is what would have re-provisioned the deleted lane durables.

## What changed

`operator` moves to `itsbagelbot.dev/role=node`; `metricsServer` and `webhooks` stay on `cp`.

The control-plane pin is right for the two components the apiserver calls synchronously — metricsServer backs the `v1beta1.external.metrics.k8s.io` aggregated APIService, webhooks back the `keda-admission` ValidatingWebhookConfiguration, and an unreachable aggregated APIService stalls API discovery cluster-wide rather than just KEDA. The operator only followed them to keep the metricsServer to operator gRPC hop node-local.

On the app tier every gossiped address is on-link or local, so the leader-follow resolves whichever one it picks.

The control-plane toleration is dropped from the operator: app nodes carry no taint, and leaving it would let the scheduler put it back. Both tiers stay `required`, not `preferred`.

Cost: the metricsServer to operator gRPC hop becomes cross-node — one pod-mesh round trip per HPA metric fetch, roughly every 15s per ScaledObject.

## Alternative not taken

`client_advertise` on the NATS side, so members stop gossiping VLAN, tailnet and pod addresses. That fixes the root rather than the symptom, but it changes how every client discovers the cluster, fleet-wide. This moves one deployment. Narrow one first.

Also rejected: pointing the triggers at the nats-monitoring Tailscale Service. Same second hop, same outcome — already documented in the file.

## Verification

```
operator      affinity=[node]  tolerations=false
metricsServer affinity=[cp]    tolerations=true
webhooks      affinity=[cp]    tolerations=true
```

After merge, confirm the chart read the key rather than dropping it as unused YAML — the failure mode this file already warns about — then watch the `monitoring server endpoint` errors stop:

```
kubectl -n keda get deploy keda-operator -o jsonpath='{.spec.template.spec.affinity}'
kubectl -n keda logs deploy/keda-operator --since=5m | grep -c "monitoring server endpoint"
```

## Unrelated, currently in flight

`keda-operator` is also crash-looping on `leader election lost` / `apiserver not ready` (5 restarts, latest 01:06:12Z), which coincides with the cilium restart on cp1 at 01:03:14Z. That is control-plane datapath work in progress, not this. Each restart bursts a scaler failure for every trigger, which inflates the error counts above.