### PR TITLE
fix(stats): name the traffic board from the feed board it already read

### DIFF
--- a/console/dashboard/src/lib/server/public-boards.ts
+++ b/console/dashboard/src/lib/server/public-boards.ts
@@ -131,12 +131,13 @@ async function counterBoard(name: string): Promise<Map<string, number> | null> {
 }
 
 /**
- * Name one channel for the board.
+ * Name one channel the users service has to be asked about.
  *
- * The users service is the only authority on a channel's login (never a
- * caller-supplied string), and its answer is cached per channel for minutes, so
- * a board refresh usually resolves every row without an RPC. A lookup that
- * fails leaves the row unnamed rather than dropping it — the numbers are still
+ * Only reached for a channel the feed board did not already name (see
+ * nameTraffic). The users service is the only authority on a channel's login —
+ * never a caller-supplied string — and its answer is cached per channel for
+ * minutes, so even these rows usually resolve without an RPC. A lookup that
+ * fails leaves the row unnamed rather than dropping it: the numbers are still
  * true, and the page prints an "unnamed channel" label.
  */
 async function channelName(id: string): Promise<string> {
@@ -159,20 +160,39 @@ function mergeTraffic(messages: Map<string, number>, events: Map<string, number>
 }
 
 /**
- * Cut the merged rows to the shown size and name them. The cut comes first, so
- * a board refresh costs at most BOARD_SIZE name lookups however deep the two
- * counter boards were read.
+ * Cut the merged rows to the shown size and name them.
+ *
+ * The feed board is read on the same tick and stores each channel's name with
+ * its row, so it already answers the naming question for every channel that has
+ * ever fed the bagel — which, on a board ranked by traffic, is most of them.
+ * Those names are taken as they are: asking the users service for a name we
+ * were just handed would be a second round trip for the same answer, and it
+ * would print the two boards' names differently (the stored display name beside
+ * the bare login) for the same channel on the same page.
+ *
+ * The users service is the fallback for the rest, and the cut comes first, so a
+ * refresh costs at most BOARD_SIZE lookups however deep the counter boards were
+ * read — usually none.
  */
-async function nameTraffic(rows: ChannelTraffic[]): Promise<ChannelTraffic[]> {
+async function nameTraffic(rows: ChannelTraffic[], known: Map<string, string>): Promise<ChannelTraffic[]> {
   const shown = rows.slice(0, BOARD_SIZE);
-  const names = await Promise.all(shown.map((row) => channelName(row.id)));
+  const names = await Promise.all(shown.map((row) => known.get(row.id) ?? channelName(row.id)));
   return shown.map((row, i) => ({ ...row, name: names[i] }));
 }
 
-async function loadTraffic(): Promise<ChannelTraffic[] | null> {
+/** The names the feed board already carries, by broadcaster id. */
+function feedNames(feed: PublicBoards['feed'] | null): Map<string, string> {
+  const names = new Map<string, string>();
+  for (const entry of feed?.entries ?? []) {
+    if (entry.id && entry.name) names.set(entry.id, entry.name);
+  }
+  return names;
+}
+
+async function loadTraffic(known: Map<string, string>): Promise<ChannelTraffic[] | null> {
   const [messages, events] = await Promise.all([counterBoard(COUNTER_MESSAGES), counterBoard(COUNTER_EVENTS)]);
   if (messages === null || events === null) return null;
-  return nameTraffic(mergeTraffic(messages, events));
+  return nameTraffic(mergeTraffic(messages, events), known);
 }
 
 const EMPTY_FEED = { total: 0, ranked: 0, entries: [] as FeedEntry[] };
@@ -220,8 +240,16 @@ function sharedBoards(): Promise<PublicBoards> {
   });
 }
 
+/**
+ * Both boards, in two stages rather than one: the feed board is read first
+ * because it names channels for free, and the traffic board's own lookups are
+ * then only for the channels it did not cover. The two counter queries behind
+ * the traffic board still run concurrently with each other, so the extra stage
+ * costs one round trip, and saves up to ten.
+ */
 async function loadBoards(): Promise<PublicBoards> {
-  const [channels, feed] = await Promise.all([loadTraffic(), loadFeed()]);
+  const feed = await loadFeed();
+  const channels = await loadTraffic(feedNames(feed));
   return {
     channels: channels ?? [],
     feed: feed ?? EMPTY_FEED,

--- a/console/dashboard/src/routes/(public)/stats/+page.svelte
+++ b/console/dashboard/src/routes/(public)/stats/+page.svelte
@@ -291,6 +291,15 @@
 
   const traffic = $derived(boards.channels);
   const feed = $derived(boards.feed);
+
+  // Both boards label a channel with the name the fleet stored for it, which is
+  // a display name: usually the login with capitals, which the public channel
+  // page lowercases on the way in — but not always (a localized display name
+  // has no login shape at all). Link by id when the label cannot be one, rather
+  // than linking somewhere that 404s.
+  const LOGIN_SHAPE = /^[A-Za-z0-9_]{1,25}$/;
+  const channelHref = (row: { id: string; name: string }) =>
+    `/user/${LOGIN_SHAPE.test(row.name) ? row.name : row.id}`;
 </script>
 
 <svelte:head>
@@ -395,7 +404,7 @@
                     <td class="rank">{i + 1}</td>
                     <td class="chan">
                       {#if row.name}
-                        <a href="/user/{row.name}">{row.name}</a>
+                        <a href={channelHref(row)}>{row.name}</a>
                       {:else}
                         <span class="unnamed">{t('stats.unknownChannel')}</span>
                       {/if}
@@ -433,7 +442,7 @@
                 <span class="rank">{i + 1}</span>
                 <span class="chan">
                   {#if row.name}
-                    <a href="/user/{row.name}">{row.name}</a>
+                    <a href={channelHref(row)}>{row.name}</a>
                   {:else}
                     <span class="unnamed">{t('stats.unknownChannel')}</span>
                   {/if}


### PR DESCRIPTION
The two boards on `/stats` named the same channel differently on the same page: the feed board printed the display name stored with each channel's row (`ItsMavey`), the traffic board printed the bare login it asked the users service for (`itsmavey`). The second answer also cost a round trip per listed channel to learn something the first read had already handed us.

## What changes

The feed board is read on the same tick and stores a name with every row, so it now answers the naming question for every channel that has ever fed the bagel — which, on a board ranked by traffic, is most of them. The users service stays the fallback for the rest, still cached per channel for minutes.

The two reads become sequential rather than concurrent: **one** extra round trip, **up to ten** saved, and the pair sits behind the shared 2s snapshot either way, so the page cost is unchanged in the common case and lower in the usual one.

## Linking follows the label

A stored display name is usually the login with capitals — which the public channel page lowercases on the way in — but it does not have to be one at all (a localized display name has no login shape). A label that cannot be a login now links by broadcaster id, which that page already accepts, instead of 404ing. Applies to both boards; the feed board has carried that risk since it shipped.

## Verification

- `bun run check` 0 errors; production build passes the demo-gate and production-clean verifiers; shared suite 149 pass.
- Rendered in DEMO: both boards label and link identically (`/user/bagelwatch` from either board).