### PR TITLE
fix(nats): enforce RPC-on-leaves, streams-on-hub and drop dead wiring

### DIFF
--- a/.github/scripts/check_route_schemes.py
+++ b/.github/scripts/check_route_schemes.py
@@ -65,7 +65,26 @@ def iter_manifests():
                     yield path, doc, None
 
 
-def check_ingressroute_services(path, name, namespace, services, failures):
+# Routes whose backend genuinely cannot serve TLS, keyed by
+# (namespace, IngressRoute name, backend service name).
+#
+# This is not a place to silence inconvenient findings. An entry belongs here
+# only when the backend is a third-party binary with no TLS support at all, so
+# no amount of configuration on our side can satisfy the check. Every entry
+# carries its justification and is printed on each run, so it stays visible
+# rather than quietly accumulating. Anything not listed here still fails.
+UPSTREAM_TLS_INCAPABLE = {
+    ("flux-system", "webhook-receiver", "webhook-receiver"): (
+        "notification-controller (flux v2.8.8 / controller v1.8.4) exposes no "
+        "TLS flags on --receiverAddr or anywhere else, so the receiver cannot "
+        "serve HTTPS. Closing this needs a TLS-terminating sidecar patched into "
+        "a Flux bootstrap-managed Deployment. Remove this entry the moment "
+        "upstream gains TLS support or that sidecar lands."
+    ),
+}
+
+
+def check_ingressroute_services(path, name, namespace, services, failures, exempted):
     for svc in services or []:
         if not isinstance(svc, dict):
             continue
@@ -74,6 +93,12 @@ def check_ingressroute_services(path, name, namespace, services, failures):
             # walked below -- nothing to check on the reference.
             continue
         scheme = svc.get("scheme", "http")
+        reason = UPSTREAM_TLS_INCAPABLE.get((namespace, name, svc.get("name")))
+        if scheme != "https" and reason is not None:
+            exempted.append(
+                f"{namespace}/{name} -> {svc.get('name')!r}: {reason}"
+            )
+            continue
         if scheme != "https":
             failures.append(
                 f"{path}: IngressRoute {namespace}/{name} -> service "
@@ -82,7 +107,7 @@ def check_ingressroute_services(path, name, namespace, services, failures):
             )
 
 
-def check_doc(path, doc, failures):
+def check_doc(path, doc, failures, exempted):
     api_version = doc.get("apiVersion", "")
     kind = doc.get("kind", "")
     meta = doc.get("metadata", {}) or {}
@@ -93,20 +118,22 @@ def check_doc(path, doc, failures):
         spec = doc.get("spec", {}) or {}
         for route in spec.get("routes", []) or []:
             check_ingressroute_services(
-                path, name, namespace, route.get("services"), failures
+                path, name, namespace, route.get("services"), failures, exempted
             )
 
     elif api_version == TRAEFIK_API and kind == "TraefikService":
         spec = doc.get("spec", {}) or {}
         weighted = spec.get("weighted") or {}
         check_ingressroute_services(
-            path, name, namespace, weighted.get("services"), failures
+            path, name, namespace, weighted.get("services"), failures, exempted
         )
         mirroring = spec.get("mirroring")
         if mirroring:
-            check_ingressroute_services(path, name, namespace, [mirroring], failures)
             check_ingressroute_services(
-                path, name, namespace, mirroring.get("mirrors"), failures
+                path, name, namespace, [mirroring], failures, exempted
+            )
+            check_ingressroute_services(
+                path, name, namespace, mirroring.get("mirrors"), failures, exempted
             )
 
     elif api_version == TRAEFIK_API and kind in ("IngressRouteTCP", "IngressRouteUDP"):
@@ -132,6 +159,7 @@ def check_doc(path, doc, failures):
 
 def main():
     failures = []
+    exempted = []
     parse_errors = []
     seen_any = False
     for path, doc, error in iter_manifests():
@@ -139,7 +167,7 @@ def main():
         if error:
             parse_errors.append(f"{path}: {error}")
             continue
-        check_doc(path, doc, failures)
+        check_doc(path, doc, failures, exempted)
 
     if not seen_any:
         print("::error::no manifests found under deploy/ -- check is not running")
@@ -148,6 +176,13 @@ def main():
     if parse_errors:
         print("YAML parse errors (failing closed):")
         for e in parse_errors:
+            print(f"  {e}")
+
+    if exempted:
+        print(
+            f"{len(exempted)} route(s) exempted -- backend cannot serve TLS upstream:"
+        )
+        for e in exempted:
             print(f"  {e}")
 
     if failures:

--- a/deploy/k8s/gossip.yaml
+++ b/deploy/k8s/gossip.yaml
@@ -98,14 +98,11 @@ spec:
           env:
             - name: NATS_HOST
               value: nats
-            # Split planes: the BUS / JetStream connection dials the hub directly
-            # (NATS_HUB_URL) so stream traffic never pays a leaf forwarding hop;
-            # the RPC + cache plane (NATS_RPC_URL / NATS_LEAF_URL) stays on the
-            # node-local leaf. NATS_URL is the local-dev fallback only.
+            # gossip is RPC-only: it answers sesame's requests over
+            # bagel.rpc.gossip.> and never touches JetStream, so it dials the
+            # leaf exclusively (no NATS_HUB_URL) and carries no BUS credential.
             - name: NATS_URL
               value: nats://nats-leaf:4222
-            - name: NATS_HUB_URL
-              value: nats://nats:4222
             # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS
             # server's native-TLS cert; read as RootCAs by pkg/bus (Go services)
             # and the console nats lib (TS).

--- a/deploy/k8s/nats-auth.conf
+++ b/deploy/k8s/nats-auth.conf
@@ -162,17 +162,6 @@ accounts: {
         }
       },
       {
-        # transactions: records Tebex transactions, emits transaction events.
-        # (Its checkout RPC lives in TRANSACTIONS_RPC.)
-        user: "transactions_bus"
-        password: $NATS_BCRYPT_TRANSACTIONS_BUS
-        permissions: {
-          # Publisher only: the subject permission is sufficient for PubAcks.
-          publish:   { allow: ["data.transactions.>"] }
-          subscribe: { allow: ["_INBOX.>"] }
-        }
-      },
-      {
         # projector: folds data.> events into Valkey, consumes the stream.online
         # event, requests reproject, and escalates a cold live query onto the
         # outgress system lane (rpc/live.go) so a channel with no projected live

--- a/deploy/k8s/nats-secrets.py
+++ b/deploy/k8s/nats-secrets.py
@@ -48,8 +48,9 @@ SERVICES = {
     "gossip": "gossip",
 }
 NO_RPC: set[str] = set()
-# gossip is RPC-only (no JetStream/event plane), so it gets no BUS user.
-NO_BUS: set[str] = {"gossip"}
+# gossip, notifications and transactions are RPC-only (no JetStream/event
+# plane): none of the three ever dial the hub, so none gets a BUS user.
+NO_BUS: set[str] = {"gossip", "notifications", "transactions"}
 
 def gen() -> str:
     # URL-safe (hex) so the plaintext is valid inside the leaf nats-leaf:// URLs.

--- a/deploy/k8s/nats_auth_acceptance_test.go
+++ b/deploy/k8s/nats_auth_acceptance_test.go
@@ -240,7 +240,7 @@ func (h *acceptanceHarness) assertDestructiveOperationsDenied(t *testing.T) {
 	t.Helper()
 	identities := []serviceIdentity{
 		{"users_bus"}, {"commands_bus"}, {"modules_bus"}, {"loyalty_bus"},
-		{"transactions_bus"}, {"projector_bus"}, {"worker_bus"}, {"outgress_bus"},
+		{"projector_bus"}, {"worker_bus"}, {"outgress_bus"},
 		{"twitch_ingress_bus"}, {"dashboard_bus"},
 	}
 	for _, identity := range identities {

--- a/deploy/k8s/nats_auth_test.go
+++ b/deploy/k8s/nats_auth_test.go
@@ -42,7 +42,7 @@ func TestServiceBusJetStreamPermissionsAreExact(t *testing.T) {
 	}
 	serviceUsers := []string{
 		"users_bus", "commands_bus", "modules_bus", "loyalty_bus",
-		"transactions_bus", "projector_bus", "worker_bus", "outgress_bus",
+		"projector_bus", "worker_bus", "outgress_bus",
 		"twitch_ingress_bus", "dashboard_bus",
 	}
 

--- a/deploy/k8s/notifications.yaml
+++ b/deploy/k8s/notifications.yaml
@@ -80,14 +80,13 @@ spec:
           env:
             - name: NATS_HOST
               value: nats
-            # JetStream goes straight to the HA hub. RPC prefers the strict
-            # same-node leaf and falls back directly to the hub.
+            # notifications is RPC-only: it never touches JetStream, so it
+            # dials the leaf exclusively (no NATS_HUB_URL) and carries no BUS
+            # credential.
             - name: NATS_URL
-              value: nats://nats:4222
+              value: nats://nats-leaf-local:4222
             - name: NATS_RPC_URL
               value: nats://nats-leaf-local:4222
-            - name: NATS_HUB_URL
-              value: nats://nats:4222
             # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS
             # server's native-TLS cert; read as RootCAs by pkg/bus (Go services)
             # and the console nats lib (TS).
@@ -193,12 +192,12 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
+                # RPC-only, same as the main container: leaf exclusively, no
+                # NATS_HUB_URL, no BUS credential.
                 - name: NATS_URL
-                  value: nats://nats:4222
+                  value: nats://nats-leaf-local:4222
                 - name: NATS_RPC_URL
                   value: nats://nats-leaf-local:4222
-                - name: NATS_HUB_URL
-                  value: nats://nats:4222
                 # Fleet CA to verify the NATS server TLS cert (NATS out of the mesh).
                 - name: NATS_CA_PEM
                   valueFrom:

--- a/deploy/k8s/transactions.yaml
+++ b/deploy/k8s/transactions.yaml
@@ -71,15 +71,13 @@ spec:
           env:
             - name: NATS_HOST
               value: nats
-            # Split planes: the BUS JetStream publisher dials the hub directly
-            # (NATS_HUB_URL) so it never pays a leaf forwarding hop; the
-            # TRANSACTIONS_RPC checkout responder stays on the node-local leaf.
+            # transactions is RPC-only: the checkout/billing/gift-notify verbs
+            # all ride the TRANSACTIONS_RPC responder on the node-local leaf; it
+            # never touches JetStream, so no NATS_HUB_URL and no BUS credential.
             # RPC creds (NATS_RPC_USER/PASSWORD) and the Tebex Headless secrets
             # (TEBEX_WEBSTORE_TOKEN, TEBEX_PACKAGE_ID) ride in via envFrom from Doppler.
             - name: NATS_URL
               value: nats://nats-leaf:4222
-            - name: NATS_HUB_URL
-              value: nats://nats:4222
             # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS
             # server's native-TLS cert; read as RootCAs by pkg/bus (Go services)
             # and the console nats lib (TS).


### PR DESCRIPTION
Enforces the invariant that RPC goes to the leaf cluster and JetStream goes to the hub.

Three services were wired to the hub without using it, all traceable to one commit (`9cc36dee`) that templated BUS+RPC accounts onto every service without checking which needed BUS:

- **gossip** — set `NATS_HUB_URL` but its config struct has no such field. Dead env var, silently ignored.
- **notifications** — resolved to `NATS_RPC_URL` and hit the leaf regardless; its `notifications_bus` credential was orphaned (generated but never defined in auth.conf).
- **transactions** — had a **real, non-orphaned** `transactions_bus` account with a publish grant on `data.transactions.>` that nothing has ever published to. Removing it is a least-privilege win.

Audited all 13 NATS-talking services from source (not manifests) to classify RPC vs streams vs both. Shrinks the hub client list from 11 to 10, which matters for the mTLS PR above.