### PR TITLE
chore(valkey): enforce mTLS, in two separately-landable phases

### DIFF
--- a/console/shared/lib/server/boot.ts
+++ b/console/shared/lib/server/boot.ts
@@ -36,7 +36,9 @@ export function initConsoleRuntime(env: Env, assertConfigSane: (env: Env) => voi
           sentinelAddr: env.VALKEY_SENTINEL_ADDR,
           sentinelMaster: env.VALKEY_MASTER_SET,
           tlsCa: env.VALKEY_TLS_CA_PEM,
-          tlsServerName: env.VALKEY_TLS_SERVER_NAME
+          tlsServerName: env.VALKEY_TLS_SERVER_NAME,
+          tlsClientCertFile: env.VALKEY_TLS_CLIENT_CERT_FILE,
+          tlsClientKeyFile: env.VALKEY_TLS_CLIENT_KEY_FILE
         }
       : undefined,
     cacheInvalidationPrefix: env.NATS_CACHE_INVALIDATION_PREFIX ?? 'bagel.cache.invalidate'

--- a/console/shared/lib/server/config.ts
+++ b/console/shared/lib/server/config.ts
@@ -36,6 +36,14 @@ export interface ValkeyConfig {
   tlsCa?: string;
   /** Expected server identity; defaults to the stable in-cluster Service DNS. */
   tlsServerName?: string;
+  /**
+   * mTLS: paths to the mounted valkey-client-tls Secret (tls.crt/tls.key), not
+   * PEM content. Required once the server enforces tls-auth-clients yes; both
+   * must be set together or both left unset (unset = pre-flip / not yet
+   * rolled out on this Deployment).
+   */
+  tlsClientCertFile?: string;
+  tlsClientKeyFile?: string;
 }
 
 export interface ServerConfig {

--- a/console/shared/lib/server/valkey-connection.ts
+++ b/console/shared/lib/server/valkey-connection.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Adam Ousmer. All rights reserved.
 // Proprietary. No license granted. See LICENSE.md.
 
+import { readFileSync } from 'node:fs';
 import type { ConnectionOptions } from 'node:tls';
 import type { ValkeyConfig } from './config';
 
@@ -10,11 +11,21 @@ const DEFAULT_SERVER_NAME = 'valkey.valkey.svc.cluster.local';
 
 export function valkeyTLSOptions(cfg: ValkeyConfig): ConnectionOptions | undefined {
   if (!cfg.tlsCa) return undefined;
-  return {
+  const options: ConnectionOptions = {
     ca: cfg.tlsCa,
     servername: cfg.tlsServerName || DEFAULT_SERVER_NAME,
     minVersion: 'TLSv1.2'
   };
+  // mTLS: read from the mounted Secret volume at connection-build time (this
+  // function runs from initConsoleRuntime's boot step, never at module eval,
+  // so it is not subject to the $env/dynamic/private top-level-await
+  // deadlock this file's callers already avoid). Both-or-neither, matching
+  // the shared Go client's VALKEY_TLS_CLIENT_CERT_FILE/KEY_FILE contract.
+  if (cfg.tlsClientCertFile && cfg.tlsClientKeyFile) {
+    options.cert = readFileSync(cfg.tlsClientCertFile);
+    options.key = readFileSync(cfg.tlsClientKeyFile);
+  }
+  return options;
 }
 
 export function valkeyEndpoint(

--- a/deploy/infra/pki/certificates.yaml
+++ b/deploy/infra/pki/certificates.yaml
@@ -205,3 +205,41 @@ spec:
     - localhost
   ipAddresses:
     - 127.0.0.1
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: valkey-client-tls
+  namespace: production
+spec:
+  secretName: valkey-client-tls
+  duration: 2160h # 90d
+  renewBefore: 360h # 15d
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: fleet-intermediate-issuer
+    kind: ClusterIssuer
+    group: cert-manager.io
+  # One shared client cert for every consumer (sesame, outgress, gossip,
+  # projector, console-dashboard, console-admin), deliberately mirroring the
+  # "one shared server cert" decision above: tls-auth-clients yes only checks
+  # chain-to-CA (tls-auth-clients-user is off), it does not map cert CN/identity
+  # to ACL users. Per-service certs would buy per-service revocation and
+  # nothing else today, at the cost of 6x the Certificate/Secret/rotation
+  # surface. Revisit if tls-auth-clients-user mapping is ever adopted.
+  #
+  # config-init and all six health probes do NOT use this cert: they already
+  # mount valkey-server-tls and reuse tls.crt/tls.key directly as their
+  # outbound client identity (see statefulset.yaml). This Certificate is only
+  # for the app-tier clients outside the valkey namespace.
+  #
+  # No SANs required for function -- Valkey's TLS layer does not check client
+  # cert SAN/EKU (valkey-server-tls above carries no Extended Key Usage
+  # extension either, which is why it already doubles as both a server cert
+  # and, for the valkey pods' own outbound links, a client cert). dnsNames
+  # below are for openssl/debugging readability only.
+  commonName: valkey-client.production.svc.cluster.local
+  dnsNames:
+    - valkey-client.production.svc.cluster.local

--- a/deploy/infra/valkey/config/sentinel.conf
+++ b/deploy/infra/valkey/config/sentinel.conf
@@ -5,8 +5,11 @@ tls-port 26380
 tls-cert-file /etc/valkey/tls/tls.crt
 tls-key-file /etc/valkey/tls/tls.key
 tls-ca-cert-file /etc/valkey/tls/ca.crt
-tls-auth-clients no
+tls-auth-clients yes
 tls-replication yes
+bind 0.0.0.0
+
+# status.hostIP and the sentinel container's own --bind CLI flag wins anyway.
 # Monitor the primary by its stable StatefulSet DNS name. Replication, Sentinel
 # gossip, failover and clients all address members through that name, so the
 # topology survives rescheduling even though it now resolves to a node address;

--- a/deploy/infra/valkey/config/valkey.conf
+++ b/deploy/infra/valkey/config/valkey.conf
@@ -5,9 +5,16 @@ tls-port 6380
 tls-cert-file /etc/valkey/tls/tls.crt
 tls-key-file /etc/valkey/tls/tls.key
 tls-ca-cert-file /etc/valkey/tls/ca.crt
-tls-auth-clients no
+tls-auth-clients yes
 tls-replication yes
 bind 0.0.0.0
+
+# (status.hostIP), which a ConfigMap cannot express. config-init writes
+# "bind <node-ip> 127.0.0.1" into /data/valkey.conf on every boot, and the
+# valkey container's own --bind CLI flag is authoritative over that file
+# regardless (same precedence every other retained-vs-CLI setting in this
+# StatefulSet already follows). Do not reintroduce a static bind line here;
+# it would be silently overwritten and would mislead anyone reading this file.
 # This fleet is intentionally one Sentinel-managed keyspace, not Valkey
 # Cluster. Keep replicas read-only so Sentinel is the only authority that can
 # promote a writable primary. The StatefulSet repeats both values as command

--- a/deploy/infra/valkey/statefulset.yaml
+++ b/deploy/infra/valkey/statefulset.yaml
@@ -74,8 +74,15 @@ spec:
           # writable primary. A host allowlist was never a staleness guarantee
           # either, since any allowlisted host could hold stale data.
           POD_FQDN="${POD_NAME}.valkey-headless.valkey.svc.cluster.local"
+          # mTLS: config-init is itself a Valkey client (it queries Sentinel over
+          # 26380 to find the live master). Once tls-auth-clients is yes on the
+          # sentinel listener this connection is gated like any other client and
+          # needs a cert. Reuse the already-mounted server cert as our client
+          # identity -- Valkey does not restrict by EKU/purpose and this fleet
+          # deliberately keeps one shared cert instead of minting a second one
+          # for an initContainer that only ever talks to its own Sentinel peers.
           lookup_master() {
-            { REDISCLI_AUTH="${CORE}" valkey-cli -h valkey.valkey.svc.cluster.local -p 26380 --tls --cacert /etc/valkey/tls/ca.crt --sni valkey.valkey.svc.cluster.local --no-auth-warning sentinel get-master-addr-by-name myprimary 2>/dev/null || true; } \
+            { REDISCLI_AUTH="${CORE}" valkey-cli -h valkey.valkey.svc.cluster.local -p 26380 --tls --cacert /etc/valkey/tls/ca.crt --cert /etc/valkey/tls/tls.crt --key /etc/valkey/tls/tls.key --sni valkey.valkey.svc.cluster.local --no-auth-warning sentinel get-master-addr-by-name myprimary 2>/dev/null || true; } \
               | head -n 1 | tr -d '"'
           }
           LIVE_MASTER=$(lookup_master)
@@ -133,6 +140,15 @@ spec:
           # Reconcile this member's stable DNS identity before Valkey starts.
           sed -i '/^replica-announce-ip /d' /data/valkey.conf
           echo "replica-announce-ip ${POD_FQDN}" >> /data/valkey.conf
+          # Bind only the node's own internal (VLAN) address plus loopback, not
+          # every interface hostNetwork exposes (public, Tailscale, the pod
+          # overlay). 127.0.0.1 stays because the liveness/readiness/startup
+          # probes below connect with no -h, i.e. to localhost -- dropping it
+          # here would fail every probe on every pod simultaneously. This is
+          # belt-and-suspenders: the --bind CLI flag on the valkey container is
+          # what is actually authoritative on every boot (see the flag-vs-file
+          # precedence note below), this just keeps a retained /data file
+          # truthful for anyone reading it directly.
           # A planned failover may have changed the live primary after Valkey's
           # last CONFIG REWRITE. When Sentinel answered above, its current view
           # is authoritative: the primary must have no replicaof line and every
@@ -163,6 +179,9 @@ spec:
           fi
           sed -i '/^sentinel announce-ip /d' /data/sentinel.conf
           echo "sentinel announce-ip ${POD_FQDN}" >> /data/sentinel.conf
+          # Same bind restriction as the data listener; see the comment above
+          # the valkey.conf bind block. The sentinel container's own --bind
+          # CLI flag is authoritative, this is the retained-file mirror.
           sed -i '/^sentinel resolve-hostnames /d; /^sentinel announce-hostnames /d' /data/sentinel.conf
           {
             echo "sentinel resolve-hostnames yes"
@@ -258,8 +277,13 @@ spec:
         - /etc/valkey/tls/tls.key
         - --tls-ca-cert-file
         - /etc/valkey/tls/ca.crt
+        # mTLS enforced: every peer on 6380 (app clients, replicas, Sentinel's
+        # own monitoring connections) must now present a cert chaining to
+        # tls-ca-cert-file above. CLI-flag authoritative over any retained
+        # /data/valkey.conf, same rule the rest of this command block already
+        # follows.
         - --tls-auth-clients
-        - "no"
+        - "yes"
         - --tls-replication
         - "yes"
         env:
@@ -288,6 +312,13 @@ spec:
             - --tls
             - --cacert
             - /etc/valkey/tls/ca.crt
+            # Probes are Valkey clients too: with tls-auth-clients yes they need
+            # a cert like everything else connecting to 6380. Reuse the mounted
+            # server cert -- it never leaves this pod's own filesystem.
+            - --cert
+            - /etc/valkey/tls/tls.crt
+            - --key
+            - /etc/valkey/tls/tls.key
             - --sni
             - valkey.valkey.svc.cluster.local
             - ping
@@ -310,6 +341,13 @@ spec:
             - --tls
             - --cacert
             - /etc/valkey/tls/ca.crt
+            # Probes are Valkey clients too: with tls-auth-clients yes they need
+            # a cert like everything else connecting to 6380. Reuse the mounted
+            # server cert -- it never leaves this pod's own filesystem.
+            - --cert
+            - /etc/valkey/tls/tls.crt
+            - --key
+            - /etc/valkey/tls/tls.key
             - --sni
             - valkey.valkey.svc.cluster.local
             - ping
@@ -327,6 +365,13 @@ spec:
             - --tls
             - --cacert
             - /etc/valkey/tls/ca.crt
+            # Probes are Valkey clients too: with tls-auth-clients yes they need
+            # a cert like everything else connecting to 6380. Reuse the mounted
+            # server cert -- it never leaves this pod's own filesystem.
+            - --cert
+            - /etc/valkey/tls/tls.crt
+            - --key
+            - /etc/valkey/tls/tls.key
             - --sni
             - valkey.valkey.svc.cluster.local
             - ping
@@ -381,8 +426,11 @@ spec:
         - /etc/valkey/tls/tls.key
         - --tls-ca-cert-file
         - /etc/valkey/tls/ca.crt
+        # mTLS enforced on 26380 too: SENTINEL-issuing clients, other sentinels'
+        # gossip connections, and this sentinel's own connections out to the
+        # data-port master (see config-init's lookup_master) all present a cert.
         - --tls-auth-clients
-        - "no"
+        - "yes"
         - --tls-replication
         - "yes"
         env:
@@ -402,6 +450,10 @@ spec:
             - --tls
             - --cacert
             - /etc/valkey/tls/ca.crt
+            - --cert
+            - /etc/valkey/tls/tls.crt
+            - --key
+            - /etc/valkey/tls/tls.key
             - --sni
             - valkey.valkey.svc.cluster.local
             - ping
@@ -424,6 +476,10 @@ spec:
             - --tls
             - --cacert
             - /etc/valkey/tls/ca.crt
+            - --cert
+            - /etc/valkey/tls/tls.crt
+            - --key
+            - /etc/valkey/tls/tls.key
             - --sni
             - valkey.valkey.svc.cluster.local
             - ping
@@ -441,6 +497,10 @@ spec:
             - --tls
             - --cacert
             - /etc/valkey/tls/ca.crt
+            - --cert
+            - /etc/valkey/tls/tls.crt
+            - --key
+            - /etc/valkey/tls/tls.key
             - --sni
             - valkey.valkey.svc.cluster.local
             - ping

--- a/deploy/k8s/console-admin.yaml
+++ b/deploy/k8s/console-admin.yaml
@@ -142,6 +142,14 @@ spec:
                   key: ca.pem
             - name: VALKEY_TLS_SERVER_NAME
               value: valkey.valkey.svc.cluster.local
+            # mTLS: pkg/valkey's clientTLSConfig() treats these two as
+            # both-or-neither. Land this (a no-op while tls-auth-clients is
+            # still "no") on every consumer BEFORE flipping the statefulset,
+            # not after.
+            - name: VALKEY_TLS_CLIENT_CERT_FILE
+              value: /etc/valkey/client-tls/tls.crt
+            - name: VALKEY_TLS_CLIENT_KEY_FILE
+              value: /etc/valkey/client-tls/tls.key
             - name: NATS_RPC_URL
               value: nats://nats-leaf:4222
             - name: NATS_LEAF_URL
@@ -255,6 +263,10 @@ spec:
           envFrom:
             - secretRef:
                 name: console-admin-env
+          volumeMounts:
+            - name: valkey-client-tls
+              mountPath: /etc/valkey/client-tls
+              readOnly: true
           ports:
             - containerPort: 3000
           resources:
@@ -278,6 +290,10 @@ spec:
           readinessProbe:
             httpGet: {path: /readyz, port: 3000}
             periodSeconds: 10
+      volumes:
+        - name: valkey-client-tls
+          secret:
+            secretName: valkey-client-tls
       terminationGracePeriodSeconds: 45
       tolerations:
         - key: node.kubernetes.io/unreachable

--- a/deploy/k8s/console-dashboard.yaml
+++ b/deploy/k8s/console-dashboard.yaml
@@ -160,6 +160,10 @@ spec:
                   key: ca.pem
             - name: VALKEY_TLS_SERVER_NAME
               value: valkey.valkey.svc.cluster.local
+            - name: VALKEY_TLS_CLIENT_CERT_FILE
+              value: /etc/valkey/client-tls/tls.crt
+            - name: VALKEY_TLS_CLIENT_KEY_FILE
+              value: /etc/valkey/client-tls/tls.key
             - name: NATS_RPC_URL
               value: nats://nats-leaf:4222
             - name: NATS_LEAF_URL
@@ -237,6 +241,7 @@ spec:
             - containerPort: 3000
           volumeMounts:
             - {name: tls, mountPath: /etc/console/tls, readOnly: true}
+            - {name: valkey-client-tls, mountPath: /etc/valkey/client-tls, readOnly: true}
           resources:
             requests:
               cpu: 25m
@@ -275,6 +280,9 @@ spec:
         - name: tls
           secret:
             secretName: console-dashboard-tls
+        - name: valkey-client-tls
+          secret:
+            secretName: valkey-client-tls
 ---
 apiVersion: v1
 kind: Service

--- a/deploy/k8s/gossip.yaml
+++ b/deploy/k8s/gossip.yaml
@@ -118,6 +118,14 @@ spec:
                   key: ca.pem
             - name: VALKEY_TLS_SERVER_NAME
               value: valkey.valkey.svc.cluster.local
+            # mTLS: pkg/valkey's clientTLSConfig() treats these two as
+            # both-or-neither. Land this (a no-op while tls-auth-clients is
+            # still "no") on every consumer BEFORE flipping the statefulset,
+            # not after.
+            - name: VALKEY_TLS_CLIENT_CERT_FILE
+              value: /etc/valkey/client-tls/tls.crt
+            - name: VALKEY_TLS_CLIENT_KEY_FILE
+              value: /etc/valkey/client-tls/tls.key
             - name: NATS_RPC_URL
               value: nats://nats-leaf:4222
             - name: NATS_LEAF_URL
@@ -138,6 +146,10 @@ spec:
           envFrom:
             - secretRef:
                 name: gossip-env
+          volumeMounts:
+            - name: valkey-client-tls
+              mountPath: /etc/valkey/client-tls
+              readOnly: true
           ports:
             - containerPort: 8080
           resources:
@@ -165,6 +177,10 @@ spec:
             httpGet: {path: /healthz, port: 8080}
             failureThreshold: 18 # 18 × 5s = 90s max startup window
             periodSeconds: 5
+      volumes:
+        - name: valkey-client-tls
+          secret:
+            secretName: valkey-client-tls
       terminationGracePeriodSeconds: 45
 ---
 apiVersion: policy/v1

--- a/deploy/k8s/outgress.yaml
+++ b/deploy/k8s/outgress.yaml
@@ -130,6 +130,14 @@ spec:
                   key: ca.pem
             - name: VALKEY_TLS_SERVER_NAME
               value: valkey.valkey.svc.cluster.local
+            # mTLS: pkg/valkey's clientTLSConfig() treats these two as
+            # both-or-neither. Land this (a no-op while tls-auth-clients is
+            # still "no") on every consumer BEFORE flipping the statefulset,
+            # not after.
+            - name: VALKEY_TLS_CLIENT_CERT_FILE
+              value: /etc/valkey/client-tls/tls.crt
+            - name: VALKEY_TLS_CLIENT_KEY_FILE
+              value: /etc/valkey/client-tls/tls.key
             - name: NATS_RPC_URL
               value: nats://nats-leaf:4222
             - name: NATS_LEAF_URL
@@ -203,6 +211,10 @@ spec:
           envFrom:
             - secretRef:
                 name: outgress-env
+          volumeMounts:
+            - name: valkey-client-tls
+              mountPath: /etc/valkey/client-tls
+              readOnly: true
           ports:
             - containerPort: 8080
           resources:
@@ -230,6 +242,10 @@ spec:
             httpGet: {path: /healthz, port: 8080}
             failureThreshold: 18
             periodSeconds: 5
+      volumes:
+        - name: valkey-client-tls
+          secret:
+            secretName: valkey-client-tls
       terminationGracePeriodSeconds: 45
 ---
 apiVersion: policy/v1

--- a/deploy/k8s/projector.yaml
+++ b/deploy/k8s/projector.yaml
@@ -114,6 +114,14 @@ spec:
                   key: ca.pem
             - name: VALKEY_TLS_SERVER_NAME
               value: valkey.valkey.svc.cluster.local
+            # mTLS: pkg/valkey's clientTLSConfig() treats these two as
+            # both-or-neither. Land this (a no-op while tls-auth-clients is
+            # still "no") on every consumer BEFORE flipping the statefulset,
+            # not after.
+            - name: VALKEY_TLS_CLIENT_CERT_FILE
+              value: /etc/valkey/client-tls/tls.crt
+            - name: VALKEY_TLS_CLIENT_KEY_FILE
+              value: /etc/valkey/client-tls/tls.key
             - name: NATS_RPC_URL
               value: nats://nats-leaf:4222
             - name: NATS_LEAF_URL
@@ -165,6 +173,10 @@ spec:
           envFrom:
             - secretRef:
                 name: projector-env
+          volumeMounts:
+            - name: valkey-client-tls
+              mountPath: /etc/valkey/client-tls
+              readOnly: true
           ports:
             - containerPort: 8080
           resources:
@@ -192,6 +204,10 @@ spec:
             httpGet: {path: /healthz, port: 8080}
             failureThreshold: 18
             periodSeconds: 5
+      volumes:
+        - name: valkey-client-tls
+          secret:
+            secretName: valkey-client-tls
       terminationGracePeriodSeconds: 45
 ---
 apiVersion: policy/v1

--- a/deploy/k8s/sesame.yaml
+++ b/deploy/k8s/sesame.yaml
@@ -131,6 +131,14 @@ spec:
                   key: ca.pem
             - name: VALKEY_TLS_SERVER_NAME
               value: valkey.valkey.svc.cluster.local
+            # mTLS: pkg/valkey's clientTLSConfig() treats these two as
+            # both-or-neither. Land this (a no-op while tls-auth-clients is
+            # still "no") on every consumer BEFORE flipping the statefulset,
+            # not after.
+            - name: VALKEY_TLS_CLIENT_CERT_FILE
+              value: /etc/valkey/client-tls/tls.crt
+            - name: VALKEY_TLS_CLIENT_KEY_FILE
+              value: /etc/valkey/client-tls/tls.key
             - name: NATS_RPC_URL
               value: tls://nats-leaf:4222
             - name: NATS_LEAF_URL
@@ -231,6 +239,9 @@ spec:
             - name: fleet-ca
               mountPath: /etc/nats-ca
               readOnly: true
+            - name: valkey-client-tls
+              mountPath: /etc/valkey/client-tls
+              readOnly: true
           ports:
             - containerPort: 8080
           resources:
@@ -267,6 +278,9 @@ spec:
         - name: fleet-ca
           configMap:
             name: fleet-ca
+        - name: valkey-client-tls
+          secret:
+            secretName: valkey-client-tls
       terminationGracePeriodSeconds: 45
 ---
 apiVersion: policy/v1

--- a/pkg/valkey/tls.go
+++ b/pkg/valkey/tls.go
@@ -33,11 +33,37 @@ func clientTLSConfig() (*tls.Config, error) {
 	if serverName == "" {
 		serverName = defaultTLSServerName
 	}
-	return &tls.Config{
+	config := &tls.Config{
 		RootCAs:    pool,
 		ServerName: serverName,
 		MinVersion: tls.VersionTLS12,
-	}, nil
+	}
+
+	// mTLS: Valkey's tls-auth-clients yes rejects any connection (data port
+	// AND Sentinel port -- both share this one config) that does not present
+	// a cert chaining to the CA above. Deliberately file-based, not a PEM env
+	// var like VALKEY_TLS_CA_PEM: that CA is public, this is a private key,
+	// and a Secret volume mount keeps it out of `kubectl describe pod`, env
+	// dumps, and any log/panic handler that serializes the process env.
+	certFile := os.Getenv("VALKEY_TLS_CLIENT_CERT_FILE")
+	keyFile := os.Getenv("VALKEY_TLS_CLIENT_KEY_FILE")
+	if certFile == "" && keyFile == "" {
+		// Deliberately permissive: unset means "server not requiring client
+		// auth yet," which is the state every consumer is in until its own
+		// Deployment is updated with the cert volume. This is what makes the
+		// per-service mount + cert-issuance rollout a no-op ahead of the
+		// tls-auth-clients flip, instead of a synchronized flag day.
+		return config, nil
+	}
+	if certFile == "" || keyFile == "" {
+		return nil, fmt.Errorf("valkey: VALKEY_TLS_CLIENT_CERT_FILE and VALKEY_TLS_CLIENT_KEY_FILE must both be set or both be empty")
+	}
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		return nil, fmt.Errorf("valkey: loading client cert/key: %w", err)
+	}
+	config.Certificates = []tls.Certificate{cert}
+	return config, nil
 }
 
 func cloneTLSConfig(config *tls.Config) *tls.Config {


### PR DESCRIPTION
Valkey runs `tls-auth-clients no` today — TLS without client certs. This adds the client cert and flips enforcement, split so phase 1 is a no-op in production.

**Phase 1** (safe now): issue `valkey-client-tls`, wire it behind a both-or-neither gate in the two chokepoints (`pkg/valkey/tls.go` for Go, the console shared lib for TS), mount it into the six client Deployments. Server still says `no`, so nothing can break.

**Phase 2** (gated): `tls-auth-clients yes`, `bind` restriction, and `--cert`/`--key` on `config-init` **and all six exec health probes**. Those probes are themselves Valkey clients — flipping enforcement without them fails every probe fleet-wide, instantly. They dial `127.0.0.1`, which is why it stays in the bind list.

Sentinel needs no new cert: `tls-client-cert-file` is unset, so it already uses `tls-cert-file` as its outbound identity for sentinel-to-master, sentinel-to-sentinel and replica-to-master.

Phase 2 requires all six Deployments verified live with the cert mounted first.