### PR TITLE
fix(dashboard): make session revocation actually take effect

### DIFF
--- a/console/dashboard/src/lib/server/guard.ts
+++ b/console/dashboard/src/lib/server/guard.ts
@@ -104,7 +104,10 @@ async function assertAccountUsable(event: RequestEvent, s: Session): Promise<voi
 
   if (await isSessionRevoked({ sid: s.sid, userId: s.user_id, iat: s.iat })) {
     wipe(event);
-    throw redirect(303, '/login?e=signedout');
+    // Not ?e=signedout: that notice tells the visitor their account no longer
+    // exists, which is the ghost-session case below. A revoked session is a
+    // live account the user deliberately signed out.
+    throw redirect(303, '/login?e=revoked');
   }
 
   try {

--- a/console/dashboard/src/routes/(app)/settings/+page.server.ts
+++ b/console/dashboard/src/routes/(app)/settings/+page.server.ts
@@ -236,6 +236,6 @@ export const actions: Actions = {
     if (s.sid) await revokeSession(s.sid, s.expires_at - now);
 
     cookies.delete(COOKIE, { path: '/', secure: url.protocol === 'https:' });
-    throw redirect(303, '/login?e=signedout');
+    throw redirect(303, '/login?e=revoked');
   }
 };

--- a/console/dashboard/src/routes/login/+page.svelte
+++ b/console/dashboard/src/routes/login/+page.svelte
@@ -12,6 +12,7 @@
   // Why the visitor bounced back here, when the app sent them with a reason.
   const NOTICES: Record<string, string> = {
     signedout: t('login.noticeSignedout'),
+    revoked: t('login.noticeRevoked'),
     banned: t('login.noticeBanned'),
     link: t('login.noticeLink'),
     retry: t('login.noticeRetry'),

--- a/console/shared/lib/i18n/locales/en.json
+++ b/console/shared/lib/i18n/locales/en.json
@@ -67,6 +67,7 @@
     "featEncrypted": "End-to-end encrypted",
     "featEdge": "Fast from anywhere",
     "noticeSignedout": "You were signed out. That account no longer exists on ItsBagelBot.",
+    "noticeRevoked": "You were signed out on every device. Sign in again to continue.",
     "noticeBanned": "This account can no longer use the console.",
     "noticeLink": "That share link is no longer valid. Ask the broadcaster for a new one.",
     "noticeRetry": "Sign-in did not finish on our side. Nothing was saved. Please try again.",

--- a/console/shared/lib/i18n/locales/fr.json
+++ b/console/shared/lib/i18n/locales/fr.json
@@ -67,6 +67,7 @@
     "featEncrypted": "Chiffrement de bout en bout",
     "featEdge": "Rapide partout",
     "noticeSignedout": "Vous avez été déconnecté. Ce compte n'existe plus sur ItsBagelBot.",
+    "noticeRevoked": "Vous avez été déconnecté sur tous vos appareils. Reconnectez-vous pour continuer.",
     "noticeBanned": "Ce compte ne peut plus utiliser la console.",
     "noticeLink": "Ce lien de partage n'est plus valide. Demandez un nouveau lien au diffuseur.",
     "noticeRetry": "La connexion n'a pas abouti. Rien n'a été sauvegardé. Veuillez réessayer.",

--- a/console/shared/lib/server/valkey-store.ts
+++ b/console/shared/lib/server/valkey-store.ts
@@ -41,6 +41,18 @@ const OP_TIMEOUT_MS = 200;
 // every page render.
 const breaker = new CircuitBreaker({ name: 'valkey', failureThreshold: 3, resetMs: 5_000 });
 
+// Revocation reads get their OWN breaker, deliberately not the shared read-tier
+// one above. A cached read tripping that breaker is harmless — the caller falls
+// through to RPC — but it must never take the session-revocation check down with
+// it: a security control silently disabled by an unrelated component's failure
+// is exactly how a revoked session stays alive. Same failure-open posture, just
+// not the same fate.
+const revocationBreaker = new CircuitBreaker({
+  name: 'valkey-session-revocation-read',
+  failureThreshold: 3,
+  resetMs: 5_000
+});
+
 /**
  * Run a Valkey op under the breaker + a per-op timeout. Returns `fallback` (the
  * caller's miss sentinel) on a disabled store, an open circuit, a timeout, or
@@ -161,7 +173,7 @@ export async function getRevocation({ sid, userId }: RevocationKeys): Promise<[s
     // rather than skipping the check, or "sign out everywhere" would miss
     // exactly the long-lived cookies it exists to kill.
     const keys = sid ? [sessionRevokedKey(sid), sessionRevokedAllKey(userId)] : [sessionRevokedAllKey(userId)];
-    const values = await breaker.run(() =>
+    const values = await revocationBreaker.run(() =>
       withTimeout(c.mget(...keys), OP_TIMEOUT_MS, 'valkey session-revocation read')
     );
     const [sidHit, allAt] = sid ? values : [null, values[0]];

--- a/deploy/k8s/console-admin.yaml
+++ b/deploy/k8s/console-admin.yaml
@@ -156,6 +156,17 @@ spec:
                 configMapKeyRef:
                   name: fleet-ca
                   key: ca.pem
+            - name: VALKEY_ADDR
+              # Authoritative here, not in Doppler: dashboard-env/console-admin-env
+              # still carry valkey.valkey.svc.cluster.local from before the cache
+              # moved to its own namespace, and that name is NXDOMAIN — every
+              # node-local read failed, the read breaker sat open, and the session
+              # revocation check failed open on every request. The sentinel address
+              # was already right, which is why writes landed and only reads broke.
+              # An explicit env entry wins over envFrom, so the stale copy is inert.
+              # The port is cosmetic: valkeyEndpoint rewrites it to the TLS port
+              # whenever a CA is present, which it is (VALKEY_TLS_CA_PEM below).
+              value: valkey-local.cache.svc.cluster.local:6380
             - name: VALKEY_TLS_SERVER_NAME
               value: valkey.cache.svc.cluster.local
             # mTLS: pkg/valkey's clientTLSConfig() treats these two as

--- a/deploy/k8s/console-dashboard.yaml
+++ b/deploy/k8s/console-dashboard.yaml
@@ -174,6 +174,17 @@ spec:
                 configMapKeyRef:
                   name: fleet-ca
                   key: ca.pem
+            - name: VALKEY_ADDR
+              # Authoritative here, not in Doppler: dashboard-env/console-admin-env
+              # still carry valkey.valkey.svc.cluster.local from before the cache
+              # moved to its own namespace, and that name is NXDOMAIN — every
+              # node-local read failed, the read breaker sat open, and the session
+              # revocation check failed open on every request. The sentinel address
+              # was already right, which is why writes landed and only reads broke.
+              # An explicit env entry wins over envFrom, so the stale copy is inert.
+              # The port is cosmetic: valkeyEndpoint rewrites it to the TLS port
+              # whenever a CA is present, which it is (VALKEY_TLS_CA_PEM below).
+              value: valkey-local.cache.svc.cluster.local:6380
             - name: VALKEY_TLS_SERVER_NAME
               value: valkey.cache.svc.cluster.local
             - name: VALKEY_TLS_CLIENT_CERT_FILE


### PR DESCRIPTION
Both defects you hit on the live deploy, plus the reason revocation could never have worked.

## 1. Revocation never took effect — stale Valkey host, not the feature

Your instinct about in-process caching was right, just a circuit breaker rather than a cache. The pod logs show:

```
[valkey-store] session-revocation read failed, failing open   err: circuit "valkey" is open
```

…and **no matching write failure**. The revocation landed; the read never saw it.

Chasing why that breaker was open found a pre-existing misconfiguration: `dashboard-env` and `console-admin-env` still carry `VALKEY_ADDR=valkey.valkey.svc.cluster.local` from before the cache moved to its own namespace. That name is **NXDOMAIN** (verified). Only the host was wrong — the sentinel address already pointed at `cache`, which is exactly why **writes** worked and only reads broke, and the port is cosmetic because `valkeyEndpoint` rewrites it to the TLS port whenever a CA is present.

This was silently degrading more than revocation: every cached read fell through to RPC, and the fleet-wide rate limiter fell back to per-pod buckets (three pods each enforcing the full budget). Nothing surfaced it because those paths degrade quietly — the new revocation logging is what made it visible.

Fixed in the manifest next to the TLS wiring it depends on: an address is not a secret, and an explicit `env` entry wins over `envFrom`, so the stale Doppler copy is inert. Verified `valkey-local.cache.svc.cluster.local:6380` accepts connections and the old name does not resolve. TLS material, client cert and mounts were already correct.

**`gossip-env` carries the same stale host** and needs the same correction — different client path, so left for its own change.

## 2. Revocation borrowed the deleted-account notice

Both revocation exits redirected to `?e=signedout`, whose copy reads *"You were signed out. That account no longer exists on ItsBagelBot."* — written for the ghost-session gate sitting right below it. Signing out of your own devices is not an account deletion and must not say so. New `?e=revoked` notice in EN and FR; the ghost-session exit keeps `signedout`.

## 3. A security control must not share an unrelated breaker

Even with the address fixed, the revocation read ran under `valkey-store`'s single read-tier breaker, shared with every cached read. A cached read tripping it is harmless — the caller falls through to RPC. Taking the revocation check down with it is not: that is precisely how a revoked session stays alive. Revocation reads now have their own breaker, same fail-open posture, separate fate.

## Verified

`svelte-check` 0 errors · `bun test shared` 143 pass · production build passes both demo gates · `check-i18n` parity.
