### PR TITLE
fix(dashboard): keep the invalidation stream on the owner's own session

### DIFF
--- a/console/dashboard/src/routes/events/+server.ts
+++ b/console/dashboard/src/routes/events/+server.ts
@@ -16,13 +16,16 @@ const DEMO = dev && env.DEMO === '1';
 // grant / …) the same bus that evicts the server cache pushes the scope here and
 // the client re-fetches. No polling.
 //
-// Owner or delegate: we stream the effective board id (delegate_of ?? user_id),
-// matching the id the reads are keyed on.
+// Owners only. A delegate's pages already SSR fresh on every navigation (the
+// client never opens this stream for them), and the board they operate is not
+// theirs: streaming it would hand them a change signal for families their
+// grant does not cover — `ban:<owner>`, `billing-state:<owner>` — which is
+// exactly the inference the section scoping exists to prevent.
 export const GET: RequestHandler = ({ locals, request }) => {
   const s = locals.session;
   // DEMO has no real session; stream a demo board so the plumbing is exercisable
   // locally (no NATS events arrive, but the connection + keepalive do).
-  const boardId = s ? (s.delegate_of ?? s.user_id) : DEMO ? 'demo' : null;
+  const boardId = s && !s.delegate_of ? s.user_id : DEMO ? 'demo' : null;
   if (!boardId) return new Response('unauthorized', { status: 401 });
 
   let cleanup = () => {};
@@ -46,8 +49,12 @@ export const GET: RequestHandler = ({ locals, request }) => {
       send(': connected\n\n');
       send('event: ready\ndata: 1\n\n');
 
-      const unsubscribe = subscribe(boardId, (scope) => {
-        send(`event: invalidate\ndata: ${scope}\n\n`);
+      // The payload is a constant, not the scope name: the client refetches
+      // everything on any invalidate (see (app)/+layout.svelte), so the scope
+      // is dead data on the wire — and dead data that names which family of
+      // the owner's state changed.
+      const unsubscribe = subscribe(boardId, () => {
+        send('event: invalidate\ndata: 1\n\n');
       });
 
       // Keepalive comment so idle proxies (the Cloudflare tunnel) don't reap the


### PR DESCRIPTION
Found while auditing tenant isolation across the dashboard.

`/events` streamed the **effective** board id (`delegate_of ?? user_id`), so a delegate who opened the endpoint by hand got an invalidation signal for every scope family on the owner's board — including `ban:<owner>` and `billing-state:<owner>`, families their grant does not cover. That is a metadata inference the section scoping exists to prevent.

The client never opens the stream for a delegate ((app)/+layout.svelte skips it — delegate pages SSR fresh on every navigation), so scoping the endpoint to owners matches the contract the client already assumes. The payload also carried the scope name, which no consumer reads (the client calls `invalidateAll()` on any event), so it is now a constant.

### Rest of the isolation audit — no other findings

- Every store/RPC call site resolves its board id from `effectiveId(session)`; no id reaches a store from form data, query, or params. The two request-sourced ids are safe: `owner_user_id` (opt-out) only drops the caller's *own* grant, and `allowed_user_id` is a digit-filtered viewer lock, not a board.
- `/delegate/enter` requires a normal session (refuses delegate and impersonated ones), re-verifies the grant server-side, and takes sections from the grant — never from input. Enter/exit preserve `iat`/`expires_at`, so switching boards cannot extend a lifetime.
- `guard.ts` runs for every authenticated request (actions and endpoints included) and default-denies any `(app)` path outside the delegate's granted sections.
- The public profile exposes only the creator code plus filtered commands/modules — no account status, tier, or PII.
- Session cookie: AES-256-GCM with AAD over an app-isolated 32-byte key, tamper → `null`, `iat`/`expires_at` validated with a 30s skew bound, and a per-kind TTL cap (7d normal, 1h impersonation) that a re-seal cannot extend. `httpOnly`, `secure`, `sameSite=lax` at all four set sites.