### PR TITLE
chore(deploy): retain application deployment manifests in deploy/k8s

### DIFF
--- a/deploy/k8s/commands.yaml
+++ b/deploy/k8s/commands.yaml
@@ -1,0 +1,163 @@
+# Copyright (c) 2026 Adam Ousmer. All rights reserved.
+# Proprietary. No license granted. See LICENSE.md.
+
+apiVersion: secrets.doppler.com/v1alpha1
+kind: DopplerSecret
+metadata:
+  name: commands-env
+  namespace: production
+spec:
+  host: https://api.doppler.com
+  tokenSecret:
+    name: commands-doppler-token
+  managedSecret:
+    name: commands-env
+    namespace: production
+    type: Opaque
+  resyncSeconds: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: commands
+  namespace: production
+  annotations:
+    secrets.doppler.com/reload: "true"
+spec:
+  replicas: 3 # one per hot-path node: node4, node5, node6
+  revisionHistoryLimit: 3
+  minReadySeconds: 10
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: commands
+  template:
+    metadata:
+      labels:
+        app: commands
+    spec:
+      tolerations:
+        - key: node.kubernetes.io/unreachable
+          operator: Exists
+          effect: NoExecute
+          tolerationSeconds: 60
+        - key: node.kubernetes.io/not-ready
+          operator: Exists
+          effect: NoExecute
+          tolerationSeconds: 60
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: itsbagelbot.dev/role
+                    operator: NotIn
+                    values: [cp, worker]
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  app: commands
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          matchLabelKeys: [pod-template-hash]
+          labelSelector:
+            matchLabels:
+              app: commands
+      # Required pod anti-affinity prevents old and new ReplicaSets from ever
+      # stacking two commands pods on one hot-path node.
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        seccompProfile: {type: RuntimeDefault}
+      containers:
+        - name: commands
+          image: ghcr.io/adamousmer/itsbagelbot/commands:main-1786934707-b71a0f43997c@sha256:dcd4e4b2d2617cb04fdac53c1801ac3caa46f19b9583c486cb9c13e5acd2a723 # {"$imagepolicy": "flux-system:commands"}
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: NATS_HOST
+              value: nats
+            # Split planes: the BUS / JetStream connection dials the hub directly
+            # (NATS_HUB_URL) so stream traffic never pays a leaf forwarding hop;
+            # the RPC + cache plane (NATS_RPC_URL / NATS_LEAF_URL) stays on the
+            # node-local leaf. NATS_URL is the local-dev fallback only.
+            - name: NATS_URL
+              value: nats://nats-leaf:4222
+            - name: NATS_HUB_URL
+              value: nats://nats:4222
+            - name: NATS_HUB_PUBLISH_URL
+              value: nats://nats:4222
+            # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS
+            # server's native-TLS cert; read as RootCAs by pkg/bus (Go services)
+            # and the console nats lib (TS).
+            - name: NATS_CA_PEM
+              valueFrom:
+                configMapKeyRef:
+                  name: fleet-ca
+                  key: ca.pem
+            - name: NATS_RPC_URL
+              value: nats://nats-leaf:4222
+            - name: NATS_LEAF_URL
+              value: nats://nats-leaf:4222
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: DB_MAX_OPEN_CONNS
+              value: "4"
+            - name: DB_QUERY_CONCURRENCY
+              value: "4"
+            - name: DB_AUTO_MIGRATE
+              value: "true"
+            - name: GOMEMLIMIT
+              value: 160MiB
+          envFrom:
+            - secretRef:
+                name: commands-env
+          ports:
+            - containerPort: 8080
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities: {drop: ["ALL"]}
+          lifecycle:
+            preStop:
+              httpGet:
+                path: /drain
+                port: 8080
+          livenessProbe:
+            httpGet: {path: /healthz, port: 8080}
+            periodSeconds: 30
+          readinessProbe:
+            httpGet: {path: /readyz, port: 8080}
+            periodSeconds: 10
+          startupProbe:
+            httpGet: {path: /healthz, port: 8080}
+            failureThreshold: 18 # 18 × 5s = 90s max startup window
+            periodSeconds: 5
+      terminationGracePeriodSeconds: 45
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: commands
+  namespace: production
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: commands

--- a/deploy/k8s/console-admin.yaml
+++ b/deploy/k8s/console-admin.yaml
@@ -1,0 +1,352 @@
+# Copyright (c) 2026 Adam Ousmer. All rights reserved.
+# Proprietary. No license granted. See LICENSE.md.
+
+# Console admin (SvelteKit SSR). Operator-only, reachable ONLY over Tailscale at
+# https://admin.tail451e6d.ts.net via the Tailscale operator (class `tailscale`,
+# ProxyGroup ts-ingress) - NOT traefik, no cloudflared route. Replaces the Go
+# `admin` tier.
+#
+# HA + cross-pod sessions
+#   Unlike the old Go admin (which pinned ClientIP because its CSRF token lived
+#   in pod memory), this app is stateless: encrypted-cookie session + SvelteKit
+#   origin-checked CSRF. So sessionAffinity is dropped and any pod serves any
+#   request. Access is gated by the tailnet policy AND the DB-backed staff
+#   allowlist (auth.check) on top of the admin's own isolated encrypted session.
+#
+# Region spread: replicas spread across the 3 cities (see console-dashboard.yaml
+# for the required node region/zone labels); the operator proxy prefers the
+# in-region admin pod via the Service's PreferClose.
+apiVersion: secrets.doppler.com/v1alpha1
+kind: DopplerSecret
+metadata:
+  name: console-admin-env
+  namespace: production
+spec:
+  host: https://api.doppler.com
+  tokenSecret:
+    name: admin-doppler-token
+  managedSecret:
+    name: console-admin-env
+    namespace: production
+    type: Opaque
+  resyncSeconds: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: console-admin
+  namespace: production
+  annotations:
+    secrets.doppler.com/reload: "true"
+spec:
+  replicas: 3 # one per application node; no cp or worker toleration
+  revisionHistoryLimit: 3
+  minReadySeconds: 10
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: console-admin
+  template:
+    metadata:
+      labels:
+        app: console-admin
+    spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/region
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: console-admin
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+          # Scope the hard rule to the incoming ReplicaSet. With maxSurge=1
+          # the first new pod may share a host with an old pod, while the
+          # second new pod is forced onto the other normal node.
+          matchLabelKeys: [pod-template-hash]
+          labelSelector:
+            matchLabels:
+              app: console-admin
+      affinity:
+        # Admin has no worker-pool toleration today; make that placement
+        # contract explicit so a future broad toleration cannot move both
+        # operator replicas away from node2/node3.
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: itsbagelbot.dev/role
+                    operator: NotIn
+                    values: ["worker"]
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - {key: app, operator: In, values: [console-admin]}
+                topologyKey: kubernetes.io/hostname
+      # Resolve external hosts (Twitch OAuth login) without the cluster
+      # search-domain fan-out (ndots:1) and serialize A/AAAA to dodge the
+      # conntrack race; cap any DNS stall well under a few seconds.
+      dnsConfig:
+        options:
+          - {name: ndots, value: "1"}
+          - {name: single-request-reopen}
+          - {name: timeout, value: "2"}
+          - {name: attempts, value: "2"}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        seccompProfile: {type: RuntimeDefault}
+      containers:
+        - name: console-admin
+          image: ghcr.io/adamousmer/itsbagelbot/console-admin:main-1786934707-b71a0f43997c@sha256:2ac92be183b1a3cea6ed1ee81f706317ad43dd92b752db397b85b0184ab4f81d # {"$imagepolicy": "flux-system:console-admin"}
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: PORT
+              value: "3000"
+            - name: NODE_ENV
+              value: production
+            # adapter-bun sits behind cloudflared+traefik+tailscale; ORIGIN lets
+            # SvelteKit validate form POSTs (origin-checked CSRF) against the
+            # public URL instead of the internal http://:3000 origin (was 403).
+            - name: ORIGIN
+              value: https://admin.tail451e6d.ts.net
+            # Split planes: the BUS / JetStream connection dials the hub directly
+            # (NATS_HUB_URL) so stream traffic never pays a leaf forwarding hop;
+            # the RPC + cache plane (NATS_RPC_URL / NATS_LEAF_URL) stays on the
+            # node-local leaf. NATS_URL is the local-dev fallback only.
+            - name: NATS_URL
+              value: nats://nats-leaf:4222
+            - name: NATS_HUB_URL
+              value: nats://nats:4222
+            # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS
+            # server's native-TLS cert; read as RootCAs by pkg/bus (Go services)
+            # and the console nats lib (TS).
+            - name: NATS_CA_PEM
+              valueFrom:
+                configMapKeyRef:
+                  name: fleet-ca
+                  key: ca.pem
+            - name: VALKEY_TLS_CA_PEM
+              valueFrom:
+                configMapKeyRef:
+                  name: fleet-ca
+                  key: ca.pem
+            - name: VALKEY_TLS_SERVER_NAME
+              value: valkey.valkey.svc.cluster.local
+            # mTLS: pkg/valkey's clientTLSConfig() treats these two as
+            # both-or-neither. Land this (a no-op while tls-auth-clients is
+            # still "no") on every consumer BEFORE flipping the statefulset,
+            # not after.
+            - name: VALKEY_TLS_CLIENT_CERT_FILE
+              value: /etc/valkey/client-tls/tls.crt
+            - name: VALKEY_TLS_CLIENT_KEY_FILE
+              value: /etc/valkey/client-tls/tls.key
+            - name: NATS_RPC_URL
+              value: nats://nats-leaf:4222
+            - name: NATS_LEAF_URL
+              value: nats://nats-leaf:4222
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            # Operator traffic has a much smaller working set than dashboard
+            # traffic. The default is also 250; declaring it here makes the
+            # production memory/retention tradeoff explicit and tunable.
+            - name: ADMIN_L1_CACHE_CAPACITY
+              value: "250"
+            - name: NATS_ADMIN_SUBJECT
+              value: twitch.ingress.admin.shards.get
+            - name: NATS_STATUS_SUBJECT_PREFIX
+              value: twitch.ingress.status
+            - name: NATS_ADMIN_USER_SUBJECT_PREFIX
+              value: bagel.rpc.admin.user
+            # DB-backed staff auth + audit (users service). Defaults match the
+            # service; pinned here for clarity.
+            - name: NATS_ADMIN_AUTH_SUBJECT_PREFIX
+              value: bagel.rpc.admin.user.auth
+            - name: NATS_ADMIN_AUDIT_SUBJECT_PREFIX
+              value: bagel.rpc.admin.user.audit
+            - name: NATS_ADMIN_NOTIFICATIONS_SUBJECT_PREFIX
+              value: bagel.rpc.admin.notifications
+            # Twitch OAuth callback for operator sign-in (admin host).
+            - name: TWITCH_REDIRECT_URI
+              value: https://admin.tail451e6d.ts.net/auth/callback
+            # Absolute dashboard origin used when the admin console mints
+            # cross-app "view as" links. Without this, links resolve on the
+            # admin host and bounce through its login gate.
+            - name: DASHBOARD_PUBLIC_ORIGIN
+              value: https://dashboard.itsbagelbot.com
+            # Ed25519 PRIVATE key (base64 PKCS8 DER) for signing view-as handoff
+            # tokens. The admin is the only holder of the private half; the
+            # dashboard verifies with the matching public key and can never forge.
+            # The admin session key remains isolated.
+            - name: IMPERSONATION_PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: console-admin-env
+                  key: IMPERSONATION_PRIVATE_KEY
+            # ── New Relic APM. Agent preloaded via --import in the Containerfile;
+            # the license key arrives through the Doppler secret in envFrom. No
+            # config file — everything is declared here so it is auditable in git.
+            - name: NEW_RELIC_APP_NAME
+              value: console-admin
+            - name: NEW_RELIC_NO_CONFIG_FILE
+              value: "true"
+            - name: NEW_RELIC_LOG
+              value: stdout
+            - name: NEW_RELIC_LOG_LEVEL
+              value: info
+            # Distributed tracing + span events + code-level metrics (span->source).
+            - name: NEW_RELIC_DISTRIBUTED_TRACING_ENABLED
+              value: "true"
+            - name: NEW_RELIC_SPAN_EVENTS_ENABLED
+              value: "true"
+            - name: NEW_RELIC_CODE_LEVEL_METRICS_ENABLED
+              value: "true"
+            # Logs-in-context: the cluster Fluent Bit DaemonSet already forwards
+            # stdout to New Relic, so the agent must NOT forward too (double-send).
+            # It decorates stdout with trace/entity linking metadata and emits
+            # log-level metrics, so forwarded logs correlate back to APM traces.
+            - name: NEW_RELIC_APPLICATION_LOGGING_ENABLED
+              value: "true"
+            - name: NEW_RELIC_APPLICATION_LOGGING_FORWARDING_ENABLED
+              value: "false"
+            - name: NEW_RELIC_APPLICATION_LOGGING_LOCAL_DECORATING_ENABLED
+              value: "true"
+            - name: NEW_RELIC_APPLICATION_LOGGING_METRICS_ENABLED
+              value: "true"
+            # Entity labels for filtering; pod name as the process display name.
+            - name: NEW_RELIC_LABELS
+              value: "service:console-admin;tier:web;component:ssr"
+            - name: NEW_RELIC_PROCESS_HOST_DISPLAY_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          # Secrets from Doppler (admin/prd -> console-admin-env). Admin
+          # sessions are isolated from other tiers:
+          #   SESSION_KEY            — 32-byte base64, admin-only (own Doppler
+          #                            config). Seals/opens the admin session.
+          #   TWITCH_CLIENT_ID       — Twitch app client id.
+          #   TWITCH_CLIENT_SECRET   — Twitch app client secret.
+          #   IMPERSONATION_PRIVATE_KEY — Ed25519 private half that signs
+          #                            short-lived view-as handoff tokens.
+          #   DOPPLER_TOKEN_<SERVICE> — per-service Doppler tokens (USERS,
+          #                            COMMANDS, MODULES, TRANSACTIONS,
+          #                            NOTIFICATIONS), each scoped to that one
+          #                            project. Preferred by the secrets page.
+          #   DOPPLER_MANAGEMENT_TOKEN — legacy broad Doppler token; only a
+          #                            fallback for services without a scoped
+          #                            token, flagged as over-privileged in
+          #                            the secrets UI.
+          #   DB_ADMIN_ADDR/DB_ADMIN_USER/DB_ADMIN_PASS — privileged MySQL
+          #                            credential used only by the secrets
+          #                            page to create schema-local runtime users.
+          #   DB_ADMIN_CA_CERT         — dedicated HeatWave endpoint CA PEM for
+          #                            that privileged connection. DB credential
+          #                            operations fail closed until this is
+          #                            present; the internal fleet-ca is not the
+          #                            HeatWave issuer.
+          # The dashboard holds only the matching public key in its own Doppler
+          # project/config.
+          # The Twitch app MUST register the redirect URI above. Staff identity
+          # is the DB allowlist (seeded via OWNER_BOOTSTRAP_IDS on the users
+          # service); the legacy ADMIN_USER_IDS env is no longer consulted.
+          envFrom:
+            - secretRef:
+                name: console-admin-env
+          volumeMounts:
+            - name: valkey-client-tls
+              mountPath: /etc/valkey/client-tls
+              readOnly: true
+          ports:
+            - containerPort: 3000
+          resources:
+            requests:
+              cpu: 25m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities: {drop: ["ALL"]}
+          lifecycle:
+            preStop:
+              sleep:
+                seconds: 10
+          livenessProbe:
+            httpGet: {path: /healthz, port: 3000}
+            periodSeconds: 30
+          readinessProbe:
+            httpGet: {path: /readyz, port: 3000}
+            periodSeconds: 10
+      volumes:
+        - name: valkey-client-tls
+          secret:
+            secretName: valkey-client-tls
+      terminationGracePeriodSeconds: 45
+      tolerations:
+        - key: node.kubernetes.io/unreachable
+          operator: Exists
+          effect: NoExecute
+          tolerationSeconds: 60
+        - key: node.kubernetes.io/not-ready
+          operator: Exists
+          effect: NoExecute
+          tolerationSeconds: 60
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: console-admin
+  namespace: production
+spec:
+  # No sessionAffinity: stateless sessions make every pod interchangeable.
+  # PreferClose keeps the operator proxy on the in-region admin pod.
+  trafficDistribution: PreferClose
+  selector:
+    app: console-admin
+  ports:
+    - name: http
+      port: 80
+      targetPort: 3000
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: console-admin
+  namespace: production
+  annotations:
+    tailscale.com/proxy-group: ts-ingress
+spec:
+  ingressClassName: tailscale
+  defaultBackend:
+    service:
+      name: console-admin
+      port:
+        number: 80
+  tls:
+    - hosts:
+        - admin
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: console-admin
+  namespace: production
+spec:
+  minAvailable: 1 # 2 replicas on the 3-node fleet: keep one serving while the
+  # other is disrupted (node drain, rolling update, etc.)
+  selector:
+    matchLabels:
+      app: console-admin

--- a/deploy/k8s/console-dashboard.yaml
+++ b/deploy/k8s/console-dashboard.yaml
@@ -1,0 +1,349 @@
+# Copyright (c) 2026 Adam Ousmer. All rights reserved.
+# Proprietary. No license granted. See LICENSE.md.
+
+# Console dashboard (SvelteKit SSR). Public at https://dashboard.itsbagelbot.com
+# via cloudflared -> traefik. Replaces the Go `dashboard` tier.
+#
+# HA + cross-pod sessions
+#   Sessions are stateless: an AES-256-GCM encrypted cookie (SESSION_KEY, shared
+#   to every replica via the Doppler secret) and SvelteKit's origin-checked CSRF.
+#   No per-pod state, so ANY pod can serve ANY request. That is why this deploy
+#   drops the old sticky-cookie affinity entirely -> true HA (lose a pod or a
+#   whole city, every other pod still serves the same sessions).
+#
+# Region (edge) routing across the 3 cities
+#   Nodes must be labelled per city, with zone == city so "same zone" means
+#   "same city":
+#     kubectl label node <n> topology.kubernetes.io/region=<city> \
+#                            topology.kubernetes.io/zone=<city> --overwrite
+#   Path: Cloudflare edge -> closest cloudflared connector (per-node DaemonSet)
+#   -> node-local traefik (per-node DaemonSet, Service PreferClose). traefik then
+#   routes to THIS Service's ClusterIP (nativeLB: true below) instead of load-
+#   balancing pod endpoints directly, so it inherits trafficDistribution:
+#   PreferClose and keeps the request inside the entry city, spilling to another
+#   city only when the local pods are gone.
+#
+# Secrets: uses the Doppler-synced `dashboard-env` secret (project dashboard /
+# config prd) that the old Go tier used - same TWITCH_CLIENT_ID/
+# SECRET, authenticated NATS creds (NATS_HOST/PORT/USER/PASSWORD), and the 32-byte
+# DASHBOARD_SESSION_KEY (mapped to SESSION_KEY below). Only TWITCH_REDIRECT_URI
+# was added to that config for the new OAuth callback. Billing links are also
+# read from this secret when present: TEBEX_PREMIUM_CHECKOUT_URL opens the
+# hosted checkout, and TEBEX_CANCEL_URL opens Tebex subscription management.
+apiVersion: secrets.doppler.com/v1alpha1
+kind: DopplerSecret
+metadata:
+  name: dashboard-env
+  namespace: production
+spec:
+  host: https://api.doppler.com
+  tokenSecret:
+    name: dashboard-doppler-token
+  managedSecret:
+    name: dashboard-env
+    namespace: production
+    type: Opaque
+  resyncSeconds: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: console-dashboard
+  namespace: production
+  annotations:
+    secrets.doppler.com/reload: "true"
+spec:
+  replicas: 3 # one per schedulable node (node2, node3, node4; no worker toleration)
+  revisionHistoryLimit: 3
+  minReadySeconds: 10
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: console-dashboard
+  template:
+    metadata:
+      labels:
+        app: console-dashboard
+    spec:
+      # Hard guard: the dashboard must NEVER run on the worker pool. The taint
+      # already repels it (no toleration here), this required nodeAffinity makes
+      # it impossible even if a toleration is ever added by mistake.
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: itsbagelbot.dev/role
+                    operator: NotIn
+                    values: ["worker"]
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              app: console-dashboard
+          matchLabelKeys:
+            - pod-template-hash
+      # DaemonSet placement keeps one dashboard pod per schedulable node, so
+      # cloudflared -> traefik can prefer a local backend on every node.
+      # Resolve external hosts (Twitch OAuth login) without the cluster
+      # search-domain fan-out (ndots:1) and serialize A/AAAA to dodge the
+      # conntrack race; cap any DNS stall well under a few seconds.
+      dnsConfig:
+        options:
+          - {name: ndots, value: "1"}
+          - {name: single-request-reopen}
+          - {name: timeout, value: "2"}
+          - {name: attempts, value: "2"}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        seccompProfile: {type: RuntimeDefault}
+      containers:
+        - name: console-dashboard
+          image: ghcr.io/adamousmer/itsbagelbot/console-dashboard:main-1786934707-b71a0f43997c@sha256:b554f2c6bdfa8fdf7e38a33628f46a9d8527a1740ac09ff68fb7bd9d114c06d2 # {"$imagepolicy": "flux-system:console-dashboard"}
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: PORT
+              value: "3000"
+            # Serve HTTPS from adapter-node (serve-node.js) using the cert-manager
+            # console-dashboard-tls cert, so the traefik->console hop is TLS.
+            # Traefik re-encrypts via the console-dashboard-transport
+            # ServersTransport.
+            - name: TLS_CERT_FILE
+              value: /etc/console/tls/tls.crt
+            - name: TLS_KEY_FILE
+              value: /etc/console/tls/tls.key
+            - name: NODE_ENV
+              value: production
+            # adapter-node sits behind cloudflared+traefik. The app answers
+            # under two public hostnames (dashboard. and stats.itsbagelbot.com),
+            # so instead of pinning one ORIGIN it derives each request's origin
+            # from traefik's forwarded headers — traefik always sets both, and
+            # overwrites client-supplied values, so the origin-checked CSRF on
+            # form POSTs stays sound. The stats host reroutes '/' to the public
+            # stats page in the app (src/hooks.ts).
+            - name: PROTOCOL_HEADER
+              value: x-forwarded-proto
+            - name: HOST_HEADER
+              value: x-forwarded-host
+            # Pin the in-cluster NATS endpoint. The Doppler secret's NATS_HOST is
+            # a stale cross-namespace FQDN (nats.bagelbot...) that does not
+            # resolve here; NATS_URL overrides it. Auth (NATS_USER/PASSWORD) still
+            # comes from the secret.
+            # Split planes: the BUS / JetStream connection dials the hub directly
+            # (NATS_HUB_URL) so stream traffic never pays a leaf forwarding hop;
+            # the RPC + cache plane (NATS_RPC_URL / NATS_LEAF_URL) stays on the
+            # node-local leaf. NATS_URL is the local-dev fallback only.
+            - name: NATS_URL
+              value: nats://nats-leaf:4222
+            - name: NATS_HUB_URL
+              value: nats://nats:4222
+            # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS
+            # server's native-TLS cert; read as RootCAs by pkg/bus (Go services)
+            # and the console nats lib (TS).
+            - name: NATS_CA_PEM
+              valueFrom:
+                configMapKeyRef:
+                  name: fleet-ca
+                  key: ca.pem
+            - name: VALKEY_TLS_CA_PEM
+              valueFrom:
+                configMapKeyRef:
+                  name: fleet-ca
+                  key: ca.pem
+            - name: VALKEY_TLS_SERVER_NAME
+              value: valkey.valkey.svc.cluster.local
+            - name: VALKEY_TLS_CLIENT_CERT_FILE
+              value: /etc/valkey/client-tls/tls.crt
+            - name: VALKEY_TLS_CLIENT_KEY_FILE
+              value: /etc/valkey/client-tls/tls.key
+            - name: NATS_RPC_URL
+              value: nats://nats-leaf:4222
+            - name: NATS_LEAF_URL
+              value: nats://nats-leaf:4222
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            # Per-process L1 cache bound. The default is also 1,000; keep it
+            # explicit here so production tuning is visible and independent of
+            # the admin console's smaller working set.
+            - name: DASHBOARD_L1_CACHE_CAPACITY
+              value: "1000"
+            - name: NATS_PROJECTOR_DASHBOARD_SUBJECT_PREFIX
+              value: bagel.rpc.projector.dashboard
+            - name: NATS_NOTIFICATIONS_SUBJECT_PREFIX
+              value: bagel.rpc.notifications
+            # Reuse the old tier's 32-byte AES key as the session key.
+            - name: SESSION_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: dashboard-env
+                  key: DASHBOARD_SESSION_KEY
+            # Ed25519 PUBLIC key (base64 SPKI DER) for verifying view-as handoff
+            # tokens minted by console-admin. The dashboard never holds the
+            # private half, so a dashboard compromise cannot forge view-as links.
+            - name: IMPERSONATION_PUBLIC_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: dashboard-env
+                  key: IMPERSONATION_PUBLIC_KEY
+            # New Relic APM (agent preloaded in the Containerfile). License key
+            # comes from the Doppler secret via envFrom; app name is explicit so
+            # it reports as its own entity.
+            - name: NEW_RELIC_APP_NAME
+              value: console-dashboard
+            - name: NEW_RELIC_NO_CONFIG_FILE
+              value: "true"
+            - name: NEW_RELIC_DISTRIBUTED_TRACING_ENABLED
+              value: "true"
+            - name: NEW_RELIC_LOG
+              value: stdout
+            - name: NEW_RELIC_LOG_LEVEL
+              value: info
+            # Span events + code-level metrics (span -> source line).
+            - name: NEW_RELIC_SPAN_EVENTS_ENABLED
+              value: "true"
+            - name: NEW_RELIC_CODE_LEVEL_METRICS_ENABLED
+              value: "true"
+            # Logs-in-context: the cluster Fluent Bit DaemonSet already forwards
+            # stdout to New Relic, so the agent must NOT forward too (double-send).
+            # It decorates stdout with trace/entity linking metadata and emits
+            # log-level metrics, so forwarded logs correlate back to APM traces.
+            - name: NEW_RELIC_APPLICATION_LOGGING_ENABLED
+              value: "true"
+            - name: NEW_RELIC_APPLICATION_LOGGING_FORWARDING_ENABLED
+              value: "false"
+            - name: NEW_RELIC_APPLICATION_LOGGING_LOCAL_DECORATING_ENABLED
+              value: "true"
+            - name: NEW_RELIC_APPLICATION_LOGGING_METRICS_ENABLED
+              value: "true"
+            # Entity labels for filtering; pod name as the process display name.
+            - name: NEW_RELIC_LABELS
+              value: "service:console-dashboard;tier:web;component:ssr"
+            - name: NEW_RELIC_PROCESS_HOST_DISPLAY_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          # TWITCH_CLIENT_ID/SECRET/REDIRECT_URI + NATS_HOST/PORT/USER/PASSWORD
+          # from the existing Doppler-synced secret.
+          envFrom:
+            - secretRef:
+                name: dashboard-env
+          ports:
+            - containerPort: 3000
+          volumeMounts:
+            - {name: tls, mountPath: /etc/console/tls, readOnly: true}
+            - {name: valkey-client-tls, mountPath: /etc/valkey/client-tls, readOnly: true}
+          resources:
+            requests:
+              cpu: 25m
+              memory: 128Mi
+            limits:
+              cpu: "1"
+              memory: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities: {drop: ["ALL"]}
+          lifecycle:
+            preStop:
+              # Give kube-proxy / traefik time to drain this endpoint
+              # before SIGTERM fires. Prevents connection-refused 500s during rolls.
+              sleep:
+                seconds: 10
+          # scheme HTTPS: the server now terminates TLS on 3000 (see serve-node.js).
+          livenessProbe:
+            httpGet: {path: /healthz, port: 3000, scheme: HTTPS}
+            periodSeconds: 30
+          readinessProbe:
+            httpGet: {path: /readyz, port: 3000, scheme: HTTPS}
+            periodSeconds: 10
+      terminationGracePeriodSeconds: 45
+      tolerations:
+        - key: node.kubernetes.io/unreachable
+          operator: Exists
+          effect: NoExecute
+          tolerationSeconds: 60
+        - key: node.kubernetes.io/not-ready
+          operator: Exists
+          effect: NoExecute
+          tolerationSeconds: 60
+      volumes:
+        - name: tls
+          secret:
+            secretName: console-dashboard-tls
+        - name: valkey-client-tls
+          secret:
+            secretName: valkey-client-tls
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: console-dashboard
+  namespace: production
+spec:
+  # Region-aware: prefer same-city (zone==city) endpoints; spill cross-city only
+  # when no local pod is ready. traefik uses this ClusterIP via nativeLB.
+  trafficDistribution: PreferClose
+  selector:
+    app: console-dashboard
+  ports:
+    - name: http
+      port: 80
+      targetPort: 3000
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: console-dashboard
+  namespace: production
+spec:
+  entryPoints: [websecure]
+  routes:
+    - match: Host(`dashboard.itsbagelbot.com`) || Host(`stats.itsbagelbot.com`)
+      kind: Rule
+      services:
+        - name: console-dashboard
+          port: 80
+          # HTTPS to the backend: serve-node.js now terminates TLS, so traefik
+          # re-encrypts via the ServersTransport below (rootCAs = the cert's own
+          # fleet-CA ca.crt). This makes the traefik->console hop TLS end-to-end.
+          scheme: https
+          serversTransport: console-dashboard-transport
+          # Route to the Service ClusterIP (not pod endpoints) so traefik
+          # inherits the Service's PreferClose region routing. No sticky cookie:
+          # sessions are stateless, so any in-region pod is interchangeable.
+          nativeLB: true
+  tls: {}
+---
+apiVersion: traefik.io/v1alpha1
+kind: ServersTransport
+metadata:
+  name: console-dashboard-transport
+  namespace: production
+spec:
+  # Verify the console pod's serve-node.js cert against the fleet CA. serverName
+  # matches the cert SAN (the Service name). rootCAsSecrets reads the CA from the
+  # cert-manager secret's ca.crt key (Traefik v3). No InsecureSkipVerify.
+  serverName: console-dashboard
+  rootCAsSecrets:
+    - console-dashboard-tls
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: console-dashboard
+  namespace: production
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: console-dashboard

--- a/deploy/k8s/gossip.yaml
+++ b/deploy/k8s/gossip.yaml
@@ -1,0 +1,195 @@
+# Copyright (c) 2026 Adam Ousmer. All rights reserved.
+# Proprietary. No license granted. See LICENSE.md.
+
+# gossip: the fleet's external-API gossip. Sesame requests third-party data
+# (urchin.gg Coral, MCSR Ranked, fortnite-api.com) over NATS RPC
+# (bagel.rpc.gossip.>); the gossip fetches, normalizes, and caches replies in
+# Valkey. It is the only app that dials those external hosts.
+#
+# gossip-env (Doppler) carries VALKEY_*, URCHIN_API_KEY (provider disabled
+# without it), optional MCSR_API_KEY, NEW_RELIC_*, and the NATS_RPC_USER /
+# NATS_RPC_PASSWORD pair for the GOSSIP_RPC account. The fortnite provider
+# stays dark until FORTNITE_ENABLED=true is set there; keyless it runs
+# shop-only (!store via fortnite-api.com's public shop), and FORTNITE_API_KEY
+# (an api-fortnite.com key) additionally lights !fnstats. The "season" stats
+# window auto-resolves the season start from the stats upstream hourly;
+# FORTNITE_SEASON_START_UNIX optionally overrides it manually.
+apiVersion: secrets.doppler.com/v1alpha1
+kind: DopplerSecret
+metadata:
+  name: gossip-env
+  namespace: production
+spec:
+  host: https://api.doppler.com
+  tokenSecret:
+    name: gossip-doppler-token
+  managedSecret:
+    name: gossip-env
+    namespace: production
+    type: Opaque
+  resyncSeconds: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gossip
+  namespace: production
+  annotations:
+    secrets.doppler.com/reload: "true"
+spec:
+  # Stateless and cache-backed: keep one local RPC responder beside Sesame on
+  # each hot-path node; the working set is one HTTP client and Valkey connection.
+  replicas: 3
+  revisionHistoryLimit: 3
+  minReadySeconds: 10
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: gossip
+  template:
+    metadata:
+      labels:
+        app: gossip
+    spec:
+      tolerations:
+        - key: node.kubernetes.io/unreachable
+          operator: Exists
+          effect: NoExecute
+          tolerationSeconds: 60
+        - key: node.kubernetes.io/not-ready
+          operator: Exists
+          effect: NoExecute
+          tolerationSeconds: 60
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: itsbagelbot.dev/role
+                    operator: NotIn
+                    values: [cp, worker]
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  app: gossip
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          matchLabelKeys: [pod-template-hash]
+          labelSelector:
+            matchLabels:
+              app: gossip
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        seccompProfile: {type: RuntimeDefault}
+      containers:
+        - name: gossip
+          image: ghcr.io/adamousmer/itsbagelbot/gossip:main-1786934707-b71a0f43997c@sha256:20b13100b7babad9a99641f9cf609a61bc52ec2819cca07be92b32dc4132ee21 # {"$imagepolicy": "flux-system:gossip"}
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: NATS_HOST
+              value: nats
+            # gossip is RPC-only: it answers sesame's requests over
+            # bagel.rpc.gossip.> and never touches JetStream, so it dials the
+            # leaf exclusively (no NATS_HUB_URL) and carries no BUS credential.
+            - name: NATS_URL
+              value: nats://nats-leaf:4222
+            # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS
+            # server's native-TLS cert; read as RootCAs by pkg/bus (Go services)
+            # and the console nats lib (TS).
+            - name: NATS_CA_PEM
+              valueFrom:
+                configMapKeyRef:
+                  name: fleet-ca
+                  key: ca.pem
+            - name: VALKEY_TLS_CA_PEM
+              valueFrom:
+                configMapKeyRef:
+                  name: fleet-ca
+                  key: ca.pem
+            - name: VALKEY_TLS_SERVER_NAME
+              value: valkey.valkey.svc.cluster.local
+            # mTLS: pkg/valkey's clientTLSConfig() treats these two as
+            # both-or-neither. Land this (a no-op while tls-auth-clients is
+            # still "no") on every consumer BEFORE flipping the statefulset,
+            # not after.
+            - name: VALKEY_TLS_CLIENT_CERT_FILE
+              value: /etc/valkey/client-tls/tls.crt
+            - name: VALKEY_TLS_CLIENT_KEY_FILE
+              value: /etc/valkey/client-tls/tls.key
+            - name: NATS_RPC_URL
+              value: nats://nats-leaf:4222
+            - name: NATS_LEAF_URL
+              value: nats://nats-leaf:4222
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            # Node-local Valkey TLS reads stay on the pod network; writes ride Sentinel.
+            - name: NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: VALKEY_LOCAL_ADDR
+              value: valkey-local.valkey.svc.cluster.local:6380
+            - name: GOMEMLIMIT
+              value: 96MiB
+          envFrom:
+            - secretRef:
+                name: gossip-env
+          volumeMounts:
+            - name: valkey-client-tls
+              mountPath: /etc/valkey/client-tls
+              readOnly: true
+          ports:
+            - containerPort: 8080
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 250m
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities: {drop: ["ALL"]}
+          lifecycle:
+            preStop:
+              httpGet:
+                path: /drain
+                port: 8080
+          livenessProbe:
+            httpGet: {path: /healthz, port: 8080}
+            periodSeconds: 30
+          readinessProbe:
+            httpGet: {path: /readyz, port: 8080}
+            periodSeconds: 10
+          startupProbe:
+            httpGet: {path: /healthz, port: 8080}
+            failureThreshold: 18 # 18 × 5s = 90s max startup window
+            periodSeconds: 5
+      volumes:
+        - name: valkey-client-tls
+          secret:
+            secretName: valkey-client-tls
+      terminationGracePeriodSeconds: 45
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: gossip
+  namespace: production
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: gossip

--- a/deploy/k8s/kustomization.yaml
+++ b/deploy/k8s/kustomization.yaml
@@ -1,0 +1,55 @@
+# Copyright (c) 2026 Adam Ousmer. All rights reserved.
+# Proprietary. No license granted. See LICENSE.md.
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: production
+resources:
+  - console-admin.yaml
+  - commands.yaml
+  - console-dashboard.yaml
+  # console-admin.yaml now replaces the Go admin tier, sharing the admin.tail451e6d.ts.net host.
+  # gossip is the external-API proxy + cache (urchin.gg, MCSR Ranked) sesame
+  # queries over bagel.rpc.gossip.>.
+  - gossip.yaml
+  # loyalty is the points/watchtime/counters data service behind sesame's
+  # loyalty module (bagel.rpc.loyalty.> + the data.loyalty.* consumers).
+  # Onboarded 2026-07-11: bagel_loyalty schema + loyalty_svc user, Doppler
+  # project `loyalty` (+ loyalty-doppler-token), loyalty_bus/loyalty_rpc auth,
+  # and the digest-pinned image are all in place.
+  - loyalty.yaml
+  - modules.yaml
+  - notifications.yaml
+  - outgress.yaml
+  - projector.yaml
+  - transactions.yaml
+  - users.yaml
+  # sesame is the Twitch event worker (it replaced the legacy app/worker). It keeps
+  # the "worker" lane consumer group (SESAME_CONSUMER_NAME=worker), so it inherited
+  # the same JetStream consumer across the cutover with no replay or gap.
+  - sesame.yaml
+  - twitch-ingress.yaml
+  - network-policies.yaml
+  # Edge error pages: unrouted hosts + dead-backend 5xx get web/'s coded
+  # 404/500 instead of traefik's plain-text defaults.
+  - web-error-pages.yaml
+  - nats.yaml
+  - nats-leaf.yaml
+  - nats-auth-dopplersecret.yaml
+# NATS broker config, formerly created by apply-nats.sh. The configmaps hold
+# only the server conf + the auth conf ($ENV placeholders expanded at runtime
+# from the nats-auth-env secret). disableNameSuffixHash keeps the names stable
+# (nats-config / nats-leaf-config) so the volume mounts resolve and the
+# config-reloader sidecar hot-reloads on content change instead of forcing a
+# pod roll on every edit.
+configMapGenerator:
+  - name: nats-config
+    files:
+      - nats.conf=nats-server.conf
+      - auth.conf=nats-auth.conf
+  - name: nats-leaf-config
+    files:
+      - nats.conf=nats-leaf-server.conf
+      - auth.conf=nats-auth.conf
+generatorOptions:
+  disableNameSuffixHash: true

--- a/deploy/k8s/loyalty.yaml
+++ b/deploy/k8s/loyalty.yaml
@@ -1,0 +1,161 @@
+# Copyright (c) 2026 Adam Ousmer. All rights reserved.
+# Proprietary. No license granted. See LICENSE.md.
+
+apiVersion: secrets.doppler.com/v1alpha1
+kind: DopplerSecret
+metadata:
+  name: loyalty-env
+  namespace: production
+spec:
+  host: https://api.doppler.com
+  tokenSecret:
+    name: loyalty-doppler-token
+  managedSecret:
+    name: loyalty-env
+    namespace: production
+    type: Opaque
+  resyncSeconds: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: loyalty
+  namespace: production
+  annotations:
+    secrets.doppler.com/reload: "true"
+spec:
+  # Keep one local loyalty RPC responder beside Sesame on every hot-path node.
+  # Event folds remain queue-grouped across the three replicas.
+  replicas: 3
+  revisionHistoryLimit: 3
+  minReadySeconds: 10
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: loyalty
+  template:
+    metadata:
+      labels:
+        app: loyalty
+    spec:
+      tolerations:
+        - key: node.kubernetes.io/unreachable
+          operator: Exists
+          effect: NoExecute
+          tolerationSeconds: 60
+        - key: node.kubernetes.io/not-ready
+          operator: Exists
+          effect: NoExecute
+          tolerationSeconds: 60
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: itsbagelbot.dev/role
+                    operator: NotIn
+                    values: [cp, worker]
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  app: loyalty
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          matchLabelKeys: [pod-template-hash]
+          labelSelector:
+            matchLabels:
+              app: loyalty
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        seccompProfile: {type: RuntimeDefault}
+      containers:
+        - name: loyalty
+          image: ghcr.io/adamousmer/itsbagelbot/loyalty:main-1786934707-b71a0f43997c@sha256:c25aafc2a32a124e20729a4099f8d1afc3b44c8c8e7007a134cfe13ea5f35d6a # {"$imagepolicy": "flux-system:loyalty"}
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: NATS_HOST
+              value: nats
+            # Split planes: the BUS / JetStream connection dials the hub directly
+            # (NATS_HUB_URL) so stream traffic never pays a leaf forwarding hop;
+            # the RPC + cache plane (NATS_RPC_URL / NATS_LEAF_URL) stays on the
+            # node-local leaf. NATS_URL is the local-dev fallback only.
+            - name: NATS_URL
+              value: nats://nats-leaf:4222
+            - name: NATS_HUB_URL
+              value: nats://nats:4222
+            # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS
+            # server's native-TLS cert; read as RootCAs by pkg/bus (Go services)
+            # and the console nats lib (TS).
+            - name: NATS_CA_PEM
+              valueFrom:
+                configMapKeyRef:
+                  name: fleet-ca
+                  key: ca.pem
+            - name: NATS_RPC_URL
+              value: nats://nats-leaf:4222
+            - name: NATS_LEAF_URL
+              value: nats://nats-leaf:4222
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: DB_MAX_OPEN_CONNS
+              value: "4"
+            - name: DB_QUERY_CONCURRENCY
+              value: "4"
+            - name: DB_AUTO_MIGRATE
+              value: "true"
+            - name: GOMEMLIMIT
+              value: 160MiB
+          envFrom:
+            - secretRef:
+                name: loyalty-env
+          ports:
+            - containerPort: 8080
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities: {drop: ["ALL"]}
+          lifecycle:
+            preStop:
+              httpGet:
+                path: /drain
+                port: 8080
+          livenessProbe:
+            httpGet: {path: /healthz, port: 8080}
+            periodSeconds: 30
+          readinessProbe:
+            httpGet: {path: /readyz, port: 8080}
+            periodSeconds: 10
+          startupProbe:
+            httpGet: {path: /healthz, port: 8080}
+            failureThreshold: 18 # 18 × 5s = 90s max startup window
+            periodSeconds: 5
+      terminationGracePeriodSeconds: 45
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: loyalty
+  namespace: production
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: loyalty

--- a/deploy/k8s/modules.yaml
+++ b/deploy/k8s/modules.yaml
@@ -1,0 +1,184 @@
+# Copyright (c) 2026 Adam Ousmer. All rights reserved.
+# Proprietary. No license granted. See LICENSE.md.
+
+apiVersion: secrets.doppler.com/v1alpha1
+kind: DopplerSecret
+metadata:
+  name: modules-env
+  namespace: production
+spec:
+  host: https://api.doppler.com
+  tokenSecret:
+    name: modules-doppler-token
+  managedSecret:
+    name: modules-env
+    namespace: production
+    type: Opaque
+  resyncSeconds: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: modules
+  namespace: production
+  annotations:
+    secrets.doppler.com/reload: "true"
+spec:
+  replicas: 3 # one per hot-path node: node4, node5, node6
+  revisionHistoryLimit: 3
+  minReadySeconds: 10
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: modules
+  template:
+    metadata:
+      labels:
+        app: modules
+    spec:
+      tolerations:
+        - key: node.kubernetes.io/unreachable
+          operator: Exists
+          effect: NoExecute
+          tolerationSeconds: 60
+        - key: node.kubernetes.io/not-ready
+          operator: Exists
+          effect: NoExecute
+          tolerationSeconds: 60
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: itsbagelbot.dev/role
+                    operator: NotIn
+                    values: [cp, worker]
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  app: modules
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          matchLabelKeys: [pod-template-hash]
+          labelSelector:
+            matchLabels:
+              app: modules
+      # Required pod anti-affinity prevents old and new ReplicaSets from ever
+      # stacking two modules pods on one hot-path node.
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        seccompProfile: {type: RuntimeDefault}
+      containers:
+        - name: modules
+          image: ghcr.io/adamousmer/itsbagelbot/modules:main-1786934707-b71a0f43997c@sha256:237d4b4baed7c4b7743519798c8b65e9d01b3ac8a942f8df04adf0314fb4bd5f # {"$imagepolicy": "flux-system:modules"}
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: NATS_HOST
+              value: nats
+            # Split planes: the BUS / JetStream connection dials the hub directly
+            # (NATS_HUB_URL) so stream traffic never pays a leaf forwarding hop;
+            # the RPC + cache plane (NATS_RPC_URL / NATS_LEAF_URL) stays on the
+            # node-local leaf. NATS_URL is the local-dev fallback only.
+            - name: NATS_URL
+              value: nats://nats-leaf:4222
+            - name: NATS_HUB_URL
+              value: nats://nats:4222
+            - name: NATS_HUB_PUBLISH_URL
+              value: nats://nats:4222
+            # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS
+            # server's native-TLS cert; read as RootCAs by pkg/bus (Go services)
+            # and the console nats lib (TS).
+            - name: NATS_CA_PEM
+              valueFrom:
+                configMapKeyRef:
+                  name: fleet-ca
+                  key: ca.pem
+            - name: NATS_RPC_URL
+              value: nats://nats-leaf:4222
+            - name: NATS_LEAF_URL
+              value: nats://nats-leaf:4222
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: DB_MAX_OPEN_CONNS
+              value: "4"
+            - name: DB_QUERY_CONCURRENCY
+              value: "4"
+            - name: DB_AUTO_MIGRATE
+              value: "true"
+            - name: GOMEMLIMIT
+              value: 160MiB
+            # Tink keyset for at-rest Govee API-key encryption (this service's
+            # own keyset, distinct from users'), consumed as a file. The mount is
+            # optional (see volumes): until the TINK_KEYSET secret is provisioned
+            # the file is absent and the service degrades to "govee off" rather
+            # than crash-looping.
+            - name: TINK_KEYSET_PATH
+              value: /etc/tink/keyset.json
+          envFrom:
+            - secretRef:
+                name: modules-env
+          volumeMounts:
+            - name: tink-keyset
+              mountPath: /etc/tink
+              readOnly: true
+          ports:
+            - containerPort: 8080
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities: {drop: ["ALL"]}
+          lifecycle:
+            preStop:
+              httpGet:
+                path: /drain
+                port: 8080
+          livenessProbe:
+            httpGet: {path: /healthz, port: 8080}
+            periodSeconds: 30
+          readinessProbe:
+            httpGet: {path: /readyz, port: 8080}
+            periodSeconds: 10
+          startupProbe:
+            httpGet: {path: /healthz, port: 8080}
+            failureThreshold: 18 # 18 × 5s = 90s max startup window
+            periodSeconds: 5
+      terminationGracePeriodSeconds: 45
+      volumes:
+        # Optional: a missing TINK_KEYSET key leaves the file absent, and the
+        # service disables govee key custody instead of failing to start.
+        - name: tink-keyset
+          secret:
+            secretName: modules-env
+            optional: true
+            items:
+              - key: TINK_KEYSET
+                path: keyset.json
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: modules
+  namespace: production
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: modules

--- a/deploy/k8s/nats-auth-dopplersecret.yaml
+++ b/deploy/k8s/nats-auth-dopplersecret.yaml
@@ -1,0 +1,26 @@
+# Copyright (c) 2026 Adam Ousmer. All rights reserved.
+# Proprietary. No license granted. See LICENSE.md.
+
+# nats-auth-env, the broker-side credential secret consumed (envFrom) by the
+# nats and nats-leaf containers: the per-account bcrypt hashes that resolve the
+# $NATS_BCRYPT_* placeholders in nats-auth.conf.
+#
+# Sourced from the `nats` Doppler project (config prd). Rotate with
+# deploy/k8s/nats-secrets.py, which regenerates plaintext + bcrypt together and
+# writes here; the operator resyncs this secret. NOTE: the hashes are
+# env-injected, so the nats / nats-leaf pods must be restarted to pick up a
+# rotation (the conf file hot-reloads via the config-reloader, the env does not).
+apiVersion: secrets.doppler.com/v1alpha1
+kind: DopplerSecret
+metadata:
+  name: nats-auth-env
+  namespace: production
+spec:
+  host: https://api.doppler.com
+  tokenSecret:
+    name: nats-doppler-token
+  managedSecret:
+    name: nats-auth-env
+    namespace: production
+    type: Opaque
+  resyncSeconds: 60

--- a/deploy/k8s/nats-auth-smoke.conf
+++ b/deploy/k8s/nats-auth-smoke.conf
@@ -1,0 +1,16 @@
+# Local-only broker fixture for TestScopedBusUsersBindAllowedStreams.
+#
+# Run it with dummy values for every NATS_BCRYPT_* variable; never point this
+# plaintext listener or its shared test password at a non-loopback interface.
+port: 14222
+host: "127.0.0.1"
+server_name: "nats-auth-smoke"
+
+jetstream {
+  domain: hub
+  store_dir: "/tmp/itsbagelbot-nats-auth-smoke"
+  max_mem: 128MB
+  max_file: 128MB
+}
+
+include "nats-auth.conf"

--- a/deploy/k8s/nats-auth.conf
+++ b/deploy/k8s/nats-auth.conf
@@ -1,0 +1,813 @@
+# NATS authentication and authorization for the BagelBot fleet.
+#
+# Included by the hub server config (and mirrored on the leaf). Passwords are
+# bcrypt hashes resolved from environment variables injected into the nats
+# container from the nats-auth-env secret; the matching plaintext lives only in
+# each service's Doppler project.
+#
+# Account-level isolation model (ADR: per-account least privilege)
+# ----------------------------------------------------------------
+# The fleet is split into account boundaries, not just per-user subject ACLs, so
+# a compromised credential can reach only the subjects its account explicitly
+# imports — regardless of any single ACL mistake.
+#
+#   * BUS  — the shared durable event plane. Owns the five JetStream streams
+#     (BAGEL_DATA, TWITCH_INGRESS, TWITCH_INGRESS_RETRY, TWITCH_OUTGRESS and
+#     TWITCH_OUTGRESS_SYSTEM), plus TWITCH_INGRESS_STANDARD, which is
+#     pre-authorized here and becomes the sixth when the standard-lane partition
+#     lands. It carries data.> /
+#     twitch.> traffic plus the JetStream API. JetStream is account-scoped, so
+#     every service that publishes into or consumes from a stream connects here
+#     with its *_bus user. This plane carries event payloads only, never secrets.
+#
+#   * <SERVICE>_RPC — one account per service for the core request/reply + cache
+#     invalidation plane (bagel.rpc.*, bagel.cache.invalidate.*). A service
+#     answers only the RPCs it exports and can issue only the RPCs it imports.
+#     OAuth tokens transit USERS_RPC's exported services exclusively
+#     (bagel.rpc.internal.tokens.>, dashboard/admin user RPCs), so no other
+#     account can subscribe to them even by accident.
+#
+# Each runtime holds two connections: a BUS connection (NATS_USER/PASSWORD) for
+# JetStream goes directly to the TLS hub, and a per-service-account connection
+# (NATS_RPC_USER/PASSWORD) for RPC + cache stays on the node-local leaf tier.
+# JetStream clients connect directly to the hub. NATS resolves the configured
+# hub domain locally, so both Go services and the admin console are authorized
+# on the standard $JS.API prefix. Leaves run no JetStream and have no link to
+# the hub.
+# Stream management has one runtime owner per stream: users owns BAGEL_DATA,
+# worker/sesame owns TWITCH_INGRESS and TWITCH_INGRESS_RETRY, and outgress owns
+# TWITCH_OUTGRESS plus TWITCH_OUTGRESS_SYSTEM. Every other grant is
+# consumer-only and stream-scoped.
+#
+# Flow-control ($JS.FC) publish grants are ack authority, not acknowledgement
+# noise: for an AckFlowControl consumer the server never subscribes to $JS.ACK,
+# so the flow-control reply is the only thing that advances the replicated ack
+# floor — and the sequence guard that bounds an ordinary ack does not apply to
+# it. Grant them per stream, to the account that binds the consumer, and never
+# as a wildcard.
+#
+# Pull ($JS.API.CONSUMER.MSG.NEXT) is the fetch verb of the shared-durable pull
+# lane, and it is the one JetStream verb a push consumer never sends: a push
+# consumer is handed messages on its delivery subject, a pull consumer has to
+# ask for each batch. A denied MSG.NEXT therefore does not look like a delivery
+# failure. The consumer is created, the stream fills, every fetch is refused and
+# the lane reports zero events per second with the only evidence in the broker
+# log (measured on the 2026-08-15 live bench). Grant it beside the consumer
+# verbs of the streams whose lanes can actually bind a receipt-level consumer,
+# per stream, never wildcarded across streams. Explicit-ACK consumers do not
+# need it: pkg/bus binds those with a DeliverSubject and a queue group, so
+# projector and outgress hold no MSG.NEXT on their TWITCH_INGRESS bindings.
+#
+# Service exports answer only requests they received (the account-level
+# equivalent of the old allow_responses:true). Cache-invalidation is modelled as
+# stream exports so subscribers import exactly the sections they evict.
+
+accounts: {
+
+  # ───────────────────────── Shared durable event plane ─────────────────────
+  BUS: {
+    # Map form still enables JetStream for the account. cluster_traffic: owner
+    # gives BUS its own RAFT egress goroutine: by default every raft
+    # append/response/heartbeat for all streams and consumers is serialized
+    # through the single $SYS account sendq per server. Delivery: pod roll,
+    # not SIGHUP — accounts-block reload semantics are not trusted for this.
+    jetstream: {
+      cluster_traffic: owner
+    }
+    users: [
+      {
+        # users: publishes user change events; folds its own changes; replays on
+        # reproject. (RPC/cache live in USERS_RPC.)
+        user: "users_bus"
+        password: $NATS_BCRYPT_USERS_BUS
+        permissions: {
+          publish: {
+            allow: [
+              "data.users.>",
+              # users is the sole BAGEL_DATA stream owner.
+              "$JS.API.STREAM.INFO.BAGEL_DATA",
+              "$JS.API.STREAM.CREATE.BAGEL_DATA",
+              "$JS.API.STREAM.UPDATE.BAGEL_DATA",
+              # Broadcast + durable consumers on BAGEL_DATA.
+              "$JS.API.CONSUMER.INFO.BAGEL_DATA.>",
+              "$JS.API.CONSUMER.CREATE.BAGEL_DATA.>",
+              "$JS.API.CONSUMER.DURABLE.CREATE.BAGEL_DATA.>",
+              "$JS.API.CONSUMER.DELETE.BAGEL_DATA.>",
+              # NATS 2.14 can emit either v1 or domain/account-qualified v2 ACKs.
+              "$JS.ACK.BAGEL_DATA.>",
+              "$JS.ACK.*.*.BAGEL_DATA.>"
+            ]
+          }
+          subscribe: { allow: ["data.users.>", "data.reproject.request", "_INBOX.>"] }
+        }
+      },
+      {
+        user: "commands_bus"
+        password: $NATS_BCRYPT_COMMANDS_BUS
+        permissions: {
+          publish: {
+            allow: [
+              "data.commands.>",
+              "$JS.API.STREAM.INFO.BAGEL_DATA",
+              "$JS.API.CONSUMER.INFO.BAGEL_DATA.>",
+              "$JS.API.CONSUMER.CREATE.BAGEL_DATA.>",
+              "$JS.API.CONSUMER.DURABLE.CREATE.BAGEL_DATA.>",
+              "$JS.API.CONSUMER.DELETE.BAGEL_DATA.>",
+              "$JS.ACK.BAGEL_DATA.>",
+              "$JS.ACK.*.*.BAGEL_DATA.>"
+            ]
+          }
+          subscribe: { allow: ["data.commands.>", "_INBOX.>"] }
+        }
+      },
+      {
+        user: "modules_bus"
+        password: $NATS_BCRYPT_MODULES_BUS
+        permissions: {
+          publish: {
+            allow: [
+              "data.modules.>",
+              "$JS.API.STREAM.INFO.BAGEL_DATA",
+              "$JS.API.CONSUMER.INFO.BAGEL_DATA.>",
+              "$JS.API.CONSUMER.CREATE.BAGEL_DATA.>",
+              "$JS.API.CONSUMER.DURABLE.CREATE.BAGEL_DATA.>",
+              "$JS.API.CONSUMER.DELETE.BAGEL_DATA.>",
+              "$JS.ACK.BAGEL_DATA.>",
+              "$JS.ACK.*.*.BAGEL_DATA.>"
+            ]
+          }
+          subscribe: { allow: ["data.modules.>", "data.reproject.request", "_INBOX.>"] }
+        }
+      },
+      {
+        # loyalty: folds the worker's summed point/counter deltas
+        # (data.loyalty.earned / data.loyalty.counters) into its rows, and
+        # deletes a broadcaster's rows on account deletion. It publishes no
+        # events of its own. (RPC lives in LOYALTY_RPC.)
+        user: "loyalty_bus"
+        password: $NATS_BCRYPT_LOYALTY_BUS
+        permissions: {
+          publish: {
+            allow: [
+              "$JS.API.STREAM.INFO.BAGEL_DATA",
+              "$JS.API.CONSUMER.INFO.BAGEL_DATA.>",
+              "$JS.API.CONSUMER.CREATE.BAGEL_DATA.>",
+              "$JS.API.CONSUMER.DURABLE.CREATE.BAGEL_DATA.>",
+              "$JS.API.CONSUMER.DELETE.BAGEL_DATA.>",
+              "$JS.ACK.BAGEL_DATA.>",
+              "$JS.ACK.*.*.BAGEL_DATA.>"
+            ]
+          }
+          subscribe: { allow: ["data.loyalty.>", "data.users.deleted", "_INBOX.>"] }
+        }
+      },
+      {
+        # projector: folds data.> events into Valkey, consumes the stream.online
+        # event, requests reproject, and escalates a cold live query onto the
+        # outgress system lane (rpc/live.go) so a channel with no projected live
+        # state gets re-checked against Twitch instead of staying offline. (Its
+        # dashboard/status RPCs live in PROJECTOR_RPC.)
+        user: "projector_bus"
+        password: $NATS_BCRYPT_PROJECTOR_BUS
+        permissions: {
+          publish: {
+            allow: [
+              "data.reproject.request",
+              "twitch.outgress.system",
+              # BAGEL_DATA consumers.
+              "$JS.API.STREAM.INFO.BAGEL_DATA",
+              "$JS.API.CONSUMER.INFO.BAGEL_DATA.>",
+              "$JS.API.CONSUMER.CREATE.BAGEL_DATA.>",
+              "$JS.API.CONSUMER.DURABLE.CREATE.BAGEL_DATA.>",
+              "$JS.API.CONSUMER.DELETE.BAGEL_DATA.>",
+              "$JS.ACK.BAGEL_DATA.>",
+              "$JS.ACK.*.*.BAGEL_DATA.>",
+              # TWITCH_INGRESS stream-status consumer. Explicit-ACK push, so no
+              # MSG.NEXT; and no TWITCH_INGRESS_STANDARD verbs, because the
+              # partition moves only the standard lane's own subject and the
+              # projector binds twitch.ingress.event.stream, which stays put. If
+              # the partition ever moves a subject this service reads, its
+              # consumer verb set has to move with it in the same change.
+              "$JS.API.STREAM.INFO.TWITCH_INGRESS",
+              "$JS.API.CONSUMER.INFO.TWITCH_INGRESS.>",
+              "$JS.API.CONSUMER.CREATE.TWITCH_INGRESS.>",
+              "$JS.API.CONSUMER.DURABLE.CREATE.TWITCH_INGRESS.>",
+              "$JS.API.CONSUMER.DELETE.TWITCH_INGRESS.>",
+              "$JS.ACK.TWITCH_INGRESS.>",
+              "$JS.ACK.*.*.TWITCH_INGRESS.>"
+            ]
+          }
+          subscribe: {
+            allow: [
+              "data.users.>",
+              "data.modules.>",
+              "data.commands.>",
+              "twitch.ingress.event.stream",
+              "_INBOX.>"
+            ]
+          }
+        }
+      },
+      {
+        # worker: drains the premium/standard ingress lanes and publishes the
+        # resulting actions onto the outgress lane. (Projection RPC + cache live
+        # in WORKER_RPC.)
+        user: "worker_bus"
+        password: $NATS_BCRYPT_WORKER_BUS
+        permissions: {
+          # data.commands.used: the worker-side use-counter (sesame's useReporter)
+          # publishes summed command-execution ticks; the commands service folds
+          # them into uses = uses + n. Least-privilege: only .used, never the full
+          # data.commands.> tree — command CRUD/change events are the commands
+          # service's to emit, not the worker's.
+          # data.loyalty.>: the loyalty reporter's summed point accruals and
+          # counter bumps, folded by the loyalty service the same way.
+          # twitch.ingress.retry.>: the delayed-redelivery lane. A flow-control
+          # consumer has no per-message pending state to NAK against, so the
+          # only redelivery sesame has is publishing the failed event back as a
+          # scheduled message on TWITCH_INGRESS_RETRY. Without this grant the
+          # exceptional path is silently dropped, not retried.
+          publish: {
+            allow: [
+              "twitch.outgress.>",
+              "twitch.ingress.retry.>",
+              "data.commands.used",
+              "data.loyalty.>",
+              # worker/sesame is the sole TWITCH_INGRESS stream owner and its
+              # premium/standard consumer manager.
+              "$JS.API.STREAM.INFO.TWITCH_INGRESS",
+              "$JS.API.STREAM.CREATE.TWITCH_INGRESS",
+              "$JS.API.STREAM.UPDATE.TWITCH_INGRESS",
+              "$JS.API.CONSUMER.INFO.TWITCH_INGRESS.>",
+              "$JS.API.CONSUMER.CREATE.TWITCH_INGRESS.>",
+              "$JS.API.CONSUMER.DURABLE.CREATE.TWITCH_INGRESS.>",
+              "$JS.API.CONSUMER.DELETE.TWITCH_INGRESS.>",
+              # The fetch verb of the shared-durable pull lane, which is the
+              # default receipt-level shape. sesame is the only identity that
+              # binds one: the scope guard admits receipt-level consumption on
+              # the hot ingress lanes alone, and nothing else consumes them.
+              "$JS.API.CONSUMER.MSG.NEXT.TWITCH_INGRESS.>",
+              "$JS.ACK.TWITCH_INGRESS.>",
+              "$JS.ACK.*.*.TWITCH_INGRESS.>",
+              # It owns the retry lane too: same service, same lifecycle, and
+              # the lane is meaningless without the consumer that drains it.
+              # No MSG.NEXT here on purpose: the retry lane is exceptional,
+              # low-rate traffic and is drained on the ordinary explicit-ACK
+              # push path whatever mode the hot lanes run in, so a fetch verb
+              # would be authority for a call this credential never makes.
+              "$JS.API.STREAM.INFO.TWITCH_INGRESS_RETRY",
+              "$JS.API.STREAM.CREATE.TWITCH_INGRESS_RETRY",
+              "$JS.API.STREAM.UPDATE.TWITCH_INGRESS_RETRY",
+              "$JS.API.CONSUMER.INFO.TWITCH_INGRESS_RETRY.>",
+              "$JS.API.CONSUMER.CREATE.TWITCH_INGRESS_RETRY.>",
+              "$JS.API.CONSUMER.DURABLE.CREATE.TWITCH_INGRESS_RETRY.>",
+              "$JS.API.CONSUMER.DELETE.TWITCH_INGRESS_RETRY.>",
+              "$JS.ACK.TWITCH_INGRESS_RETRY.>",
+              "$JS.ACK.*.*.TWITCH_INGRESS_RETRY.>",
+              # TWITCH_INGRESS_STANDARD is the standard lane's own stream, added
+              # by the lane partition so the two hot lanes stop sharing one
+              # serialized RAFT proposal loop. The subjects move out of
+              # TWITCH_INGRESS; the owner does not, so sesame gets exactly the
+              # verb set it holds above, on the new name. Granted ahead of the
+              # stream because the ACL has to be live in the broker BEFORE the
+              # service reconcile creates it: a config push is a git merge plus
+              # a reload, and a rollout that lands first fails its own
+              # STREAM.CREATE. Dormant until then, and consumer/owner verbs on a
+              # stream that does not exist reach nothing.
+              "$JS.API.STREAM.INFO.TWITCH_INGRESS_STANDARD",
+              "$JS.API.STREAM.CREATE.TWITCH_INGRESS_STANDARD",
+              "$JS.API.STREAM.UPDATE.TWITCH_INGRESS_STANDARD",
+              "$JS.API.CONSUMER.INFO.TWITCH_INGRESS_STANDARD.>",
+              "$JS.API.CONSUMER.CREATE.TWITCH_INGRESS_STANDARD.>",
+              "$JS.API.CONSUMER.DURABLE.CREATE.TWITCH_INGRESS_STANDARD.>",
+              "$JS.API.CONSUMER.DELETE.TWITCH_INGRESS_STANDARD.>",
+              "$JS.API.CONSUMER.MSG.NEXT.TWITCH_INGRESS_STANDARD.>",
+              "$JS.ACK.TWITCH_INGRESS_STANDARD.>",
+              "$JS.ACK.*.*.TWITCH_INGRESS_STANDARD.>",
+              # Flow-control responses for the AckFlowControl lane consumers.
+              # Under that ack policy the server does not subscribe to $JS.ACK at
+              # all: this reply subject is the ONLY channel that clears the
+              # outstanding flow-control id and decrements the consumer's pending
+              # bytes. Denied, the window never reopens — delivery hard-stops
+              # after roughly the first 2 MiB and neither a new flow-control
+              # request nor the 1 Hz heartbeat can recover it, so both hot lanes
+              # go to zero events/second seconds after every pod start.
+              #
+              # Scoped to the stream, never the bare $JS.FC wildcard: the
+              # sequence guard that normally bounds an ack is disabled for
+              # flow-control consumers, so publish rights on a flow-control
+              # subject are unbounded authority to move another consumer's ack
+              # floor.
+              #
+              # Shape is the v1 reply subject ($JS.FC.<stream>.<consumer>.<4
+              # chars>), which is what the server sends while js_ack_fc_v2 stays
+              # off. Turning that option on moves the stream out of the third
+              # token and this grant stops matching — revisit it in the same
+              # change, or the lanes wedge exactly as they did without it.
+              #
+              # Both hot-lane streams, because flow stays selectable per
+              # deployment (NATS_CONSUME_MODE=flow) after the partition: a lane
+              # that can bind a flow consumer needs its flow-control reply or it
+              # wedges at the first window.
+              "$JS.FC.TWITCH_INGRESS.>",
+              "$JS.FC.TWITCH_INGRESS_STANDARD.>"
+            ]
+          }
+          subscribe: {
+            allow: [
+              "twitch.ingress.event.premium",
+              "twitch.ingress.event.standard",
+              "twitch.ingress.retry.>",
+              "_INBOX.>"
+            ]
+          }
+        }
+      },
+      {
+        # outgress: drains the outgress lane, and binds its own durable consumer
+        # on the stream (live) lane to re-verify mod status when a channel goes
+        # live (the projector binds its own durable on the same subject). (Token
+        # + conduit RPC live in OUTGRESS_RPC.)
+        user: "outgress_bus"
+        password: $NATS_BCRYPT_OUTGRESS_BUS
+        permissions: {
+          publish: {
+            allow: [
+              # outgress owns both work-queue streams.
+              "$JS.API.STREAM.INFO.TWITCH_OUTGRESS",
+              "$JS.API.STREAM.CREATE.TWITCH_OUTGRESS",
+              "$JS.API.STREAM.UPDATE.TWITCH_OUTGRESS",
+              "$JS.API.STREAM.INFO.TWITCH_OUTGRESS_SYSTEM",
+              "$JS.API.STREAM.CREATE.TWITCH_OUTGRESS_SYSTEM",
+              "$JS.API.STREAM.UPDATE.TWITCH_OUTGRESS_SYSTEM",
+              # Chat work-queue consumers.
+              "$JS.API.CONSUMER.INFO.TWITCH_OUTGRESS.>",
+              "$JS.API.CONSUMER.CREATE.TWITCH_OUTGRESS.>",
+              "$JS.API.CONSUMER.DURABLE.CREATE.TWITCH_OUTGRESS.>",
+              "$JS.API.CONSUMER.DELETE.TWITCH_OUTGRESS.>",
+              "$JS.ACK.TWITCH_OUTGRESS.>",
+              "$JS.ACK.*.*.TWITCH_OUTGRESS.>",
+              # Control work-queue consumer.
+              "$JS.API.CONSUMER.INFO.TWITCH_OUTGRESS_SYSTEM.>",
+              "$JS.API.CONSUMER.CREATE.TWITCH_OUTGRESS_SYSTEM.>",
+              "$JS.API.CONSUMER.DURABLE.CREATE.TWITCH_OUTGRESS_SYSTEM.>",
+              "$JS.API.CONSUMER.DELETE.TWITCH_OUTGRESS_SYSTEM.>",
+              "$JS.ACK.TWITCH_OUTGRESS_SYSTEM.>",
+              "$JS.ACK.*.*.TWITCH_OUTGRESS_SYSTEM.>",
+              # Read-only stream-lane consumer; no TWITCH_INGRESS management.
+              # Its lanes are work queues and its ingress bindings are
+              # explicit-ACK push consumers, so no MSG.NEXT anywhere here: a
+              # work-queue stream deletes on ack and requires per-message
+              # acknowledgement, which is the one contract the receipt-level
+              # shapes do not offer. The stream and authz subjects it reads stay
+              # on TWITCH_INGRESS through the partition, so it gains no verbs on
+              # TWITCH_INGRESS_STANDARD either.
+              "$JS.API.STREAM.INFO.TWITCH_INGRESS",
+              "$JS.API.CONSUMER.INFO.TWITCH_INGRESS.>",
+              "$JS.API.CONSUMER.CREATE.TWITCH_INGRESS.>",
+              "$JS.API.CONSUMER.DURABLE.CREATE.TWITCH_INGRESS.>",
+              "$JS.API.CONSUMER.DELETE.TWITCH_INGRESS.>",
+              "$JS.ACK.TWITCH_INGRESS.>",
+              "$JS.ACK.*.*.TWITCH_INGRESS.>"
+            ]
+          }
+          # twitch.ingress.status.authz.* carries the authorization lifecycle
+          # (user.authorization.grant/revoke + per-subscription revocations);
+          # outgress binds durable consumers there to reconcile enrollment
+          # state (mark revoked, re-enroll on grant).
+          subscribe: { allow: ["twitch.outgress.>", "twitch.ingress.event.stream", "twitch.ingress.status.authz.>", "_INBOX.>"] }
+        }
+      },
+      {
+        # twitch-ingress: publishes the Twitch firehose into the stream subjects
+        # via core publish (no JetStream API). Its :gnat_bus connection.
+        user: "twitch_ingress_bus"
+        password: $NATS_BCRYPT_TWITCH_INGRESS_BUS
+        permissions: {
+          publish:   { allow: ["twitch.ingress.event.>", "twitch.ingress.status.>"] }
+          subscribe: { allow: ["_INBOX.>"] }
+        }
+      },
+      {
+        # dashboard: web tier; enqueues EventSub on/off jobs on the outgress
+        # system lane so Helix calls share the fleet rate-limit bucket. Only its
+        # stream-feed publish lives on BUS; all RPC lives in DASHBOARD_RPC.
+        user: "dashboard_bus"
+        password: $NATS_BCRYPT_DASHBOARD_BUS
+        permissions: {
+          publish:   { allow: ["twitch.outgress.system"] }
+          subscribe: { allow: ["_INBOX.>"] }
+        }
+      },
+      {
+        # admin: operator tool; enqueues per-user EventSub restarts on the
+        # outgress system lane, requests reprojections, watches the ingress
+        # status stream, and reads JetStream stream/consumer state for lane
+        # telemetry. This connection is already direct-to-hub, so JetStream
+        # authorization sees the standard $JS.API prefix (not a leaf-domain
+        # import prefix).
+        user: "admin_bus"
+        password: $NATS_BCRYPT_ADMIN_BUS
+        permissions: {
+          publish: {
+            allow: [
+              "twitch.outgress.system",
+              "data.reproject.request",
+              "$JS.API.INFO",
+              "$JS.API.STREAM.NAMES",
+              "$JS.API.STREAM.LIST",
+              "$JS.API.STREAM.INFO.>",
+              "$JS.API.CONSUMER.NAMES.>",
+              "$JS.API.CONSUMER.LIST.>",
+              "$JS.API.CONSUMER.INFO.>",
+              "$JS.API.CONSUMER.CREATE.>",
+              "$JS.API.CONSUMER.DURABLE.CREATE.>",
+              "$JS.API.CONSUMER.DELETE.>",
+              "$JS.API.CONSUMER.MSG.NEXT.>",
+              # Leader spread is a manual operator policy: after any hub roll
+              # the operator re-places stream leaders with a stepdown. The
+              # assigned spread follows the client pinning in the manifests
+              # (sesame dials nats-0, outgress dials nats-1):
+              # TWITCH_INGRESS→nats-0, TWITCH_INGRESS_STANDARD→nats-2,
+              # TWITCH_OUTGRESS→nats-1, BAGEL_DATA and
+              # TWITCH_OUTGRESS_SYSTEM→nats-0. The two hot ingress leaders on
+              # one member is the exact shape the partition exists to avoid,
+              # and the standard lane stays off outgress's member so the reply
+              # path never pays the co-lead penalty. Only the stepdown verb is granted —
+              # no stream create/update/delete rides along with it.
+              "$JS.API.STREAM.LEADER.STEPDOWN.>",
+              "$JS.API.STREAM.CREATE.KV_admin_lanes",
+              "$JS.API.STREAM.UPDATE.KV_admin_lanes",
+              "$JS.API.STREAM.MSG.GET.KV_admin_lanes",
+              "$JS.API.DIRECT.GET.KV_admin_lanes",
+              "$JS.API.DIRECT.GET.KV_admin_lanes.>",
+              # No benchmark-stream grants live here. admin_bus used to carry
+              # CREATE/UPDATE/DELETE plus $JS.FC on a fixed
+              # R3_SHADOW_BENCH name for the load rig. The rig is gone and so
+              # are they: $JS.FC is ack-floor authority, and an account holding
+              # stream-mutation verbs permanently so that an occasional
+              # benchmark does not need a config push is authority granted for a
+              # workload that is not running. A future load test brings its own
+              # grant, on its own stream, for the duration of the run.
+              "$KV.admin_lanes.>"
+            ]
+          }
+          subscribe: {
+            allow: [
+              "twitch.ingress.status.>",
+              "_INBOX.>"
+            ]
+          }
+        }
+      }
+    ]
+  }
+
+  # ───────────────────────── Per-service RPC accounts ───────────────────────
+  # USERS_RPC owns user/token data; answers dashboard, admin, delegation,
+  # projection and token RPCs; publishes user-section cache invalidations.
+  USERS_RPC: {
+    users: [ { user: "users_rpc", password: $NATS_BCRYPT_USERS_RPC } ]
+    exports: [
+      { service: "bagel.rpc.health.users" }
+      { service: "bagel.rpc.health.users.node.*" }
+      { service: "bagel.rpc.dashboard.>" }
+      { service: "bagel.rpc.admin.user.>" }
+      { service: "bagel.rpc.delegation.>" }
+      { service: "bagel.rpc.internal.billing.apply" }
+      { service: "bagel.rpc.internal.billing.apply.node.*" }
+      { service: "bagel.rpc.internal.projection.users.get" }
+      { service: "bagel.rpc.internal.projection.users.get.node.*" }
+      { service: "bagel.rpc.internal.tokens.>" }
+      # Decrypted contact email for transactional mail; import-gated like the
+      # token RPCs so only mail-sending services can reach it.
+      { service: "bagel.rpc.internal.users.email.get" }
+      { service: "bagel.rpc.internal.users.email.get.node.*" }
+      { stream: "bagel.cache.invalidate.grant" }
+      { stream: "bagel.cache.invalidate.status" }
+      { stream: "bagel.cache.invalidate.delegation" }
+      { stream: "bagel.cache.invalidate.locale" }
+    ]
+  }
+
+  # COMMANDS_RPC owns command data; answers the commands CRUD RPC and the
+  # commands projection RPC.
+  COMMANDS_RPC: {
+    users: [ { user: "commands_rpc", password: $NATS_BCRYPT_COMMANDS_RPC } ]
+    exports: [
+      { service: "bagel.rpc.health.commands" }
+      { service: "bagel.rpc.health.commands.node.*" }
+      { service: "bagel.rpc.commands.>" }
+      { service: "bagel.rpc.internal.projection.commands.get" }
+      { service: "bagel.rpc.internal.projection.commands.get.node.*" }
+    ]
+  }
+
+  # MODULES_RPC owns module data; answers the modules CRUD RPC (dashboard
+  # toggle/save + built-in command on/off state, keyed by module name) and the
+  # modules projection RPC.
+  MODULES_RPC: {
+    users: [ { user: "modules_rpc", password: $NATS_BCRYPT_MODULES_RPC } ]
+    exports: [
+      { service: "bagel.rpc.health.modules" }
+      { service: "bagel.rpc.health.modules.node.*" }
+      { service: "bagel.rpc.modules.>" }
+      { service: "bagel.rpc.internal.projection.modules.get" }
+      { service: "bagel.rpc.internal.projection.modules.get.node.*" }
+      # Decrypted per-broadcaster Govee API key; import-gated to GOSSIP_RPC
+      # alone (the one service that dials Govee), mirroring USERS_RPC's tokens.
+      # The dashboard set/clear/status verbs ride the public bagel.rpc.modules.>
+      # export above and never return the key.
+      { service: "bagel.rpc.internal.govee.key.>" }
+    ]
+  }
+
+  # LOYALTY_RPC owns loyalty standings and counters; answers the balance,
+  # leaderboard and counter verbs sesame (and the future dashboard tab) call.
+  LOYALTY_RPC: {
+    users: [ { user: "loyalty_rpc", password: $NATS_BCRYPT_LOYALTY_RPC } ]
+    exports: [
+      { service: "bagel.rpc.health.loyalty" }
+      { service: "bagel.rpc.health.loyalty.node.*" }
+      { service: "bagel.rpc.loyalty.>" }
+    ]
+  }
+
+  # PROJECTOR_RPC answers the broadcaster-status RPC and the dashboard read RPCs
+  # from the projection; publishes command/module cache invalidations; requests
+  # the data services' projections to pre-warm.
+  PROJECTOR_RPC: {
+    users: [ { user: "projector_rpc", password: $NATS_BCRYPT_PROJECTOR_RPC } ]
+    exports: [
+      { service: "bagel.rpc.health.projector" }
+      { service: "bagel.rpc.health.projector.node.*" }
+      { service: "bagel.rpc.projector.dashboard.>" }
+      { service: "bagel.rpc.broadcaster.status.get" }
+      { service: "bagel.rpc.broadcaster.status.get.node.*" }
+      { service: "bagel.rpc.broadcaster.live.get" }
+      { service: "bagel.rpc.broadcaster.live.get.node.*" }
+      { stream: "bagel.cache.invalidate.commands" }
+      { stream: "bagel.cache.invalidate.modules" }
+      # Live-state pings from the stream-event fold (broadcastLiveInvalidate):
+      # without this export the worker's live cache only hears its own
+      # replicas, never the projector's go-live/offline fan-out.
+      { stream: "bagel.cache.invalidate.live" }
+    ]
+    imports: [
+      { service: { account: "USERS_RPC",    subject: "bagel.rpc.internal.projection.users.get" } }
+      { service: { account: "USERS_RPC",    subject: "bagel.rpc.internal.projection.users.get.node.*" } }
+      { service: { account: "COMMANDS_RPC", subject: "bagel.rpc.internal.projection.commands.get" } }
+      { service: { account: "COMMANDS_RPC", subject: "bagel.rpc.internal.projection.commands.get.node.*" } }
+      { service: { account: "MODULES_RPC",  subject: "bagel.rpc.internal.projection.modules.get" } }
+      { service: { account: "MODULES_RPC",  subject: "bagel.rpc.internal.projection.modules.get.node.*" } }
+    ]
+  }
+
+  # OUTGRESS_RPC answers its management RPC; loads/rotates the bot token through
+  # USERS_RPC and resolves the live conduit id from TWITCH_INGRESS_RPC.
+  OUTGRESS_RPC: {
+    users: [ { user: "outgress_rpc", password: $NATS_BCRYPT_OUTGRESS_RPC } ]
+    exports: [
+      { service: "bagel.rpc.health.outgress" }
+      { service: "bagel.rpc.health.outgress.node.*" }
+      { service: "bagel.rpc.outgress.>" }
+    ]
+    imports: [
+      { service: { account: "USERS_RPC",          subject: "bagel.rpc.internal.tokens.>" } }
+      { service: { account: "TWITCH_INGRESS_RPC",  subject: "bagel.rpc.ingress.conduit.get" } }
+      { service: { account: "TWITCH_INGRESS_RPC",  subject: "bagel.rpc.ingress.conduit.get.node.*" } }
+      # Reauth nudge when Twitch revokes a broadcaster's authorization: the
+      # locale read localizes the copy, the notifications send delivers the
+      # dashboard bell entry (same verb the transactions gift notice uses).
+      { service: { account: "USERS_RPC",          subject: "bagel.rpc.dashboard.state_get" } }
+      { service: { account: "USERS_RPC",          subject: "bagel.rpc.dashboard.state_get.node.*" } }
+      { service: { account: "NOTIFICATIONS_RPC",  subject: "bagel.rpc.admin.notifications.send" } }
+      { service: { account: "NOTIFICATIONS_RPC",  subject: "bagel.rpc.admin.notifications.send.node.*" } }
+    ]
+  }
+
+  # TRANSACTIONS_RPC answers the dashboard checkout RPC (Tebex basket minting).
+  # It resolves and vets gift recipients through the users admin lookup, and
+  # sends the "you received premium" direct notification when a gifted payment
+  # webhook lands. Entitlements still come back through the Tebex webhook.
+  TRANSACTIONS_RPC: {
+    users: [ { user: "transactions_rpc", password: $NATS_BCRYPT_TRANSACTIONS_RPC } ]
+    exports: [
+      { service: "bagel.rpc.health.transactions" }
+      { service: "bagel.rpc.health.transactions.node.*" }
+      { service: "bagel.rpc.transactions.>" }
+    ]
+    imports: [
+      { service: { account: "USERS_RPC",         subject: "bagel.rpc.admin.user.get" } }
+      { service: { account: "USERS_RPC",         subject: "bagel.rpc.admin.user.get.node.*" } }
+      { service: { account: "USERS_RPC",         subject: "bagel.rpc.internal.billing.apply" } }
+      { service: { account: "USERS_RPC",         subject: "bagel.rpc.internal.billing.apply.node.*" } }
+      { service: { account: "USERS_RPC",         subject: "bagel.rpc.internal.users.email.get" } }
+      { service: { account: "USERS_RPC",         subject: "bagel.rpc.internal.users.email.get.node.*" } }
+      { service: { account: "NOTIFICATIONS_RPC", subject: "bagel.rpc.admin.notifications.send" } }
+      { service: { account: "NOTIFICATIONS_RPC", subject: "bagel.rpc.admin.notifications.send.node.*" } }
+    ]
+  }
+
+  # NOTIFICATIONS_RPC owns user/admin notification RPCs and publishes
+  # notification cache invalidations; it can resolve direct-send usernames via
+  # the users admin lookup RPC.
+  NOTIFICATIONS_RPC: {
+    users: [ { user: "notifications_rpc", password: $NATS_BCRYPT_NOTIFICATIONS_RPC } ]
+    exports: [
+      { service: "bagel.rpc.health.notifications" }
+      { service: "bagel.rpc.health.notifications.node.*" }
+      { service: "bagel.rpc.notifications.>" }
+      { service: "bagel.rpc.admin.notifications.>" }
+      { stream: "bagel.cache.invalidate.notifications" }
+    ]
+    imports: [
+      { service: { account: "USERS_RPC", subject: "bagel.rpc.admin.user.get" } }
+      { service: { account: "USERS_RPC", subject: "bagel.rpc.admin.user.get.node.*" } }
+    ]
+  }
+
+  # GOSSIP_RPC answers the external-API endpoints (urchin.gg, MCSR Ranked,
+  # Govee) sesame's modules request. Fetches + Valkey caching happen inside the
+  # gossip service. It imports one secret: the per-broadcaster Govee API key,
+  # which the govee provider authenticates its control/devices calls with.
+  GOSSIP_RPC: {
+    users: [ { user: "gossip_rpc", password: $NATS_BCRYPT_GOSSIP_RPC } ]
+    exports: [
+      { service: "bagel.rpc.health.gossip" }
+      { service: "bagel.rpc.health.gossip.node.*" }
+      { service: "bagel.rpc.gossip.>" }
+    ]
+    imports: [
+      { service: { account: "MODULES_RPC", subject: "bagel.rpc.internal.govee.key.>" } }
+    ]
+  }
+
+  # WORKER_RPC resolves config through the PROJECTOR (Valkey owner): module and
+  # command cold-key fallbacks hit the projector's dashboard get verbs, which
+  # hydrate the projection so the next read is a Valkey hit. The only data
+  # services it still reaches are users (projection read; the projector has no
+  # user-shaped verb) and commands' CRUD verbs (the !cmd chat saves — a write
+  # path, not a config read). Imports the cache-invalidation sections it caches
+  # (status, grant, locale, commands, modules, live).
+  WORKER_RPC: {
+    users: [ { user: "worker_rpc", password: $NATS_BCRYPT_WORKER_RPC } ]
+    exports: [
+      { service: "bagel.rpc.health.sesame" }
+      { service: "bagel.rpc.health.sesame.node.*" }
+    ]
+    imports: [
+      { service: { account: "USERS_RPC",    subject: "bagel.rpc.internal.projection.users.get" } }
+      { service: { account: "USERS_RPC",    subject: "bagel.rpc.internal.projection.users.get.node.*" } }
+      { service: { account: "COMMANDS_RPC", subject: "bagel.rpc.commands.>" } }
+      # Quotes book: the quotes module reads/writes rows through the modules
+      # service's quote verbs. Scoped to the quote subtree, not the whole
+      # modules CRUD surface (which owns module toggles/config).
+      { service: { account: "MODULES_RPC", subject: "bagel.rpc.modules.quote.>" } }
+      # Personality feed counter: the built-in personality module persists the
+      # global "feed the bagel" tally through the modules service. Scoped to
+      # the one verb, same rationale as the quote subtree above.
+      { service: { account: "MODULES_RPC", subject: "bagel.rpc.modules.personality.feed" } }
+      { service: { account: "MODULES_RPC", subject: "bagel.rpc.modules.personality.feed.node.*" } }
+      { service: { account: "PROJECTOR_RPC", subject: "bagel.rpc.projector.dashboard.commands.get" } }
+      { service: { account: "PROJECTOR_RPC", subject: "bagel.rpc.projector.dashboard.commands.get.node.*" } }
+      { service: { account: "PROJECTOR_RPC", subject: "bagel.rpc.projector.dashboard.modules.get" } }
+      { service: { account: "PROJECTOR_RPC", subject: "bagel.rpc.projector.dashboard.modules.get.node.*" } }
+      { service: { account: "PROJECTOR_RPC", subject: "bagel.rpc.broadcaster.live.get" } }
+      { service: { account: "PROJECTOR_RPC", subject: "bagel.rpc.broadcaster.live.get.node.*" } }
+      { service: { account: "GOSSIP_RPC",  subject: "bagel.rpc.gossip.>" } }
+      # Loyalty: cold-read loader for the counter/balance Valkey view plus the
+      # !counter management verbs.
+      { service: { account: "LOYALTY_RPC",  subject: "bagel.rpc.loyalty.>" } }
+      # Chatters listing for the loyalty watch tick — scoped to the one verb,
+      # not the whole outgress management surface.
+      { service: { account: "OUTGRESS_RPC", subject: "bagel.rpc.outgress.chatters.get" } }
+      { service: { account: "OUTGRESS_RPC", subject: "bagel.rpc.outgress.chatters.get.node.*" } }
+      # Followage read for the !followage command — the authenticated Twitch
+      # Get Channel Followers behind outgress, scoped to the one verb.
+      { service: { account: "OUTGRESS_RPC", subject: "bagel.rpc.outgress.followage.get" } }
+      { service: { account: "OUTGRESS_RPC", subject: "bagel.rpc.outgress.followage.get.node.*" } }
+      # Account-age read for the !accountage command — the authenticated Twitch
+      # Get Users behind outgress, scoped to the one verb.
+      { service: { account: "OUTGRESS_RPC", subject: "bagel.rpc.outgress.accountage.get" } }
+      { service: { account: "OUTGRESS_RPC", subject: "bagel.rpc.outgress.accountage.get.node.*" } }
+      { stream: { account: "USERS_RPC",     subject: "bagel.cache.invalidate.status" } }
+      { stream: { account: "USERS_RPC",     subject: "bagel.cache.invalidate.grant" } }
+      { stream: { account: "USERS_RPC",     subject: "bagel.cache.invalidate.locale" } }
+      { stream: { account: "PROJECTOR_RPC", subject: "bagel.cache.invalidate.commands" } }
+      { stream: { account: "PROJECTOR_RPC", subject: "bagel.cache.invalidate.modules" } }
+      { stream: { account: "PROJECTOR_RPC", subject: "bagel.cache.invalidate.live" } }
+    ]
+  }
+
+  # DASHBOARD_RPC: web tier. Requests user upserts/grants/tiers, custom command
+  # CRUD, module toggle/config CRUD, projected reads and EventSub channel state;
+  # evicts every cache section. May not export anything, so it can never answer
+  # another service's request.
+  DASHBOARD_RPC: {
+    users: [ { user: "dashboard_rpc", password: $NATS_BCRYPT_DASHBOARD_RPC } ]
+    imports: [
+      { service: { account: "USERS_RPC",     subject: "bagel.rpc.dashboard.>" } }
+      { service: { account: "USERS_RPC",     subject: "bagel.rpc.admin.user.audit.>" } }
+      { service: { account: "USERS_RPC",     subject: "bagel.rpc.delegation.>" } }
+      { service: { account: "COMMANDS_RPC",  subject: "bagel.rpc.commands.>" } }
+      { service: { account: "MODULES_RPC",   subject: "bagel.rpc.modules.>" } }
+      { service: { account: "PROJECTOR_RPC", subject: "bagel.rpc.projector.dashboard.>" } }
+      { service: { account: "PROJECTOR_RPC", subject: "bagel.rpc.broadcaster.status.get" } }
+      { service: { account: "PROJECTOR_RPC", subject: "bagel.rpc.broadcaster.status.get.node.*" } }
+      { service: { account: "OUTGRESS_RPC",  subject: "bagel.rpc.outgress.channel.get" } }
+      { service: { account: "OUTGRESS_RPC",  subject: "bagel.rpc.outgress.channel.get.node.*" } }
+      { service: { account: "OUTGRESS_RPC",  subject: "bagel.rpc.outgress.channelpoints.>" } }
+      # Viewer lookup for the counters page's manual bucket add: resolves a
+      # typed username to its Twitch id through the authenticated Get Users
+      # behind outgress, scoped to the one verb.
+      { service: { account: "OUTGRESS_RPC",  subject: "bagel.rpc.outgress.accountage.get" } }
+      { service: { account: "OUTGRESS_RPC",  subject: "bagel.rpc.outgress.accountage.get.node.*" } }
+      # Loyalty tab reads/manages standings and counters through the same verbs
+      # sesame uses.
+      { service: { account: "LOYALTY_RPC",   subject: "bagel.rpc.loyalty.>" } }
+      # Govee device picker: the dashboard lists the broadcaster's lights through
+      # the gossip service (which holds the decrypted key), scoped to just that verb.
+      { service: { account: "GOSSIP_RPC",   subject: "bagel.rpc.gossip.govee.devices" } }
+      { service: { account: "GOSSIP_RPC",   subject: "bagel.rpc.gossip.govee.devices.node.*" } }
+      { service: { account: "NOTIFICATIONS_RPC", subject: "bagel.rpc.notifications.>" } }
+      { service: { account: "TRANSACTIONS_RPC",  subject: "bagel.rpc.transactions.>" } }
+      { stream: { account: "USERS_RPC",     subject: "bagel.cache.invalidate.grant" } }
+      { stream: { account: "USERS_RPC",     subject: "bagel.cache.invalidate.status" } }
+      { stream: { account: "USERS_RPC",     subject: "bagel.cache.invalidate.delegation" } }
+      { stream: { account: "USERS_RPC",     subject: "bagel.cache.invalidate.locale" } }
+      { stream: { account: "PROJECTOR_RPC", subject: "bagel.cache.invalidate.commands" } }
+      { stream: { account: "PROJECTOR_RPC", subject: "bagel.cache.invalidate.modules" } }
+      { stream: { account: "NOTIFICATIONS_RPC", subject: "bagel.cache.invalidate.notifications" } }
+    ]
+  }
+
+  # ADMIN_RPC: operator tool. Requests user administration, EventSub channel
+  # state and ingress shard control; evicts the status/grant sections it caches.
+  ADMIN_RPC: {
+    users: [ { user: "admin_rpc", password: $NATS_BCRYPT_ADMIN_RPC } ]
+    imports: [
+      { service: { account: "USERS_RPC",          subject: "bagel.rpc.health.users" } }
+      { service: { account: "USERS_RPC",          subject: "bagel.rpc.health.users.node.*" } }
+      { service: { account: "COMMANDS_RPC",       subject: "bagel.rpc.health.commands" } }
+      { service: { account: "COMMANDS_RPC",       subject: "bagel.rpc.health.commands.node.*" } }
+      { service: { account: "MODULES_RPC",        subject: "bagel.rpc.health.modules" } }
+      { service: { account: "MODULES_RPC",        subject: "bagel.rpc.health.modules.node.*" } }
+      { service: { account: "LOYALTY_RPC",        subject: "bagel.rpc.health.loyalty" } }
+      { service: { account: "LOYALTY_RPC",        subject: "bagel.rpc.health.loyalty.node.*" } }
+      { service: { account: "PROJECTOR_RPC",      subject: "bagel.rpc.health.projector" } }
+      { service: { account: "PROJECTOR_RPC",      subject: "bagel.rpc.health.projector.node.*" } }
+      { service: { account: "OUTGRESS_RPC",       subject: "bagel.rpc.health.outgress" } }
+      { service: { account: "OUTGRESS_RPC",       subject: "bagel.rpc.health.outgress.node.*" } }
+      { service: { account: "TRANSACTIONS_RPC",   subject: "bagel.rpc.health.transactions" } }
+      { service: { account: "TRANSACTIONS_RPC",   subject: "bagel.rpc.health.transactions.node.*" } }
+      { service: { account: "NOTIFICATIONS_RPC",  subject: "bagel.rpc.health.notifications" } }
+      { service: { account: "NOTIFICATIONS_RPC",  subject: "bagel.rpc.health.notifications.node.*" } }
+      { service: { account: "GOSSIP_RPC",        subject: "bagel.rpc.health.gossip" } }
+      { service: { account: "GOSSIP_RPC",        subject: "bagel.rpc.health.gossip.node.*" } }
+      { service: { account: "WORKER_RPC",         subject: "bagel.rpc.health.sesame" } }
+      { service: { account: "WORKER_RPC",         subject: "bagel.rpc.health.sesame.node.*" } }
+      { service: { account: "TWITCH_INGRESS_RPC", subject: "bagel.rpc.health.ingress" } }
+      { service: { account: "TWITCH_INGRESS_RPC", subject: "bagel.rpc.health.ingress.node.*" } }
+      { service: { account: "USERS_RPC",          subject: "bagel.rpc.admin.user.>" } }
+      # Bot-global counters: the admin console manages the reserved user_id=0
+      # namespace through the counter verbs. Scoped to the counter subtree —
+      # balances stay out of the operator tool.
+      { service: { account: "LOYALTY_RPC",        subject: "bagel.rpc.loyalty.counter.>" } }
+      { service: { account: "OUTGRESS_RPC",       subject: "bagel.rpc.outgress.channel.get" } }
+      { service: { account: "OUTGRESS_RPC",       subject: "bagel.rpc.outgress.channel.get.node.*" } }
+      { service: { account: "TWITCH_INGRESS_RPC", subject: "twitch.ingress.admin.shards.>" } }
+      { service: { account: "NOTIFICATIONS_RPC",  subject: "bagel.rpc.admin.notifications.>" } }
+      { stream: { account: "USERS_RPC", subject: "bagel.cache.invalidate.status" } }
+      { stream: { account: "USERS_RPC", subject: "bagel.cache.invalidate.grant" } }
+      { stream: { account: "NOTIFICATIONS_RPC", subject: "bagel.cache.invalidate.notifications" } }
+    ]
+  }
+
+  # TWITCH_INGRESS_RPC answers the admin shard control RPC and the authoritative
+  # conduit-id RPC; requests broadcaster status; evicts its lane status cache.
+  TWITCH_INGRESS_RPC: {
+    users: [ { user: "twitch_ingress_rpc", password: $NATS_BCRYPT_TWITCH_INGRESS_RPC } ]
+    exports: [
+      { service: "bagel.rpc.health.ingress" }
+      { service: "bagel.rpc.health.ingress.node.*" }
+      { service: "twitch.ingress.admin.shards.>" }
+      { service: "bagel.rpc.ingress.conduit.get" }
+      { service: "bagel.rpc.ingress.conduit.get.node.*" }
+    ]
+    imports: [
+      { service: { account: "PROJECTOR_RPC", subject: "bagel.rpc.broadcaster.status.get" } }
+      { service: { account: "PROJECTOR_RPC", subject: "bagel.rpc.broadcaster.status.get.node.*" } }
+      { stream: { account: "USERS_RPC", subject: "bagel.cache.invalidate.status" } }
+    ]
+  }
+
+  # System account for server monitoring; no fleet service uses it.
+  SYS: {
+    users: [
+      { user: "sys", password: $NATS_BCRYPT_SYS }
+    ]
+  }
+}
+
+system_account: SYS

--- a/deploy/k8s/nats-leaf-server.conf
+++ b/deploy/k8s/nats-leaf-server.conf
@@ -1,0 +1,99 @@
+# Leaf NATS servers (nats-leaf DaemonSet). Mounted at /etc/nats/nats.conf by
+# deploy/k8s/nats-leaf.yaml; auth.conf is mirrored from the hub so leaf-local
+# clients authenticate identically. RPC accounts are native to this standalone
+# leaf cluster and route directly leaf-to-leaf. Streams never traverse leaves;
+# BUS and JetStream clients connect straight to the TLS hub listener.
+#
+# COUPLED TO pkg/bus/connect.go (the client half of this topology). Keep these
+# aligned when either side changes:
+#   * plane split — RPC dials the leaf (serverList/NATS_LEAF_URL), JetStream
+#     dials the hub (busURL/NATS_HUB_URL) with JS domain "hub"; this file must
+#     keep the leaf JetStream-free or that split silently stops holding;
+#   * TLS posture — server-auth only against the fleet CA (tlsSecureOption/
+#     NATS_CA_PEM); clients authenticate with bcrypt user/password, so enabling
+#     `verify` on the client-facing listener here would break every service;
+#   * keepalives — ping_interval/ping_max below pair with the client's
+#     PingInterval/MaxPingsOutstanding in baseOptions;
+#   * server_name prefix — failback.go matches the "<node>--" prefix to detect
+#     a same-node leaf connection.
+
+# The node prefix lets clients distinguish a same-node connection from a
+# fallback. POD_NAME keeps identities unique during maxSurge leaf rollouts.
+server_name: $NATS_SERVER_NAME
+
+# The leaves share the node netns with the hub, which owns 4222/6222/8222.
+# These offsets are the leaf's half of that split; the nats-leaf Services keep
+# publishing 4222/8222 so no client URL changes.
+port: 4223
+http_port: 8223
+
+max_connections: 1024
+max_payload: 8MB
+# Match the hub's per-connection burst buffer. The leaf is the RPC path and hub
+# fallback relay; 16MB stalled the large-window native-TLS acceptance run.
+max_pending: 64MB
+# Tightened from 10s — fast RPC clients drain well under 2s.
+write_deadline: "2s"
+
+# Detect dead clients faster
+ping_interval: "20s"
+ping_max: 3
+
+# Client-facing TLS for leaf-local app connections (RPC plane + any BUS fallback).
+# Server-auth only: clients verify this cert against the fleet CA and authenticate
+# with bcrypt user/password. Cert secret (nats-leaf-tls) is cert-manager-issued,
+# mounted at /etc/nats/certs; the reloader watches it for renewal hot-reload.
+tls {
+  cert_file: "/etc/nats/certs/tls.crt"
+  key_file:  "/etc/nats/certs/tls.key"
+  ca_file:   "/etc/nats/certs/ca.crt"
+  timeout: 5
+}
+
+# Lame-duck graceful shutdown. The pod preStop signals LDM (SIGUSR2) before the
+# socket closes: the leaf stops accepting new connections and migrates its
+# existing clients to a healthy leaf over the drain window, so a DaemonSet roll
+# or node drain no longer surfaces as a hard RPC disconnect on that node.
+# (duration min is 30s; terminationGracePeriodSeconds on the pod covers it.)
+lame_duck_grace_period: "5s"
+lame_duck_duration: "30s"
+
+# The leaf tier deliberately has no hub remotes. RPC accounts and their
+# imports/exports exist on every leaf and cross-node interest uses this leaf
+# cluster directly, so RPC survives a hub outage without duplicate routes.
+
+# Cluster the leaf servers among themselves so cross-node RPC routes directly
+# leaf-to-leaf instead of hopping through the hub, and so the leaf tier keeps
+# serving request/reply if the hub link drops. Routes resolve via the
+# nats-leaf-peers headless service (publishNotReadyAddresses, so a forming leaf
+# is still discoverable). The cluster name differs from the hub's ("bagelbot")
+# so the two never merge.
+#
+# A clustered queue group does not provide responder locality: requests are
+# balanced randomly across interested members and may take a direct
+# leaf-to-leaf hop even when a local responder exists. Applications therefore
+# publish to a node-qualified RPC subject first and retain the generic queue as
+# their no-responder HA fallback.
+cluster {
+  name: "nats-leaf"
+  port: 6223
+  # Mutual TLS between leaf peers (all present the CA-signed nats-leaf cert), the
+  # wire encryption for cross-node leaf-to-leaf RPC once the mesh is gone.
+  tls {
+    cert_file: "/etc/nats/certs/tls.crt"
+    key_file:  "/etc/nats/certs/tls.key"
+    ca_file:   "/etc/nats/certs/ca.crt"
+    verify: true
+    timeout: 5
+  }
+  routes: [ "nats://nats-leaf-peers.production.svc.cluster.local:6223" ]
+  # DNS already resolves every leaf pod. Suppress route gossip so each pair
+  # keeps one route instead of opening parallel paths that can duplicate queue
+  # interest propagation.
+  no_advertise: true
+}
+
+max_subscriptions: 0
+max_control_line: 4KB
+
+include "auth.conf"

--- a/deploy/k8s/nats-leaf.yaml
+++ b/deploy/k8s/nats-leaf.yaml
@@ -1,0 +1,274 @@
+# Copyright (c) 2026 Adam Ousmer. All rights reserved.
+# Proprietary. No license granted. See LICENSE.md.
+
+# Leaf NATS servers, one per schedulable Kubernetes node. The nats-leaf-config configmap is
+# generated from nats-leaf-server.conf + nats-auth.conf by the Flux kustomize
+# configMapGenerator (deploy/k8s/kustomization.yaml); credentials (bcrypt
+# hashes and the leaf remote URL) come from the nats-auth-env secret.
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: nats-leaf
+  name: nats-leaf
+  namespace: production
+spec:
+  revisionHistoryLimit: 5
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      # A surge pod would have to bind the same host listeners as the leaf it
+      # replaces, so the scheduler would leave it Pending forever and the roll
+      # would never advance. Replace in place instead: the preStop lame-duck
+      # drain migrates that node's clients to a healthy leaf before the socket
+      # closes, and the nats-leaf Service covers the gap cluster-wide.
+      maxSurge: 0
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: nats-leaf
+  template:
+    metadata:
+      annotations:
+        # Wire encryption is NATS-native TLS (client + cluster + the leaf->hub
+        # remotes; nats-leaf-server.conf). The pods run in the host netns, so
+        # that TLS is the only encryption layer: the CNI's WireGuard tunnel is
+        # not in the path and does not re-encrypt it.
+        # Cluster listener/routes and TLS blocks cannot be introduced by a config
+        # reload; bump this to force a rolling restart when the topology changes.
+        itsbagelbot.dev/config-revision: "leaf-hostnet-v3-port-split"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "7778"
+        prometheus.io/scrape: "true"
+        # See nats.yaml: the prometheus agent's default job never matches nats;
+        # this annotation hits the unfiltered "newrelic" job.
+        newrelic.io/scrape: "true"
+      labels:
+        app: nats-leaf
+    spec:
+# No tolerations, deliberately. A leaf is the per-node Core NATS RPC tier
+      # for pods that dial nats-leaf-local, so it belongs on exactly the nodes
+      # that run application pods. It has no business on the control plane:
+      # node1 runs only coredns (node-local), the New Relic agents (which ship
+      # externally), and nothing that opens an RPC connection, so a leaf there
+      # was pure overhead sitting in the way of node1 leaving the pod mesh.
+      #
+      # This used to be a bare `tolerations:` null key left behind when the
+      # worker-pool and nats-ingress entries were dropped. Null parses fine and
+      # reads as "no tolerations", so it was not a bug on its own, but it hid
+      # one: node1 was tainted itsbagelbot.dev/role=cp:NoSchedule AFTER a leaf
+      # had already been scheduled there, and NoSchedule does not evict, so the
+      # stale pod survived every reconcile. Deleting it is enough; with no
+      # matching toleration the DaemonSet cannot place it again.
+      #
+      # The leaf listens on the node's own addresses. It shares the netns with
+      # the hub member on that node, so every listener sits one above the hub's:
+      # client 4223, cluster 6223, monitor 8223, exporter 7778. The Services
+      # below still publish 4222/8222, so no client URL changes.
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      # Shared PID namespace lets the config-reloader sidecar SIGHUP the
+      # nats-server process (same uid 1000) when the mounted config changes.
+      shareProcessNamespace: true
+      # Covers the lame-duck drain (grace 5s + duration 30s) the preStop runs
+      # before the leaf exits; keep above that sum so the kubelet does not SIGKILL
+      # a leaf mid-migration.
+      terminationGracePeriodSeconds: 45
+      # nats runs as uid/gid 1000; fsGroup makes the leaf-local JetStream
+      # emptyDir writable. Durable streams live on the hub, not these leaves.
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile: {type: RuntimeDefault}
+      containers:
+        - name: nats
+          image: nats:2.14.4-alpine@sha256:f2123f533c2b0cada0a5c5ec434fb2b8cfe1cf220215ef9d7517e1372917ad66
+          imagePullPolicy: IfNotPresent
+          # --pid writes a pidfile the reloader reads to signal this process.
+          command: ["/bin/sh", "-c"]
+          args:
+            - 'export NATS_SERVER_NAME="${NODE_NAME}--${POD_NAME}"; exec nats-server --config /etc/nats/nats.conf --pid /var/run/nats/nats.pid'
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            # Leaves are JS-disabled local RPC relays; without a heap target the
+            # Go GC let RSS drift to 130-180Mi per node. 192MiB keeps the GC
+            # honest while staying above the leaf's real working set (client
+            # buffers + leaf mesh routes).
+            - name: GOMEMLIMIT
+              value: 192MiB
+          envFrom:
+            - secretRef:
+                name: nats-auth-env
+          ports:
+            - {containerPort: 4223, name: client}
+            - {containerPort: 8223, name: monitor}
+            - {containerPort: 6223, name: cluster}
+          volumeMounts:
+            - {name: config, mountPath: /etc/nats, readOnly: true}
+            - {name: certs, mountPath: /etc/nats/certs, readOnly: true}
+            - {name: pid, mountPath: /var/run/nats}
+          resources:
+            # Leaves are encrypted local relays, not durable stores; keep burst
+            # headroom but avoid reserving hub-sized memory on every node.
+            # Sized against GOMEMLIMIT=192MiB above: ~210-220Mi steady RSS
+            # (heap target + goroutine stacks + mmap), 512Mi hard cap.
+            requests: {cpu: 50m, memory: 96Mi}
+            limits: {cpu: 2000m, memory: 512Mi}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities: {drop: ["ALL"]}
+            readOnlyRootFilesystem: true
+          startupProbe:
+            httpGet: {path: /healthz, port: monitor}
+            periodSeconds: 5
+            failureThreshold: 10
+            timeoutSeconds: 1
+          livenessProbe:
+            httpGet: {path: /healthz, port: monitor}
+            initialDelaySeconds: 5
+            periodSeconds: 15
+            timeoutSeconds: 3
+            failureThreshold: 12
+          readinessProbe:
+            # Plain /healthz: the leaves run core NATS only (JetStream disabled),
+            # so a JS-scoped probe would never report ready.
+            httpGet: {path: /healthz, port: monitor}
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+          lifecycle:
+            preStop:
+              exec:
+                # Enter lame-duck (SIGUSR2 via the pidfile) so this leaf migrates
+                # its clients to a healthy leaf before the socket closes, then
+                # hold the container until the drain finishes. The sleep must
+                # outlast lame_duck_grace_period + lame_duck_duration (35s); a
+                # bare SIGTERM would otherwise abort the graceful drain.
+                command: ["/bin/sh", "-c", "nats-server --signal ldm=/var/run/nats/nats.pid; sleep 36"]
+        # Watches the mounted config (nats.conf + auth.conf, sourced from the
+        # nats-leaf-config configmap) and SIGHUPs nats-server on change, so a
+        # git push updating the Flux-managed configMapGenerator hot-reloads
+        # without a manual signal or a pod restart.
+        # TODO(deploy): pin to a digest like the other images.
+        - name: reloader
+          image: natsio/nats-server-config-reloader:0.23.0@sha256:64cb6c858e794906d3167378e02b7e0feb83c4e14c07b371eb8d921ef8c4a60b
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-pid"
+            - "/var/run/nats/nats.pid"
+            - "-config"
+            - "/etc/nats/nats.conf"
+            - "-config"
+            - "/etc/nats/auth.conf"
+            # Watch the TLS cert so a cert-manager renewal SIGHUPs nats to reload
+            # the new cert without a pod restart.
+            - "-config"
+            - "/etc/nats/certs/tls.crt"
+          volumeMounts:
+            - {name: config, mountPath: /etc/nats, readOnly: true}
+            - {name: certs, mountPath: /etc/nats/certs, readOnly: true}
+            - {name: pid, mountPath: /var/run/nats}
+          resources:
+            requests: {cpu: 5m, memory: 16Mi}
+            limits: {cpu: 50m, memory: 64Mi}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities: {drop: ["ALL"]}
+            readOnlyRootFilesystem: true
+        - name: prometheus-nats-exporter
+          image: natsio/prometheus-nats-exporter:0.20.1@sha256:4fbf6dacb84780a45a1c3af9b1080c69451a288d20902deae671b80717bb8f61
+          imagePullPolicy: IfNotPresent
+          args: ["-port", "7778", "-varz", "-connz", "-subz", "-routez", "-jsz=all", "http://localhost:8223"]
+          ports:
+            - {containerPort: 7778, name: metrics}
+          resources:
+            requests: {cpu: 5m, memory: 32Mi}
+            limits: {cpu: 100m, memory: 128Mi}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities: {drop: ["ALL"]}
+      volumes:
+        - name: config
+          configMap:
+            name: nats-leaf-config
+        - name: certs
+          secret:
+            secretName: nats-leaf-tls
+        - name: pid
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: nats-leaf
+  name: nats-leaf
+  namespace: production
+spec:
+  # Same-node first, then same-zone, then cluster-wide. Unlike Local this keeps
+  # applications available while their node's leaf is down; unlike PreferClose
+  # it makes node locality explicit on Kubernetes 1.34+. Short ClientIP
+  # affinity keeps one pod's independent RPC/cache connections on the same
+  # fallback leaf, but expires before the controlled 90s failback check.
+  trafficDistribution: PreferSameNode
+  sessionAffinity: ClientIP
+  sessionAffinityConfig:
+    clientIP:
+      timeoutSeconds: 60
+  selector:
+    app: nats-leaf
+  ports:
+    - {name: client, port: 4222, targetPort: client}
+    - {name: monitor, port: 8222, targetPort: monitor}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: nats-leaf
+  name: nats-leaf-local
+  namespace: production
+spec:
+  # Health/failback probe only. With no local endpoint this Service is
+  # unreachable, so clients never mistake a remote leaf for the recovered
+  # same-node leaf. Probe the HTTP monitor port rather than opening a plaintext
+  # TCP connection to the native-TLS client listener (which polluted NATS logs
+  # with handshake failures every failback interval).
+  internalTrafficPolicy: Local
+  selector:
+    app: nats-leaf
+  ports:
+    - {name: client, port: 4222, targetPort: client}
+    - {name: monitor, port: 8222, targetPort: monitor}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: nats-leaf
+  name: nats-leaf-peers
+  namespace: production
+spec:
+  # Headless route-discovery for the leaf cluster: the route URL resolves to every
+  # leaf's node address, so each node dials every peer and forms a clean full mesh
+  # (a ClusterIP would load-balance the route dial and leave the mesh incomplete).
+  # publishNotReadyAddresses lets a still-forming leaf seed the cluster on rollout.
+  # Nothing is proxied through a headless Service, so these ports are the leaf's
+  # real listeners rather than the published 4222/8222 client contract.
+  clusterIP: None
+  publishNotReadyAddresses: true
+  selector:
+    app: nats-leaf
+  ports:
+    - {name: client, port: 4223, targetPort: client}
+    - {name: monitor, port: 8223, targetPort: monitor}
+    - {name: cluster, port: 6223, targetPort: cluster}

--- a/deploy/k8s/nats-secrets.py
+++ b/deploy/k8s/nats-secrets.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Adam Ousmer. All rights reserved.
+# Proprietary. No license granted. See LICENSE.md.
+"""Generate and load the NATS per-account credentials into Doppler.
+
+This is the single source of truth for rotating NATS auth. NATS stores bcrypt
+hashes while services use the matching plaintext, and Doppler cannot compute
+bcrypt — so plaintext and hash must be generated together. Re-running this script
+IS a rotation: it regenerates every password, writes the plaintext to each
+service's Doppler project and the bcrypt hashes to the `nats`
+Doppler project (which the operator syncs into the `nats-auth-env` secret the
+broker reads).
+
+Endpoints (NATS_URL/RPC_URL/LEAF_URL/HUB_URL, ingress *_HOST) live in the k8s
+manifests, not here — this only touches credentials.
+
+Usage:
+    python3 deploy/k8s/nats-secrets.py --dry-run   # show what would change
+    python3 deploy/k8s/nats-secrets.py             # generate + write to Doppler
+
+After a real run the broker hashes change, so the nats + nats-leaf pods must be
+restarted to re-read nats-auth-env (env-injected; the conf file hot-reloads but
+env does not). The Doppler operator restarts the app services automatically.
+"""
+import secrets
+import subprocess
+import sys
+
+import bcrypt
+
+DRY = "--dry-run" in sys.argv
+CONFIG = "prd"
+
+# service name (account stem) -> Doppler project
+SERVICES = {
+    "users": "users",
+    "commands": "commands",
+    "loyalty": "loyalty",
+    "modules": "modules",
+    "projector": "projector",
+    "outgress": "outgress",
+    "worker": "worker",
+    "twitch_ingress": "twitch-ingress",
+    "dashboard": "dashboard",
+    "admin": "admin",
+    "transactions": "transactions",
+    "notifications": "notifications",
+    "gossip": "gossip",
+}
+NO_RPC: set[str] = set()
+# gossip, notifications and transactions are RPC-only (no JetStream/event
+# plane): none of the three ever dial the hub, so none gets a BUS user.
+NO_BUS: set[str] = {"gossip", "notifications", "transactions"}
+
+def gen() -> str:
+    # URL-safe (hex) so the plaintext is valid inside the leaf nats-leaf:// URLs.
+    return secrets.token_hex(24)
+
+
+def bcrypt_hash(pw: str) -> str:
+    # cost 11, $2a prefix — the form the NATS Go server accepts.
+    return bcrypt.hashpw(pw.encode(), bcrypt.gensalt(11, prefix=b"2a")).decode()
+
+
+def doppler_set(project: str, kv: dict[str, str]) -> None:
+    keys = ", ".join(sorted(kv))
+    if DRY:
+        print(f"[dry-run] doppler -p {project} -c {CONFIG} set: {keys}")
+        return
+    args = ["doppler", "secrets", "set", "-p", project, "-c", CONFIG, "--no-interactive", "--silent"]
+    args += [f"{k}={v}" for k, v in kv.items()]
+    subprocess.run(args, check=True)
+    print(f"  wrote {len(kv)} keys to {project}/{CONFIG}: {keys}")
+
+
+def main() -> None:
+    broker: dict[str, str] = {}  # nats project -> nats-auth-env
+
+    print("== per-service credentials ==")
+    for svc, project in SERVICES.items():
+        kv: dict[str, str] = {}
+        if svc not in NO_BUS:
+            bus_pw = gen()
+            kv["NATS_USER"] = f"{svc}_bus"
+            kv["NATS_PASSWORD"] = bus_pw
+            broker[f"NATS_BCRYPT_{svc.upper()}_BUS"] = bcrypt_hash(bus_pw)
+        if svc not in NO_RPC:
+            rpc_pw = gen()
+            kv["NATS_RPC_USER"] = f"{svc}_rpc"
+            kv["NATS_RPC_PASSWORD"] = rpc_pw
+            broker[f"NATS_BCRYPT_{svc.upper()}_RPC"] = bcrypt_hash(rpc_pw)
+        doppler_set(project, kv)
+
+    # System account (server monitoring; no fleet service uses it).
+    broker["NATS_BCRYPT_SYS"] = bcrypt_hash(gen())
+
+    print("== broker hashes (nats-auth-env via the 'nats' Doppler project) ==")
+    doppler_set("nats", broker)
+
+    print("\ndone." if not DRY else "\ndry-run complete (no writes).")
+
+
+if __name__ == "__main__":
+    main()

--- a/deploy/k8s/nats-server.conf
+++ b/deploy/k8s/nats-server.conf
@@ -1,0 +1,180 @@
+# Hub NATS server. Mounted at /etc/nats/nats.conf by deploy/k8s/nats.yaml;
+# auth.conf (from nats-auth.conf) sits next to it in the same configmap, and the
+# bcrypt hashes it references arrive through the nats-auth-env secret.
+
+server_name: $POD_NAME
+# Stable per-pod ordinal tag. The stream catalog no longer places anything on it:
+# every stream is now R3, and an ordinal tag exists on exactly one server, so a
+# placement constrained to it can never satisfy three peers. Kept because it is
+# the identity operator tooling addresses for a deliberate move or step-down, and
+# unlike a Kubernetes node label it follows the JetStream peer across restarts.
+server_tags: [$POD_NAME]
+
+# Listener
+port: 4222
+http_port: 8222
+
+# Connection limits — generous for many workers
+max_connections: 1024
+max_payload: 8MB
+# Per-connection outbound buffer for batch acknowledgements and consumer fanout.
+# This matches the leaf and gives the direct TLS firehose enough headroom to
+# avoid slow-consumer churn during a 700k burst.
+max_pending: 128MB
+
+# Write deadline for slow consumers — tightened from 10s for faster bad-client
+# eviction on the RPC bus; legitimate subscribers drain well under 2s.
+write_deadline: "10s"
+
+# Detect dead clients faster
+ping_interval: "20s"
+ping_max: 3
+
+# Client-facing TLS: the wire encryption for client connections, on top of the
+# WireGuard pod network.
+# verify:false = server-auth only: the server presents its cert and clients verify
+# it against the fleet CA (NATS_CA_PEM), but clients authenticate with their bcrypt
+# user/password (auth.conf), not client certs — so there are no per-service certs.
+# The cert secret (nats-hub-tls) is issued by cert-manager and mounted at
+# /etc/nats/certs; the config-reloader watches it so renewals hot-reload on SIGHUP.
+tls {
+  cert_file: "/etc/nats/certs/tls.crt"
+  key_file:  "/etc/nats/certs/tls.key"
+  ca_file:   "/etc/nats/certs/ca.crt"
+  timeout: 5
+}
+
+# There is intentionally no leafnode listener. Leaves form the standalone RPC
+# cluster; all stream traffic enters this hub through the client TLS listener.
+
+# Cluster configuration for HA
+cluster {
+  name: "bagelbot"
+  port: 6222
+  # BUS gets its own route connection instead of sharing a pooled route with
+  # control accounts. The isolated 2026-07-16 R3 matrix found s2_fast sustained
+  # ~75k/s with zero final lag, while s2_auto left the low-RTT route
+  # uncompressed, accumulated a 275MB slow-consumer write, reconnected, and
+  # reached only ~70k/s. Keep the measured winner explicit; auto is unsafe for
+  # this asymmetric three-voter topology.
+  accounts: ["BUS"]
+  compression: {
+    mode: s2_fast
+  }
+  # Mutual TLS between the hub RAFT peers: low cardinality (3 members), all present
+  # the CA-signed cert, so verify:true is cheap defense-in-depth for the JetStream
+  # consensus traffic once the mesh is gone.
+  tls {
+    cert_file: "/etc/nats/certs/tls.crt"
+    key_file:  "/etc/nats/certs/tls.key"
+    ca_file:   "/etc/nats/certs/ca.crt"
+    verify: true
+    timeout: 5
+  }
+  routes: [
+    "nats-route://nats-0.nats-headless.production.svc.cluster.local:6222"
+    "nats-route://nats-1.nats-headless.production.svc.cluster.local:6222"
+    "nats-route://nats-2.nats-headless.production.svc.cluster.local:6222"
+  ]
+}
+
+# JetStream configuration. `domain: hub` makes this the authoritative
+# JetStream cluster; leaves run no JetStream.
+#
+# Every stream in the catalog is R3, which means these limits are per-member
+# floors rather than one member's worst case: each peer holds a full replica of
+# each stream, so the same arithmetic applies identically on all three.
+#
+#   max_mem  — accounts for memory-backed STREAM BYTES and nothing else:
+#              TWITCH_INGRESS 1 GiB + TWITCH_OUTGRESS 256 MiB = 1.25 GiB per
+#              member. (TWITCH_INGRESS_RETRY, 32 MiB, is defined in the catalog
+#              but NOT provisioned — sesame only creates it when
+#              NATS_CONSUME_FLOW is on, which it is not. Add it here when that
+#              changes.) Three sizeable consumers sit outside that accounting,
+#              so no amount of max_mem back-pressure can stop them:
+#                * a memory stream's RAFT WAL is itself a memStore, holding up
+#                  to a second copy of the stream between snapshots (~1.25 GiB);
+#                * atomic batch staging on R>1 is a newMemStore that is never
+#                  registered with account storage accounting;
+#                * the per-stream ingest queue below is 128 MiB EACH, and the
+#                  count is streams the BROKER holds, not fleet catalog entries:
+#                  4 provisioned catalog streams + KV_admin_lanes = 5 today,
+#                  6 once the retry lane is provisioned. ≈ 640 MiB.
+#              Real per-member worst case ≈ 1.25 (streams) + 1.25 (WAL) + 0.6
+#              (ingest queues) + the Go runtime and connection buffers ≈ 4.1
+#              GiB against the pod's 5Gi limit: under 1 GiB of true headroom,
+#              not the ~3.7 GiB a 5Gi-minus-1.25GiB reading suggests. The pod's
+#              memory REQUEST is 4Gi, deliberately below that worst case, so a
+#              member catching up a full catalog can exceed its request and
+#              enters the kubelet's eviction ranking — see the resources block
+#              in nats.yaml.
+#              The thing that actually stops a runaway member is the container
+#              limit (an OOM kill), not max_mem. pkg/bus/provision_test.go's
+#              TestMemoryStreamsFitTheHubMemoryBudget models these same terms;
+#              keep the two in step.
+#              4GB stays: it is comfortably above the accounted 1.3 GiB with
+#              room for dedup ids and broker state, and lowering it is not a
+#              free edit — nats-server refuses to hot-reload a *decrease*
+#              ("config reload not supported for decreasing jetstream max
+#              memory and store"), so a lower number here wedges every later
+#              SIGHUP until all three pods are restarted by hand. Raising is
+#              reloadable; lowering is a pod roll. Raising either stream's
+#              MaxBytes means raising this on all three members at once — and
+#              redoing the arithmetic above.
+#   max_file — file-backed streams: BAGEL_DATA 512 MiB + TWITCH_OUTGRESS_SYSTEM
+#              64 MiB = ~576 MiB per member, comfortably inside 2GB.
+jetstream {
+  store_dir: /data/jetstream
+  domain: hub
+  max_mem: 4GB
+  max_file: 2GB
+  # Per-stream ingest queue. The 2.14.3 defaults are 100_000 messages and
+  # 128 MiB (streamDefaultMaxQueueMsgs / streamDefaultMaxQueueBytes), so the
+  # message count below is a 2.6x raise and the byte value is the stock default
+  # restated: the byte limit is the real memory guardrail, and this is where an
+  # operator looks for it. Ten asynchronous publisher connections can
+  # legitimately have 163,840 PubAcks in flight — past the 100k default — and
+  # every message beyond the queue is refused with JSStreamTooManyRequests well
+  # before CPU or memory saturate.
+  #
+  # Both keys are non-reloadable (no diffOptions case; they land in the "config
+  # reload not supported" arm), so CHANGING either value is a pod roll, not a
+  # SIGHUP. They only stay reload-safe as long as they stay put.
+  max_buffered_msgs: 262144
+  max_buffered_size: 128MB
+  # There is deliberately no `limits { batch { … } }` block. Two independent
+  # reasons, either sufficient:
+  #
+  #   1. JetStreamLimits is not hot-reloadable. reload.go's diffOptions has no
+  #      case for it, so it falls into the default arm and the whole reload is
+  #      abandoned — reloads are all-or-nothing. This configmap is delivered by
+  #      SIGHUP on content change (kustomization.yaml sets disableNameSuffixHash
+  #      precisely so an edit does not roll the quorum), so a batch block would
+  #      not merely fail to apply: every subsequent reload would re-diff the
+  #      same delta and fail too, killing the ACL hot-push and the cert-manager
+  #      TLS renewal reload until an operator restarted all three members.
+  #   2. Nothing needs it. The concurrency that actually ships is the Elixir
+  #      ingress fleet's 2 schedulers (ERL_FLAGS +S 2:2) x 8 in-flight cohorts x
+  #      3 replicas = 48 concurrently-open batches per stream, just under the
+  #      stock atomic limit of 50.
+  #
+  #      That arithmetic is load-bearing in both directions. If the replica
+  #      count, the scheduler count or INGRESS_PUBLISH_BATCH_INFLIGHT goes up,
+  #      the fleet crosses the cap and every excess open is refused 10210/429,
+  #      dropping the wire back to per-message publishes under load — which is
+  #      the cost the atomic wire exists to remove, arriving when the fleet is
+  #      busiest. And raising max_inflight_per_stream to make room would also
+  #      LOWER the fast-ingest ceiling (one shared knob, 1000 default there) and
+  #      multiply worst-case staging RAM on the leader — RAM max_mem cannot see.
+  #
+  # If a batch limit ever does become necessary it must ship with a forced pod
+  # roll (a config checksum annotation on the StatefulSet pod template), never
+  # by SIGHUP.
+}
+
+# Limits per account (default account)
+max_subscriptions: 0
+max_control_line: 4KB
+
+# Per-service users and subject ACLs.
+include "auth.conf"

--- a/deploy/k8s/nats.yaml
+++ b/deploy/k8s/nats.yaml
@@ -1,0 +1,387 @@
+# Copyright (c) 2026 Adam Ousmer. All rights reserved.
+# Proprietary. No license granted. See LICENSE.md.
+
+# Hub NATS server. The nats-config configmap is generated from
+# nats-server.conf + nats-auth.conf by the Flux kustomize configMapGenerator
+# (deploy/k8s/kustomization.yaml); bcrypt hashes come from the nats-auth-env
+# secret.
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    app: nats
+  name: nats
+  namespace: production
+spec:
+  serviceName: nats-headless
+  replicas: 3
+  podManagementPolicy: Parallel
+  revisionHistoryLimit: 10
+  # Ready is not the same as settled. A member reports healthy as soon as its
+  # own assigned assets are current, but the peers that just caught it up are
+  # still flushing snapshots and re-forming consumer groups. 30s of quiet before
+  # the rolling update takes the next member stops a roll from chaining three
+  # catch-ups back to back — which on a memory-backed R3 catalog is three full
+  # replica re-syncs with no gap between them.
+  minReadySeconds: 30
+  selector:
+    matchLabels:
+      app: nats
+  template:
+    metadata:
+      annotations:
+        # Wire encryption is NATS-native TLS (nats-server.conf). The pods run in
+        # the host netns, so that TLS is the only encryption layer: the CNI's
+        # WireGuard tunnel is not in the path and does not re-encrypt it.
+        prometheus.io/path: /metrics
+        prometheus.io/port: "7777"
+        prometheus.io/scrape: "true"
+        # newrelic-prometheus-agent's default job gates prometheus.io/scrape
+        # behind its integrations_filter app allowlist, which has no nats entry;
+        # the chart's "newrelic" job scrapes this annotation unfiltered.
+        newrelic.io/scrape: "true"
+      labels:
+        app: nats
+    spec:
+      # The hub listens on the node's own addresses: client 4222, cluster 6222,
+      # monitor 8222, exporter 7777. Kubernetes promotes each declared
+      # containerPort to a host port here, so the scheduler already refuses to
+      # place two members on one node. Cluster DNS is still required, because
+      # the routes below resolve through the headless Service.
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      tolerations:
+        - key: node.kubernetes.io/unreachable
+          operator: Exists
+          effect: NoExecute
+          tolerationSeconds: 60
+        - key: node.kubernetes.io/not-ready
+          operator: Exists
+          effect: NoExecute
+          tolerationSeconds: 60
+      # No taint tolerations beyond the eviction pair above, and no host
+      # allowlist. The app tier is uniform hardware, so the scheduler is left to
+      # place members freely; the control plane is excluded because it carries a
+      # role taint this spec deliberately does not tolerate.
+      #
+      # What went: a dedicated=nats-ingress toleration that existed so a member
+      # could follow its node-bound volume onto a specific host, and a hostname
+      # exclusion for a home-wifi node now retired. Both encoded a
+      # hardware asymmetry that no longer exists, and with node1 now the 2-core
+      # control plane the toleration had become actively harmful.
+      affinity:
+        # Hard one-member-per-node, replacing a ScheduleAnyway hostname spread.
+        # The soft form permitted two members on a single host, which quietly
+        # turned any single node loss into a QUORUM loss (2 of 3 gone at once).
+        # Required anti-affinity makes surviving one node loss structural rather
+        # than a scheduling accident, and with three members on three app-tier
+        # nodes it is exactly satisfiable.
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  app: nats
+      # nats runs as uid/gid 1000; fsGroup makes the JetStream PVC writable.
+      # Shared PID namespace lets the config-reloader sidecar SIGHUP the
+      # nats-server process (same uid 1000) when the mounted config changes.
+      shareProcessNamespace: true
+      # nats runs as uid/gid 1000; fsGroup makes the JetStream PVC writable.
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile: {type: RuntimeDefault}
+      containers:
+        - name: nats
+          image: nats:2.14.4-alpine@sha256:f2123f533c2b0cada0a5c5ec434fb2b8cfe1cf220215ef9d7517e1372917ad66
+          imagePullPolicy: IfNotPresent
+          # --pid writes a pidfile the reloader reads to signal this process.
+          args: ["--config", "/etc/nats/nats.conf", "--pid", "/var/run/nats/nats.pid"]
+          envFrom:
+            - secretRef:
+                name: nats-auth-env
+          env:
+            # The Go runtime sizes its scheduler from the cgroup CPU limit, but
+            # only when one is set; with requests-only it reads the host's core
+            # count (12 here) and starts that many Ps against a much smaller
+            # quota, paying CFS throttling and scheduler contention on a commit
+            # path that is already lock-heavy. Pinning it to the limit measured
+            # lower hub CPU and higher throughput at once. Keep equal to
+            # resources.limits.cpu.
+            - name: GOMAXPROCS
+              value: "5"
+            # Without this the Go GC has no idea a ceiling exists: JetStream is
+            # allowed 4GiB of memory streams, and the heap grows toward that plus
+            # the RAFT WAL and connection buffers until the kernel OOM-kills the
+            # member - which is exactly how two members were lost under load.
+            # A soft limit below the container limit makes the GC work harder
+            # instead of dying. Keep it ~80% of resources.limits.memory.
+            - name: GOMEMLIMIT
+              value: "4GiB"
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          ports:
+            - {containerPort: 4222, name: client}
+            - {containerPort: 8222, name: monitor}
+            - {containerPort: 6222, name: cluster}
+          volumeMounts:
+            - {name: config, mountPath: /etc/nats, readOnly: true}
+            - {name: certs, mountPath: /etc/nats/certs, readOnly: true}
+            - {name: jetstream-data, mountPath: /data/jetstream}
+            - {name: pid, mountPath: /var/run/nats}
+          resources:
+            # The LIMITS are the real ceiling and do not move: 5 cores because
+            # GOMAXPROCS is pinned to them, and 5Gi because memory-backed streams
+            # need headroom above JetStream's 4GB max_mem for dedup indexes,
+            # connections and the Go runtime — and with every stream R3, each
+            # member holds a copy of all of them rather than only the ones it
+            # leads. Keep max_mem in nats-server.conf under this ceiling:
+            # JetStream sizes memory streams against max_mem and cannot see the
+            # container limit. The OOM that briefly justified an 8Gi ceiling was
+            # a 1 GiB memory-backed R3 bench stream resident on every member on
+            # top of this catalog, not the catalog itself.
+            #
+            # The REQUESTS are deliberately below them, which makes this pod
+            # Burstable rather than Guaranteed. The upstream NATS chart
+            # recommends requests == limits so the member is eligible for the
+            # kubelet's static CPU policy — but this fleet runs
+            # cpuManagerPolicy: none, so that eligibility buys nothing today and
+            # reserving 5 cores per node bought nothing either. Measured steady
+            # state is ~1.3 cores on the leader, so a request of 2 covers it with
+            # ~50% headroom while the limit still lets a catch-up burst take all
+            # five. That returns 3 cores and 1Gi per app node to the scheduler on
+            # a 12-core, ~11 GiB tier.
+            #
+            # The cost, stated so it is not rediscovered: memory usage above the
+            # request puts this pod into the kubelet's memory-pressure eviction
+            # ranking, which at requests == limits it sat outside entirely. The
+            # modelled per-member worst case is ~4.2 GiB (see the max_mem block
+            # in nats-server.conf), so 4Gi sits just under it — steady state is
+            # far below, but a member catching up a full memory-backed catalog
+            # is not. If a hub member is ever evicted under node pressure, raise
+            # this to 4500Mi before looking anywhere else. If cpuManagerPolicy
+            # ever becomes static, revisit the CPU request too.
+            requests: {cpu: "2", memory: 4Gi}
+            limits: {cpu: "5", memory: 5Gi}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities: {drop: ["ALL"]}
+            readOnlyRootFilesystem: true
+          lifecycle:
+            preStop:
+              exec:
+                # Allow in-flight JetStream operations and client reconnects to
+                # drain before the socket closes. Shortens the 500 blast radius
+                # during NATS restarts.
+                command: ["/bin/sh", "-c", "sleep 10"]
+          startupProbe:
+            # 10 minutes, not 50 seconds. Full /healthz stays 503 until every
+            # assigned stream and consumer is current, and an R3 memory-backed
+            # catalog re-syncs its whole dataset from the leader on boot: a
+            # restarted member measured 6.5 minutes to go green. A budget shorter
+            # than that is self-perpetuating - the kubelet kills the member
+            # mid-catchup, the restart begins the catchup again, and the pod
+            # never leaves CrashLoopBackOff. Restarting during startup is free;
+            # killing a member that is doing exactly what it should is not.
+            httpGet: {path: /healthz, port: monitor}
+            periodSeconds: 5
+            failureThreshold: 120
+            timeoutSeconds: 1
+          livenessProbe:
+            httpGet: {path: /healthz, port: monitor}
+            initialDelaySeconds: 5
+            periodSeconds: 15
+            timeoutSeconds: 3
+            failureThreshold: 12
+          readinessProbe:
+            httpGet: {path: "/healthz?js-enabled-only=true", port: monitor}
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+        # Watches the mounted config (nats.conf + auth.conf, sourced from the
+        # nats-config configmap) and SIGHUPs nats-server on change, so a git
+        # push updating the Flux-managed configMapGenerator hot-reloads without
+        # a manual signal or a pod restart.
+        # TODO(deploy): pin to a digest like the other images.
+        - name: reloader
+          image: natsio/nats-server-config-reloader:0.23.0@sha256:64cb6c858e794906d3167378e02b7e0feb83c4e14c07b371eb8d921ef8c4a60b
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-pid"
+            - "/var/run/nats/nats.pid"
+            - "-config"
+            - "/etc/nats/nats.conf"
+            - "-config"
+            - "/etc/nats/auth.conf"
+            # Watch the TLS cert so a cert-manager renewal SIGHUPs nats to reload
+            # the new cert without a pod restart.
+            - "-config"
+            - "/etc/nats/certs/tls.crt"
+          volumeMounts:
+            - {name: config, mountPath: /etc/nats, readOnly: true}
+            - {name: certs, mountPath: /etc/nats/certs, readOnly: true}
+            - {name: pid, mountPath: /var/run/nats}
+          resources:
+            requests: {cpu: 5m, memory: 16Mi}
+            limits: {cpu: 50m, memory: 64Mi}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities: {drop: ["ALL"]}
+            readOnlyRootFilesystem: true
+        - name: prometheus-nats-exporter
+          image: natsio/prometheus-nats-exporter:0.20.1@sha256:4fbf6dacb84780a45a1c3af9b1080c69451a288d20902deae671b80717bb8f61
+          imagePullPolicy: IfNotPresent
+          args: ["-varz", "-connz", "-subz", "-routez", "-jsz=all", "http://localhost:8222"]
+          ports:
+            - {containerPort: 7777, name: metrics}
+          resources:
+            requests: {cpu: 5m, memory: 32Mi}
+            limits: {cpu: 100m, memory: 128Mi}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities: {drop: ["ALL"]}
+      volumes:
+        - name: config
+          configMap:
+            name: nats-config
+        - name: certs
+          secret:
+            secretName: nats-hub-tls
+        - name: pid
+          emptyDir: {}
+  # JetStream keeps a PERSISTENT volume, chosen with both failure modes measured
+  # on 2026-07-27.
+  #
+  # The cost of NOT having one: a member restarts with no store directory, logs
+  # "JetStream cluster bootstrapping", and must re-establish every stream AND all
+  # 24+ consumer RAFT groups from its peers. Measured that day, members sat
+  # "not current" on 10-27 groups for many minutes after each restart, which
+  # shows up as chat replies that are slow or dropped past MaxDeliver. The
+  # expense is the GROUP COUNT, not the data: the streams held under a thousand
+  # messages.
+  #
+  # The cost of having one: local-path binds the PV to the node that provisioned
+  # it, so a member whose node dies sits Pending forever on "didn't match
+  # PersistentVolume's node affinity". That is what happened to nats-1 when node5
+  # was lost, and it took JetStream below quorum and crashlooped every service
+  # that opens a consumer at startup.
+  #
+  # Note what the volume does and does not buy. TWITCH_INGRESS and
+  # TWITCH_OUTGRESS are MemoryStorage, so their data never touches this disk and
+  # a restart always re-fetches them. What the volume actually preserves is the
+  # file-backed streams (BAGEL_DATA, KV_admin_lanes, TWITCH_OUTGRESS_SYSTEM) and,
+  # crucially, the consumer/RAFT state that makes a restart cheap.
+  #
+  # RECOVERY when a node dies and a member is stranded: delete that member's PVC.
+  # The StatefulSet provisions a fresh one on a live node and the member re-syncs
+  # from its two peers. It is one command, and it is the documented answer rather
+  # than something to rediscover under pressure.
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: jetstream-data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 4Gi
+---
+# The hub is a three-voter RAFT quorum: losing two members at once loses every
+# stream's write path, and for the memory-backed ones it loses the data too. The
+# rolling update is already serial and readiness-gated, but a VOLUNTARY
+# disruption is not — a node drain or a cluster-autoscaler action will happily
+# evict two hub pods in parallel unless something says otherwise. This is that
+# something.
+#
+# It matters more here than it looks: the required podAntiAffinity puts exactly
+# one member on each of the three app nodes, so there is no slack to reschedule
+# into. Draining two nodes without this budget is an outage, not a migration.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app: nats
+  name: nats
+  namespace: production
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: nats
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: nats
+  name: nats
+  namespace: production
+spec:
+  # JetStream clients dial this Service directly. Prefer the hub on the same
+  # node so app-tier clients avoid an unnecessary cross-node hop.
+  trafficDistribution: PreferSameNode
+  selector:
+    app: nats
+  ports:
+    - {name: client, port: 4222, targetPort: client}
+    - {name: monitor, port: 8222, targetPort: monitor}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: nats
+  name: nats-headless
+  namespace: production
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  selector:
+    app: nats
+  ports:
+    - {name: cluster, port: 6222, targetPort: cluster}
+---
+# NATS monitoring (/jsz) published on the tailnet, so KEDA can poll consumer lag
+# from the control plane WITHOUT a pod-network path to the application tier.
+#
+# WHY THIS EXISTS
+# ---------------
+# KEDA's metricsServer backs an aggregated APIService, so it must sit beside the
+# apiserver on node1 (see deploy/infra/keda/release.yaml). It reaches the KEDA
+# operator over gRPC, so the operator has to live on node1 too, and the operator
+# is what polls NATS. That made the operator's poll the last piece of cross-node
+# POD traffic leaving node1, which is precisely what the private-VLAN topology
+# must not require: node1 is at OCI with no path to 10.10.0.0/24, and reaching it
+# through a tailscale SUBNET ROUTE puts every advertiser in the failure path.
+#
+# Routing it through the ts-ingress ProxyGroup instead means node1 dials a stable
+# tailnet name over HOST networking, which is exactly what node1 is allowed to do.
+# The ProxyGroup runs 3 ha-spread replicas, so no single proxy or node carries it,
+# unlike a NodePort pinned to one node's address.
+#
+# The ScaledObject triggers in outgress.yaml / sesame.yaml point at this name with
+# useHttps "true"; the cert is a real MagicDNS cert, so no custom CA is involved.
+# Reaching it needs a tag:cp -> tag:k8s grant in the tailnet policy.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: nats-monitoring
+  namespace: production
+  annotations:
+    tailscale.com/proxy-group: ts-ingress
+spec:
+  ingressClassName: tailscale
+  defaultBackend:
+    service:
+      name: nats
+      port:
+        number: 8222
+  tls:
+    - hosts:
+        - nats-monitoring

--- a/deploy/k8s/nats_auth_acceptance_test.go
+++ b/deploy/k8s/nats_auth_acceptance_test.go
@@ -1,0 +1,380 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package k8s
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"ItsBagelBot/pkg/bus"
+
+	"github.com/nats-io/nats.go"
+	"go.uber.org/zap"
+)
+
+type acceptanceHarness struct {
+	url      string
+	password string
+	log      *zap.Logger
+}
+
+type serviceIdentity struct {
+	user string
+}
+
+type streamOwner struct {
+	identity serviceIdentity
+	specs    []bus.StreamSpec
+}
+
+type streamBinding struct {
+	identity serviceIdentity
+	group    string
+	subject  string
+}
+
+type consumerGrant struct {
+	identity serviceIdentity
+	streams  []string
+}
+
+type publishProbe struct {
+	identity serviceIdentity
+	subject  string
+}
+
+type permissionProbe struct {
+	identity serviceIdentity
+	subject  string
+}
+
+type violationExpectation struct {
+	permissionErr <-chan error
+	subject       string
+}
+
+// TestScopedBusUsersBindAllowedStreams exercises the same pkg/bus stream and
+// consumer calls the services make in production. It is opt-in because it
+// needs a local NATS 2.14 fixture running this directory's auth config;
+// point NATS_AUTHZ_ACCEPTANCE_URL and NATS_AUTHZ_ACCEPTANCE_PASSWORD at it.
+func TestScopedBusUsersBindAllowedStreams(t *testing.T) {
+	harness := newAcceptanceHarness(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	harness.reconcileOwnedStreams(t, ctx)
+	harness.assertAllowedBindings(t)
+	harness.assertRequiredAckPermissions(t)
+	harness.assertPullFetchPermission(t)
+	harness.assertConsumerIsolation(t)
+	harness.assertDestructiveOperationsDenied(t)
+	harness.assertNodeLocalRPCImport(t)
+}
+
+func newAcceptanceHarness(t *testing.T) *acceptanceHarness {
+	t.Helper()
+	url := os.Getenv("NATS_AUTHZ_ACCEPTANCE_URL")
+	if url == "" {
+		t.Skip("set NATS_AUTHZ_ACCEPTANCE_URL to run the local NATS authorization smoke test")
+	}
+	password := os.Getenv("NATS_AUTHZ_ACCEPTANCE_PASSWORD")
+	if password == "" {
+		t.Fatal("NATS_AUTHZ_ACCEPTANCE_PASSWORD is required")
+	}
+	harness := &acceptanceHarness{url: url, password: password, log: zap.NewNop()}
+	harness.configureEnv(t)
+	return harness
+}
+
+func (h *acceptanceHarness) reconcileOwnedStreams(t *testing.T, ctx context.Context) {
+	t.Helper()
+	owners := []streamOwner{
+		{serviceIdentity{"users_bus"}, []bus.StreamSpec{localStream(bus.BagelDataStream)}},
+		{serviceIdentity{"worker_bus"}, []bus.StreamSpec{localStream(bus.TwitchIngressStream)}},
+		{serviceIdentity{"outgress_bus"}, []bus.StreamSpec{localStream(bus.OutgressStream), localStream(bus.OutgressSystemStream)}},
+	}
+	for _, owner := range owners {
+		h.activate(t, owner.identity)
+		if err := bus.EnsureStreams(ctx, h.url, owner.specs, h.log); err != nil {
+			t.Fatalf("%s could not reconcile its owned stream(s): %v", owner.identity.user, err)
+		}
+	}
+}
+
+func (h *acceptanceHarness) assertAllowedBindings(t *testing.T) {
+	t.Helper()
+	bindings := []streamBinding{
+		// Both broadcast (ephemeral) and durable paths are represented.
+		{serviceIdentity{"users_bus"}, "", "data.users.changed"},
+		{serviceIdentity{"users_bus"}, "authz_users", "data.reproject.request"},
+		{serviceIdentity{"commands_bus"}, "", "data.commands.changed"},
+		{serviceIdentity{"commands_bus"}, "authz_commands", "data.commands.used"},
+		{serviceIdentity{"modules_bus"}, "", "data.modules.changed"},
+		{serviceIdentity{"modules_bus"}, "authz_modules", "data.users.deleted"},
+		{serviceIdentity{"loyalty_bus"}, "authz_loyalty", "data.loyalty.earned"},
+		{serviceIdentity{"projector_bus"}, "authz_projector", "data.users.changed"},
+		{serviceIdentity{"projector_bus"}, "authz_projector", "twitch.ingress.event.stream"},
+		{serviceIdentity{"worker_bus"}, "authz_worker", "twitch.ingress.event.premium"},
+		{serviceIdentity{"outgress_bus"}, "authz_outgress", "twitch.outgress.premium"},
+		{serviceIdentity{"outgress_bus"}, "authz_outgress", "twitch.outgress.system"},
+		{serviceIdentity{"outgress_bus"}, "authz_outgress", "twitch.ingress.event.stream"},
+		// Authorization lifecycle consumers (revocation marking + grant re-enroll).
+		{serviceIdentity{"outgress_bus"}, "authz_outgress", "twitch.ingress.status.authz.granted"},
+		{serviceIdentity{"outgress_bus"}, "authz_outgress", "twitch.ingress.status.authz.revoked"},
+		{serviceIdentity{"outgress_bus"}, "authz_outgress", "twitch.ingress.status.authz.subrevoked"},
+	}
+	for _, binding := range bindings {
+		binding := binding
+		t.Run("bind_"+binding.identity.user+"_"+binding.subject, func(t *testing.T) {
+			h.assertAllowedBinding(t, binding)
+		})
+	}
+}
+
+func (h *acceptanceHarness) assertAllowedBinding(t *testing.T, binding streamBinding) {
+	t.Helper()
+	h.activate(t, binding.identity)
+	sub, err := bus.NewSubscriber(h.url, binding.group, h.log)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = sub.Close() }()
+	subCtx, stop := context.WithCancel(context.Background())
+	defer stop()
+	if _, err := sub.Subscribe(subCtx, binding.subject); err != nil {
+		t.Fatalf("allowed binding failed: %v", err)
+	}
+}
+
+func (h *acceptanceHarness) assertRequiredAckPermissions(t *testing.T) {
+	t.Helper()
+	grants := []consumerGrant{
+		{serviceIdentity{"users_bus"}, []string{"BAGEL_DATA"}},
+		{serviceIdentity{"commands_bus"}, []string{"BAGEL_DATA"}},
+		{serviceIdentity{"modules_bus"}, []string{"BAGEL_DATA"}},
+		{serviceIdentity{"loyalty_bus"}, []string{"BAGEL_DATA"}},
+		{serviceIdentity{"projector_bus"}, []string{"BAGEL_DATA", "TWITCH_INGRESS"}},
+		{serviceIdentity{"worker_bus"}, []string{"TWITCH_INGRESS"}},
+		{serviceIdentity{"outgress_bus"}, []string{"TWITCH_OUTGRESS", "TWITCH_OUTGRESS_SYSTEM", "TWITCH_INGRESS"}},
+	}
+	for _, grant := range grants {
+		h.assertStreamAcks(t, grant)
+	}
+}
+
+func (h *acceptanceHarness) assertStreamAcks(t *testing.T, grant consumerGrant) {
+	t.Helper()
+	for _, stream := range grant.streams {
+		// NATS 2.14 may issue either legacy or domain/account-qualified ACK
+		// reply subjects. Exercise both permission shapes directly.
+		h.assertPublishAllowed(t, publishProbe{grant.identity, "$JS.ACK." + stream + ".authz.1.1.1.0.0"})
+		h.assertPublishAllowed(t, publishProbe{grant.identity, "$JS.ACK.hub.account." + stream + ".authz.1.1.1.0.0"})
+	}
+}
+
+func (h *acceptanceHarness) assertPublishAllowed(t *testing.T, probe publishProbe) {
+	t.Helper()
+	nc, permissionErr := h.connectWithPermissionErrors(t, probe.identity)
+	defer nc.Close()
+	if err := nc.Publish(probe.subject, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := nc.FlushTimeout(300 * time.Millisecond); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-permissionErr:
+		t.Fatalf("%s could not publish required ACK %s: %v", probe.identity.user, probe.subject, err)
+	case <-time.After(25 * time.Millisecond):
+	}
+}
+
+// assertPullFetchPermission covers the verb the receipt-level pull lane runs on.
+// A denied MSG.NEXT is invisible from the client side: the consumer is created,
+// the stream fills, and every fetch is refused, so the lane reports zero events
+// per second with nothing but a broker-log violation to read. The permission is
+// gated on the publish, which is what this probes; the consumer name in the
+// subject only has to be inside the granted prefix.
+func (h *acceptanceHarness) assertPullFetchPermission(t *testing.T) {
+	t.Helper()
+	identity := serviceIdentity{"worker_bus"}
+	for _, stream := range []string{"TWITCH_INGRESS", "TWITCH_INGRESS_STANDARD"} {
+		subject := "$JS.API.CONSUMER.MSG.NEXT." + stream + ".worker_twitch_ingress_event_standard"
+		h.assertPublishAllowed(t, publishProbe{identity, subject})
+	}
+}
+
+func (h *acceptanceHarness) assertConsumerIsolation(t *testing.T) {
+	t.Helper()
+	identity := serviceIdentity{"loyalty_bus"}
+	nc, permissionErr := h.connectWithPermissionErrors(t, identity)
+	defer nc.Close()
+	js, err := nc.JetStream(nats.Domain("hub"), nats.MaxWait(300*time.Millisecond))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Leave Name/Durable empty so nats.go sends the legacy create endpoint with
+	// the wildcard filter in the JSON body, not as an invalid publish subject.
+	_, err = js.AddConsumer("TWITCH_INGRESS", &nats.ConsumerConfig{
+		DeliverSubject: "_INBOX.authz.loyalty.stolen",
+		DeliverPolicy:  nats.DeliverNewPolicy,
+		AckPolicy:      nats.AckExplicitPolicy,
+		FilterSubject:  "twitch.ingress.event.>",
+	})
+	if err == nil {
+		t.Fatal("loyalty_bus unexpectedly created a TWITCH_INGRESS consumer")
+	}
+	assertAuthorizationViolation(t, violationExpectation{
+		permissionErr: permissionErr,
+		subject:       "$JS.API.CONSUMER.CREATE.TWITCH_INGRESS",
+	})
+}
+
+func (h *acceptanceHarness) assertDestructiveOperationsDenied(t *testing.T) {
+	t.Helper()
+	identities := []serviceIdentity{
+		{"users_bus"}, {"commands_bus"}, {"modules_bus"}, {"loyalty_bus"},
+		{"projector_bus"}, {"worker_bus"}, {"outgress_bus"},
+		{"twitch_ingress_bus"}, {"dashboard_bus"},
+	}
+	for _, identity := range identities {
+		h.assertDestructiveOperationsDeniedFor(t, identity)
+	}
+}
+
+func (h *acceptanceHarness) assertNodeLocalRPCImport(t *testing.T) {
+	t.Helper()
+	const subject = "bagel.rpc.health.users"
+	const localSubject = subject + ".node.node2"
+	const traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+	t.Setenv("NODE_NAME", "node2")
+
+	responder, responderErr := h.connectWithPermissionErrors(t, serviceIdentity{"users_rpc"})
+	defer responder.Close()
+	if _, err := responder.QueueSubscribe(localSubject, "authz-locality", func(msg *nats.Msg) {
+		_ = msg.Respond([]byte("node2:" + msg.Header.Get("traceparent")))
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := responder.Flush(); err != nil {
+		t.Fatal(err)
+	}
+
+	requester, requesterErr := h.connectWithPermissionErrors(t, serviceIdentity{"admin_rpc"})
+	defer requester.Close()
+	request := nats.NewMsg(subject)
+	request.Header.Set("traceparent", traceparent)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	reply, err := bus.RequestMsgWithContext(ctx, requester, request)
+	if err != nil {
+		t.Fatalf("node-qualified cross-account request failed: %v", err)
+	}
+	if want := "node2:" + traceparent; string(reply.Data) != want {
+		t.Fatalf("node-qualified cross-account reply = %q, want %q", reply.Data, want)
+	}
+	assertNoPermissionViolation(t, responderErr, subject)
+	assertNoPermissionViolation(t, requesterErr, subject)
+}
+
+func (h *acceptanceHarness) assertDestructiveOperationsDeniedFor(t *testing.T, identity serviceIdentity) {
+	t.Helper()
+	for _, operation := range []string{"PURGE", "DELETE"} {
+		operation := operation
+		t.Run(fmt.Sprintf("deny_%s_%s", identity.user, operation), func(t *testing.T) {
+			h.assertRequestDenied(t, permissionProbe{
+				identity: identity,
+				subject:  "$JS.API.STREAM." + operation + ".BAGEL_DATA",
+			})
+		})
+	}
+}
+
+func localStream(spec bus.StreamSpec) bus.StreamSpec {
+	spec.Storage = nats.MemoryStorage
+	spec.Replicas = 1
+	spec.PlacementTags = nil
+	spec.MaxBytes = 8 << 20
+	return spec
+}
+
+func (h *acceptanceHarness) configureEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("NATS_USER", "")
+	t.Setenv("NATS_PASSWORD", "")
+	t.Setenv("NATS_HUB_URL", h.url)
+	t.Setenv("NATS_HUB_PUBLISH_URL", h.url)
+	t.Setenv("NATS_JS_DOMAIN", "hub")
+	t.Setenv("NATS_CA_PEM", "")
+	t.Setenv("NATS_PUBLISH_CONNECTIONS", "1")
+}
+
+func (h *acceptanceHarness) activate(t *testing.T, identity serviceIdentity) {
+	t.Helper()
+	if err := os.Setenv("NATS_USER", identity.user); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Setenv("NATS_PASSWORD", h.password); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func (h *acceptanceHarness) assertRequestDenied(t *testing.T, probe permissionProbe) {
+	t.Helper()
+	nc, permissionErr := h.connectWithPermissionErrors(t, probe.identity)
+	defer nc.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+	if _, err := nc.RequestWithContext(ctx, probe.subject, nil); err == nil {
+		t.Fatalf("%s unexpectedly received a response to forbidden request %s", probe.identity.user, probe.subject)
+	}
+	assertAuthorizationViolation(t, violationExpectation{permissionErr: permissionErr, subject: probe.subject})
+}
+
+func (h *acceptanceHarness) connectWithPermissionErrors(t *testing.T, identity serviceIdentity) (*nats.Conn, <-chan error) {
+	t.Helper()
+	permissionErr := make(chan error, 1)
+	nc, err := nats.Connect(h.url,
+		nats.UserInfo(identity.user, h.password),
+		nats.Timeout(300*time.Millisecond),
+		nats.MaxReconnects(0),
+		nats.ErrorHandler(func(_ *nats.Conn, _ *nats.Subscription, err error) {
+			select {
+			case permissionErr <- err:
+			default:
+			}
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return nc, permissionErr
+}
+
+func assertAuthorizationViolation(t *testing.T, expectation violationExpectation) {
+	t.Helper()
+	select {
+	case err := <-expectation.permissionErr:
+		if !strings.Contains(err.Error(), "Permissions Violation") || !strings.Contains(err.Error(), expectation.subject) {
+			t.Fatalf("denial was not the expected authorization violation for %s: %v", expectation.subject, err)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("no authorization violation reported for forbidden subject %s", expectation.subject)
+	}
+}
+
+func assertNoPermissionViolation(t *testing.T, permissionErr <-chan error, subject string) {
+	t.Helper()
+	select {
+	case err := <-permissionErr:
+		t.Fatalf("unexpected authorization error for %s: %v", subject, err)
+	case <-time.After(25 * time.Millisecond):
+	}
+}

--- a/deploy/k8s/nats_auth_test.go
+++ b/deploy/k8s/nats_auth_test.go
@@ -1,0 +1,266 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package k8s
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+	"testing"
+)
+
+const jetStreamAPI = "$JS.API."
+
+var busUserPattern = regexp.MustCompile(`(?m)^[ \t]*user: "([a-z_]+_bus)"`)
+var jsSubjectPattern = regexp.MustCompile(`"(\$JS[^"]+)"`)
+var streamMutationPattern = regexp.MustCompile(`^\$JS\.API\.STREAM\.(CREATE|UPDATE|DELETE|LEADER\.STEPDOWN)\.`)
+
+// TestServiceBusJetStreamPermissionsAreExact is the regression gate for the
+// BUS-account blast radius. A broad $JS.> grant, an extra stream, or a newly
+// added management verb must be reviewed here instead of silently reaching
+// every stream in the account.
+func TestServiceBusJetStreamPermissionsAreExact(t *testing.T) {
+	config := sourceFile{name: "nats-auth.conf"}.read(t)
+	blocks := (authConfig{body: config}).busUserBlocks(t)
+
+	consumers := map[string][]string{
+		"users_bus":     {"BAGEL_DATA"},
+		"commands_bus":  {"BAGEL_DATA"},
+		"modules_bus":   {"BAGEL_DATA"},
+		"loyalty_bus":   {"BAGEL_DATA"},
+		"projector_bus": {"BAGEL_DATA", "TWITCH_INGRESS"},
+		"worker_bus":    {"TWITCH_INGRESS", "TWITCH_INGRESS_RETRY", "TWITCH_INGRESS_STANDARD"},
+		"outgress_bus":  {"TWITCH_OUTGRESS", "TWITCH_OUTGRESS_SYSTEM", "TWITCH_INGRESS"},
+	}
+	owners := map[string][]string{
+		"users_bus":    {"BAGEL_DATA"},
+		"worker_bus":   {"TWITCH_INGRESS", "TWITCH_INGRESS_RETRY", "TWITCH_INGRESS_STANDARD"},
+		"outgress_bus": {"TWITCH_OUTGRESS", "TWITCH_OUTGRESS_SYSTEM"},
+	}
+	serviceUsers := []string{
+		"users_bus", "commands_bus", "modules_bus", "loyalty_bus",
+		"projector_bus", "worker_bus", "outgress_bus",
+		"twitch_ingress_bus", "dashboard_bus",
+	}
+
+	for _, user := range serviceUsers {
+		t.Run(user, func(t *testing.T) {
+			block, ok := blocks[user]
+			if !ok {
+				t.Fatalf("missing %s authorization block", user)
+			}
+			got := block.jetStreamSubjects()
+			want := expectedJetStreamSubjects(streamGrants{
+				consumerStreams: consumers[user],
+				ownedStreams:    owners[user],
+				flowControl:     flowControlStreams[user],
+				pullFetch:       pullFetchStreams[user],
+			})
+			if !slices.Equal(got, want) {
+				t.Fatalf("JetStream grants differ (-want +got):\nwant %v\n got %v", want, got)
+			}
+		})
+	}
+}
+
+// TestAdminStreamMutationGrantsAreOnlyItsOwnKV holds admin_bus to the one
+// stream it actually owns, plus the leader-stepdown verb that implements the
+// manual leader-spread policy after hub rolls. It used to also carry
+// create/update/delete and $JS.FC on a fixed benchmark stream name so a load
+// rig could run without a config push. That is standing ack-floor and
+// stream-mutation authority for a workload that is not running, and it
+// outlived the rig by itself — which is exactly how a permission becomes
+// permanent. A future load test brings its own grant for the duration of its
+// run. Stepdown is the deliberate exception: it moves leaders and nothing
+// else, and the spread must be restorable during an incident without a config
+// push.
+func TestAdminStreamMutationGrantsAreOnlyItsOwnKV(t *testing.T) {
+	config := sourceFile{name: "nats-auth.conf"}.read(t)
+	block, ok := (authConfig{body: config}).busUserBlocks(t)["admin_bus"]
+	if !ok {
+		t.Fatal("missing admin_bus authorization block")
+	}
+
+	var got []string
+	for _, subject := range block.jetStreamSubjects() {
+		if streamMutationPattern.MatchString(subject) {
+			got = append(got, subject)
+		}
+		if strings.Contains(subject, "BENCH") || strings.Contains(subject, "SHADOW") {
+			t.Errorf("admin_bus still grants a benchmark-stream subject: %s", subject)
+		}
+	}
+	want := []string{
+		"$JS.API.STREAM.CREATE.KV_admin_lanes",
+		"$JS.API.STREAM.LEADER.STEPDOWN.>",
+		"$JS.API.STREAM.UPDATE.KV_admin_lanes",
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("admin stream mutation grants differ (-want +got):\nwant %v\n got %v", want, got)
+	}
+}
+
+// TestRuntimeStreamOwnershipMatchesACL keeps startup reconciliation aligned
+// with the three identities that receive STREAM.CREATE/UPDATE above.
+func TestRuntimeStreamOwnershipMatchesACL(t *testing.T) {
+	mainFiles, err := filepath.Glob(filepath.Join("..", "..", "app", "*", "main.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	check := streamOwnershipCheck{
+		want: map[string]string{
+			"users": "[]bus.StreamSpec{bus.BagelDataStream}",
+			// Both ingress lane streams, in this order. EnsureStreams reconciles
+			// the slice in order and the partition's narrowing update must run
+			// before the new stream claims the subject, so the order is part of
+			// the assertion, not incidental formatting.
+			"sesame":   "bus.IngressLaneSpecs()",
+			"outgress": "[]bus.StreamSpec{bus.OutgressStream, bus.OutgressSystemStream}",
+		},
+		seen: make(map[string]bool, 3),
+	}
+
+	for _, name := range mainFiles {
+		check.inspect(t, sourceFile{name: name})
+	}
+	for service := range check.want {
+		if !check.seen[service] {
+			t.Errorf("stream owner %s does not call EnsureStreams", service)
+		}
+	}
+}
+
+type streamOwnershipCheck struct {
+	want map[string]string
+	seen map[string]bool
+}
+
+type sourceFile struct {
+	name string
+}
+
+// flowControlStreams names, per user, the streams whose consumers acknowledge
+// through the AckFlowControl reply subject rather than $JS.ACK. Publishing to
+// $JS.FC is how such a consumer acks at all, so the grant is mandatory — and it
+// is ack-equivalent authority on that consumer, which is why it is scoped to a
+// single stream and asserted here rather than folded into the per-stream set.
+var flowControlStreams = map[string][]string{
+	"worker_bus": {"TWITCH_INGRESS", "TWITCH_INGRESS_STANDARD"},
+}
+
+// pullFetchStreams names, per user, the streams whose lanes may bind a
+// shared-durable pull consumer. MSG.NEXT is that consumer's fetch verb and no
+// push consumer ever sends it, so it is listed separately rather than folded
+// into the per-stream consumer set: granting it to a service that only binds
+// push consumers is authority for a call that service never makes, and NOT
+// granting it to one that pulls is a silent zero-delivery lane rather than a
+// visible error. Only the hot ingress lanes qualify for receipt-level
+// consumption (pkg/bus isHotIngressLane), and sesame is their only consumer.
+var pullFetchStreams = map[string][]string{
+	"worker_bus": {"TWITCH_INGRESS", "TWITCH_INGRESS_STANDARD"},
+}
+
+type streamGrants struct {
+	consumerStreams []string
+	ownedStreams    []string
+	flowControl     []string
+	pullFetch       []string
+}
+
+type authConfig struct {
+	body string
+}
+
+type busUserBlock struct {
+	body string
+}
+
+func (c *streamOwnershipCheck) inspect(t *testing.T, file sourceFile) {
+	t.Helper()
+	body := file.read(t)
+	if !strings.Contains(body, "bus.EnsureStreams(") {
+		return
+	}
+	service := filepath.Base(filepath.Dir(file.name))
+	snippet, ok := c.want[service]
+	if !ok {
+		t.Errorf("%s reconciles streams but has no stream-owner ACL", service)
+		return
+	}
+	if !strings.Contains(body, snippet) {
+		t.Errorf("%s does not reconcile only its owned stream(s): want %s", service, snippet)
+	}
+	c.seen[service] = true
+}
+
+func expectedJetStreamSubjects(grants streamGrants) []string {
+	set := make(map[string]struct{})
+	for _, stream := range grants.flowControl {
+		set["$JS.FC."+stream+".>"] = struct{}{}
+	}
+	for _, stream := range grants.pullFetch {
+		set[jetStreamAPI+"CONSUMER.MSG.NEXT."+stream+".>"] = struct{}{}
+	}
+	for _, stream := range grants.consumerStreams {
+		for _, subject := range []string{
+			jetStreamAPI + "STREAM.INFO." + stream,
+			jetStreamAPI + "CONSUMER.INFO." + stream + ".>",
+			jetStreamAPI + "CONSUMER.CREATE." + stream + ".>",
+			jetStreamAPI + "CONSUMER.DURABLE.CREATE." + stream + ".>",
+			jetStreamAPI + "CONSUMER.DELETE." + stream + ".>",
+			"$JS.ACK." + stream + ".>",
+			"$JS.ACK.*.*." + stream + ".>",
+		} {
+			set[subject] = struct{}{}
+		}
+	}
+	for _, stream := range grants.ownedStreams {
+		set[jetStreamAPI+"STREAM.INFO."+stream] = struct{}{}
+		set[jetStreamAPI+"STREAM.CREATE."+stream] = struct{}{}
+		set[jetStreamAPI+"STREAM.UPDATE."+stream] = struct{}{}
+	}
+	return sortedKeys(set)
+}
+
+func (b busUserBlock) jetStreamSubjects() []string {
+	set := make(map[string]struct{})
+	for _, match := range jsSubjectPattern.FindAllStringSubmatch(b.body, -1) {
+		set[match[1]] = struct{}{}
+	}
+	return sortedKeys(set)
+}
+
+func sortedKeys(set map[string]struct{}) []string {
+	keys := make([]string, 0, len(set))
+	for key := range set {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+	return keys
+}
+
+func (c authConfig) busUserBlocks(t *testing.T) map[string]busUserBlock {
+	t.Helper()
+	matches := busUserPattern.FindAllStringSubmatchIndex(c.body, -1)
+	blocks := make(map[string]busUserBlock, len(matches))
+	for i, match := range matches {
+		end := len(c.body)
+		if i+1 < len(matches) {
+			end = matches[i+1][0]
+		}
+		blocks[c.body[match[2]:match[3]]] = busUserBlock{body: c.body[match[0]:end]}
+	}
+	return blocks
+}
+
+func (f sourceFile) read(t *testing.T) string {
+	t.Helper()
+	body, err := os.ReadFile(f.name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(body)
+}

--- a/deploy/k8s/nats_publish_locality_test.go
+++ b/deploy/k8s/nats_publish_locality_test.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package k8s
+
+import (
+	"regexp"
+	"testing"
+)
+
+func TestJetStreamPublishersUseNodeLocalHubService(t *testing.T) {
+	publishers := []struct {
+		manifest string
+		variable string
+		value    string
+	}{
+		{"twitch-ingress.yaml", "NATS_HUB_HOST", "nats"},
+		{"commands.yaml", "NATS_HUB_PUBLISH_URL", "nats://nats:4222"},
+		{"modules.yaml", "NATS_HUB_PUBLISH_URL", "nats://nats:4222"},
+		{"projector.yaml", "NATS_HUB_PUBLISH_URL", "nats://nats:4222"},
+		{"sesame.yaml", "NATS_HUB_PUBLISH_URL", "tls://nats:4222"},
+		{"users.yaml", "NATS_HUB_PUBLISH_URL", "nats://nats:4222"},
+	}
+
+	for _, publisher := range publishers {
+		t.Run(publisher.manifest, func(t *testing.T) {
+			manifest := sourceFile{name: publisher.manifest}.read(t)
+			pattern := regexp.MustCompile(`(?m)^\s*- name: ` + regexp.QuoteMeta(publisher.variable) +
+				`\n\s+value: ` + regexp.QuoteMeta(publisher.value) + `$`)
+			if !pattern.MatchString(manifest) {
+				t.Fatalf("%s must set %s=%s", publisher.manifest, publisher.variable, publisher.value)
+			}
+		})
+	}
+}
+
+func TestHubServicePrefersSameNode(t *testing.T) {
+	manifest := sourceFile{name: "nats.yaml"}.read(t)
+	service := regexp.MustCompile(`(?s)kind: Service\nmetadata:.*?\n  name: nats\n.*?trafficDistribution: PreferSameNode`).FindString(manifest)
+	if service == "" {
+		t.Fatal("nats Service must retain trafficDistribution: PreferSameNode")
+	}
+}

--- a/deploy/k8s/nats_rpc_locality_test.go
+++ b/deploy/k8s/nats_rpc_locality_test.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package k8s
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+var serviceSubjectPattern = regexp.MustCompile(`\{ service:.*(?:subject: )?"([^"]+)"`)
+
+func TestExactRPCGrantsIncludeNodeLocalVariant(t *testing.T) {
+	config := sourceFile{name: "nats-auth.conf"}.read(t)
+	counts := serviceGrantCounts(config)
+	exact := exactServiceGrants(counts)
+
+	for subject, count := range exact {
+		local := subject + ".node.*"
+		if counts[local] < count {
+			t.Errorf("exact service grant %q occurs %d times; local grant %q occurs %d times",
+				subject, count, local, counts[local])
+		}
+	}
+	if len(exact) < 10 {
+		t.Fatalf("checked only %d exact RPC grants; parser likely stopped matching the config", len(exact))
+	}
+}
+
+func serviceGrantCounts(config string) map[string]int {
+	counts := make(map[string]int)
+	for _, line := range strings.Split(config, "\n") {
+		match := serviceSubjectPattern.FindStringSubmatch(line)
+		if len(match) == 2 {
+			counts[match[1]]++
+		}
+	}
+	return counts
+}
+
+func exactServiceGrants(counts map[string]int) map[string]int {
+	exact := make(map[string]int)
+	for subject, count := range counts {
+		if !strings.HasSuffix(subject, ".>") && !strings.HasSuffix(subject, ".node.*") {
+			exact[subject] = count
+		}
+	}
+	return exact
+}

--- a/deploy/k8s/nats_server_config_test.go
+++ b/deploy/k8s/nats_server_config_test.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package k8s
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func TestHubRoutesRetainMeasuredCompressionMode(t *testing.T) {
+	config := sourceFile{name: "nats-server.conf"}.read(t)
+	cluster := regexp.MustCompile(`(?s)cluster \{.*?\n\}`).FindString(config)
+	if cluster == "" {
+		t.Fatal("nats-server.conf has no cluster block")
+	}
+	if !regexp.MustCompile(`(?m)^\s*mode:\s*s2_fast\s*$`).MatchString(cluster) {
+		t.Fatal("BUS routes must retain the measured s2_fast compression mode")
+	}
+	if regexp.MustCompile(`(?m)^\s*mode:\s*s2_auto\s*$`).MatchString(cluster) ||
+		regexp.MustCompile(`(?m)^\s*rtt_thresholds:`).MatchString(cluster) {
+		t.Fatal("adaptive route compression regressed the asymmetric R3 topology")
+	}
+}
+
+// A hub member and a leaf share the node's network namespace, so their
+// listeners are host-wide and every port either binds must be disjoint.
+func TestHostNetworkListenersDoNotCollide(t *testing.T) {
+	hub := sourceFile{name: "nats.yaml"}.read(t)
+	leaf := sourceFile{name: "nats-leaf.yaml"}.read(t)
+
+	requireHostNetns(t, "nats.yaml", hub)
+	requireHostNetns(t, "nats-leaf.yaml", leaf)
+
+	leafPorts := containerPorts(t, leaf)
+	for port := range containerPorts(t, hub) {
+		if leafPorts[port] {
+			t.Errorf("hub and leaf both bind host port %s", port)
+		}
+	}
+}
+
+// Moving the leaf listeners must stay invisible to callers: the routed
+// Services keep publishing the ports every client URL already names.
+func TestLeafServicesKeepPublishedClientPorts(t *testing.T) {
+	manifest := sourceFile{name: "nats-leaf.yaml"}.read(t)
+	published := map[string]int{
+		"- {name: client, port: 4222, targetPort: client}":   2,
+		"- {name: monitor, port: 8222, targetPort: monitor}": 2,
+	}
+	for entry, want := range published {
+		if got := strings.Count(manifest, entry); got != want {
+			t.Errorf("%q appears %d times, want %d (nats-leaf + nats-leaf-local)", entry, got, want)
+		}
+	}
+}
+
+func requireHostNetns(t *testing.T, name, manifest string) {
+	t.Helper()
+	for _, required := range []string{"hostNetwork: true", "dnsPolicy: ClusterFirstWithHostNet"} {
+		if !strings.Contains(manifest, required) {
+			t.Fatalf("%s must set %q", name, required)
+		}
+	}
+}
+
+func containerPorts(t *testing.T, manifest string) map[string]bool {
+	t.Helper()
+	ports := make(map[string]bool)
+	for _, match := range regexp.MustCompile(`containerPort: (\d+)`).FindAllStringSubmatch(manifest, -1) {
+		ports[match[1]] = true
+	}
+	if len(ports) == 0 {
+		t.Fatal("no container ports parsed; the manifest layout likely changed")
+	}
+	return ports
+}
+
+func TestHubJetStreamIngestWindowStaysByteBounded(t *testing.T) {
+	config := sourceFile{name: "nats-server.conf"}.read(t)
+	jetstream := regexp.MustCompile(`(?s)jetstream \{.*?\n\}`).FindString(config)
+	if jetstream == "" {
+		t.Fatal("nats-server.conf has no JetStream block")
+	}
+	for _, required := range []string{
+		"max_buffered_msgs: 262144",
+		"max_buffered_size: 128MB",
+	} {
+		if !strings.Contains(jetstream, required) {
+			t.Fatalf("JetStream ingest guard %q is missing", required)
+		}
+	}
+}

--- a/deploy/k8s/network-policies.yaml
+++ b/deploy/k8s/network-policies.yaml
@@ -1,0 +1,103 @@
+# Copyright (c) 2026 Adam Ousmer. All rights reserved.
+# Proprietary. No license granted. See LICENSE.md.
+
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-apps
+  namespace: production
+spec:
+  # Apply only to our specific apps to avoid breaking NATS or other infrastructure in the namespace
+  podSelector:
+    matchExpressions:
+      - key: app
+        operator: In
+        values: [users, commands, loyalty, modules, transactions, projector, sesame, twitch-ingress, outgress, console-dashboard, console-admin, gossip, notifications, notifications-cleanup]
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Allow all pods in bagelbot namespace to reach each other for now.
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: production
+    # Allow Traefik ingress controller to reach dashboard
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+    # Allow Tailscale ingress controller to reach admin
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: tailscale
+  egress:
+    # Resolve through cluster DNS only. Leaving `to` empty here would turn port
+    # 53 into a DNS-tunnelling escape hatch to any Internet address.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    # Allow communication to any pod in bagelbot (e.g. NATS)
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: production
+    # Allow communication to Valkey namespace
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: valkey
+---
+# Every long-running application currently exports APM directly to New Relic
+# over HTTPS. Product integrations also use HTTPS from gossip, ingress,
+# outgress, sesame, transactions and the consoles. Keep this grant explicit so
+# a workload cannot silently inherit it merely by joining default-deny-apps.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-public-https
+  namespace: production
+spec:
+  podSelector:
+    matchExpressions:
+      - key: app
+        operator: In
+        values: [users, commands, loyalty, modules, transactions, projector, sesame, twitch-ingress, outgress, console-dashboard, console-admin, gossip, notifications]
+  policyTypes:
+    - Egress
+  egress:
+    - ports:
+        - port: 443
+          protocol: TCP
+---
+# Data owners reach the managed HeatWave endpoint over the routed OCI private
+# subnet. Restricting both the workloads and destination prevents port 3306
+# from becoming a generic public-Internet exfiltration path. console-admin is
+# included for its explicit schema-credential administration workflow.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-heatwave
+  namespace: production
+spec:
+  podSelector:
+    matchExpressions:
+      - key: app
+        operator: In
+        values: [users, commands, loyalty, modules, transactions, notifications, console-admin]
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 10.0.0.0/16
+      ports:
+        - port: 3306
+          protocol: TCP

--- a/deploy/k8s/network-tune/90-bagelbot-net.conf
+++ b/deploy/k8s/network-tune/90-bagelbot-net.conf
@@ -1,0 +1,20 @@
+# Copyright (c) 2026 Adam Ousmer. All rights reserved.
+# Proprietary. No license granted. See LICENSE.md.
+
+# Cluster-wide network tuning. Lives at /etc/sysctl.d/90-bagelbot-net.conf on
+# every node. This repo copy is the source of truth for node rebuilds (same
+# lesson as the k3s GOMEMLIMIT drift).
+#
+# rmem/wmem: wireguard-go (tailscaled) requests ~7.5 MiB socket buffers; the
+# EL10 default cap of 4 MiB silently clamped them, which fed cross-node UDP
+# burst drops (the 5s DNS stall incident). 16 MiB gives headroom for the
+# tailscale socket and the flannel VXLAN socket alike.
+net.core.rmem_max = 16777216
+net.core.wmem_max = 16777216
+
+# Per-CPU ingress queue for bursts; raises every node from the 1000 default.
+net.core.netdev_max_backlog = 16384
+
+# Packetization-layer PMTU probing: insurance against any silent MTU
+# blackhole once tailscale0 runs above the 1280 floor (TS_DEBUG_MTU=1350).
+net.ipv4.tcp_mtu_probing = 1

--- a/deploy/k8s/network-tune/tailscale-udp-gro.service
+++ b/deploy/k8s/network-tune/tailscale-udp-gro.service
@@ -1,0 +1,16 @@
+# Copyright (c) 2026 Adam Ousmer. All rights reserved.
+# Proprietary. No license granted. See LICENSE.md.
+
+[Unit]
+Description=Enable UDP GRO forwarding on the Tailscale underlay
+Documentation=https://tailscale.com/docs/reference/best-practices/performance
+After=network-online.target tailscaled.service
+Wants=network-online.target tailscaled.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/tailscale-udp-gro.sh
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/k8s/network-tune/tailscale-udp-gro.sh
+++ b/deploy/k8s/network-tune/tailscale-udp-gro.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Adam Ousmer. All rights reserved.
+# Proprietary. No license granted. See LICENSE.md.
+# Preserve Tailscale's documented Linux forwarding offload on the physical
+# underlay. The k3s pod path is VXLAN -> tailscale0 -> this device, so disabling
+# UDP GRO forwarding forces avoidable packet-per-packet work after every boot.
+set -euo pipefail
+
+IP=/usr/sbin/ip
+ETHTOOL=/usr/sbin/ethtool
+
+dev=${TAILSCALE_UNDERLAY_DEV:-}
+if [[ -z $dev ]]; then
+  dev=$($IP -o route get 8.8.8.8 | awk '{print $5; exit}')
+fi
+[[ -n $dev && -e /sys/class/net/$dev ]] || {
+  echo "unable to find Tailscale underlay device" >&2
+  exit 1
+}
+
+$ETHTOOL -K "$dev" rx-udp-gro-forwarding on rx-gro-list off
+$ETHTOOL -k "$dev" | awk '
+  /^rx-gro-list:/ { gro_list = $2 }
+  /^rx-udp-gro-forwarding:/ { udp_gro = $2 }
+  END {
+    if (gro_list != "off" || udp_gro != "on") exit 1
+  }
+'

--- a/deploy/k8s/network-tune/tailscaled-10-mtu.conf
+++ b/deploy/k8s/network-tune/tailscaled-10-mtu.conf
@@ -1,0 +1,19 @@
+# Copyright (c) 2026 Adam Ousmer. All rights reserved.
+# Proprietary. No license granted. See LICENSE.md.
+
+# Lives at /etc/systemd/system/tailscaled.service.d/10-mtu.conf on every node.
+# Repo copy is the rebuild source of truth.
+#
+# Raises tailscale0 from the 1280 default to 1350 (wire ≈ 1430 with wireguard
+# overhead). Verified 2026-07-15: every inter-node underlay path passes ≥1460
+# wire. The tightest path measured was a PPPoE home uplink at ~1492, on a node
+# since retired; datacenter to datacenter passes the full 1500. flannel
+# re-derives 1300 for flannel.1/cni0/pods on the next k3s (agent) restart.
+# net.ipv4.tcp_mtu_probing=1 (90-bagelbot-net.conf) is the blackhole backstop.
+#
+# Rollback: delete this file, daemon-reload, restart tailscaled + k3s(-agent).
+# CAUTION: after any tailscaled restart, verify cross-node POD traffic per
+# node (curl a pod IP from another node). 2026-07-15: node1 and node3 kept
+# host-level connectivity but stranded flannel VXLAN until k3s-agent restart.
+[Service]
+Environment=TS_DEBUG_MTU=1350

--- a/deploy/k8s/network_policies_test.go
+++ b/deploy/k8s/network_policies_test.go
@@ -1,0 +1,144 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package k8s
+
+import (
+	"io"
+	"os"
+	"slices"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+type networkPolicyManifest struct {
+	Kind     string `yaml:"kind"`
+	Metadata struct {
+		Name string `yaml:"name"`
+	} `yaml:"metadata"`
+	Spec struct {
+		PodSelector struct {
+			MatchExpressions []struct {
+				Key    string   `yaml:"key"`
+				Values []string `yaml:"values"`
+			} `yaml:"matchExpressions"`
+		} `yaml:"podSelector"`
+		Egress []struct {
+			To []struct {
+				NamespaceSelector *struct {
+					MatchLabels map[string]string `yaml:"matchLabels"`
+				} `yaml:"namespaceSelector"`
+				IPBlock *struct {
+					CIDR string `yaml:"cidr"`
+				} `yaml:"ipBlock"`
+			} `yaml:"to"`
+			Ports []struct {
+				Port     int    `yaml:"port"`
+				Protocol string `yaml:"protocol"`
+			} `yaml:"ports"`
+		} `yaml:"egress"`
+	} `yaml:"spec"`
+}
+
+func loadNetworkPolicies(t *testing.T) map[string]networkPolicyManifest {
+	t.Helper()
+	f, err := os.Open("network-policies.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	policies := make(map[string]networkPolicyManifest)
+	decoder := yaml.NewDecoder(f)
+	for {
+		var manifest networkPolicyManifest
+		if err := decoder.Decode(&manifest); err != nil {
+			if err == io.EOF {
+				break
+			}
+			t.Fatal(err)
+		}
+		if manifest.Kind == "NetworkPolicy" {
+			policies[manifest.Metadata.Name] = manifest
+		}
+	}
+	return policies
+}
+
+func selectedApps(t *testing.T, policy networkPolicyManifest) []string {
+	t.Helper()
+	for _, expression := range policy.Spec.PodSelector.MatchExpressions {
+		if expression.Key == "app" {
+			apps := slices.Clone(expression.Values)
+			slices.Sort(apps)
+			return apps
+		}
+	}
+	t.Fatal("policy has no app selector")
+	return nil
+}
+
+func sorted(values ...string) []string {
+	slices.Sort(values)
+	return values
+}
+
+func requirePolicy(t *testing.T, policies map[string]networkPolicyManifest, name string) networkPolicyManifest {
+	t.Helper()
+	policy, ok := policies[name]
+	if !ok {
+		t.Fatalf("%s policy is missing", name)
+	}
+	return policy
+}
+
+func policyHasPort(policy networkPolicyManifest, target int) bool {
+	for _, rule := range policy.Spec.Egress {
+		for _, port := range rule.Ports {
+			if port.Port == target {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func TestDefaultPolicyHasNoBlanketExternalEgress(t *testing.T) {
+	base := requirePolicy(t, loadNetworkPolicies(t), "default-deny-apps")
+	if !slices.Contains(selectedApps(t, base), "notifications-cleanup") {
+		t.Fatal("notifications cleanup job escaped the default-deny policy")
+	}
+	if policyHasPort(base, 443) {
+		t.Fatal("default policy grants blanket external port 443")
+	}
+	if policyHasPort(base, 3306) {
+		t.Fatal("default policy grants blanket external port 3306")
+	}
+}
+
+func TestPublicHTTPSEgressAllowlist(t *testing.T) {
+	publicHTTPS := requirePolicy(t, loadNetworkPolicies(t), "allow-public-https")
+	wantHTTPS := sorted("commands", "console-admin", "console-dashboard", "gossip", "loyalty", "modules", "notifications", "outgress", "projector", "sesame", "transactions", "twitch-ingress", "users")
+	if got := selectedApps(t, publicHTTPS); !slices.Equal(got, wantHTTPS) {
+		t.Fatalf("public HTTPS allowlist = %v, want %v", got, wantHTTPS)
+	}
+}
+
+func TestHeatWaveEgressAllowlist(t *testing.T) {
+	heatwave := requirePolicy(t, loadNetworkPolicies(t), "allow-heatwave")
+	wantHeatWave := sorted("commands", "console-admin", "loyalty", "modules", "notifications", "transactions", "users")
+	if got := selectedApps(t, heatwave); !slices.Equal(got, wantHeatWave) {
+		t.Fatalf("HeatWave allowlist = %v, want %v", got, wantHeatWave)
+	}
+	if len(heatwave.Spec.Egress) != 1 {
+		t.Fatal("HeatWave policy must have exactly one egress rule")
+	}
+	if len(heatwave.Spec.Egress[0].To) != 1 {
+		t.Fatal("HeatWave rule must have exactly one destination")
+	}
+	ipBlock := heatwave.Spec.Egress[0].To[0].IPBlock
+	if ipBlock == nil || ipBlock.CIDR != "10.0.0.0/16" {
+		t.Fatal("HeatWave egress must stay confined to the routed OCI private subnet")
+	}
+}

--- a/deploy/k8s/notifications.yaml
+++ b/deploy/k8s/notifications.yaml
@@ -1,0 +1,219 @@
+# Copyright (c) 2026 Adam Ousmer. All rights reserved.
+# Proprietary. No license granted. See LICENSE.md.
+
+apiVersion: secrets.doppler.com/v1alpha1
+kind: DopplerSecret
+metadata:
+  name: notifications-env
+  namespace: production
+spec:
+  host: https://api.doppler.com
+  tokenSecret:
+    name: notifications-doppler-token
+  managedSecret:
+    name: notifications-env
+    namespace: production
+    type: Opaque
+  resyncSeconds: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: notifications
+  namespace: production
+  annotations:
+    secrets.doppler.com/reload: "true"
+spec:
+  replicas: 3 # one per application node
+  revisionHistoryLimit: 3
+  minReadySeconds: 10
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: notifications
+  template:
+    metadata:
+      labels:
+        app: notifications
+    spec:
+      tolerations:
+        - key: node.kubernetes.io/unreachable
+          operator: Exists
+          effect: NoExecute
+          tolerationSeconds: 60
+        - key: node.kubernetes.io/not-ready
+          operator: Exists
+          effect: NoExecute
+          tolerationSeconds: 60
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+          matchLabelKeys: [pod-template-hash]
+          labelSelector:
+            matchLabels:
+              app: notifications
+      # Three replicas and three eligible domains keep one notifications pod
+      # per hot-path node after every ReplicaSet rollout.
+      # Resolve external hosts without the cluster search-domain fan-out
+      # (ndots:1) and serialize A/AAAA to dodge the conntrack race; cap any
+      # DNS stall well under a few seconds.
+      dnsConfig:
+        options:
+          - {name: ndots, value: "1"}
+          - {name: single-request-reopen}
+          - {name: timeout, value: "2"}
+          - {name: attempts, value: "2"}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        seccompProfile: {type: RuntimeDefault}
+      containers:
+        - name: notifications
+          image: ghcr.io/adamousmer/itsbagelbot/notifications:main-1786934707-b71a0f43997c@sha256:6fa6c0eb0481e7247d19b6ca1eaf5456cd491c41aae6a9ce7b5a0cbb39affc34 # {"$imagepolicy": "flux-system:notifications"}
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: NATS_HOST
+              value: nats
+            # notifications is RPC-only: it never touches JetStream, so it
+            # dials the leaf exclusively (no NATS_HUB_URL) and carries no BUS
+            # credential.
+            - name: NATS_URL
+              value: nats://nats-leaf-local:4222
+            - name: NATS_RPC_URL
+              value: nats://nats-leaf-local:4222
+            # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS
+            # server's native-TLS cert; read as RootCAs by pkg/bus (Go services)
+            # and the console nats lib (TS).
+            - name: NATS_CA_PEM
+              valueFrom:
+                configMapKeyRef:
+                  name: fleet-ca
+                  key: ca.pem
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: DB_MAX_OPEN_CONNS
+              value: "4"
+            - name: DB_QUERY_CONCURRENCY
+              value: "4"
+            - name: DB_AUTO_MIGRATE
+              value: "true"
+            - name: GOMEMLIMIT
+              value: 160MiB
+          envFrom:
+            - secretRef:
+                name: notifications-env
+          ports:
+            - containerPort: 8080
+          resources:
+            requests:
+              cpu: 15m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities: {drop: ["ALL"]}
+          lifecycle:
+            preStop:
+              httpGet:
+                path: /drain
+                port: 8080
+          livenessProbe:
+            httpGet: {path: /healthz, port: 8080}
+            periodSeconds: 30
+          readinessProbe:
+            httpGet: {path: /readyz, port: 8080}
+            periodSeconds: 10
+          startupProbe:
+            httpGet: {path: /healthz, port: 8080}
+            failureThreshold: 18 # 18 × 5s = 90s max startup window
+            periodSeconds: 5
+      terminationGracePeriodSeconds: 45
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: notifications
+  namespace: production
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: notifications
+---
+# Janitor: fires the internal cleanup verb once per day so exactly one service
+# replica (queue group) hard-deletes globally-expired notifications; their
+# per-user read receipts cascade. Reuses the service image with the `cleanup`
+# arg and the service's own NATS creds (notifications-env), so no extra image or
+# NATS account is needed — the cleanup subject is internal to the
+# NOTIFICATIONS_RPC account and unreachable from anywhere else.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: notifications-cleanup
+  namespace: production
+spec:
+  schedule: "17 3 * * *" # daily, off the top of the hour
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 300
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 120
+      backoffLimit: 2
+      template:
+        metadata:
+          labels:
+            app: notifications-cleanup
+        spec:
+          restartPolicy: OnFailure
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+            seccompProfile: {type: RuntimeDefault}
+          containers:
+            - name: cleanup
+              image: ghcr.io/adamousmer/itsbagelbot/notifications:main-1786934707-b71a0f43997c@sha256:6fa6c0eb0481e7247d19b6ca1eaf5456cd491c41aae6a9ce7b5a0cbb39affc34 # {"$imagepolicy": "flux-system:notifications"}
+              imagePullPolicy: IfNotPresent
+              args: ["cleanup"]
+              env:
+                - name: NODE_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: spec.nodeName
+                # RPC-only, same as the main container: leaf exclusively, no
+                # NATS_HUB_URL, no BUS credential.
+                - name: NATS_URL
+                  value: nats://nats-leaf-local:4222
+                - name: NATS_RPC_URL
+                  value: nats://nats-leaf-local:4222
+                # Fleet CA to verify the NATS server TLS cert (NATS out of the mesh).
+                - name: NATS_CA_PEM
+                  valueFrom:
+                    configMapKeyRef:
+                      name: fleet-ca
+                      key: ca.pem
+              envFrom:
+                - secretRef:
+                    name: notifications-env
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+                limits:
+                  cpu: 250m
+                  memory: 64Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities: {drop: ["ALL"]}

--- a/deploy/k8s/outgress.yaml
+++ b/deploy/k8s/outgress.yaml
@@ -1,0 +1,332 @@
+# Copyright (c) 2026 Adam Ousmer. All rights reserved.
+# Proprietary. No license granted. See LICENSE.md.
+
+apiVersion: secrets.doppler.com/v1alpha1
+kind: DopplerSecret
+metadata:
+  name: outgress-env
+  namespace: production
+spec:
+  host: https://api.doppler.com
+  tokenSecret:
+    name: outgress-doppler-token
+  managedSecret:
+    name: outgress-env
+    namespace: production
+    type: Opaque
+  resyncSeconds: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: outgress
+  namespace: production
+  annotations:
+    secrets.doppler.com/reload: "true"
+spec:
+  # replicas intentionally omitted: the outgress ScaledObject below owns this
+  # field via its generated HPA (floor 3, matching the old static count).
+  # kustomize-controller stops setting it, so SSA hands ownership to the HPA
+  # instead of fighting it every reconcile.
+  revisionHistoryLimit: 3
+  minReadySeconds: 10
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: outgress
+  template:
+    metadata:
+      labels:
+        app: outgress
+    spec:
+      tolerations:
+        - key: node.kubernetes.io/unreachable
+          operator: Exists
+          effect: NoExecute
+          tolerationSeconds: 60
+        - key: node.kubernetes.io/not-ready
+          operator: Exists
+          effect: NoExecute
+          tolerationSeconds: 60
+      # Application tier only, selected by role so the rule cannot go stale
+      # when the fleet changes shape.
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: itsbagelbot.dev/role
+                    operator: NotIn
+                    values: [cp, worker]
+      topologySpreadConstraints:
+        # matchLabelKeys scopes the skew to the CURRENT ReplicaSet: during a
+        # maxSurge=0 roll the outgoing pods no longer count, so every rollout
+        # re-spreads one-per-node instead of piling onto whichever node freed
+        # capacity first (bit the ingress on 2026-07-10: 3/0/1). Soft constraint
+        # stays soft, so a node outage never wedges scheduling; the KEDA floor
+        # (>= one per hot-path node) plus the ReplicaSet downscaler's
+        # remove-co-located-duplicates-first ranking keep steady state at
+        # >= 1 per node.
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+          matchLabelKeys: [pod-template-hash]
+          labelSelector:
+            matchLabels:
+              app: outgress
+      # DaemonSet placement keeps one outgress pod per schedulable node.
+      # Resolving api.twitch.tv is on the hot path. With the default ndots:5 the
+      # external FQDN first fans out into cluster-domain queries (…svc.cluster.local
+      # etc.), each a chance to hit the cross-node DNS stall; ndots:1 sends the
+      # absolute name first. A shorter timeout with a retry caps a stall well under
+      # the 5s outgress message lifetime instead of blowing it.
+      dnsConfig:
+        options:
+          - {name: ndots, value: "1"}
+          - {name: single-request-reopen}
+          - {name: timeout, value: "2"}
+          - {name: attempts, value: "2"}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        seccompProfile: {type: RuntimeDefault}
+      containers:
+        - name: outgress
+          image: ghcr.io/adamousmer/itsbagelbot/outgress:main-1786934707-b71a0f43997c@sha256:97a8eac46332a17e8a556770802da42de30ed1a5faa3fce13cd47bc384f8a201 # {"$imagepolicy": "flux-system:outgress"}
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: NATS_HOST
+              value: nats
+            # Split planes: the BUS / JetStream connection dials the hub directly
+            # (NATS_HUB_URL) so stream traffic never pays a leaf forwarding hop;
+            # the RPC + cache plane (NATS_RPC_URL / NATS_LEAF_URL) stays on the
+            # node-local leaf. NATS_URL is the local-dev fallback only.
+            # The lane consumers dial nats-1 directly: TWITCH_OUTGRESS is
+            # placement-pinned there (pkg/bus/provision.go), so the
+            # PreferSameNode `nats` Service would route every delivery and ack
+            # through a non-leader member on other nodes. The per-pod headless
+            # name is a hub cert SAN and follows the pod across nodes.
+            - name: NATS_URL
+              value: nats://nats-leaf:4222
+            - name: NATS_HUB_URL
+              value: nats://nats-1.nats-headless.production.svc.cluster.local:4222
+            # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS
+            # server's native-TLS cert; read as RootCAs by pkg/bus (Go services)
+            # and the console nats lib (TS).
+            - name: NATS_CA_PEM
+              valueFrom:
+                configMapKeyRef:
+                  name: fleet-ca
+                  key: ca.pem
+            - name: VALKEY_TLS_CA_PEM
+              valueFrom:
+                configMapKeyRef:
+                  name: fleet-ca
+                  key: ca.pem
+            - name: VALKEY_TLS_SERVER_NAME
+              value: valkey.valkey.svc.cluster.local
+            # mTLS: pkg/valkey's clientTLSConfig() treats these two as
+            # both-or-neither. Land this (a no-op while tls-auth-clients is
+            # still "no") on every consumer BEFORE flipping the statefulset,
+            # not after.
+            - name: VALKEY_TLS_CLIENT_CERT_FILE
+              value: /etc/valkey/client-tls/tls.crt
+            - name: VALKEY_TLS_CLIENT_KEY_FILE
+              value: /etc/valkey/client-tls/tls.key
+            - name: NATS_RPC_URL
+              value: nats://nats-leaf:4222
+            - name: NATS_LEAF_URL
+              value: nats://nats-leaf:4222
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: VALKEY_LOCAL_ADDR
+              value: valkey-local.valkey.svc.cluster.local:6380
+            - name: GOMEMLIMIT
+              value: 512MiB
+            # Receipt-level consumption is deliberately absent here, not merely
+            # unset. Outgress drains work-queue streams, whose retention deletes
+            # a message on ack and therefore requires a per-message explicit ack
+            # (pkg/bus isHotIngressLane excludes them by that rule); its
+            # TWITCH_INGRESS bindings are the stream and authz subjects, which
+            # the same guard declines. Both shapes are structurally wrong for
+            # this service, so these stay commented and outgress_bus holds no
+            # $JS.API.CONSUMER.MSG.NEXT grant to match:
+            #
+            #   - name: NATS_CONSUME_FLOW
+            #     value: "on"
+            #   - name: NATS_CONSUME_MODE
+            #     value: pull
+            #
+            # The rollout that flips the hot lanes is sesame's alone.
+            # Sized for the 50-100k firehose (see sesame.yaml). A high MIN keeps
+            # send concurrency resident so throughput does not wait on the slow
+            # +1-per-tick autoscaler to climb from a cold floor under a burst.
+            - name: OUTGRESS_MIN_ROUTINES
+              value: "50"
+            - name: OUTGRESS_MAX_ROUTINES
+              value: "250"
+            - name: OUTGRESS_MAX_CONSUMERS
+              value: "3"
+            - name: OUTGRESS_SCALE_UP_AFTER
+              value: 1s
+            - name: OUTGRESS_SCALE_DOWN_AFTER
+              value: 60s
+            - name: OUTGRESS_PREMIUM_RESERVE_PERCENT
+              value: "25"
+            - name: OUTGRESS_SYSTEM_WORKERS
+              value: "4"
+            # Use the scheduled node as the conservative locality boundary.
+            # Kubernetes cannot expose a node topology label through the
+            # downward API, and the fleet intentionally runs one outgress pod
+            # per node. Distinct node localities therefore use the safe remote
+            # peer-borrow timeout instead of misclassifying WAN peers as local.
+            # This is operational identity, not a secret, so do not make pod
+            # startup depend on Doppler carrying it.
+            - name: OUTGRESS_REGION
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+                  # Remaining lease tuning (replicas, epoch, etc.) may be supplied
+                  # by outgress-env via Doppler.
+            # Reject a quota plan that does not reflect a real multi-pod fleet.
+            # Two is the safe floor: a lone member borrows from nobody and would
+            # claim the full Twitch quota (fail open -> 429s), whereas any plan of
+            # 2+ divides the leased share so the fleet total stays <= 100%. Below
+            # this floor the coordinator defers and every pod runs on the shared,
+            # serialized emergency partition (fail closed). 2 (not 3) still forms a
+            # valid plan during a maxUnavailable:1 rollout, when only 2 pods are up.
+            - name: OUTGRESS_LEASE_MIN_MEMBERS
+              value: "2"
+          envFrom:
+            - secretRef:
+                name: outgress-env
+          volumeMounts:
+            - name: valkey-client-tls
+              mountPath: /etc/valkey/client-tls
+              readOnly: true
+          ports:
+            - containerPort: 8080
+          resources:
+            requests:
+              cpu: 75m
+              memory: 128Mi
+            limits:
+              cpu: 1000m
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities: {drop: ["ALL"]}
+          lifecycle:
+            preStop:
+              httpGet:
+                path: /drain
+                port: 8080
+          livenessProbe:
+            httpGet: {path: /healthz, port: 8080}
+            periodSeconds: 30
+          readinessProbe:
+            httpGet: {path: /readyz, port: 8080}
+            periodSeconds: 10
+          startupProbe:
+            httpGet: {path: /healthz, port: 8080}
+            failureThreshold: 18
+            periodSeconds: 5
+      volumes:
+        - name: valkey-client-tls
+          secret:
+            secretName: valkey-client-tls
+      terminationGracePeriodSeconds: 45
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: outgress
+  namespace: production
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: outgress
+---
+# Scales on whichever of the three lanes backs up worst (HPA takes the max
+# recommended replicas across triggers), plus a CPU floor for load that isn't
+# lane-shaped. minReplicaCount 3 matches the old static replicas; outgress is
+# ultimately Twitch-rate-limited (quota is tracked fleet-wide in Valkey, not
+# per-pod - see docs/microservices/outgress.md), so maxReplicaCount stays
+# modest: this buys resilience and headroom under sustained backlog, not more
+# Twitch throughput. Consumer names are bus.durableName(group, subject) from
+# app/outgress/main.go's three LaneConfigs; lag = num_pending + num_ack_pending
+# on that durable (see pkg/bus/bus.go laneConsumerConfig). Tune thresholds from
+# the admin lane-telemetry view (reads $JS.hub.API.CONSUMER.INFO.> live).
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: outgress
+  namespace: production
+spec:
+  scaleTargetRef:
+    name: outgress
+  pollingInterval: 15
+  cooldownPeriod: 300
+  minReplicaCount: 3
+  # 4 per application node. Outgress is Twitch-rate-limited,
+  # so headroom here is for lag-driven burst drain, not sustained throughput.
+  maxReplicaCount: 12
+  fallback:
+    failureThreshold: 3
+    replicas: 3
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleUp:
+          stabilizationWindowSeconds: 0
+          policies:
+            - {type: Pods, value: 2, periodSeconds: 60}
+        scaleDown:
+          stabilizationWindowSeconds: 300
+          policies:
+            - {type: Pods, value: 1, periodSeconds: 120}
+  triggers:
+    - type: cpu
+      metricType: Utilization
+      metadata:
+        value: "75"
+    - type: nats-jetstream
+      metadata:
+        # ClusterIP, not the tailnet Service. See the long note in sesame.yaml:
+        # KEDA's clustered scaler follows the cluster to the leader's advertised
+        # POD IP, so a single tailnet Service does not remove the pod-network
+        # dependency.
+        natsServerMonitoringEndpoint: nats.production.svc.cluster.local:8222
+        account: BUS
+        stream: TWITCH_OUTGRESS
+        consumer: outgress-premium_twitch_outgress_premium
+        lagThreshold: "30"
+        activationLagThreshold: "5"
+    - type: nats-jetstream
+      metadata:
+        natsServerMonitoringEndpoint: nats.production.svc.cluster.local:8222
+        account: BUS
+        stream: TWITCH_OUTGRESS
+        consumer: outgress-standard_twitch_outgress_standard
+        lagThreshold: "150"
+        activationLagThreshold: "20"
+    - type: nats-jetstream
+      metadata:
+        natsServerMonitoringEndpoint: nats.production.svc.cluster.local:8222
+        account: BUS
+        stream: TWITCH_OUTGRESS_SYSTEM
+        consumer: outgress-system_twitch_outgress_system
+        lagThreshold: "20"
+        activationLagThreshold: "5"

--- a/deploy/k8s/projector.yaml
+++ b/deploy/k8s/projector.yaml
@@ -1,0 +1,222 @@
+# Copyright (c) 2026 Adam Ousmer. All rights reserved.
+# Proprietary. No license granted. See LICENSE.md.
+
+apiVersion: secrets.doppler.com/v1alpha1
+kind: DopplerSecret
+metadata:
+  name: projector-env
+  namespace: production
+spec:
+  host: https://api.doppler.com
+  tokenSecret:
+    name: projector-doppler-token
+  managedSecret:
+    name: projector-env
+    namespace: production
+    type: Opaque
+  resyncSeconds: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: projector
+  namespace: production
+  annotations:
+    secrets.doppler.com/reload: "true"
+spec:
+  replicas: 3 # one per hot-path node: node4, node5, node6
+  revisionHistoryLimit: 3
+  minReadySeconds: 10
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: projector
+  template:
+    metadata:
+      labels:
+        app: projector
+    spec:
+      tolerations:
+        - key: node.kubernetes.io/unreachable
+          operator: Exists
+          effect: NoExecute
+          tolerationSeconds: 60
+        - key: node.kubernetes.io/not-ready
+          operator: Exists
+          effect: NoExecute
+          tolerationSeconds: 60
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: itsbagelbot.dev/role
+                    operator: NotIn
+                    values: [cp, worker]
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  app: projector
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          matchLabelKeys: [pod-template-hash]
+          labelSelector:
+            matchLabels:
+              app: projector
+      # Required pod anti-affinity prevents old and new ReplicaSets from ever
+      # stacking two projector pods on one hot-path node.
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        seccompProfile: {type: RuntimeDefault}
+      containers:
+        - name: projector
+          image: ghcr.io/adamousmer/itsbagelbot/projector:main-1786934707-b71a0f43997c@sha256:a8d4d3d4caf5add19d8c973a9d66e899a6f77d7cf2b263345e51a77de82ff230 # {"$imagepolicy": "flux-system:projector"}
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: NATS_HOST
+              value: nats
+            # Split planes: the BUS / JetStream connection dials the hub directly
+            # (NATS_HUB_URL) so stream traffic never pays a leaf forwarding hop;
+            # the RPC + cache plane (NATS_RPC_URL / NATS_LEAF_URL) stays on the
+            # node-local leaf. NATS_URL is the local-dev fallback only.
+            # BAGEL_DATA folds remain pinned to nats-1. The independent publisher
+            # pool uses the PreferSameNode hub Service so its TLS/socket/batch
+            # work is distributed across the three brokers before NATS routes
+            # each commit to the stream leader.
+            - name: NATS_URL
+              value: nats://nats-leaf:4222
+            - name: NATS_HUB_URL
+              value: nats://nats-1.nats-headless.production.svc.cluster.local:4222
+            - name: NATS_HUB_PUBLISH_URL
+              value: nats://nats:4222
+            # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS
+            # server's native-TLS cert; read as RootCAs by pkg/bus (Go services)
+            # and the console nats lib (TS).
+            - name: NATS_CA_PEM
+              valueFrom:
+                configMapKeyRef:
+                  name: fleet-ca
+                  key: ca.pem
+            - name: VALKEY_TLS_CA_PEM
+              valueFrom:
+                configMapKeyRef:
+                  name: fleet-ca
+                  key: ca.pem
+            - name: VALKEY_TLS_SERVER_NAME
+              value: valkey.valkey.svc.cluster.local
+            # mTLS: pkg/valkey's clientTLSConfig() treats these two as
+            # both-or-neither. Land this (a no-op while tls-auth-clients is
+            # still "no") on every consumer BEFORE flipping the statefulset,
+            # not after.
+            - name: VALKEY_TLS_CLIENT_CERT_FILE
+              value: /etc/valkey/client-tls/tls.crt
+            - name: VALKEY_TLS_CLIENT_KEY_FILE
+              value: /etc/valkey/client-tls/tls.key
+            - name: NATS_RPC_URL
+              value: nats://nats-leaf:4222
+            - name: NATS_LEAF_URL
+              value: nats://nats-leaf:4222
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: VALKEY_LOCAL_ADDR
+              value: valkey-local.valkey.svc.cluster.local:6380
+            # Receipt-level consumption is deliberately absent here, not merely
+            # unset. The projector's bindings are the BAGEL_DATA folds and
+            # twitch.ingress.event.stream, and pkg/bus admits the pull and flow
+            # shapes on the hot ingress lanes alone (isHotIngressLane), so these
+            # two would be accepted, declined per subject, and logged as
+            # "receipt-level consumption declined outside the hot ingress
+            # lanes". Setting them would read as a canary that soaks and prove
+            # nothing about the shape sesame actually runs.
+            #
+            #   - name: NATS_CONSUME_FLOW
+            #     value: "on"
+            #   - name: NATS_CONSUME_MODE
+            #     value: pull
+            #
+            # They become meaningful only if the scope guard widens to a subject
+            # this service reads, and that change owes projector_bus a
+            # $JS.API.CONSUMER.MSG.NEXT grant in nats-auth.conf in the same
+            # commit: a denied fetch is a silent zero-delivery lane, not an
+            # error.
+            - name: NATS_PROJECTOR_DASHBOARD_SUBJECT_PREFIX
+              value: bagel.rpc.projector.dashboard
+            - name: PROJECTOR_WRITE_CONCURRENCY
+              value: "8"
+            # Stream-online refreshes keep a full settings snapshot warm for a
+            # day. Dashboard command/module reads hydrate missing sections in
+            # the background with a shorter two-hour retention window.
+            - name: PROJECTOR_LIVE_HYDRATION_TTL
+              value: 24h
+            - name: PROJECTOR_QUERY_HYDRATION_TTL
+              value: 2h
+            - name: PROJECTOR_HYDRATION_CONCURRENCY
+              value: "8"
+            - name: GOMEMLIMIT
+              value: 256MiB
+          envFrom:
+            - secretRef:
+                name: projector-env
+          volumeMounts:
+            - name: valkey-client-tls
+              mountPath: /etc/valkey/client-tls
+              readOnly: true
+          ports:
+            - containerPort: 8080
+          resources:
+            requests:
+              cpu: 50m
+              memory: 96Mi
+            limits:
+              cpu: 750m
+              memory: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities: {drop: ["ALL"]}
+          lifecycle:
+            preStop:
+              httpGet:
+                path: /drain
+                port: 8080
+          livenessProbe:
+            httpGet: {path: /healthz, port: 8080}
+            periodSeconds: 30
+          readinessProbe:
+            httpGet: {path: /readyz, port: 8080}
+            periodSeconds: 10
+          startupProbe:
+            httpGet: {path: /healthz, port: 8080}
+            failureThreshold: 18
+            periodSeconds: 5
+      volumes:
+        - name: valkey-client-tls
+          secret:
+            secretName: valkey-client-tls
+      terminationGracePeriodSeconds: 45
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: projector
+  namespace: production
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: projector

--- a/deploy/k8s/sesame.yaml
+++ b/deploy/k8s/sesame.yaml
@@ -1,0 +1,385 @@
+# Copyright (c) 2026 Adam Ousmer. All rights reserved.
+# Proprietary. No license granted. See LICENSE.md.
+
+# Sesame keeps the established pkg/bus consumer group ("worker"), but owns its
+# Doppler project and read-only service token. The old worker token is retained
+# out-of-band only as a short-lived rollback path during the project cutover.
+apiVersion: secrets.doppler.com/v1alpha1
+kind: DopplerSecret
+metadata:
+  name: sesame-env
+  namespace: production
+spec:
+  host: https://api.doppler.com
+  tokenSecret:
+    name: sesame-doppler-token
+  managedSecret:
+    name: sesame-env
+    namespace: production
+    type: Opaque
+  resyncSeconds: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sesame
+  namespace: production
+  annotations:
+    secrets.doppler.com/reload: "true"
+spec:
+  # replicas intentionally omitted: the sesame ScaledObject below owns this
+  # field via its generated HPA (floor 4, matching the old static count).
+  # kustomize-controller stops setting it, so SSA hands ownership to the HPA
+  # instead of fighting it every reconcile.
+  revisionHistoryLimit: 3
+  minReadySeconds: 10
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: sesame
+  template:
+    metadata:
+      labels:
+        app: sesame
+    spec:
+      tolerations:
+        - key: node.kubernetes.io/unreachable
+          operator: Exists
+          effect: NoExecute
+          tolerationSeconds: 60
+        - key: node.kubernetes.io/not-ready
+          operator: Exists
+          effect: NoExecute
+          tolerationSeconds: 60
+      # Eligible nodes are selected by ROLE, so this survives the fleet
+      # changing shape. The graded per-hostname preferences that used to live
+      # here are gone: they existed to steer the two extra replicas onto the
+      # one big-CPU host and away from the host that also carried the control
+      # plane and the valkey master. The app tier is uniform hardware now and
+      # carries neither, so every preference was either inert or actively
+      # fighting the spread constraint below. That constraint is authoritative.
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: itsbagelbot.dev/role
+                    operator: NotIn
+                    values: [cp, worker]
+      topologySpreadConstraints:
+        # matchLabelKeys scopes the skew to the CURRENT ReplicaSet: during a
+        # maxSurge=0 roll the outgoing pods no longer count, so every rollout
+        # re-spreads one-per-node instead of piling onto whichever node freed
+        # capacity first (bit the ingress on 2026-07-10: 3/0/1). DoNotSchedule
+        # enforces a hard constraint: under ScheduleAnyway all six replicas
+        # once piled onto node6, so a single node disruption took out the
+        # entire fleet (2026-08-05). Three healthy replicas fit 1/1/1 across
+        # the three application nodes; during a node outage existing pods keep
+        # serving and replacement capacity waits rather than overloading a
+        # surviving node.
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+          matchLabelKeys: [pod-template-hash]
+          labelSelector:
+            matchLabels:
+              app: sesame
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        seccompProfile: {type: RuntimeDefault}
+      containers:
+        - name: sesame
+          image: ghcr.io/adamousmer/itsbagelbot/sesame:main-1786934707-b71a0f43997c@sha256:61a63712be28992c5974e8baa91fc44b7db610b197262432df7638abf306757a # {"$imagepolicy": "flux-system:sesame"}
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: NATS_HOST
+              value: nats
+            # Durable BUS/JetStream traffic goes directly to the hub. The leaf
+            # cluster is the independent Core NATS RPC tier only; sending stream
+            # PubAcks through it adds a cross-leaf round trip and stalls large
+            # windows.
+            #
+            # Consumers remain pinned beside TWITCH_INGRESS on nats-0. Publishers
+            # use the PreferSameNode `nats` Service: the R3 qualification measured
+            # ~75k/s node-local vs ~60.6k/s when every client dialed the leader.
+            # The stream leader still performs the RAFT commit, while client TLS,
+            # socket and batch work is spread over all three hub members.
+            - name: NATS_URL
+              value: tls://nats:4222
+            - name: NATS_HUB_URL
+              value: tls://nats-0.nats-headless.production.svc.cluster.local:4222
+            - name: NATS_HUB_PUBLISH_URL
+              value: tls://nats:4222
+            # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS
+            # server's native-TLS cert; read as RootCAs by pkg/bus (Go services)
+            # and the console nats lib (TS).
+            - name: NATS_CA_PEM
+              valueFrom:
+                configMapKeyRef:
+                  name: fleet-ca
+                  key: ca.pem
+            - name: VALKEY_TLS_CA_PEM
+              valueFrom:
+                configMapKeyRef:
+                  name: fleet-ca
+                  key: ca.pem
+            - name: VALKEY_TLS_SERVER_NAME
+              value: valkey.valkey.svc.cluster.local
+            # mTLS: pkg/valkey's clientTLSConfig() treats these two as
+            # both-or-neither. Land this (a no-op while tls-auth-clients is
+            # still "no") on every consumer BEFORE flipping the statefulset,
+            # not after.
+            - name: VALKEY_TLS_CLIENT_CERT_FILE
+              value: /etc/valkey/client-tls/tls.crt
+            - name: VALKEY_TLS_CLIENT_KEY_FILE
+              value: /etc/valkey/client-tls/tls.key
+            - name: NATS_RPC_URL
+              value: tls://nats-leaf:4222
+            - name: NATS_LEAF_URL
+              value: tls://nats-leaf:4222
+            - name: SSL_CERT_FILE
+              value: /etc/nats-ca/ca.pem
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: VALKEY_LOCAL_ADDR
+              value: valkey-local.valkey.svc.cluster.local:6380
+            - name: GOMEMLIMIT
+              value: 512MiB
+            # CANARY FLAG FOR THE PULL ROLLOUT. Flipping NATS_CONSUME_FLOW to
+            # "on" is the canary: it moves both hot ingress lanes from
+            # per-message explicit acks to the shared-durable pull consumer, and
+            # it provisions TWITCH_INGRESS_RETRY plus its reader in the same
+            # step. Sesame carries it because sesame is the only service that
+            # can: pkg/bus admits receipt-level consumption on the hot ingress
+            # lanes alone (isHotIngressLane), and nothing else binds them. The
+            # read-side consumers on BAGEL_DATA and the outgress work queues are
+            # push consumers by construction and the flag is inert there, so
+            # there is no lower-risk service to soak it on first.
+            #
+            # Shipped off, and off is a real state rather than a missing one: it
+            # is the kill switch an operator reaches for during an incident, so
+            # it is pinned here where they will look. Both values are pinned so
+            # the canary is a one-word diff and the rollback is the same word
+            # back; the mode is spelled out rather than defaulted so the lane's
+            # shape cannot change under the fleet from a library default.
+            #
+            # The broker ACL is a hard prerequisite and lands first: a pull
+            # consumer fetches on $JS.API.CONSUMER.MSG.NEXT, and without that
+            # grant the lane goes to zero events per second with no client-side
+            # error at all (see nats-auth.conf, worker_bus).
+            - name: NATS_CONSUME_FLOW
+              value: "on"
+            - name: NATS_CONSUME_MODE
+              value: pull
+            # PARTITION FLAG. "on" reshapes the ingress lane catalog to the
+            # two-stream partition (narrow TWITCH_INGRESS, create
+            # TWITCH_INGRESS_STANDARD) on the next sesame reconcile. Ships off
+            # so the code merge is a zero-behaviour deploy; flipping it is its
+            # own operator window and REQUIRES every twitch-ingress pod to
+            # already run per-subject cohort staging, or mixed atomic batches
+            # from an old ingress image are silently rejected. Verify the
+            # ingress rollout is converged on a post-partition image first.
+            - name: NATS_INGRESS_PARTITION
+              value: "on"
+            # Reuse the worker's shared lane consumer so this is a true drop-in:
+            # no DeliverAll replay, and rollout overlap load-balances instead of
+            # double-processing.
+            - name: SESAME_CONSUMER_NAME
+              value: worker
+            # Production acceptance found the former generic subscription path
+            # serialized the pod at 20/s through the leaf. The fleet-owned concurrent hub
+            # subscriber sustains four queue subscriptions with 100 handler slots
+            # each. This fills one confirmed PubAck cohort per publisher connection;
+            # 200 slots added only ~2% throughput while more than doubling p95.
+            - name: SESAME_MIN_ROUTINES
+              value: "100"
+            - name: SESAME_MAX_ROUTINES
+              value: "100"
+            - name: SESAME_MIN_CONSUMERS
+              value: "4"
+            - name: SESAME_MAX_CONSUMERS
+              value: "4"
+            # Four ordered publishers hash by broadcaster: one channel remains
+            # ordered while unrelated channels can overlap confirmation cohorts.
+            - name: NATS_PUBLISH_CONNECTIONS
+              value: "4"
+            - name: SESAME_SCALE_UP_AFTER
+              value: 2s
+            - name: SESAME_SCALE_DOWN_AFTER
+              value: 45s
+            - name: SESAME_PREMIUM_RESERVE_PERCENT
+              value: "25"
+            # Live status: dedicated Valkey key with a TTL backstop; on expiry sesame
+            # re-checks the stream against Twitch via the outgress system lane,
+            # falling back to the projector live RPC on a cold key.
+            - name: SESAME_LIVE_TTL
+              value: 12h
+            - name: NATS_OUTGRESS_SYSTEM_SUBJECT
+              value: twitch.outgress.system
+            - name: NATS_BROADCASTER_LIVE_SUBJECT
+              value: bagel.rpc.broadcaster.live.get
+          envFrom:
+            # sesame-env (Doppler) carries VALKEY_*, NATS_CACHE_INVALIDATION_PREFIX,
+            # and TWITCH_SPECIAL_USER_IDS — the same values the worker read.
+            - secretRef:
+                name: sesame-env
+          volumeMounts:
+            - name: fleet-ca
+              mountPath: /etc/nats-ca
+              readOnly: true
+            - name: valkey-client-tls
+              mountPath: /etc/valkey/client-tls
+              readOnly: true
+          ports:
+            - containerPort: 8080
+          resources:
+            requests:
+              # Quiet replicas use only ~3-7m. Reserve the lightweight floor,
+              # not a synthetic full-load core share. The CPU scaler below uses
+              # an absolute AverageValue, so this request does not make scaling
+              # fire on tiny idle fluctuations. The 2-core limit preserves burst
+              # capacity while five floor replicas reserve only 500m.
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: "2"
+              memory: 768Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities: {drop: ["ALL"]}
+          lifecycle:
+            preStop:
+              httpGet:
+                path: /drain
+                port: 8080
+          livenessProbe:
+            httpGet: {path: /healthz, port: 8080}
+            periodSeconds: 30
+          readinessProbe:
+            httpGet: {path: /readyz, port: 8080}
+            periodSeconds: 10
+          startupProbe:
+            httpGet: {path: /healthz, port: 8080}
+            failureThreshold: 18
+            periodSeconds: 5
+      volumes:
+        - name: fleet-ca
+          configMap:
+            name: fleet-ca
+        - name: valkey-client-tls
+          secret:
+            secretName: valkey-client-tls
+      terminationGracePeriodSeconds: 45
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: sesame
+  namespace: production
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: sesame
+---
+# Sesame's engine is sub-100us p95; confirmed NATS input/output is the measured
+# capacity boundary. minReplicaCount 3 keeps a warm baseline spread 1/1/1 over
+# the three application nodes (the Deployment's hard hostname DoNotSchedule
+# spread decides the shape) so a burst does not wait on a scale-up.
+# Consumer names are bus.durableName("worker", subject) - sesame
+# shares the worker's pre-existing durable via fleetSubscriber (app/sesame/main.go
+# bus.NewSubscriber(cfg.NATSURL, cfg.ConsumerName, log), ConsumerName=worker),
+# not per-lane groups like outgress. lag = num_pending + num_ack_pending on
+# that durable (see pkg/bus/bus.go laneConsumerConfig). Tune thresholds from
+# the admin lane-telemetry view (reads $JS.hub.API.CONSUMER.INFO.> live).
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: sesame
+  namespace: production
+spec:
+  scaleTargetRef:
+    name: sesame
+  pollingInterval: 15
+  cooldownPeriod: 300
+  minReplicaCount: 3
+  maxReplicaCount: 12
+  fallback:
+    failureThreshold: 3
+    replicas: 3
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleUp:
+          stabilizationWindowSeconds: 0
+          policies:
+            - {type: Pods, value: 2, periodSeconds: 30}
+        scaleDown:
+          stabilizationWindowSeconds: 300
+          policies:
+            - {type: Pods, value: 1, periodSeconds: 120}
+  triggers:
+    - type: cpu
+      # Keep scheduling reservation separate from scaling intent. Utilization
+      # is request-relative and would make a 100m request trigger at only 75m.
+      # Full-path observations were 220-339m/pod, so 300m is a useful sustained
+      # work signal while JetStream lag remains the backlog-oriented trigger.
+      metricType: AverageValue
+      metadata:
+        value: "300m"
+    - type: nats-jetstream
+      metadata:
+        # In-cluster ClusterIP, on purpose, and it needs NO tailscale subnet
+        # route even though the operator runs on the control plane: node1's
+        # flannel reaches the app tier over kernel WireGuard's roamed PUBLIC
+        # endpoints (see deploy/infra/keda/release.yaml and the inventory notes).
+        #
+        # Do not move this to the nats-monitoring tailnet Service. It was tried
+        # on 2026-07-27: the /jsz fetch works, but KEDA's clustered-JetStream
+        # scaler then follows the cluster to the consumer's leader and dials that
+        # member's monitoring endpoint by its ADVERTISED POD IP:
+        #   Get "https://10.42.3.205/varz": dial tcp 10.42.3.205:443: refused
+        # so a single fronting Service cannot satisfy it; every NATS member would
+        # have to be reachable under the address NATS itself advertises.
+        #
+        # Two further traps if this is ever retried. Tailnet names need a
+        # TRAILING DOT here: the pod resolver runs ndots:5, this name has 4 dots,
+        # so the search list is walked first and resolution fails outright. And
+        # KEDA does not fail loudly, it suppresses the error and serves the
+        # static `fallback` replicas below, so autoscaling stops while the HPA
+        # still reads healthy.
+        natsServerMonitoringEndpoint: nats.production.svc.cluster.local:8222
+        account: BUS
+        stream: TWITCH_INGRESS
+        consumer: worker_twitch_ingress_event_premium
+        # The slowest node measured 6.68k commands/s under simultaneous
+        # three-node load. Premium reserves 25% of that conservative capacity.
+        lagThreshold: "1500"
+        activationLagThreshold: "500"
+    - type: nats-jetstream
+      metadata:
+        natsServerMonitoringEndpoint: nats.production.svc.cluster.local:8222
+        account: BUS
+        # The standard durable lives on the partitioned stream. Naming the old
+        # stream here after the partition would read a consumer that no longer
+        # exists, and KEDA fails soft: it serves the static `fallback` replicas
+        # while the HPA still reads healthy.
+        stream: TWITCH_INGRESS_STANDARD
+        consumer: worker_twitch_ingress_event_standard
+        # Do not add a whole pod for breadcrumbs: at the five-pod floor this
+        # scales only beyond ~30k queued standard events at the five-pod floor,
+        # not a few hundred events of ordinary jitter.
+        lagThreshold: "6000"
+        activationLagThreshold: "2000"

--- a/deploy/k8s/topology_spread_test.go
+++ b/deploy/k8s/topology_spread_test.go
@@ -1,0 +1,323 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package k8s
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+type workloadManifest struct {
+	Kind     string `yaml:"kind"`
+	Metadata struct {
+		Name string `yaml:"name"`
+	} `yaml:"metadata"`
+	Spec struct {
+		Template struct {
+			Spec struct {
+				TopologySpreadConstraints []struct {
+					MinDomains        int      `yaml:"minDomains"`
+					TopologyKey       string   `yaml:"topologyKey"`
+					WhenUnsatisfiable string   `yaml:"whenUnsatisfiable"`
+					MatchLabelKeys    []string `yaml:"matchLabelKeys"`
+				} `yaml:"topologySpreadConstraints"`
+				Affinity struct {
+					NodeAffinity struct {
+						Required struct {
+							NodeSelectorTerms []struct {
+								MatchExpressions []struct {
+									Key      string   `yaml:"key"`
+									Operator string   `yaml:"operator"`
+									Values   []string `yaml:"values"`
+								} `yaml:"matchExpressions"`
+							} `yaml:"nodeSelectorTerms"`
+						} `yaml:"requiredDuringSchedulingIgnoredDuringExecution"`
+					} `yaml:"nodeAffinity"`
+				} `yaml:"affinity"`
+			} `yaml:"spec"`
+		} `yaml:"template"`
+		VolumeClaimTemplates []struct {
+			Metadata struct {
+				Name string `yaml:"name"`
+			} `yaml:"metadata"`
+		} `yaml:"volumeClaimTemplates"`
+	} `yaml:"spec"`
+}
+
+func loadDeployment(t *testing.T, filename, name string) workloadManifest {
+	t.Helper()
+
+	f, err := os.Open(filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	decoder := yaml.NewDecoder(f)
+	for {
+		var manifest workloadManifest
+		if err := decoder.Decode(&manifest); err != nil {
+			if err == io.EOF {
+				break
+			}
+			t.Fatal(err)
+		}
+		if manifest.Kind == "Deployment" && manifest.Metadata.Name == name {
+			return manifest
+		}
+	}
+
+	t.Fatalf("%s Deployment is missing from %s", name, filename)
+	return workloadManifest{}
+}
+
+func hostnameSpread(t *testing.T, manifest workloadManifest) struct {
+	MinDomains        int      `yaml:"minDomains"`
+	TopologyKey       string   `yaml:"topologyKey"`
+	WhenUnsatisfiable string   `yaml:"whenUnsatisfiable"`
+	MatchLabelKeys    []string `yaml:"matchLabelKeys"`
+} {
+	t.Helper()
+	for _, constraint := range manifest.Spec.Template.Spec.TopologySpreadConstraints {
+		if constraint.TopologyKey == "kubernetes.io/hostname" {
+			return constraint
+		}
+	}
+	t.Fatalf("%s has no hostname topology spread constraint", manifest.Metadata.Name)
+	return struct {
+		MinDomains        int      `yaml:"minDomains"`
+		TopologyKey       string   `yaml:"topologyKey"`
+		WhenUnsatisfiable string   `yaml:"whenUnsatisfiable"`
+		MatchLabelKeys    []string `yaml:"matchLabelKeys"`
+	}{}
+}
+
+// TestSpreadIsHardWithoutMinDomains asserts the placement policy the fleet
+// settled on after 2026-08-05: spread MUST be enforced, but WITHOUT minDomains.
+//
+// History: the fleet tried three policies.
+//
+//  1. DoNotSchedule + minDomains (2026-07-10 → 2026-07-27): when node5 died,
+//     thirteen deployments sat at 2/3 with a permanently Pending third replica
+//     because the scheduler could not place it without exceeding maxSkew against
+//     a domain that no longer had a schedulable node. minDomains made it worse:
+//     when it exceeds the eligible domain count, skew is measured against a
+//     global minimum of zero and EVERY replica becomes unschedulable.
+//
+//  2. ScheduleAnyway (2026-07-27 → 2026-08-05): avoided the withholding
+//     problem, but the scheduler treated spread as a preference and piled all
+//     six sesame replicas onto node6. When node6 rebooted on 2026-08-05, the
+//     entire sesame fleet was disrupted simultaneously.
+//
+//  3. DoNotSchedule WITHOUT minDomains (2026-08-06 → present): the scheduler
+//     enforces even placement across available nodes. Without minDomains, a
+//     lost node simply reduces the domain count and new pods land on surviving
+//     nodes within maxSkew. Replica counts are tuned to 1-per-node at the floor
+//     (3 replicas across 3 app nodes = 1/1/1), so a node outage loses at most
+//     one replica instead of the whole fleet.
+//
+// Quorum services are the deliberate exception and are NOT listed here: nats and
+// valkey keep required podAntiAffinity, because two members of a three-member
+// quorum sharing a node means one node loss costs the quorum.
+func TestSpreadIsHardWithoutMinDomains(t *testing.T) {
+	for _, tt := range []struct{ file, name string }{
+		{"console-admin.yaml", "console-admin"},
+		{"console-dashboard.yaml", "console-dashboard"},
+		{"notifications.yaml", "notifications"},
+		{"transactions.yaml", "transactions"},
+		{"twitch-ingress.yaml", "twitch-ingress"},
+		{"outgress.yaml", "outgress"},
+		{"sesame.yaml", "sesame"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			constraint := hostnameSpread(t, loadDeployment(t, tt.file, tt.name))
+			if constraint.WhenUnsatisfiable != "DoNotSchedule" {
+				t.Errorf("hostname spread is %q; must be DoNotSchedule to enforce even placement (ScheduleAnyway piled all replicas onto one node on 2026-08-05)",
+					constraint.WhenUnsatisfiable)
+			}
+			if !slices.Contains(constraint.MatchLabelKeys, "pod-template-hash") {
+				t.Error("hostname spread must be scoped to the incoming ReplicaSet via matchLabelKeys")
+			}
+			if constraint.MinDomains != 0 {
+				t.Errorf("minDomains = %d; do NOT set minDomains — it withholds ALL replicas when it exceeds the eligible domain count (see 2026-07-27 incident)",
+					constraint.MinDomains)
+			}
+		})
+	}
+}
+
+// excludesWorkerPool captures the placement rule under test: a nodeAffinity
+// match expression that keeps the workload off worker-role nodes.
+//
+// The key moved from itsbagelbot.dev/pool=worker-pool to
+// itsbagelbot.dev/role=worker when node roles were unified onto one key
+// (cp / node / worker). No worker-role node exists yet, so this guard is
+// currently inert — it is kept expressed on the live key so that it starts
+// holding the moment one is added, rather than silently pointing at a retired
+// label that nothing would ever match.
+func excludesWorkerPool(key, operator string, values []string) bool {
+	return key == "itsbagelbot.dev/role" &&
+		operator == "NotIn" &&
+		slices.Contains(values, "worker")
+}
+
+// TestNoWorkloadSelectsNodesByHostname guards the failure mode this directory
+// kept re-learning: a nodeAffinity that names individual hosts goes stale the
+// moment the fleet changes shape, and a stale term is silently inert rather than
+// loud. Retiring a node left rules reading "NotIn [worker1]" and "NotIn [node1]"
+// long after both hosts were gone, each carrying a comment admitting it was
+// already inert. Selecting on itsbagelbot.dev/role instead keeps the intent
+// ("not the control plane", "not a burst worker") true across fleet changes.
+//
+// Only nodeAffinity is in scope. topologySpreadConstraints and podAntiAffinity
+// legitimately use kubernetes.io/hostname as a topology KEY, which spreads
+// across whatever hosts exist rather than naming any of them.
+func TestNoWorkloadSelectsNodesByHostname(t *testing.T) {
+	for _, located := range loadDirectoryManifests(t) {
+		for _, selector := range hostnameNodeSelectors(located.workloadManifest) {
+			t.Errorf("%s/%s selects nodes by hostname (%s); select on itsbagelbot.dev/role instead",
+				located.filename, located.Metadata.Name, selector)
+		}
+	}
+}
+
+// locatedManifest keeps a decoded manifest next to the file it came from, so a
+// failure can name the file without that filename being threaded through the
+// call chain as a bare string argument.
+type locatedManifest struct {
+	workloadManifest
+	filename string
+}
+
+// loadDirectoryManifests decodes every YAML document in this directory.
+func loadDirectoryManifests(t *testing.T) []locatedManifest {
+	t.Helper()
+
+	var located []locatedManifest
+	for _, filename := range manifestFilenames(t) {
+		f, err := os.Open(filename)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, manifest := range decodeManifests(t, f) {
+			located = append(located, locatedManifest{workloadManifest: manifest, filename: filename})
+		}
+		f.Close()
+	}
+	return located
+}
+
+func manifestFilenames(t *testing.T) []string {
+	t.Helper()
+
+	filenames, err := filepath.Glob("*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(filenames) == 0 {
+		t.Fatal("no manifests found; the glob is wrong")
+	}
+	return filenames
+}
+
+// pinningIsWorthIt lists the StatefulSets allowed to claim a PersistentVolume.
+//
+// A local-path PVC binds its PV to whichever node provisioned it, so a member
+// whose node dies sits Pending on "didn't match PersistentVolume's node
+// affinity" until someone deletes the claim. On 2026-07-27 that stranded nats-1
+// on a dead node5, took JetStream below quorum, and crashlooped every service
+// that opens a consumer at startup. Pinning is therefore opt-in and has to earn
+// its place, which only nats does:
+//
+//   - nats: a cold start re-establishes every stream AND all 24+ consumer RAFT
+//     groups from its peers. Measured that day, a restarted member sat "not
+//     current" on 10-27 groups for minutes, surfacing as chat replies that were
+//     slow or dropped past MaxDeliver. The cost scales with GROUP COUNT, not
+//     data: the streams held under a thousand messages.
+//
+// Valkey is deliberately absent. Its master/replica topology rebuilds a member
+// with one full resync of a small derived dataset, so an empty volume costs a
+// few seconds rather than minutes of degraded consumer state.
+var pinningIsWorthIt = map[string]string{
+	"nats": "cold start rebuilds 24+ consumer RAFT groups; see the volumeClaimTemplates comment in nats.yaml",
+}
+
+// TestOnlyDocumentedStatefulSetsPinAVolume keeps the exception list honest.
+//
+// This has to be a test rather than a comment because volumeClaimTemplates is
+// IMMUTABLE. Server-side apply will neither add nor remove one: dropping it
+// leaves the claim template in place and adds the new volume alongside,
+// producing a duplicate volume name while Flux still reports the reconcile as
+// successful. Either direction needs a delete-and-recreate of the StatefulSet,
+// so the decision must be caught in review rather than at deploy time.
+func TestOnlyDocumentedStatefulSetsPinAVolume(t *testing.T) {
+	for _, located := range loadDirectoryManifests(t) {
+		if located.Kind != "StatefulSet" || len(located.Spec.VolumeClaimTemplates) == 0 {
+			continue
+		}
+		if _, ok := pinningIsWorthIt[located.Metadata.Name]; ok {
+			continue
+		}
+		for _, vct := range located.Spec.VolumeClaimTemplates {
+			t.Errorf("%s/%s claims volume %q but is not in pinningIsWorthIt; a local-path PVC strands the pod when its node dies, so either justify it there or use an emptyDir and let replication rebuild the member",
+				located.filename, located.Metadata.Name, vct.Metadata.Name)
+		}
+	}
+}
+
+// decodeManifests reads every YAML document from r through the workload shape.
+// Documents that are not workloads (Services, ConfigMaps, CRs) simply decode to
+// a zero value with no selector terms, so they cost nothing to carry and no
+// shape filtering is needed here.
+func decodeManifests(t *testing.T, r io.Reader) []workloadManifest {
+	t.Helper()
+
+	var manifests []workloadManifest
+	decoder := yaml.NewDecoder(r)
+	for {
+		var manifest workloadManifest
+		if err := decoder.Decode(&manifest); err != nil {
+			if err != io.EOF {
+				t.Fatal(err)
+			}
+			return manifests
+		}
+		manifests = append(manifests, manifest)
+	}
+}
+
+// hostnameNodeSelectors reports each required nodeAffinity expression that
+// selects on kubernetes.io/hostname, rendered for the failure message.
+func hostnameNodeSelectors(manifest workloadManifest) []string {
+	var selectors []string
+	for _, term := range manifest.Spec.Template.Spec.Affinity.NodeAffinity.Required.NodeSelectorTerms {
+		for _, expression := range term.MatchExpressions {
+			if expression.Key == "kubernetes.io/hostname" {
+				selectors = append(selectors, fmt.Sprintf("%s %v", expression.Operator, expression.Values))
+			}
+		}
+	}
+	return selectors
+}
+
+func TestConsoleAdminExplicitlyExcludesWorkerPool(t *testing.T) {
+	admin := loadDeployment(t, "console-admin.yaml", "console-admin")
+	terms := admin.Spec.Template.Spec.Affinity.NodeAffinity.Required.NodeSelectorTerms
+
+	for _, term := range terms {
+		for _, expression := range term.MatchExpressions {
+			if excludesWorkerPool(expression.Key, expression.Operator, expression.Values) {
+				return
+			}
+		}
+	}
+
+	t.Fatal("console-admin must explicitly exclude the worker pool")
+}

--- a/deploy/k8s/transactions.yaml
+++ b/deploy/k8s/transactions.yaml
@@ -1,0 +1,218 @@
+# Copyright (c) 2026 Adam Ousmer. All rights reserved.
+# Proprietary. No license granted. See LICENSE.md.
+
+apiVersion: secrets.doppler.com/v1alpha1
+kind: DopplerSecret
+metadata:
+  name: transactions-env
+  namespace: production
+spec:
+  host: https://api.doppler.com
+  tokenSecret:
+    name: transactions-doppler-token
+  managedSecret:
+    name: transactions-env
+    namespace: production
+    type: Opaque
+  resyncSeconds: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: transactions
+  namespace: production
+  annotations:
+    secrets.doppler.com/reload: "true"
+spec:
+  replicas: 3 # one per hot-path node: node4, node5, node6
+  revisionHistoryLimit: 3
+  minReadySeconds: 10
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: transactions
+  template:
+    metadata:
+      labels:
+        app: transactions
+    spec:
+      tolerations:
+        - key: node.kubernetes.io/unreachable
+          operator: Exists
+          effect: NoExecute
+          tolerationSeconds: 60
+        - key: node.kubernetes.io/not-ready
+          operator: Exists
+          effect: NoExecute
+          tolerationSeconds: 60
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+          matchLabelKeys: [pod-template-hash]
+          labelSelector:
+            matchLabels:
+              app: transactions
+      # Three replicas and three eligible domains keep one transactions pod
+      # per hot-path node after every ReplicaSet rollout.
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        seccompProfile: {type: RuntimeDefault}
+      containers:
+        - name: transactions
+          image: ghcr.io/adamousmer/itsbagelbot/transactions:main-1786934707-b71a0f43997c@sha256:a9ee4742296f794188b7f1424d66514ef8b0b666edb13e201f01ff9f87c6ed05 # {"$imagepolicy": "flux-system:transactions"}
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: NATS_HOST
+              value: nats
+            # transactions is RPC-only: the checkout/billing/gift-notify verbs
+            # all ride the TRANSACTIONS_RPC responder on the node-local leaf; it
+            # never touches JetStream, so no NATS_HUB_URL and no BUS credential.
+            # RPC creds (NATS_RPC_USER/PASSWORD) and the Tebex Headless secrets
+            # (TEBEX_WEBSTORE_TOKEN, TEBEX_PACKAGE_ID) ride in via envFrom from Doppler.
+            - name: NATS_URL
+              value: nats://nats-leaf:4222
+            # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS
+            # server's native-TLS cert; read as RootCAs by pkg/bus (Go services)
+            # and the console nats lib (TS).
+            - name: NATS_CA_PEM
+              valueFrom:
+                configMapKeyRef:
+                  name: fleet-ca
+                  key: ca.pem
+            - name: NATS_LEAF_URL
+              value: nats://nats-leaf:4222
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: DB_MAX_OPEN_CONNS
+              value: "4"
+            - name: DB_QUERY_CONCURRENCY
+              value: "4"
+            - name: DB_AUTO_MIGRATE
+              value: "true"
+            # Tebex Developers > Webhooks > Endpoints secret. The Fiber webhook
+            # handler refuses requests until this is configured.
+            - name: TEBEX_WEBHOOK_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: transactions-env
+                  key: TEBEX_WEBHOOK_SECRET
+                  optional: true
+            - name: GOMEMLIMIT
+              value: 160MiB
+            # Serve HTTPS on 8080 using the cert-manager transactions-tls cert,
+            # so the traefik->transactions hop is TLS. Traefik re-encrypts via
+            # the transactions-transport ServersTransport. Both env vars are
+            # required together (main.go fails fast on a mismatched pair);
+            # unset keeps the listener plaintext.
+            - name: TLS_CERT_FILE
+              value: /etc/transactions/tls/tls.crt
+            - name: TLS_KEY_FILE
+              value: /etc/transactions/tls/tls.key
+          envFrom:
+            - secretRef:
+                name: transactions-env
+          ports:
+            - containerPort: 8080
+          volumeMounts:
+            - {name: tls, mountPath: /etc/transactions/tls, readOnly: true}
+          resources:
+            requests:
+              cpu: 15m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities: {drop: ["ALL"]}
+          lifecycle:
+            preStop:
+              httpGet:
+                path: /drain
+                port: 8080
+                scheme: HTTPS
+          # scheme HTTPS: the server now terminates TLS on 8080.
+          livenessProbe:
+            httpGet: {path: /healthz, port: 8080, scheme: HTTPS}
+            periodSeconds: 30
+          readinessProbe:
+            httpGet: {path: /readyz, port: 8080, scheme: HTTPS}
+            periodSeconds: 10
+          startupProbe:
+            httpGet: {path: /healthz, port: 8080, scheme: HTTPS}
+            failureThreshold: 18 # 18 × 5s = 90s max startup window
+            periodSeconds: 5
+      terminationGracePeriodSeconds: 45
+      volumes:
+        - name: tls
+          secret:
+            secretName: transactions-tls
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: transactions
+  namespace: production
+spec:
+  trafficDistribution: PreferClose
+  selector:
+    app: transactions
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: transactions-webhooks
+  namespace: production
+spec:
+  entryPoints: [websecure]
+  routes:
+    - match: Host(`webhooks.itsbagelbot.com`) && (PathPrefix(`/tebex`) || PathPrefix(`/webhooks/tebex`))
+      kind: Rule
+      services:
+        - name: transactions
+          port: 80
+          # HTTPS to the backend: main.go now terminates TLS when
+          # TLS_CERT_FILE/TLS_KEY_FILE are set, so traefik re-encrypts via the
+          # ServersTransport below (rootCAs = the cert's own fleet-CA ca.crt).
+          # This makes the traefik->transactions hop TLS end-to-end.
+          scheme: https
+          serversTransport: transactions-transport
+          nativeLB: true
+  tls: {}
+---
+apiVersion: traefik.io/v1alpha1
+kind: ServersTransport
+metadata:
+  name: transactions-transport
+  namespace: production
+spec:
+  # Verify the transactions pod's TLS cert against the fleet CA. serverName
+  # matches the cert SAN (the Service name). rootCAsSecrets reads the CA from
+  # the cert-manager secret's ca.crt key (Traefik v3). No InsecureSkipVerify.
+  serverName: transactions
+  rootCAsSecrets:
+    - transactions-tls
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: transactions
+  namespace: production
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: transactions

--- a/deploy/k8s/twitch-ingress.yaml
+++ b/deploy/k8s/twitch-ingress.yaml
@@ -1,0 +1,282 @@
+# Copyright (c) 2026 Adam Ousmer. All rights reserved.
+# Proprietary. No license granted. See LICENSE.md.
+
+# Twitch Ingress (Elixir/BEAM). Secrets sync from Doppler project
+# `twitch-ingress` (config prd) via the operator; the token secret
+# `twitch-ingress-doppler-token` is created out-of-band, never committed.
+apiVersion: secrets.doppler.com/v1alpha1
+kind: DopplerSecret
+metadata:
+  name: twitch-ingress-env
+  namespace: production
+spec:
+  host: https://api.doppler.com
+  tokenSecret:
+    name: twitch-ingress-doppler-token
+  managedSecret:
+    name: twitch-ingress-env
+    namespace: production
+    type: Opaque
+  resyncSeconds: 60
+---
+# Headless service: libcluster (Kubernetes.DNS strategy) resolves it to pod
+# IPs to form the BEAM cluster. publishNotReadyAddresses lets nodes find each
+# other before readiness, which is required for initial cluster formation.
+apiVersion: v1
+kind: Service
+metadata:
+  name: twitch-ingress-headless
+  namespace: production
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  selector:
+    app: twitch-ingress
+  ports:
+    - name: epmd
+      port: 4369
+    - name: erlang-dist
+      port: 9100
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: twitch-ingress
+  namespace: production
+  annotations:
+    secrets.doppler.com/reload: "true"
+spec:
+  replicas: 3 # one per eligible hot-path node: node4, node5, node6
+  revisionHistoryLimit: 3
+  # On SIGTERM each pod hands its conduit shards off make-before-break
+  # (Ingress.Drain): the successor binds on a peer before the local socket
+  # closes, so a rollout drops no events. Still hold each replacement pod
+  # Ready for a full minute before killing the next old pod: the Horde
+  # registry converges between swaps, keeping one drain in flight at a time
+  # — the 2026-07-10 mid-stream incident was pods cycling within a minute of
+  # each other, stacking registry races ("registry pick unreachable") into a
+  # ~5 min chat outage.
+  minReadySeconds: 60
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: twitch-ingress
+  template:
+    metadata:
+      labels:
+        app: twitch-ingress
+    spec:
+      tolerations:
+        - key: node.kubernetes.io/unreachable
+          operator: Exists
+          effect: NoExecute
+          tolerationSeconds: 60
+        - key: node.kubernetes.io/not-ready
+          operator: Exists
+          effect: NoExecute
+          tolerationSeconds: 60
+      # Eligible nodes are the application tier, selected by role rather than
+      # by hostname so the rule cannot go stale when the fleet changes shape.
+      # The three replicas spread one per eligible node in steady state.
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: itsbagelbot.dev/role
+                    operator: NotIn
+                    values: [cp, worker]
+      topologySpreadConstraints:
+        # matchLabelKeys scopes the skew to the CURRENT ReplicaSet: during a
+        # maxSurge=0 roll the outgoing pods no longer count, so every rollout
+        # re-spreads one-per-node instead of piling onto whichever node freed
+        # capacity first (bit the ingress on 2026-07-10: 3/0/1). With three
+        # replicas and three eligible nodes, maxSkew=1 plus DoNotSchedule makes
+        # the steady-state placement exactly 1/1/1.
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+          matchLabelKeys: [pod-template-hash]
+          labelSelector:
+            matchLabels:
+              app: twitch-ingress
+      # Resolve external hosts (Twitch EventSub/Helix) without the cluster
+      # search-domain fan-out (ndots:1) and serialize A/AAAA to dodge the
+      # conntrack race; cap any DNS stall well under a few seconds.
+      dnsConfig:
+        options:
+          - {name: ndots, value: "1"}
+          - {name: single-request-reopen}
+          - {name: timeout, value: "2"}
+          - {name: attempts, value: "2"}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999 # the image's `ingress` user; numeric so kubelet can verify
+        runAsGroup: 999
+        seccompProfile: {type: RuntimeDefault}
+      containers:
+        - name: ingress
+          image: ghcr.io/adamousmer/itsbagelbot/twitch-ingress:main-1786934707-b71a0f43997c@sha256:7a51353fce6f98ed9883f0a307bb76c372a7b73ae546c2edb68b0937ce20b936 # {"$imagepolicy": "flux-system:twitch-ingress"}
+          imagePullPolicy: IfNotPresent
+          envFrom:
+            - secretRef:
+                name: twitch-ingress-env
+          env:
+            - name: NATS_HOST
+              value: nats
+            # The RPC plane (:gnat) stays on the node-local leaf. The BUS firehose
+            # plane (:gnat_bus) uses the `nats` Service, whose PreferSameNode
+            # routing lands each ingress publisher on the hub member beside it.
+            # Production R3 qualification measured ~75k/s through this route vs
+            # ~60.6k/s when every publisher dialed the stream leader directly:
+            # distributing client TLS/socket/batch work outweighs the NATS route
+            # hop to the RAFT leader. The leaf remains RPC-only and never carries
+            # JetStream traffic.
+            - name: NATS_LEAF_HOST
+              value: nats-leaf
+            - name: NATS_HUB_HOST
+              value: nats
+            # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS
+            # server's native-TLS cert; decoded to ssl_opts cacerts in
+            # config/runtime.exs. Both :gnat (leaf) and :gnat_bus (hub) verify
+            # against it.
+            - name: NATS_CA_PEM
+              valueFrom:
+                configMapKeyRef:
+                  name: fleet-ca
+                  key: ca.pem
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            # Worker node (machine) the pod is scheduled on, surfaced to the
+            # admin console so shard cards show the host name, not the pod IP.
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: RELEASE_DISTRIBUTION
+              value: name
+            - name: RELEASE_NODE
+              value: ingress@$(POD_IP)
+            - name: RELEASE_COOKIE
+              valueFrom:
+                secretKeyRef:
+                  name: twitch-ingress-env
+                  key: BAGELBOT_ERLANG_COOKIE
+            - name: NEW_RELIC_APP_NAME
+              value: "ItsBagelBot-Ingress"
+            - name: NEW_RELIC_LOGS_IN_CONTEXT
+              value: "forwarder"
+            - name: INGRESS_DISPATCHER_MAX_RUNNING
+              value: "512"
+            - name: INGRESS_DISPATCHER_MAX_QUEUE
+              value: "20000"
+            # Shipped inert (above max_running+max_queue's realistic reach) for
+            # burn-in; tighten to "2048" once the new broadcaster_cap drop
+            # metric shows real per-broadcaster admission patterns in prod.
+            - name: INGRESS_DISPATCHER_MAX_PER_BROADCASTER
+              value: "16000"
+            # Scheduler-local JetStream cohorts collect for at most 1ms. The
+            # publisher is structurally dedup-free, so no environment toggle
+            # can accidentally restore the broker's Nats-Msg-Id index tax.
+            - name: INGRESS_PUBLISH_BATCH_SIZE
+              value: "128"
+            - name: INGRESS_PUBLISH_BATCH_WAIT_MS
+              value: "1"
+            # Cohort wire, set explicitly even though it matches the shipped
+            # default, because that is what makes the rollback a value edit here
+            # rather than a rebuild. "atomic" writes the cohort as one ADR-050
+            # batch and resolves it with a single commit PubAck, so the R3 lane
+            # stream pays RAFT quorum latency once per cohort instead of once per
+            # event; "single" is the per-event PubAck compatibility path.
+            #
+            # Blast radius, which is what an operator flips this for: on
+            # "atomic" an ambiguous outcome (ack timeout, malformed reply, a send
+            # error mid-batch) drops the WHOLE cohort — up to
+            # INGRESS_PUBLISH_BATCH_SIZE=128 events — where the same outcome on
+            # "single" costs exactly 1. Nothing is lost silently: every drop
+            # lands in Nats/PublishFailed. The signal is that counter's SHAPE —
+            # cohort-sized steps rather than one event at a time. Step-shaped
+            # growth means set this to "single" and take the per-event quorum
+            # cost back. Anything other than these two values warns on stderr
+            # and stays "atomic".
+            - name: INGRESS_PUBLISH_WIRE
+              value: "atomic"
+            # Unresolved atomic batches per shard, sized so the FLEET stays under
+            # the broker's stock cap of 50 open atomic batches per stream — every
+            # shard opens against the same TWITCH_INGRESS. 3 replicas x 2
+            # schedulers (+S 2:2) = 6 shards, so 8 each = 48.
+            #
+            # This arithmetic is load-bearing. Raise `replicas` above, change the
+            # +S flag in ERL_FLAGS, or raise this number, and the fleet crosses
+            # the cap: every open past it comes back 10210/429 and re-drives per
+            # message, which silently removes the batching the wire above exists
+            # for, and does so exactly when the fleet is busiest.
+            # app/ingress/test/nats_publisher_wire_test.exs asserts the product,
+            # so changing one of the three without the others fails a test.
+            #
+            # Nats/PublishBatchFallback rising with 429s means the fleet is over
+            # the cap; Nats/PublishBatchBypassed means this local window filled,
+            # which is a commit-latency alarm rather than a budget one.
+            - name: INGRESS_PUBLISH_BATCH_INFLIGHT
+              value: "8"
+            # Match normal and dirty schedulers to the two-CPU cgroup below.
+            # `short` normal-scheduler busy-wait was modestly faster than
+            # `none` across repeated direct-dispatch runs, while dirty
+            # schedulers stay at `none` because ingress does no sustained dirty
+            # NIF work. More than two schedulers only creates cgroup contention
+            # on this three-replica deployment.
+            - name: ERL_FLAGS
+              # Range, not a single port: probe/remote-shell hidden nodes
+              # need their own listen port besides the main VM's.
+              value: >-
+                +S 2:2 +SDcpu 2:2 +SDio 2 +sbwt short +sbwtdcpu none +sbwtdio none -kernel inet_dist_listen_min 9100 -kernel inet_dist_listen_max 9110
+          resources:
+            requests:
+              # Live steady state is 195-240m across all three node-local pods.
+              cpu: 250m
+              memory: 256Mi
+            limits:
+              cpu: "2"
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities: {drop: ["ALL"]}
+          lifecycle:
+            preStop:
+              # Delay SIGTERM so cluster membership settles before the BEAM
+              # starts its shard drain (Ingress.Drain runs in prep_stop on
+              # SIGTERM: successor binds on a peer, then the local socket
+              # closes). Drain (~12s worst case) + this sleep must stay
+              # inside terminationGracePeriodSeconds.
+              sleep:
+                seconds: 10
+          livenessProbe:
+            exec:
+              command: ["/app/bin/ingress", "pid"]
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 5
+          readinessProbe:
+            exec:
+              command: ["/app/bin/ingress", "pid"]
+            initialDelaySeconds: 5
+            periodSeconds: 15
+            timeoutSeconds: 5
+      terminationGracePeriodSeconds: 45
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: twitch-ingress
+  namespace: production
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: twitch-ingress

--- a/deploy/k8s/users.yaml
+++ b/deploy/k8s/users.yaml
@@ -1,0 +1,189 @@
+# Copyright (c) 2026 Adam Ousmer. All rights reserved.
+# Proprietary. No license granted. See LICENSE.md.
+
+apiVersion: secrets.doppler.com/v1alpha1
+kind: DopplerSecret
+metadata:
+  name: users-env
+  namespace: production
+spec:
+  host: https://api.doppler.com
+  tokenSecret:
+    name: users-doppler-token
+  managedSecret:
+    name: users-env
+    namespace: production
+    type: Opaque
+  resyncSeconds: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: users
+  namespace: production
+  annotations:
+    secrets.doppler.com/reload: "true"
+spec:
+  replicas: 3 # one per hot-path node: node4, node5, node6
+  revisionHistoryLimit: 3
+  minReadySeconds: 10
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: users
+  template:
+    metadata:
+      labels:
+        app: users
+    spec:
+      tolerations:
+        - key: node.kubernetes.io/unreachable
+          operator: Exists
+          effect: NoExecute
+          tolerationSeconds: 60
+        - key: node.kubernetes.io/not-ready
+          operator: Exists
+          effect: NoExecute
+          tolerationSeconds: 60
+      # Keep RPC responders beside Sesame on the three hot-path nodes. The node1
+      # exclusion below is inert since node1 left the fleet; kept so the applied
+      # spec is unchanged.
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: itsbagelbot.dev/role
+                    operator: NotIn
+                    values: [cp, worker]
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  app: users
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          matchLabelKeys: [pod-template-hash]
+          labelSelector:
+            matchLabels:
+              app: users
+      # Three replicas + three eligible nodes + required pod anti-affinity yields
+      # exactly one users pod per hot-path node, including during rolls.
+      # Resolve external hosts (Twitch OAuth token refresh) without the cluster
+      # search-domain fan-out (ndots:1) and serialize A/AAAA to dodge the
+      # conntrack race; cap any DNS stall well under a few seconds.
+      dnsConfig:
+        options:
+          - {name: ndots, value: "1"}
+          - {name: single-request-reopen}
+          - {name: timeout, value: "2"}
+          - {name: attempts, value: "2"}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        seccompProfile: {type: RuntimeDefault}
+      containers:
+        - name: users
+          image: ghcr.io/adamousmer/itsbagelbot/users:main-1786934707-b71a0f43997c@sha256:ff0cb9a2547caac8a514c2756c86f72381f7c9bd3db57aff954c9ecc426a5f9b # {"$imagepolicy": "flux-system:users"}
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: NATS_HOST
+              value: nats
+            # Split planes: the BUS / JetStream connection dials the hub directly
+            # (NATS_HUB_URL) so stream traffic never pays a leaf forwarding hop;
+            # the RPC + cache plane (NATS_RPC_URL / NATS_LEAF_URL) stays on the
+            # node-local leaf. NATS_URL is the local-dev fallback only.
+            - name: NATS_URL
+              value: nats://nats-leaf:4222
+            - name: NATS_HUB_URL
+              value: nats://nats:4222
+            - name: NATS_HUB_PUBLISH_URL
+              value: nats://nats:4222
+            # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS
+            # server's native-TLS cert; read as RootCAs by pkg/bus (Go services)
+            # and the console nats lib (TS).
+            - name: NATS_CA_PEM
+              valueFrom:
+                configMapKeyRef:
+                  name: fleet-ca
+                  key: ca.pem
+            - name: NATS_RPC_URL
+              value: nats://nats-leaf:4222
+            - name: NATS_LEAF_URL
+              value: nats://nats-leaf:4222
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: DB_MAX_OPEN_CONNS
+              value: "4"
+            - name: DB_QUERY_CONCURRENCY
+              value: "4"
+            - name: DB_AUTO_MIGRATE
+              value: "true"
+            - name: GOMEMLIMIT
+              value: 160MiB
+          envFrom:
+            - secretRef:
+                name: users-env
+          volumeMounts:
+            # Tink keyset for at-rest token encryption, synced from Doppler
+            # (TINK_KEYSET key of users-env) and consumed as a file via
+            # TINK_KEYSET_PATH=/etc/tink/keyset.json.
+            - name: tink-keyset
+              mountPath: /etc/tink
+              readOnly: true
+          ports:
+            - containerPort: 8080
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities: {drop: ["ALL"]}
+          lifecycle:
+            preStop:
+              httpGet:
+                path: /drain
+                port: 8080
+          livenessProbe:
+            httpGet: {path: /healthz, port: 8080}
+            periodSeconds: 30
+          readinessProbe:
+            httpGet: {path: /readyz, port: 8080}
+            periodSeconds: 10
+          startupProbe:
+            httpGet: {path: /healthz, port: 8080}
+            failureThreshold: 18 # 18 × 5s = 90s max startup window
+            periodSeconds: 5
+      terminationGracePeriodSeconds: 45
+      volumes:
+        - name: tink-keyset
+          secret:
+            secretName: users-env
+            items:
+              - key: TINK_KEYSET
+                path: keyset.json
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: users
+  namespace: production
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: users

--- a/deploy/k8s/web-error-pages.yaml
+++ b/deploy/k8s/web-error-pages.yaml
@@ -1,0 +1,62 @@
+# Copyright (c) 2026 Adam Ousmer. All rights reserved.
+# Proprietary. No license granted. See LICENSE.md.
+
+# Unrouted hostnames at the traefik edge (anything the tunnel wildcard admits
+# that no router claims) proxy straight through to the marketing site, path
+# intact. An unknown path gets web/'s coded 404 page under a genuine 404
+# status — and because the path is NOT rewritten, the page's own assets
+# (/_astro/*, styles, fonts) resolve through the same catch-all to the real
+# files with the right MIME types. (The first cut rewrote every path to a
+# 404-forcing one, which turned each asset request into an HTML error page:
+# MIME refusals and CSP noise all the way down.)
+#
+# The marketing apex resolves to Cloudflare's static hosting directly (NOT back
+# through the tunnel — verified: the apex serves with no tunnel route present),
+# so proxying to it cannot loop into cloudflared.
+#
+# Requires providers.kubernetesCRD.allowExternalNameServices=true in the
+# traefik HelmChartConfig (deploy/infra/cluster/traefik-config.yaml).
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-origin
+  namespace: production
+spec:
+  type: ExternalName
+  externalName: itsbagelbot.com
+  ports:
+    - name: https
+      port: 443
+---
+apiVersion: traefik.io/v1alpha1
+kind: ServersTransport
+metadata:
+  name: web-origin-transport
+  namespace: production
+spec:
+  # Public Cloudflare certificate, verified against the system trust pool (no
+  # rootCAsSecrets). SNI pinned to the site: the ExternalName dial would
+  # otherwise present the cluster-internal name.
+  serverName: itsbagelbot.com
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: unrouted-host-fallback
+  namespace: production
+spec:
+  entryPoints: [websecure]
+  routes:
+    # Explicit rock-bottom priority so every real router (all of which carry
+    # longer, auto-prioritized rules) wins first.
+    - match: HostRegexp(`^.+$`)
+      kind: Rule
+      priority: 1
+      services:
+        - name: web-origin
+          port: 443
+          scheme: https
+          serversTransport: web-origin-transport
+          # Host must be the marketing site for Cloudflare to route it.
+          passHostHeader: false
+  tls: {}


### PR DESCRIPTION
## Summary
Restores application deployment manifests in `deploy/k8s` (sesame, outgress, users, commands, loyalty, modules, notifications, projector, transactions, twitch-ingress, gossip, console, nats, etc.) alongside `deploy/cilium/values.yaml`.