### PR TITLE
fix(nats): enforce RPC-on-leaves, streams-on-hub and drop dead wiring

### DIFF
--- a/deploy/k8s/gossip.yaml
+++ b/deploy/k8s/gossip.yaml
@@ -98,14 +98,11 @@ spec:
           env:
             - name: NATS_HOST
               value: nats
-            # Split planes: the BUS / JetStream connection dials the hub directly
-            # (NATS_HUB_URL) so stream traffic never pays a leaf forwarding hop;
-            # the RPC + cache plane (NATS_RPC_URL / NATS_LEAF_URL) stays on the
-            # node-local leaf. NATS_URL is the local-dev fallback only.
+            # gossip is RPC-only: it answers sesame's requests over
+            # bagel.rpc.gossip.> and never touches JetStream, so it dials the
+            # leaf exclusively (no NATS_HUB_URL) and carries no BUS credential.
             - name: NATS_URL
               value: nats://nats-leaf:4222
-            - name: NATS_HUB_URL
-              value: nats://nats:4222
             # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS
             # server's native-TLS cert; read as RootCAs by pkg/bus (Go services)
             # and the console nats lib (TS).

--- a/deploy/k8s/nats-auth.conf
+++ b/deploy/k8s/nats-auth.conf
@@ -162,17 +162,6 @@ accounts: {
         }
       },
       {
-        # transactions: records Tebex transactions, emits transaction events.
-        # (Its checkout RPC lives in TRANSACTIONS_RPC.)
-        user: "transactions_bus"
-        password: $NATS_BCRYPT_TRANSACTIONS_BUS
-        permissions: {
-          # Publisher only: the subject permission is sufficient for PubAcks.
-          publish:   { allow: ["data.transactions.>"] }
-          subscribe: { allow: ["_INBOX.>"] }
-        }
-      },
-      {
         # projector: folds data.> events into Valkey, consumes the stream.online
         # event, requests reproject, and escalates a cold live query onto the
         # outgress system lane (rpc/live.go) so a channel with no projected live

--- a/deploy/k8s/nats-secrets.py
+++ b/deploy/k8s/nats-secrets.py
@@ -48,8 +48,9 @@ SERVICES = {
     "gossip": "gossip",
 }
 NO_RPC: set[str] = set()
-# gossip is RPC-only (no JetStream/event plane), so it gets no BUS user.
-NO_BUS: set[str] = {"gossip"}
+# gossip, notifications and transactions are RPC-only (no JetStream/event
+# plane): none of the three ever dial the hub, so none gets a BUS user.
+NO_BUS: set[str] = {"gossip", "notifications", "transactions"}
 
 def gen() -> str:
     # URL-safe (hex) so the plaintext is valid inside the leaf nats-leaf:// URLs.

--- a/deploy/k8s/nats_auth_acceptance_test.go
+++ b/deploy/k8s/nats_auth_acceptance_test.go
@@ -240,7 +240,7 @@ func (h *acceptanceHarness) assertDestructiveOperationsDenied(t *testing.T) {
 	t.Helper()
 	identities := []serviceIdentity{
 		{"users_bus"}, {"commands_bus"}, {"modules_bus"}, {"loyalty_bus"},
-		{"transactions_bus"}, {"projector_bus"}, {"worker_bus"}, {"outgress_bus"},
+		{"projector_bus"}, {"worker_bus"}, {"outgress_bus"},
 		{"twitch_ingress_bus"}, {"dashboard_bus"},
 	}
 	for _, identity := range identities {

--- a/deploy/k8s/nats_auth_test.go
+++ b/deploy/k8s/nats_auth_test.go
@@ -42,7 +42,7 @@ func TestServiceBusJetStreamPermissionsAreExact(t *testing.T) {
 	}
 	serviceUsers := []string{
 		"users_bus", "commands_bus", "modules_bus", "loyalty_bus",
-		"transactions_bus", "projector_bus", "worker_bus", "outgress_bus",
+		"projector_bus", "worker_bus", "outgress_bus",
 		"twitch_ingress_bus", "dashboard_bus",
 	}
 

--- a/deploy/k8s/notifications.yaml
+++ b/deploy/k8s/notifications.yaml
@@ -80,14 +80,13 @@ spec:
           env:
             - name: NATS_HOST
               value: nats
-            # JetStream goes straight to the HA hub. RPC prefers the strict
-            # same-node leaf and falls back directly to the hub.
+            # notifications is RPC-only: it never touches JetStream, so it
+            # dials the leaf exclusively (no NATS_HUB_URL) and carries no BUS
+            # credential.
             - name: NATS_URL
-              value: nats://nats:4222
+              value: nats://nats-leaf-local:4222
             - name: NATS_RPC_URL
               value: nats://nats-leaf-local:4222
-            - name: NATS_HUB_URL
-              value: nats://nats:4222
             # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS
             # server's native-TLS cert; read as RootCAs by pkg/bus (Go services)
             # and the console nats lib (TS).
@@ -193,12 +192,12 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
+                # RPC-only, same as the main container: leaf exclusively, no
+                # NATS_HUB_URL, no BUS credential.
                 - name: NATS_URL
-                  value: nats://nats:4222
+                  value: nats://nats-leaf-local:4222
                 - name: NATS_RPC_URL
                   value: nats://nats-leaf-local:4222
-                - name: NATS_HUB_URL
-                  value: nats://nats:4222
                 # Fleet CA to verify the NATS server TLS cert (NATS out of the mesh).
                 - name: NATS_CA_PEM
                   valueFrom:

--- a/deploy/k8s/transactions.yaml
+++ b/deploy/k8s/transactions.yaml
@@ -71,15 +71,13 @@ spec:
           env:
             - name: NATS_HOST
               value: nats
-            # Split planes: the BUS JetStream publisher dials the hub directly
-            # (NATS_HUB_URL) so it never pays a leaf forwarding hop; the
-            # TRANSACTIONS_RPC checkout responder stays on the node-local leaf.
+            # transactions is RPC-only: the checkout/billing/gift-notify verbs
+            # all ride the TRANSACTIONS_RPC responder on the node-local leaf; it
+            # never touches JetStream, so no NATS_HUB_URL and no BUS credential.
             # RPC creds (NATS_RPC_USER/PASSWORD) and the Tebex Headless secrets
             # (TEBEX_WEBSTORE_TOKEN, TEBEX_PACKAGE_ID) ride in via envFrom from Doppler.
             - name: NATS_URL
               value: nats://nats-leaf:4222
-            - name: NATS_HUB_URL
-              value: nats://nats:4222
             # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS
             # server's native-TLS cert; read as RootCAs by pkg/bus (Go services)
             # and the console nats lib (TS).


### PR DESCRIPTION
Enforces the invariant that RPC goes to the leaf cluster and JetStream goes to the hub.

Three services were wired to the hub without using it, all traceable to one commit (`9cc36dee`) that templated BUS+RPC accounts onto every service without checking which needed BUS:

- **gossip** — set `NATS_HUB_URL` but its config struct has no such field. Dead env var, silently ignored.
- **notifications** — resolved to `NATS_RPC_URL` and hit the leaf regardless; its `notifications_bus` credential was orphaned (generated but never defined in auth.conf).
- **transactions** — had a **real, non-orphaned** `transactions_bus` account with a publish grant on `data.transactions.>` that nothing has ever published to. Removing it is a least-privilege win.

Audited all 13 NATS-talking services from source, not manifests, to classify RPC vs streams vs both. Shrinks the hub client list from 11 to 10, which matters for the mTLS PR above.

Bottom of stack #582.