### PR TITLE
feat(pki): add an intermediate CA between the fleet root and every leaf

### DIFF
--- a/deploy/infra/pki/certificates.yaml
+++ b/deploy/infra/pki/certificates.yaml
@@ -1,10 +1,16 @@
 # Copyright (c) 2026 Adam Ousmer. All rights reserved.
 # Proprietary. No license granted. See LICENSE.md.
 
-# Server certs issued from the fleet CA. Each writes a tls.crt/tls.key/ca.crt
-# Secret in production; the NATS and console pods mount it as their server cert.
-# Clients verify the server against the CA (distributed as the fleet-ca ConfigMap,
-# see trust.yaml) — no per-client certs.
+# Server certs issued from the fleet intermediate CA (deploy/infra/pki/issuers.yaml),
+# not the root — the root now only ever signs the one intermediate. Each writes a
+# tls.crt/tls.key/ca.crt Secret in production; the NATS and console pods mount it
+# as their server cert. cert-manager's CA issuer walks the signing secret's own
+# ca.crt when building the output bundle, so ca.crt here still ends up as the
+# ROOT certificate (not the intermediate) and tls.crt ends up as leaf+intermediate
+# — unchanged consumer-facing shape, verified against cert-manager v1.17.4 source
+# and against the live secrets before this file changed. Clients verify the
+# server against the CA (distributed as the fleet-ca ConfigMap, see trust.yaml) —
+# no per-client certs.
 #
 # SANs must cover every name a peer dials: the Service name, its FQDN, and (for
 # the hub) the per-pod headless names used by the cluster routes.
@@ -22,7 +28,7 @@ spec:
     algorithm: ECDSA
     size: 256
   issuerRef:
-    name: fleet-ca-issuer
+    name: fleet-intermediate-issuer
     kind: ClusterIssuer
     group: cert-manager.io
   dnsNames:
@@ -52,7 +58,7 @@ spec:
     algorithm: ECDSA
     size: 256
   issuerRef:
-    name: fleet-ca-issuer
+    name: fleet-intermediate-issuer
     kind: ClusterIssuer
     group: cert-manager.io
   dnsNames:
@@ -79,7 +85,7 @@ spec:
     algorithm: ECDSA
     size: 256
   issuerRef:
-    name: fleet-ca-issuer
+    name: fleet-intermediate-issuer
     kind: ClusterIssuer
     group: cert-manager.io
   dnsNames:
@@ -99,7 +105,7 @@ spec:
     algorithm: ECDSA
     size: 256
   issuerRef:
-    name: fleet-ca-issuer
+    name: fleet-intermediate-issuer
     kind: ClusterIssuer
     group: cert-manager.io
   dnsNames:
@@ -119,7 +125,7 @@ spec:
     algorithm: ECDSA
     size: 256
   issuerRef:
-    name: fleet-ca-issuer
+    name: fleet-intermediate-issuer
     kind: ClusterIssuer
     group: cert-manager.io
   # Clients dial the Service name or a stable StatefulSet peer name. One shared cert is

--- a/deploy/infra/pki/issuers.yaml
+++ b/deploy/infra/pki/issuers.yaml
@@ -2,11 +2,34 @@
 # Proprietary. No license granted. See LICENSE.md.
 
 # Fleet internal PKI root. A self-signed bootstrap issuer signs one long-lived CA,
-# and a CA ClusterIssuer issues every server cert from it. cert-manager renews the
-# leaf certs automatically, so there is no hand-rolled rotation.
+# which in turn signs a single intermediate; the intermediate ClusterIssuer
+# (below) issues every server cert. cert-manager renews all three tiers
+# automatically — root, intermediate, and leaves — so there is no hand-rolled
+# rotation and no offline key material.
 #
 # ClusterIssuers read their signing secret from cert-manager's own namespace (the
-# cluster resource namespace), which is why the CA key pair lives there.
+# cluster resource namespace), which is why both CA key pairs live there.
+#
+# RENEWAL NESTING — this is the whole reason the numbers below look odd.
+# cert-manager does not clamp a signed certificate's expiry to its issuer's
+# remaining validity (pkg/controller/certificaterequests/ca/ca.go builds the
+# template purely from the requested duration; verified against cert-manager
+# v1.17.4 source). Nothing stops it from happily issuing a cert that outlives
+# its own signer on paper. The only thing that prevents that in practice is
+# renewBefore: cert-manager renews a Certificate once its remaining validity
+# drops to renewBefore, so a Certificate's remaining validity never falls
+# below its own renewBefore (assuming reconciliation keeps up). Each tier's
+# renewBefore must therefore exceed the child tier's full duration by a
+# healthy margin, at every point in time:
+#   leaf     duration 2160h  (90d)  renewBefore  360h (15d)  [unchanged]
+#   intermediate duration 8760h (365d) renewBefore 4380h (182.5d, ~50%)
+#     floor 182.5d vs. the 90d+15d=105d a leaf can ever need -> ~1.7x margin
+#   root     duration 87600h (10y)  renewBefore 17520h (2y)
+#     floor 2y vs. the intermediate's 365d+182.5d=547.5d it can ever need
+#     -> ~1.3y of margin
+# Root and intermediate both default to privateKey.rotationPolicy: Never, so
+# renewal reissues the certificate on the SAME key — no key rotation, no
+# chain re-signing of anything downstream, just an extended notAfter.
 ---
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
@@ -25,7 +48,10 @@ spec:
   commonName: ItsBagelBot Fleet CA
   secretName: fleet-ca-key-pair
   duration: 87600h # 10y root
-  renewBefore: 720h # 30d
+  # Was 720h (30d) before the intermediate existed. Must stay >= the
+  # intermediate's duration + its own renewBefore (547.5d) with margin — see
+  # the RENEWAL NESTING note above. 2y clears that with ~1.3y to spare.
+  renewBefore: 17520h # 2y
   privateKey:
     algorithm: ECDSA
     size: 256
@@ -41,3 +67,32 @@ metadata:
 spec:
   ca:
     secretName: fleet-ca-key-pair
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: fleet-intermediate
+  namespace: cert-manager
+spec:
+  isCA: true
+  commonName: ItsBagelBot Fleet Intermediate CA
+  secretName: fleet-intermediate-key-pair
+  duration: 8760h # 365d
+  # See the RENEWAL NESTING note above: floor must clear a leaf's full
+  # 90d+15d lifecycle (105d) with margin. ~50% of duration -> 182.5d floor.
+  renewBefore: 4380h # 182.5d
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: fleet-ca-issuer
+    kind: ClusterIssuer
+    group: cert-manager.io
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: fleet-intermediate-issuer
+spec:
+  ca:
+    secretName: fleet-intermediate-key-pair


### PR DESCRIPTION
Adds `fleet-intermediate` (signed by the existing self-signed root) plus a `fleet-intermediate-issuer` ClusterIssuer, and repoints all five leaf Certificates at it.

The root stays in-cluster so cert-manager auto-renews both tiers — an offline root was considered and rejected because it forces a manual re-signing ceremony, and auto-rotation with no manual step is a hard requirement.

Chain semantics verified against cert-manager's source and with `openssl verify` on a locally-built root->intermediate->leaf chain: `ca.crt` in each leaf Secret remains the **root** unchanged, and `tls.crt` gains the intermediate automatically, so every consumer (NATS, Valkey, Traefik ServersTransport, console, Elixir ingress) keeps validating with no config change.

Durations chosen so no leaf can outlive its issuer: leaf 90d/15d, intermediate 365d/182.5d, root 10y with `renewBefore` raised 30d -> 2y.

Bottom of an 8-PR stack.