### PR TITLE
chore(console): bolota 0.1.6

### DIFF
--- a/console/bun.lock
+++ b/console/bun.lock
@@ -52,7 +52,7 @@
       "name": "@bagel/shared",
       "version": "0.0.0",
       "dependencies": {
-        "@luzir/bolota": "0.1.5",
+        "@luzir/bolota": "0.1.6",
         "iovalkey": "^0.4.0",
         "lenis": "^1.3.18",
         "motion": "^12.0.0",
@@ -103,7 +103,7 @@
 
     "@js-sdsl/ordered-map": ["@js-sdsl/ordered-map@4.4.2", "", {}, "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw=="],
 
-    "@luzir/bolota": ["@luzir/bolota@0.1.5", "", {}, "sha512-blbyL+q7A10syo2hN6zft4gaG6/s15vowKtVNcUDPKyWJC1jKwghIYCQZfcjqpw0f+8XG2TAWOXoE24j/U/DDg=="],
+    "@luzir/bolota": ["@luzir/bolota@0.1.6", "", {}, "sha512-xVadeemh1Y6aSjCGlzv93y8x4p1s8gufKR1abpWSbXAsatVICmoZDX34z+R5c15bYWrF0ZNDdsHT5d7jebxCSA=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
 

--- a/console/shared/package.json
+++ b/console/shared/package.json
@@ -39,7 +39,7 @@
     "./svelte-config": "./svelte-config.js"
   },
   "dependencies": {
-    "@luzir/bolota": "0.1.5",
+    "@luzir/bolota": "0.1.6",
     "iovalkey": "^0.4.0",
     "lenis": "^1.3.18",
     "motion": "^12.0.0",


### PR DESCRIPTION
Expression changes take 0.55s instead of 0.8s. Everything else about the avatars is unchanged.

Still an exact pin rather than a caret: 0.1.4 was published by mistake and unpublished, and a range still resolves to it out of any bun cache that saw it.