### PR TITLE
feat(nats): require client certificates on the hub and leaf listeners

### DIFF
--- a/app/ingress/config/runtime.exs
+++ b/app/ingress/config/runtime.exs
@@ -269,12 +269,22 @@ nats_cacerts =
 # boot-time crash, loud and in one place, not a silent gap that only
 # surfaces once the hub/leaf verify:true lands.
 #
-# KNOWN GAP: nothing here watches these files for renewal. Gnat's :ssl option
-# reads certfile/keyfile from disk once, at connect time; cert-manager
-# rotates nats-bus-client-tls in place before expiry, and a long-lived
-# connection that never reconnects across the rotation window keeps
-# presenting the expired cert — an unexplained connect failure weeks after
-# deploy, not at deploy time. Not solved here.
+# ROTATION: certfile/keyfile below are PATHS, not file content, and that is
+# what makes this rotation-safe already, with no extra code. Erlang/OTP's
+# :ssl reads certfile/keyfile off disk at connection setup for EACH new TLS
+# connection it makes -- it is not a one-time load cached for the life of the
+# BEAM node. Gnat re-establishes a fresh :ssl connection on every reconnect
+# (a dropped TCP link, a hub/leaf roll, ...), so every reconnect after
+# cert-manager rewrites this path (renewal lands at day 75 of the cert's
+# 90-day lifetime) picks up the rotated content automatically. This is the
+# same rotation-safety pkg/bus/connect.go gets from a
+# tls.Config.GetClientCertificate callback and console/shared's nats.ts gets
+# from nats.js's certFile option -- three different mechanisms converging on
+# the same property: read the path fresh per connection, never cache the
+# bytes for the process lifetime. An already-open connection is not
+# re-validated mid-session and keeps working on the old cert until it
+# naturally reconnects; since the old cert stays valid to day 90 and renewal
+# lands at day 75, any reconnect in that 15-day window is enough.
 nats_client_certfile = "/etc/nats/client-certs/tls.crt"
 nats_client_keyfile = "/etc/nats/client-certs/tls.key"
 

--- a/app/ingress/config/runtime.exs
+++ b/app/ingress/config/runtime.exs
@@ -263,10 +263,11 @@ nats_cacerts =
 # this is the single Elixir chokepoint: presenting a client cert to a
 # listener that does not (yet) require one is harmless.
 #
-# NOT YET REQUIRED: nats_client_cert_present being false just leaves ssl_opts
-# exactly as it was (server-auth only, today's behavior), so this can ship
-# and be confirmed present on the pod ahead of the hub/leaf verify:true that
-# will actually require it.
+# NOW REQUIRED whenever TLS itself is on (nats_cacerts set): this Deployment
+# was confirmed presenting a cert under the prior, permissive commit before
+# this one shipped, so the raise below turns a missing/unreadable cert into a
+# boot-time crash, loud and in one place, not a silent gap that only
+# surfaces once the hub/leaf verify:true lands.
 #
 # KNOWN GAP: nothing here watches these files for renewal. Gnat's :ssl option
 # reads certfile/keyfile from disk once, at connect time; cert-manager
@@ -280,6 +281,10 @@ nats_client_keyfile = "/etc/nats/client-certs/tls.key"
 nats_client_cert_present =
   File.exists?(nats_client_certfile) and File.exists?(nats_client_keyfile)
 
+if nats_cacerts && !nats_client_cert_present do
+  raise "nats mTLS client certificate required but not found at #{nats_client_certfile}"
+end
+
 nats_server = fn host, user, pass ->
   # Required for local-first HA: a missing node-qualified responder must return
   # immediately so Ingress.Rpc can safely fall back to the generic queue.
@@ -288,21 +293,17 @@ nats_server = fn host, user, pass ->
   base =
     if nats_cacerts do
       # SNI must match a cert SAN — the Service name (nats / nats-leaf).
-      ssl_opts = [
-        verify: :verify_peer,
-        cacerts: nats_cacerts,
-        server_name_indication: String.to_charlist(host),
-        depth: 3
-      ]
-
-      ssl_opts =
-        if nats_client_cert_present do
-          Keyword.merge(ssl_opts, certfile: nats_client_certfile, keyfile: nats_client_keyfile)
-        else
-          ssl_opts
-        end
-
-      Map.merge(base, %{tls: true, ssl_opts: ssl_opts})
+      Map.merge(base, %{
+        tls: true,
+        ssl_opts: [
+          verify: :verify_peer,
+          cacerts: nats_cacerts,
+          server_name_indication: String.to_charlist(host),
+          depth: 3,
+          certfile: nats_client_certfile,
+          keyfile: nats_client_keyfile
+        ]
+      })
     else
       base
     end

--- a/app/ingress/config/runtime.exs
+++ b/app/ingress/config/runtime.exs
@@ -253,6 +253,33 @@ nats_cacerts =
       nil
   end
 
+# mTLS: fixed mount path this Deployment gets via the fleet-wide kustomize
+# patch in deploy/k8s/kustomization.yaml (the nats-bus-client-tls Secret,
+# issued in deploy/infra/pki/certificates.yaml) — not a per-service env var.
+# Same path pkg/bus/connect.go and console/shared/lib/server/nats.ts read by
+# default; see connect.go's header for why a fixed path replaced the original
+# per-service env var design. Applied to both nats_server call sites below
+# (RPC to the leaf and BUS to the hub) via the one function both share, so
+# this is the single Elixir chokepoint: presenting a client cert to a
+# listener that does not (yet) require one is harmless.
+#
+# NOT YET REQUIRED: nats_client_cert_present being false just leaves ssl_opts
+# exactly as it was (server-auth only, today's behavior), so this can ship
+# and be confirmed present on the pod ahead of the hub/leaf verify:true that
+# will actually require it.
+#
+# KNOWN GAP: nothing here watches these files for renewal. Gnat's :ssl option
+# reads certfile/keyfile from disk once, at connect time; cert-manager
+# rotates nats-bus-client-tls in place before expiry, and a long-lived
+# connection that never reconnects across the rotation window keeps
+# presenting the expired cert — an unexplained connect failure weeks after
+# deploy, not at deploy time. Not solved here.
+nats_client_certfile = "/etc/nats/client-certs/tls.crt"
+nats_client_keyfile = "/etc/nats/client-certs/tls.key"
+
+nats_client_cert_present =
+  File.exists?(nats_client_certfile) and File.exists?(nats_client_keyfile)
+
 nats_server = fn host, user, pass ->
   # Required for local-first HA: a missing node-qualified responder must return
   # immediately so Ingress.Rpc can safely fall back to the generic queue.
@@ -261,15 +288,21 @@ nats_server = fn host, user, pass ->
   base =
     if nats_cacerts do
       # SNI must match a cert SAN — the Service name (nats / nats-leaf).
-      Map.merge(base, %{
-        tls: true,
-        ssl_opts: [
-          verify: :verify_peer,
-          cacerts: nats_cacerts,
-          server_name_indication: String.to_charlist(host),
-          depth: 3
-        ]
-      })
+      ssl_opts = [
+        verify: :verify_peer,
+        cacerts: nats_cacerts,
+        server_name_indication: String.to_charlist(host),
+        depth: 3
+      ]
+
+      ssl_opts =
+        if nats_client_cert_present do
+          Keyword.merge(ssl_opts, certfile: nats_client_certfile, keyfile: nats_client_keyfile)
+        else
+          ssl_opts
+        end
+
+      Map.merge(base, %{tls: true, ssl_opts: ssl_opts})
     else
       base
     end

--- a/console/shared/lib/server/nats.ts
+++ b/console/shared/lib/server/nats.ts
@@ -221,15 +221,19 @@ function options(role: Role): ConnectionOptions {
   // console-dashboard and console-admin import, so one change here covers
   // both deployments' 'bus' and 'rpc' connections.
   //
-  // NOT YET REQUIRED: a missing cert leaves opts.tls exactly as assigned
-  // above (server-auth only, today's behavior), so this can ship and be
-  // confirmed present on both pods ahead of the verify:true that will
-  // actually require it.
+  // NOW REQUIRED whenever TLS itself is on (caPem set): both console
+  // deployments were confirmed presenting a cert under the prior, permissive
+  // commit before this one shipped, so a missing/unreadable cert here is a
+  // thrown error at connect time, loud and in one place, not a silent gap
+  // that only surfaces once the hub/leaf verify:true lands.
   if (caPem) {
     const clientCert = loadClientCert();
-    if (clientCert) {
-      opts.tls = { ca: caPem, cert: clientCert.cert, key: clientCert.key };
+    if (!clientCert) {
+      throw new Error(
+        `nats mTLS client certificate required but unavailable at ${CLIENT_CERT_FILE}`
+      );
     }
+    opts.tls = { ca: caPem, cert: clientCert.cert, key: clientCert.key };
   }
   return opts;
 }

--- a/console/shared/lib/server/nats.ts
+++ b/console/shared/lib/server/nats.ts
@@ -5,7 +5,7 @@
 // reused across requests (connection setup is the expensive part; a warm conn
 // keeps request/reply in the low-ms range, which is what the p99 budget needs).
 import newrelic from 'newrelic';
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync } from 'node:fs';
 import {
   connect,
   JSONCodec,
@@ -25,29 +25,36 @@ const jc = JSONCodec();
 // Same path pkg/bus/connect.go and app/ingress/config/runtime.exs read by
 // default; see connect.go's header for why a fixed path replaced the
 // original per-service env var design.
+//
+// ROTATION: passed to nats.js as `certFile`/`keyFile` (paths), deliberately
+// NOT read into `cert`/`key` (inline content) by this file. nats.js's Node
+// transport (loadClientCerts in node_transport.js) reads certFile/keyFile
+// fresh off disk on every dial attempt — including nats.js's own internal
+// automatic reconnects (dodialLoop in protocol.js calls transport.connect
+// again on every retry, which re-reads the files each time; verified against
+// the installed nats@2.29.2 package). A one-time read into inline PEM
+// content would defeat that: this module's own options() only gets
+// re-invoked by localLeafReady/get() on a fully cold dial, not on nats.js's
+// internal reconnect loop, which reuses the ConnectionOptions object it was
+// first constructed with — a captured PEM string in that object would never
+// change no matter how many times the connection reconnects. A path string
+// has no such problem: cert-manager rotates nats-bus-client-tls in place (a
+// content change at the SAME path, not a new file), so the next reconnect
+// after rotation picks it up with no extra code, mirroring
+// pkg/bus/connect.go's GetClientCertificate callback and Erlang/OTP's own
+// per-connect certfile read in app/ingress/config/runtime.exs. An
+// already-open connection is not re-validated mid-session and keeps working
+// on the old cert until it naturally reconnects; since cert-manager renews
+// at day 75 of a 90-day cert, any reconnect in that 15-day window is enough.
 const CLIENT_CERT_FILE = '/etc/nats/client-certs/tls.crt';
 const CLIENT_KEY_FILE = '/etc/nats/client-certs/tls.key';
 
-// loadClientCert reads this service's mTLS client certificate from the fixed
-// mount path, or returns undefined when the files are not there yet (not a
-// hard failure — see the NOT YET REQUIRED note on its call site) or fail to
-// read.
-//
-// KNOWN GAP: nothing here watches these files for renewal. cert-manager
-// rotates nats-bus-client-tls in place before expiry; this process only
-// reads the files when a connection actually (re)dials, so a long-running
-// pod that never reconnects across the rotation window keeps presenting the
-// expired cert in memory until its next TLS handshake — an unexplained
-// connect failure weeks after deploy, not a startup-time error. Not solved
-// here.
-function loadClientCert(): { cert: string; key: string } | undefined {
-  if (!existsSync(CLIENT_CERT_FILE) || !existsSync(CLIENT_KEY_FILE)) return undefined;
-  try {
-    return { cert: readFileSync(CLIENT_CERT_FILE, 'utf8'), key: readFileSync(CLIENT_KEY_FILE, 'utf8') };
-  } catch (err) {
-    console.error('nats client cert unreadable', CLIENT_CERT_FILE, err);
-    return undefined;
-  }
+// clientCertMounted reports whether both files exist right now. Checked once
+// per cold dial (see options()'s call site) — cheap existence checks, not a
+// read of the file content, so nats.js's own loadClientCerts still does the
+// actual (rotation-safe) read at connect time.
+function clientCertMounted(): boolean {
+  return existsSync(CLIENT_CERT_FILE) && existsSync(CLIENT_KEY_FILE);
 }
 
 // Collapse numeric/id path tokens so per-subject RPC segments stay low-cardinality
@@ -219,21 +226,22 @@ function options(role: Role): ConnectionOptions {
   // — presenting a client cert to a listener that does not (yet) require one
   // is harmless, and this console lib is the single TS chokepoint both
   // console-dashboard and console-admin import, so one change here covers
-  // both deployments' 'bus' and 'rpc' connections.
+  // both deployments' 'bus' and 'rpc' connections. certFile/keyFile (not
+  // cert/key) is what makes this rotation-safe — see CLIENT_CERT_FILE's
+  // comment above.
   //
-  // NOW REQUIRED whenever TLS itself is on (caPem set): both console
-  // deployments were confirmed presenting a cert under the prior, permissive
-  // commit before this one shipped, so a missing/unreadable cert here is a
-  // thrown error at connect time, loud and in one place, not a silent gap
-  // that only surfaces once the hub/leaf verify:true lands.
+  // REQUIRED whenever TLS itself is on (caPem set): both console deployments
+  // were confirmed presenting a cert before this shipped, so a missing cert
+  // here is a thrown error at connect time, loud and in one place, not a
+  // silent gap that only surfaces once the hub/leaf verify:true lands. An
+  // unreadable-but-present file is nats.js's own error to raise (from
+  // loadClientCerts, at actual dial time) — this function only checks
+  // existence up front.
   if (caPem) {
-    const clientCert = loadClientCert();
-    if (!clientCert) {
-      throw new Error(
-        `nats mTLS client certificate required but unavailable at ${CLIENT_CERT_FILE}`
-      );
+    if (!clientCertMounted()) {
+      throw new Error(`nats mTLS client certificate required but unavailable at ${CLIENT_CERT_FILE}`);
     }
-    opts.tls = { ca: caPem, cert: clientCert.cert, key: clientCert.key };
+    opts.tls = { ca: caPem, certFile: CLIENT_CERT_FILE, keyFile: CLIENT_KEY_FILE };
   }
   return opts;
 }

--- a/console/shared/lib/server/nats.ts
+++ b/console/shared/lib/server/nats.ts
@@ -5,6 +5,7 @@
 // reused across requests (connection setup is the expensive part; a warm conn
 // keeps request/reply in the low-ms range, which is what the p99 budget needs).
 import newrelic from 'newrelic';
+import { existsSync, readFileSync } from 'node:fs';
 import {
   connect,
   JSONCodec,
@@ -17,6 +18,37 @@ import {
 import { requestLocalFirst, rpcSubjectsForNode } from './nats-rpc-locality';
 
 const jc = JSONCodec();
+
+// mTLS: fixed mount path this Deployment gets via the fleet-wide kustomize
+// patch in deploy/k8s/kustomization.yaml (the nats-bus-client-tls Secret,
+// issued in deploy/infra/pki/certificates.yaml) — not a per-service env var.
+// Same path pkg/bus/connect.go and app/ingress/config/runtime.exs read by
+// default; see connect.go's header for why a fixed path replaced the
+// original per-service env var design.
+const CLIENT_CERT_FILE = '/etc/nats/client-certs/tls.crt';
+const CLIENT_KEY_FILE = '/etc/nats/client-certs/tls.key';
+
+// loadClientCert reads this service's mTLS client certificate from the fixed
+// mount path, or returns undefined when the files are not there yet (not a
+// hard failure — see the NOT YET REQUIRED note on its call site) or fail to
+// read.
+//
+// KNOWN GAP: nothing here watches these files for renewal. cert-manager
+// rotates nats-bus-client-tls in place before expiry; this process only
+// reads the files when a connection actually (re)dials, so a long-running
+// pod that never reconnects across the rotation window keeps presenting the
+// expired cert in memory until its next TLS handshake — an unexplained
+// connect failure weeks after deploy, not a startup-time error. Not solved
+// here.
+function loadClientCert(): { cert: string; key: string } | undefined {
+  if (!existsSync(CLIENT_CERT_FILE) || !existsSync(CLIENT_KEY_FILE)) return undefined;
+  try {
+    return { cert: readFileSync(CLIENT_CERT_FILE, 'utf8'), key: readFileSync(CLIENT_KEY_FILE, 'utf8') };
+  } catch (err) {
+    console.error('nats client cert unreadable', CLIENT_CERT_FILE, err);
+    return undefined;
+  }
+}
 
 // Collapse numeric/id path tokens so per-subject RPC segments stay low-cardinality
 // in New Relic (e.g. `...status.12345` -> `...status.*`).
@@ -181,6 +213,24 @@ function options(role: Role): ConnectionOptions {
   // (local dev against a plaintext server) keeps the connection plaintext.
   const caPem = process.env.NATS_CA_PEM;
   if (caPem) opts.tls = { ca: caPem };
+  // mTLS: both the hub's 4222 listener (role 'bus') and the leaf's 4223
+  // listener (role 'rpc') require a client cert once their tls.verify:true
+  // lands (nats-server.conf / nats-leaf-server.conf). Applied to both roles
+  // — presenting a client cert to a listener that does not (yet) require one
+  // is harmless, and this console lib is the single TS chokepoint both
+  // console-dashboard and console-admin import, so one change here covers
+  // both deployments' 'bus' and 'rpc' connections.
+  //
+  // NOT YET REQUIRED: a missing cert leaves opts.tls exactly as assigned
+  // above (server-auth only, today's behavior), so this can ship and be
+  // confirmed present on both pods ahead of the verify:true that will
+  // actually require it.
+  if (caPem) {
+    const clientCert = loadClientCert();
+    if (clientCert) {
+      opts.tls = { ca: caPem, cert: clientCert.cert, key: clientCert.key };
+    }
+  }
   return opts;
 }
 

--- a/deploy/infra/pki/certificates.yaml
+++ b/deploy/infra/pki/certificates.yaml
@@ -14,6 +14,20 @@
 #
 # SANs must cover every name a peer dials: the Service name, its FQDN, and (for
 # the hub) the per-pod headless names used by the cluster routes.
+#
+# nats-bus-client-tls below is the one exception: a CLIENT cert, not a server
+# cert. The hub's 4222 listener and the leaf's 4223 listener both set
+# verify:true (nats-server.conf, nats-leaf-server.conf), so every service
+# connection to either must present a cert chaining to this same CA or the
+# TLS handshake is refused before auth.conf's bcrypt user/password check ever
+# runs. One shared cert for every connecting service is intentional, echoing
+# valkey-server-tls above: verify:true here is chain-of-trust only (NOT
+# verify_and_map), so it does not need a distinct identity per client — every
+# holder is equally trusted to attempt the existing per-account bcrypt auth,
+# exactly as before. commonName is a label, not a security boundary;
+# dnsNames/ipAddresses are irrelevant since nats-server's verify:true does not
+# hostname-check the CLIENT cert (only the reverse, server->client, direction
+# is SAN-sensitive, and that is nats-hub-tls/nats-leaf-tls above).
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -44,6 +58,32 @@ spec:
     - localhost
   ipAddresses:
     - 127.0.0.1
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: nats-bus-client-tls
+  namespace: production
+spec:
+  secretName: nats-bus-client-tls
+  duration: 2160h # 90d
+  renewBefore: 360h # 15d
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: fleet-intermediate-issuer
+    kind: ClusterIssuer
+    group: cert-manager.io
+  # cert-manager requires at least one of commonName/dnsNames/uris/ipAddresses;
+  # this is a client cert with no hostname meaning, so commonName is a plain
+  # label. usages defaults to ["digital signature", "key encipherment"] only —
+  # add "client auth" explicitly so the CA-issued cert states what it is for.
+  commonName: "nats-bus-client"
+  usages:
+    - digital signature
+    - key encipherment
+    - client auth
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate

--- a/deploy/k8s/kustomization.yaml
+++ b/deploy/k8s/kustomization.yaml
@@ -36,6 +36,91 @@ resources:
   - nats.yaml
   - nats-leaf.yaml
   - nats-auth-dopplersecret.yaml
+# mTLS: mounts the shared nats-bus-client-tls Secret (deploy/infra/pki/
+# certificates.yaml) into every service that dials the hub or the leaf, at
+# the fixed path pkg/bus/connect.go, console/shared/lib/server/nats.ts and
+# app/ingress/config/runtime.exs all read by default
+# (/etc/nats/client-certs/tls.{crt,key}). One patch instead of a hand-edit
+# per manifest: a forgotten per-service edit is exactly the failure mode this
+# avoids -- a service silently missing the mount would connect with no
+# client cert and only find out once the server's tls.verify:true lands.
+#
+# Split into three target groups because JSON6902 "add" cannot append to an
+# array key that does not exist yet on the target document (RFC 6902: "-"
+# addresses the element after the last one of an EXISTING array), but CAN
+# create a key that is entirely absent. All three targets use array index 0
+# for the container (never a name match), which is safe because every
+# Deployment/CronJob resource in this kustomization runs exactly one
+# container in its pod template -- verified against `kubectl kustomize
+# deploy/k8s` output, not assumed.
+#
+#   group A -- no volumes/volumeMounts key at all yet: commands, loyalty,
+#     projector, outgress, gossip, notifications, transactions,
+#     twitch-ingress, console-admin (9 Deployments). "add" creates the key.
+#   group B -- already carries a volumes/volumeMounts array (tink-keyset,
+#     fleet-ca or tls, per service): modules, sesame, users,
+#     console-dashboard (4 Deployments). "add .../-" appends without
+#     touching the existing entries.
+#   group C -- notifications-cleanup: a CronJob, not a Deployment, so it has
+#     its own pod template one level deeper
+#     (spec.jobTemplate.spec.template.spec) and needs its own target. It
+#     runs the same RPC-only NOTIFICATIONS_RPC credential as the
+#     notifications Deployment (leaf-only, args: ["cleanup"]), so it needs
+#     the cert too.
+#
+# transactions.yaml is deliberately not hand-edited (a separate branch,
+# feat/transactions-tls, is already carrying unrelated TLS work there) --
+# this patch reaches its Deployment anyway because it matches by kind/name
+# at the kustomize build layer, not by editing the file.
+patches:
+  - target:
+      kind: Deployment
+      name: "commands|loyalty|projector|outgress|gossip|notifications|transactions|twitch-ingress|console-admin"
+    patch: |-
+      - op: add
+        path: /spec/template/spec/volumes
+        value:
+          - name: nats-bus-client-tls
+            secret:
+              secretName: nats-bus-client-tls
+      - op: add
+        path: /spec/template/spec/containers/0/volumeMounts
+        value:
+          - name: nats-bus-client-tls
+            mountPath: /etc/nats/client-certs
+            readOnly: true
+  - target:
+      kind: Deployment
+      name: "modules|sesame|users|console-dashboard"
+    patch: |-
+      - op: add
+        path: /spec/template/spec/volumes/-
+        value:
+          name: nats-bus-client-tls
+          secret:
+            secretName: nats-bus-client-tls
+      - op: add
+        path: /spec/template/spec/containers/0/volumeMounts/-
+        value:
+          name: nats-bus-client-tls
+          mountPath: /etc/nats/client-certs
+          readOnly: true
+  - target:
+      kind: CronJob
+      name: "notifications-cleanup"
+    patch: |-
+      - op: add
+        path: /spec/jobTemplate/spec/template/spec/volumes
+        value:
+          - name: nats-bus-client-tls
+            secret:
+              secretName: nats-bus-client-tls
+      - op: add
+        path: /spec/jobTemplate/spec/template/spec/containers/0/volumeMounts
+        value:
+          - name: nats-bus-client-tls
+            mountPath: /etc/nats/client-certs
+            readOnly: true
 # NATS broker config, formerly created by apply-nats.sh. The configmaps hold
 # only the server conf + the auth conf ($ENV placeholders expanded at runtime
 # from the nats-auth-env secret). disableNameSuffixHash keeps the names stable

--- a/deploy/k8s/nats-leaf-server.conf
+++ b/deploy/k8s/nats-leaf-server.conf
@@ -9,9 +9,10 @@
 #   * plane split — RPC dials the leaf (serverList/NATS_LEAF_URL), JetStream
 #     dials the hub (busURL/NATS_HUB_URL) with JS domain "hub"; this file must
 #     keep the leaf JetStream-free or that split silently stops holding;
-#   * TLS posture — server-auth only against the fleet CA (tlsSecureOption/
-#     NATS_CA_PEM); clients authenticate with bcrypt user/password, so enabling
-#     `verify` on the client-facing listener here would break every service;
+#   * TLS posture — mTLS against the fleet CA (tlsSecureOption/NATS_CA_PEM
+#     for the server cert, clientCertFile/clientKeyFile for the client cert
+#     this listener's verify:true now requires); clients still authenticate
+#     with bcrypt user/password on top (auth.conf), unchanged;
 #   * keepalives — ping_interval/ping_max below pair with the client's
 #     PingInterval/MaxPingsOutstanding in baseOptions;
 #   * server_name prefix — failback.go matches the "<node>--" prefix to detect
@@ -40,13 +41,33 @@ ping_interval: "20s"
 ping_max: 3
 
 # Client-facing TLS for leaf-local app connections (RPC plane + any BUS fallback).
-# Server-auth only: clients verify this cert against the fleet CA and authenticate
-# with bcrypt user/password. Cert secret (nats-leaf-tls) is cert-manager-issued,
-# mounted at /etc/nats/certs; the reloader watches it for renewal hot-reload.
+# verify:true = mTLS, same posture and same nats-bus-client-tls cert as the
+# hub's 4222 listener (nats-server.conf) — plain chain-of-trust verification,
+# NOT verify_and_map; auth.conf's bcrypt user/password -> account mapping is
+# unchanged and still the only thing that decides which account a connection
+# lands in.
+# BLAST RADIUS is LARGER than the hub's: every RPC account in auth.conf dials
+# this listener, not just the 10 BUS-account clients above. That is USERS_RPC,
+# COMMANDS_RPC, MODULES_RPC, LOYALTY_RPC, PROJECTOR_RPC, OUTGRESS_RPC,
+# TRANSACTIONS_RPC, NOTIFICATIONS_RPC, GOSSIP_RPC, WORKER_RPC, DASHBOARD_RPC,
+# ADMIN_RPC and TWITCH_INGRESS_RPC — 13 accounts, counted directly off this
+# file's auth.conf, i.e. every fleet service including the three that hold no
+# BUS credential (transactions, gossip, notifications: RPC-only, per
+# nats-secrets.py's NO_BUS set, but still RPC clients of this port). The same
+# fixed-path load in pkg/bus/connect.go, console/shared/lib/server/nats.ts and
+# app/ingress/config/runtime.exs, and the same fleet-wide kustomize mount
+# patch, cover this listener too — there is no separate cert or separate
+# wiring for RPC vs BUS, only the one shared nats-bus-client-tls Secret.
+# Cert secret (nats-leaf-tls) is cert-manager-issued, mounted at
+# /etc/nats/certs; the reloader watches it for renewal hot-reload.
+# NOTE: same non-reloadable caveat as the hub's tls block — introducing/
+# changing this block is believed to need a rolling pod restart, not a bare
+# SIGHUP.
 tls {
   cert_file: "/etc/nats/certs/tls.crt"
   key_file:  "/etc/nats/certs/tls.key"
   ca_file:   "/etc/nats/certs/ca.crt"
+  verify: true
   timeout: 5
 }
 

--- a/deploy/k8s/nats-server.conf
+++ b/deploy/k8s/nats-server.conf
@@ -32,15 +32,40 @@ ping_max: 3
 
 # Client-facing TLS: the wire encryption for client connections, on top of the
 # WireGuard pod network.
-# verify:false = server-auth only: the server presents its cert and clients verify
-# it against the fleet CA (NATS_CA_PEM), but clients authenticate with their bcrypt
-# user/password (auth.conf), not client certs — so there are no per-service certs.
+# verify:true = mTLS: every client must now present a cert chaining to the
+# fleet CA (nats-bus-client-tls, see deploy/infra/pki/certificates.yaml) or
+# the TLS handshake fails before NATS' own CONNECT/auth step ever runs. This
+# is plain chain-of-trust verification, NOT verify_and_map: it does not
+# extract an identity from the cert and does not touch account resolution.
+# Every account/user mapping in auth.conf (bcrypt user/password -> BUS
+# account) is completely unchanged and still runs, now as a second,
+# independent authentication factor layered under the existing one. A client
+# with a valid cert but no/wrong bcrypt creds is still rejected by auth.conf
+# exactly as before; a client with valid creds but no cert never reaches that
+# check.
+# BLAST RADIUS: every one of the 10 BUS-account clients (users, commands,
+# modules, loyalty, projector, worker/sesame, outgress, twitch_ingress,
+# dashboard, admin — verified against this file's own auth.conf; transactions,
+# gossip and notifications are RPC-only and never dial this port, per
+# nats-secrets.py's NO_BUS set) needs its client cert mounted and wired in
+# BEFORE this flips to verify:true, or it fails closed at connect.
+# pkg/bus/connect.go, console/shared/lib/server/nats.ts and
+# app/ingress/config/runtime.exs all load the cert from one fixed mount path
+# by default now (no per-service env var), and deploy/k8s/kustomization.yaml
+# mounts the nats-bus-client-tls Secret into every Deployment/CronJob that
+# needs it via one fleet-wide kustomize patch.
 # The cert secret (nats-hub-tls) is issued by cert-manager and mounted at
 # /etc/nats/certs; the config-reloader watches it so renewals hot-reload on SIGHUP.
+# NOTE: unlike a cert-renewal content change, turning verify ON is believed to
+# need a rolling pod restart, not a bare SIGHUP — introducing/changing a TLS
+# block is not among the cases reload.go's diffOptions treats as
+# hot-reloadable (see this file's jetstream block above for the general
+# pattern of what is and is not reload-safe here).
 tls {
   cert_file: "/etc/nats/certs/tls.crt"
   key_file:  "/etc/nats/certs/tls.key"
   ca_file:   "/etc/nats/certs/ca.crt"
+  verify: true
   timeout: 5
 }
 

--- a/pkg/bus/connect.go
+++ b/pkg/bus/connect.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"sync"
 	"time"
 
 	"github.com/nats-io/nats.go"
@@ -56,14 +57,12 @@ import (
 // verify_and_map, so it layers under the existing auth rather than replacing
 // any part of it.
 //
-// KNOWN GAP: nothing here watches the mounted client cert file for renewal.
-// The NATS server pods have a config-reloader sidecar for their own server
-// cert; this client has no equivalent. cert-manager rotates
-// nats-bus-client-tls in place before expiry, but a long-lived connection
-// that never reconnects across the rotation window keeps using the
-// certificate that was loaded into memory at process start — surfacing as
-// an unexplained connect failure weeks after deploy (the next reconnect,
-// not a graceful cert swap), not at deploy time. Not solved here.
+// ROTATION: the client cert is loaded via a tls.Config.GetClientCertificate
+// callback (globalClientCert/clientCertCache below), not a one-time static
+// tls.Config.Certificates value, specifically so a cert-manager rotation
+// gets picked up on the next handshake instead of failing at expiry with no
+// warning in between. See clientCertCache's doc comment for the mechanism
+// and clientCertFile/clientKeyFile's for why it is a fixed path.
 
 // JSDomain is the JetStream domain the fleet's streams live in. Clients dial the
 // leaf (whose own JetStream domain is "leaf"), so every JetStream context must be
@@ -203,41 +202,104 @@ const (
 )
 
 // errNoClientCert marks "no cert at the mount path" as distinct from "a cert
-// is there but broken." tlsSecureOption treats the two differently: absent is
-// the expected state before the cert/mount has rolled out fleet-wide (or
-// before the enforcing commit lands), broken never is.
+// is there but broken." clientCertCache.get and tlsSecureOption treat the two
+// differently: absent means the fleet-wide mount has not landed on this pod
+// (or has been removed under it), broken means a real misconfiguration.
 var errNoClientCert = errors.New("no client certificate at mount path")
 
-// loadClientCert reads this service's mTLS client certificate from the fixed
-// mount path. Returns errNoClientCert, not a hard failure, when the files
-// simply are not there yet.
-func loadClientCert(certFile, keyFile string) (tls.Certificate, error) {
-	if _, err := os.Stat(certFile); err != nil {
-		return tls.Certificate{}, errNoClientCert
+// clientCertCache holds this process's parsed mTLS client certificate plus
+// the mtimes it was parsed from, so repeated handshakes do not each pay a
+// disk read + X509 parse — only a changed mtime does.
+//
+// This exists instead of a one-time load into tls.Config.Certificates
+// because a static value is captured once, at connection-option
+// construction, and never revisited: cert-manager renews nats-bus-client-tls
+// at day 75 of its 90-day lifetime, and a process that loaded the cert once
+// at startup would keep presenting the DAY-0 cert until day 90, then fail —
+// with nothing failing in between to warn anyone. That is a dated,
+// fleet-wide outage on a predictable schedule. tls.Config.GetClientCertificate
+// is invoked on every handshake (including nats.go's own automatic
+// reconnects), so wiring the cache's get method in as that callback (see
+// tlsSecureOption) makes every reconnect after day 75 pick up the rotated
+// file automatically — no watcher, no sidecar, no restart, no forced
+// reconnection logic. An already-open connection is not re-validated
+// mid-session, so it keeps working on the old cert until it naturally drops
+// (a hub/leaf roll, a network blip); since the old cert stays valid through
+// day 90 and renewal lands at day 75, any reconnect in that 15-day window is
+// enough.
+type clientCertCache struct {
+	mu     sync.Mutex
+	cert   *tls.Certificate
+	certAt time.Time
+	keyAt  time.Time
+}
+
+// get returns the parsed client certificate for certFile/keyFile, reusing
+// the cached parse when neither file's mtime has moved since the last call.
+// Returns errNoClientCert when the files are not there. A reload that fails
+// while a previous cert is already cached logs the failure and keeps serving
+// that previous cert — a transient or partial write to the mounted Secret
+// should not take an otherwise-healthy process's next handshake down.
+func (c *clientCertCache) get(certFile, keyFile string) (*tls.Certificate, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	certInfo, err := os.Stat(certFile)
+	if err != nil {
+		if c.cert != nil {
+			return c.cert, nil
+		}
+		return nil, errNoClientCert
 	}
+	keyInfo, err := os.Stat(keyFile)
+	if err != nil {
+		if c.cert != nil {
+			return c.cert, nil
+		}
+		return nil, errNoClientCert
+	}
+
+	if c.cert != nil && certInfo.ModTime().Equal(c.certAt) && keyInfo.ModTime().Equal(c.keyAt) {
+		return c.cert, nil
+	}
+
 	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
 	if err != nil {
-		return tls.Certificate{}, fmt.Errorf("load client cert %s: %w", certFile, err)
+		if c.cert != nil {
+			zap.L().Error("nats client cert reload failed, keeping previous cert",
+				zap.String("cert_file", certFile), zap.Error(err))
+			return c.cert, nil
+		}
+		return nil, fmt.Errorf("load client cert %s: %w", certFile, err)
 	}
-	return cert, nil
+
+	c.cert = &cert
+	c.certAt = certInfo.ModTime()
+	c.keyAt = keyInfo.ModTime()
+	return c.cert, nil
 }
+
+// globalClientCert is the one cache every connection in the process shares —
+// they all present the same fleet-wide cert at the same fixed path, so there
+// is nothing to gain from a cache per connection.
+var globalClientCert clientCertCache
 
 // tlsSecureOption returns a nats.Secure option that verifies the broker's server
 // cert against the fleet CA (NATS_CA_PEM, distributed by trust-manager as the
 // fleet-ca ConfigMap), or nil when no CA is configured — local dev against a
 // plaintext server stays plaintext. Also presents this service's own client
-// certificate (clientCertFile/clientKeyFile), which is now REQUIRED whenever
-// TLS itself is on: the hub's 4222 and leaf's 4223 listeners set
-// verify:true, so a connection with no client cert fails the TLS handshake
-// before auth.conf's bcrypt user/password check ever runs, and a process
-// that dialed with no cert would only find that out at connect time, over
-// and over, never coming up healthy.
+// certificate via GetClientCertificate (globalClientCert, rotation-safe —
+// see its doc comment), which is REQUIRED whenever TLS itself is on: the
+// hub's 4222 and leaf's 4223 listeners set verify:true, so a connection with
+// no client cert fails the TLS handshake before auth.conf's bcrypt
+// user/password check ever runs.
 //
-// NOW REQUIRED, no longer the permissive fallback of the prior commit: every
-// service was confirmed presenting a cert under that commit before this one
-// shipped, so a missing/unreadable cert here is a boot-time crash, loud and
-// in one place, not a silent gap that only surfaces once the hub/leaf
-// verify:true lands.
+// The eager get() call below (once per option-construction call, i.e. once
+// per process start and once per nats.go reconnect-loop entry) is what makes
+// a missing/unreadable cert a boot-time crash in one place rather than a
+// connect loop that just quietly never presents one — GetClientCertificate
+// alone would only surface the failure inside a handshake, indistinguishable
+// from any other connect failure in the logs.
 func tlsSecureOption() nats.Option {
 	caPEM := env.Get("NATS_CA_PEM", "")
 	if caPEM == "" {
@@ -247,15 +309,19 @@ func tlsSecureOption() nats.Option {
 	if !pool.AppendCertsFromPEM([]byte(caPEM)) {
 		return nil
 	}
-	cfg := &tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS12}
 
-	cert, err := loadClientCert(clientCertFile, clientKeyFile)
-	if err != nil {
+	if _, err := globalClientCert.get(clientCertFile, clientKeyFile); err != nil {
 		zap.L().Fatal("nats mTLS client certificate required but unavailable",
 			zap.String("cert_file", clientCertFile), zap.Error(err))
 	}
-	cfg.Certificates = []tls.Certificate{cert}
-	return nats.Secure(cfg)
+
+	return nats.Secure(&tls.Config{
+		RootCAs:    pool,
+		MinVersion: tls.VersionTLS12,
+		GetClientCertificate: func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			return globalClientCert.get(clientCertFile, clientKeyFile)
+		},
+	})
 }
 
 // rpcOptions authenticate the per-service account on the RPC plane. The creds

--- a/pkg/bus/connect.go
+++ b/pkg/bus/connect.go
@@ -6,6 +6,9 @@ package bus
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
+	"fmt"
+	"os"
 	"regexp"
 	"time"
 
@@ -35,6 +38,32 @@ import (
 // posture, keepalives, server_name prefix; see the header there for the full
 // list) and deploy/k8s/nats-server.conf (hub). Change either side with the
 // other open.
+//
+// mTLS: both the hub's client listener (4222, nats-server.conf) and the
+// leaf's client listener (4223, nats-leaf-server.conf) require a client
+// certificate once their tls.verify:true lands. clientCertFile/clientKeyFile
+// below is the ONE fixed mount path every service gets, fleet-wide, from the
+// kustomize patch in deploy/k8s/kustomization.yaml (the shared
+// nats-bus-client-tls Secret, issued in deploy/infra/pki/certificates.yaml)
+// — not a per-service env var. tlsSecureOption is shared by rpcOptions and
+// busOptions (in fact by every nats.Connect call site in this package:
+// bus.go, batch_publisher.go, flow_delivery.go, provision.go,
+// pull_consumer.go all fall through busOptions/rpcOptions), so this one
+// function is the entire Go-side chokepoint — pkg/svcboot's MustNATS has no
+// TLS logic of its own, it composes bus.Connect/NewPublisher/NewSubscriber
+// like every other caller. Account isolation (bcrypt user/password ->
+// account, auth.conf) is unchanged: this is chain-of-trust verify:true, not
+// verify_and_map, so it layers under the existing auth rather than replacing
+// any part of it.
+//
+// KNOWN GAP: nothing here watches the mounted client cert file for renewal.
+// The NATS server pods have a config-reloader sidecar for their own server
+// cert; this client has no equivalent. cert-manager rotates
+// nats-bus-client-tls in place before expiry, but a long-lived connection
+// that never reconnects across the rotation window keeps using the
+// certificate that was loaded into memory at process start — surfacing as
+// an unexplained connect failure weeks after deploy (the next reconnect,
+// not a graceful cert swap), not at deploy time. Not solved here.
 
 // JSDomain is the JetStream domain the fleet's streams live in. Clients dial the
 // leaf (whose own JetStream domain is "leaf"), so every JetStream context must be
@@ -158,11 +187,55 @@ func logAsyncError(_ *nats.Conn, sub *nats.Subscription, err error) {
 		zap.Error(err))
 }
 
+// clientCertFile / clientKeyFile are the fixed mount path every service's
+// manifest gets via the fleet-wide kustomize patch in
+// deploy/k8s/kustomization.yaml (the nats-bus-client-tls Secret, issued in
+// deploy/infra/pki/certificates.yaml). Fixed and non-configurable per
+// service on purpose: a per-service env var meant every manifest had to
+// remember to set it, and a forgotten one connected with no client cert and
+// only failed once the server's verify:true landed — silent until then. One
+// baked-in path means the only way to not present a cert is to not mount
+// the Secret, which the fleet-wide patch does unconditionally for every
+// Deployment/CronJob that dials NATS.
+const (
+	clientCertFile = "/etc/nats/client-certs/tls.crt"
+	clientKeyFile  = "/etc/nats/client-certs/tls.key"
+)
+
+// errNoClientCert marks "no cert at the mount path" as distinct from "a cert
+// is there but broken." tlsSecureOption treats the two differently: absent is
+// the expected state before the cert/mount has rolled out fleet-wide (or
+// before the enforcing commit lands), broken never is.
+var errNoClientCert = errors.New("no client certificate at mount path")
+
+// loadClientCert reads this service's mTLS client certificate from the fixed
+// mount path. Returns errNoClientCert, not a hard failure, when the files
+// simply are not there yet.
+func loadClientCert(certFile, keyFile string) (tls.Certificate, error) {
+	if _, err := os.Stat(certFile); err != nil {
+		return tls.Certificate{}, errNoClientCert
+	}
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("load client cert %s: %w", certFile, err)
+	}
+	return cert, nil
+}
+
 // tlsSecureOption returns a nats.Secure option that verifies the broker's server
 // cert against the fleet CA (NATS_CA_PEM, distributed by trust-manager as the
 // fleet-ca ConfigMap), or nil when no CA is configured — local dev against a
-// plaintext server stays plaintext. Server-auth only: the client still
-// authenticates with its bcrypt user/password, not a client cert.
+// plaintext server stays plaintext. Also presents this service's own client
+// certificate (clientCertFile/clientKeyFile) when the fleet-wide mount has
+// one — needed once the hub's 4222 and leaf's 4223 listeners set
+// verify:true, since a connection without one then fails the TLS handshake
+// before auth.conf's bcrypt user/password check ever runs.
+//
+// NOT YET REQUIRED: a missing cert silently falls back to the server-auth-only
+// behavior this had before, so the cert and its fleet-wide mount can ship and
+// be confirmed present on every pod ahead of the hub/leaf verify:true that
+// will actually require it. A cert that IS present but unreadable/corrupt is
+// still logged — that is a real misconfiguration, not a staged-rollout state.
 func tlsSecureOption() nats.Option {
 	caPEM := env.Get("NATS_CA_PEM", "")
 	if caPEM == "" {
@@ -172,7 +245,14 @@ func tlsSecureOption() nats.Option {
 	if !pool.AppendCertsFromPEM([]byte(caPEM)) {
 		return nil
 	}
-	return nats.Secure(&tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS12})
+	cfg := &tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS12}
+
+	if cert, err := loadClientCert(clientCertFile, clientKeyFile); err == nil {
+		cfg.Certificates = []tls.Certificate{cert}
+	} else if !errors.Is(err, errNoClientCert) {
+		zap.L().Error("nats client cert unreadable", zap.String("cert_file", clientCertFile), zap.Error(err))
+	}
+	return nats.Secure(cfg)
 }
 
 // rpcOptions authenticate the per-service account on the RPC plane. The creds

--- a/pkg/bus/connect.go
+++ b/pkg/bus/connect.go
@@ -226,16 +226,18 @@ func loadClientCert(certFile, keyFile string) (tls.Certificate, error) {
 // cert against the fleet CA (NATS_CA_PEM, distributed by trust-manager as the
 // fleet-ca ConfigMap), or nil when no CA is configured — local dev against a
 // plaintext server stays plaintext. Also presents this service's own client
-// certificate (clientCertFile/clientKeyFile) when the fleet-wide mount has
-// one — needed once the hub's 4222 and leaf's 4223 listeners set
-// verify:true, since a connection without one then fails the TLS handshake
-// before auth.conf's bcrypt user/password check ever runs.
+// certificate (clientCertFile/clientKeyFile), which is now REQUIRED whenever
+// TLS itself is on: the hub's 4222 and leaf's 4223 listeners set
+// verify:true, so a connection with no client cert fails the TLS handshake
+// before auth.conf's bcrypt user/password check ever runs, and a process
+// that dialed with no cert would only find that out at connect time, over
+// and over, never coming up healthy.
 //
-// NOT YET REQUIRED: a missing cert silently falls back to the server-auth-only
-// behavior this had before, so the cert and its fleet-wide mount can ship and
-// be confirmed present on every pod ahead of the hub/leaf verify:true that
-// will actually require it. A cert that IS present but unreadable/corrupt is
-// still logged — that is a real misconfiguration, not a staged-rollout state.
+// NOW REQUIRED, no longer the permissive fallback of the prior commit: every
+// service was confirmed presenting a cert under that commit before this one
+// shipped, so a missing/unreadable cert here is a boot-time crash, loud and
+// in one place, not a silent gap that only surfaces once the hub/leaf
+// verify:true lands.
 func tlsSecureOption() nats.Option {
 	caPEM := env.Get("NATS_CA_PEM", "")
 	if caPEM == "" {
@@ -247,11 +249,12 @@ func tlsSecureOption() nats.Option {
 	}
 	cfg := &tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS12}
 
-	if cert, err := loadClientCert(clientCertFile, clientKeyFile); err == nil {
-		cfg.Certificates = []tls.Certificate{cert}
-	} else if !errors.Is(err, errNoClientCert) {
-		zap.L().Error("nats client cert unreadable", zap.String("cert_file", clientCertFile), zap.Error(err))
+	cert, err := loadClientCert(clientCertFile, clientKeyFile)
+	if err != nil {
+		zap.L().Fatal("nats mTLS client certificate required but unavailable",
+			zap.String("cert_file", clientCertFile), zap.Error(err))
 	}
+	cfg.Certificates = []tls.Certificate{cert}
 	return nats.Secure(cfg)
 }
 

--- a/pkg/bus/connect_test.go
+++ b/pkg/bus/connect_test.go
@@ -4,6 +4,7 @@
 package bus
 
 import (
+	"bytes"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -98,23 +99,24 @@ func TestBusPublishURLPrefersNodeLocalOverride(t *testing.T) {
 	}
 }
 
-// loadClientCert must not treat a missing mount as an error worth logging —
-// that is the expected state before the cert/mount has rolled out fleet-wide,
-// and tlsSecureOption relies on errNoClientCert specifically to stay quiet
-// about it (see the "NOT YET REQUIRED" comment there).
-func TestLoadClientCertMissingFileIsQuiet(t *testing.T) {
+// clientCertCache.get must not treat a missing mount as an error worth
+// logging — that is the expected state before the cert/mount has rolled out
+// fleet-wide, and errNoClientCert exists specifically so callers can tell the
+// two apart.
+func TestClientCertCacheMissingFileIsQuiet(t *testing.T) {
 	dir := t.TempDir()
-	_, err := loadClientCert(filepath.Join(dir, "tls.crt"), filepath.Join(dir, "tls.key"))
+	var cache clientCertCache
+	_, err := cache.get(filepath.Join(dir, "tls.crt"), filepath.Join(dir, "tls.key"))
 	if !errors.Is(err, errNoClientCert) {
 		t.Fatalf("err = %v, want errNoClientCert", err)
 	}
 }
 
 // A cert file that exists but is not a valid PEM keypair is a real
-// misconfiguration (a corrupt mount, wrong Secret key, ...), not the staged
-// rollout's "not there yet" state, so it must NOT collapse to
-// errNoClientCert — tlsSecureOption logs this branch.
-func TestLoadClientCertCorruptFileIsNotSilent(t *testing.T) {
+// misconfiguration (a corrupt mount, wrong Secret key, ...), not the "not
+// there yet" state, so it must NOT collapse to errNoClientCert —
+// tlsSecureOption's eager check Fatals on this branch.
+func TestClientCertCacheCorruptFileIsNotSilent(t *testing.T) {
 	dir := t.TempDir()
 	certFile := filepath.Join(dir, "tls.crt")
 	keyFile := filepath.Join(dir, "tls.key")
@@ -125,7 +127,8 @@ func TestLoadClientCertCorruptFileIsNotSilent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err := loadClientCert(certFile, keyFile)
+	var cache clientCertCache
+	_, err := cache.get(certFile, keyFile)
 	if err == nil {
 		t.Fatal("want an error for a corrupt cert file")
 	}
@@ -136,26 +139,101 @@ func TestLoadClientCertCorruptFileIsNotSilent(t *testing.T) {
 
 // A valid keypair at the mount path must load successfully — the fleet-wide
 // mount's whole purpose.
-func TestLoadClientCertValidKeypairLoads(t *testing.T) {
+func TestClientCertCacheValidKeypairLoads(t *testing.T) {
 	dir := t.TempDir()
 	certFile := filepath.Join(dir, "tls.crt")
 	keyFile := filepath.Join(dir, "tls.key")
-	writeSelfSignedKeypair(t, certFile, keyFile)
+	writeSelfSignedKeypair(t, certFile, keyFile, "gen-1")
 
-	cert, err := loadClientCert(certFile, keyFile)
+	var cache clientCertCache
+	cert, err := cache.get(certFile, keyFile)
 	if err != nil {
-		t.Fatalf("loadClientCert: %v", err)
+		t.Fatalf("get: %v", err)
 	}
 	if len(cert.Certificate) == 0 {
 		t.Fatal("loaded certificate has no DER bytes")
 	}
 }
 
-// writeSelfSignedKeypair generates a throwaway ECDSA cert/key pair and writes
-// it as PEM to the given paths — enough for tls.LoadX509KeyPair to parse
-// successfully; the fleet CA chain-of-trust itself is exercised by
-// tlsSecureOption's RootCAs pool, not by this loader.
-func writeSelfSignedKeypair(t *testing.T, certFile, keyFile string) {
+// The whole point of GetClientCertificate over a static tls.Config.Certificates
+// value: once cert-manager rewrites the mounted file with a rotated cert (a
+// new mtime, same path), the NEXT get() call must return the new cert, not
+// the one cached from before — otherwise every handshake after day 75 of a
+// 90-day cert keeps presenting the stale one until it hard-fails at day 90.
+func TestClientCertCacheReloadsOnFileChange(t *testing.T) {
+	dir := t.TempDir()
+	certFile := filepath.Join(dir, "tls.crt")
+	keyFile := filepath.Join(dir, "tls.key")
+	firstDER := writeSelfSignedKeypair(t, certFile, keyFile, "gen-1")
+
+	var cache clientCertCache
+	first, err := cache.get(certFile, keyFile)
+	if err != nil {
+		t.Fatalf("get (first): %v", err)
+	}
+	if !bytes.Equal(first.Certificate[0], firstDER) {
+		t.Fatal("first get() did not return the cert on disk")
+	}
+
+	// Simulate cert-manager's renewal: same paths, different content, and a
+	// forced mtime bump so this doesn't race a filesystem with coarse mtime
+	// resolution.
+	secondDER := writeSelfSignedKeypair(t, certFile, keyFile, "gen-2")
+	bumpMtime(t, certFile, keyFile)
+
+	second, err := cache.get(certFile, keyFile)
+	if err != nil {
+		t.Fatalf("get (second): %v", err)
+	}
+	if bytes.Equal(second.Certificate[0], firstDER) {
+		t.Fatal("get() after a file change still returned the stale cached cert")
+	}
+	if !bytes.Equal(second.Certificate[0], secondDER) {
+		t.Fatal("get() after a file change did not return the new cert on disk")
+	}
+}
+
+// A reload that fails (mount briefly corrupt mid-write, wrong permissions,
+// ...) must not take an already-healthy process's next handshake down over
+// it — get() keeps serving the last good cert and only logs the failure.
+func TestClientCertCacheKeepsStaleCertOnReloadFailure(t *testing.T) {
+	dir := t.TempDir()
+	certFile := filepath.Join(dir, "tls.crt")
+	keyFile := filepath.Join(dir, "tls.key")
+	goodDER := writeSelfSignedKeypair(t, certFile, keyFile, "gen-1")
+
+	var cache clientCertCache
+	if _, err := cache.get(certFile, keyFile); err != nil {
+		t.Fatalf("get (first): %v", err)
+	}
+
+	if err := os.WriteFile(certFile, []byte("corrupt mid-rotation"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	bumpMtime(t, certFile, keyFile)
+
+	core, logs := observer.New(zap.ErrorLevel)
+	defer zap.ReplaceGlobals(zap.New(core))()
+
+	cert, err := cache.get(certFile, keyFile)
+	if err != nil {
+		t.Fatalf("get should degrade to the cached cert, not error: %v", err)
+	}
+	if !bytes.Equal(cert.Certificate[0], goodDER) {
+		t.Fatal("get() did not keep serving the last good cert on a failed reload")
+	}
+	if len(logs.All()) == 0 {
+		t.Fatal("a failed reload must still be logged, even though it is not fatal")
+	}
+}
+
+// writeSelfSignedKeypair generates a throwaway ECDSA cert/key pair, writes it
+// as PEM to the given paths, and returns the certificate's raw DER bytes so
+// callers can tell two generated certs apart by content. cn distinguishes
+// successive generations against the same paths in the reload tests; the
+// fleet CA chain-of-trust itself is exercised by tlsSecureOption's RootCAs
+// pool, not by this cache.
+func writeSelfSignedKeypair(t *testing.T, certFile, keyFile, cn string) []byte {
 	t.Helper()
 
 	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
@@ -164,7 +242,7 @@ func writeSelfSignedKeypair(t *testing.T, certFile, keyFile string) {
 	}
 	template := &x509.Certificate{
 		SerialNumber: big.NewInt(1),
-		Subject:      pkix.Name{CommonName: "test-client"},
+		Subject:      pkix.Name{CommonName: cn},
 		NotBefore:    time.Now().Add(-time.Hour),
 		NotAfter:     time.Now().Add(time.Hour),
 		KeyUsage:     x509.KeyUsageDigitalSignature,
@@ -183,6 +261,22 @@ func writeSelfSignedKeypair(t *testing.T, certFile, keyFile string) {
 	}
 	if err := os.WriteFile(keyFile, pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyBytes}), 0o600); err != nil {
 		t.Fatal(err)
+	}
+	return der
+}
+
+// bumpMtime forces both files' mtimes forward. A rewrite that lands within
+// the same filesystem mtime tick as the original (common on fast test
+// hardware / tmpfs) would otherwise look unchanged to clientCertCache.get,
+// which keys its cache on mtime specifically to avoid re-parsing on every
+// handshake.
+func bumpMtime(t *testing.T, files ...string) {
+	t.Helper()
+	future := time.Now().Add(time.Hour)
+	for _, f := range files {
+		if err := os.Chtimes(f, future, future); err != nil {
+			t.Fatal(err)
+		}
 	}
 }
 

--- a/pkg/bus/connect_test.go
+++ b/pkg/bus/connect_test.go
@@ -4,8 +4,18 @@
 package bus
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"errors"
+	"math/big"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/nats-io/nats.go"
 	"go.uber.org/zap"
@@ -85,6 +95,94 @@ func TestBusPublishURLPrefersNodeLocalOverride(t *testing.T) {
 
 	if got := busPublishURL("ignored"); got != "nats://nats:4222" {
 		t.Fatalf("busPublishURL = %q, want node-local hub Service", got)
+	}
+}
+
+// loadClientCert must not treat a missing mount as an error worth logging —
+// that is the expected state before the cert/mount has rolled out fleet-wide,
+// and tlsSecureOption relies on errNoClientCert specifically to stay quiet
+// about it (see the "NOT YET REQUIRED" comment there).
+func TestLoadClientCertMissingFileIsQuiet(t *testing.T) {
+	dir := t.TempDir()
+	_, err := loadClientCert(filepath.Join(dir, "tls.crt"), filepath.Join(dir, "tls.key"))
+	if !errors.Is(err, errNoClientCert) {
+		t.Fatalf("err = %v, want errNoClientCert", err)
+	}
+}
+
+// A cert file that exists but is not a valid PEM keypair is a real
+// misconfiguration (a corrupt mount, wrong Secret key, ...), not the staged
+// rollout's "not there yet" state, so it must NOT collapse to
+// errNoClientCert — tlsSecureOption logs this branch.
+func TestLoadClientCertCorruptFileIsNotSilent(t *testing.T) {
+	dir := t.TempDir()
+	certFile := filepath.Join(dir, "tls.crt")
+	keyFile := filepath.Join(dir, "tls.key")
+	if err := os.WriteFile(certFile, []byte("not a cert"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyFile, []byte("not a key"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := loadClientCert(certFile, keyFile)
+	if err == nil {
+		t.Fatal("want an error for a corrupt cert file")
+	}
+	if errors.Is(err, errNoClientCert) {
+		t.Fatal("a corrupt file must not be reported as errNoClientCert — that hides a real misconfiguration")
+	}
+}
+
+// A valid keypair at the mount path must load successfully — the fleet-wide
+// mount's whole purpose.
+func TestLoadClientCertValidKeypairLoads(t *testing.T) {
+	dir := t.TempDir()
+	certFile := filepath.Join(dir, "tls.crt")
+	keyFile := filepath.Join(dir, "tls.key")
+	writeSelfSignedKeypair(t, certFile, keyFile)
+
+	cert, err := loadClientCert(certFile, keyFile)
+	if err != nil {
+		t.Fatalf("loadClientCert: %v", err)
+	}
+	if len(cert.Certificate) == 0 {
+		t.Fatal("loaded certificate has no DER bytes")
+	}
+}
+
+// writeSelfSignedKeypair generates a throwaway ECDSA cert/key pair and writes
+// it as PEM to the given paths — enough for tls.LoadX509KeyPair to parse
+// successfully; the fleet CA chain-of-trust itself is exercised by
+// tlsSecureOption's RootCAs pool, not by this loader.
+func writeSelfSignedKeypair(t *testing.T, certFile, keyFile string) {
+	t.Helper()
+
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test-client"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(certFile, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	keyBytes, err := x509.MarshalECPrivateKey(priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyFile, pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyBytes}), 0o600); err != nil {
+		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
Hub cluster (6222) and leaf cluster (6223) were already mTLS with `verify: true`. This closes the remaining gap: the **client** listeners on 4222 and 4223.

Uses `verify: true`, not `verify_and_map` — pure chain-of-trust layered *underneath* the existing bcrypt user/password to account mapping, which stays untouched.

Enforcement lives in three shared chokepoints rather than per-service env wiring, so a service that forgets the mount fails loudly at boot instead of silently connecting without a cert: `pkg/bus/connect.go`, the console's shared NATS module, and the Elixir `runtime.exs`. The Secret reaches pods through **one** kustomize patch (13 Deployments plus the notifications CronJob) instead of 13 hand edits.

**Certificates rotate every 90 days**, so the cert loads through `tls.Config.GetClientCertificate` — invoked per handshake, mtime-cached — rather than assigned statically. Without that, every service breaks roughly 90 days after issuance with nothing failing in between. nats.js re-reads `certFile`/`keyFile` on each reconnect and Erlang `:ssl` reads paths fresh per connection, so TS and Elixir get the same property.

Commits are ordered cert → mount → permissive load → required load → `verify: true`, so the fleet can be verified as presenting certs before the server demands them.