### PR TITLE
fix(valkey): re-read the client certificate on rotation instead of once at startup

### DIFF
--- a/console/shared/lib/server/valkey-connection.test.ts
+++ b/console/shared/lib/server/valkey-connection.test.ts
@@ -3,6 +3,9 @@
 
 // @ts-ignore Bun supplies this module at test runtime; it is not a production dependency.
 import { describe, expect, test } from 'bun:test';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import {
   VALKEY_TLS_DATA_PORT,
   VALKEY_TLS_SENTINEL_PORT,
@@ -30,5 +33,45 @@ describe('Valkey native TLS connection policy', () => {
     });
     expect(valkeySentinelNAT('100.99.41.21:6379')).toEqual({ host: '100.99.41.21', port: 6380 });
     expect(valkeySentinelNAT('100.99.41.21:6380')).toBeNull();
+  });
+
+  test('mTLS cert/key stay unset without both env-mounted paths (both-or-neither)', () => {
+    expect(valkeyTLSOptions({ addr: 'valkey:6379', tlsCa: 'pem' })).not.toHaveProperty('cert');
+    expect(
+      valkeyTLSOptions({ addr: 'valkey:6379', tlsCa: 'pem', tlsClientCertFile: '/only/cert' })
+    ).not.toHaveProperty('cert');
+  });
+
+  // Refs #560: the client cert must be re-read from disk on every reconnect,
+  // not baked in once at options-build time, or a cert-manager rotation at
+  // day 75 leaves the process presenting an expired cert at day 90. iovalkey's
+  // connectors re-copy the `tls` options object into the socket options on
+  // every connect() call, and Object.assign invokes property getters at copy
+  // time -- so re-reading `options.cert`/`options.key` here stands in for
+  // that per-reconnect re-copy and proves the getter, not a cached value, is
+  // what iovalkey will observe on the next handshake.
+  test('mTLS cert/key are re-read from disk on every access, not cached from construction', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'valkey-mtls-'));
+    const certFile = join(dir, 'tls.crt');
+    const keyFile = join(dir, 'tls.key');
+    writeFileSync(certFile, 'cert-v1');
+    writeFileSync(keyFile, 'key-v1');
+
+    const options = valkeyTLSOptions({
+      addr: 'valkey:6379',
+      tlsCa: 'pem',
+      tlsClientCertFile: certFile,
+      tlsClientKeyFile: keyFile
+    });
+
+    expect(options?.cert?.toString()).toBe('cert-v1');
+    expect(options?.key?.toString()).toBe('key-v1');
+
+    // cert-manager's renewal: same path, rotated content.
+    writeFileSync(certFile, 'cert-v2');
+    writeFileSync(keyFile, 'key-v2');
+
+    expect(options?.cert?.toString()).toBe('cert-v2');
+    expect(options?.key?.toString()).toBe('key-v2');
   });
 });

--- a/console/shared/lib/server/valkey-connection.ts
+++ b/console/shared/lib/server/valkey-connection.ts
@@ -16,14 +16,30 @@ export function valkeyTLSOptions(cfg: ValkeyConfig): ConnectionOptions | undefin
     servername: cfg.tlsServerName || DEFAULT_SERVER_NAME,
     minVersion: 'TLSv1.2'
   };
-  // mTLS: read from the mounted Secret volume at connection-build time (this
-  // function runs from initConsoleRuntime's boot step, never at module eval,
-  // so it is not subject to the $env/dynamic/private top-level-await
-  // deadlock this file's callers already avoid). Both-or-neither, matching
-  // the shared Go client's VALKEY_TLS_CLIENT_CERT_FILE/KEY_FILE contract.
+  // mTLS, reloaded per reconnect rather than read once: iovalkey's connectors
+  // (StandaloneConnector and SentinelConnector) hold onto this exact `tls`
+  // object for the client's whole lifetime and Object.assign it into the
+  // socket options fresh on every connect() call -- i.e. on every reconnect,
+  // which is this long-lived client's equivalent of "the next handshake."
+  // Object.assign invokes property getters at copy time, so defining cert/key
+  // as getters (not static Buffers captured once here) means the mounted
+  // Secret volume is re-read at that moment. A cert-manager rotation at day
+  // 75 reaches the client on its next reconnect with no process restart --
+  // the same fix as the Go client's GetClientCertificate, expressed through
+  // this library's own re-copy mechanism since Node's tls module has no
+  // per-handshake callback for client certs (only servers get SNICallback).
+  // No mtime cache here unlike the Go side: reconnects are rare (network
+  // blips, breaker resets), not a per-request hot path, so re-reading two
+  // small files each time costs nothing worth guarding against.
+  // Both-or-neither, matching the shared Go client's
+  // VALKEY_TLS_CLIENT_CERT_FILE/KEY_FILE contract.
   if (cfg.tlsClientCertFile && cfg.tlsClientKeyFile) {
-    options.cert = readFileSync(cfg.tlsClientCertFile);
-    options.key = readFileSync(cfg.tlsClientKeyFile);
+    const certFile = cfg.tlsClientCertFile;
+    const keyFile = cfg.tlsClientKeyFile;
+    Object.defineProperties(options, {
+      cert: { enumerable: true, get: () => readFileSync(certFile) },
+      key: { enumerable: true, get: () => readFileSync(keyFile) }
+    });
   }
   return options;
 }

--- a/pkg/valkey/tls.go
+++ b/pkg/valkey/tls.go
@@ -10,6 +10,8 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"sync"
+	"time"
 )
 
 const (
@@ -58,12 +60,95 @@ func clientTLSConfig() (*tls.Config, error) {
 	if certFile == "" || keyFile == "" {
 		return nil, fmt.Errorf("valkey: VALKEY_TLS_CLIENT_CERT_FILE and VALKEY_TLS_CLIENT_KEY_FILE must both be set or both be empty")
 	}
-	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	// GetClientCertificate, not Certificates: the latter is read once when
+	// this *tls.Config is built and then frozen, so a process that lives
+	// past cert-manager's day-75 rotation keeps presenting the cert issued
+	// at boot until it expires at day 90 and every handshake starts failing.
+	// GetClientCertificate is invoked by crypto/tls on every handshake,
+	// which gives the reloader below a chance to notice the rotated file.
+	reloader, err := newClientCertReloader(certFile, keyFile)
 	if err != nil {
 		return nil, fmt.Errorf("valkey: loading client cert/key: %w", err)
 	}
-	config.Certificates = []tls.Certificate{cert}
+	config.GetClientCertificate = reloader.getClientCertificate
 	return config, nil
+}
+
+// clientCertReloader caches the parsed client certificate and re-reads it
+// from disk only when the cert file's mtime or size has moved since the last
+// read. A stat is orders of magnitude cheaper than LoadX509KeyPair (which
+// re-parses PEM and re-derives the key), and mtime+size is enough to detect
+// cert-manager's renewal: the kubelet's Secret volume rotates in the new
+// cert via an atomic symlink swap, which always changes both. Byte-for-byte
+// content hashing would catch a same-second same-size edit that this misses,
+// but that isn't a shape cert-manager rotation produces, so it isn't worth
+// reading the file on every handshake to guard against it.
+type clientCertReloader struct {
+	certFile string
+	keyFile  string
+
+	mu      sync.RWMutex
+	cert    *tls.Certificate
+	modTime time.Time
+	size    int64
+}
+
+func newClientCertReloader(certFile, keyFile string) (*clientCertReloader, error) {
+	reloader := &clientCertReloader{certFile: certFile, keyFile: keyFile}
+	if err := reloader.reload(); err != nil {
+		return nil, err
+	}
+	return reloader, nil
+}
+
+// getClientCertificate implements tls.Config.GetClientCertificate.
+func (r *clientCertReloader) getClientCertificate(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+	if r.changed() {
+		// Best effort: if the file is mid-write (the symlink swap isn't
+		// atomic against a concurrent stat+read on every filesystem) or the
+		// rotated pair is briefly invalid, keep serving the cached cert
+		// instead of failing a live handshake over it. The next handshake
+		// tries again.
+		_ = r.reload()
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if r.cert == nil {
+		return nil, fmt.Errorf("valkey: no client certificate loaded")
+	}
+	return r.cert, nil
+}
+
+func (r *clientCertReloader) changed() bool {
+	info, err := os.Stat(r.certFile)
+	if err != nil {
+		return false
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return !info.ModTime().Equal(r.modTime) || info.Size() != r.size
+}
+
+func (r *clientCertReloader) reload() error {
+	info, err := os.Stat(r.certFile)
+	if err != nil {
+		return err
+	}
+	cert, err := tls.LoadX509KeyPair(r.certFile, r.keyFile)
+	if err != nil {
+		return err
+	}
+	// LoadX509KeyPair leaves Leaf nil (parsed lazily per handshake by
+	// default); parse it once here so it's cached alongside everything else.
+	if leaf, err := x509.ParseCertificate(cert.Certificate[0]); err == nil {
+		cert.Leaf = leaf
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.cert = &cert
+	r.modTime = info.ModTime()
+	r.size = info.Size()
+	return nil
 }
 
 func cloneTLSConfig(config *tls.Config) *tls.Config {

--- a/pkg/valkey/tls_test.go
+++ b/pkg/valkey/tls_test.go
@@ -1,0 +1,283 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package valkey
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestClientTLSConfigGateBothOrNeither pins the existing env gate: this
+// change must not disturb it. Unset stays today's "no client auth yet"
+// behavior; exactly one set is still a startup error.
+func TestClientTLSConfigGateBothOrNeither(t *testing.T) {
+	ca, _ := testTLSCA(t)
+	t.Setenv("VALKEY_TLS_CA_PEM", string(pemEncodeCert(ca)))
+
+	t.Run("neither set", func(t *testing.T) {
+		t.Setenv("VALKEY_TLS_CLIENT_CERT_FILE", "")
+		t.Setenv("VALKEY_TLS_CLIENT_KEY_FILE", "")
+
+		config, err := clientTLSConfig()
+		require.NoError(t, err)
+		require.NotNil(t, config)
+		assert.Nil(t, config.GetClientCertificate)
+		assert.Empty(t, config.Certificates)
+	})
+
+	t.Run("only cert set", func(t *testing.T) {
+		t.Setenv("VALKEY_TLS_CLIENT_CERT_FILE", "/dev/null")
+		t.Setenv("VALKEY_TLS_CLIENT_KEY_FILE", "")
+
+		_, err := clientTLSConfig()
+		assert.ErrorContains(t, err, "must both be set or both be empty")
+	})
+
+	t.Run("only key set", func(t *testing.T) {
+		t.Setenv("VALKEY_TLS_CLIENT_CERT_FILE", "")
+		t.Setenv("VALKEY_TLS_CLIENT_KEY_FILE", "/dev/null")
+
+		_, err := clientTLSConfig()
+		assert.ErrorContains(t, err, "must both be set or both be empty")
+	})
+}
+
+// TestClientTLSConfigUsesGetClientCertificateNotStaticCertificates guards the
+// actual bug fix: Certificates is a startup-only snapshot, GetClientCertificate
+// is called by crypto/tls on every handshake. Regressing to the former is the
+// exact shape of #560.
+func TestClientTLSConfigUsesGetClientCertificateNotStaticCertificates(t *testing.T) {
+	ca, caKey := testTLSCA(t)
+	certFile, keyFile, _ := writeTestClientCert(t, ca, caKey, "client-v1", 1)
+
+	t.Setenv("VALKEY_TLS_CLIENT_CERT_FILE", certFile)
+	t.Setenv("VALKEY_TLS_CLIENT_KEY_FILE", keyFile)
+	t.Setenv("VALKEY_TLS_CA_PEM", string(pemEncodeCert(ca)))
+
+	config, err := clientTLSConfig()
+	require.NoError(t, err)
+	require.NotNil(t, config.GetClientCertificate)
+	assert.Empty(t, config.Certificates, "Certificates must stay unset: a non-empty value here is read once at Config construction and never again")
+}
+
+// TestClientCertReloaderPresentsRotatedCertOnNextHandshake is the point of
+// this change: cert-manager rotates the file on disk at day 75 without the
+// process restarting, and the very next handshake -- not a redeploy -- must
+// present the new cert. This drives two real TLS handshakes end to end over
+// a net.Pipe and inspects what the server actually received.
+func TestClientCertReloaderPresentsRotatedCertOnNextHandshake(t *testing.T) {
+	ca, caKey := testTLSCA(t)
+	certFile, keyFile, certV1 := writeTestClientCert(t, ca, caKey, "client-v1", 1)
+
+	clientConfig := &tls.Config{
+		ServerName: "valkey-test.local",
+		RootCAs:    certPoolOf(ca),
+		MinVersion: tls.VersionTLS12,
+	}
+	reloader, err := newClientCertReloader(certFile, keyFile)
+	require.NoError(t, err)
+	clientConfig.GetClientCertificate = reloader.getClientCertificate
+
+	serverConfig := testServerTLSConfig(t, ca, caKey)
+
+	// Handshake #1: reloader has only ever seen v1.
+	presented := doTestHandshake(t, clientConfig, serverConfig)
+	assert.Equal(t, certV1.SerialNumber, presented.SerialNumber, "first handshake should present the cert loaded at construction")
+	assert.Equal(t, "client-v1", presented.Subject.CommonName)
+
+	// cert-manager's renewal: the Secret volume's atomic symlink swap lands
+	// a same-path, different-content pair with a fresh mtime.
+	_, _, certV2 := writeTestClientCertAt(t, ca, caKey, certFile, keyFile, "client-v2", 2)
+	futureTime := time.Now().Add(time.Hour)
+	require.NoError(t, os.Chtimes(certFile, futureTime, futureTime))
+
+	// Handshake #2: no restart, same *tls.Config, same reloader -- must pick
+	// up the rotated cert this time.
+	presented = doTestHandshake(t, clientConfig, serverConfig)
+	assert.Equal(t, certV2.SerialNumber, presented.SerialNumber, "second handshake must present the ROTATED cert, not the one cached at startup")
+	assert.Equal(t, "client-v2", presented.Subject.CommonName)
+	assert.NotEqual(t, certV1.SerialNumber, presented.SerialNumber)
+}
+
+// TestClientCertReloaderCachesWhenFileUnchanged proves the reloader does not
+// stat-and-reparse the key pair on every handshake: back-to-back calls
+// against an untouched file must return the exact same cached *tls.Certificate.
+func TestClientCertReloaderCachesWhenFileUnchanged(t *testing.T) {
+	ca, caKey := testTLSCA(t)
+	certFile, keyFile, _ := writeTestClientCert(t, ca, caKey, "client-v1", 1)
+
+	reloader, err := newClientCertReloader(certFile, keyFile)
+	require.NoError(t, err)
+
+	first, err := reloader.getClientCertificate(nil)
+	require.NoError(t, err)
+	second, err := reloader.getClientCertificate(nil)
+	require.NoError(t, err)
+
+	assert.Same(t, first, second, "unchanged file must not trigger a reparse")
+}
+
+// TestClientCertReloaderKeepsServingCachedCertOnReloadFailure covers the
+// required degrade path: a rotated file that's briefly invalid (mid-write,
+// truncated) must not fail a live handshake. The last good cert keeps serving
+// until a subsequent, successful reload replaces it.
+func TestClientCertReloaderKeepsServingCachedCertOnReloadFailure(t *testing.T) {
+	ca, caKey := testTLSCA(t)
+	certFile, keyFile, certV1 := writeTestClientCert(t, ca, caKey, "client-v1", 1)
+
+	reloader, err := newClientCertReloader(certFile, keyFile)
+	require.NoError(t, err)
+
+	// Corrupt the cert file in place and bump mtime/size so changed() fires.
+	require.NoError(t, os.WriteFile(certFile, []byte("not a certificate"), 0o600))
+	futureTime := time.Now().Add(time.Hour)
+	require.NoError(t, os.Chtimes(certFile, futureTime, futureTime))
+
+	cert, err := reloader.getClientCertificate(nil)
+	require.NoError(t, err, "a broken rotated file must not fail the handshake")
+	require.NotNil(t, cert.Leaf)
+	assert.Equal(t, certV1.SerialNumber, cert.Leaf.SerialNumber, "must keep serving the last good cert")
+}
+
+// --- test fixtures -----------------------------------------------------
+
+func testTLSCA(t *testing.T) (*x509.Certificate, *ecdsa.PrivateKey) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Valkey_Test_CA"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	require.NoError(t, err)
+	cert, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+	return cert, key
+}
+
+func certPoolOf(certs ...*x509.Certificate) *x509.CertPool {
+	pool := x509.NewCertPool()
+	for _, cert := range certs {
+		pool.AddCert(cert)
+	}
+	return pool
+}
+
+func pemEncodeCert(cert *x509.Certificate) []byte {
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
+}
+
+// writeTestClientCert issues a fresh ca-signed client-auth cert/key pair
+// under CommonName cn and serial number, and writes them to a new temp dir.
+func writeTestClientCert(t *testing.T, ca *x509.Certificate, caKey *ecdsa.PrivateKey, cn string, serial int64) (certFile, keyFile string, cert *x509.Certificate) {
+	t.Helper()
+	dir := t.TempDir()
+	return writeTestClientCertAt(t, ca, caKey, filepath.Join(dir, "tls.crt"), filepath.Join(dir, "tls.key"), cn, serial)
+}
+
+// writeTestClientCertAt issues a fresh cert/key pair signed by ca and writes
+// it to an EXISTING path, standing in for cert-manager rewriting the same
+// file the reloader is already watching.
+func writeTestClientCertAt(t *testing.T, ca *x509.Certificate, caKey *ecdsa.PrivateKey, certFile, keyFile, cn string, serial int64) (certFileOut, keyFileOut string, cert *x509.Certificate) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := x509.Certificate{
+		SerialNumber:          big.NewInt(serial),
+		Subject:               pkix.Name{CommonName: cn},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &template, ca, &key.PublicKey, caKey)
+	require.NoError(t, err)
+	cert, err = x509.ParseCertificate(der)
+	require.NoError(t, err)
+
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	require.NoError(t, err)
+
+	require.NoError(t, os.WriteFile(certFile, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), 0o600))
+	require.NoError(t, os.WriteFile(keyFile, pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}), 0o600))
+
+	return certFile, keyFile, cert
+}
+
+// testServerTLSConfig builds a Valkey-stand-in server config that requires
+// and verifies a client certificate against ca, mirroring tls-auth-clients.
+func testServerTLSConfig(t *testing.T, ca *x509.Certificate, caKey *ecdsa.PrivateKey) *tls.Config {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	template := x509.Certificate{
+		SerialNumber:          big.NewInt(99),
+		Subject:               pkix.Name{CommonName: "valkey-test-server"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		DNSNames:              []string{"valkey-test.local"},
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &template, ca, &key.PublicKey, caKey)
+	require.NoError(t, err)
+
+	return &tls.Config{
+		Certificates: []tls.Certificate{{Certificate: [][]byte{der}, PrivateKey: key}},
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientCAs:    certPoolOf(ca),
+		MinVersion:   tls.VersionTLS12,
+	}
+}
+
+// doTestHandshake runs one real client/server TLS handshake over an in-memory
+// pipe and returns the certificate the server actually received from the
+// client -- the same thing crypto/tls would send over the wire to Valkey.
+func doTestHandshake(t *testing.T, clientConfig, serverConfig *tls.Config) *x509.Certificate {
+	t.Helper()
+
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+	defer serverConn.Close()
+
+	clientTLS := tls.Client(clientConn, clientConfig)
+	serverTLS := tls.Server(serverConn, serverConfig)
+
+	clientErr := make(chan error, 1)
+	go func() { clientErr <- clientTLS.Handshake() }()
+
+	require.NoError(t, serverTLS.Handshake())
+	require.NoError(t, <-clientErr)
+
+	peers := serverTLS.ConnectionState().PeerCertificates
+	require.NotEmpty(t, peers, "server must have received a client certificate")
+	return peers[0]
+}


### PR DESCRIPTION
Refs #560.

Certificates have a 90-day lifetime and renew at day 75. A process that loads its cert at startup keeps presenting the **old** one until it expires at day 90, then every handshake fails — roughly three months after a deploy, with nothing failing in between to explain it.

Go side switches from a static `tls.Config.Certificates` to `GetClientCertificate`, which Go invokes per handshake, backed by a mutex-guarded cache that re-reads only when the file's mtime or size changes. A failed reload keeps serving the last good cert rather than failing the handshake.

TypeScript side: `iovalkey` copies its `tls` options object on **every** `connect()`, including its own reconnects, so `cert`/`key` became getters backed by `readFileSync` instead of eagerly-read Buffers. Node has no per-handshake client-cert callback, so this is the equivalent seam.

Includes a test that proves rotation rather than describing it: handshake with cert v1, replace the file on disk, handshake again, assert the server received v2.