### PR TITLE
fix(web): name anonymous form fields, drop unsafe-inline from header CSP

### DIFF
--- a/web/public/_headers
+++ b/web/public/_headers
@@ -1,3 +1,17 @@
+# Mirrors the <meta http-equiv="Content-Security-Policy"> in src/layouts/Layout.astro.
+# The two policies intersect in the browser, so any drift silently makes the
+# stricter one win; keep them in sync.
+#
+# script-src has no 'unsafe-inline': every executable script is an external
+# bundle (vite assetsInlineLimit:0 in astro.config.mjs keeps it that way). The
+# inline <script type="application/ld+json"> / "application/json" islands are
+# data blocks, never executed, and browsers do not apply script-src to them
+# (verified: no securitypolicyviolation event on a prod build).
+#
+# style-src keeps 'unsafe-inline': the reveal system sets --reveal-i through
+# style="" attributes on ~360 elements per page, and Astro inlines small
+# stylesheets. Dropping it needs style-src-attr, which pre-2022 browsers ignore
+# and would fall back to blocking those attributes.
 /*
-  Content-Security-Policy: default-src 'self'; base-uri 'self'; object-src 'none'; frame-src 'none'; frame-ancestors 'none'; form-action 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com; connect-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com https://cloudflareinsights.com
+  Content-Security-Policy: default-src 'self'; base-uri 'self'; object-src 'none'; frame-src 'none'; frame-ancestors 'none'; form-action 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; script-src 'self' https://static.cloudflareinsights.com; connect-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com https://cloudflareinsights.com
   X-Frame-Options: DENY

--- a/web/src/components/builder/CommandBuilder.astro
+++ b/web/src/components/builder/CommandBuilder.astro
@@ -80,7 +80,7 @@ for (const surface of data.surfaces) {
                 <small class="hint" id="cb-name-hint">{ui.nameHint}</small>
             </div>
 
-            <label class="response">{ui.responseLabel} <small><b data-count>0</b>/500</small><textarea rows="4" maxlength="2504" data-template></textarea></label>
+            <label class="response">{ui.responseLabel} <small><b data-count>0</b>/500</small><textarea id="cb-template" name="template" rows="4" maxlength="2504" data-template></textarea></label>
             <div class="recipes" data-recipes><span>{ui.recipesLabel}</span></div>
 
             <section class="palette">
@@ -95,13 +95,13 @@ for (const surface of data.surfaces) {
                 <div class="more-grid">
                     <div class="span2"><label for="cb-aliases">{ui.aliasLabel}</label><input id="cb-aliases" placeholder="hi, heya" data-aliases aria-describedby="cb-alias-hint" /><small class="hint" id="cb-alias-hint">{ui.aliasHint}</small></div>
                     <label>{ui.permLabel}
-                        <select data-perm>
+                        <select id="cb-perm" name="perm" data-perm>
                             {data.perms.map((p) => <option value={p.value}>{p.label}</option>)}
                         </select>
                     </label>
                     <div><label for="cb-cooldown">{ui.cooldownLabel}</label><input id="cb-cooldown" type="number" min="0" max="86400" value="0" data-cooldown aria-describedby="cb-cd-hint" /><small class="hint" id="cb-cd-hint">{ui.cooldownHint}</small></div>
                     <label class="span2">{ui.styleLabel}
-                        <select data-style>
+                        <select id="cb-style" name="style" data-style>
                             {data.styles.map((s) => <option value={s.value}>{s.label}</option>)}
                         </select>
                     </label>
@@ -521,12 +521,17 @@ for (const surface of data.surfaces) {
             const nameInput = document.createElement('input');
             nameInput.type = 'text';
             nameInput.className = 'ctr-name';
+            // Named so the field is not anonymous to the browser (Chrome flags
+            // id-less, name-less form fields); defaultName comes from the var's
+            // {counter:x} token, which is unique per card.
+            nameInput.name = `counter-${defaultName}-name`;
             nameInput.placeholder = defaultName;
             nameInput.maxLength = data.limits.nameMax;
             nameInput.setAttribute('aria-label', ui.counterNameAria);
 
             const scopeSelect = document.createElement('select');
             scopeSelect.className = 'ctr-scope';
+            scopeSelect.name = `counter-${defaultName}-scope`;
             scopeSelect.setAttribute('aria-label', ui.counterScopeAria);
             for (const scope of scopes) {
                 const opt = document.createElement('option');

--- a/web/src/components/home/Playground.astro
+++ b/web/src/components/home/Playground.astro
@@ -79,6 +79,8 @@ const playStrings = {
 
             <form class="play__composer" data-play-form>
                 <input
+                    id="play-input"
+                    name="message"
                     class="play__input"
                     data-play-input
                     type="text"


### PR DESCRIPTION
Two findings from a Chrome/Lighthouse pass on `web/`.

## 1. "A form field element should have an id or name attribute"

Six controls had neither:

| file | field | added |
|---|---|---|
| `home/Playground.astro` | chat composer input | `id="play-input" name="message"` |
| `builder/CommandBuilder.astro` | response `<textarea>` | `id="cb-template" name="template"` |
| `builder/CommandBuilder.astro` | permission `<select>` | `id="cb-perm" name="perm"` |
| `builder/CommandBuilder.astro` | style `<select>` | `id="cb-style" name="style"` |
| `builder/CommandBuilder.astro` | `.ctr-name` (built at runtime) | `name="counter-{token}-name"` |
| `builder/CommandBuilder.astro` | `.ctr-scope` (built at runtime) | `name="counter-{token}-scope"` |

The two runtime controls take their name from the card's own `{counter:x}` token, so they stay unique when several counter cards are on screen. Every control is addressed through a `data-*` selector, so the client scripts are untouched.

## 2. CSP

Not a live block. On a production build there are zero `securitypolicyviolation` events and zero console errors — every executable script is an external bundle (`assetsInlineLimit: 0`), and the inline `application/ld+json` / `application/json` islands are data blocks that browsers do not gate on `script-src` (confirmed by injecting both types plus a `<style>` under the live policy).

The actual problem was drift: `public/_headers` still carried `'unsafe-inline'` in `script-src` while the meta CSP in `Layout.astro` had already dropped it. The two policies intersect in the browser, so the site was already running under the stricter one and the header was only misreporting its own posture. The two now match, and `_headers` records why they must stay in sync.

`style-src` keeps `'unsafe-inline'`: the reveal system sets `--reveal-i` through `style=""` on ~360 elements per page, and dropping it would need `style-src-attr`, which pre-2022 browsers ignore in favour of blocking those attributes.

## Verification

- All built pages (EN + FR home, command-builder, pricing, contact, guides, 404): 0 fields missing both `id` and `name`.
- Builder still works live: counter rename → `{counter:deaths}`, insert into template, char counter updates.
- `dist/_headers` has exactly one `unsafe-inline` left (`style-src`).
- `playwright`: 16 passed, 2 failed — `site.spec.js:118` (static gates) and `site.spec.js:262` (guides hub `.gcard` count). Both fail identically on `main` without this change; pre-existing and unrelated.