### PR TITLE
chore(cilium): version cp1's masquerade override and the VLAN route migration

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -26,9 +26,13 @@ deploy/
 │               valkey / tailscale), and image-automation policies. Bootstrap
 │               sync path is deploy/flux/clusters/production. See flux/README.md.
 │
-└── ansible/    One-time bare-metal node provisioning (base tuning, firewall,
-                k3s agent, SELinux, SSH removal, tailscale). Not Flux-managed;
-                run via ansible/provision.sh. See ansible/README.md.
+├── ansible/    One-time bare-metal node provisioning (base tuning, firewall,
+│               k3s agent, SELinux, SSH removal, tailscale). Not Flux-managed;
+│               run via ansible/provision.sh. See ansible/README.md.
+│
+└── cilium/     CNI resources for the manual `helm upgrade --install` Cilium
+                release. Not Flux-managed -- Cilium is what Flux's cluster
+                runs on top of, so it cannot reconcile it. See cilium/README.md.
 ```
 
 ## Container build files

--- a/deploy/ansible/vlan-peer-routes-migration.md
+++ b/deploy/ansible/vlan-peer-routes-migration.md
@@ -1,0 +1,197 @@
+<!-- Copyright (c) 2026 Adam Ousmer. All rights reserved.
+     Proprietary. No license granted. See LICENSE.md. -->
+# Replace `cilium-vlan-peer-routes` with native NetworkManager routes
+
+**This is a one-time, hand-run migration procedure, not automation.** It lives
+here because `deploy/ansible/` is this repo's existing home for host/node
+material and every other file this touches (the private VLAN interface, the
+node inventory) is already documented there -- not because it should stay a
+markdown runbook long-term. Once it has been run against the fleet, delete
+this file; the standing rule on this repo is that runbooks rot and only code
+and tests stay on `main`. It was NOT folded into an Ansible role (unlike
+`roles/cilium_node_routes`, which does the same class of thing) because doing
+so correctly needs the current real inventory, and this branch only has
+`inventory.cluster.ini.example`, whose `[cluster]` section still names the
+VLAN trio `node4`/`node5`/`node6` with `node1` as the OCI control plane --
+that does not match the `node1`/`node2`/`node3` naming this migration was
+scoped against. Reconcile that naming before or while turning this into a
+role; do not assume the two schemes refer to the same hosts without checking.
+
+## Why NetworkManager instead of the systemd unit
+
+`/usr/local/sbin/cilium-vlan-peer-routes` + `cilium-vlan-peer-routes.service`
+install static host routes at boot, once, as a `oneshot` unit, and nothing
+re-asserts them afterward. That is a real failure class, not a theoretical
+one: the routes vanishing once already silently isolated a node -- strict
+`rp_filter` ate the asymmetric replies, and the only tell was
+`wg show <iface> dump` reporting `rx>0, tx>0, handshake=0` (data flowing one
+way, no fresh handshake). NetworkManager owns interface `eth1` already (see
+`roles/private_vlan`), and it reapplies everything in a connection profile,
+including static routes, on every activation -- boot, `connection up`,
+`device reapply`, NetworkManager restart -- so the class of "routes present
+at some point, silently gone later" goes away.
+
+**The live routing table does not change.** The `ip route replace` step
+below installs the exact same route the old script installs. Only where it
+is *persisted* changes: from a oneshot unit to the NetworkManager profile.
+That is deliberate -- it keeps this migration a no-op for traffic while it
+is in flight.
+
+## Address map
+
+Placeholders match the `{{ VAR }}` convention already used in
+`inventory.cluster.ini.example` and `render-inventory.sh`
+(`NODE1_PUBLIC_IP`, etc.) -- this repo is public, and per that file's own
+warning, committed node addresses "disclose which hosts form one cluster and
+which single host is the control plane." Resolve every placeholder from
+Doppler (`infra-bootstrap/prd`) or your own notes before running anything
+below; do not hardcode the real values into a copy of this file that gets
+committed.
+
+| Node  | Public IP placeholder | VLAN IP        |
+|-------|------------------------|-----------------|
+| node1 | `{{ NODE1_PUBLIC_IP }}` | `10.10.0.4`    |
+| node2 | `{{ NODE2_PUBLIC_IP }}` | `10.10.0.5`    |
+| node3 | `{{ NODE3_PUBLIC_IP }}` | `10.10.0.6`    |
+
+## 0. Per node: find the real NetworkManager connection name for eth1
+
+`roles/private_vlan` creates the profile as `conn_name: vlan-private`, but
+confirm it live before running anything that assumes it -- a manually
+recovered node or a re-run under a different name would make every command
+below silently target the wrong profile:
+
+```bash
+nmcli -t -f NAME,DEVICE connection show --active | grep ':eth1$'
+```
+
+Use the `NAME` field from that output (`$CONN` below) in every step. Assume
+`vlan-private` only after this confirms it.
+
+## 1. Persist the routes on the connection profile (per node)
+
+Run on each node, substituting that node's peers and its own public IP as
+`src`. This only writes the stored profile -- it does not touch the running
+system yet.
+
+**node1** (peers: node2, node3):
+```bash
+nmcli connection modify "$CONN" +ipv4.routes "{{ NODE2_PUBLIC_IP }}/32 10.10.0.5 src={{ NODE1_PUBLIC_IP }}"
+nmcli connection modify "$CONN" +ipv4.routes "{{ NODE3_PUBLIC_IP }}/32 10.10.0.6 src={{ NODE1_PUBLIC_IP }}"
+```
+
+**node2** (peers: node1, node3):
+```bash
+nmcli connection modify "$CONN" +ipv4.routes "{{ NODE1_PUBLIC_IP }}/32 10.10.0.4 src={{ NODE2_PUBLIC_IP }}"
+nmcli connection modify "$CONN" +ipv4.routes "{{ NODE3_PUBLIC_IP }}/32 10.10.0.6 src={{ NODE2_PUBLIC_IP }}"
+```
+
+**node3** (peers: node1, node2):
+```bash
+nmcli connection modify "$CONN" +ipv4.routes "{{ NODE1_PUBLIC_IP }}/32 10.10.0.4 src={{ NODE3_PUBLIC_IP }}"
+nmcli connection modify "$CONN" +ipv4.routes "{{ NODE2_PUBLIC_IP }}/32 10.10.0.5 src={{ NODE3_PUBLIC_IP }}"
+```
+
+The `src=` attribute is load-bearing, not cosmetic: without it the kernel
+picks whatever source the route selection algorithm would normally choose for
+that destination, the peer's WireGuard sees a reply from an address it does
+not recognise as the tunnel's endpoint, and its own reverse-path filter drops
+it -- the exact isolation failure this migration exists to make impossible.
+
+**Rollback (per route, per node):** `-ipv4.routes` with the identical string
+removes exactly that entry; nmcli matches by content, not by index. Confirm
+with step 3's `nmcli -g ipv4.routes` command that a route which no longer
+belongs is actually gone.
+```bash
+nmcli connection modify "$CONN" -ipv4.routes "{{ NODE2_PUBLIC_IP }}/32 10.10.0.5 src={{ NODE1_PUBLIC_IP }}"
+```
+
+## 2. Apply the same routes live (per node)
+
+Installs the routes on the running system immediately, without reactivating
+`$CONN` -- reactivating would flap the interface, and this node's peer
+connectivity depends on it staying up during the cutover. This step alone is
+what the old script already did every boot; nothing here changes behavior.
+
+**node1:**
+```bash
+ip route replace {{ NODE2_PUBLIC_IP }}/32 via 10.10.0.5 dev eth1 src {{ NODE1_PUBLIC_IP }}
+ip route replace {{ NODE3_PUBLIC_IP }}/32 via 10.10.0.6 dev eth1 src {{ NODE1_PUBLIC_IP }}
+```
+
+**node2:**
+```bash
+ip route replace {{ NODE1_PUBLIC_IP }}/32 via 10.10.0.4 dev eth1 src {{ NODE2_PUBLIC_IP }}
+ip route replace {{ NODE3_PUBLIC_IP }}/32 via 10.10.0.6 dev eth1 src {{ NODE2_PUBLIC_IP }}
+```
+
+**node3:**
+```bash
+ip route replace {{ NODE1_PUBLIC_IP }}/32 via 10.10.0.4 dev eth1 src {{ NODE3_PUBLIC_IP }}
+ip route replace {{ NODE2_PUBLIC_IP }}/32 via 10.10.0.5 dev eth1 src {{ NODE3_PUBLIC_IP }}
+```
+
+**Rollback:** re-run the identical `ip route replace` from the still-running
+old unit (`systemctl start cilium-vlan-peer-routes.service`), or delete the
+live route and let the old unit's next boot reinstall it:
+```bash
+ip route del {{ NODE2_PUBLIC_IP }}/32 dev eth1
+```
+
+## 3. Verify, on every node, before touching the old unit
+
+```bash
+nmcli -g ipv4.routes connection show "$CONN"
+ip route show | grep 10.10
+```
+
+Confirm every peer's `/32` is listed in both, with the right `via` and `src`.
+Then confirm the tunnel itself is healthy end to end -- this is the check
+that would have caught the prior silent isolation immediately instead of
+after the fact:
+
+```bash
+wg show <iface> dump   # e.g. flannel-wg; use whatever `wg show` lists here
+```
+
+Every peer line needs a recent handshake timestamp, not just nonzero
+rx/tx -- `rx>0, tx>0, handshake=0` is exactly the failure this migration
+exists to prevent from recurring silently.
+
+**Do not proceed to step 4 on ANY node until step 3 passes on ALL THREE.**
+The old unit is still live and still correct at this point; there is no time
+pressure to remove it early, and removing it before every peer confirms is
+how a partial cutover turns into the same asymmetric-route isolation this
+replaces.
+
+## 4. Disable and remove the old unit and script (only after step 3 passes fleet-wide)
+
+Back up before deleting, so rollback does not depend on redownloading or
+recreating the script from memory:
+
+```bash
+FRAGMENT=$(systemctl show -p FragmentPath --value cilium-vlan-peer-routes.service)
+mkdir -p /root/cilium-vlan-peer-routes.bak
+cp "$FRAGMENT" /usr/local/sbin/cilium-vlan-peer-routes /root/cilium-vlan-peer-routes.bak/
+```
+
+Then, per node:
+
+```bash
+systemctl disable --now cilium-vlan-peer-routes.service
+rm -f "$FRAGMENT" /usr/local/sbin/cilium-vlan-peer-routes
+systemctl daemon-reload
+systemctl reset-failed cilium-vlan-peer-routes.service 2>/dev/null || true
+```
+
+**Rollback:**
+```bash
+cp /root/cilium-vlan-peer-routes.bak/cilium-vlan-peer-routes /usr/local/sbin/
+cp /root/cilium-vlan-peer-routes.bak/cilium-vlan-peer-routes.service "$FRAGMENT"
+systemctl daemon-reload
+systemctl enable --now cilium-vlan-peer-routes.service
+```
+
+Re-run step 3's verification after rollback too -- restoring the unit does
+not by itself prove the routes it re-asserts still match what step 1 left in
+the NetworkManager profile.

--- a/deploy/cilium/README.md
+++ b/deploy/cilium/README.md
@@ -1,0 +1,36 @@
+<!-- Copyright (c) 2026 Adam Ousmer. All rights reserved.
+     Proprietary. No license granted. See LICENSE.md. -->
+# Cilium (manual Helm release)
+
+Cilium is installed with `helm upgrade --install`, not by Flux -- it is the
+CNI underneath the cluster Flux itself runs on, so it cannot depend on the
+thing it bootstraps. Nothing in `deploy/flux/` or `deploy/infra/` reconciles
+anything here, and nothing reverts a manual change made against the live
+release either. This directory exists so that any resource applied
+out-of-band still has a record in the repo of what should be live and why,
+even though applying it is a manual step.
+
+## Resources
+
+- `cp1-legacy-masquerade-nodeconfig.yaml` -- `CiliumNodeConfig` that disables
+  BPF masquerade on cp1 only, because cp1's egress interface has a secondary
+  public /32 the underlying cloud VNIC never registered, and BPF masquerade
+  SNATs to that address regardless of route selection. See the comment at the
+  top of the file for the full failure mode. Apply with:
+
+  ```
+  kubectl apply -f deploy/cilium/cp1-legacy-masquerade-nodeconfig.yaml
+  ```
+
+  Re-apply after any Cilium reinstall/upgrade that touches cp1 -- a fresh
+  install will not recreate this on its own.
+
+## Checking what's actually live
+
+`CiliumNodeConfig` and Helm values drift silently since nothing here is
+enforced. Before trusting this directory, diff it against the cluster:
+
+```
+kubectl get ciliumnodeconfig -n kube-system -o yaml
+helm get values cilium -n kube-system
+```

--- a/deploy/cilium/cp1-legacy-masquerade-nodeconfig.yaml
+++ b/deploy/cilium/cp1-legacy-masquerade-nodeconfig.yaml
@@ -1,0 +1,63 @@
+# Copyright (c) 2026 Adam Ousmer. All rights reserved.
+# Proprietary. No license granted. See LICENSE.md.
+
+# Disables Cilium's BPF masquerade on cp1 ONLY, falling back to iptables
+# masquerade for pod egress on that one node. Everywhere else keeps BPF
+# masquerade as the Helm release's default; this CiliumNodeConfig overrides
+# nothing outside its nodeSelector.
+#
+# WHY, because it is not obvious from the diff:
+#
+# cp1's egress NIC carries two IPv4 addresses: the private address the cloud
+# provider's VNIC actually issued and holds the default route (so it is also
+# the route's preferred source), and the node's public address, attached as a
+# secondary /32. Cilium's BPF masquerade path SNATs pod egress to whatever
+# address Cilium considers the node's InternalIP -- the public secondary --
+# regardless of what the kernel's own route selection would pick for that
+# destination. The cloud provider's VNIC enforces a source/destination check
+# and drops any packet whose source address the VNIC was not issued, so every
+# BPF-masqueraded packet leaving cp1 was silently dropped one hop upstream of
+# the host: deploys, cert issuance, and KEDA metrics scraping all lost pod
+# egress on cp1, while the host itself (which owns the private address) sat
+# perfectly healthy the entire time.
+#
+# iptables masquerade does not have this failure mode: MASQUERADE targets the
+# outgoing route's preferred source rather than a fixed node-IP config value.
+# For the on-link default route that resolves to the private address the VNIC
+# actually owns, so the provider's check passes.
+#
+# cp1 is the only node where the Cilium node IP differs from the address its
+# egress interface was actually issued, which is why this override is scoped
+# to cp1 alone and must not be widened: every other node's node IP already IS
+# its interface's preferred source, so BPF masquerade is correct there and
+# stays enabled by the Helm values. cp1 is also a 2-core control plane that
+# schedules no application pods, so trading away eBPF-accelerated masquerade
+# here for correctness has no throughput cost worth measuring.
+#
+# Diagnosed 2026-08-17. The decisive test: ping the on-link default gateway
+# from inside a pod network namespace on cp1. It failed while the identical
+# ping from the host succeeded, and a tcpdump on the gateway-facing interface
+# showed the pod's echo request leaving with the node's PUBLIC address as
+# source against the gateway (a same-subnet-only address) as destination --
+# an off-subnet source on a destination that only exists on the local
+# segment, which is exactly what the provider's source/destination check
+# exists to drop.
+#
+# Cilium here is a manual Helm release, not Flux-managed (deploy/cilium/README.md),
+# so nothing reconciles or reverts this resource, but nothing recreates it
+# either. Re-apply it after any full Cilium reinstall or upgrade that touches
+# cp1, and check for it first if pod egress on cp1 ever goes fully dark again:
+#
+#   kubectl get ciliumnodeconfig -n kube-system cp1-legacy-masquerade
+#   kubectl apply -f deploy/cilium/cp1-legacy-masquerade-nodeconfig.yaml
+apiVersion: cilium.io/v2
+kind: CiliumNodeConfig
+metadata:
+  namespace: kube-system
+  name: cp1-legacy-masquerade
+spec:
+  nodeSelector:
+    matchLabels:
+      kubernetes.io/hostname: cp1
+  defaults:
+    enable-bpf-masquerade: "false"


### PR DESCRIPTION
Two pieces of infrastructure that existed only as live cluster state or a hand-written script.

**1. cp1's CiliumNodeConfig.** Applied live during an incident, in no file anywhere. Cilium is a manual Helm release, so nothing reverts it — but nothing recreates it either, and losing it silently kills *all* pod egress on cp1 (deploys, cert issuance, KEDA metrics).

The why, because it is deeply non-obvious: cp1's NIC carries two IPv4 addresses — the OCI VCN address the VNIC is registered with, and the public IP. Cilium's **BPF** masquerade SNATs to the node's InternalIP; **iptables** masquerade uses the route's preferred source. OCI's VNIC source/destination check drops traffic from an address the VNIC isn't registered with, so BPF masquerade produced total pod-egress loss while the host itself was fine. cp1 is the only node where node-ip differs from the egress interface's registered address.

**2. The VLAN peer-route migration.** `cilium-vlan-peer-routes` is a oneshot systemd unit that installs static host routes and has nothing re-asserting them — when they vanished, strict rp_filter ate the asymmetric replies and silently isolated a node. NetworkManager owns the interface and reapplies its own routes on activation, which removes that failure class. Documents the per-node `+ipv4.routes` commands with the load-bearing `src=` attribute, verification, and rollback.