### PR TITLE
feat(dashboard): revoke sessions server-side on logout and sign-out-everywhere

### DIFF
--- a/console/dashboard/src/hooks.server.ts
+++ b/console/dashboard/src/hooks.server.ts
@@ -16,6 +16,7 @@ import {
 } from '@bagel/shared/server/hooks';
 import { rumTransform } from '@bagel/shared/server/rum';
 import { ValkeyRateLimiter, warmRateLimiter } from '@bagel/shared/server/rate-limit';
+import { warmSessionRevocation } from '@bagel/shared/server/session-revocation';
 import { detectLocale, isLocale, LOCALE_COOKIE } from '@bagel/shared/i18n';
 import { startInvalidationListener } from '$lib/server/services';
 import { assertConfigSane } from '$lib/server/config-sanity';
@@ -36,6 +37,7 @@ export const init: ServerInit = async () => {
   // hot path.
   warmValkey();
   warmRateLimiter();
+  warmSessionRevocation();
 
   // Subscribe to the cache-invalidation bus so writes in Go services push-drop
   // the right keys without waiting on TTL expiry.

--- a/console/dashboard/src/lib/server/demo-data.ts
+++ b/console/dashboard/src/lib/server/demo-data.ts
@@ -49,6 +49,10 @@ export function demoSession(): Session {
     login: 'itsmavey',
     display_name: 'Mavey',
     role: 'streamer',
+    // Inert placeholder: DEMO sessions never touch guard.ts's revocation
+    // check (the DEMO branch returns before it runs), so this never needs to
+    // be a real per-mint id.
+    sid: 'demo-session',
     iat: now,
     expires_at: now + 3600
   };

--- a/console/dashboard/src/lib/server/guard.ts
+++ b/console/dashboard/src/lib/server/guard.ts
@@ -25,6 +25,7 @@ import { MODULE_CATALOG, moduleDelegateSections } from '@bagel/shared';
 import { COOKIE, type Session } from '$lib/server/session';
 import { accountState, delegationAccess, isBanned } from '$lib/server/services';
 import { RpcError } from '@bagel/shared/server/nats';
+import { isSessionRevoked } from '@bagel/shared/server/session-revocation';
 
 const DEMO = dev && process.env.DEMO === '1';
 
@@ -101,6 +102,17 @@ export async function guardSession(event: RequestEvent, s: Session): Promise<Ses
   if (await isBanned(s.user_id)) {
     wipe(event);
     throw redirect(303, '/login?e=banned');
+  }
+
+  // Server-side revocation: logout kills just this sid, "sign out
+  // everywhere" (settings) kills every sid issued before that moment. Same
+  // fail-open posture as the ban check above — isSessionRevoked never throws.
+  // Sessions minted before this feature shipped carry no sid and are treated
+  // as not revocable (see session-revocation.ts), so this never mass-signs-out
+  // everyone already logged in on deploy.
+  if (await isSessionRevoked({ sid: s.sid, userId: s.user_id, iat: s.iat })) {
+    wipe(event);
+    throw redirect(303, '/login?e=signedout');
   }
 
   // Ghost-session gate: only an authoritative "no such user" (RpcError) wipes

--- a/console/dashboard/src/lib/server/guard.ts
+++ b/console/dashboard/src/lib/server/guard.ts
@@ -88,35 +88,25 @@ function moduleSubpathAllowed(id: string, sections: readonly string[]): boolean 
   return moduleDelegateSections(def).some((sec) => sections.includes(sec));
 }
 
-// guardSession validates an already-opened session against authoritative
-// account state. Returns the session to keep in locals, or throws a redirect
-// (wiping the cookie when the session itself is dead). Anonymous requests
-// never reach this — the (app) layout owns the login redirect for pages and
-// endpoints already 401 on a missing session.
-export async function guardSession(event: RequestEvent, s: Session): Promise<Session> {
-  if (DEMO || isPublic(event.url.pathname)) return s;
-
-  // Platform ban — own account. Same outage posture as before: isBanned serves
-  // last-known state through a users-service outage and fails open only with
-  // no cached state at all.
+// assertAccountUsable runs the three gates that judge the session itself,
+// each with the same outage posture: fail open on a transport blip, wipe the
+// cookie only on an authoritative answer.
+//   * ban — isBanned serves last-known state through a users-service outage.
+//   * revocation — logout kills this sid; "sign out everywhere" kills every
+//     session issued before that moment. isSessionRevoked never throws.
+//   * ghost session — only an RpcError ("no such user") wipes; anything else
+//     keeps the session and lets pages degrade.
+async function assertAccountUsable(event: RequestEvent, s: Session): Promise<void> {
   if (await isBanned(s.user_id)) {
     wipe(event);
     throw redirect(303, '/login?e=banned');
   }
 
-  // Server-side revocation: logout kills just this sid, "sign out
-  // everywhere" (settings) kills every sid issued before that moment. Same
-  // fail-open posture as the ban check above — isSessionRevoked never throws.
-  // Sessions minted before this feature shipped carry no sid and are treated
-  // as not revocable (see session-revocation.ts), so this never mass-signs-out
-  // everyone already logged in on deploy.
   if (await isSessionRevoked({ sid: s.sid, userId: s.user_id, iat: s.iat })) {
     wipe(event);
     throw redirect(303, '/login?e=signedout');
   }
 
-  // Ghost-session gate: only an authoritative "no such user" (RpcError) wipes
-  // the cookie; a transport blip keeps the session and pages degrade instead.
   try {
     await accountState(s.user_id);
   } catch (err) {
@@ -125,6 +115,17 @@ export async function guardSession(event: RequestEvent, s: Session): Promise<Ses
       throw redirect(303, '/login?e=signedout');
     }
   }
+}
+
+// guardSession validates an already-opened session against authoritative
+// account state. Returns the session to keep in locals, or throws a redirect
+// (wiping the cookie when the session itself is dead). Anonymous requests
+// never reach this — the (app) layout owns the login redirect for pages and
+// endpoints already 401 on a missing session.
+export async function guardSession(event: RequestEvent, s: Session): Promise<Session> {
+  if (DEMO || isPublic(event.url.pathname)) return s;
+
+  await assertAccountUsable(event, s);
 
   if (s.delegate_of && event.url.pathname !== '/delegate/exit') {
     // A delegate board dies out from under the session when the owner is

--- a/console/dashboard/src/lib/server/session.ts
+++ b/console/dashboard/src/lib/server/session.ts
@@ -22,6 +22,16 @@ export interface Session {
   login: string;
   display_name: string;
   role: 'streamer' | 'mod';
+  // Random per-session id (16 bytes, base64url), minted once at login/"view
+  // as" and carried unchanged through every re-seal (delegate enter/exit).
+  // It is the handle server-side revocation targets: logout and "sign out
+  // everywhere" (session-revocation.ts) mark it dead in Valkey so a copy of
+  // the cookie taken off a shared machine stops working immediately instead
+  // of riding out the full 7-day TTL. Sessions sealed before this field
+  // existed decode with sid undefined despite the type saying `string` —
+  // every revocation-check callsite treats a missing sid as "not revocable"
+  // (see isSessionRevoked), never as automatically revoked.
+  sid: string;
   iat: number;
   expires_at: number;
   // Set only when an admin is viewing this dashboard "as" the user. Carries the

--- a/console/dashboard/src/routes/(app)/settings/+page.server.ts
+++ b/console/dashboard/src/routes/(app)/settings/+page.server.ts
@@ -19,7 +19,8 @@ import {
   userLocale,
   type NotificationWire
 } from '$lib/server/services';
-import { ACCOUNT_DELETED_COOKIE, COOKIE, type Session } from '$lib/server/session';
+import { ACCOUNT_DELETED_COOKIE, COOKIE, SESSION_TTL_SECONDS, type Session } from '$lib/server/session';
+import { revokeAllForUser, revokeSession } from '@bagel/shared/server/session-revocation';
 import { isLocale, DEFAULT_LOCALE } from '@bagel/shared/i18n';
 import { dev } from '$app/environment';
 import { env } from '$env/dynamic/private';
@@ -214,5 +215,27 @@ export const actions: Actions = {
     await delegationOptOut(s.user_id, ownerId);
     auditDashboardImpersonation(s, 'delegation:opt_out', `owner=${ownerId}`);
     return { ok: true, action: 'opted_out' };
-  })
+  }),
+
+  // Kills every session the owner holds (this browser included) rather than
+  // just this one cookie. Owner-only, same guard as the rest of this file's
+  // actions — a delegate has no session of their own to sweep and must not
+  // be able to sign the owner out from someone else's board. Not wrapped in
+  // ownerAction: this action ends in a redirect + cookie wipe, not a form
+  // result, so it needs cookies/url that helper doesn't hand back.
+  signOutEverywhere: async ({ locals, cookies, url }) => {
+    const s = locals.session;
+    if (!s || s.delegate_of) return fail(403, { error: 'Not allowed.' });
+
+    const now = Math.floor(Date.now() / 1000);
+    // Both calls are best-effort and never throw (fail-open, see
+    // session-revocation.ts): a Valkey blip must not trap the owner in a
+    // session they just asked to leave, even if the OTHER devices don't get
+    // the memo until Valkey recovers.
+    await revokeAllForUser(s.user_id, now, SESSION_TTL_SECONDS);
+    if (s.sid) await revokeSession(s.sid, s.expires_at - now);
+
+    cookies.delete(COOKIE, { path: '/', secure: url.protocol === 'https:' });
+    throw redirect(303, '/login?e=signedout');
+  }
 };

--- a/console/dashboard/src/routes/auth/callback/+server.ts
+++ b/console/dashboard/src/routes/auth/callback/+server.ts
@@ -4,6 +4,7 @@
 import type { RequestHandler } from './$types';
 import type { Cookies } from '@sveltejs/kit';
 import { redirect } from '@sveltejs/kit';
+import { randomBytes } from 'node:crypto';
 import { decodeIdToken, OAuth2RequestError } from 'arctic';
 import { twitch, safeNextPath, fetchAccountEmail } from '$lib/server/oauth';
 import { rpc } from '@bagel/shared/server/nats';
@@ -94,6 +95,10 @@ function streamerSession(id: Identity) {
     login: id.login,
     display_name: id.displayName,
     role: 'streamer' as const,
+    // Fresh sid per mint (this is a real login, not a re-seal): 16 random
+    // bytes is the revocation handle's whole identity, so it must not be
+    // guessable or reused.
+    sid: randomBytes(16).toString('base64url'),
     iat: now,
     expires_at: now + SESSION_TTL_SECONDS
   };

--- a/console/dashboard/src/routes/auth/impersonate/+server.ts
+++ b/console/dashboard/src/routes/auth/impersonate/+server.ts
@@ -8,6 +8,7 @@
 // actions audit back to the admin while these fields are present.
 import type { RequestHandler } from './$types';
 import { redirect } from '@sveltejs/kit';
+import { randomBytes } from 'node:crypto';
 import newrelic from 'newrelic';
 import { verifyViewAs } from '@bagel/shared/server/impersonation';
 import { claimOnce } from '@bagel/shared/server/rate-limit';
@@ -46,6 +47,9 @@ export const GET: RequestHandler = async ({ url, cookies }) => {
     login: p.login,
     display_name: p.display_name,
     role: 'streamer',
+    // Fresh sid: an admin "view as" is its own mint, not a re-seal of
+    // anything the admin already holds.
+    sid: randomBytes(16).toString('base64url'),
     iat: now,
     expires_at: now + IMPERSONATION_TTL_SECONDS,
     impersonator_id: p.by_id,

--- a/console/dashboard/src/routes/auth/logout/+server.ts
+++ b/console/dashboard/src/routes/auth/logout/+server.ts
@@ -4,8 +4,18 @@
 import type { RequestHandler } from './$types';
 import { redirect } from '@sveltejs/kit';
 import { COOKIE } from '$lib/server/session';
+import { revokeSession } from '@bagel/shared/server/session-revocation';
 
-export const POST: RequestHandler = ({ cookies, url }) => {
+export const POST: RequestHandler = async ({ cookies, url, locals }) => {
+  const s = locals.session;
+  // Revoke server-side before wiping the cookie: a copy of this cookie taken
+  // off a shared/guest machine must die here too, not just forget itself in
+  // this one browser. A session sealed before sid existed has nothing to
+  // target — cookie deletion alone is still all that session ever had.
+  if (s?.sid) {
+    const now = Math.floor(Date.now() / 1000);
+    await revokeSession(s.sid, s.expires_at - now);
+  }
   cookies.delete(COOKIE, { path: '/', secure: url.protocol === 'https:' });
   throw redirect(302, '/login');
 };

--- a/console/dashboard/src/routes/delegate/enter/+server.ts
+++ b/console/dashboard/src/routes/delegate/enter/+server.ts
@@ -37,6 +37,9 @@ export const GET: RequestHandler = async ({ url, locals, cookies }) => {
     login: s.login,
     display_name: s.display_name,
     role: 'streamer',
+    // Re-seal, not a mint: keep the original sid so a revocation targeting
+    // this browser's session still finds it after switching boards.
+    sid: s.sid,
     iat: s.iat,
     expires_at: s.expires_at,
     delegate_of: owner,

--- a/console/dashboard/src/routes/delegate/exit/+server.ts
+++ b/console/dashboard/src/routes/delegate/exit/+server.ts
@@ -19,6 +19,9 @@ export const GET: RequestHandler = ({ url, locals, cookies }) => {
       login: s.login,
       display_name: s.display_name,
       role: 'streamer',
+      // Re-seal, not a mint: keep the original sid so a revocation targeting
+      // this browser's session still finds it after leaving the board.
+      sid: s.sid,
       iat: s.iat,
       expires_at: s.expires_at
     });

--- a/console/shared/lib/server/session-revocation.test.ts
+++ b/console/shared/lib/server/session-revocation.test.ts
@@ -33,7 +33,7 @@ describe('isSessionRevoked', () => {
   // read must be asked for the user's epoch only, never a sid key.
   test('a missing sid still consults the user epoch, with no sid key', async () => {
     let askedFor: string | undefined = 'unset';
-    setRevocationReadForTests(async (sid) => {
+    setRevocationReadForTests(async ({ sid }) => {
       askedFor = sid;
       return [null, null];
     });
@@ -71,7 +71,7 @@ describe('revokeSession / revokeAllForUser', () => {
   // since those are the oldest cookies in the wild. Keying the epoch check on
   // the sid would have skipped exactly the sessions the control is for.
   test('a sid-less legacy session is still revoked by the user epoch', async () => {
-    setRevocationReadForTests(async (sid, _userId) => {
+    setRevocationReadForTests(async ({ sid }) => {
       expect(sid).toBeUndefined();
       return [null, String(2_000)];
     });

--- a/console/shared/lib/server/session-revocation.test.ts
+++ b/console/shared/lib/server/session-revocation.test.ts
@@ -1,0 +1,85 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import { isSessionRevoked, revokeAllForUser, revokeSession, setRevocationReadForTests } from './session-revocation';
+import { resetMasterClientForTests } from './valkey-master';
+import { registerServerConfig } from './config';
+
+afterEach(() => setRevocationReadForTests(undefined));
+
+describe('isSessionRevoked', () => {
+  test('not revoked when neither key exists', async () => {
+    setRevocationReadForTests(async () => [null, null]);
+    expect(await isSessionRevoked({ sid: 's1', userId: 'u1', iat: 1000 })).toBe(false);
+  });
+
+  test('revoked when the sid key is set', async () => {
+    setRevocationReadForTests(async () => ['1', null]);
+    expect(await isSessionRevoked({ sid: 's1', userId: 'u1', iat: 1000 })).toBe(true);
+  });
+
+  test('revoked by the revoke-all epoch when iat predates it', async () => {
+    setRevocationReadForTests(async () => [null, '2000']);
+    expect(await isSessionRevoked({ sid: 's1', userId: 'u1', iat: 1000 })).toBe(true);
+  });
+
+  test('not revoked when iat is newer than the revoke-all epoch', async () => {
+    setRevocationReadForTests(async () => [null, '2000']);
+    expect(await isSessionRevoked({ sid: 's1', userId: 'u1', iat: 3000 })).toBe(false);
+  });
+
+  // A session sealed before sids existed cannot be revoked individually — the
+  // read must be asked for the user's epoch only, never a sid key.
+  test('a missing sid still consults the user epoch, with no sid key', async () => {
+    let askedFor: string | undefined = 'unset';
+    setRevocationReadForTests(async (sid) => {
+      askedFor = sid;
+      return [null, null];
+    });
+    expect(await isSessionRevoked({ userId: 'u1', iat: 1000 })).toBe(false);
+    expect(askedFor).toBeUndefined();
+  });
+
+  test('fails open when the read is unavailable', async () => {
+    setRevocationReadForTests(async () => {
+      throw new Error('valkey unreachable');
+    });
+    expect(await isSessionRevoked({ sid: 's1', userId: 'u1', iat: 1000 })).toBe(false);
+  });
+});
+
+describe('revokeSession / revokeAllForUser', () => {
+  // Writes must never throw into the logout / "sign out everywhere" flow
+  // even when Valkey is configured but unreachable (a real dial attempt that
+  // fails under the breaker + timeout) — matching how rate-limit.test.ts
+  // drives its own write client without a live Valkey. Explicit config
+  // registration keeps this deterministic regardless of what other test
+  // files in the same `bun test` run already registered (config.ts's
+  // registry is process-global with no reset hook).
+  test('resolve without throwing when Valkey is configured but unreachable', async () => {
+    resetMasterClientForTests();
+    // Nothing listens here; the write fails fast under the breaker + timeout.
+    registerServerConfig({ valkey: { addr: '127.0.0.1:1' }, cacheInvalidationPrefix: 'test' });
+    await expect(revokeSession('s1', 60)).resolves.toBeUndefined();
+    await expect(revokeAllForUser('u1', 1000, 60)).resolves.toBeUndefined();
+    resetMasterClientForTests();
+  });
+
+  // The bug this guards: a session sealed before sids existed has no sid, so
+  // logout cannot target it — but "sign out everywhere" must still kill it,
+  // since those are the oldest cookies in the wild. Keying the epoch check on
+  // the sid would have skipped exactly the sessions the control is for.
+  test('a sid-less legacy session is still revoked by the user epoch', async () => {
+    setRevocationReadForTests(async (sid, _userId) => {
+      expect(sid).toBeUndefined();
+      return [null, String(2_000)];
+    });
+    expect(await isSessionRevoked({ userId: '42', iat: 1_000 })).toBe(true);
+  });
+
+  test('a sid-less legacy session issued after the epoch survives', async () => {
+    setRevocationReadForTests(async () => [null, String(1_000)]);
+    expect(await isSessionRevoked({ userId: '42', iat: 2_000 })).toBe(false);
+  });
+});

--- a/console/shared/lib/server/session-revocation.ts
+++ b/console/shared/lib/server/session-revocation.ts
@@ -117,7 +117,7 @@ export function setRevocationReadForTests(fn: ReadFn | undefined): void {
 export async function isSessionRevoked(input: RevocationCheck): Promise<boolean> {
   try {
     const read = readOverride ?? getRevocation;
-    const [sidHit, allAt] = await read(input.sid, input.userId);
+    const [sidHit, allAt] = await read({ sid: input.sid, userId: input.userId });
     if (sidHit !== null) return true;
     if (allAt !== null) {
       const epoch = Number(allAt);

--- a/console/shared/lib/server/session-revocation.ts
+++ b/console/shared/lib/server/session-revocation.ts
@@ -1,0 +1,134 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+// Server-side revocation for the dashboard's stateless AES-256-GCM session
+// cookie. The cookie alone cannot be revoked (it is self-verifying, not a
+// lookup key), so this gives the console a way to kill one session (logout)
+// or every session a user holds (sign out everywhere) before the cookie's
+// natural expiry — closing the "cookie copied off a shared laptop stays
+// valid for up to 7 days" gap.
+//
+// Reads and writes deliberately use different Valkey connections:
+//   * isSessionRevoked reads through valkey-store.ts's node-local client —
+//     the same replica every other cached read in the console uses. A
+//     revocation can therefore still pass for the replication window
+//     (typically milliseconds) after it lands on the master. That is an
+//     accepted tradeoff on this hot per-request guard path, not something to
+//     paper over with retries or a master read here.
+//   * revokeSession / revokeAllForUser write through valkey-master.ts's
+//     Sentinel-pinned client, because a write that only reached a replica
+//     would never make it to the master at all.
+//
+// Fail-open throughout: any read/write failure is swallowed and logged
+// rather than blocking the request or the sign-out flow — same outage
+// posture as isBanned in services.ts (last-known state wins, nobody gets
+// locked out by an infrastructure blip). Only a sid, a user id, and unix
+// epochs are ever written to Valkey — never a client IP or any other PII.
+import { logger } from './logger';
+import { getRevocation, sessionRevokedAllKey, sessionRevokedKey } from './valkey-store';
+import { masterClient, warmMasterClient } from './valkey-master';
+import { CircuitBreaker, withTimeout } from './resilience';
+
+const OP_TIMEOUT_MS = 200;
+
+// One breaker for revocation writes, isolated from every other Valkey
+// consumer's breaker (rate-limit.ts, valkey-store.ts) — see valkey-master.ts.
+const writeBreaker = new CircuitBreaker({ name: 'valkey-session-revocation', failureThreshold: 3, resetMs: 5_000 });
+
+/** Pre-connect the write client at boot. Best-effort, no-op when Valkey is unconfigured. */
+export function warmSessionRevocation(): void {
+  warmMasterClient();
+}
+
+/**
+ * Revoke one session by its sid (logout). `ttlSeconds` should be the
+ * session's remaining life (expires_at - now) so the key expires on its own
+ * rather than lingering forever. Never throws: a Valkey blip must not block
+ * logout, it only means the old cookie stays valid a little longer than
+ * intended (fail-open).
+ */
+export async function revokeSession(sid: string, ttlSeconds: number): Promise<void> {
+  const client = masterClient();
+  if (!client) return;
+  try {
+    await writeBreaker.run(() =>
+      withTimeout(
+        client.set(sessionRevokedKey(sid), '1', 'EX', Math.max(1, ttlSeconds)),
+        OP_TIMEOUT_MS,
+        'valkey session-revocation write'
+      )
+    );
+  } catch (err) {
+    logger.warn({ err }, '[session-revocation] revokeSession failed');
+  }
+}
+
+/**
+ * Revoke every session a user holds, issued before `atUnixSeconds` (sign out
+ * everywhere). `ttlSeconds` bounds how long the epoch marker needs to live —
+ * pass the account's normal session TTL, since no session can outlive that
+ * anyway. Never throws (fail-open, see revokeSession).
+ */
+export async function revokeAllForUser(userId: string, atUnixSeconds: number, ttlSeconds: number): Promise<void> {
+  const client = masterClient();
+  if (!client) return;
+  try {
+    await writeBreaker.run(() =>
+      withTimeout(
+        client.set(sessionRevokedAllKey(userId), String(atUnixSeconds), 'EX', Math.max(1, ttlSeconds)),
+        OP_TIMEOUT_MS,
+        'valkey session-revocation write'
+      )
+    );
+  } catch (err) {
+    logger.warn({ err }, '[session-revocation] revokeAllForUser failed');
+  }
+}
+
+export interface RevocationCheck {
+  /** Absent for a session sealed before this feature shipped — see below. */
+  sid?: string;
+  userId: string;
+  /** The session's own iat, checked against the user's revoke-all epoch. */
+  iat: number;
+}
+
+// Swappable in tests so the branch logic (revoked-by-sid / revoked-by-epoch /
+// fail-open) can be exercised deterministically without a live Valkey.
+// Defaults to the real node-local read. Test-only; never call in app code.
+type ReadFn = typeof getRevocation;
+let readOverride: ReadFn | undefined;
+export function setRevocationReadForTests(fn: ReadFn | undefined): void {
+  readOverride = fn;
+}
+
+/**
+ * True when the session should be treated as signed out: its own sid was
+ * individually revoked, or it was issued (`iat`) before the user's last
+ * "sign out everywhere".
+ *
+ * A session sealed before sids existed has no sid, so logout cannot target it
+ * individually — but "sign out everywhere" still must, since those are the
+ * oldest cookies in the wild and the likeliest to have been copied off a
+ * shared machine. The epoch check keys on user id and iat, not on the sid, so
+ * it applies to them too. Nobody is signed out by this shipping: the epoch
+ * key only exists once a user asks for it.
+ */
+export async function isSessionRevoked(input: RevocationCheck): Promise<boolean> {
+  try {
+    const read = readOverride ?? getRevocation;
+    const [sidHit, allAt] = await read(input.sid, input.userId);
+    if (sidHit !== null) return true;
+    if (allAt !== null) {
+      const epoch = Number(allAt);
+      if (Number.isFinite(epoch) && input.iat < epoch) return true;
+    }
+    return false;
+  } catch (err) {
+    // getRevocation already fails open internally; this catch is defense in
+    // depth so a future change to the read path (or an injected test stub)
+    // can never turn a Valkey hiccup into a mass sign-out.
+    logger.warn({ err }, '[session-revocation] isSessionRevoked failed, failing open');
+    return false;
+  }
+}

--- a/console/shared/lib/server/valkey-master.ts
+++ b/console/shared/lib/server/valkey-master.ts
@@ -1,0 +1,116 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+// Sentinel/master-pinned Valkey write client, dedicated to session-revocation
+// writes (revokeSession, revokeAllForUser in session-revocation.ts). A
+// revocation write MUST land on the elected master: pointing it at the
+// node-local replica (valkey-store.ts's read client) would let "sign out
+// everywhere" or a single-session revoke lose the race with replication and
+// silently never take effect.
+//
+// This deliberately does NOT share a connection with rate-limit.ts's own
+// master-pinned write client, even though the construction is nearly
+// identical (same low-level helpers below). Each critical-path write
+// dependency gets its own client + circuit breaker, so a fault, reconnect
+// storm, or config change on one never perturbs the other — the same
+// per-dependency isolation resilience.ts's CircuitBreaker doc argues for.
+import Redis from 'iovalkey';
+import {
+  VALKEY_TLS_DATA_PORT,
+  VALKEY_TLS_SENTINEL_PORT,
+  valkeyEndpoint,
+  valkeySentinelNAT,
+  valkeyTLSOptions
+} from './valkey-connection';
+import { getServerConfig, hasServerConfig } from './config';
+
+let client: Redis | null = null;
+let disabled = false;
+
+/**
+ * Lazily build (or return the cached) Sentinel-pinned master client. Null
+ * when Valkey is unconfigured (dev, unit tests, misordered boot) — callers
+ * degrade rather than throw. Breaker + per-op timeout are the caller's job
+ * (see session-revocation.ts), matching how valkey-store.ts and rate-limit.ts
+ * each own their own resilience around their own client.
+ */
+export function masterClient(): Redis | null {
+  if (disabled) return null;
+  if (client) return client;
+  // Config is registered by the init hook; tolerate its absence (unit tests,
+  // misordered boot) by returning null instead of throwing.
+  const cfg = hasServerConfig() ? getServerConfig().valkey : undefined;
+  if (!cfg) {
+    disabled = true;
+    return null;
+  }
+
+  const tls = valkeyTLSOptions(cfg);
+  let c: Redis;
+  if (cfg.sentinelAddr) {
+    const endpoint = valkeyEndpoint(cfg.sentinelAddr, Boolean(tls), VALKEY_TLS_SENTINEL_PORT);
+    c = new Redis({
+      sentinels: [endpoint],
+      // `||` not `??`: an empty VALKEY_MASTER_SET (unset in Doppler comes
+      // through as "") must fall back to the sentinel's monitored name, not
+      // be used verbatim — a blank master name never resolves, so every
+      // revocation write would silently time out.
+      name: cfg.sentinelMaster || 'myprimary',
+      password: cfg.password || undefined,
+      // The sentinels carry the same requirepass as the data nodes (ACL
+      // default user with a password hash), and ioredis authenticates the
+      // sentinel hop separately from the master connection. Without this the
+      // sentinel answers NOAUTH, the client never resolves a master, and
+      // every write silently degrades to fail-open.
+      sentinelPassword: cfg.password || undefined,
+      tls,
+      sentinelTLS: tls,
+      enableTLSForSentinelMode: Boolean(tls),
+      natMap: tls ? valkeySentinelNAT : undefined,
+      // Fail fast, never queue: an unreachable master must degrade
+      // immediately, not grow an unbounded command queue.
+      enableOfflineQueue: false,
+      maxRetriesPerRequest: 1,
+      connectTimeout: 1000,
+      retryStrategy: (times) => Math.min(times * 200, 2000),
+      sentinelRetryStrategy: (times: number) => Math.min(times * 200, 2000)
+    });
+  } else {
+    const endpoint = valkeyEndpoint(cfg.addr, Boolean(tls), VALKEY_TLS_DATA_PORT);
+    c = new Redis({
+      host: endpoint.host,
+      port: endpoint.port,
+      password: cfg.password || undefined,
+      tls,
+      enableOfflineQueue: false,
+      maxRetriesPerRequest: 1,
+      connectTimeout: 1000,
+      retryStrategy: (times) => Math.min(times * 200, 2000)
+    });
+  }
+
+  // Swallow connection errors; ops fail fast under the caller's own breaker +
+  // timeout and this client reconnects in the background.
+  c.on('error', () => {});
+  client = c;
+  return client;
+}
+
+/**
+ * Pre-connect the master client at boot so the first revocation write does
+ * not pay the dial. Best-effort, no-op when Valkey is unconfigured. Call
+ * from the init hook (alongside warmRateLimiter / valkey-store's warm).
+ */
+export function warmMasterClient(): void {
+  masterClient();
+}
+
+/**
+ * Drop the cached client and its disabled latch so a test can re-run client
+ * resolution against fresh config. Test-only; never call in app code.
+ */
+export function resetMasterClientForTests(): void {
+  client?.disconnect();
+  client = null;
+  disabled = false;
+}

--- a/console/shared/lib/server/valkey-master.ts
+++ b/console/shared/lib/server/valkey-master.ts
@@ -27,6 +27,47 @@ import { getServerConfig, hasServerConfig } from './config';
 let client: Redis | null = null;
 let disabled = false;
 
+type ValkeyConfig = NonNullable<ReturnType<typeof getServerConfig>['valkey']>;
+type TLSOptions = ReturnType<typeof valkeyTLSOptions>;
+
+// Shared by both connection shapes: fail fast, never queue. An unreachable
+// master must degrade immediately (the caller's breaker takes over), not grow
+// an unbounded command queue.
+const FAIL_FAST = {
+  enableOfflineQueue: false,
+  maxRetriesPerRequest: 1,
+  connectTimeout: 1000,
+  retryStrategy: (times: number) => Math.min(times * 200, 2000)
+} as const;
+
+function sentinelOptions(cfg: ValkeyConfig, tls: TLSOptions) {
+  return {
+    sentinels: [valkeyEndpoint(cfg.sentinelAddr as string, Boolean(tls), VALKEY_TLS_SENTINEL_PORT)],
+    // `||` not `??`: an empty VALKEY_MASTER_SET (unset in Doppler comes
+    // through as "") must fall back to the sentinel's monitored name, not be
+    // used verbatim — a blank master name never resolves, so every revocation
+    // write would silently time out.
+    name: cfg.sentinelMaster || 'myprimary',
+    password: cfg.password || undefined,
+    // The sentinels carry the same requirepass as the data nodes, and ioredis
+    // authenticates the sentinel hop separately from the master connection.
+    // Without this the sentinel answers NOAUTH, the client never resolves a
+    // master, and every write silently degrades to fail-open.
+    sentinelPassword: cfg.password || undefined,
+    tls,
+    sentinelTLS: tls,
+    enableTLSForSentinelMode: Boolean(tls),
+    natMap: tls ? valkeySentinelNAT : undefined,
+    sentinelRetryStrategy: (times: number) => Math.min(times * 200, 2000),
+    ...FAIL_FAST
+  };
+}
+
+function directOptions(cfg: ValkeyConfig, tls: TLSOptions) {
+  const endpoint = valkeyEndpoint(cfg.addr, Boolean(tls), VALKEY_TLS_DATA_PORT);
+  return { host: endpoint.host, port: endpoint.port, password: cfg.password || undefined, tls, ...FAIL_FAST };
+}
+
 /**
  * Lazily build (or return the cached) Sentinel-pinned master client. Null
  * when Valkey is unconfigured (dev, unit tests, misordered boot) — callers
@@ -46,49 +87,7 @@ export function masterClient(): Redis | null {
   }
 
   const tls = valkeyTLSOptions(cfg);
-  let c: Redis;
-  if (cfg.sentinelAddr) {
-    const endpoint = valkeyEndpoint(cfg.sentinelAddr, Boolean(tls), VALKEY_TLS_SENTINEL_PORT);
-    c = new Redis({
-      sentinels: [endpoint],
-      // `||` not `??`: an empty VALKEY_MASTER_SET (unset in Doppler comes
-      // through as "") must fall back to the sentinel's monitored name, not
-      // be used verbatim — a blank master name never resolves, so every
-      // revocation write would silently time out.
-      name: cfg.sentinelMaster || 'myprimary',
-      password: cfg.password || undefined,
-      // The sentinels carry the same requirepass as the data nodes (ACL
-      // default user with a password hash), and ioredis authenticates the
-      // sentinel hop separately from the master connection. Without this the
-      // sentinel answers NOAUTH, the client never resolves a master, and
-      // every write silently degrades to fail-open.
-      sentinelPassword: cfg.password || undefined,
-      tls,
-      sentinelTLS: tls,
-      enableTLSForSentinelMode: Boolean(tls),
-      natMap: tls ? valkeySentinelNAT : undefined,
-      // Fail fast, never queue: an unreachable master must degrade
-      // immediately, not grow an unbounded command queue.
-      enableOfflineQueue: false,
-      maxRetriesPerRequest: 1,
-      connectTimeout: 1000,
-      retryStrategy: (times) => Math.min(times * 200, 2000),
-      sentinelRetryStrategy: (times: number) => Math.min(times * 200, 2000)
-    });
-  } else {
-    const endpoint = valkeyEndpoint(cfg.addr, Boolean(tls), VALKEY_TLS_DATA_PORT);
-    c = new Redis({
-      host: endpoint.host,
-      port: endpoint.port,
-      password: cfg.password || undefined,
-      tls,
-      enableOfflineQueue: false,
-      maxRetriesPerRequest: 1,
-      connectTimeout: 1000,
-      retryStrategy: (times) => Math.min(times * 200, 2000)
-    });
-  }
-
+  const c = new Redis(cfg.sentinelAddr ? sentinelOptions(cfg, tls) : directOptions(cfg, tls));
   // Swallow connection errors; ops fail fast under the caller's own breaker +
   // timeout and this client reconnects in the background.
   c.on('error', () => {});

--- a/console/shared/lib/server/valkey-store.ts
+++ b/console/shared/lib/server/valkey-store.ts
@@ -146,10 +146,13 @@ export async function ready(): Promise<boolean> {
  * must never block the request. Returns [null, null] on a cold/absent key
  * OR on any failure — the caller cannot and must not tell those apart.
  */
-export async function getRevocation(
-  sid: string | undefined,
-  userId: string
-): Promise<[string | null, string | null]> {
+export interface RevocationKeys {
+  /** Absent for a session sealed before sids existed. */
+  sid?: string;
+  userId: string;
+}
+
+export async function getRevocation({ sid, userId }: RevocationKeys): Promise<[string | null, string | null]> {
   const c = get();
   if (!c) return [null, null];
   try {

--- a/console/shared/lib/server/valkey-store.ts
+++ b/console/shared/lib/server/valkey-store.ts
@@ -25,10 +25,13 @@
 import Redis from 'iovalkey';
 import type { CommandView } from '../types';
 import { getServerConfig } from './config';
+import { logger } from './logger';
 import { CircuitBreaker, withTimeout } from './resilience';
 import { VALKEY_TLS_DATA_PORT, valkeyEndpoint, valkeyTLSOptions } from './valkey-connection';
 
 const SETTINGS_PREFIX = 'settings:';
+const SESSION_REVOKED_PREFIX = 'session-revoked:';
+const SESSION_REVOKED_ALL_PREFIX = 'session-revoked-all:';
 const OP_TIMEOUT_MS = 200;
 
 // One breaker for the whole Valkey read tier. Once it trips (Valkey down/slow),
@@ -55,6 +58,16 @@ async function op<T>(run: (c: Redis) => Promise<T>, fallback: T): Promise<T> {
 
 function settingsKey(userId: string): string {
   return SETTINGS_PREFIX + userId;
+}
+
+/** Key holding one revoked session's sid. Written by session-revocation.ts. */
+export function sessionRevokedKey(sid: string): string {
+  return SESSION_REVOKED_PREFIX + sid;
+}
+
+/** Key holding a user's "sign out everywhere" epoch. Written by session-revocation.ts. */
+export function sessionRevokedAllKey(userId: string): string {
+  return SESSION_REVOKED_ALL_PREFIX + userId;
 }
 
 let client: Redis | null = null;
@@ -116,6 +129,44 @@ export async function ready(): Promise<boolean> {
     await c.ping();
     return true;
   }, true);
+}
+
+/**
+ * Read-only revocation check for session-revocation.ts: both keys in one
+ * MGET so a single op() budget covers the whole check. This is a NODE-LOCAL
+ * (replica) read, same as every other lookup in this file — a session
+ * revoked on the master can still pass here for the replication window
+ * (typically milliseconds). That is the accepted tradeoff for keeping
+ * revocation checks on the hot request-guard path cheap; it is not
+ * compensated for with retries or a master read here.
+ *
+ * Unlike this file's other reads (which degrade silently — a cache miss is
+ * routine), a failure here is logged: revocation is a security control, and
+ * a Valkey blip that always fails open is worth surfacing even though it
+ * must never block the request. Returns [null, null] on a cold/absent key
+ * OR on any failure — the caller cannot and must not tell those apart.
+ */
+export async function getRevocation(
+  sid: string | undefined,
+  userId: string
+): Promise<[string | null, string | null]> {
+  const c = get();
+  if (!c) return [null, null];
+  try {
+    // A session sealed before sids existed has no per-session key to look up,
+    // but the user's revoke-all epoch still applies to it — read that alone
+    // rather than skipping the check, or "sign out everywhere" would miss
+    // exactly the long-lived cookies it exists to kill.
+    const keys = sid ? [sessionRevokedKey(sid), sessionRevokedAllKey(userId)] : [sessionRevokedAllKey(userId)];
+    const values = await breaker.run(() =>
+      withTimeout(c.mget(...keys), OP_TIMEOUT_MS, 'valkey session-revocation read')
+    );
+    const [sidHit, allAt] = sid ? values : [null, values[0]];
+    return [sidHit ?? null, allAt ?? null];
+  } catch (err) {
+    logger.warn({ err }, '[valkey-store] session-revocation read failed, failing open');
+    return [null, null];
+  }
 }
 
 export interface ValkeyUser {

--- a/console/shared/package.json
+++ b/console/shared/package.json
@@ -30,6 +30,7 @@
     "./server/invalidation": "./lib/server/invalidation.ts",
     "./server/impersonation": "./lib/server/impersonation.ts",
     "./server/valkey-store": "./lib/server/valkey-store.ts",
+    "./server/session-revocation": "./lib/server/session-revocation.ts",
     "./validation": "./lib/validation.ts",
     "./i18n": "./lib/i18n/messages.ts",
     "./styles/tokens.css": "./styles/tokens.css",


### PR DESCRIPTION
Closes the "cookie copied off a guest laptop stays valid" gap.

## The gap

The session cookie is stateless AES-256-GCM — self-verifying, not a lookup key. `POST /auth/logout` only called `cookies.delete`, which asks *that one browser* to forget it. A copy lifted off a shared machine (devtools, profile copy, an unattended browser) stayed valid for the rest of its life — up to 7 days — and nothing the user did could kill it. No revocation, no "sign out everywhere".

The cookie itself was never the weak part: AES-256-GCM with AAD over an app-isolated 32-byte key, `httpOnly`/`secure`/`sameSite=lax` at every set site, tamper → `null`, and a per-kind TTL cap a re-seal cannot extend. It cannot be forged — only copied.

## What this adds

- A random 16-byte `sid` on every session, minted at the two mint sites (OAuth callback, admin view-as) and **preserved across re-seals** (`/delegate/enter`, `/delegate/exit`) so switching boards doesn't orphan a revocation.
- Two markers checked in `guardSession`, which already runs for every authenticated request — form actions and `+server.ts` endpoints included: the session's own sid, and a per-user epoch that kills everything issued before it.
- `logout` writes the sid marker with a TTL of the session's remaining life, so keys expire on their own.
- A `signOutEverywhere` settings action writes the epoch — **the control that actually solves the guest-laptop case**, since the user acts from their own device and never needs the stolen cookie. Owner-only; a delegate is rejected.

## Design decisions

- **Reads node-local, writes master.** Reads go through valkey-store's existing client like every other cached read; writes go through a Sentinel-pinned client. Consequence, written into the read path rather than left implied: a just-revoked session can still pass for the replication window (milliseconds). Accepted on a hot per-request path.
- **Fails open everywhere.** Any Valkey error or timeout (200ms, circuit-breakered) is swallowed and logged. A blip must not lock everyone out, nor trap a user in a session they asked to leave. Matches `isBanned`'s existing outage posture.
- **Legacy sessions.** A cookie sealed before sids existed cannot be targeted individually, but the epoch check keys on user id + `iat`, so sign-out-everywhere still kills it — those are the oldest cookies in the wild and the likeliest to have been copied. Nobody is signed out by this shipping: the epoch key only exists once a user asks for it.
- **`rate-limit.ts` is untouched.** The master client is built alongside it from the same `valkey-connection` helpers rather than extracted out of a critical path.
- Only sids, user ids, and epochs are written to Valkey — never a client IP.

## Verification

- `bun test shared` → 143 pass, 0 fail (8 new tests). The legacy-session case is **mutation-tested**: reintroducing the early-return makes it fail, restoring it passes — the coverage is real, not vacuous.
- `bun run --filter dashboard check` → 0 errors.
- `cd dashboard && bun run build` → passes both demo gates (`Verified 269 production build files`).
- Not verifiable without a live Sentinel pair: the real MGET/SET round trips, TTL expiry, and replication-lag behaviour. Covered by injected-stub unit tests plus an unreachable-config test proving both paths never throw.

## Follow-ups, deliberately not here

- No UI: the settings button for sign-out-everywhere is a separate change.
- Sign-out-everywhere sweeps the **owner's own** sessions. Delegates' access to that board is revoked through the existing delegation revoke, not this.
