### PR TITLE
feat(nav): add stats and status links

### DIFF
--- a/console/dashboard/src/routes/(app)/+layout.svelte
+++ b/console/dashboard/src/routes/(app)/+layout.svelte
@@ -130,6 +130,7 @@
     ...(!isDelegate
       ? [{ href: '/settings', icon: 'settings', label: t('nav.settings'), active: section === 'settings' }]
       : [])
+    ,{ href: 'https://stats.itsbagelbot.com', icon: 'bar-chart', label: t('nav.stats'), active: false }
   ] as NavLink[]);
 
   const groups = $derived([{ label: t('nav.manage'), items }] as NavGroupDef[]);
@@ -171,6 +172,7 @@
     {/if}
   {/snippet}
   {#snippet topActions()}
+    <a href="https://status.itsbagelbot.com" class="status-link" target="_blank" rel="noopener noreferrer">{t('nav.status')}</a>
     {#if !isDelegate}
       <NotificationBell
         notifications={(data.bellNotifications ?? [])}
@@ -187,6 +189,20 @@
   {/snippet}
   {@render children()}
 </AppShell>
+
+<style>
+  .status-link {
+    font-family: var(--bb-font-body, inherit);
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--bb-muted, #a39b8b);
+    text-decoration: none;
+    transition: color 180ms ease;
+  }
+  .status-link:hover {
+    color: var(--bb-tan-pale, #eceae1);
+  }
+</style>
 
 <!-- Hidden mark-read form the bell submits into; ?/markRead lives on the
      /settings route but SvelteKit actions can target any page. -->

--- a/console/shared/lib/i18n/locales/en.json
+++ b/console/shared/lib/i18n/locales/en.json
@@ -37,6 +37,8 @@
     "channelpoints": "Channel Points",
     "timers": "Timers",
     "billing": "Billing",
+    "stats": "Stats",
+    "status": "Status",
     "settings": "Settings"
   },
   "topbar": {
@@ -91,6 +93,7 @@
       "guides": "Guides",
       "contact": "Contact",
       "stats": "Stats",
+      "status": "Status",
       "cta": "Add to Twitch"
     },
     "footer": {
@@ -267,6 +270,8 @@
     "commands": "Commands",
     "modules": "Modules",
     "billing": "Billing",
+    "stats": "Stats",
+    "status": "Status",
     "editAccess": "Edit access",
     "notifications": "Notifications",
     "notificationsEmpty": "Nothing yet. Messages from the ItsBagelBot team will show up here.",

--- a/console/shared/lib/i18n/locales/fr.json
+++ b/console/shared/lib/i18n/locales/fr.json
@@ -37,6 +37,8 @@
     "channelpoints": "Points de chaîne",
     "timers": "Minuteries",
     "billing": "Facturation",
+    "stats": "Stats",
+    "status": "Statut",
     "settings": "Paramètres"
   },
   "topbar": {
@@ -267,6 +269,8 @@
     "commands": "Commandes",
     "modules": "Modules",
     "billing": "Facturation",
+    "stats": "Stats",
+    "status": "Statut",
     "editAccess": "Modifier l'accès",
     "notifications": "Notifications",
     "notificationsEmpty": "Rien pour le moment. Les messages de l'équipe ItsBagelBot apparaîtront ici.",

--- a/web/src/components/layout/Nav.astro
+++ b/web/src/components/layout/Nav.astro
@@ -19,6 +19,8 @@ const links = [
     { href: localizePath("/pricing", lang),  label: t('nav.pricing')  },
     { href: localizePath("/guides", lang),   label: t('nav.guides')   },
     { href: localizePath("/contact", lang),  label: t('nav.contact')  },
+    { href: "https://stats.itsbagelbot.com", label: t('nav.stats')    },
+    { href: "https://status.itsbagelbot.com",label: t('nav.status')   },
 ];
 
 const cta = { href: `https://dashboard.itsbagelbot.com${lang === defaultLang ? '' : `?lang=${lang}`}`, label: t('nav.cta') };

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -2,6 +2,8 @@
   "nav.pricing": "Pricing",
   "nav.guides": "Guides",
   "nav.contact": "Contact",
+  "nav.stats": "Stats",
+  "nav.status": "Status",
   "nav.cta": "Add to Twitch",
   "nav.getApp": "Get the app",
   "nav.primary": "Primary",

--- a/web/src/i18n/locales/fr.json
+++ b/web/src/i18n/locales/fr.json
@@ -2,6 +2,8 @@
   "nav.pricing": "Tarifs",
   "nav.guides": "Guides",
   "nav.contact": "Contact",
+  "nav.stats": "Stats",
+  "nav.status": "Statut",
   "nav.cta": "Ajouter à Twitch",
   "nav.getApp": "Installer l'app",
   "nav.primary": "Principal",


### PR DESCRIPTION
Adds the required Stats and Status links to both the web marketing site navigation and the dashboard console navigation.