### PR TITLE
fix(ingress): heal shards the registry has lost

### DIFF
--- a/app/ingress/lib/ingress/admin_rpc.ex
+++ b/app/ingress/lib/ingress/admin_rpc.ex
@@ -13,6 +13,13 @@ defmodule Ingress.AdminRpc do
   Shards that are registered but mid-connect can be slow to answer; they are
   reported as `unresponsive` rather than holding up the reply.
 
+  Shards are enumerated from `Ingress.ShardInventory` (the supervisor's own
+  child list) rather than from the registry alone, and each entry carries
+  `managed`. A registry-only enumeration cannot see a session whose
+  registration a CRDT merge dropped, which is how a shard serving live events
+  came to be reported as an empty slot and a zombie shard above `desired` came
+  to be reported as nothing at all.
+
   The `shard_count` field reflects the effective desired count from
   `Ingress.ShardScaler`, not the static config value. Additional top-level
   fields (`desired_count`, `target`, `min_shards`, `autoscale`) expose the
@@ -25,7 +32,7 @@ defmodule Ingress.AdminRpc do
   use Gnat.Server
   require Logger
 
-  alias Ingress.{Capacity, JSON, ShardScaler}
+  alias Ingress.{Capacity, JSON, ShardInventory, ShardScaler}
 
   @call_timeout_ms 2_000
 
@@ -45,30 +52,23 @@ defmodule Ingress.AdminRpc do
     desired = scaler.desired
     nodes = [node() | Node.list()] |> Enum.uniq()
 
-    # Enumerate all currently-registered shards (not just 0..desired-1); during
-    # a shrink a shard may still be stopping, and the snapshot should include it
-    # so the console shows an accurate in-flight view.
-    registered_ids =
-      Horde.Registry.select(Ingress.Registry, [
-        {{{:shard, :"$1"}, :_, :_}, [], [:"$1"]}
-      ])
+    # Three sources, because no single one is complete. The supervisor's child
+    # list is the only view of sessions the registry has lost -- omit it and a
+    # shard serving without a registration is reported as an empty slot while
+    # events flow through it, and one above `desired` is not reported at all.
+    # The registry still contributes ids whose session did not answer its probe
+    # (reported `unresponsive`, not silently dropped), and the desired range
+    # contributes slots that genuinely have nothing running. Enumerating past
+    # `desired` is deliberate: during a shrink a shard may still be stopping.
+    inventory = ShardInventory.by_shard()
+    registered_ids = registered_shard_ids()
 
     all_ids =
-      (registered_ids ++ Enum.to_list(0..(max(desired, 1) - 1)))
+      (Map.keys(inventory) ++ registered_ids ++ Enum.to_list(0..(max(desired, 1) - 1)))
       |> Enum.uniq()
       |> Enum.sort()
 
-    shards =
-      all_ids
-      |> Task.async_stream(&shard_status/1,
-        timeout: @call_timeout_ms + 500,
-        on_timeout: :kill_task
-      )
-      |> Enum.zip(all_ids)
-      |> Enum.map(fn
-        {{:ok, status}, _shard_id} -> status
-        {{:exit, _reason}, shard_id} -> %{shard_id: shard_id, state: "unresponsive"}
-      end)
+    shards = Enum.map(all_ids, &shard_status(&1, inventory, registered_ids))
 
     %{
       generated_at: DateTime.utc_now(),
@@ -90,19 +90,29 @@ defmodule Ingress.AdminRpc do
     }
   end
 
-  defp shard_status(shard_id) do
-    case Horde.Registry.lookup(Ingress.Registry, {:shard, shard_id}) do
-      [{pid, _}] ->
-        try do
-          Ingress.ShardSession.status(pid, @call_timeout_ms)
-        catch
-          :exit, _ -> %{shard_id: shard_id, state: "unresponsive", node: node(pid)}
-        end
+  defp registered_shard_ids do
+    Horde.Registry.select(Ingress.Registry, [
+      {{{:shard, :"$1"}, :_, :_}, [], [:"$1"]}
+    ])
+  end
 
-      [] ->
-        %{shard_id: shard_id, state: "unregistered"}
+  # A live session answers for its own slot, carrying `managed` so the console
+  # can distinguish a shard the cluster is steering from one merely running.
+  # With no session, the registry decides which of the two silences this is: a
+  # name pointing at a process that would not answer its probe is
+  # `unresponsive`, an empty slot is `unregistered`.
+  defp shard_status(shard_id, inventory, registered_ids) do
+    case Map.fetch(inventory, shard_id) do
+      {:ok, status} -> status
+      :error -> vacant_status(shard_id, shard_id in registered_ids)
     end
   end
+
+  defp vacant_status(shard_id, true),
+    do: %{shard_id: shard_id, state: "unresponsive", managed: true}
+
+  defp vacant_status(shard_id, false),
+    do: %{shard_id: shard_id, state: "unregistered", managed: false}
 
   defp manager_status do
     case Horde.Registry.lookup(Ingress.Registry, :conduit_manager) do

--- a/app/ingress/lib/ingress/conduit_manager.ex
+++ b/app/ingress/lib/ingress/conduit_manager.ex
@@ -27,6 +27,7 @@ defmodule Ingress.ConduitManager do
   alias Ingress.Metrics
   alias Ingress.ShardDistribution
   alias Ingress.ShardHealth
+  alias Ingress.ShardInventory
   alias Ingress.ShardScaler
   alias Ingress.ShardSession
   alias Ingress.Twitch.Api
@@ -66,7 +67,11 @@ defmodule Ingress.ConduitManager do
        # shard_id => {rescue pid, seen count when the rescue was spawned}
        rescues: %{},
        placement_nodes: [],
-       placement_stable_ticks: 0
+       placement_stable_ticks: 0,
+       # True while another process holds the `:conduit_manager` name and this
+       # one is deliberately doing nothing. Tracked so the standby is logged on
+       # the transition instead of on every tick.
+       standby?: false
      }, {:continue, :reconcile}}
   end
 
@@ -81,7 +86,47 @@ defmodule Ingress.ConduitManager do
   @impl true
   def handle_info(:reconcile, state), do: {:noreply, reconcile(state)}
 
+  # The registry merge that can strip a shard of its name can strip the
+  # singleton of its own, and a manager that keeps reconciling without it is
+  # not harmless: on 2026-08-20 two managers drove the same conduit for twenty
+  # minutes, each issuing its own Helix resize for the same target. A manager
+  # that no longer owns the name stands by rather than exits -- it is
+  # supervised `:permanent`, so stopping it would restart it straight into a
+  # name that is already taken. An empty lookup is registry lag, not a verdict.
   defp reconcile(state) do
+    case singleton_status(state) do
+      {:standby, state} ->
+        Process.send_after(self(), :reconcile, @reconcile_interval_ms)
+        state
+
+      {:active, state} ->
+        converge(state)
+    end
+  end
+
+  defp singleton_status(state) do
+    case Horde.Registry.lookup(Ingress.Registry, :conduit_manager) do
+      [{pid, _}] when pid != self() -> {:standby, enter_standby(state)}
+      _ours_or_lagging -> {:active, leave_standby(state)}
+    end
+  end
+
+  defp enter_standby(%{standby?: true} = state), do: state
+
+  defp enter_standby(state) do
+    Logger.warning("conduit manager no longer holds the singleton name; standing by")
+    Metrics.count("Conduit/ManagerStandby")
+    %{state | standby?: true}
+  end
+
+  defp leave_standby(%{standby?: false} = state), do: state
+
+  defp leave_standby(state) do
+    Logger.info("conduit manager holds the singleton name again; resuming reconcile")
+    %{state | standby?: false}
+  end
+
+  defp converge(state) do
     case ensure_conduit(state) do
       {:ok, conduit_id, applied_shard_count} ->
         state = %{state | conduit_id: conduit_id, applied_shard_count: applied_shard_count}
@@ -186,6 +231,7 @@ defmodule Ingress.ConduitManager do
     applied = maybe_resize_conduit(conduit_id, desired, applied)
 
     stop_excess_shards(desired)
+    sweep_unmanaged_shards(desired)
     start_missing_shards(conduit_id, desired, snapshot)
     applied
   end
@@ -218,21 +264,34 @@ defmodule Ingress.ConduitManager do
       case Horde.Registry.lookup(Ingress.Registry, {:shard, shard_id}) do
         [{pid, _}] ->
           Logger.info("stopping excess shard #{shard_id} (desired=#{desired})")
-
-          case Horde.DynamicSupervisor.terminate_child(Ingress.ShardSupervisor, pid) do
-            :ok ->
-              :ok
-
-            {:error, :not_found} ->
-              stop_orphan_shard(shard_id, pid)
-
-            {:error, reason} ->
-              Logger.warning("stop shard #{shard_id} failed: #{inspect(reason)}")
-          end
+          terminate_shard(shard_id, pid)
 
         [] ->
           :ok
       end
+    end
+  end
+
+  # The registry-driven pass above is blind to a session whose registration a
+  # CRDT merge dropped, and that blindness is not academic: the 5->3 scale-down
+  # on 2026-08-20 reaped shard 3 and walked straight past shard 4, which kept a
+  # bound socket for a slot the conduit no longer had. Sweep the supervisor's
+  # own child list -- the view that survives a merge -- for anything the
+  # registry cannot show. Decisions live in `Ingress.ShardHealth`.
+  defp sweep_unmanaged_shards(desired) do
+    for {pid, status} <- ShardInventory.unmanaged(),
+        ShardHealth.unmanaged_action(status, desired) == :stop do
+      Logger.warning("stopping unmanaged shard #{status.shard_id} (supervised, unregistered)")
+      Metrics.count("Conduit/UnmanagedShardStops")
+      terminate_shard(status.shard_id, pid)
+    end
+  end
+
+  defp terminate_shard(shard_id, pid) do
+    case Horde.DynamicSupervisor.terminate_child(Ingress.ShardSupervisor, pid) do
+      :ok -> :ok
+      {:error, :not_found} -> stop_orphan_shard(shard_id, pid)
+      {:error, reason} -> Logger.warning("stop shard #{shard_id} failed: #{inspect(reason)}")
     end
   end
 
@@ -557,12 +616,7 @@ defmodule Ingress.ConduitManager do
   end
 
   defp restart_shard({conduit_id, shard_id}, pid) do
-    case Horde.DynamicSupervisor.terminate_child(Ingress.ShardSupervisor, pid) do
-      :ok -> :ok
-      {:error, :not_found} -> stop_orphan_shard(shard_id, pid)
-      {:error, reason} -> Logger.warning("stop shard #{shard_id} failed: #{inspect(reason)}")
-    end
-
+    terminate_shard(shard_id, pid)
     start_shard(conduit_id, shard_id)
   end
 

--- a/app/ingress/lib/ingress/shard_health.ex
+++ b/app/ingress/lib/ingress/shard_health.ex
@@ -90,6 +90,30 @@ defmodule Ingress.ShardHealth do
     Enum.reject(0..(desired - 1), &(&1 in enabled))
   end
 
+  @doc """
+  What to do with a live session that holds no registry entry under its own
+  shard id.
+
+    * `:stop` -- the slot no longer exists (`shard_id` at or above `desired`).
+      Nothing else will ever reap it: `stop_excess_shards/1` discovers shards
+      through the registry, which is exactly the view this session is missing
+      from, so it would otherwise outlive every scale-down holding a socket
+      bound to a conduit slot Twitch no longer has.
+    * `:ignore` -- a rescue session (unnamed by design), a session mid-handoff
+      (name deliberately released to a successor), or a slot still inside the
+      desired range. The in-range case is left to the session's own
+      registration self-check, which repairs the name without dropping a
+      socket Twitch may still be routing to.
+
+  A status from an ingress older than the self-check carries no `name_state`.
+  Such a session can only reach the `:stop` clause with an out-of-range id, and
+  a rescue is only ever spawned for a slot below `desired`, so the missing key
+  cannot cost a rescue its life.
+  """
+  def unmanaged_action(%{name_state: name_state}, _desired) when name_state != :named, do: :ignore
+  def unmanaged_action(%{shard_id: shard_id}, desired) when shard_id >= desired, do: :stop
+  def unmanaged_action(_status, _desired), do: :ignore
+
   defp settled?(%DateTime{} = bound_at, now),
     do: DateTime.diff(now, bound_at, :millisecond) >= @rebind_grace_ms
 

--- a/app/ingress/lib/ingress/shard_inventory.ex
+++ b/app/ingress/lib/ingress/shard_inventory.ex
@@ -1,0 +1,88 @@
+# Copyright (c) 2026 Adam Ousmer. All rights reserved.
+# Proprietary. No license granted. See LICENSE.md.
+
+defmodule Ingress.ShardInventory do
+  @moduledoc """
+  What the supervisor is actually running, as opposed to what the registry
+  says it is running.
+
+  Every other discovery path in the ingress enumerates shards through
+  `Ingress.Registry`, and that is precisely the view that can be wrong: a
+  registry CRDT merge after a netsplit heal drops registrations for processes
+  that are still alive and serving. On 2026-08-20 that left shard 0 serving
+  under no name (reported to the console as `unregistered` while events flowed
+  through it) and shard 4 holding a bound socket for a conduit slot a
+  scale-down had already deleted -- invisible to `stop_excess_shards/1`, which
+  can only reap what the registry can show it.
+
+  `Horde.DynamicSupervisor`'s child list survives that merge, so it is the view
+  used to find sessions the registry has lost. Probes run in parallel with a
+  bounded timeout: a wedged session must not stall the sweep or the admin
+  snapshot, and one that cannot answer is simply left out rather than guessed
+  at -- the rescue path in `Ingress.ConduitManager` owns wedged slots.
+  """
+
+  alias Ingress.ShardSession
+
+  @probe_timeout_ms 2_000
+
+  @doc """
+  Every live `Ingress.ShardSession` in the cluster as `{pid, status}`. Sessions
+  that do not answer a status call within the probe timeout are omitted.
+  """
+  def sessions do
+    Ingress.ShardSupervisor
+    |> Horde.DynamicSupervisor.which_children()
+    |> Enum.filter(&session_child?/1)
+    |> Task.async_stream(&probe_child/1,
+      timeout: @probe_timeout_ms + 500,
+      on_timeout: :kill_task
+    )
+    |> Enum.flat_map(fn
+      {:ok, {_pid, %{shard_id: _}} = entry} -> [entry]
+      _dead_or_unreachable -> []
+    end)
+  catch
+    :exit, _ -> []
+  end
+
+  @doc """
+  Sessions holding no registry entry under their own shard id, as
+  `{pid, status}`. A session whose name is held by a *different* pid counts as
+  unmanaged too: it is running outside anything the cluster can steer.
+  """
+  def unmanaged do
+    for {pid, status} <- sessions(), not registered?(pid, status), do: {pid, status}
+  end
+
+  @doc """
+  Live sessions keyed by shard id, each tagged `managed: true` when the
+  registry maps its shard id to that pid.
+
+  Where two sessions claim one id -- a rescue alongside a named session, or a
+  duplicate mid-resolution -- the managed one wins. `false` sorts before `true`
+  in Erlang term order, so sorting on the flag puts the managed copy last and
+  `Map.new/2` keeps it.
+  """
+  def by_shard do
+    sessions()
+    |> Enum.map(fn {pid, status} -> Map.put(status, :managed, registered?(pid, status)) end)
+    |> Enum.sort_by(& &1.managed)
+    |> Map.new(&{&1.shard_id, &1})
+  end
+
+  defp session_child?({_id, pid, :worker, [ShardSession]}) when is_pid(pid), do: true
+  defp session_child?(_child), do: false
+
+  defp probe_child({_id, pid, _type, _modules}), do: {pid, probe(pid)}
+
+  defp probe(pid) do
+    ShardSession.status(pid, @probe_timeout_ms)
+  catch
+    :exit, _ -> :unreachable
+  end
+
+  defp registered?(pid, %{shard_id: shard_id}) do
+    match?([{^pid, _}], Horde.Registry.lookup(Ingress.Registry, {:shard, shard_id}))
+  end
+end

--- a/app/ingress/lib/ingress/shard_session.ex
+++ b/app/ingress/lib/ingress/shard_session.ex
@@ -50,6 +50,18 @@ defmodule Ingress.ShardSession do
   @takeover_deadline_ms 5_000
   @base_backoff_ms 1_000
   @max_backoff_ms 60_000
+  # How often a session verifies it still holds its cluster-wide name. A
+  # registry CRDT merge after a netsplit heal drops registrations for processes
+  # that are still alive: on 2026-08-20 shards 0 and 4 kept serving bound
+  # sockets with no registry entry, which made them invisible to every converge
+  # pass (all of which discover shards through the registry) and left shard 4
+  # bound to a conduit slot a scale-down had already removed. Nothing else
+  # re-registers -- the only two paths back into the registry are duplicate
+  # takeover and rebalance rollback, and neither fires when the name is simply
+  # free -- so unregistered-but-serving is otherwise a stable state. 30s is two
+  # ticks inside the reconciler's 15s interval, so a lost name costs at most one
+  # health pass of invisibility.
+  @registry_check_interval_ms 30_000
 
   defstruct shard_id: nil,
             conduit_id: nil,
@@ -69,6 +81,13 @@ defmodule Ingress.ShardSession do
             last_frame_system_ms: nil,
             # duplicate-shard takeover in flight: %{winner:, monitor:, timer:}
             takeover: nil,
+            # Whether this session believes it owns `{:shard, id}` in the
+            # registry: `:named` (it should), `:released` (handed the name to a
+            # successor for a drain or rebalance) or `:rescue` (never had one).
+            # Only a `:named` session may repair a missing registration --
+            # re-registering a released copy would steal the name back
+            # mid-handoff, and a rescue is unnamed by design.
+            name_state: :named,
             # Optional Mint connection options used by the isolated WebSocket
             # benchmark for its temporary CA. Production leaves this empty.
             ws_connect_opts: [],
@@ -115,9 +134,11 @@ defmodule Ingress.ShardSession do
     state = %__MODULE__{
       shard_id: shard_id,
       conduit_id: Keyword.fetch!(opts, :conduit_id),
+      name_state: if(Keyword.get(opts, :rescue?, false), do: :rescue, else: :named),
       ws_connect_opts: Keyword.get(opts, :ws_connect_opts, [])
     }
 
+    schedule_registry_check()
     {:ok, state, {:continue, :connect}}
   end
 
@@ -142,7 +163,7 @@ defmodule Ingress.ShardSession do
   @impl true
   def handle_call(:release_name, _from, state) do
     Horde.Registry.unregister(Ingress.Registry, {:shard, state.shard_id})
-    {:reply, :ok, state}
+    {:reply, :ok, %{state | name_state: :released}}
   end
 
   # A steady-state rebalance uses the same make-before-break handoff as a
@@ -152,8 +173,18 @@ defmodule Ingress.ShardSession do
   @impl true
   def handle_call(:reclaim_name, _from, state) do
     result = Horde.Registry.register(Ingress.Registry, {:shard, state.shard_id}, nil)
-    {:reply, result, state}
+    {:reply, result, %{state | name_state: reclaimed_name_state(result, state.name_state)}}
   end
+
+  # Holding the name again -- freshly registered, or already ours because the
+  # release never propagated -- puts the session back under the self-check that
+  # repairs a lost registration. Any other answer leaves the handoff alone.
+  defp reclaimed_name_state({:ok, _pid}, _previous), do: :named
+
+  defp reclaimed_name_state({:error, {:already_registered, pid}}, _prev) when pid == self(),
+    do: :named
+
+  defp reclaimed_name_state(_result, previous), do: previous
 
   # The other copy of this shard is bound but lost the registry merge; it is
   # taking the registration over and asks us to stand down. If we bound
@@ -191,6 +222,9 @@ defmodule Ingress.ShardSession do
     %{
       shard_id: state.shard_id,
       state: derive_state(state),
+      # Callers that reap or re-register sessions need to tell a session that
+      # lost its name from one that gave it up; `state` alone cannot.
+      name_state: state.name_state,
       node: node(),
       # Worker node (machine) name from the downward-API env, so the admin
       # console can show the host instead of the pod IP carried in `node`.
@@ -219,6 +253,11 @@ defmodule Ingress.ShardSession do
 
   @impl true
   def handle_info(:retry_connect, state), do: {:noreply, connect(state)}
+
+  def handle_info(:registry_check, state) do
+    schedule_registry_check()
+    {:noreply, verify_registration(state)}
+  end
 
   def handle_info(:welcome_deadline, %{session_id: nil} = state) do
     Logger.warning("no session_welcome within deadline; reconnecting")
@@ -691,6 +730,43 @@ defmodule Ingress.ShardSession do
     end
 
     state |> teardown() |> schedule_retry()
+  end
+
+  # --- registration self-check -----------------------------------------------
+
+  defp schedule_registry_check,
+    do: Process.send_after(self(), :registry_check, @registry_check_interval_ms)
+
+  # A session that should own its name but does not is repaired here, because
+  # nothing else will: `Ingress.ConduitManager` discovers shards through the
+  # registry, so a session missing from it is missing from the reconciler too.
+  # Skipped while a takeover is in flight -- that path is deliberately
+  # unregistered until its own deadline resolves the duplicate.
+  defp verify_registration(%{name_state: :named, takeover: nil} = state) do
+    case Horde.Registry.lookup(Ingress.Registry, {:shard, state.shard_id}) do
+      [{pid, _}] when pid == self() -> state
+      [{_other, _}] -> state
+      [] -> reregister(state)
+    end
+  end
+
+  defp verify_registration(state), do: state
+
+  # The name is held by another pid: this copy is a duplicate, not an orphan.
+  # Deliberately not resolved here -- an unregistered copy receives no
+  # name-conflict signal, and killing whichever copy noticed first would as
+  # often close the socket Twitch is actually routing to. The reconciler's
+  # health pass settles it from Twitch's own view of the slot.
+  defp reregister(state) do
+    case Horde.Registry.register(Ingress.Registry, {:shard, state.shard_id}, nil) do
+      {:ok, _pid} ->
+        Logger.warning("shard registration was missing; re-registered")
+        Metrics.count("Shard/RegistrationRepairs")
+        state
+
+      {:error, {:already_registered, _pid}} ->
+        state
+    end
   end
 
   # --- duplicate-shard takeover helpers --------------------------------------

--- a/app/ingress/test/shard_health_test.exs
+++ b/app/ingress/test/shard_health_test.exs
@@ -42,6 +42,35 @@ defmodule Ingress.ShardHealthTest do
     end
   end
 
+  describe "unmanaged_action/2" do
+    defp unmanaged(id, name_state \\ :named),
+      do: %{shard_id: id, name_state: name_state, state: "connected", bound: true}
+
+    test "stops a session for a slot the conduit no longer has" do
+      assert ShardHealth.unmanaged_action(unmanaged(4), 3) == :stop
+    end
+
+    test "leaves an in-range slot to the session's own registration self-check" do
+      assert ShardHealth.unmanaged_action(unmanaged(0), 3) == :ignore
+    end
+
+    test "never touches a rescue session, which is unnamed by design" do
+      assert ShardHealth.unmanaged_action(unmanaged(4, :rescue), 3) == :ignore
+      assert ShardHealth.unmanaged_action(unmanaged(0, :rescue), 3) == :ignore
+    end
+
+    test "never touches a session mid-handoff, which released its name on purpose" do
+      assert ShardHealth.unmanaged_action(unmanaged(4, :released), 3) == :ignore
+    end
+
+    test "a status from an older ingress still gets its out-of-range slot reaped" do
+      legacy = %{shard_id: 4, state: "connected", bound: true}
+
+      assert ShardHealth.unmanaged_action(legacy, 3) == :stop
+      assert ShardHealth.unmanaged_action(%{legacy | shard_id: 1}, 3) == :ignore
+    end
+  end
+
   describe "heal_action/3" do
     test "unreachable session is restarted" do
       assert ShardHealth.heal_action(:unreachable, 1, @now) == :restart

--- a/console/admin/src/routes/(admin)/shards/+page.svelte
+++ b/console/admin/src/routes/(admin)/shards/+page.svelte
@@ -5,7 +5,7 @@
   import { onMount, untrack } from 'svelte';
   import type { SubmitFunction } from '@sveltejs/kit';
   import { Icon, PageHead, AlertBanner, Skeleton, toast } from '@bagel/shared';
-  import type { ShardSnapshot } from '@bagel/shared';
+  import type { Shard, ShardSnapshot } from '@bagel/shared';
   import {
     barWidth,
     eventsPerSecond,
@@ -132,9 +132,21 @@
     if (!ms || ms <= 0) return '—';
     return `${Math.round(ms / 1000)}s window`;
   }
-  function stateBadge(state: string): { label: string; tone: string } {
-    if (state === 'connected') return { label: 'healthy', tone: 'green' };
-    if (state === 'reconnecting' || state === 'connecting') return { label: 'restarting', tone: 'warn' };
+  // derive_state/1 in ingress emits connecting | binding | migrating while a
+  // socket is coming up or being handed over. All three are transient and heal
+  // on their own, so none is a fault worth waking an operator for; only
+  // backoff and unresponsive mean the shard is actually stuck.
+  const RESTARTING = new Set(['connecting', 'reconnecting', 'binding', 'migrating']);
+
+  // `unregistered` means no process at all answers for the slot, which is a
+  // different failure from a session ingress is running but cannot steer
+  // (managed === false). Conflating the two is what let a shard serving live
+  // events and a zombie shard both read as "degraded".
+  function stateBadge(s: Shard): { label: string; tone: string } {
+    if (s.state === 'unregistered') return { label: 'missing', tone: 'err' };
+    if (s.managed === false) return { label: 'unmanaged', tone: 'warn' };
+    if (s.state === 'connected') return { label: 'healthy', tone: 'green' };
+    if (RESTARTING.has(s.state)) return { label: 'restarting', tone: 'warn' };
     return { label: 'degraded', tone: 'err' };
   }
   function podIndex(raw?: string): string {
@@ -326,7 +338,7 @@
 
     <div class="shard-grid">
       {#each snap.shards as s (s.shard_id)}
-        {@const sb = stateBadge(s.state)}
+        {@const sb = stateBadge(s)}
         {@const utilization = loadUtilization(s.load)}
         {@const ltone = loadTone(s.load)}
         <div class="card shard-card">
@@ -340,6 +352,9 @@
           </div>
           <div class="shard-meta">
             <span>{s.bound ? 'bound' : 'unbound'}</span>
+            {#if s.managed === false && s.state !== 'unregistered'}
+              <span class="warn-tag">no registry entry</span>
+            {/if}
             {#if s.handshake_in_flight}<span class="warn-tag">handshaking</span>{/if}
             <span>{keepalive(s.keepalive_ms)}</span>
             <span>{s.attempts ?? 0} att</span>

--- a/console/shared/lib/types.ts
+++ b/console/shared/lib/types.ts
@@ -177,6 +177,11 @@ export interface Shard {
   keepalive_ms?: number;
   attempts?: number;
   load?: number;
+  // False when ingress is running this session without a registry entry for
+  // it: the socket serves, but no converge pass can see or steer it. Optional
+  // so a snapshot from an ingress older than the unmanaged-shard sweep still
+  // renders (absent reads as "no claim", not as "unmanaged").
+  managed?: boolean;
 }
 
 export interface ShardSnapshot {


### PR DESCRIPTION
## Problem

A registry CRDT merge after a netsplit heal drops registrations for `ShardSession` processes that are still alive and serving. Nothing re-creates them — the only two paths back into `Ingress.Registry` are duplicate takeover and rebalance rollback, and neither fires when the name is simply free. Every converge pass discovers shards through the registry, so an unregistered session is invisible to all of them, permanently.

Observed on the live cluster 2026-08-20:

| shard | pid | registry | reality |
|---|---|---|---|
| 0 | `0.2966.0` | absent | serving, Twitch reports the slot `enabled`, console reported the slot empty |
| 4 | `0.2638.0` | absent | bound socket for a conduit slot the 5→3 scale-down removed, never reaped |

`stop_excess_shards/1` reaped shard 3 (registered) and walked straight past shard 4. `ShardHealth.startable_ids/2` correctly refused to start a replacement for shard 0, because Twitch reports that slot enabled — so the hole never closed either. A second `ConduitManager` lost the singleton name in the same merge and spent twenty minutes issuing its own Helix resizes alongside the registered one.

## Fix

**`ShardSession`** tracks whether it believes it holds its name (`:named`, `:released` for a drain/rebalance handoff, `:rescue` for the unnamed rescue path) and re-registers a `:named` session that finds its slot empty. A name held by a different pid is deliberately left alone: an unregistered copy receives no conflict signal, and killing whichever copy noticed first would as often close the socket Twitch is routing to — the health pass arbitrates that from Twitch's own view.

**`ShardInventory`** (new) enumerates sessions from `Horde.DynamicSupervisor.which_children/1`, the one view a registry merge does not corrupt. Probes run in parallel with a bounded timeout so a wedged session cannot stall a sweep or a console poll.

**`ConduitManager`** sweeps that inventory each tick via the new pure `ShardHealth.unmanaged_action/2` — reap at or above `desired`, leave in-range slots to the session's own self-check — and stands by when it no longer owns `:conduit_manager` rather than exiting into a `:permanent` restart against a taken name. `terminate_shard/2` collapses three copies of the same terminate-then-fallback block.

**`AdminRpc`** builds its snapshot from the inventory plus the registry plus the desired range, tagging each row `managed`. The console splits the old `degraded` catch-all into **missing** (no process) and **unmanaged** (running, unsteerable), and stops rendering transient `binding` / `migrating` states as faults.

## Verification

`mix test` 215 passed (5 new for `unmanaged_action/2`, including the mixed-version case where a status from an older ingress carries no `name_state`), `mix format --check-formatted` clean, admin `svelte-check` 0 errors, admin build and production-clean gate pass.

Dry-run of the new decision logic against the live cluster, read-only:

```
shard 4 registered=false state=connected -> stop
shard 0 registered=false state=connected -> ignore   (self-check re-registers it)
shard 1 registered=true  -> untouched
shard 2 registered=true  -> untouched

rows the console would render:
shard 0  state=connected  managed=false
shard 1  state=connected  managed=true
shard 2  state=connected  managed=true
shard 4  state=connected  managed=false

conduit managers:
0.2664.0 standby=true
0.3148.0 standby=false
```

## Rollout note

The first converge tick after rollout closes shard 4's socket. That is the intent, but it is a live socket close.