### PR TITLE
fix(admin): enforce the service namespace when setting a db credential

### DIFF
--- a/console/admin/src/lib/server/secrets.ts
+++ b/console/admin/src/lib/server/secrets.ts
@@ -315,12 +315,17 @@ function dbEnvOf(cred: DbCredentialInput, svc: ServiceDef, autoMigrate: boolean)
 }
 
 // assertManageable rejects credentials this console must never touch: the
-// privileged admin user itself, and (for revokes) users outside the service's
-// namespace.
-function assertManageable(cred: Pick<DbCredentialInput, 'dbUser'>, svc?: ServiceDef): void {
+// privileged admin user itself, and users outside the service's own namespace.
+//
+// The namespace check matters on the write paths, not just revokes: every
+// caller hands the resulting user to provisionDbUser, which GRANTs it on that
+// service's schema. Without it, naming another service's user here would widen
+// that user's access to this schema too — the one thing the per-service
+// schema+user split exists to prevent.
+function assertManageable(cred: Pick<DbCredentialInput, 'dbUser'>, svc: ServiceDef): void {
   assertFormat(cred.dbUser, FORMATS.dbUser);
   if (cred.dbUser === adminDbUser()) throw new Error('refusing to manage the admin database user');
-  if (svc && !cred.dbUser.startsWith(svc.expectedUserPrefix)) {
+  if (!cred.dbUser.startsWith(svc.expectedUserPrefix)) {
     throw new Error(`user must start with ${svc.expectedUserPrefix}`);
   }
 }
@@ -346,7 +351,7 @@ export async function setCredential(
   cred: DbCredentialInput
 ): Promise<{ dbUser: string }> {
   const svc = services[id];
-  assertManageable(cred);
+  assertManageable(cred, svc);
   assertFormat(cred.dbPass, FORMATS.dbPassword);
   await provisionDbUser(cred, svc);
   await updateDoppler(svc, dbEnvOf(cred, svc, true));


### PR DESCRIPTION
Found while auditing the repo for direct database access, injection, and unbounded CRUD.

`assertManageable` took `svc` as an optional argument, and only `rotateCredential`/`revokeCredential` passed it. `setCredential` called it without, so the prefix check (`dbUser.startsWith(svc.expectedUserPrefix)`) was skipped on that path.

Consequence is not naming hygiene: every caller hands the resulting user to `provisionDbUser`, which `GRANT`s it on that service's schema. A manager-role admin could therefore name **another service's** user on this form and widen that user's access to this schema too — precisely what the per-service schema+user split prevents. `svc` is now required and the check unconditional.

### The rest of the audit — clean

- **console/dashboard has no direct database access at all.** Zero `mysql2`/`pg`/`sqlite`/ORM imports; every read and write goes out over NATS RPC through `services.ts`. Verified by full-tree grep, not just by inspection.
- **No reachable SQL injection anywhere.** The only hand-built SQL is (a) loyalty's bulk upsert, whose query text is compile-time constant with all values on `?` placeholders, and (b) admin's credential DDL, where MySQL cannot parameterize identifiers — but `accountSql` re-validates `dbUser` against `/^[A-Za-z0-9_]{3,32}$/` immediately before interpolating, and `schemaSql` accepts only five fixed schema names. No `sql.Raw`, `db.Raw`, or `Where(fmt.Sprintf(...))` anywhere.
- **No unbounded destructive path.** Every ent `.Delete()` is predicate-scoped to a session-derived id; the one unscoped delete (`DeleteExpired`, `ExpiresAtLTE(now)`) is an internal cron job with no RPC or HTTP entry point.
- Go services each own only their own schema (ADR 0005); no cross-service schema reach found.