### PR TITLE
chore(deploy): pin both consoles to the revocation-fix images

### DIFF
--- a/deploy/k8s/console-admin.yaml
+++ b/deploy/k8s/console-admin.yaml
@@ -116,7 +116,7 @@ spec:
         seccompProfile: {type: RuntimeDefault}
       containers:
         - name: console-admin
-          image: ghcr.io/adamousmer/itsbagelbot/console-admin:main-1787105223-984f2e360732@sha256:7feac71cfe8e39e8627dcc67a8d077575407398c608424dc1802ad814474a0d7 # {"$imagepolicy": "flux-system:console-admin"}
+          image: ghcr.io/adamousmer/itsbagelbot/console-admin:main-1787146401-5f6df5e1b0c5@sha256:f6c4c6378454dd8e9d47f66f9bde1122df0aa0a2fa3c7615ea3f51293879cc54 # {"$imagepolicy": "flux-system:console-admin"}
           imagePullPolicy: IfNotPresent
           env:
             # mTLS client identity for both NATS planes (nats-client-tls,

--- a/deploy/k8s/console-dashboard.yaml
+++ b/deploy/k8s/console-dashboard.yaml
@@ -116,7 +116,7 @@ spec:
         seccompProfile: {type: RuntimeDefault}
       containers:
         - name: console-dashboard
-          image: ghcr.io/adamousmer/itsbagelbot/console-dashboard:main-1787105223-984f2e360732@sha256:c950e43d919e9979906083ee24b9ced01ac9c10385bb3f4f6caab195b9387b7c
+          image: ghcr.io/adamousmer/itsbagelbot/console-dashboard:main-1787146401-5f6df5e1b0c5@sha256:8b5e36d454f0e41bdfb1f6c4dbab8b2e630e4a664b215b2125b47d69acae82fa
           imagePullPolicy: IfNotPresent
           env:
             - name: PORT


### PR DESCRIPTION
Deploy pin for #600. Built from `5f6df5e1` by run 32258766426, all four arch builds green.

- console-dashboard → `sha256:8b5e36d4…`
- console-admin → `sha256:f6c4c637…`