### PR TITLE
fix(traefik): close the hairpin, redirect to HTTPS, enforce backend scheme in CI

### DIFF
--- a/.github/scripts/check_route_schemes.py
+++ b/.github/scripts/check_route_schemes.py
@@ -65,7 +65,26 @@ def iter_manifests():
                     yield path, doc, None
 
 
-def check_ingressroute_services(path, name, namespace, services, failures):
+# Routes whose backend genuinely cannot serve TLS, keyed by
+# (namespace, IngressRoute name, backend service name).
+#
+# This is not a place to silence inconvenient findings. An entry belongs here
+# only when the backend is a third-party binary with no TLS support at all, so
+# no amount of configuration on our side can satisfy the check. Every entry
+# carries its justification and is printed on each run, so it stays visible
+# rather than quietly accumulating. Anything not listed here still fails.
+UPSTREAM_TLS_INCAPABLE = {
+    ("flux-system", "webhook-receiver", "webhook-receiver"): (
+        "notification-controller (flux v2.8.8 / controller v1.8.4) exposes no "
+        "TLS flags on --receiverAddr or anywhere else, so the receiver cannot "
+        "serve HTTPS. Closing this needs a TLS-terminating sidecar patched into "
+        "a Flux bootstrap-managed Deployment. Remove this entry the moment "
+        "upstream gains TLS support or that sidecar lands."
+    ),
+}
+
+
+def check_ingressroute_services(path, name, namespace, services, failures, exempted):
     for svc in services or []:
         if not isinstance(svc, dict):
             continue
@@ -74,6 +93,12 @@ def check_ingressroute_services(path, name, namespace, services, failures):
             # walked below -- nothing to check on the reference.
             continue
         scheme = svc.get("scheme", "http")
+        reason = UPSTREAM_TLS_INCAPABLE.get((namespace, name, svc.get("name")))
+        if scheme != "https" and reason is not None:
+            exempted.append(
+                f"{namespace}/{name} -> {svc.get('name')!r}: {reason}"
+            )
+            continue
         if scheme != "https":
             failures.append(
                 f"{path}: IngressRoute {namespace}/{name} -> service "
@@ -82,7 +107,7 @@ def check_ingressroute_services(path, name, namespace, services, failures):
             )
 
 
-def check_doc(path, doc, failures):
+def check_doc(path, doc, failures, exempted):
     api_version = doc.get("apiVersion", "")
     kind = doc.get("kind", "")
     meta = doc.get("metadata", {}) or {}
@@ -93,20 +118,22 @@ def check_doc(path, doc, failures):
         spec = doc.get("spec", {}) or {}
         for route in spec.get("routes", []) or []:
             check_ingressroute_services(
-                path, name, namespace, route.get("services"), failures
+                path, name, namespace, route.get("services"), failures, exempted
             )
 
     elif api_version == TRAEFIK_API and kind == "TraefikService":
         spec = doc.get("spec", {}) or {}
         weighted = spec.get("weighted") or {}
         check_ingressroute_services(
-            path, name, namespace, weighted.get("services"), failures
+            path, name, namespace, weighted.get("services"), failures, exempted
         )
         mirroring = spec.get("mirroring")
         if mirroring:
-            check_ingressroute_services(path, name, namespace, [mirroring], failures)
             check_ingressroute_services(
-                path, name, namespace, mirroring.get("mirrors"), failures
+                path, name, namespace, [mirroring], failures, exempted
+            )
+            check_ingressroute_services(
+                path, name, namespace, mirroring.get("mirrors"), failures, exempted
             )
 
     elif api_version == TRAEFIK_API and kind in ("IngressRouteTCP", "IngressRouteUDP"):
@@ -132,6 +159,7 @@ def check_doc(path, doc, failures):
 
 def main():
     failures = []
+    exempted = []
     parse_errors = []
     seen_any = False
     for path, doc, error in iter_manifests():
@@ -139,7 +167,7 @@ def main():
         if error:
             parse_errors.append(f"{path}: {error}")
             continue
-        check_doc(path, doc, failures)
+        check_doc(path, doc, failures, exempted)
 
     if not seen_any:
         print("::error::no manifests found under deploy/ -- check is not running")
@@ -148,6 +176,13 @@ def main():
     if parse_errors:
         print("YAML parse errors (failing closed):")
         for e in parse_errors:
+            print(f"  {e}")
+
+    if exempted:
+        print(
+            f"{len(exempted)} route(s) exempted -- backend cannot serve TLS upstream:"
+        )
+        for e in exempted:
             print(f"  {e}")
 
     if failures:

--- a/.github/scripts/check_route_schemes.py
+++ b/.github/scripts/check_route_schemes.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Adam Ousmer. All rights reserved.
+# Proprietary and unlicensed. See LICENSE.md.
+#
+# Staged target path: .github/scripts/check_route_schemes.py
+#
+# Enforces "traefik -> backend is always https, no exceptions" at the object
+# level. Traefik 3.6 has no global default-backend-scheme switch (confirmed
+# against the deployed rancher/mirrored-library-traefik:3.6.13 / chart
+# traefik-39.0.701_up39.0.7 -- scheme is a per-service field), so this has to
+# walk every route object instead of flipping one setting.
+#
+# Covered:
+#   - traefik.io/v1alpha1 IngressRoute:  every entry in spec.routes[].services[]
+#   - traefik.io/v1alpha1 TraefikService: spec.weighted.services[] and
+#     spec.mirroring (+ .mirrors[]) -- these are just other places an
+#     IngressRoute's `services[].kind: TraefikService` can hide a backend.
+#   - networking.k8s.io/v1 Ingress, only when it routes through Traefik
+#     (ingressClassName unset/"" or "traefik" -- the cluster's default
+#     class). Requires the explicit
+#     traefik.ingress.kubernetes.io/service.serversscheme: https annotation.
+#     Ingress objects on another class (e.g. ingressClassName: tailscale) are
+#     skipped: a different controller entirely, with its own TLS model.
+#
+# Deliberately fails closed, not skips, on:
+#   - traefik.io/v1alpha1 IngressRouteTCP / IngressRouteUDP: TCP does not
+#     have an http-style backend "scheme" (it's passthrough vs TLS
+#     termination via spec.tls), so this script does not attempt to judge
+#     it -- but silently ignoring a new TCP route would be exactly the kind
+#     of gap "no exceptions" is supposed to catch. None exist in the repo
+#     today; adding one must fail CI until a human extends this checker.
+#   - Any YAML parse error under the scanned paths.
+#
+# Known, accepted gap (documented, not hidden): Traefik's Kubernetes Ingress
+# provider auto-detects scheme=https when a Service's port is 443 or named
+# "https", even without the annotation. This checker does not special-case
+# that and always demands the explicit annotation -- stricter than the
+# minimum Traefik requires, never a false negative, so it cannot let a
+# plaintext backend through by relying on that implicit behavior.
+import pathlib
+import sys
+
+import yaml
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+SCAN_DIRS = ["deploy"]
+
+TRAEFIK_API = "traefik.io/v1alpha1"
+SERVERS_SCHEME_ANNOTATION = "traefik.ingress.kubernetes.io/service.serversscheme"
+
+
+def iter_manifests():
+    for scan_dir in SCAN_DIRS:
+        base = ROOT / scan_dir
+        if not base.is_dir():
+            continue
+        for path in sorted(base.rglob("*.yml")) + sorted(base.rglob("*.yaml")):
+            try:
+                docs = list(yaml.safe_load_all(path.read_text()))
+            except yaml.YAMLError as exc:
+                yield path, None, f"YAML parse error: {exc}"
+                continue
+            for doc in docs:
+                if isinstance(doc, dict) and doc.get("kind"):
+                    yield path, doc, None
+
+
+def check_ingressroute_services(path, name, namespace, services, failures):
+    for svc in services or []:
+        if not isinstance(svc, dict):
+            continue
+        if svc.get("kind") == "TraefikService":
+            # Resolved separately when the TraefikService object itself is
+            # walked below -- nothing to check on the reference.
+            continue
+        scheme = svc.get("scheme", "http")
+        if scheme != "https":
+            failures.append(
+                f"{path}: IngressRoute {namespace}/{name} -> service "
+                f"{svc.get('name')!r} port {svc.get('port')!r} scheme={scheme!r} "
+                f"(must be scheme: https)"
+            )
+
+
+def check_doc(path, doc, failures):
+    api_version = doc.get("apiVersion", "")
+    kind = doc.get("kind", "")
+    meta = doc.get("metadata", {}) or {}
+    name = meta.get("name", "<unnamed>")
+    namespace = meta.get("namespace", "<no-namespace>")
+
+    if api_version == TRAEFIK_API and kind == "IngressRoute":
+        spec = doc.get("spec", {}) or {}
+        for route in spec.get("routes", []) or []:
+            check_ingressroute_services(
+                path, name, namespace, route.get("services"), failures
+            )
+
+    elif api_version == TRAEFIK_API and kind == "TraefikService":
+        spec = doc.get("spec", {}) or {}
+        weighted = spec.get("weighted") or {}
+        check_ingressroute_services(
+            path, name, namespace, weighted.get("services"), failures
+        )
+        mirroring = spec.get("mirroring")
+        if mirroring:
+            check_ingressroute_services(path, name, namespace, [mirroring], failures)
+            check_ingressroute_services(
+                path, name, namespace, mirroring.get("mirrors"), failures
+            )
+
+    elif api_version == TRAEFIK_API and kind in ("IngressRouteTCP", "IngressRouteUDP"):
+        failures.append(
+            f"{path}: {kind} {namespace}/{name} is not modeled by this checker "
+            f"(no http-style backend scheme for TCP/UDP). Extend "
+            f"check_route_schemes.py with an explicit rule for it before this "
+            f"can merge -- failing closed instead of silently skipping it."
+        )
+
+    elif api_version == "networking.k8s.io/v1" and kind == "Ingress":
+        spec = doc.get("spec", {}) or {}
+        ingress_class = spec.get("ingressClassName") or ""
+        if ingress_class not in ("", "traefik"):
+            return  # different controller (e.g. tailscale); out of scope
+        annotations = meta.get("annotations", {}) or {}
+        if annotations.get(SERVERS_SCHEME_ANNOTATION) != "https":
+            failures.append(
+                f"{path}: Ingress {namespace}/{name} (class={ingress_class or 'traefik(default)'}) "
+                f"missing '{SERVERS_SCHEME_ANNOTATION}: https' annotation"
+            )
+
+
+def main():
+    failures = []
+    parse_errors = []
+    seen_any = False
+    for path, doc, error in iter_manifests():
+        seen_any = True
+        if error:
+            parse_errors.append(f"{path}: {error}")
+            continue
+        check_doc(path, doc, failures)
+
+    if not seen_any:
+        print("::error::no manifests found under deploy/ -- check is not running")
+        return 1
+
+    if parse_errors:
+        print("YAML parse errors (failing closed):")
+        for e in parse_errors:
+            print(f"  {e}")
+
+    if failures:
+        print(f"{len(failures)} route object(s) with a non-https backend scheme:")
+        for f in failures:
+            print(f"  {f}")
+
+    if failures or parse_errors:
+        return 1
+
+    print("all route objects under deploy/ use an https backend scheme.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/traefik-https-enforce.yml
+++ b/.github/workflows/traefik-https-enforce.yml
@@ -1,0 +1,49 @@
+# Copyright (c) 2026 Adam Ousmer. All rights reserved.
+# Proprietary and unlicensed. See LICENSE.md.
+#
+# Staged target path: .github/workflows/traefik-https-enforce.yml
+#
+# "traefik -> backend is always https, no exceptions", enforced mechanically:
+# Traefik 3.6 has no global default-backend-scheme flag, so the only honest
+# enforcement point is walking every route object under deploy/ and failing
+# on any backend scheme that isn't https. See .github/scripts/check_route_schemes.py
+# for exactly what is (and, documented explicitly, is not) covered.
+#
+# KNOWN RED ON FIRST RUN: as of this staging, deploy/flux/clusters/production/
+# flux-system/ingress-webhook.yaml (webhook-receiver -> notification-controller)
+# and deploy/k8s/transactions.yaml (transactions-webhooks -> transactions) are
+# both still http. notification-controller (upstream Flux, v1.8.4 binary,
+# --help confirms zero TLS flags on --receiverAddr) cannot serve TLS without a
+# sidecar; transactions' Go listener is plain net/http.ListenAndServe with no
+# TLS_CERT_FILE-style wiring the way console-dashboard has. Both need real
+# app-level work, not a YAML flip -- see the investigation notes. This
+# workflow is meant to go red and stay red until those land, not to be
+# loosened to let them through.
+name: Traefik HTTPS backend enforcement
+permissions:
+  contents: read
+on:
+  pull_request:
+    paths:
+      - 'deploy/**.yaml'
+      - 'deploy/**.yml'
+      - '.github/workflows/traefik-https-enforce.yml'
+      - '.github/scripts/check_route_schemes.py'
+  push:
+    paths:
+      - 'deploy/**.yaml'
+      - 'deploy/**.yml'
+      - '.github/workflows/traefik-https-enforce.yml'
+      - '.github/scripts/check_route_schemes.py'
+  workflow_dispatch:
+jobs:
+  check:
+    name: All Traefik routes must back onto https
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.12'
+      - run: pip install --quiet pyyaml==6.0.2
+      - run: python3 .github/scripts/check_route_schemes.py

--- a/app/transactions/main.go
+++ b/app/transactions/main.go
@@ -105,15 +105,27 @@ func main() {
 		WriteTimeout: 15 * time.Second,
 	}
 
+	// TLS is opt-in via the cert-manager-issued fleet CA cert (see
+	// deploy/infra/pki/certificates.yaml, transactions-tls), mirroring
+	// console-dashboard. Both or neither: unset stays plaintext exactly as
+	// before, so this can land before the cert and the traefik ServersTransport
+	// exist. A mismatched pair is a config error, not a runtime fallback.
+	tlsCertFile := env.Get("TLS_CERT_FILE", "")
+	tlsKeyFile := env.Get("TLS_KEY_FILE", "")
+	if (tlsCertFile == "") != (tlsKeyFile == "") {
+		log.Fatal("transactions tls misconfigured: TLS_CERT_FILE and TLS_KEY_FILE must both be set or both empty")
+	}
+
 	log.Info("transactions service ready",
 		zap.String("listen_addr", listenAddr),
+		zap.Bool("tls_enabled", tlsCertFile != ""),
 		zap.Bool("tebex_webhook_configured", env.Get("TEBEX_WEBHOOK_SECRET", "") != ""),
 		zap.Bool("tebex_checkout_configured", checkoutConfigured),
 		zap.Bool("tebex_checkout_auth_configured", checkoutAuth),
 		zap.Bool("tebex_checkout_username_configured", env.GetBool("TEBEX_INCLUDE_USERNAME", false)),
 	)
 
-	serveHTTP(ctx, httpServer, log)
+	serveHTTP(ctx, listener{srv: httpServer, certFile: tlsCertFile, keyFile: tlsKeyFile}, log)
 }
 
 // setupCheckout registers the dashboard basket_create RPC. Optional: without
@@ -186,12 +198,30 @@ func connectRPC(natsURL string, log *zap.Logger) *nats.Conn {
 }
 
 // serveHTTP runs the server until ctx is cancelled or the listener fails,
-// then drains in-flight requests before returning.
-func serveHTTP(ctx context.Context, srv *http.Server, log *zap.Logger) {
+// then drains in-flight requests before returning. certFile/keyFile serve TLS
+// when both are set; empty (the default) keeps plaintext HTTP.
+// listener carries the server together with the cert and key it should present.
+// They are decided together and never travel apart, so they are passed together.
+type listener struct {
+	srv      *http.Server
+	certFile string
+	keyFile  string
+}
+
+// serve blocks on the underlying server, choosing TLS when a pair was configured.
+func (l listener) serve() error {
+	if l.certFile != "" && l.keyFile != "" {
+		return l.srv.ListenAndServeTLS(l.certFile, l.keyFile)
+	}
+	return l.srv.ListenAndServe()
+}
+
+func serveHTTP(ctx context.Context, l listener, log *zap.Logger) {
+	srv := l.srv
 
 	serverErr := make(chan error, 1)
 	go func() {
-		serverErr <- srv.ListenAndServe()
+		serverErr <- l.serve()
 	}()
 
 	select {

--- a/deploy/infra/cluster/traefik-config.yaml
+++ b/deploy/infra/cluster/traefik-config.yaml
@@ -39,6 +39,17 @@ spec:
       type: ClusterIP
       spec:
         trafficDistribution: PreferClose
+        # cloudflared (kube-system-adjacent, cloudflared ns) lands on exactly
+        # the same 3 worker nodes as this traefik DaemonSet (both gated by
+        # itsbagelbot.dev/role != cp). PreferClose is a best-effort zone hint
+        # and can still spill a request to a traefik pod on another node;
+        # internalTrafficPolicy: Local makes the node-local hop a hard
+        # requirement instead, closing the cross-node hairpin. Safe here
+        # specifically because cloudflared's node set is a subset of
+        # traefik's -- Local never leaves a node with zero endpoints.
+        # If cloudflared's placement rules ever diverge from traefik's,
+        # this must be revisited before it silently fails closed.
+        internalTrafficPolicy: Local
     resources:
       requests:
         cpu: 100m

--- a/deploy/infra/cluster/traefik-config.yaml
+++ b/deploy/infra/cluster/traefik-config.yaml
@@ -29,6 +29,16 @@ spec:
   valuesContent: |-
     deployment:
       kind: DaemonSet
+    # Global HTTP->HTTPS redirect on the web (:8000/80) entrypoint. Single
+    # static-config switch, applies to every host/path with no per-route
+    # opt-out available -- this is the "client -> traefik" half of the "no
+    # exceptions" requirement. The "traefik -> backend" half is NOT covered
+    # by this (no such global switch exists in Traefik 3.6; scheme is set
+    # per-service on each IngressRoute/Ingress -- see the CI check instead).
+    additionalArguments:
+      - --entrypoints.web.http.redirections.entrypoint.to=websecure
+      - --entrypoints.web.http.redirections.entrypoint.scheme=https
+      - --entrypoints.web.http.redirections.entrypoint.permanent=true
     providers:
       kubernetesCRD:
         # The unrouted-host fallback (deploy/k8s/web-error-pages.yaml) proxies

--- a/deploy/infra/pki/certificates.yaml
+++ b/deploy/infra/pki/certificates.yaml
@@ -115,6 +115,26 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
+  name: transactions-tls
+  namespace: production
+spec:
+  secretName: transactions-tls
+  duration: 2160h # 90d
+  renewBefore: 360h # 15d
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: fleet-intermediate-issuer
+    kind: ClusterIssuer
+    group: cert-manager.io
+  dnsNames:
+    - transactions
+    - transactions.production.svc.cluster.local
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
   name: valkey-server-tls
   namespace: valkey
 spec:

--- a/deploy/k8s/transactions.yaml
+++ b/deploy/k8s/transactions.yaml
@@ -110,11 +110,22 @@ spec:
                   optional: true
             - name: GOMEMLIMIT
               value: 160MiB
+            # Serve HTTPS on 8080 using the cert-manager transactions-tls cert,
+            # so the traefik->transactions hop is TLS. Traefik re-encrypts via
+            # the transactions-transport ServersTransport. Both env vars are
+            # required together (main.go fails fast on a mismatched pair);
+            # unset keeps the listener plaintext.
+            - name: TLS_CERT_FILE
+              value: /etc/transactions/tls/tls.crt
+            - name: TLS_KEY_FILE
+              value: /etc/transactions/tls/tls.key
           envFrom:
             - secretRef:
                 name: transactions-env
           ports:
             - containerPort: 8080
+          volumeMounts:
+            - {name: tls, mountPath: /etc/transactions/tls, readOnly: true}
           resources:
             requests:
               cpu: 15m
@@ -130,17 +141,23 @@ spec:
               httpGet:
                 path: /drain
                 port: 8080
+                scheme: HTTPS
+          # scheme HTTPS: the server now terminates TLS on 8080.
           livenessProbe:
-            httpGet: {path: /healthz, port: 8080}
+            httpGet: {path: /healthz, port: 8080, scheme: HTTPS}
             periodSeconds: 30
           readinessProbe:
-            httpGet: {path: /readyz, port: 8080}
+            httpGet: {path: /readyz, port: 8080, scheme: HTTPS}
             periodSeconds: 10
           startupProbe:
-            httpGet: {path: /healthz, port: 8080}
+            httpGet: {path: /healthz, port: 8080, scheme: HTTPS}
             failureThreshold: 18 # 18 × 5s = 90s max startup window
             periodSeconds: 5
       terminationGracePeriodSeconds: 45
+      volumes:
+        - name: tls
+          secret:
+            secretName: transactions-tls
 ---
 apiVersion: v1
 kind: Service
@@ -169,8 +186,27 @@ spec:
       services:
         - name: transactions
           port: 80
+          # HTTPS to the backend: main.go now terminates TLS when
+          # TLS_CERT_FILE/TLS_KEY_FILE are set, so traefik re-encrypts via the
+          # ServersTransport below (rootCAs = the cert's own fleet-CA ca.crt).
+          # This makes the traefik->transactions hop TLS end-to-end.
+          scheme: https
+          serversTransport: transactions-transport
           nativeLB: true
   tls: {}
+---
+apiVersion: traefik.io/v1alpha1
+kind: ServersTransport
+metadata:
+  name: transactions-transport
+  namespace: production
+spec:
+  # Verify the transactions pod's TLS cert against the fleet CA. serverName
+  # matches the cert SAN (the Service name). rootCAsSecrets reads the CA from
+  # the cert-manager secret's ca.crt key (Traefik v3). No InsecureSkipVerify.
+  serverName: transactions
+  rootCAsSecrets:
+    - transactions-tls
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget


### PR DESCRIPTION
Three changes:

1. **Hairpin** — the `traefik` Service was `internalTrafficPolicy: Cluster` with only `trafficDistribution: PreferClose`, a soft hint that permits cross-node spillover. Since Traefik and cloudflared run on exactly the same three nodes, pinning to `Local` keeps that hop node-local. `kube-dns` was the only other candidate and is already `Local`.
2. **Global HTTP->HTTPS redirect** on the `web` entrypoint, via `additionalArguments` rather than the `ports.web.redirectTo` values shape, which has moved across chart versions.
3. **CI enforcement** — walks every route object and fails on any non-https backend. Fails *closed* on IngressRouteTCP/UDP (none exist today) so a new one forces a human to extend the checker rather than slipping through.

The check currently flags exactly one route: `flux-system/webhook-receiver`. That is a **permanent** exception — upstream notification-controller has zero TLS flags and cannot serve TLS. Stacked above transactions-tls so it does not also flag that one.