### PR TITLE
chore(k8s): use the native preStop sleep action instead of exec sleep

### DIFF
--- a/deploy/k8s/console-admin.yaml
+++ b/deploy/k8s/console-admin.yaml
@@ -282,8 +282,8 @@ spec:
             capabilities: {drop: ["ALL"]}
           lifecycle:
             preStop:
-              exec:
-                command: ["/bin/sh", "-c", "sleep 10"]
+              sleep:
+                seconds: 10
           livenessProbe:
             httpGet: {path: /healthz, port: 3000}
             periodSeconds: 30

--- a/deploy/k8s/console-dashboard.yaml
+++ b/deploy/k8s/console-dashboard.yaml
@@ -255,10 +255,10 @@ spec:
             capabilities: {drop: ["ALL"]}
           lifecycle:
             preStop:
-              exec:
-                # Give kube-proxy / traefik time to drain this endpoint
-                # before SIGTERM fires. Prevents connection-refused 500s during rolls.
-                command: ["/bin/sh", "-c", "sleep 10"]
+              # Give kube-proxy / traefik time to drain this endpoint
+              # before SIGTERM fires. Prevents connection-refused 500s during rolls.
+              sleep:
+                seconds: 10
           # scheme HTTPS: the server now terminates TLS on 3000 (see serve-node.js).
           livenessProbe:
             httpGet: {path: /healthz, port: 3000, scheme: HTTPS}

--- a/deploy/k8s/twitch-ingress.yaml
+++ b/deploy/k8s/twitch-ingress.yaml
@@ -249,13 +249,13 @@ spec:
             capabilities: {drop: ["ALL"]}
           lifecycle:
             preStop:
-              exec:
-                # Delay SIGTERM so cluster membership settles before the BEAM
-                # starts its shard drain (Ingress.Drain runs in prep_stop on
-                # SIGTERM: successor binds on a peer, then the local socket
-                # closes). Drain (~12s worst case) + this sleep must stay
-                # inside terminationGracePeriodSeconds.
-                command: ["/bin/sh", "-c", "sleep 10"]
+              # Delay SIGTERM so cluster membership settles before the BEAM
+              # starts its shard drain (Ingress.Drain runs in prep_stop on
+              # SIGTERM: successor binds on a peer, then the local socket
+              # closes). Drain (~12s worst case) + this sleep must stay
+              # inside terminationGracePeriodSeconds.
+              sleep:
+                seconds: 10
           livenessProbe:
             exec:
               command: ["/app/bin/ingress", "pid"]


### PR DESCRIPTION
`lifecycle.preStop.sleep.seconds` replaces `exec.command: ["sleep","10"]` in three manifests. KEP-3960 is GA and the cluster runs v1.35.5, so this drops a shell-out per pod termination.

`nats-leaf.yaml` is deliberately **not** converted — its preStop is `nats-server --signal ldm=...; sleep 36`, a sequenced signal-then-wait that the native sleep action cannot express. `nats.yaml` is left for the NATS workstream to avoid conflicting with the mTLS PR below.

Top of the stack.