### PR TITLE
perf(bus): R1 pull durable with KV-coordinated self-heal

### DIFF
--- a/deploy/k8s/nats-auth.conf
+++ b/deploy/k8s/nats-auth.conf
@@ -331,6 +331,10 @@ accounts: {
               # here does not fail a boot: lane_coord.go treats any
               # provisioning or KV error as "run lock-free," which is the
               # lane's behavior before this bucket existed at all.
+              # nats.go's CreateKeyValue probes the account with $JS.API.INFO
+              # before it touches the bucket stream (kv.go), so the bucket
+              # grants below are unreachable without it. Read-only.
+              "$JS.API.INFO",
               "$JS.API.STREAM.CREATE.KV_lane_coord",
               "$JS.API.STREAM.UPDATE.KV_lane_coord",
               "$JS.API.STREAM.INFO.KV_lane_coord",

--- a/deploy/k8s/nats-auth.conf
+++ b/deploy/k8s/nats-auth.conf
@@ -310,7 +310,34 @@ accounts: {
               # that can bind a flow consumer needs its flow-control reply or it
               # wedges at the first window.
               "$JS.FC.TWITCH_INGRESS.>",
-              "$JS.FC.TWITCH_INGRESS_STANDARD.>"
+              "$JS.FC.TWITCH_INGRESS_STANDARD.>",
+              # lane_coord: the KV bucket the pull lane durable (R1, above)
+              # uses to coordinate its own rebuild after a peer that held the
+              # consumer's state goes down without the durable ever reporting
+              # missing. STREAM.CREATE provisions the bucket on first pod
+              # boot; STREAM.UPDATE covers CreateKeyValue's own idempotent
+              # path on every later boot, when it finds the bucket already
+              # there and reconciles the two fields (Discard, AllowDirect)
+              # nats.go always normalizes before comparing — omitting it
+              # turns every restart after the first into a silent
+              # coordination outage instead of a no-op. STREAM.INFO backs
+              # both that reconcile and the plain bucket bind. DIRECT.GET
+              # (plus its per-key subject) is the actual key read: KV
+              # buckets default AllowDirect on, so Get never falls through to
+              # STREAM.MSG.GET in practice, but the grant costs nothing and
+              # a server-version difference should not be a silent
+              # degradation. $KV.lane_coord.> is the core-publish subject
+              # every Put/Create/Update/Delete goes out on. A missing grant
+              # here does not fail a boot: lane_coord.go treats any
+              # provisioning or KV error as "run lock-free," which is the
+              # lane's behavior before this bucket existed at all.
+              "$JS.API.STREAM.CREATE.KV_lane_coord",
+              "$JS.API.STREAM.UPDATE.KV_lane_coord",
+              "$JS.API.STREAM.INFO.KV_lane_coord",
+              "$JS.API.STREAM.MSG.GET.KV_lane_coord",
+              "$JS.API.DIRECT.GET.KV_lane_coord",
+              "$JS.API.DIRECT.GET.KV_lane_coord.>",
+              "$KV.lane_coord.>"
             ]
           }
           subscribe: {

--- a/deploy/k8s/nats-auth.conf
+++ b/deploy/k8s/nats-auth.conf
@@ -236,17 +236,25 @@ accounts: {
               # worker/sesame is the sole TWITCH_INGRESS stream owner and its
               # premium/standard consumer manager.
               "$JS.API.STREAM.INFO.TWITCH_INGRESS",
+              "$JS.hub.API.STREAM.INFO.TWITCH_INGRESS",
               "$JS.API.STREAM.CREATE.TWITCH_INGRESS",
+              "$JS.hub.API.STREAM.CREATE.TWITCH_INGRESS",
               "$JS.API.STREAM.UPDATE.TWITCH_INGRESS",
+              "$JS.hub.API.STREAM.UPDATE.TWITCH_INGRESS",
               "$JS.API.CONSUMER.INFO.TWITCH_INGRESS.>",
+              "$JS.hub.API.CONSUMER.INFO.TWITCH_INGRESS.>",
               "$JS.API.CONSUMER.CREATE.TWITCH_INGRESS.>",
+              "$JS.hub.API.CONSUMER.CREATE.TWITCH_INGRESS.>",
               "$JS.API.CONSUMER.DURABLE.CREATE.TWITCH_INGRESS.>",
+              "$JS.hub.API.CONSUMER.DURABLE.CREATE.TWITCH_INGRESS.>",
               "$JS.API.CONSUMER.DELETE.TWITCH_INGRESS.>",
+              "$JS.hub.API.CONSUMER.DELETE.TWITCH_INGRESS.>",
               # The fetch verb of the shared-durable pull lane, which is the
               # default receipt-level shape. sesame is the only identity that
               # binds one: the scope guard admits receipt-level consumption on
               # the hot ingress lanes alone, and nothing else consumes them.
               "$JS.API.CONSUMER.MSG.NEXT.TWITCH_INGRESS.>",
+              "$JS.hub.API.CONSUMER.MSG.NEXT.TWITCH_INGRESS.>",
               "$JS.ACK.TWITCH_INGRESS.>",
               "$JS.ACK.*.*.TWITCH_INGRESS.>",
               # It owns the retry lane too: same service, same lifecycle, and
@@ -256,12 +264,19 @@ accounts: {
               # push path whatever mode the hot lanes run in, so a fetch verb
               # would be authority for a call this credential never makes.
               "$JS.API.STREAM.INFO.TWITCH_INGRESS_RETRY",
+              "$JS.hub.API.STREAM.INFO.TWITCH_INGRESS_RETRY",
               "$JS.API.STREAM.CREATE.TWITCH_INGRESS_RETRY",
+              "$JS.hub.API.STREAM.CREATE.TWITCH_INGRESS_RETRY",
               "$JS.API.STREAM.UPDATE.TWITCH_INGRESS_RETRY",
+              "$JS.hub.API.STREAM.UPDATE.TWITCH_INGRESS_RETRY",
               "$JS.API.CONSUMER.INFO.TWITCH_INGRESS_RETRY.>",
+              "$JS.hub.API.CONSUMER.INFO.TWITCH_INGRESS_RETRY.>",
               "$JS.API.CONSUMER.CREATE.TWITCH_INGRESS_RETRY.>",
+              "$JS.hub.API.CONSUMER.CREATE.TWITCH_INGRESS_RETRY.>",
               "$JS.API.CONSUMER.DURABLE.CREATE.TWITCH_INGRESS_RETRY.>",
+              "$JS.hub.API.CONSUMER.DURABLE.CREATE.TWITCH_INGRESS_RETRY.>",
               "$JS.API.CONSUMER.DELETE.TWITCH_INGRESS_RETRY.>",
+              "$JS.hub.API.CONSUMER.DELETE.TWITCH_INGRESS_RETRY.>",
               "$JS.ACK.TWITCH_INGRESS_RETRY.>",
               "$JS.ACK.*.*.TWITCH_INGRESS_RETRY.>",
               # TWITCH_INGRESS_STANDARD is the standard lane's own stream, added
@@ -275,13 +290,21 @@ accounts: {
               # STREAM.CREATE. Dormant until then, and consumer/owner verbs on a
               # stream that does not exist reach nothing.
               "$JS.API.STREAM.INFO.TWITCH_INGRESS_STANDARD",
+              "$JS.hub.API.STREAM.INFO.TWITCH_INGRESS_STANDARD",
               "$JS.API.STREAM.CREATE.TWITCH_INGRESS_STANDARD",
+              "$JS.hub.API.STREAM.CREATE.TWITCH_INGRESS_STANDARD",
               "$JS.API.STREAM.UPDATE.TWITCH_INGRESS_STANDARD",
+              "$JS.hub.API.STREAM.UPDATE.TWITCH_INGRESS_STANDARD",
               "$JS.API.CONSUMER.INFO.TWITCH_INGRESS_STANDARD.>",
+              "$JS.hub.API.CONSUMER.INFO.TWITCH_INGRESS_STANDARD.>",
               "$JS.API.CONSUMER.CREATE.TWITCH_INGRESS_STANDARD.>",
+              "$JS.hub.API.CONSUMER.CREATE.TWITCH_INGRESS_STANDARD.>",
               "$JS.API.CONSUMER.DURABLE.CREATE.TWITCH_INGRESS_STANDARD.>",
+              "$JS.hub.API.CONSUMER.DURABLE.CREATE.TWITCH_INGRESS_STANDARD.>",
               "$JS.API.CONSUMER.DELETE.TWITCH_INGRESS_STANDARD.>",
+              "$JS.hub.API.CONSUMER.DELETE.TWITCH_INGRESS_STANDARD.>",
               "$JS.API.CONSUMER.MSG.NEXT.TWITCH_INGRESS_STANDARD.>",
+              "$JS.hub.API.CONSUMER.MSG.NEXT.TWITCH_INGRESS_STANDARD.>",
               "$JS.ACK.TWITCH_INGRESS_STANDARD.>",
               "$JS.ACK.*.*.TWITCH_INGRESS_STANDARD.>",
               # Flow-control responses for the AckFlowControl lane consumers.
@@ -335,12 +358,19 @@ accounts: {
               # before it touches the bucket stream (kv.go), so the bucket
               # grants below are unreachable without it. Read-only.
               "$JS.API.INFO",
+              "$JS.hub.API.INFO",
               "$JS.API.STREAM.CREATE.KV_lane_coord",
+              "$JS.hub.API.STREAM.CREATE.KV_lane_coord",
               "$JS.API.STREAM.UPDATE.KV_lane_coord",
+              "$JS.hub.API.STREAM.UPDATE.KV_lane_coord",
               "$JS.API.STREAM.INFO.KV_lane_coord",
+              "$JS.hub.API.STREAM.INFO.KV_lane_coord",
               "$JS.API.STREAM.MSG.GET.KV_lane_coord",
+              "$JS.hub.API.STREAM.MSG.GET.KV_lane_coord",
               "$JS.API.DIRECT.GET.KV_lane_coord",
+              "$JS.hub.API.DIRECT.GET.KV_lane_coord",
               "$JS.API.DIRECT.GET.KV_lane_coord.>",
+              "$JS.hub.API.DIRECT.GET.KV_lane_coord.>",
               "$KV.lane_coord.>"
             ]
           }

--- a/deploy/k8s/nats_auth_test.go
+++ b/deploy/k8s/nats_auth_test.go
@@ -224,13 +224,31 @@ func (c *streamOwnershipCheck) inspect(t *testing.T, file sourceFile) {
 
 func expectedJetStreamSubjects(grants streamGrants) []string {
 	set := make(map[string]struct{})
-	for _, stream := range grants.flowControl {
+	addFlowControlSubjects(set, grants.flowControl)
+	addPullFetchSubjects(set, grants.pullFetch)
+	addConsumerStreamSubjects(set, grants.consumerStreams)
+	addOwnedStreamSubjects(set, grants.ownedStreams)
+	addKeyValueSubjects(set, grants.keyValueOwned)
+	if grants.hubDomainTwins {
+		addHubDomainTwins(set)
+	}
+	return sortedKeys(set)
+}
+
+func addFlowControlSubjects(set map[string]struct{}, streams []string) {
+	for _, stream := range streams {
 		set["$JS.FC."+stream+".>"] = struct{}{}
 	}
-	for _, stream := range grants.pullFetch {
+}
+
+func addPullFetchSubjects(set map[string]struct{}, streams []string) {
+	for _, stream := range streams {
 		set[jetStreamAPI+"CONSUMER.MSG.NEXT."+stream+".>"] = struct{}{}
 	}
-	for _, stream := range grants.consumerStreams {
+}
+
+func addConsumerStreamSubjects(set map[string]struct{}, streams []string) {
+	for _, stream := range streams {
 		for _, subject := range []string{
 			jetStreamAPI + "STREAM.INFO." + stream,
 			jetStreamAPI + "CONSUMER.INFO." + stream + ".>",
@@ -243,18 +261,24 @@ func expectedJetStreamSubjects(grants streamGrants) []string {
 			set[subject] = struct{}{}
 		}
 	}
-	for _, stream := range grants.ownedStreams {
+}
+
+func addOwnedStreamSubjects(set map[string]struct{}, streams []string) {
+	for _, stream := range streams {
 		set[jetStreamAPI+"STREAM.INFO."+stream] = struct{}{}
 		set[jetStreamAPI+"STREAM.CREATE."+stream] = struct{}{}
 		set[jetStreamAPI+"STREAM.UPDATE."+stream] = struct{}{}
 	}
-	if len(grants.keyValueOwned) > 0 {
+}
+
+func addKeyValueSubjects(set map[string]struct{}, buckets []string) {
+	if len(buckets) > 0 {
 		// nats.go's CreateKeyValue probes the account with $JS.API.INFO before
 		// it touches the bucket stream, so owning any KV bucket implies the
 		// account-info read. It is read-only and account-scoped.
 		set[jetStreamAPI+"INFO"] = struct{}{}
 	}
-	for _, bucket := range grants.keyValueOwned {
+	for _, bucket := range buckets {
 		kvStream := "KV_" + bucket
 		for _, subject := range []string{
 			jetStreamAPI + "STREAM.CREATE." + kvStream,
@@ -267,14 +291,14 @@ func expectedJetStreamSubjects(grants streamGrants) []string {
 			set[subject] = struct{}{}
 		}
 	}
-	if grants.hubDomainTwins {
-		for subject := range set {
-			if rest, ok := strings.CutPrefix(subject, jetStreamAPI); ok {
-				set["$JS.hub.API."+rest] = struct{}{}
-			}
+}
+
+func addHubDomainTwins(set map[string]struct{}) {
+	for subject := range set {
+		if rest, ok := strings.CutPrefix(subject, jetStreamAPI); ok {
+			set["$JS.hub.API."+rest] = struct{}{}
 		}
 	}
-	return sortedKeys(set)
 }
 
 func (b busUserBlock) jetStreamSubjects() []string {

--- a/deploy/k8s/nats_auth_test.go
+++ b/deploy/k8s/nats_auth_test.go
@@ -59,6 +59,7 @@ func TestServiceBusJetStreamPermissionsAreExact(t *testing.T) {
 				flowControl:     flowControlStreams[user],
 				pullFetch:       pullFetchStreams[user],
 				keyValueOwned:   keyValueOwnedBuckets[user],
+				hubDomainTwins:  hubDomainTwinUsers[user],
 			})
 			if !slices.Equal(got, want) {
 				t.Fatalf("JetStream grants differ (-want +got):\nwant %v\n got %v", want, got)
@@ -180,6 +181,19 @@ type streamGrants struct {
 	flowControl     []string
 	pullFetch       []string
 	keyValueOwned   []string
+	hubDomainTwins  bool
+}
+
+// hubDomainTwinUsers names the users whose $JS.API grants are mirrored under
+// the hub JetStream domain prefix ($JS.hub.API). The modern jetstream context
+// (jsapi.NewWithDomain, used by the pull lane and lane_coord) addresses every
+// API call through the domain prefix, and the hub checks the published subject
+// BEFORE its domain mapping rewrites it — measured live 2026-08-17, when a
+// config reload started denying $JS.hub.API.CONSUMER.MSG.NEXT and silently
+// stopped both pull lanes. Legacy-context users (push consumers, RPC) never
+// send the prefixed form and must not carry the wider grant.
+var hubDomainTwinUsers = map[string]bool{
+	"worker_bus": true,
 }
 
 type authConfig struct {
@@ -251,6 +265,13 @@ func expectedJetStreamSubjects(grants streamGrants) []string {
 			jetStreamAPI + "DIRECT.GET." + kvStream + ".>",
 		} {
 			set[subject] = struct{}{}
+		}
+	}
+	if grants.hubDomainTwins {
+		for subject := range set {
+			if rest, ok := strings.CutPrefix(subject, jetStreamAPI); ok {
+				set["$JS.hub.API."+rest] = struct{}{}
+			}
 		}
 	}
 	return sortedKeys(set)

--- a/deploy/k8s/nats_auth_test.go
+++ b/deploy/k8s/nats_auth_test.go
@@ -234,6 +234,12 @@ func expectedJetStreamSubjects(grants streamGrants) []string {
 		set[jetStreamAPI+"STREAM.CREATE."+stream] = struct{}{}
 		set[jetStreamAPI+"STREAM.UPDATE."+stream] = struct{}{}
 	}
+	if len(grants.keyValueOwned) > 0 {
+		// nats.go's CreateKeyValue probes the account with $JS.API.INFO before
+		// it touches the bucket stream, so owning any KV bucket implies the
+		// account-info read. It is read-only and account-scoped.
+		set[jetStreamAPI+"INFO"] = struct{}{}
+	}
 	for _, bucket := range grants.keyValueOwned {
 		kvStream := "KV_" + bucket
 		for _, subject := range []string{

--- a/deploy/k8s/nats_auth_test.go
+++ b/deploy/k8s/nats_auth_test.go
@@ -58,6 +58,7 @@ func TestServiceBusJetStreamPermissionsAreExact(t *testing.T) {
 				ownedStreams:    owners[user],
 				flowControl:     flowControlStreams[user],
 				pullFetch:       pullFetchStreams[user],
+				keyValueOwned:   keyValueOwnedBuckets[user],
 			})
 			if !slices.Equal(got, want) {
 				t.Fatalf("JetStream grants differ (-want +got):\nwant %v\n got %v", want, got)
@@ -163,11 +164,22 @@ var pullFetchStreams = map[string][]string{
 	"worker_bus": {"TWITCH_INGRESS", "TWITCH_INGRESS_STANDARD"},
 }
 
+// keyValueOwnedBuckets names, per user, the KV buckets that user provisions
+// (create-if-absent) and reads/writes directly, as opposed to the wildcard
+// $JS.API.STREAM.* an admin-tool account might hold. worker_bus (sesame) is
+// lane_coord's only owner: it is the only identity that ever binds a pull
+// consumer (pullFetchStreams above), and lane_coord exists only to
+// coordinate that consumer's rebuild (pkg/bus/lane_coord.go).
+var keyValueOwnedBuckets = map[string][]string{
+	"worker_bus": {"lane_coord"},
+}
+
 type streamGrants struct {
 	consumerStreams []string
 	ownedStreams    []string
 	flowControl     []string
 	pullFetch       []string
+	keyValueOwned   []string
 }
 
 type authConfig struct {
@@ -221,6 +233,19 @@ func expectedJetStreamSubjects(grants streamGrants) []string {
 		set[jetStreamAPI+"STREAM.INFO."+stream] = struct{}{}
 		set[jetStreamAPI+"STREAM.CREATE."+stream] = struct{}{}
 		set[jetStreamAPI+"STREAM.UPDATE."+stream] = struct{}{}
+	}
+	for _, bucket := range grants.keyValueOwned {
+		kvStream := "KV_" + bucket
+		for _, subject := range []string{
+			jetStreamAPI + "STREAM.CREATE." + kvStream,
+			jetStreamAPI + "STREAM.UPDATE." + kvStream,
+			jetStreamAPI + "STREAM.INFO." + kvStream,
+			jetStreamAPI + "STREAM.MSG.GET." + kvStream,
+			jetStreamAPI + "DIRECT.GET." + kvStream,
+			jetStreamAPI + "DIRECT.GET." + kvStream + ".>",
+		} {
+			set[subject] = struct{}{}
+		}
 	}
 	return sortedKeys(set)
 }

--- a/pkg/bus/lane_coord.go
+++ b/pkg/bus/lane_coord.go
@@ -1,0 +1,464 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package bus
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"ItsBagelBot/pkg/env"
+
+	"github.com/nats-io/nats.go"
+	jsapi "github.com/nats-io/nats.go/jetstream"
+	"go.uber.org/zap"
+)
+
+// The pull lane durable dropped to a single replica (pull_consumer.go)
+// because replicated ack state costs a raft proposal per delivered message,
+// which is the one cost this lane shape exists to avoid. R1 buys that back at
+// the price R3 used to hide: a peer holding the durable can go down without
+// the consumer ever reporting gone, so the fetch loop's only trigger — the
+// durable no longer resolving — never fires, and the lane fetches into a
+// black hole for as long as that peer stays down.
+//
+// This file is the fix: a small NATS KV bucket ("lane_coord") every pod in
+// the fleet can reach, used for exactly two things —
+//
+//   - a floor checkpoint, so a rebuilt durable resumes where the dead one left
+//     off instead of replaying the retained window or, on DeliverNew, silently
+//     skipping whatever the fleet had not yet acked;
+//   - a create-if-absent lock, so a fleet of pods that all notice the same
+//     dead durable at once do not all delete-and-recreate it concurrently,
+//     each one racing the last one's create.
+//
+// Every operation here degrades to the pre-existing lock-free rebuild
+// (pull_consumer.go's rebuildConsumer) the instant the bucket cannot be
+// trusted: never provisioned, a denied ACL (which nats.go surfaces as a
+// context deadline, not a permissions error, so a timeout is treated
+// identically to an outright failure), a partition, all of it. KV is
+// coordination, never correctness, and nothing here may block delivery.
+const (
+	// laneCoordBucket is the one fleet-wide coordination bucket. Not a knob:
+	// every pod must agree on this name for the lock and floor keys below to
+	// mean anything across pods.
+	laneCoordBucket = "lane_coord"
+	// laneFloorPrefix and laneRebuildPrefix key the two purposes this bucket
+	// exists for (see above) inside that one bucket, per durable name, so
+	// unrelated lanes never contend on each other's lock or floor.
+	laneFloorPrefix   = "floor."
+	laneRebuildPrefix = "rebuild."
+
+	defaultPullProbeTimeout = time.Second
+	// defaultPullLockStale must clear laneReplaceTimeout (pull_consumer.go,
+	// currently 20s): floorAwareRebind's delete+recreate runs under that one
+	// shared budget, not two separate ones, so a lock stolen before the
+	// budget can even be spent would pull it out from under a winner that is
+	// still legitimately working. 30s leaves margin above the full 20s.
+	defaultPullLockStale = 30 * time.Second
+
+	laneCoordProvisionTimeout = 5 * time.Second
+	// laneCoordOpTimeout bounds every ordinary Get/Put/Create/Update/Delete.
+	// Short on purpose: these calls run inline on the ticker and the
+	// fetch-error path, and a slow bucket must degrade fast rather than hold
+	// either one open.
+	laneCoordOpTimeout = 2 * time.Second
+)
+
+func laneFloorKey(name string) string   { return laneFloorPrefix + name }
+func laneRebuildKey(name string) string { return laneRebuildPrefix + name }
+
+// pullProbeTimeout bounds the INFO call noteFetchError uses to tell a
+// peer-down R1 consumer apart from an ordinary transient error. It has to
+// stay well under maxWait's retry cadence or the probe itself becomes the
+// spin this mechanism exists to avoid.
+func pullProbeTimeout() time.Duration {
+	return positiveDuration(env.GetDuration("NATS_PULL_PROBE_TIMEOUT", defaultPullProbeTimeout), defaultPullProbeTimeout)
+}
+
+// pullLockStale is how old a held rebuild lock has to be before another pod
+// will steal it. It has to clear an ordinary rebuild's own round trip — the
+// delete and the create both run under floorAwareRebind's single
+// laneReplaceTimeout budget (pull_consumer.go), not a budget each — with room
+// to spare, or a pod still legitimately working would lose its own lock
+// mid-rebuild.
+func pullLockStale() time.Duration {
+	return positiveDuration(env.GetDuration("NATS_PULL_LOCK_STALE", defaultPullLockStale), defaultPullLockStale)
+}
+
+// laneCoordinator is the slice of the KV API the rebuild lock and floor
+// checkpoint use. Narrow for the same reason pullConsumerProvisioner is: it
+// keeps the coordination tests honest about which calls this mechanism may
+// make, and it lets a test drive a lock race or a floor read without a
+// broker.
+type laneCoordinator interface {
+	Get(ctx context.Context, key string) (jsapi.KeyValueEntry, error)
+	Put(ctx context.Context, key string, value []byte) (uint64, error)
+	Create(ctx context.Context, key string, value []byte) (uint64, error)
+	Update(ctx context.Context, key string, value []byte, revision uint64) (uint64, error)
+	// Delete is always revision-checked: releaseRebuildLock's whole point is
+	// to refuse deleting a lock this pod no longer owns (see there), so the
+	// interface offers no unconditional delete to reach for by mistake.
+	Delete(ctx context.Context, key string, revision uint64) error
+}
+
+// realLaneCoordinator adapts jetstream.KeyValue to laneCoordinator. The
+// adapter exists only because KeyValue.Create carries a variadic options
+// parameter this mechanism never uses, which keeps *kvs from satisfying the
+// narrower interface directly.
+type realLaneCoordinator struct{ kv jsapi.KeyValue }
+
+func (r realLaneCoordinator) Get(ctx context.Context, key string) (jsapi.KeyValueEntry, error) {
+	return r.kv.Get(ctx, key)
+}
+
+func (r realLaneCoordinator) Put(ctx context.Context, key string, value []byte) (uint64, error) {
+	return r.kv.Put(ctx, key, value)
+}
+
+func (r realLaneCoordinator) Create(ctx context.Context, key string, value []byte) (uint64, error) {
+	return r.kv.Create(ctx, key, value)
+}
+
+func (r realLaneCoordinator) Update(ctx context.Context, key string, value []byte, revision uint64) (uint64, error) {
+	return r.kv.Update(ctx, key, value, revision)
+}
+
+func (r realLaneCoordinator) Delete(ctx context.Context, key string, revision uint64) error {
+	return r.kv.Delete(ctx, key, jsapi.LastRevision(revision))
+}
+
+// laneCoordProvisioner is the slice of the KV manager the lazy bucket
+// provision uses.
+type laneCoordProvisioner interface {
+	CreateKeyValue(ctx context.Context, cfg jsapi.KeyValueConfig) (jsapi.KeyValue, error)
+	KeyValue(ctx context.Context, bucket string) (jsapi.KeyValue, error)
+}
+
+func laneCoordConfig() jsapi.KeyValueConfig {
+	return jsapi.KeyValueConfig{
+		Bucket:      laneCoordBucket,
+		Description: "ItsBagelBot pull-lane rebuild coordination: floor checkpoints and rebuild locks",
+		History:     1,
+		Replicas:    3,
+		Storage:     jsapi.MemoryStorage,
+	}
+}
+
+// ensureLaneCoord provisions the bucket idempotently and binds a handle to
+// it, once, at pull-subscriber construction — never at package init, so a
+// broker that is not reachable yet at import time cannot fail a process that
+// has not even tried to connect.
+//
+// Every failure returns nil instead of an error the caller must branch on:
+// every call site already treats a nil coordinator as "run lock-free," which
+// is what this whole mechanism degrades to the instant it cannot be trusted.
+func ensureLaneCoord(nc *nats.Conn, log *zap.Logger) laneCoordinator {
+	js, err := jsapi.NewWithDomain(nc, JSDomain())
+	if err != nil {
+		log.Warn("lane coordination bucket unavailable; rebuilds fall back to lock-free", zap.Error(err))
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), laneCoordProvisionTimeout)
+	defer cancel()
+	kv, err := provisionLaneCoordBucket(ctx, js, laneCoordConfig())
+	if err != nil {
+		log.Warn("lane coordination bucket unavailable; rebuilds fall back to lock-free", zap.Error(err))
+		return nil
+	}
+	return realLaneCoordinator{kv: kv}
+}
+
+// provisionLaneCoordBucket is create-only, tolerant of another pod having
+// already won the create — the same pattern streamReconciler.create uses for
+// the stream catalog (provision.go). A denied create surfaces as a context
+// deadline (see the package doc's ACL note above), which propagates here like
+// any other provisioning failure; the caller degrades the same way regardless
+// of which.
+func provisionLaneCoordBucket(ctx context.Context, js laneCoordProvisioner, cfg jsapi.KeyValueConfig) (jsapi.KeyValue, error) {
+	kv, err := js.CreateKeyValue(ctx, cfg)
+	if err == nil {
+		return kv, nil
+	}
+	if errors.Is(err, jsapi.ErrBucketExists) {
+		return js.KeyValue(ctx, cfg.Bucket)
+	}
+	return nil, err
+}
+
+// recordAckedSequence captures the stream sequence advanceFloor has just
+// confirmed acked, for checkpointFloor to persist. It runs on the ack cadence
+// (once per batch or once per tick, pull_consumer.go), never per delivered
+// message, so the extra Metadata() call here costs nothing the hot path was
+// built to avoid.
+//
+// The caller only reaches this after wire.Ack() returned nil — never before,
+// and never on an ack error. Ack is fire-and-forget over the wire, so a
+// failure means the broker may never have seen it; checkpointing that
+// sequence would let a rebuild resume past a message the fleet never
+// actually acknowledged, which is a skip rather than the redelivery this
+// whole mechanism is allowed to cost.
+func (s *pullSubscriber) recordAckedSequence(wire jsapi.Msg) {
+	metadata, err := wire.Metadata()
+	if err != nil || metadata.Sequence.Stream == 0 {
+		return
+	}
+	s.ackedStreamSeq.Store(metadata.Sequence.Stream)
+}
+
+// checkpointFloor persists the newest acked stream sequence to the
+// coordination bucket, but only when it moved since the last write: a Put is
+// a raft proposal on the bucket's own R3 stream, and writing one every tick
+// whether or not the floor advanced would reintroduce, at tick cadence
+// instead of message cadence, the exact per-proposal cost the parent change
+// removes from the hot path. Called only from advanceFloorPeriodically's
+// ticker goroutine — see the field doc on pullSubscriber.checkpointedSeq.
+func (s *pullSubscriber) checkpointFloor() {
+	if s.coord == nil {
+		return
+	}
+	seq := s.ackedStreamSeq.Load()
+	if seq == 0 || seq == s.checkpointedSeq.Load() {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), laneCoordOpTimeout)
+	defer cancel()
+	value := []byte(strconv.FormatUint(seq, 10))
+	if _, err := s.coord.Put(ctx, laneFloorKey(s.name), value); err != nil {
+		s.noteCheckpointErr(err)
+		return
+	}
+	s.checkpointedSeq.Store(seq)
+}
+
+func (s *pullSubscriber) noteCheckpointErr(err error) {
+	if count := s.checkpointErrs.Add(1); count == 1 || count%1_000 == 0 {
+		s.log.Warn("lane floor checkpoint failed",
+			zap.String("subject", s.subject),
+			zap.Int64("checkpoint_errors", count),
+			zap.Error(err))
+	}
+}
+
+// consumerUnavailable decides whether a fetch failure justifies a rebuild.
+// consumerGone (pull_consumer.go) is unambiguous and never needs the probe
+// below. Everything else is only worth probing while the client itself has a
+// live connection — with the transport down the probe would just fail on
+// that, telling the caller nothing the fetch error had not already said, and
+// a rebuild attempted over a dead connection cannot succeed anyway.
+func (s *pullSubscriber) consumerUnavailable(err error) bool {
+	if consumerGone(err) {
+		return true
+	}
+	if s.connected == nil || !s.connected() {
+		return false
+	}
+	return s.probeConsumerGone()
+}
+
+// probeConsumerGone is the R1-era gap this file closes: a peer holding the
+// durable can go down without the durable ever reporting missing to
+// ConsumerNotFound/Deleted, so an ordinary fetch just times out forever. A
+// bounded INFO call tells that apart from an election or a slow responder
+// that is still going to answer — a probe success means the fetch failure was
+// transient and the existing pause/retry already covers it.
+func (s *pullSubscriber) probeConsumerGone() bool {
+	ctx, cancel := context.WithTimeout(context.Background(), pullProbeTimeout())
+	defer cancel()
+	_, err := s.consumer.Info(ctx)
+	if err == nil {
+		return false
+	}
+	return consumerGone(err) || errors.Is(err, context.DeadlineExceeded)
+}
+
+// coordinatedRebuild is noteFetchError's entry point in place of a direct
+// rebuildConsumer call. Without it, every pod that notices the same gone
+// durable in the same cycle deletes and recreates it independently, each one
+// racing the last one's create — the exact stampede a fleet-wide durable
+// cannot afford under load.
+//
+// The lock lives in the coordination bucket rather than on the durable
+// itself: the durable is precisely what may be missing or unreachable, so
+// there is nowhere on it to stake a claim. Every branch that cannot reach the
+// bucket falls through to the pre-existing lock-free rebuild — coordination
+// only ever adds safety on top of that fallback, never gates it.
+func (s *pullSubscriber) coordinatedRebuild() {
+	if s.coord == nil {
+		s.rebuildConsumer()
+		return
+	}
+	lock := s.acquireRebuildLock()
+	switch lock.result {
+	case rebuildLockWon:
+		s.floorAwareRebuild()
+		s.releaseRebuildLock(lock.revision)
+	case rebuildLockUnavailable:
+		s.rebuildConsumer()
+	case rebuildLockLost:
+		// Another pod already owns this cycle's rebuild; the ordinary pause
+		// noteFetchError already takes is this pod's wait.
+	}
+}
+
+// rebuildLockResult is acquireRebuildLock's verdict.
+type rebuildLockResult int
+
+const (
+	rebuildLockWon rebuildLockResult = iota
+	rebuildLockLost
+	rebuildLockUnavailable
+)
+
+// rebuildLockAcquisition pairs the verdict with the revision this pod's own
+// Create/Update landed at (zero when it did not win). releaseRebuildLock
+// needs that exact revision: a plain unconditional delete would just as
+// happily delete a lock a different pod has since won by stealing this one,
+// see there.
+type rebuildLockAcquisition struct {
+	result   rebuildLockResult
+	revision uint64
+}
+
+// acquireRebuildLock is the create-if-absent lock with a staleness steal.
+// Create is atomic on the broker, so exactly one racing pod ever sees
+// rebuildLockWon for a given cycle.
+func (s *pullSubscriber) acquireRebuildLock() rebuildLockAcquisition {
+	ctx, cancel := context.WithTimeout(context.Background(), laneCoordOpTimeout)
+	defer cancel()
+	key := laneRebuildKey(s.name)
+	rev, err := s.coord.Create(ctx, key, rebuildLockValue())
+	if err == nil {
+		return rebuildLockAcquisition{result: rebuildLockWon, revision: rev}
+	}
+	if !errors.Is(err, jsapi.ErrKeyExists) {
+		return rebuildLockAcquisition{result: rebuildLockUnavailable}
+	}
+	return s.tryStealRebuildLock(ctx, key)
+}
+
+// tryStealRebuildLock reads the held lock and steals it via a CAS update once
+// it is older than pullLockStale — old enough that its winner most likely
+// crashed mid-rebuild rather than still being at work. Losing the CAS means
+// another pod's steal (or the true owner's own retry) landed first; that pod
+// owns this cycle now.
+func (s *pullSubscriber) tryStealRebuildLock(ctx context.Context, key string) rebuildLockAcquisition {
+	entry, err := s.coord.Get(ctx, key)
+	if err != nil {
+		return rebuildLockAcquisition{result: rebuildLockUnavailable}
+	}
+	if !rebuildLockStale(entry.Value()) {
+		return rebuildLockAcquisition{result: rebuildLockLost}
+	}
+	rev, err := s.coord.Update(ctx, key, rebuildLockValue(), entry.Revision())
+	if err != nil {
+		return rebuildLockAcquisition{result: rebuildLockLost}
+	}
+	return rebuildLockAcquisition{result: rebuildLockWon, revision: rev}
+}
+
+// releaseRebuildLock always fires after a winner's rebuild attempt, success
+// or failure: holding the lock past that point only delays the next pod that
+// notices the same failure, and the stale-steal above already bounds the
+// blast radius of never releasing it at all.
+//
+// The delete is revision-checked against the exact Create/Update this pod's
+// own acquireRebuildLock landed at — never a bare delete-by-key. A rebuild
+// slow enough to cross pullLockStale can have its lock stolen by another pod
+// mid-work; an unconditional delete issued after that pod's own rebuild
+// would delete THEIR lock, reopening it to a third pod while the second is
+// still working. Losing this CAS means exactly that happened, and the
+// correct response is to leave the (someone else's) lock alone.
+func (s *pullSubscriber) releaseRebuildLock(revision uint64) {
+	ctx, cancel := context.WithTimeout(context.Background(), laneCoordOpTimeout)
+	defer cancel()
+	_ = s.coord.Delete(ctx, laneRebuildKey(s.name), revision)
+}
+
+// rebuildLockValue stamps this pod's identity and the instant it took the
+// lock. The identity is diagnostic only; the instant is what rebuildLockStale
+// judges a stuck winner by.
+func rebuildLockValue() []byte {
+	return []byte(podIdentity() + " " + strconv.FormatInt(time.Now().UnixNano(), 10))
+}
+
+// rebuildLockStale reports whether a held lock is old enough to steal. A
+// value this mechanism did not write (wrong shape, an unparsable instant) is
+// treated as stale rather than as a permanent block: a foreign value here
+// means the key was never in this mechanism's exclusive care to begin with,
+// and stale-and-stealable is the safer read of that than stale-and-stuck.
+func rebuildLockStale(value []byte) bool {
+	fields := strings.Fields(string(value))
+	if len(fields) != 2 {
+		return true
+	}
+	took, err := strconv.ParseInt(fields[1], 10, 64)
+	if err != nil {
+		return true
+	}
+	return time.Since(time.Unix(0, took)) > pullLockStale()
+}
+
+// floorAwareRebuild is the lock winner's rebuild. Unlike rebuildConsumer's
+// lock-free path (pull_consumer.go, always DeliverNew), it resumes from the
+// fleet's floor checkpoint when one exists, which is the entire reason a
+// winner is worth electing instead of every pod just racing rebuildConsumer.
+func (s *pullSubscriber) floorAwareRebuild() {
+	s.takePending()
+	consumer, err := s.floorRebind()
+	s.completeRebuild(consumer, err)
+}
+
+// floorAwareRebind performs the delete+recreate directly, reusing
+// replacePullConsumer (pull_consumer.go) rather than bindPullConsumer's
+// update-first path: that path exists to convert a push consumer left
+// occupying the name, and it echoes whatever DeliverPolicy/OptStartSeq the
+// occupant currently has — which for a rebuild is precisely the dead
+// consumer's own position, the one thing rebuildDesiredConfig exists to
+// override.
+func (s *pullSubscriber) floorAwareRebind() (jsapi.Consumer, error) {
+	js, err := jsapi.NewWithDomain(s.nc, JSDomain())
+	if err != nil {
+		return nil, fmt.Errorf("bus: modern jetstream context: %w", err)
+	}
+	return replacePullConsumer(js, s.stream, s.rebuildDesiredConfig(), errors.New("bus: probe-triggered rebuild"))
+}
+
+// rebuildDesiredConfig resumes the rebuilt durable from the fleet's floor
+// checkpoint instead of the dead consumer's own position: that position
+// belongs to the consumer this rebuild exists because it can no longer be
+// trusted, and inheriting it would either replay the whole retained window or,
+// on DeliverNew, silently skip whatever the fleet had not yet acked.
+func (s *pullSubscriber) rebuildDesiredConfig() jsapi.ConsumerConfig {
+	desired := s.desired
+	floor, ok := s.readFloorCheckpoint()
+	if !ok {
+		desired.DeliverPolicy = jsapi.DeliverNewPolicy
+		desired.OptStartSeq = 0
+		return desired
+	}
+	desired.DeliverPolicy = jsapi.DeliverByStartSequencePolicy
+	desired.OptStartSeq = floor + 1
+	return desired
+}
+
+func (s *pullSubscriber) readFloorCheckpoint() (uint64, bool) {
+	if s.coord == nil {
+		return 0, false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), laneCoordOpTimeout)
+	defer cancel()
+	entry, err := s.coord.Get(ctx, laneFloorKey(s.name))
+	if err != nil {
+		return 0, false
+	}
+	seq, err := strconv.ParseUint(string(entry.Value()), 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return seq, true
+}

--- a/pkg/bus/pull_consumer.go
+++ b/pkg/bus/pull_consumer.go
@@ -73,10 +73,16 @@ const (
 	// set — which every other pod is drawing from — shrinks by that much.
 	defaultPullAckEvery = 250 * time.Millisecond
 
-	// defaultPullReplicas matches the lane streams' own replica count. The durable
-	// has to survive exactly what the stream survives, and a consumer cannot ask
-	// for more replicas than the stream it reads has.
-	defaultPullReplicas = 3
+	// defaultPullReplicas is R1, not the stream's own replica count. Quorum
+	// consensus on the consumer's ack state is a raft proposal PER DELIVERED
+	// MESSAGE, on the hot path, which collapses drain throughput at lane rate
+	// — the exact cost this shape exists to avoid; see the 2026-08-16 note on
+	// pullConsumerConfig for why R1 alone is not enough. Availability now
+	// comes from lane_coord.go instead of replicated state: a probe-triggered
+	// rebuild notices a peer-down consumer that never reports gone, and every
+	// pod resumes it from a shared floor checkpoint rather than the fresh
+	// DeliverNew a lock-free rebuild would otherwise fall back to.
+	defaultPullReplicas = 1
 
 	// laneUnhealthyAfter is how long the fetch loop may stay in its error path
 	// before the lane reports itself unready. It has to clear an ordinary consumer
@@ -116,17 +122,32 @@ func pullConsumerConfig(subject, name string) jsapi.ConsumerConfig {
 		// fleet has stopped fetching from it. It is the same window the flow lane
 		// gives a pod to reconnect inside without losing its position.
 		InactiveThreshold: flowInactiveThreshold,
-		// Consumer state is replicated with the stream it reads.
+		// Consumer state is R1, deliberately not matched to the stream's own
+		// replica count.
 		//
-		// This was R1, on the reasoning that per-consumer ack state is leader RAFT
-		// work on the hot path and that the fleet would simply re-provision after
-		// losing it. The second half was never true: nothing rebuilt a lane durable,
-		// so a single peer owned the whole fleet's ability to consume. On 2026-08-16
-		// one member lost peer routing for 23 minutes, the meta layer moved these
-		// durables eleven times while it churned and then lost them, and every pod
-		// spun on a name that no longer resolved for the next seven hours.
-		// Quorum-replicated state survives one member, which is the failure that
-		// actually happens; rebuildConsumer covers losing all of them at once.
+		// This was R1 originally, on the reasoning that per-consumer ack state is
+		// leader RAFT work on the hot path and that the fleet would simply
+		// re-provision after losing it. The second half was never true: nothing
+		// rebuilt a lane durable, so a single peer owned the whole fleet's ability
+		// to consume. On 2026-08-16 one member lost peer routing for 23 minutes,
+		// the meta layer moved these durables eleven times while it churned and
+		// then lost them, and every pod spun on a name that no longer resolved for
+		// the next seven hours. The fix at the time was R3: quorum-replicated
+		// state survives losing one member outright.
+		//
+		// R3 traded that outage for a slower one: a replicated consumer proposes
+		// its ack state to the whole raft group on every delivered batch, on the
+		// hot path, and that per-batch quorum round trip is what actually caps
+		// this lane's drain rate under load. Back to R1, but this time paired with
+		// the other half 2026-08-16 was missing: rebuildConsumer already covers
+		// losing every replica of the consumer's state at once (the durable
+		// reports ConsumerNotFound/Deleted), and lane_coord.go now covers the
+		// failure R1 alone reopens — a single peer going down still leaves the
+		// durable resolving in meta, so an ordinary fetch just times out forever
+		// instead of erroring in a way rebuildConsumer would catch. The probe in
+		// noteFetchError is what tells that apart from an election, and the floor
+		// checkpoint in lane_coord.go is what lets the rebuilt durable resume
+		// instead of replaying or skipping the window.
 		//
 		// Memory storage stays. The lane streams are memory-backed themselves, so
 		// persisting ack state to disk cannot outlive the messages it describes.
@@ -380,22 +401,46 @@ type pullSubscriber struct {
 	// rebind provisions a replacement durable. It is a field rather than a direct
 	// call so the rebuild decision is testable without a broker; the constructor
 	// always fills it with the real API path.
-	rebind  func() (jsapi.Consumer, error)
-	stream  string
-	subject string
-	name    string
-	log     *zap.Logger
+	rebind func() (jsapi.Consumer, error)
+	// floorRebind is coordinatedRebuild's winner-path provisioner (lane_coord.go):
+	// a direct delete+recreate at the fleet's floor checkpoint rather than
+	// rebind's lock-free DeliverNew. A field for the same reason rebind is.
+	floorRebind func() (jsapi.Consumer, error)
+	stream      string
+	subject     string
+	name        string
+	log         *zap.Logger
+
+	// coord is the lane_coord.go KV handle. Nil is a first-class state, not an
+	// error: it means the bucket never provisioned (or a later op failed), and
+	// every call site that reads it treats nil as "run lock-free," which is
+	// this whole mechanism's fallback.
+	coord laneCoordinator
+	// connected reports whether the client can currently reach the broker at
+	// all. A field rather than a direct s.nc.Status() call so the probe-timeout
+	// path is testable without a live connection; the constructor always fills
+	// it with the real check.
+	connected func() bool
 
 	batch    int
 	maxWait  time.Duration
 	ackEvery time.Duration
 
-	retried   atomic.Int64
-	dropped   atomic.Int64
-	fetchErrs atomic.Int64
-	ackErrs   atomic.Int64
-	rebuilt   atomic.Int64
-	closed    atomic.Bool
+	retried        atomic.Int64
+	dropped        atomic.Int64
+	fetchErrs      atomic.Int64
+	ackErrs        atomic.Int64
+	rebuilt        atomic.Int64
+	checkpointErrs atomic.Int64
+	closed         atomic.Bool
+
+	// ackedStreamSeq is the stream sequence of the newest delivery advanceFloor
+	// has acked, and checkpointedSeq is the value last written to the floor
+	// key. Both are read and written across the pump and ticker goroutines
+	// (whichever last calls advanceFloor vs. the ticker's own checkpointFloor),
+	// so both are atomics rather than fields ackMu also guards.
+	ackedStreamSeq  atomic.Uint64
+	checkpointedSeq atomic.Uint64
 
 	// errSince is the unix-nano instant the fetch loop entered its error path, or
 	// zero while it is healthy. An idle lane never sets it — Next simply blocks —
@@ -442,6 +487,10 @@ func newPullLaneSubscriber(cfg flowLaneConfig) (*pullSubscriber, error) {
 		return nil, err
 	}
 	s := newPullSubscriber(cfg, nc, consumer, name)
+	// Lazy, not package-init: a broker that is not reachable yet at import time
+	// must not fail a process that has not even dialled it, and this bucket is
+	// coordination, never a boot dependency (see lane_coord.go).
+	s.coord = ensureLaneCoord(nc, s.log)
 	s.start()
 	return s, nil
 }
@@ -463,6 +512,8 @@ func newPullSubscriber(cfg flowLaneConfig, nc *nats.Conn, consumer jsapi.Consume
 		cancel:  cancel,
 	}
 	s.rebind = func() (jsapi.Consumer, error) { return ensurePullConsumer(s.nc, s.stream, s.desired) }
+	s.floorRebind = s.floorAwareRebind
+	s.connected = func() bool { return s.nc != nil && s.nc.Status() == nats.CONNECTED }
 	return s
 }
 
@@ -655,13 +706,23 @@ func (s *pullSubscriber) advanceFloor() {
 	if err := wire.Ack(); err != nil {
 		// The floor is cumulative, so the next ack re-covers whatever this one
 		// missed; a lost ack costs redelivery latency rather than the binding.
+		//
+		// Recording the sequence is skipped on this path on purpose: Ack is
+		// fire-and-forget over the wire, so a failure here (a dropped
+		// connection — exactly the peer-down scenario lane_coord.go exists
+		// for) means the broker never saw this ack. Checkpointing it anyway
+		// would let a later rebuild resume past a message the fleet never
+		// actually acknowledged — a skip, not a redelivery, and skipping is
+		// the one outcome this mechanism may never trade availability for.
 		if count := s.ackErrs.Add(1); count == 1 || count%1_000 == 0 {
 			s.log.Warn("lane floor ack failed",
 				zap.String("subject", s.subject),
 				zap.Int64("ack_errors", count),
 				zap.Error(err))
 		}
+		return
 	}
+	s.recordAckedSequence(wire)
 }
 
 func (s *pullSubscriber) takePending() jsapi.Msg {
@@ -677,6 +738,12 @@ func (s *pullSubscriber) takePending() jsapi.Msg {
 // would otherwise hold every message it has already delivered unacked for as
 // long as the pool is busy — and on a shared durable that pending set is the one
 // every other pod is drawing from.
+//
+// It is also the only goroutine allowed to write the floor checkpoint (see
+// lane_coord.go): the checkpoint has to sit behind the same ack this loop
+// already publishes, and putting it on this cadence rather than the pump's
+// hot path is what keeps a KV Put off the per-message cost this file's parent
+// change exists to remove.
 func (s *pullSubscriber) advanceFloorPeriodically() {
 	defer s.workers.Done()
 	ticker := time.NewTicker(s.ackEvery)
@@ -687,6 +754,7 @@ func (s *pullSubscriber) advanceFloorPeriodically() {
 			return
 		case <-ticker.C:
 			s.advanceFloor()
+			s.checkpointFloor()
 		}
 	}
 }
@@ -710,7 +778,8 @@ func (s *pullSubscriber) scheduleRetry(delivery pullDelivery) {
 // fetch returns immediately, so a leader election or a denied MSG.NEXT
 // permission would otherwise burn a core re-requesting thousands of times a
 // second. The pause is the fetch's own wait, which is the cadence the loop
-// already runs at.
+// already runs at, and is also what naturally bounds consumerUnavailable's
+// probe to at most once per error: this method runs once per pause cycle.
 func (s *pullSubscriber) noteFetchError(err error) bool {
 	if s.closed.Load() {
 		return false
@@ -724,8 +793,8 @@ func (s *pullSubscriber) noteFetchError(err error) bool {
 			zap.Int64("fetch_errors", count),
 			zap.Error(err))
 	}
-	if consumerGone(err) {
-		s.rebuildConsumer()
+	if s.consumerUnavailable(err) {
+		s.coordinatedRebuild()
 	}
 	return s.pause(s.maxWait)
 }
@@ -748,7 +817,10 @@ func consumerGone(err error) bool {
 	return errors.Is(err, jsapi.ErrConsumerNotFound) || errors.Is(err, jsapi.ErrConsumerDeleted)
 }
 
-// rebuildConsumer re-provisions the shared durable after the server has lost it.
+// rebuildConsumer re-provisions the shared durable lock-free: no coordination
+// bucket, no floor, always DeliverNew. It is coordinatedRebuild's fallback
+// (lane_coord.go) whenever the bucket cannot be trusted, and — via s.rebind —
+// the exact path this lane always ran before the bucket existed at all.
 //
 // The lane durable is fleet-wide and genuinely deletable: InactiveThreshold
 // expires it once the whole fleet stops fetching, and losing every replica of
@@ -764,8 +836,15 @@ func (s *pullSubscriber) rebuildConsumer() {
 	// The old consumer's receipt can never be acked against a new one, and
 	// holding it would spend the next floor ack on a guaranteed failure.
 	s.takePending()
-
 	consumer, err := s.rebind()
+	s.completeRebuild(consumer, err)
+}
+
+// completeRebuild is the swap-or-log tail both rebuild paths share: the
+// lock-free one above and lane_coord.go's floor-aware winner path. Splitting
+// it out is what lets the winner path resume at a checkpoint instead of
+// DeliverNew without duplicating the counter and log lines here.
+func (s *pullSubscriber) completeRebuild(consumer jsapi.Consumer, err error) {
 	if err != nil {
 		s.log.Warn("lane consumer rebuild failed",
 			zap.String("stream", s.stream),

--- a/pkg/bus/pull_consumer_test.go
+++ b/pkg/bus/pull_consumer_test.go
@@ -670,6 +670,10 @@ type fakePullMsg struct {
 	sequence uint64
 	header   nats.Header
 	payload  []byte
+	// ackErr, when set, makes Ack fail the way a dropped connection would: the
+	// call returns without the broker ever having seen it. Nil by default, so
+	// every existing caller gets the old always-succeeds behavior.
+	ackErr error
 
 	mu     sync.Mutex
 	acked  int
@@ -716,6 +720,9 @@ func (m *fakePullMsg) TermWithReason(string) error      { return nil }
 func (m *fakePullMsg) Ack() error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	if m.ackErr != nil {
+		return m.ackErr
+	}
 	m.acked++
 	return nil
 }

--- a/pkg/bus/pull_rebuild_test.go
+++ b/pkg/bus/pull_rebuild_test.go
@@ -4,7 +4,9 @@
 package bus
 
 import (
+	"context"
 	"errors"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -302,3 +304,416 @@ func (c *pumpConsumer) Messages(...jsapi.PullMessagesOpt) (jsapi.MessagesContext
 	c.calls++
 	return c.opens[i].iter, c.opens[i].err
 }
+
+// The tests below cover lane_coord.go: the probe that tells a peer-down R1
+// consumer apart from an ordinary transient error, the KV-backed rebuild lock
+// that keeps a fleet from racing its own recreate, and the floor checkpoint a
+// rebuilt durable resumes from. Every scenario runs against fakeLaneCoord
+// rather than a broker, the same reason pullConsumerSpy exists above.
+
+// A probe that never answers is exactly the 2026-08-16 shape: the durable
+// still resolves in meta, so consumerGone never fires, and only a bounded
+// INFO call distinguishes it from a responder that is merely slow.
+func TestProbeTimeoutTriggersRebuildButAProbeSuccessDoesNot(t *testing.T) {
+	t.Setenv("NATS_PULL_PROBE_TIMEOUT", "20ms")
+
+	t.Run("probe times out", func(t *testing.T) {
+		replacement := &pullConsumerHandle{info: &jsapi.ConsumerInfo{}}
+		s, rebuilds := subscriberWithRebind(replacement, nil)
+		s.consumer = &probeConsumer{block: true}
+		s.connected = func() bool { return true }
+
+		if !s.noteFetchError(errors.New("nats: timeout")) {
+			t.Fatal("a probe-triggered rebuild must keep the pump loop running")
+		}
+		if *rebuilds != 1 {
+			t.Fatalf("rebuild attempts = %d, want 1 after the probe timed out", *rebuilds)
+		}
+	})
+
+	t.Run("probe succeeds", func(t *testing.T) {
+		s, rebuilds := subscriberWithRebind(nil, errors.New("must not be called"))
+		s.consumer = &probeConsumer{}
+		s.connected = func() bool { return true }
+
+		if !s.noteFetchError(errors.New("nats: timeout")) {
+			t.Fatal("noteFetchError must keep the pump loop running")
+		}
+		if *rebuilds != 0 {
+			t.Fatalf("rebuild attempts = %d, want 0: the probe answered, so the fetch error was transient", *rebuilds)
+		}
+	})
+
+	t.Run("not connected skips the probe entirely", func(t *testing.T) {
+		s, rebuilds := subscriberWithRebind(nil, errors.New("must not be called"))
+		s.consumer = &probeConsumer{block: true}
+		s.connected = func() bool { return false }
+
+		if !s.noteFetchError(errors.New("nats: timeout")) {
+			t.Fatal("noteFetchError must keep the pump loop running")
+		}
+		if *rebuilds != 0 {
+			t.Fatalf("rebuild attempts = %d, want 0: a disconnected client cannot rebuild anyway", *rebuilds)
+		}
+	})
+}
+
+// The lock winner performs the (floor-aware) rebuild and releases the lock
+// afterward; a pod that finds a fresh lock already held skips its own
+// rebuild for this cycle rather than racing the winner's create.
+func TestRebuildLockWinnerRebuildsAndReleasesLoserSkips(t *testing.T) {
+	coord := newFakeLaneCoord()
+	name := "worker_twitch_ingress_event_premium"
+	s := &pullSubscriber{subject: "twitch.ingress.event.premium", name: name, log: zap.NewNop(), coord: coord}
+	replacement := &pullConsumerHandle{info: &jsapi.ConsumerInfo{}}
+	var floorAttempts int
+	s.floorRebind = func() (jsapi.Consumer, error) {
+		floorAttempts++
+		return replacement, nil
+	}
+
+	s.coordinatedRebuild()
+	if floorAttempts != 1 {
+		t.Fatalf("winner rebuild attempts = %d, want 1", floorAttempts)
+	}
+	if s.consumer != jsapi.Consumer(replacement) {
+		t.Fatal("the winner must swap in the rebuilt consumer")
+	}
+	if _, err := coord.Get(context.Background(), laneRebuildKey(name)); !errors.Is(err, jsapi.ErrKeyNotFound) {
+		t.Fatalf("winner must release the lock after rebuilding, got err=%v", err)
+	}
+
+	// Seed a fresh lock, as another pod's in-progress rebuild would, and
+	// confirm this pod defers instead of racing it.
+	if _, err := coord.Create(context.Background(), laneRebuildKey(name), rebuildLockValue()); err != nil {
+		t.Fatalf("seed lock: %v", err)
+	}
+	floorAttempts = 0
+	s.coordinatedRebuild()
+	if floorAttempts != 0 {
+		t.Fatalf("a pod must not rebuild while another pod's lock is fresh, attempts = %d", floorAttempts)
+	}
+}
+
+// A lock left behind by a pod that crashed mid-rebuild must not wedge every
+// other pod forever; once it is older than the stale window, the next pod to
+// notice steals it via a revision-guarded update.
+func TestStaleRebuildLockIsStolenViaCAS(t *testing.T) {
+	t.Setenv("NATS_PULL_LOCK_STALE", "10ms")
+	coord := newFakeLaneCoord()
+	name := "worker_twitch_ingress_event_premium"
+	stale := []byte("otherpod " + strconv.FormatInt(time.Now().Add(-time.Second).UnixNano(), 10))
+	if _, err := coord.Create(context.Background(), laneRebuildKey(name), stale); err != nil {
+		t.Fatalf("seed stale lock: %v", err)
+	}
+
+	s := &pullSubscriber{subject: "twitch.ingress.event.premium", name: name, log: zap.NewNop(), coord: coord}
+	replacement := &pullConsumerHandle{info: &jsapi.ConsumerInfo{}}
+	var floorAttempts int
+	s.floorRebind = func() (jsapi.Consumer, error) {
+		floorAttempts++
+		return replacement, nil
+	}
+
+	s.coordinatedRebuild()
+	if floorAttempts != 1 {
+		t.Fatalf("a stale lock must be stolen and rebuilt, attempts = %d", floorAttempts)
+	}
+}
+
+// Coordination is an optimization, never a gate: any KV error at all —
+// nothing provisioned, denied, partitioned — has to fall through to the
+// original lock-free rebuild rather than leave the lane stuck.
+func TestKVFailureFallsBackToLockFreeRebuild(t *testing.T) {
+	coord := newFakeLaneCoord()
+	coord.err = errors.New("nats: no responders")
+
+	replacement := &pullConsumerHandle{info: &jsapi.ConsumerInfo{}}
+	s, rebuilds := subscriberWithRebind(replacement, nil)
+	s.coord = coord
+
+	s.coordinatedRebuild()
+	if *rebuilds != 1 {
+		t.Fatalf("a KV failure must fall back to the lock-free rebuild, attempts = %d", *rebuilds)
+	}
+}
+
+// The rebuilt durable must resume from the fleet's floor checkpoint rather
+// than replaying the retained window or, on a bare DeliverNew, silently
+// skipping whatever the fleet had not yet acked.
+func TestRebuildDesiredConfigUsesFloorCheckpointWhenPresent(t *testing.T) {
+	name := "worker_twitch_ingress_event_premium"
+	coord := newFakeLaneCoord()
+	if _, err := coord.Put(context.Background(), laneFloorKey(name), []byte("41")); err != nil {
+		t.Fatalf("seed floor: %v", err)
+	}
+	s := &pullSubscriber{name: name, coord: coord, desired: pullConsumerConfig("twitch.ingress.event.premium", name)}
+
+	cfg := s.rebuildDesiredConfig()
+	if cfg.DeliverPolicy != jsapi.DeliverByStartSequencePolicy || cfg.OptStartSeq != 42 {
+		t.Fatalf("desired = %+v, want DeliverByStartSequence at seq 42", cfg)
+	}
+}
+
+// With no checkpoint on record (a fresh bucket, or a lane that has never
+// acked), the rebuild must fall back to the original DeliverNew rather than
+// invent a start position.
+func TestRebuildDesiredConfigFallsBackToDeliverNewWithoutACheckpoint(t *testing.T) {
+	name := "worker_twitch_ingress_event_premium"
+	s := &pullSubscriber{name: name, coord: newFakeLaneCoord(), desired: pullConsumerConfig("twitch.ingress.event.premium", name)}
+
+	cfg := s.rebuildDesiredConfig()
+	if cfg.DeliverPolicy != jsapi.DeliverNewPolicy || cfg.OptStartSeq != 0 {
+		t.Fatalf("desired = %+v, want DeliverNew with no start sequence", cfg)
+	}
+}
+
+// The floor checkpoint is a raft proposal on the coordination bucket's own R3
+// stream, so writing one every tick regardless of progress would reintroduce,
+// at tick cadence, the exact per-proposal cost the parent change removes from
+// the hot path. It must write only when the acked sequence actually moved.
+func TestCheckpointFloorWritesOnlyWhenTheFloorAdvanced(t *testing.T) {
+	coord := newFakeLaneCoord()
+	name := "worker_twitch_ingress_event_premium"
+	s := &pullSubscriber{name: name, subject: "twitch.ingress.event.premium", log: zap.NewNop(), coord: coord}
+
+	s.pending = fakePullDelivery(10)
+	s.advanceFloor()
+	s.checkpointFloor()
+	if coord.puts != 1 {
+		t.Fatalf("puts = %d, want 1 after the first advance", coord.puts)
+	}
+	entry, err := coord.Get(context.Background(), laneFloorKey(name))
+	if err != nil {
+		t.Fatalf("read checkpoint: %v", err)
+	}
+	if string(entry.Value()) != "10" {
+		t.Fatalf("checkpoint = %q, want %q", entry.Value(), "10")
+	}
+
+	// No new receipt landed: the floor has not moved, so a repeat tick must
+	// not write again.
+	s.checkpointFloor()
+	if coord.puts != 1 {
+		t.Fatalf("puts = %d, want 1: the floor had not advanced", coord.puts)
+	}
+
+	s.pending = fakePullDelivery(11)
+	s.advanceFloor()
+	s.checkpointFloor()
+	if coord.puts != 2 {
+		t.Fatalf("puts = %d, want 2 after the floor advanced again", coord.puts)
+	}
+}
+
+// A local Ack failure (a dropped connection — exactly the peer-down scenario
+// lane_coord.go exists for) is fire-and-forget over the wire: the broker may
+// never have seen it. Checkpointing the sequence anyway would let a rebuild
+// resume past a message the fleet never actually acknowledged — a skip, not
+// a redelivery, and skipping is the one outcome this whole mechanism may
+// never trade availability for.
+func TestFailedAckNeverAdvancesTheCheckpoint(t *testing.T) {
+	coord := newFakeLaneCoord()
+	name := "worker_twitch_ingress_event_premium"
+	s := &pullSubscriber{name: name, subject: "twitch.ingress.event.premium", log: zap.NewNop(), coord: coord}
+
+	failed := fakePullDelivery(10)
+	failed.ackErr = errors.New("nats: no responders")
+	s.pending = failed
+	s.advanceFloor()
+	s.checkpointFloor()
+
+	if coord.puts != 0 {
+		t.Fatalf("puts = %d, want 0: the ack failed, so nothing may checkpoint", coord.puts)
+	}
+	if _, err := coord.Get(context.Background(), laneFloorKey(name)); !errors.Is(err, jsapi.ErrKeyNotFound) {
+		t.Fatalf("floor key must not exist after a failed ack, got err=%v", err)
+	}
+
+	// A later ack that does succeed must still checkpoint normally — the
+	// failure above must not have left the tracked sequence stuck.
+	ok := fakePullDelivery(11)
+	s.pending = ok
+	s.advanceFloor()
+	s.checkpointFloor()
+	if coord.puts != 1 {
+		t.Fatalf("puts = %d, want 1 after the next ack succeeded", coord.puts)
+	}
+	entry, err := coord.Get(context.Background(), laneFloorKey(name))
+	if err != nil {
+		t.Fatalf("read checkpoint: %v", err)
+	}
+	if string(entry.Value()) != "11" {
+		t.Fatalf("checkpoint = %q, want %q", entry.Value(), "11")
+	}
+}
+
+// A rebuild slow enough to cross pullLockStale can have its lock stolen by
+// another pod while the original winner is still working. That winner's own
+// release must not delete the stealer's lock: an unconditional delete would,
+// reopening the lock to a third pod while the second pod is still mid-rebuild.
+func TestReleaseNeverDeletesALockStolenFromUnderIt(t *testing.T) {
+	coord := newFakeLaneCoord()
+	name := "worker_twitch_ingress_event_premium"
+	s := &pullSubscriber{subject: "twitch.ingress.event.premium", name: name, log: zap.NewNop(), coord: coord}
+
+	lock := s.acquireRebuildLock()
+	if lock.result != rebuildLockWon {
+		t.Fatalf("initial acquire result = %v, want rebuildLockWon", lock.result)
+	}
+
+	// Simulate a second pod stealing the (now stale, in production) lock
+	// while the first is still "working": a steal is exactly a CAS update
+	// against the revision it read, landing at a revision the first pod never
+	// saw.
+	stolenRev, err := coord.Update(context.Background(), laneRebuildKey(name), rebuildLockValue(), lock.revision)
+	if err != nil {
+		t.Fatalf("simulate steal: %v", err)
+	}
+
+	// The original winner finishes and releases using its OWN (now stale)
+	// revision. The CAS delete must fail and leave the stealer's lock intact.
+	s.releaseRebuildLock(lock.revision)
+
+	entry, err := coord.Get(context.Background(), laneRebuildKey(name))
+	if err != nil {
+		t.Fatalf("the stealer's lock must still be held, got err=%v", err)
+	}
+	if entry.Revision() != stolenRev {
+		t.Fatalf("lock revision = %d, want the stealer's revision %d", entry.Revision(), stolenRev)
+	}
+}
+
+// probeConsumer answers Info either immediately or by blocking until its
+// context is done, so the probe-timeout branch in consumerUnavailable can be
+// driven without a broker.
+type probeConsumer struct {
+	jsapi.Consumer
+	block bool
+	err   error
+}
+
+func (c *probeConsumer) Info(ctx context.Context) (*jsapi.ConsumerInfo, error) {
+	if c.block {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	if c.err != nil {
+		return nil, c.err
+	}
+	return &jsapi.ConsumerInfo{}, nil
+}
+
+// fakeLaneCoordEntry is one stored key/value/revision triple.
+type fakeLaneCoordEntry struct {
+	value    []byte
+	revision uint64
+}
+
+// fakeLaneCoord is an in-memory laneCoordinator, standing in for the KV
+// bucket the same way pullConsumerSpy stands in for the stream API. Setting
+// err makes every method fail uniformly, which is what the KV-unavailable
+// fallback test drives.
+type fakeLaneCoord struct {
+	mu      sync.Mutex
+	entries map[string]fakeLaneCoordEntry
+	nextRev uint64
+	err     error
+
+	puts    int
+	creates int
+	deletes int
+}
+
+func newFakeLaneCoord() *fakeLaneCoord {
+	return &fakeLaneCoord{entries: make(map[string]fakeLaneCoordEntry)}
+}
+
+func (f *fakeLaneCoord) Get(_ context.Context, key string) (jsapi.KeyValueEntry, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.err != nil {
+		return nil, f.err
+	}
+	entry, ok := f.entries[key]
+	if !ok {
+		return nil, jsapi.ErrKeyNotFound
+	}
+	return &fakeKVEntry{value: entry.value, revision: entry.revision}, nil
+}
+
+func (f *fakeLaneCoord) Put(_ context.Context, key string, value []byte) (uint64, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.puts++
+	if f.err != nil {
+		return 0, f.err
+	}
+	f.nextRev++
+	f.entries[key] = fakeLaneCoordEntry{value: append([]byte(nil), value...), revision: f.nextRev}
+	return f.nextRev, nil
+}
+
+func (f *fakeLaneCoord) Create(_ context.Context, key string, value []byte) (uint64, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.creates++
+	if f.err != nil {
+		return 0, f.err
+	}
+	if _, exists := f.entries[key]; exists {
+		return 0, jsapi.ErrKeyExists
+	}
+	f.nextRev++
+	f.entries[key] = fakeLaneCoordEntry{value: append([]byte(nil), value...), revision: f.nextRev}
+	return f.nextRev, nil
+}
+
+func (f *fakeLaneCoord) Update(_ context.Context, key string, value []byte, revision uint64) (uint64, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.err != nil {
+		return 0, f.err
+	}
+	entry, ok := f.entries[key]
+	if !ok || entry.revision != revision {
+		return 0, errors.New("nats: wrong last sequence")
+	}
+	f.nextRev++
+	f.entries[key] = fakeLaneCoordEntry{value: append([]byte(nil), value...), revision: f.nextRev}
+	return f.nextRev, nil
+}
+
+// Delete is revision-checked, mirroring the real KV's CAS delete
+// (jsapi.LastRevision): a caller holding a stale revision — its lock having
+// been stolen out from under it — must fail here, not delete whatever
+// currently occupies the key.
+func (f *fakeLaneCoord) Delete(_ context.Context, key string, revision uint64) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.deletes++
+	if f.err != nil {
+		return f.err
+	}
+	entry, ok := f.entries[key]
+	if !ok {
+		return jsapi.ErrKeyNotFound
+	}
+	if entry.revision != revision {
+		return errors.New("nats: wrong last sequence")
+	}
+	delete(f.entries, key)
+	return nil
+}
+
+// fakeKVEntry satisfies jetstream.KeyValueEntry by embedding the interface,
+// so any method beyond Value/Revision panics instead of returning a zero
+// value — the same convention pullConsumerHandle uses above.
+type fakeKVEntry struct {
+	jsapi.KeyValueEntry
+	value    []byte
+	revision uint64
+}
+
+func (e *fakeKVEntry) Value() []byte    { return e.value }
+func (e *fakeKVEntry) Revision() uint64 { return e.revision }


### PR DESCRIPTION
Replicas:3 on the shared pull durable (#562) put a raft proposal on every delivered message and collapsed lane drain. Back to R1; the availability it bought is replaced by:

- Probe-triggered rebuild: a fetch error on a healthy connection probes the consumer with a bounded INFO call; timeout or not-found means the durable is unavailable (peer-down R1 looks exactly like this) and the lane rebuilds in seconds.
- `lane_coord` KV bucket (R3): rebuild lock via atomic create, revision-CAS steal after 30s, revision-checked release; floor checkpoint every 250ms so a rebuilt durable resumes at floor+1 instead of DeliverNew.
- Every KV failure degrades to the existing lock-free rebuild — KV is coordination, never correctness. The checkpoint only advances after a successful ack, so a rebuild can redeliver but never skip.
- worker_bus gains the minimal `lane_coord` grants, asserted by the exact-ACL test. Grants hot-reload via SIGHUP; the consumer change itself needs the normal sesame roll.
