### PR TITLE
fix(stats): boards tick with the counters, and agree across pods

### DIFF
--- a/console/dashboard/src/lib/server/demo-data.ts
+++ b/console/dashboard/src/lib/server/demo-data.ts
@@ -389,8 +389,10 @@ export function demoStats(now: number): PublicStats {
   };
 }
 
-// The two public leaderboards, as a fixed ranking: they are a slow lifetime
-// view, so a demo does not need them to move.
+// The two public leaderboards. The ranking is fixed — it is a lifetime view —
+// but the counts climb with the clock like demoStats does, so a demo shows the
+// same thing the live page does: boards that tick with the stream rather than
+// sitting still between reloads.
 const DEMO_CHANNELS = [
   { id: '11', name: 'bagelwatch', messages: 41_882_301, events: 68_004_112, feeds: 9_144 },
   { id: '12', name: 'nightcrust', messages: 28_100_774, events: 45_930_615, feeds: 7_820 },
@@ -404,13 +406,25 @@ const DEMO_CHANNELS = [
   { id: '20', name: 'crumbcam', messages: 1_442_007, events: 2_660_884, feeds: 611 }
 ];
 
-export function demoBoards(): PublicBoards {
+export function demoBoards(now: number): PublicBoards {
+  const secs = (now - DEMO_EPOCH) / 1000;
+  // Each channel accrues at its own pace, highest first, so the demo board
+  // moves without ever reordering itself.
+  const grown = DEMO_CHANNELS.map((c, i) => {
+    const rate = 6 - i * 0.5;
+    return {
+      ...c,
+      messages: Math.floor(c.messages + secs * rate),
+      events: Math.floor(c.events + secs * rate * 1.7),
+      feeds: Math.floor(c.feeds + secs / (600 + i * 120))
+    };
+  });
   return {
-    channels: DEMO_CHANNELS.map(({ id, name, messages, events }) => ({ id, name, messages, events })),
+    channels: grown.map(({ id, name, messages, events }) => ({ id, name, messages, events })),
     feed: {
-      total: DEMO_CHANNELS.reduce((sum, c) => sum + c.feeds, 0),
+      total: grown.reduce((sum, c) => sum + c.feeds, 0),
       ranked: 57,
-      entries: DEMO_CHANNELS.map(({ id, name, feeds }) => ({ id, name, count: feeds }))
+      entries: grown.map(({ id, name, feeds }) => ({ id, name, count: feeds }))
     },
     degraded: false
   };

--- a/console/dashboard/src/lib/server/public-boards.ts
+++ b/console/dashboard/src/lib/server/public-boards.ts
@@ -13,9 +13,15 @@
 //
 // Unlike the odometer next to them, these move slowly and cost more per read
 // (two ranked counter queries, a board query, and one name lookup per listed
-// channel), so they live behind their own cache key and their own slow policy
-// rather than riding the 1s `live` snapshot. The page polls them on a lazy
-// timer; nothing here is on a hot path.
+// channel), so a fresh read is rare. The caching is deliberately two-layer:
+//
+//   Valkey (BOARDS_TTL_MS) — ONE snapshot for the whole deployment. The fabric
+//     cache is in-process, so a pod-local window alone let three pods answer
+//     three different rankings; a reader hopping pods between two frames saw
+//     the board flicker between them. The shared key makes every pod serve the
+//     same bytes for the same window.
+//   fabric  (POLICY.board)  — a short in-process window in front of it, so a
+//     busy pod reads Valkey a few times a second at most, not once per request.
 //
 // The same three rules as public-stats.ts apply: one shared snapshot for every
 // visitor, an absent counter is honestly 0, and an unreachable service degrades
@@ -23,6 +29,7 @@
 import { rpc } from '@bagel/shared/server/nats';
 import { dev } from '$app/environment';
 import { POLICY } from '@bagel/shared/server/cache-keys';
+import { sharedSnapshot } from '@bagel/shared/server/shared-snapshot';
 import { fabric, SUB, accountState } from './services';
 
 // Gated on the build-time `dev` constant first, so Rollup erases the demo
@@ -30,6 +37,17 @@ import { fabric, SUB, accountState } from './services';
 const DEMO = dev && process.env.DEMO === '1';
 
 const CACHE_KEY = 'public-stats:boards';
+
+// The cross-pod snapshot. Versioned because the shape is stored, not derived:
+// a payload change must not be read back by an older pod mid-rollout.
+const SHARED_KEY = 'public-stats:boards:v1';
+
+// How long one snapshot serves the whole deployment. Deliberately the stream's
+// own tick: the boards ride the same 2s frames as the odometer, so a feeding or
+// a rank change lands as fast as the message counters beside it. Because the
+// key is shared, that cadence costs the fleet one board read every 2s in total
+// — not one per pod, and never one per viewer.
+const BOARDS_TTL_MS = 2_000;
 
 const COUNTER_MESSAGES = 'messages_processed';
 const COUNTER_EVENTS = 'events_processed';
@@ -184,6 +202,24 @@ async function loadFeed(): Promise<PublicBoards['feed'] | null> {
   }
 }
 
+/**
+ * The deployment-wide snapshot: one board read per tick for the whole fleet,
+ * not one per pod. Without it three pods answer three rankings and a reader
+ * hopping pods between frames watches the board flicker between them.
+ *
+ * A degraded snapshot is never published: it is the empty board, and pinning
+ * that across every pod would turn one service blip into a window of blank
+ * leaderboards everywhere.
+ */
+function sharedBoards(): Promise<PublicBoards> {
+  return sharedSnapshot({
+    key: SHARED_KEY,
+    ttlMs: BOARDS_TTL_MS,
+    load: loadBoards,
+    publish: (boards) => !boards.degraded
+  });
+}
+
 async function loadBoards(): Promise<PublicBoards> {
   const [channels, feed] = await Promise.all([loadTraffic(), loadFeed()]);
   return {
@@ -199,9 +235,9 @@ async function loadBoards(): Promise<PublicBoards> {
  * as an error.
  */
 export async function publicBoards(): Promise<PublicBoards> {
-  if (DEMO) return (await import('./demo-data')).demoBoards();
+  if (DEMO) return (await import('./demo-data')).demoBoards(Date.now());
   try {
-    return await fabric.readKey(CACHE_KEY, POLICY.board, loadBoards);
+    return await fabric.readKey(CACHE_KEY, POLICY.board, sharedBoards);
   } catch {
     return { channels: [], feed: EMPTY_FEED, degraded: true };
   }

--- a/console/dashboard/src/routes/(public)/stats/+page.svelte
+++ b/console/dashboard/src/routes/(public)/stats/+page.svelte
@@ -11,10 +11,9 @@
 
   // Fallback poll of /stats/data, armed only while the SSE stream is failed.
   const POLL_MS = 5000;
-  // The leaderboards are a lifetime ranking behind a 15s server-side fresh
-  // window, so they get their own lazy poll instead of a place in the 2s
-  // stream: a board that changes place once a week does not need a frame.
-  const BOARDS_POLL_MS = 60_000;
+  // The boards ride the same 2s stream as the counters (a `boards` event beside
+  // each snapshot frame), so this poll is only the stand-in for a failed
+  // stream, at the same cadence as the counters' own fallback.
   // 0 -> value rise on first paint (ease-out-quart, as the shared countUp action).
   const INTRO_MS = 900;
   // Time constant of the chase that re-bases the odometer onto a fresh snapshot:
@@ -177,7 +176,7 @@
     }
   }
 
-  /** Lazy refresh of the leaderboards; a hidden tab keeps its last ranking. */
+  /** Fallback refresh of the leaderboards; a hidden tab keeps its last ranking. */
   async function refreshBoards(): Promise<void> {
     if (document.hidden) return;
     try {
@@ -205,6 +204,16 @@
         // Malformed frame: ignore it, the next one is 2s out.
       }
     };
+    // The boards arrive on their own event so the counter frame keeps its
+    // shape. They are printed as sent — no extrapolation, no chase: a rank is
+    // a fact about a moment, not a trajectory.
+    es.addEventListener('boards', (ev) => {
+      try {
+        boards = JSON.parse((ev as MessageEvent<string>).data) as typeof boards;
+      } catch {
+        // Malformed frame: keep the last ranking.
+      }
+    });
     return es;
   }
 
@@ -223,9 +232,10 @@
 
     const es = openStream();
     const timer = setInterval(() => {
-      if (streamDown) void refresh();
+      if (!streamDown) return;
+      void refresh();
+      void refreshBoards();
     }, POLL_MS);
-    const boardTimer = setInterval(() => void refreshBoards(), BOARDS_POLL_MS);
 
     const onVisible = () => {
       if (document.hidden) return;
@@ -235,7 +245,8 @@
         cancelAnimationFrame(raf);
         raf = requestAnimationFrame(tick);
       }
-      if (streamDown) void refresh();
+      if (!streamDown) return;
+      void refresh();
       void refreshBoards();
     };
     document.addEventListener('visibilitychange', onVisible);
@@ -243,7 +254,6 @@
     return () => {
       es.close();
       clearInterval(timer);
-      clearInterval(boardTimer);
       document.removeEventListener('visibilitychange', onVisible);
       cancelAnimationFrame(raf);
     };

--- a/console/dashboard/src/routes/(public)/stats/stream/+server.ts
+++ b/console/dashboard/src/routes/(public)/stats/stream/+server.ts
@@ -3,6 +3,7 @@
 
 import type { RequestHandler } from './$types';
 import { publicStats } from '$lib/server/public-stats';
+import { publicBoards } from '$lib/server/public-boards';
 
 // Server-sent events stream of the public global counters for /stats. Same
 // leak-safe shape as (app)/events (hoisted idempotent cleanup wired to the
@@ -11,8 +12,15 @@ import { publicStats } from '$lib/server/public-stats';
 // no live-hub subscription to push from — the counters are polled here, once
 // per connection, and pushed down as whole snapshots.
 //
-// Cost: publicStats() reads one single-flighted cache key (POLICY.live), so N
-// concurrent viewers on a pod still cost ~1 RPC pair per second, not N.
+// Each tick carries both halves of the page: the global counters as the default
+// `data:` frame, and the per-channel boards as a named `boards` event. The
+// boards are a separate event rather than a second field so the counter frame's
+// shape (and the client's odometer path) stays exactly what it was.
+//
+// Cost: publicStats() reads one single-flighted cache key (POLICY.live) and
+// publicBoards() one more that is itself shared across pods through Valkey, so
+// N concurrent viewers on a pod still cost ~1 read per tick, not N — and the
+// boards cost the whole deployment one read per tick rather than one per pod.
 //
 // No separate keepalive timer: a data frame every 2s already keeps the
 // Cloudflare tunnel from reaping an idle connection. The data IS the ping.
@@ -34,20 +42,26 @@ export const GET: RequestHandler = ({ request }) => {
         }
       };
 
-      // One snapshot per tick, as a single `data:` JSON line. publicStats()
-      // degrades rather than rejecting; the rejection arm is belt-and-braces so
-      // a surprise there can never become an unhandled rejection on the server.
-      const push = () =>
-        publicStats().then(
+      // One snapshot of each per tick. Both readers degrade rather than
+      // rejecting; the rejection arms are belt-and-braces so a surprise in
+      // either can never become an unhandled rejection on the server. They are
+      // not awaited together: a slow board read must not delay the counters.
+      const push = () => {
+        void publicStats().then(
           (stats) => send(`data: ${JSON.stringify(stats)}\n\n`),
           () => {}
         );
+        void publicBoards().then(
+          (boards) => send(`event: boards\ndata: ${JSON.stringify(boards)}\n\n`),
+          () => {}
+        );
+      };
 
       send(': connected\n\n');
       // Don't make the first viewer wait a tick for numbers.
-      void push();
+      push();
 
-      const timer = setInterval(() => void push(), TICK_MS);
+      const timer = setInterval(push, TICK_MS);
 
       cleanup = () => {
         if (closed) return;

--- a/console/shared/lib/server/cache-keys.ts
+++ b/console/shared/lib/server/cache-keys.ts
@@ -38,12 +38,13 @@ export const POLICY = {
   entity: { freshMs: 120_000, swrMs: 600_000, staleIfErrorMs: 600_000 },
   security: { freshMs: 60_000, swrMs: 120_000, staleIfErrorMs: 300_000 },
   projected: { freshMs: 600_000, swrMs: 1_800_000 },
-  // board: the public per-channel leaderboards. Lifetime rankings move slowly
-  // and each refresh costs two ranked counter queries plus a name lookup per
-  // listed channel, so they get a slow fresh window and a long stale-if-error
-  // tail — an anonymous page keeps showing yesterday's ranking rather than an
+  // board: the public per-channel leaderboards. The window that actually paces
+  // the underlying reads is the shared Valkey snapshot behind them (see
+  // public-boards.ts); this in-process layer only keeps a busy pod from asking
+  // Valkey once per request. Short, therefore — but with a long stale-if-error
+  // tail, so an anonymous page keeps showing the last ranking rather than an
   // empty board while a service is down.
-  board: { freshMs: 15_000, swrMs: 60_000, staleIfErrorMs: 300_000 },
+  board: { freshMs: 1_000, swrMs: 2_000, staleIfErrorMs: 300_000 },
   // govee: the third-party device list + key-presence flag. Both are read on
   // every govee page load (and every /events invalidation), but the underlying
   // Govee cloud call is slow and rate-limited, so a short fresh window plus a

--- a/console/shared/lib/server/shared-snapshot.test.ts
+++ b/console/shared/lib/server/shared-snapshot.test.ts
@@ -1,0 +1,100 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import { sharedSnapshot, setSnapshotClientForTests, type SnapshotClient } from './shared-snapshot';
+
+afterEach(() => setSnapshotClientForTests(undefined));
+
+/** A stand-in Valkey holding one string, with the calls it saw. */
+function fakeClient(seed: string | null = null) {
+  const calls = { get: 0, set: 0 };
+  let stored = seed;
+  const client: SnapshotClient = {
+    async get() {
+      calls.get++;
+      return stored;
+    },
+    async set(_key, value) {
+      calls.set++;
+      stored = value;
+      return 'OK';
+    }
+  };
+  return { client, calls, read: () => stored };
+}
+
+const opts = <T>(load: () => Promise<T>, publish?: (v: T) => boolean) => ({
+  key: 'test:snapshot:v1',
+  ttlMs: 2_000,
+  load,
+  publish
+});
+
+describe('sharedSnapshot', () => {
+  test('a stored snapshot is served without computing one', async () => {
+    const { client, calls } = fakeClient(JSON.stringify({ n: 7 }));
+    setSnapshotClientForTests(client);
+    let loads = 0;
+
+    const value = await sharedSnapshot(
+      opts(async () => {
+        loads++;
+        return { n: 1 };
+      })
+    );
+
+    expect(value).toEqual({ n: 7 });
+    expect(loads).toBe(0);
+    expect(calls.set).toBe(0);
+  });
+
+  test('a miss computes once and publishes it for the other pods', async () => {
+    const store = fakeClient();
+    setSnapshotClientForTests(store.client);
+
+    const value = await sharedSnapshot(opts(async () => ({ n: 3 })));
+
+    expect(value).toEqual({ n: 3 });
+    expect(store.calls.set).toBe(1);
+    expect(store.read()).toBe(JSON.stringify({ n: 3 }));
+  });
+
+  test('a value the caller refuses to publish is served but not stored', async () => {
+    const store = fakeClient();
+    setSnapshotClientForTests(store.client);
+
+    const value = await sharedSnapshot(
+      opts(
+        async () => ({ degraded: true }),
+        (v: { degraded: boolean }) => !v.degraded
+      )
+    );
+
+    expect(value).toEqual({ degraded: true });
+    expect(store.calls.set).toBe(0);
+    expect(store.read()).toBeNull();
+  });
+
+  test('an unreadable payload falls back to a live read', async () => {
+    const { client } = fakeClient('{not json');
+    setSnapshotClientForTests(client);
+
+    expect(await sharedSnapshot(opts(async () => ({ n: 5 })))).toEqual({ n: 5 });
+  });
+
+  test('a failing client never fails the read', async () => {
+    setSnapshotClientForTests({
+      get: () => Promise.reject(new Error('down')),
+      set: () => Promise.reject(new Error('down'))
+    });
+
+    expect(await sharedSnapshot(opts(async () => ({ n: 9 })))).toEqual({ n: 9 });
+  });
+
+  test('no Valkey at all is just a local read', async () => {
+    setSnapshotClientForTests(null);
+
+    expect(await sharedSnapshot(opts(async () => ({ n: 4 })))).toEqual({ n: 4 });
+  });
+});

--- a/console/shared/lib/server/shared-snapshot.ts
+++ b/console/shared/lib/server/shared-snapshot.ts
@@ -1,0 +1,83 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+// One computed snapshot, shared by every pod of a deployment.
+//
+// The cache fabric's L1 is in-process and its L2 is the Go-owned projection, so
+// a value that is *computed* by the console (a ranking, an aggregate, anything
+// fanned out of several RPCs) has nowhere to be shared. Three pods then answer
+// three versions of it, and a reader whose requests land on different pods sees
+// the number jump back and forth — which reads as a bug, because from outside
+// it is one.
+//
+// This is the missing layer: a short-lived value in Valkey, written by whichever
+// pod computed it, read by the rest. Put the fabric in front of it (a 1s window
+// is enough) so a busy pod asks Valkey a few times a second rather than once per
+// request:
+//
+//   fabric (in-process, ~1s)  ->  sharedSnapshot (Valkey, ttlMs)  ->  load()
+//
+// Valkey is a cache here and never the source. Unconfigured (dev, tests), slow,
+// or holding a payload this build cannot parse all degrade the same way: run
+// load() locally and carry on. The only thing lost is the sharing.
+import { masterClient } from './valkey-master';
+import { withTimeout } from './resilience';
+
+/** Bound on each Valkey round trip; past it, computing locally is faster. */
+const DEFAULT_TIMEOUT_MS = 250;
+
+/** The two operations this needs from Valkey, so tests can stand in for it. */
+export interface SnapshotClient {
+  get(key: string): Promise<string | null>;
+  set(key: string, value: string, mode: 'PX', ttlMs: number): Promise<unknown>;
+}
+
+let testClient: SnapshotClient | null | undefined;
+
+/** Test seam: a stand-in client, or null for "Valkey unconfigured". Pass
+ *  undefined to restore the real one. */
+export function setSnapshotClientForTests(client: SnapshotClient | null | undefined): void {
+  testClient = client;
+}
+
+function snapshotClient(): SnapshotClient | null {
+  if (testClient !== undefined) return testClient;
+  return masterClient();
+}
+
+export interface SharedSnapshotOptions<T> {
+  /** Key to share under. Version it: the payload is stored, not derived, so a
+   *  shape change must not be read back by an older pod mid-rollout. */
+  key: string;
+  /** How long one computed value serves the whole deployment. */
+  ttlMs: number;
+  /** The real read, run on a miss. */
+  load: () => Promise<T>;
+  /** Publish gate. Return false to keep a value out of the shared key — a
+   *  degraded or partial answer is worth serving to one request and not worth
+   *  pinning on every pod for a whole window. Defaults to always publishing. */
+  publish?: (value: T) => boolean;
+  timeoutMs?: number;
+}
+
+export async function sharedSnapshot<T>(opts: SharedSnapshotOptions<T>): Promise<T> {
+  const { key, ttlMs, load, publish, timeoutMs = DEFAULT_TIMEOUT_MS } = opts;
+  const client = snapshotClient();
+  if (!client) return load();
+
+  try {
+    const hit = await withTimeout<string | null>(client.get(key), timeoutMs, `snapshot get ${key}`);
+    if (hit) return JSON.parse(hit) as T;
+  } catch {
+    // Miss, timeout, or a payload this build cannot read: compute it here.
+  }
+
+  const fresh = await load();
+  if (publish && !publish(fresh)) return fresh;
+  try {
+    await withTimeout(client.set(key, JSON.stringify(fresh), 'PX', ttlMs), timeoutMs, `snapshot set ${key}`);
+  } catch {
+    // The value is still correct for this pod; the others will compute their own.
+  }
+  return fresh;
+}

--- a/console/shared/package.json
+++ b/console/shared/package.json
@@ -30,6 +30,7 @@
     "./server/invalidation": "./lib/server/invalidation.ts",
     "./server/impersonation": "./lib/server/impersonation.ts",
     "./server/valkey-store": "./lib/server/valkey-store.ts",
+    "./server/shared-snapshot": "./lib/server/shared-snapshot.ts",
     "./server/session-revocation": "./lib/server/session-revocation.ts",
     "./validation": "./lib/validation.ts",
     "./i18n": "./lib/i18n/messages.ts",


### PR DESCRIPTION
Two things wrong with the leaderboards shipped in #615, one cause each.

## They did not live-update

The boards were kept off the 2s stream and polled every 60s behind a 15s cache, on the reasoning that a lifetime ranking changes slowly. That is true of the *ranking* and false of the *numbers beside it*: a channel's message count is the same number the odometer above it is animating, so printing it a minute late reads as a frozen page.

Each stream tick now carries the boards as a named `boards` event beside the counter frame. The client prints them as sent — no extrapolation and no chase, because a rank is a fact about a moment, not a trajectory. The 60s poll becomes what the counters' poll already is: a stand-in armed only while the stream is down.

## Pods disagreed with each other

The cache fabric's L1 is in-process and its L2 is the Go-owned projection, so a value the console *computes* (a ranking fanned out of several RPCs) has nowhere to be shared. Three pods held three independent windows, and a reader whose requests landed on different pods watched the board flip between them — which reads as a bug because from outside it is one.

`sharedSnapshot` (new, in `console/shared`) is the missing layer: one short-lived value in Valkey, written by whichever pod computed it, read by the rest, with the fabric in front of it so a busy pod asks Valkey a few times a second rather than once per request.

```
fabric (in-process, 1s)  ->  sharedSnapshot (Valkey, 2s)  ->  the real read
```

Sharing is also what makes the faster cadence affordable: **one** board read every 2s for the whole deployment, not one per pod and never one per viewer.

## Degradation

Every Valkey failure mode — unconfigured (dev, tests), slow, or holding a payload this build cannot parse — falls back to computing locally, which is exactly the behaviour on `main` today; the only thing lost is the sharing. A degraded board is served but never published: it is the empty board, and pinning that fleet-wide would turn one service blip into a window of blank leaderboards on every pod.

## Verification

- 6 new unit tests for `sharedSnapshot` (hit reuse, publish-on-miss, publish gate, unparseable payload, failing client, no Valkey). Full shared suite: 149 pass.
- `bun run check` 0 errors; production build passes the demo-gate and production-clean verifiers.
- Streamed `/stats/stream` by hand and confirmed the `boards` event lands beside each counter frame; watched a board cell climb 453 → 501 → 549 over ~10s in the browser with no reload.
- Demo fixtures now grow with the clock like `demoStats` does, so a local preview shows the same ticking as the live page.