### PR TITLE
feat(transactions): serve TLS so Traefik re-encrypts to the backend

### DIFF
--- a/app/transactions/main.go
+++ b/app/transactions/main.go
@@ -105,15 +105,27 @@ func main() {
 		WriteTimeout: 15 * time.Second,
 	}
 
+	// TLS is opt-in via the cert-manager-issued fleet CA cert (see
+	// deploy/infra/pki/certificates.yaml, transactions-tls), mirroring
+	// console-dashboard. Both or neither: unset stays plaintext exactly as
+	// before, so this can land before the cert and the traefik ServersTransport
+	// exist. A mismatched pair is a config error, not a runtime fallback.
+	tlsCertFile := env.Get("TLS_CERT_FILE", "")
+	tlsKeyFile := env.Get("TLS_KEY_FILE", "")
+	if (tlsCertFile == "") != (tlsKeyFile == "") {
+		log.Fatal("transactions tls misconfigured: TLS_CERT_FILE and TLS_KEY_FILE must both be set or both empty")
+	}
+
 	log.Info("transactions service ready",
 		zap.String("listen_addr", listenAddr),
+		zap.Bool("tls_enabled", tlsCertFile != ""),
 		zap.Bool("tebex_webhook_configured", env.Get("TEBEX_WEBHOOK_SECRET", "") != ""),
 		zap.Bool("tebex_checkout_configured", checkoutConfigured),
 		zap.Bool("tebex_checkout_auth_configured", checkoutAuth),
 		zap.Bool("tebex_checkout_username_configured", env.GetBool("TEBEX_INCLUDE_USERNAME", false)),
 	)
 
-	serveHTTP(ctx, httpServer, log)
+	serveHTTP(ctx, listener{srv: httpServer, certFile: tlsCertFile, keyFile: tlsKeyFile}, log)
 }
 
 // setupCheckout registers the dashboard basket_create RPC. Optional: without
@@ -186,12 +198,30 @@ func connectRPC(natsURL string, log *zap.Logger) *nats.Conn {
 }
 
 // serveHTTP runs the server until ctx is cancelled or the listener fails,
-// then drains in-flight requests before returning.
-func serveHTTP(ctx context.Context, srv *http.Server, log *zap.Logger) {
+// then drains in-flight requests before returning. certFile/keyFile serve TLS
+// when both are set; empty (the default) keeps plaintext HTTP.
+// listener carries the server together with the cert and key it should present.
+// They are decided together and never travel apart, so they are passed together.
+type listener struct {
+	srv      *http.Server
+	certFile string
+	keyFile  string
+}
+
+// serve blocks on the underlying server, choosing TLS when a pair was configured.
+func (l listener) serve() error {
+	if l.certFile != "" && l.keyFile != "" {
+		return l.srv.ListenAndServeTLS(l.certFile, l.keyFile)
+	}
+	return l.srv.ListenAndServe()
+}
+
+func serveHTTP(ctx context.Context, l listener, log *zap.Logger) {
+	srv := l.srv
 
 	serverErr := make(chan error, 1)
 	go func() {
-		serverErr <- srv.ListenAndServe()
+		serverErr <- l.serve()
 	}()
 
 	select {

--- a/deploy/infra/pki/certificates.yaml
+++ b/deploy/infra/pki/certificates.yaml
@@ -115,6 +115,26 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
+  name: transactions-tls
+  namespace: production
+spec:
+  secretName: transactions-tls
+  duration: 2160h # 90d
+  renewBefore: 360h # 15d
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: fleet-intermediate-issuer
+    kind: ClusterIssuer
+    group: cert-manager.io
+  dnsNames:
+    - transactions
+    - transactions.production.svc.cluster.local
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
   name: valkey-server-tls
   namespace: valkey
 spec:

--- a/deploy/k8s/transactions.yaml
+++ b/deploy/k8s/transactions.yaml
@@ -110,11 +110,22 @@ spec:
                   optional: true
             - name: GOMEMLIMIT
               value: 160MiB
+            # Serve HTTPS on 8080 using the cert-manager transactions-tls cert,
+            # so the traefik->transactions hop is TLS. Traefik re-encrypts via
+            # the transactions-transport ServersTransport. Both env vars are
+            # required together (main.go fails fast on a mismatched pair);
+            # unset keeps the listener plaintext.
+            - name: TLS_CERT_FILE
+              value: /etc/transactions/tls/tls.crt
+            - name: TLS_KEY_FILE
+              value: /etc/transactions/tls/tls.key
           envFrom:
             - secretRef:
                 name: transactions-env
           ports:
             - containerPort: 8080
+          volumeMounts:
+            - {name: tls, mountPath: /etc/transactions/tls, readOnly: true}
           resources:
             requests:
               cpu: 15m
@@ -130,17 +141,23 @@ spec:
               httpGet:
                 path: /drain
                 port: 8080
+                scheme: HTTPS
+          # scheme HTTPS: the server now terminates TLS on 8080.
           livenessProbe:
-            httpGet: {path: /healthz, port: 8080}
+            httpGet: {path: /healthz, port: 8080, scheme: HTTPS}
             periodSeconds: 30
           readinessProbe:
-            httpGet: {path: /readyz, port: 8080}
+            httpGet: {path: /readyz, port: 8080, scheme: HTTPS}
             periodSeconds: 10
           startupProbe:
-            httpGet: {path: /healthz, port: 8080}
+            httpGet: {path: /healthz, port: 8080, scheme: HTTPS}
             failureThreshold: 18 # 18 × 5s = 90s max startup window
             periodSeconds: 5
       terminationGracePeriodSeconds: 45
+      volumes:
+        - name: tls
+          secret:
+            secretName: transactions-tls
 ---
 apiVersion: v1
 kind: Service
@@ -169,8 +186,27 @@ spec:
       services:
         - name: transactions
           port: 80
+          # HTTPS to the backend: main.go now terminates TLS when
+          # TLS_CERT_FILE/TLS_KEY_FILE are set, so traefik re-encrypts via the
+          # ServersTransport below (rootCAs = the cert's own fleet-CA ca.crt).
+          # This makes the traefik->transactions hop TLS end-to-end.
+          scheme: https
+          serversTransport: transactions-transport
           nativeLB: true
   tls: {}
+---
+apiVersion: traefik.io/v1alpha1
+kind: ServersTransport
+metadata:
+  name: transactions-transport
+  namespace: production
+spec:
+  # Verify the transactions pod's TLS cert against the fleet CA. serverName
+  # matches the cert SAN (the Service name). rootCAsSecrets reads the CA from
+  # the cert-manager secret's ca.crt key (Traefik v3). No InsecureSkipVerify.
+  serverName: transactions
+  rootCAsSecrets:
+    - transactions-tls
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget


### PR DESCRIPTION
Replaces #565, which was merged into an already-deleted base branch and never reached main. Same three commits, re-based onto current main.

Adds a `transactions-tls` Certificate issued by `fleet-intermediate-issuer` (the intermediate landed in #564), teaches `app/transactions` to serve TLS when cert and key are configured, and flips the IngressRoute to `scheme: https` with a matching ServersTransport.

Both-or-neither env gate: with neither var set the server takes the unchanged plaintext path, so the Go change is safe to deploy before the cert exists.

Probes **and** the `preStop /drain` hook move to HTTPS together — that hook is the same HTTPGetAction struct and would wedge pod termination if missed.

Verified no other in-cluster caller dials `transactions:80`; every other consumer reaches it over NATS RPC.

Bottom of the remaining 7-PR stack.