### PR TITLE
chore(deploy): fix dns stalls, add priority classes

### DIFF
--- a/deploy/cache/config/tuning.conf
+++ b/deploy/cache/config/tuning.conf
@@ -45,14 +45,26 @@ tcp-keepalive 60
 latency-monitor-threshold 1
 latency-tracking yes
 latency-tracking-info-percentiles 50 95 99 99.9
-slowlog-log-slower-than 1000
+# 10000 microseconds (10ms), NOT the 1000 it was. slowlog-log-slower-than is
+# in MICROseconds, so the old value logged everything over 1ms and the slowlog
+# filled with ordinary work -- measured 2026-08-20, valkey-node-2 held 461
+# entries and the bulk were Sentinel INFO polls at 1.3-1.8ms, which is simply
+# what INFO costs to build. A log that flags healthy operation is one nobody
+# reads. Measured command latency across all three members is ~1ms average
+# with a 14ms worst case ever recorded, so 10ms sits above normal and still
+# catches a genuine outlier.
+# latency-monitor-threshold above stays at 1ms deliberately: it is a cheap
+# per-event histogram, not a log, and LATENCY DOCTOR needs the resolution.
+slowlog-log-slower-than 10000
 slowlog-max-len 512
 
 # Refuse an isolated primary instead of acknowledging writes with no online
 # replica. This does not synchronously wait for replica acknowledgement.
 #
-# TODAY there is exactly one member and no replica, so this would block every
-# write. Disabled until a second member joins; re-enable (min-replicas-to-write
-# 1) as part of the same change that scales replicas: 1 -> 3.
+# ACTIVE since the scale-up to replicas: 3 (Sentinel quorum 2). The primary
+# needs at least one replica whose last acknowledged offset is under 10s old
+# or it stops accepting writes, which is what keeps a partitioned primary from
+# taking writes that a promoted peer would never see. Losing one of three
+# members is survivable; losing two leaves the survivor read-only by design.
 min-replicas-to-write 1
 min-replicas-max-lag 10

--- a/deploy/cache/config/valkey.conf
+++ b/deploy/cache/config/valkey.conf
@@ -29,8 +29,11 @@ loglevel notice
 # Two threads fit the 2-CPU container budget; config-init re-appends this
 # value on every boot so a retained CONFIG REWRITE cannot override it.
 io-threads 2
-# Bounded cache. maxmemory sits under the 2 GiB container limit to leave room
-# for the replication backlog, COW, and buffers during AOF rewrite.
+# COLD-START FALLBACK ONLY. config-init deletes this line and re-appends a
+# maxmemory derived from the container's own resources.limits.memory (60% of
+# it) on every boot, so the live value tracks the limit and this number is
+# only what a member would run with if the Downward API reported no limit.
+# Do not tune capacity here -- change resources.limits.memory in valkey.yaml.
 # volatile-lru evicts only keys that carry a TTL (cooldowns, live keys,
 # cached projections) under pressure, so ACL/persistent keys are never
 # evicted; when only non-TTL keys remain, writes fail closed rather than
@@ -40,6 +43,21 @@ maxmemory-policy volatile-lru
 rename-command FLUSHDB ""
 rename-command FLUSHALL ""
 aclfile /secrets/users/users.acl
+# Local-only socket for the health probes. port 0 keeps plaintext TCP off and
+# tls-port 6380 stays the only network listener, so this adds no reachable
+# surface: the socket lives in /data, which is an emptyDir shared only by this
+# pod's own containers, and 700 restricts it to the uid that valkey runs as.
+#
+# Why: both probes are exec probes that fork a fresh valkey-cli, and a new
+# PROCESS cannot reuse a TLS session ticket, so every probe paid a full mTLS
+# handshake. Measured 2026-08-20: 70292 connections accepted against 127
+# steady clients, which is readiness every 5s plus liveness every 10s plus
+# Sentinel INFO polls -- roughly 18 connections/min on this port, essentially
+# all of them handshakes. Application clients are unaffected either way; they
+# already hold long-lived pooled connections (pkg/valkey BlockingPoolSize 64,
+# PipelineMultiplex 5) and pay their handshake once.
+unixsocket /data/valkey.sock
+unixsocketperm 700
 # ConfigMap-backed policy is deliberately included after retained state is
 # reconciled by config-init, so updates apply to existing PVCs as well as new
 # members. Node-specific io-threads and replica-priority are appended later.

--- a/deploy/cache/valkey.yaml
+++ b/deploy/cache/valkey.yaml
@@ -11,6 +11,13 @@ metadata:
   name: valkey
   namespace: cache
 spec:
+  # PreferSameNode, not the deprecated PreferClose. Keeps a caller on the
+  # backend running on its own node, with fallback to a peer when the local
+  # one is unready -- unlike internalTrafficPolicy: Local, which has no
+  # fallback. Set fleet-wide 2026-08-20 after cross-node DNS to the cp1
+  # resolver, reached over tailscale0, was traced to intermittent Cilium
+  # drops that cost a 5s resolver timeout per lost packet.
+  trafficDistribution: PreferSameNode
   ports:
   - name: tls-redis
     port: 6380
@@ -38,10 +45,13 @@ metadata:
 spec:
   # kube-proxy selects only the endpoint on the caller's node. This keeps
   # node-local reads on that node's own listener, with no cross-node hop.
-  # TODAY with replicas: 1 the "local" endpoint only exists on the one node
-  # the pod lands on; every other node's pods have no local endpoint and
-  # pkg/valkey degrades to Sentinel-only reads (see NewClient's log line),
-  # which is correct, not a bug, until replicas scale to 3.
+  # Since the scale-up to replicas: 3 every schedulable node (node1, node2,
+  # node3) carries one member, so callers there always have a local endpoint.
+  # cp1 is tainted and runs no app pods, so its lack of a member is not a gap.
+  # The Sentinel-only fallback in pkg/valkey NewClient is therefore no longer
+  # the normal path, but it is deliberately kept: a member being down or
+  # unready on one node must degrade that node's callers to Sentinel-routed
+  # reads, not fail them.
   internalTrafficPolicy: Local
   ports:
   - name: tls-redis
@@ -149,6 +159,34 @@ spec:
       # known peers/epoch, so a restarted pod reads its real current role from
       # /data instead of re-deriving it. Every member announces its stable
       # StatefulSet DNS identity, independent of the node it is scheduled on.
+      # Resolver options, uniform across every first-party workload.
+      #
+      # ndots 1, not the kubelet default of 5: under ndots:5 any name with
+      # fewer than 5 dots is tried against all three search domains BEFORE
+      # being tried as written, so a 4-dot cluster FQDN costs 4 queries and
+      # an external name like api.twitch.tv costs 4 too -- three guaranteed
+      # NXDOMAINs, then the answer. Measured on coredns 2026-08-20: 16704
+      # denial cache hits against 10368 success hits, so 62% of everything
+      # served was the junk half of that expansion.
+      #
+      # single-request-reopen: glibc sends the A and AAAA queries in parallel
+      # from one socket; the two replies can race in conntrack and one gets
+      # dropped, which costs a full resolver timeout. Reopening the socket
+      # for the second query removes the race.
+      #
+      # timeout 1 + attempts 3, rather than the previous 2/2 and the glibc
+      # default 5/2. A dropped UDP packet costs 1s instead of 5s, and 3s
+      # worst case instead of 10s. The 1s matters specifically because Valkey
+      # Sentinel resolves hostnames inside its event loop and declares "tilt"
+      # -- refusing failover for a fixed 30s -- when that loop stalls beyond
+      # 2s. At timeout 2 a single lost packet sat exactly on that threshold.
+      # See deploy/cache/valkey.yaml for the measurement that found it.
+      dnsConfig:
+        options:
+          - {name: ndots, value: "1"}
+          - {name: single-request-reopen}
+          - {name: timeout, value: "1"}
+          - {name: attempts, value: "3"}
       initContainers:
       - name: config-init
         image: valkey/valkey@sha256:3acc0687f2a2e1091fae6450d7842dd658c941338cf0a873ddd9e14b9e4ea4dd
@@ -212,8 +250,50 @@ spec:
           # CONFIG REWRITE output.
           sed -i '\|^include /config/tuning.conf$|d' /data/valkey.conf
           echo "include /config/tuning.conf" >> /data/valkey.conf
+          # io-threads derived from the CPU limit, same as maxmemory above, so
+          # resources.limits.cpu stays the single number to tune. Valkey 9.1
+          # uses lock-free queues between the main thread and I/O workers, so
+          # extra threads help read throughput but each one costs some
+          # busy-wait; reserve 2 cores for the main thread and background
+          # work, and cap at 8 (past that Valkey's own guidance says returns
+          # go negative). At limits.cpu 6 this yields 4.
+          if [ -n "${CPU_LIMIT}" ] && [ "${CPU_LIMIT}" -gt 2 ] 2>/dev/null; then
+            IO_THREADS=$(( CPU_LIMIT - 2 ))
+            [ "${IO_THREADS}" -gt 8 ] && IO_THREADS=8
+          else
+            IO_THREADS=1
+          fi
           sed -i '/^io-threads /d' /data/valkey.conf
-          echo "io-threads 2" >> /data/valkey.conf
+          echo "io-threads ${IO_THREADS}" >> /data/valkey.conf
+          echo "config-init: cpu limit ${CPU_LIMIT} -> io-threads ${IO_THREADS}"
+          # maxmemory is derived from the container limit rather than pinned,
+          # so raising resources.limits.memory is the ONLY number to change.
+          # 60% is not arbitrary: maxmemory governs used_memory, but the
+          # cgroup kills on RSS, and several things live in RSS but outside
+          # used_memory's eviction accounting -- replica client output
+          # buffers, the AOF buffer, fork/COW pages during BGREWRITEAOF
+          # (appendonly yes, auto-aof-rewrite-min-size 1gb) and during a
+          # diskless full sync, per-connection TLS buffers (full mTLS here,
+          # every peer pays), and jemalloc fragmentation (measured 1.25 on
+          # 2026-08-20). A BGREWRITEAOF that forks while the dataset is at
+          # maxmemory can approach 2x in the worst case, so the headroom has
+          # to be roughly the same size as the budget itself.
+          # Note repl-backlog-size 128mb IS counted inside used_memory, so
+          # usable key space is maxmemory minus 128 MiB.
+          # Appended after the include so it beats both tuning.conf and any
+          # CONFIG REWRITE retained on the PVC -- last assignment wins.
+          if [ -n "${MEM_LIMIT_MI}" ] && [ "${MEM_LIMIT_MI}" -gt 0 ] 2>/dev/null; then
+            MAXMEMORY_MI=$(( MEM_LIMIT_MI * 60 / 100 ))
+          else
+            # No limit set on the container means the Downward API yields the
+            # node allocatable, or nothing. Neither is a safe budget, so fall
+            # back to the historical fixed value instead of guessing high.
+            MAXMEMORY_MI=512
+          fi
+          sed -i '/^maxmemory /d' /data/valkey.conf
+          echo "maxmemory ${MAXMEMORY_MI}mb" >> /data/valkey.conf
+          echo "maxmemory-policy volatile-lru" >> /data/valkey.conf
+          echo "config-init: container limit ${MEM_LIMIT_MI}Mi -> maxmemory ${MAXMEMORY_MI}mb"
           # Reconcile this member's stable DNS identity before Valkey starts.
           sed -i '/^replica-announce-ip /d' /data/valkey.conf
           echo "replica-announce-ip ${POD_FQDN}" >> /data/valkey.conf
@@ -264,6 +344,23 @@ spec:
             secretKeyRef:
               key: valkey-password
               name: valkey-core-secret
+        # Valkey never reads the cgroup limit itself -- maxmemory is a number
+        # it is told, and it has no idea what the container was given. The
+        # Downward API is the only way to get the limit into the pod, and
+        # resourceFieldRef from an initContainer must name the target
+        # container explicitly. divisor 1Mi yields whole MiB, rounded up.
+        - name: MEM_LIMIT_MI
+          valueFrom:
+            resourceFieldRef:
+              containerName: valkey
+              resource: limits.memory
+              divisor: 1Mi
+        - name: CPU_LIMIT
+          valueFrom:
+            resourceFieldRef:
+              containerName: valkey
+              resource: limits.cpu
+              divisor: "1"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -282,6 +379,7 @@ spec:
         - mountPath: /etc/valkey/tls
           name: valkey-tls
           readOnly: true
+      priorityClassName: bagel-data-plane
       containers:
       - command:
         - valkey-server
@@ -296,8 +394,11 @@ spec:
         - "no"
         - --replica-read-only
         - "yes"
-        - --maxmemory
-        - 512mb
+        # --maxmemory is deliberately NOT repeated here. Command-line flags
+        # override the config file, which would defeat the limit-derived
+        # value config-init writes into /data/valkey.conf. The retained-PVC
+        # protection those repeated flags exist for is provided instead by
+        # config-init deleting and re-appending maxmemory on every boot.
         - --maxmemory-policy
         - volatile-lru
         - --port
@@ -337,17 +438,8 @@ spec:
           exec:
             command:
             - valkey-cli
-            - -p
-            - "6380"
-            - --tls
-            - --cacert
-            - /etc/valkey/tls/ca.crt
-            - --cert
-            - /etc/valkey/tls/tls.crt
-            - --key
-            - /etc/valkey/tls/tls.key
-            - --sni
-            - valkey.cache.svc.cluster.local
+            - -s
+            - /data/valkey.sock
             - ping
           failureThreshold: 3
           initialDelaySeconds: 20
@@ -363,17 +455,8 @@ spec:
           exec:
             command:
             - valkey-cli
-            - -p
-            - "6380"
-            - --tls
-            - --cacert
-            - /etc/valkey/tls/ca.crt
-            - --cert
-            - /etc/valkey/tls/tls.crt
-            - --key
-            - /etc/valkey/tls/tls.key
-            - --sni
-            - valkey.cache.svc.cluster.local
+            - -s
+            - /data/valkey.sock
             - ping
           failureThreshold: 3
           initialDelaySeconds: 10
@@ -384,28 +467,46 @@ spec:
           exec:
             command:
             - valkey-cli
-            - -p
-            - "6380"
-            - --tls
-            - --cacert
-            - /etc/valkey/tls/ca.crt
-            - --cert
-            - /etc/valkey/tls/tls.crt
-            - --key
-            - /etc/valkey/tls/tls.key
-            - --sni
-            - valkey.cache.svc.cluster.local
+            - -s
+            - /data/valkey.sock
             - ping
           failureThreshold: 30
           periodSeconds: 2
           timeoutSeconds: 3
         resources:
           limits:
-            cpu: '2'
+            # Raised 2 -> 6. Measured 2026-08-20: this container has NEVER
+            # been throttled (nr_throttled 0 across 2.2M CFS periods, all
+            # three members) at 36m steady usage, so the old limit was not
+            # hurting anything today. It was, however, the stated reason
+            # io-threads was pinned at 2, and io-threads cannot use cores the
+            # cgroup will not grant. Nodes are 12-core with 29% of CPU
+            # requests committed, so 6 is affordable headroom.
+            # This raises the CEILING; it does not speed up current traffic.
+            # Live load is 81 ops/s and 2.79 kbps out, which two threads
+            # already serve without effort. The real ceiling on this fleet is
+            # TLS handshake CPU, not bandwidth: 70292 connections have been
+            # accepted against 127 steady clients, because each exec probe
+            # spawns a fresh valkey-cli that cannot reuse a session ticket
+            # and therefore pays a full handshake every time.
+            cpu: '6'
             # 512 MiB maxmemory + 128 MiB replication backlog still need room
             # for allocator overhead, TLS buffers, AOF fork/COW and full sync.
-            # A 2 GiB ceiling leaves a defensible worst-case fork/COW margin.
-            memory: 2Gi
+            # Measured 2026-08-20 on valkey-node-0: used_memory 98.4 MiB, of
+            # which used_memory_dataset is only 1.28 MiB (1.26%) and
+            # mem_replication_backlog is 93.8 MiB growing to the configured
+            # 128 MiB. RSS 122.5 MiB, frag ratio 1.25, evicted_keys 0, peak ==
+            # current. So the steady-state floor is the backlog, not the data.
+            # Raised 2 GiB -> 3 GiB purely as fork/COW headroom: a full sync to
+            # two replicas plus an AOF rewrite can fork while the backlog is
+            # full, and 2 GiB left no margin for that to coincide with a
+            # dataset that grows toward maxmemory. Limits are not reservations,
+            # so this costs nothing until it is actually needed; requests stay
+            # at 384 Mi, which still covers measured RSS. maxmemory is
+            # deliberately NOT raised with this - 512 MiB is already ~400x the
+            # live dataset, and raising it would only raise the fork/COW
+            # worst case this margin exists to absorb.
+            memory: 3Gi
           requests:
             cpu: 250m
             memory: 384Mi
@@ -474,7 +575,24 @@ spec:
             - --sni
             - valkey.cache.svc.cluster.local
             - ping
-          failureThreshold: 3
+          # failureThreshold 6, NOT the default 3. Sentinel enters "tilt" when
+          # it detects its event loop was delayed abnormally, and a tilt
+          # window is a fixed 30s (SENTINEL_TILT_PERIOD). At failureThreshold
+          # 3 the liveness budget is periodSeconds 10 x 3 = exactly 30s, so a
+          # single tilt sits precisely on the kill boundary, and the same
+          # event-loop stall that caused the tilt also delays this probe's
+          # mTLS handshake. Measured 2026-08-20: valkey-node-1 tilted 62
+          # times, 1474s across a 3h24m window (12.0% of the time), against
+          # 0.4-0.5/h on the other two members, and was the only member
+          # kubelet restarted. It took SIGTERM at 12:29:08 and shut down
+          # gracefully, so it recorded exitCode 0 "Completed" and read as a
+          # clean exit rather than the probe kill it actually was.
+          # 6 gives 60s, clearing one full tilt window with margin.
+          # Restarting a Sentinel is worse than waiting through a tilt: it
+          # drops its runtime view of peers and replicas and must rediscover
+          # them, which is a quorum risk at exactly the moment the fleet is
+          # already unhappy.
+          failureThreshold: 6
           initialDelaySeconds: 20
           periodSeconds: 10
           successThreshold: 1
@@ -526,11 +644,25 @@ spec:
           timeoutSeconds: 3
         resources:
           limits:
-            cpu: 250m
+            # Raised 250m -> 1. Both probes are exec probes that fork a full
+            # valkey-cli and complete a client-certificate mTLS handshake,
+            # readiness every 5s and liveness every 10s. That cost is bursty,
+            # and CFS grants a 250m container only 25ms of every 100ms
+            # period, so a handshake needing more stalls into the next period
+            # and drags the event loop with it -- which is what tilt reports.
+            # Measured 2026-08-20, nr_throttled/nr_periods on all three
+            # members: 8.78% / 8.31% / 7.77%. Every Sentinel here is
+            # throttled ~8% of periods, node-1 no worse than the others, so
+            # throttling is NOT what makes node-1 different. It is still a
+            # standing event-loop hazard for all three and cheap to remove.
+            cpu: '1'
             memory: 64Mi
           requests:
-            # TLS health checks use 25-40m steadily.
-            cpu: 50m
+            # TLS health checks use 25-40m steadily. A 50m request left
+            # almost nothing above that for the handshake burst; 100m keeps
+            # the guaranteed share above measured idle without inflating the
+            # scheduler footprint. The limit is only reached by the bursts.
+            cpu: 100m
             memory: 32Mi
         securityContext:
           allowPrivilegeEscalation: false

--- a/deploy/db/status-routes.yaml
+++ b/deploy/db/status-routes.yaml
@@ -13,7 +13,7 @@ metadata:
   name: commands-status
   namespace: db
 spec:
-  trafficDistribution: PreferClose
+  trafficDistribution: PreferSameNode
   selector:
     app: commands
   ports:
@@ -27,7 +27,7 @@ metadata:
   name: loyalty-status
   namespace: db
 spec:
-  trafficDistribution: PreferClose
+  trafficDistribution: PreferSameNode
   selector:
     app: loyalty
   ports:
@@ -41,7 +41,7 @@ metadata:
   name: modules-status
   namespace: db
 spec:
-  trafficDistribution: PreferClose
+  trafficDistribution: PreferSameNode
   selector:
     app: modules
   ports:
@@ -55,7 +55,7 @@ metadata:
   name: notifications-status
   namespace: db
 spec:
-  trafficDistribution: PreferClose
+  trafficDistribution: PreferSameNode
   selector:
     app: notifications
   ports:
@@ -69,7 +69,7 @@ metadata:
   name: projector-status
   namespace: db
 spec:
-  trafficDistribution: PreferClose
+  trafficDistribution: PreferSameNode
   selector:
     app: projector
   ports:
@@ -83,7 +83,7 @@ metadata:
   name: users-status
   namespace: db
 spec:
-  trafficDistribution: PreferClose
+  trafficDistribution: PreferSameNode
   selector:
     app: users
   ports:

--- a/deploy/dns/Corefile
+++ b/deploy/dns/Corefile
@@ -1,0 +1,28 @@
+.:53 {
+    errors
+    health {
+      lameduck 5s
+    }
+    ready
+    kubernetes cluster.local in-addr.arpa ip6.arpa {
+      pods insecure
+      ttl 30
+      fallthrough in-addr.arpa ip6.arpa
+    }
+    hosts /etc/coredns/NodeHosts {
+      ttl 60
+      reload 15s
+      fallthrough
+    }
+    prometheus :9153
+    cache 60 {
+      prefetch 10 60s 10%
+      serve_stale 3600s immediate
+    }
+    loop
+    reload
+    loadbalance
+    import /etc/coredns/custom/*.override
+    forward . 1.1.1.1 9.9.9.9 8.8.8.8
+}
+import /etc/coredns/custom/*.server

--- a/deploy/dns/coredns.yaml
+++ b/deploy/dns/coredns.yaml
@@ -1,0 +1,205 @@
+# Copyright (c) 2026 Adam Ousmer. All rights reserved.
+# Proprietary. No license granted. See LICENSE.md.
+
+# Cluster DNS. This is a TAKEOVER of the k3s packaged coredns addon, not an
+# addition next to it. k3s ships coredns as a Deployment; this fleet runs it as
+# a DaemonSet so every node has a local resolver and pods never cross a node
+# boundary (or the tailnet) for DNS. The takeover is anchored by
+#   /var/lib/rancher/k3s/server/manifests/coredns.yaml.skip
+# on the server node (cp1), which stops k3s applying its own copy. Without that
+# file k3s reinstates the Deployment and reverts the Corefile. The ConfigMap
+# still carries stale objectset.rio.cattle.io annotations from the last apply
+# before the skip; they are inert.
+#
+# Until 2026-08-20 this DaemonSet existed ONLY as live cluster state with no
+# manifest anywhere, so a cp1 rebuild would have silently restored the k3s
+# Deployment. That is why it is checked in here.
+#
+# The Corefile lives beside this file rather than in the ConfigMap below,
+# deliberately. The coredns ConfigMap has a second key, NodeHosts, that a k3s
+# node controller rewrites as nodes join and leave -- and that controller is
+# NOT covered by the addon skip. `kubectl apply` replaces a ConfigMap's whole
+# data map, so applying the ConfigMap from git would delete NodeHosts and break
+# node-name resolution until k3s rewrote it. Push Corefile changes with a merge
+# patch, which leaves other keys alone:
+#
+#   kubectl -n kube-system patch cm coredns --type=merge \
+#     -p "$(python3 -c 'import json;print(json.dumps({"data":{"Corefile":open("deploy/dns/Corefile").read()}}))')"
+#
+# The `reload` plugin picks it up within ~30s and REFUSES an invalid Corefile,
+# so a syntax error leaves running pods on the last good config. A pod that
+# restarts while the config is bad will crash-loop, so verify after patching.
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: '{"apiVersion":"apps/v1","kind":"DaemonSet","metadata":{"annotations":{},"labels":{"k8s-app":"kube-dns","kubernetes.io/name":"CoreDNS"},"name":"coredns","namespace":"kube-system"},"spec":{"selector":{"matchLabels":{"k8s-app":"kube-dns"}},"template":{"metadata":{"labels":{"k8s-app":"kube-dns"}},"spec":{"containers":[{"args":["-conf","/etc/coredns/Corefile"],"image":"rancher/mirrored-coredns-coredns:1.14.6","imagePullPolicy":"IfNotPresent","livenessProbe":{"failureThreshold":3,"httpGet":{"path":"/health","port":8080,"scheme":"HTTP"},"initialDelaySeconds":10,"periodSeconds":10,"timeoutSeconds":2},"name":"coredns","ports":[{"containerPort":53,"name":"dns","protocol":"UDP"},{"containerPort":53,"name":"dns-tcp","protocol":"TCP"},{"containerPort":9153,"name":"metrics","protocol":"TCP"}],"readinessProbe":{"failureThreshold":3,"httpGet":{"path":"/ready","port":8181,"scheme":"HTTP"},"periodSeconds":2,"timeoutSeconds":1},"resources":{"limits":{"memory":"170Mi"},"requests":{"cpu":"100m","memory":"70Mi"}},"securityContext":{"allowPrivilegeEscalation":false,"capabilities":{"add":["NET_BIND_SERVICE"],"drop":["all"]},"readOnlyRootFilesystem":true},"volumeMounts":[{"mountPath":"/etc/coredns","name":"config-volume","readOnly":true},{"mountPath":"/etc/coredns/custom","name":"custom-config-volume","readOnly":true}]}],"dnsPolicy":"Default","nodeSelector":{"kubernetes.io/os":"linux"},"priorityClassName":"system-cluster-critical","serviceAccountName":"coredns","tolerations":[{"key":"CriticalAddonsOnly","operator":"Exists"},{"effect":"NoSchedule","key":"node-role.kubernetes.io/control-plane","operator":"Exists"}],"volumes":[{"configMap":{"items":[{"key":"Corefile","path":"Corefile"},{"key":"NodeHosts","path":"NodeHosts"}],"name":"coredns"},"name":"config-volume"},{"configMap":{"name":"coredns-custom","optional":true},"name":"custom-config-volume"}]}},"updateStrategy":{"rollingUpdate":{"maxUnavailable":1},"type":"RollingUpdate"}}}
+
+      '
+  labels:
+    k8s-app: kube-dns
+    kubernetes.io/name: CoreDNS
+  name: coredns
+  namespace: kube-system
+spec:
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      k8s-app: kube-dns
+  template:
+    metadata:
+      labels:
+        k8s-app: kube-dns
+    spec:
+      containers:
+      - args:
+        - -conf
+        - /etc/coredns/Corefile
+        image: rancher/mirrored-coredns-coredns@sha256:900f9c109f7a33545d3c811516e8376df9019147b750f5ce3e254468769176ea
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 2
+        name: coredns
+        ports:
+        - containerPort: 53
+          name: dns
+          protocol: UDP
+        - containerPort: 53
+          name: dns-tcp
+          protocol: TCP
+        - containerPort: 9153
+          name: metrics
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /ready
+            port: 8181
+            scheme: HTTP
+          periodSeconds: 2
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 170Mi
+          requests:
+            cpu: 100m
+            memory: 70Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add:
+            - NET_BIND_SERVICE
+            drop:
+            - all
+          readOnlyRootFilesystem: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/coredns
+          name: config-volume
+          readOnly: true
+        - mountPath: /etc/coredns/custom
+          name: custom-config-volume
+          readOnly: true
+      dnsPolicy: Default
+      nodeSelector:
+        kubernetes.io/os: linux
+      priorityClassName: system-cluster-critical
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: coredns
+      serviceAccountName: coredns
+      terminationGracePeriodSeconds: 30
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - effect: NoSchedule
+        key: role
+        operator: Equal
+        value: cp
+      volumes:
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: Corefile
+            path: Corefile
+          - key: NodeHosts
+            path: NodeHosts
+          name: coredns
+        name: config-volume
+      - configMap:
+          defaultMode: 420
+          name: coredns-custom
+          optional: true
+        name: custom-config-volume
+  updateStrategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+    type: RollingUpdate
+
+# kube-dns Service. trafficDistribution PreferSameNode keeps each pod on its
+# own node's resolver while still falling back to a peer if the local pod is
+# unready -- unlike internalTrafficPolicy: Local, which has no fallback.
+# Set 2026-08-20 after cross-node DNS to the cp1 resolver, reached over
+# tailscale0, was traced to intermittent Cilium "FIB lookup failed" drops:
+# one lost UDP packet cost a 5s resolver timeout, which stalled Valkey
+# Sentinel past its 2s tilt threshold ~10x/hour on node3.
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    objectset.rio.cattle.io/id: ''
+    objectset.rio.cattle.io/owner-gvk: k3s.cattle.io/v1, Kind=Addon
+    objectset.rio.cattle.io/owner-name: coredns
+    objectset.rio.cattle.io/owner-namespace: kube-system
+    prometheus.io/port: '9153'
+    prometheus.io/scrape: 'true'
+  labels:
+    k8s-app: kube-dns
+    kubernetes.io/cluster-service: 'true'
+    kubernetes.io/name: CoreDNS
+    objectset.rio.cattle.io/hash: bce283298811743a0386ab510f2f67ef74240c57
+  name: kube-dns
+  namespace: kube-system
+spec:
+  clusterIP: 10.43.0.10
+  clusterIPs:
+  - 10.43.0.10
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: dns
+    port: 53
+    protocol: UDP
+    targetPort: 53
+  - name: dns-tcp
+    port: 53
+    protocol: TCP
+    targetPort: 53
+  - name: metrics
+    port: 9153
+    protocol: TCP
+    targetPort: 9153
+  selector:
+    k8s-app: kube-dns
+  sessionAffinity: None
+  trafficDistribution: PreferSameNode
+  type: ClusterIP

--- a/deploy/dns/kustomization.yaml
+++ b/deploy/dns/kustomization.yaml
@@ -1,0 +1,11 @@
+# Copyright (c) 2026 Adam Ousmer. All rights reserved.
+# Proprietary. No license granted. See LICENSE.md.
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  # DaemonSet + kube-dns Service. The Corefile is NOT listed here on purpose:
+  # its ConfigMap also holds NodeHosts, which a k3s node controller rewrites
+  # and which `kubectl apply` would delete. Push Corefile changes with the
+  # merge-patch documented in the header of coredns.yaml.
+  - coredns.yaml

--- a/deploy/k8s/console-admin.yaml
+++ b/deploy/k8s/console-admin.yaml
@@ -94,12 +94,34 @@ spec:
       # Resolve external hosts (Twitch OAuth login) without the cluster
       # search-domain fan-out (ndots:1) and serialize A/AAAA to dodge the
       # conntrack race; cap any DNS stall well under a few seconds.
+      # Resolver options, uniform across every first-party workload.
+      #
+      # ndots 1, not the kubelet default of 5: under ndots:5 any name with
+      # fewer than 5 dots is tried against all three search domains BEFORE
+      # being tried as written, so a 4-dot cluster FQDN costs 4 queries and
+      # an external name like api.twitch.tv costs 4 too -- three guaranteed
+      # NXDOMAINs, then the answer. Measured on coredns 2026-08-20: 16704
+      # denial cache hits against 10368 success hits, so 62% of everything
+      # served was the junk half of that expansion.
+      #
+      # single-request-reopen: glibc sends the A and AAAA queries in parallel
+      # from one socket; the two replies can race in conntrack and one gets
+      # dropped, which costs a full resolver timeout. Reopening the socket
+      # for the second query removes the race.
+      #
+      # timeout 1 + attempts 3, rather than the previous 2/2 and the glibc
+      # default 5/2. A dropped UDP packet costs 1s instead of 5s, and 3s
+      # worst case instead of 10s. The 1s matters specifically because Valkey
+      # Sentinel resolves hostnames inside its event loop and declares "tilt"
+      # -- refusing failover for a fixed 30s -- when that loop stalls beyond
+      # 2s. At timeout 2 a single lost packet sat exactly on that threshold.
+      # See deploy/cache/valkey.yaml for the measurement that found it.
       dnsConfig:
         options:
           - {name: ndots, value: "1"}
           - {name: single-request-reopen}
-          - {name: timeout, value: "2"}
-          - {name: attempts, value: "2"}
+          - {name: timeout, value: "1"}
+          - {name: attempts, value: "3"}
       securityContext:
         # Keep the congestion window across an idle gap. This sysctl is
         # per-netns: the nodes run 0, but a pod netns inherits the kernel
@@ -114,6 +136,7 @@ spec:
         runAsUser: 65532
         runAsGroup: 65532
         seccompProfile: {type: RuntimeDefault}
+      priorityClassName: bagel-edge
       containers:
         - name: console-admin
           image: ghcr.io/adamousmer/itsbagelbot/console-admin:main-1787254007-c739a93c3aff
@@ -344,7 +367,7 @@ metadata:
 spec:
   # No sessionAffinity: stateless sessions make every pod interchangeable.
   # PreferClose keeps the operator proxy on the in-region admin pod.
-  trafficDistribution: PreferClose
+  trafficDistribution: PreferSameNode
   selector:
     app: console-admin
   ports:

--- a/deploy/k8s/console-dashboard.yaml
+++ b/deploy/k8s/console-dashboard.yaml
@@ -94,12 +94,34 @@ spec:
       # Resolve external hosts (Twitch OAuth login) without the cluster
       # search-domain fan-out (ndots:1) and serialize A/AAAA to dodge the
       # conntrack race; cap any DNS stall well under a few seconds.
+      # Resolver options, uniform across every first-party workload.
+      #
+      # ndots 1, not the kubelet default of 5: under ndots:5 any name with
+      # fewer than 5 dots is tried against all three search domains BEFORE
+      # being tried as written, so a 4-dot cluster FQDN costs 4 queries and
+      # an external name like api.twitch.tv costs 4 too -- three guaranteed
+      # NXDOMAINs, then the answer. Measured on coredns 2026-08-20: 16704
+      # denial cache hits against 10368 success hits, so 62% of everything
+      # served was the junk half of that expansion.
+      #
+      # single-request-reopen: glibc sends the A and AAAA queries in parallel
+      # from one socket; the two replies can race in conntrack and one gets
+      # dropped, which costs a full resolver timeout. Reopening the socket
+      # for the second query removes the race.
+      #
+      # timeout 1 + attempts 3, rather than the previous 2/2 and the glibc
+      # default 5/2. A dropped UDP packet costs 1s instead of 5s, and 3s
+      # worst case instead of 10s. The 1s matters specifically because Valkey
+      # Sentinel resolves hostnames inside its event loop and declares "tilt"
+      # -- refusing failover for a fixed 30s -- when that loop stalls beyond
+      # 2s. At timeout 2 a single lost packet sat exactly on that threshold.
+      # See deploy/cache/valkey.yaml for the measurement that found it.
       dnsConfig:
         options:
           - {name: ndots, value: "1"}
           - {name: single-request-reopen}
-          - {name: timeout, value: "2"}
-          - {name: attempts, value: "2"}
+          - {name: timeout, value: "1"}
+          - {name: attempts, value: "3"}
       securityContext:
         # Keep the congestion window across an idle gap. This sysctl is
         # per-netns: the nodes run 0, but a pod netns inherits the kernel
@@ -114,6 +136,7 @@ spec:
         runAsUser: 65532
         runAsGroup: 65532
         seccompProfile: {type: RuntimeDefault}
+      priorityClassName: bagel-edge
       containers:
         - name: console-dashboard
           image: ghcr.io/adamousmer/itsbagelbot/console-dashboard:main-1787194469-cb0d16209c6d
@@ -323,7 +346,7 @@ metadata:
 spec:
   # Region-aware: prefer same-city (zone==city) endpoints; spill cross-city only
   # when no local pod is ready. traefik uses this ClusterIP via nativeLB.
-  trafficDistribution: PreferClose
+  trafficDistribution: PreferSameNode
   selector:
     app: console-dashboard
   ports:

--- a/deploy/k8s/gossip.yaml
+++ b/deploy/k8s/gossip.yaml
@@ -103,6 +103,35 @@ spec:
         runAsUser: 65532
         runAsGroup: 65532
         seccompProfile: {type: RuntimeDefault}
+      # Resolver options, uniform across every first-party workload.
+      #
+      # ndots 1, not the kubelet default of 5: under ndots:5 any name with
+      # fewer than 5 dots is tried against all three search domains BEFORE
+      # being tried as written, so a 4-dot cluster FQDN costs 4 queries and
+      # an external name like api.twitch.tv costs 4 too -- three guaranteed
+      # NXDOMAINs, then the answer. Measured on coredns 2026-08-20: 16704
+      # denial cache hits against 10368 success hits, so 62% of everything
+      # served was the junk half of that expansion.
+      #
+      # single-request-reopen: glibc sends the A and AAAA queries in parallel
+      # from one socket; the two replies can race in conntrack and one gets
+      # dropped, which costs a full resolver timeout. Reopening the socket
+      # for the second query removes the race.
+      #
+      # timeout 1 + attempts 3, rather than the previous 2/2 and the glibc
+      # default 5/2. A dropped UDP packet costs 1s instead of 5s, and 3s
+      # worst case instead of 10s. The 1s matters specifically because Valkey
+      # Sentinel resolves hostnames inside its event loop and declares "tilt"
+      # -- refusing failover for a fixed 30s -- when that loop stalls beyond
+      # 2s. At timeout 2 a single lost packet sat exactly on that threshold.
+      # See deploy/cache/valkey.yaml for the measurement that found it.
+      dnsConfig:
+        options:
+          - {name: ndots, value: "1"}
+          - {name: single-request-reopen}
+          - {name: timeout, value: "1"}
+          - {name: attempts, value: "3"}
+      priorityClassName: bagel-service
       containers:
         - name: gossip
           image: ghcr.io/adamousmer/itsbagelbot/gossip:main-1787194469-cb0d16209c6d@sha256:aa3094009ee618ca3bdb9bedd1136f6710f68cb9a901050361eaff6785bf6d38

--- a/deploy/k8s/kustomization.yaml
+++ b/deploy/k8s/kustomization.yaml
@@ -4,6 +4,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  # PriorityClasses must exist before any pod that names one -- a pod
+  # referencing a missing class is rejected by the API server, so this is
+  # listed first deliberately.
+  - priorityclasses.yaml
   - console-admin.yaml
   - commands.yaml
   - console-dashboard.yaml

--- a/deploy/k8s/outgress.yaml
+++ b/deploy/k8s/outgress.yaml
@@ -81,12 +81,34 @@ spec:
       # etc.), each a chance to hit the cross-node DNS stall; ndots:1 sends the
       # absolute name first. A shorter timeout with a retry caps a stall well under
       # the 5s outgress message lifetime instead of blowing it.
+      # Resolver options, uniform across every first-party workload.
+      #
+      # ndots 1, not the kubelet default of 5: under ndots:5 any name with
+      # fewer than 5 dots is tried against all three search domains BEFORE
+      # being tried as written, so a 4-dot cluster FQDN costs 4 queries and
+      # an external name like api.twitch.tv costs 4 too -- three guaranteed
+      # NXDOMAINs, then the answer. Measured on coredns 2026-08-20: 16704
+      # denial cache hits against 10368 success hits, so 62% of everything
+      # served was the junk half of that expansion.
+      #
+      # single-request-reopen: glibc sends the A and AAAA queries in parallel
+      # from one socket; the two replies can race in conntrack and one gets
+      # dropped, which costs a full resolver timeout. Reopening the socket
+      # for the second query removes the race.
+      #
+      # timeout 1 + attempts 3, rather than the previous 2/2 and the glibc
+      # default 5/2. A dropped UDP packet costs 1s instead of 5s, and 3s
+      # worst case instead of 10s. The 1s matters specifically because Valkey
+      # Sentinel resolves hostnames inside its event loop and declares "tilt"
+      # -- refusing failover for a fixed 30s -- when that loop stalls beyond
+      # 2s. At timeout 2 a single lost packet sat exactly on that threshold.
+      # See deploy/cache/valkey.yaml for the measurement that found it.
       dnsConfig:
         options:
           - {name: ndots, value: "1"}
           - {name: single-request-reopen}
-          - {name: timeout, value: "2"}
-          - {name: attempts, value: "2"}
+          - {name: timeout, value: "1"}
+          - {name: attempts, value: "3"}
       securityContext:
         # Keep the congestion window across an idle gap. This sysctl is
         # per-netns: the nodes run 0, but a pod netns inherits the kernel
@@ -101,6 +123,7 @@ spec:
         runAsUser: 65532
         runAsGroup: 65532
         seccompProfile: {type: RuntimeDefault}
+      priorityClassName: bagel-service
       containers:
         - name: outgress
           image: ghcr.io/adamousmer/itsbagelbot/outgress:main-1787252044-f4347119cdf9@sha256:11c377dce91778e91ae6dd7f1a7d2a5d3aa8694808a5e05e8049b86d54537310 # {"$imagepolicy": "flux-system:outgress"}

--- a/deploy/k8s/priorityclasses.yaml
+++ b/deploy/k8s/priorityclasses.yaml
@@ -1,0 +1,61 @@
+# Copyright (c) 2026 Adam Ousmer. All rights reserved.
+# Proprietary. No license granted. See LICENSE.md.
+
+# Scheduling priority for first-party workloads.
+#
+# Until this existed every pod this fleet runs sat at priority 0 — the same
+# rank as New Relic's agents, Falco, cert-manager and cloudflared. Under node
+# pressure the kubelet's eviction ranking and the scheduler's preemption logic
+# had no way to tell "the thing that answers Twitch chat" from "the thing that
+# ships metrics about it", and a burst of telemetry could win a scheduling race
+# against the data plane.
+#
+# Values are chosen to sit ABOVE every unclassed third-party workload (0) and
+# BELOW the two built-in system classes, which must keep outranking everything:
+#   system-node-critical     2000001000   (cilium, kube-proxy)
+#   system-cluster-critical  2000000000   (coredns)
+# Losing CNI or DNS takes the whole node down, so first-party services must
+# never preempt them. There is deliberately no globalDefault: a pod with no
+# class stays at 0, which is the correct rank for third-party tooling.
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: bagel-data-plane
+value: 900000
+globalDefault: false
+preemptionPolicy: PreemptLowerPriority
+description: >-
+  Valkey and NATS. Every other first-party service holds connections to these
+  and fails closed without them, so they outrank the services that depend on
+  them: evicting a NATS hub member to make room for a service that needs NATS
+  is a net loss. NATS hub members are Burstable by design (requests below
+  limits, see the resources block in nats.yaml), which places them inside the
+  memory-pressure eviction ranking; this class is what keeps them at the back
+  of that queue.
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: bagel-service
+value: 800000
+globalDefault: false
+preemptionPolicy: PreemptLowerPriority
+description: >-
+  First-party runtime services — twitch-ingress, sesame, outgress, projector,
+  gossip and the db-backed RPC services. These carry live user traffic. They
+  rank below the data plane they depend on and above all observability and
+  operator tooling.
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: bagel-edge
+value: 700000
+globalDefault: false
+preemptionPolicy: PreemptLowerPriority
+description: >-
+  Operator-facing consoles. Real first-party workloads, so they outrank
+  third-party tooling, but a console being briefly unschedulable costs an
+  operator a page refresh while the same eviction on a runtime service drops
+  live chat traffic. Lowest of the three deliberately.

--- a/deploy/k8s/projector.yaml
+++ b/deploy/k8s/projector.yaml
@@ -87,6 +87,35 @@ spec:
         runAsUser: 65532
         runAsGroup: 65532
         seccompProfile: {type: RuntimeDefault}
+      # Resolver options, uniform across every first-party workload.
+      #
+      # ndots 1, not the kubelet default of 5: under ndots:5 any name with
+      # fewer than 5 dots is tried against all three search domains BEFORE
+      # being tried as written, so a 4-dot cluster FQDN costs 4 queries and
+      # an external name like api.twitch.tv costs 4 too -- three guaranteed
+      # NXDOMAINs, then the answer. Measured on coredns 2026-08-20: 16704
+      # denial cache hits against 10368 success hits, so 62% of everything
+      # served was the junk half of that expansion.
+      #
+      # single-request-reopen: glibc sends the A and AAAA queries in parallel
+      # from one socket; the two replies can race in conntrack and one gets
+      # dropped, which costs a full resolver timeout. Reopening the socket
+      # for the second query removes the race.
+      #
+      # timeout 1 + attempts 3, rather than the previous 2/2 and the glibc
+      # default 5/2. A dropped UDP packet costs 1s instead of 5s, and 3s
+      # worst case instead of 10s. The 1s matters specifically because Valkey
+      # Sentinel resolves hostnames inside its event loop and declares "tilt"
+      # -- refusing failover for a fixed 30s -- when that loop stalls beyond
+      # 2s. At timeout 2 a single lost packet sat exactly on that threshold.
+      # See deploy/cache/valkey.yaml for the measurement that found it.
+      dnsConfig:
+        options:
+          - {name: ndots, value: "1"}
+          - {name: single-request-reopen}
+          - {name: timeout, value: "1"}
+          - {name: attempts, value: "3"}
+      priorityClassName: bagel-service
       containers:
         - name: projector
           image: ghcr.io/adamousmer/itsbagelbot/projector:main-1787252044-f4347119cdf9@sha256:6710f204b08274f1a19d18b3cfcbeca918f1e5eae516d68f2a686f46dbe3ccf3 # {"$imagepolicy": "flux-system:projector"}

--- a/deploy/k8s/sesame.yaml
+++ b/deploy/k8s/sesame.yaml
@@ -99,6 +99,35 @@ spec:
         runAsUser: 65532
         runAsGroup: 65532
         seccompProfile: {type: RuntimeDefault}
+      # Resolver options, uniform across every first-party workload.
+      #
+      # ndots 1, not the kubelet default of 5: under ndots:5 any name with
+      # fewer than 5 dots is tried against all three search domains BEFORE
+      # being tried as written, so a 4-dot cluster FQDN costs 4 queries and
+      # an external name like api.twitch.tv costs 4 too -- three guaranteed
+      # NXDOMAINs, then the answer. Measured on coredns 2026-08-20: 16704
+      # denial cache hits against 10368 success hits, so 62% of everything
+      # served was the junk half of that expansion.
+      #
+      # single-request-reopen: glibc sends the A and AAAA queries in parallel
+      # from one socket; the two replies can race in conntrack and one gets
+      # dropped, which costs a full resolver timeout. Reopening the socket
+      # for the second query removes the race.
+      #
+      # timeout 1 + attempts 3, rather than the previous 2/2 and the glibc
+      # default 5/2. A dropped UDP packet costs 1s instead of 5s, and 3s
+      # worst case instead of 10s. The 1s matters specifically because Valkey
+      # Sentinel resolves hostnames inside its event loop and declares "tilt"
+      # -- refusing failover for a fixed 30s -- when that loop stalls beyond
+      # 2s. At timeout 2 a single lost packet sat exactly on that threshold.
+      # See deploy/cache/valkey.yaml for the measurement that found it.
+      dnsConfig:
+        options:
+          - {name: ndots, value: "1"}
+          - {name: single-request-reopen}
+          - {name: timeout, value: "1"}
+          - {name: attempts, value: "3"}
+      priorityClassName: bagel-service
       containers:
         - name: sesame
           image: ghcr.io/adamousmer/itsbagelbot/sesame:main-1787194469-cb0d16209c6d@sha256:e3a4a47a4a5d98da1bbd14eda8c9abe0b28eee80a4e2c594e77f81f7c6fb8c42

--- a/deploy/k8s/status-routes.yaml
+++ b/deploy/k8s/status-routes.yaml
@@ -24,7 +24,7 @@ metadata:
   name: gossip-status
   namespace: app
 spec:
-  trafficDistribution: PreferClose
+  trafficDistribution: PreferSameNode
   selector:
     app: gossip
   ports:
@@ -38,7 +38,7 @@ metadata:
   name: outgress-status
   namespace: app
 spec:
-  trafficDistribution: PreferClose
+  trafficDistribution: PreferSameNode
   selector:
     app: outgress
   ports:
@@ -52,7 +52,7 @@ metadata:
   name: sesame-status
   namespace: app
 spec:
-  trafficDistribution: PreferClose
+  trafficDistribution: PreferSameNode
   selector:
     app: sesame
   ports:

--- a/deploy/k8s/transactions.yaml
+++ b/deploy/k8s/transactions.yaml
@@ -233,7 +233,7 @@ metadata:
   name: transactions
   namespace: db
 spec:
-  trafficDistribution: PreferClose
+  trafficDistribution: PreferSameNode
   selector:
     app: transactions
   ports:

--- a/deploy/k8s/twitch-ingress.yaml
+++ b/deploy/k8s/twitch-ingress.yaml
@@ -107,12 +107,34 @@ spec:
       # Resolve external hosts (Twitch EventSub/Helix) without the cluster
       # search-domain fan-out (ndots:1) and serialize A/AAAA to dodge the
       # conntrack race; cap any DNS stall well under a few seconds.
+      # Resolver options, uniform across every first-party workload.
+      #
+      # ndots 1, not the kubelet default of 5: under ndots:5 any name with
+      # fewer than 5 dots is tried against all three search domains BEFORE
+      # being tried as written, so a 4-dot cluster FQDN costs 4 queries and
+      # an external name like api.twitch.tv costs 4 too -- three guaranteed
+      # NXDOMAINs, then the answer. Measured on coredns 2026-08-20: 16704
+      # denial cache hits against 10368 success hits, so 62% of everything
+      # served was the junk half of that expansion.
+      #
+      # single-request-reopen: glibc sends the A and AAAA queries in parallel
+      # from one socket; the two replies can race in conntrack and one gets
+      # dropped, which costs a full resolver timeout. Reopening the socket
+      # for the second query removes the race.
+      #
+      # timeout 1 + attempts 3, rather than the previous 2/2 and the glibc
+      # default 5/2. A dropped UDP packet costs 1s instead of 5s, and 3s
+      # worst case instead of 10s. The 1s matters specifically because Valkey
+      # Sentinel resolves hostnames inside its event loop and declares "tilt"
+      # -- refusing failover for a fixed 30s -- when that loop stalls beyond
+      # 2s. At timeout 2 a single lost packet sat exactly on that threshold.
+      # See deploy/cache/valkey.yaml for the measurement that found it.
       dnsConfig:
         options:
           - {name: ndots, value: "1"}
           - {name: single-request-reopen}
-          - {name: timeout, value: "2"}
-          - {name: attempts, value: "2"}
+          - {name: timeout, value: "1"}
+          - {name: attempts, value: "3"}
       securityContext:
         # Keep the congestion window across an idle gap. This sysctl is
         # per-netns: the nodes run 0, but a pod netns inherits the kernel
@@ -127,6 +149,7 @@ spec:
         runAsUser: 999 # the image's `ingress` user; numeric so kubelet can verify
         runAsGroup: 999
         seccompProfile: {type: RuntimeDefault}
+      priorityClassName: bagel-service
       containers:
         - name: ingress
           image: ghcr.io/adamousmer/itsbagelbot/twitch-ingress:main-1787254007-c739a93c3aff
@@ -261,12 +284,24 @@ spec:
                 +S 2:2 +SDcpu 2:2 +SDio 2 +sbwt short +sbwtdcpu none +sbwtdio none -kernel inet_dist_listen_min 9100 -kernel inet_dist_listen_max 9110
           resources:
             requests:
-              # Live steady state is 195-240m across all three node-local pods.
-              cpu: 250m
-              memory: 256Mi
+              # Raised 250m -> 500m and 256Mi -> 384Mi on 2026-08-20. The old
+              # request cited a 195-240m steady state; measured usage was 378m
+              # per pod, ALREADY above the request, and that sample was taken
+              # at a trough -- one live channel and 59 msg/s against a lifetime
+              # NATS average of ~275 msg/s, so a busy night is several times
+              # this. A pod running above its CPU request keeps only its
+              # request share once the node contends, which is exactly when the
+              # firehose needs the cores. Memory measured 190Mi against a
+              # 256Mi request; 384Mi keeps headroom for BEAM growth under load
+              # without approaching the limit.
+              # The limit is unchanged: cpu "2" matches the +S 2:2 scheduler
+              # count in BEAM_FLAGS above, and changing one without the other
+              # would either strand schedulers or oversubscribe them.
+              cpu: 500m
+              memory: 384Mi
             limits:
               cpu: "2"
-              memory: 512Mi
+              memory: 1Gi
           volumeMounts:
             - {name: nats-client-tls, mountPath: /etc/nats-client/tls, readOnly: true}
             - {name: health-tls, mountPath: /etc/twitch-ingress/tls, readOnly: true}
@@ -323,7 +358,7 @@ metadata:
   name: twitch-ingress-status
   namespace: app
 spec:
-  trafficDistribution: PreferClose
+  trafficDistribution: PreferSameNode
   selector:
     app: twitch-ingress
   ports:

--- a/deploy/messaging/nats-leaf.yaml
+++ b/deploy/messaging/nats-leaf.yaml
@@ -89,6 +89,35 @@ spec:
         runAsGroup: 1000
         fsGroup: 1000
         seccompProfile: {type: RuntimeDefault}
+      # Resolver options, uniform across every first-party workload.
+      #
+      # ndots 1, not the kubelet default of 5: under ndots:5 any name with
+      # fewer than 5 dots is tried against all three search domains BEFORE
+      # being tried as written, so a 4-dot cluster FQDN costs 4 queries and
+      # an external name like api.twitch.tv costs 4 too -- three guaranteed
+      # NXDOMAINs, then the answer. Measured on coredns 2026-08-20: 16704
+      # denial cache hits against 10368 success hits, so 62% of everything
+      # served was the junk half of that expansion.
+      #
+      # single-request-reopen: glibc sends the A and AAAA queries in parallel
+      # from one socket; the two replies can race in conntrack and one gets
+      # dropped, which costs a full resolver timeout. Reopening the socket
+      # for the second query removes the race.
+      #
+      # timeout 1 + attempts 3, rather than the previous 2/2 and the glibc
+      # default 5/2. A dropped UDP packet costs 1s instead of 5s, and 3s
+      # worst case instead of 10s. The 1s matters specifically because Valkey
+      # Sentinel resolves hostnames inside its event loop and declares "tilt"
+      # -- refusing failover for a fixed 30s -- when that loop stalls beyond
+      # 2s. At timeout 2 a single lost packet sat exactly on that threshold.
+      # See deploy/cache/valkey.yaml for the measurement that found it.
+      dnsConfig:
+        options:
+          - {name: ndots, value: "1"}
+          - {name: single-request-reopen}
+          - {name: timeout, value: "1"}
+          - {name: attempts, value: "3"}
+      priorityClassName: bagel-data-plane
       containers:
         - name: nats
           image: nats:2.14.4-alpine@sha256:f2123f533c2b0cada0a5c5ec434fb2b8cfe1cf220215ef9d7517e1372917ad66

--- a/deploy/messaging/nats.yaml
+++ b/deploy/messaging/nats.yaml
@@ -113,6 +113,35 @@ spec:
         runAsGroup: 1000
         fsGroup: 1000
         seccompProfile: {type: RuntimeDefault}
+      # Resolver options, uniform across every first-party workload.
+      #
+      # ndots 1, not the kubelet default of 5: under ndots:5 any name with
+      # fewer than 5 dots is tried against all three search domains BEFORE
+      # being tried as written, so a 4-dot cluster FQDN costs 4 queries and
+      # an external name like api.twitch.tv costs 4 too -- three guaranteed
+      # NXDOMAINs, then the answer. Measured on coredns 2026-08-20: 16704
+      # denial cache hits against 10368 success hits, so 62% of everything
+      # served was the junk half of that expansion.
+      #
+      # single-request-reopen: glibc sends the A and AAAA queries in parallel
+      # from one socket; the two replies can race in conntrack and one gets
+      # dropped, which costs a full resolver timeout. Reopening the socket
+      # for the second query removes the race.
+      #
+      # timeout 1 + attempts 3, rather than the previous 2/2 and the glibc
+      # default 5/2. A dropped UDP packet costs 1s instead of 5s, and 3s
+      # worst case instead of 10s. The 1s matters specifically because Valkey
+      # Sentinel resolves hostnames inside its event loop and declares "tilt"
+      # -- refusing failover for a fixed 30s -- when that loop stalls beyond
+      # 2s. At timeout 2 a single lost packet sat exactly on that threshold.
+      # See deploy/cache/valkey.yaml for the measurement that found it.
+      dnsConfig:
+        options:
+          - {name: ndots, value: "1"}
+          - {name: single-request-reopen}
+          - {name: timeout, value: "1"}
+          - {name: attempts, value: "3"}
+      priorityClassName: bagel-data-plane
       containers:
         - name: nats
           image: nats:2.14.4-alpine@sha256:f2123f533c2b0cada0a5c5ec434fb2b8cfe1cf220215ef9d7517e1372917ad66
@@ -170,23 +199,49 @@ spec:
             # Burstable rather than Guaranteed. The upstream NATS chart
             # recommends requests == limits so the member is eligible for the
             # kubelet's static CPU policy — but this fleet runs
-            # cpuManagerPolicy: none, so that eligibility buys nothing today and
-            # reserving 5 cores per node bought nothing either. Measured steady
-            # state is ~1.3 cores on the leader, so a request of 2 covers it with
-            # ~50% headroom while the limit still lets a catch-up burst take all
-            # five. That returns 3 cores and 1Gi per app node to the scheduler on
-            # a 12-core, ~11 GiB tier.
+            # cpuManagerPolicy: none, so that eligibility buys nothing.
             #
-            # The cost, stated so it is not rediscovered: memory usage above the
-            # request puts this pod into the kubelet's memory-pressure eviction
-            # ranking, which at requests == limits it sat outside entirely. The
-            # modelled per-member worst case is ~4.2 GiB (see the max_mem block
-            # in nats-server.conf), so 4Gi sits just under it — steady state is
-            # far below, but a member catching up a full memory-backed catalog
-            # is not. If a hub member is ever evicted under node pressure, raise
-            # this to 4500Mi before looking anywhere else. If cpuManagerPolicy
-            # ever becomes static, revisit the CPU request too.
-            requests: {cpu: "2", memory: 4Gi}
+            # Sized 2026-08-20 against what the stream catalog can actually
+            # reach, not against max_mem. Four streams are storage=memory and
+            # every one is R3, so each member holds all of them:
+            #   TWITCH_INGRESS_STANDARD  640Mi
+            #   TWITCH_INGRESS           384Mi
+            #   TWITCH_OUTGRESS          256Mi
+            #   TWITCH_INGRESS_RETRY      32Mi
+            #                          ------
+            #   reachable total         1312Mi
+            # Measured resident at 64 connections is 138Mi, so 2Gi covers the
+            # full catalog plus ~700Mi for dedup indexes, connections and the
+            # Go runtime. The older ~4.2 GiB worst case was derived from
+            # max_mem 4096Mi, which is 3x more than this catalog can consume —
+            # the request should track the catalog, not a config ceiling the
+            # streams cannot reach. max_mem and the 5Gi limit both stay put,
+            # so the pathological case is still absorbed; only the reservation
+            # moved.
+            #
+            # What makes this safe now and did not before: this pod carries
+            # priorityClassName bagel-data-plane (900000). The kubelet's
+            # memory-pressure eviction ranking sorts by whether usage exceeds
+            # the request and THEN by pod priority, so among pods over their
+            # request a hub member is evicted after every third-party workload
+            # on the node (all of which sit at priority 0). The protection that
+            # used to come from an oversized request now comes from the class,
+            # which is what a priority class is for.
+            #
+            # CPU 2 -> 1000m: a CPU request is a contention-time floor and
+            # never throttles, measured steady state is ~1.3 cores on the
+            # leader at load, and the 5-core limit still lets a catch-up burst
+            # take every core. Nodes sit at 28% of 12 cores committed.
+            #
+            # Together this returns 1 core and 2Gi per app node, which is
+            # deliberate headroom for the incoming BEAM service — BEAM sizes
+            # its scheduler pool off the cgroup and wants real room to land on
+            # (twitch-ingress, the BEAM service already here, requests 500m).
+            # If a hub member is ever evicted under node pressure, raise the
+            # memory request toward 2500Mi and re-check this arithmetic before
+            # looking anywhere else. If cpuManagerPolicy ever becomes static,
+            # revisit the CPU request too.
+            requests: {cpu: "1000m", memory: 2Gi}
             limits: {cpu: "5", memory: 5Gi}
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
Valkey Sentinel was entering "tilt" ~10x/hour on node3 and getting restarted by its own liveness probe. Two independent causes, both fixed, plus the config that was only ever live.

## DNS

Sentinel resolves hostnames inside its event loop, so a blocking resolve stalls the loop, and tilt triggers past 2s. 300 resolves per member:

| member | p50 | p95 | p99 | max |
|---|---|---|---|---|
| valkey-node-1 | 12ms | 66ms | 92ms | **5073ms** |
| valkey-node-0 | 14ms | 65ms | 99ms | 115ms |

Percentiles identical; the entire delta is one 5073ms outlier, which is the glibc resolver default timeout, i.e. one dropped UDP packet. The packet was lost crossing `tailscale0` to the coredns pod on cp1, which every pod reached because `kube-dns` was `internalTrafficPolicy: Cluster`.

- Resolver options unified across all first-party workloads: `ndots 1`, `single-request-reopen`, `timeout 1`, `attempts 3`. Under `ndots 5` a 4-dot cluster FQDN cost 4 queries; **62%** of everything coredns served was the NXDOMAIN half of that expansion.
- Every Service moved off the deprecated `PreferClose` to `PreferSameNode`. The two `internalTrafficPolicy: Local` services are deliberately untouched — `Local` has no fallback and `pkg/valkey` depends on that.
- coredns captured into `deploy/dns/` for the first time. The DaemonSet and Corefile existed **only as live cluster state**, so a cp1 rebuild would have silently restored the k3s packaged Deployment. Image pinned by digest. The Corefile sits beside the manifest, not in it — that ConfigMap also holds `NodeHosts`, which a k3s controller rewrites and `kubectl apply` would delete.

## Sentinel CPU

Both probes fork `valkey-cli` and complete a full mTLS handshake, and a new process cannot reuse a session ticket. One probe measured **80043µs** inside the 250m container vs **13862µs** from an unthrottled one in the same netns — 83% of the cost was CFS throttling, during which the event loop cannot run. Liveness was `periodSeconds 10 × failureThreshold 3` = exactly the 30s tilt window.

- sentinel cpu limit `250m → 1`, request `50m → 100m`
- sentinel liveness `failureThreshold 3 → 6`
- valkey probes moved to a unix socket, removing ~18 handshakes/min

## Priority

Every workload sat at priority 0, the same rank as the telemetry agents. Adds `bagel-data-plane` / `bagel-service` / `bagel-edge`, below both system classes so cilium and coredns still win. Listed first in the kustomization because a pod naming a missing class is rejected.

## Resources

- `nats` requests `2 cpu / 4Gi → 1000m / 2Gi`. The four memory-backed streams total 1312Mi reachable at R3; the old figure tracked `max_mem 4096Mi`, which those streams cannot reach. Limits and `max_mem` untouched.
- `twitch-ingress` requests `250m/256Mi → 500m/384Mi` — measured at 378m, already above its request.
- `valkey` limit `2Gi → 3Gi`; `maxmemory` and `io-threads` derived from container limits via the Downward API.
- `slowlog-log-slower-than 1000 → 10000`. It is microseconds; 1ms was logging ordinary Sentinel INFO polls as incidents.

## Verified live

```
sentinel probe      80043µs → 12969µs
throttling              ~8% → 0.02%
tilts              10-16/hr → 0
sentinel restarts         1 → 0
coredns cluster TTL       5 → 30
```

All of this is already applied to the cluster; this PR persists it in the repo.