### PR TITLE
chore(deploy): pin both consoles to the session-revocation images

### DIFF
--- a/deploy/k8s/console-admin.yaml
+++ b/deploy/k8s/console-admin.yaml
@@ -116,7 +116,7 @@ spec:
         seccompProfile: {type: RuntimeDefault}
       containers:
         - name: console-admin
-          image: ghcr.io/adamousmer/itsbagelbot/console-admin:main-1787011027-4cfd46290494@sha256:ae9db3ba9f132a45e9dee486cd1f9ce804efd9c41943beb7604e260807aae341 # {"$imagepolicy": "flux-system:console-admin"}
+          image: ghcr.io/adamousmer/itsbagelbot/console-admin:main-1787105223-984f2e360732@sha256:7feac71cfe8e39e8627dcc67a8d077575407398c608424dc1802ad814474a0d7 # {"$imagepolicy": "flux-system:console-admin"}
           imagePullPolicy: IfNotPresent
           env:
             # mTLS client identity for both NATS planes (nats-client-tls,

--- a/deploy/k8s/console-dashboard.yaml
+++ b/deploy/k8s/console-dashboard.yaml
@@ -116,7 +116,7 @@ spec:
         seccompProfile: {type: RuntimeDefault}
       containers:
         - name: console-dashboard
-          image: ghcr.io/adamousmer/itsbagelbot/console-dashboard:main-1787031492-c07af1629959@sha256:0d82b63786f9212c85c13a12e1c1fefbd5fb3bae24bc1438e3daaa6a46cbe67c
+          image: ghcr.io/adamousmer/itsbagelbot/console-dashboard:main-1787105223-984f2e360732@sha256:c950e43d919e9979906083ee24b9ced01ac9c10385bb3f4f6caab195b9387b7c
           imagePullPolicy: IfNotPresent
           env:
             - name: PORT


### PR DESCRIPTION
Deploy pin for the console security work: #594, #595, #596, #597, #598.

Both images built from `984f2e36` by run 32207399134, all four arch builds green.

- console-dashboard → `sha256:c950e43d…`
- console-admin → `sha256:7feac71c…`

The replaced digests match what is currently live on the cluster, so this is a clean bump with no drift.