### PR TITLE
fix(deploy): drop the dead NATS_HOST from gossip

### DIFF
--- a/deploy/k8s/gossip.yaml
+++ b/deploy/k8s/gossip.yaml
@@ -105,8 +105,6 @@ spec:
           image: ghcr.io/adamousmer/itsbagelbot/gossip:main-1787011027-4cfd46290494@sha256:362b71c855d238923b24eb3ef07ad1e246780467d1ae5560fc386077403273de # {"$imagepolicy": "flux-system:gossip"}
           imagePullPolicy: IfNotPresent
           env:
-            - name: NATS_HOST
-              value: nats
             # gossip is RPC-only: it answers sesame's requests over
             # bagel.rpc.gossip.> and never touches JetStream, so it dials the
             # leaf exclusively (no NATS_HUB_URL) and carries no BUS credential.


### PR DESCRIPTION
`gossip.yaml` set `NATS_HOST: nats`, which nothing in gossip reads — `NATS_HOST` is consumed only by the Elixir ingress (`config/runtime.exs`) and the consoles (`shared/server/nats.ts`). gossip reaches NATS through `NATS_URL` / `NATS_RPC_URL` / `NATS_LEAF_URL`, all set immediately below it.

The value was wrong on its face too: a bare `nats` resolves only within the pod's own namespace, and NATS lives in `messaging`. Anything that *did* read it would have failed. Removed rather than corrected, since gossip has no consumer for it.

gossip is otherwise healthy — zero errors in the last hour, and its `VALKEY_ADDR` (sentinel) / `VALKEY_LOCAL_ADDR` (node-local) / leaf URLs are all correct.