### PR TITLE
feat(clashroyale): wire the Clash Royale provider end to end

### DIFF
--- a/app/gossip/internal/config/config.go
+++ b/app/gossip/internal/config/config.go
@@ -86,6 +86,18 @@ type Config struct {
 	GoveeRateLimit        float64
 	GoveeKeySubjectPrefix string
 
+	// Clash Royale provider (!cr / !crstats / !crdecks / !crranked /
+	// !crtrophy): the official Supercell player API through RoyaleAPI's
+	// supported proxy. APIKey is a standard Supercell key created on
+	// developer.clashroyale.com whose allowed-IP list names RoyaleAPI's proxy
+	// egress 45.79.218.79 (not ours) so calls may forward through
+	// proxy.royaleapi.dev; empty = provider disabled. Neither Supercell nor
+	// the proxy publishes a hard per-key rate number, so the budget assumes a
+	// trusted key and CLASHROYALE_RATE_LIMIT must be lowered for a fresh one.
+	ClashRoyaleBaseURL   string
+	ClashRoyaleAPIKey    string
+	ClashRoyaleRateLimit float64
+
 	ListenAddr string
 }
 
@@ -150,6 +162,10 @@ func Load() *Config {
 		GoveeBaseURL:          env.Get("GOVEE_BASE_URL", "https://openapi.api.govee.com"),
 		GoveeRateLimit:        env.GetFloat("GOVEE_RATE_LIMIT", 8.0),
 		GoveeKeySubjectPrefix: env.Get("NATS_INTERNAL_GOVEE_KEY_SUBJECT_PREFIX", "bagel.rpc.internal.govee.key"),
+
+		ClashRoyaleBaseURL:   env.Get("CLASHROYALE_BASE_URL", "https://proxy.royaleapi.dev/v1"),
+		ClashRoyaleAPIKey:    env.Get("CLASHROYALE_API_KEY", ""),
+		ClashRoyaleRateLimit: env.GetFloat("CLASHROYALE_RATE_LIMIT", 600.0),
 
 		ListenAddr: env.Get("LISTEN_ADDR", ":8080"),
 	}

--- a/app/gossip/internal/providers/all.go
+++ b/app/gossip/internal/providers/all.go
@@ -9,6 +9,7 @@ package providers
 import (
 	"ItsBagelBot/app/gossip/internal/config"
 	"ItsBagelBot/app/gossip/internal/provider"
+	"ItsBagelBot/app/gossip/internal/providers/clashroyale"
 	"ItsBagelBot/app/gossip/internal/providers/fortnite"
 	"ItsBagelBot/app/gossip/internal/providers/govee"
 	"ItsBagelBot/app/gossip/internal/providers/hypixel"
@@ -36,6 +37,7 @@ func All(cfg *config.Config, d provider.Deps) []provider.Provider {
 	out = appendPaceman(out, cfg, d, log)
 	out = appendFortnite(out, cfg, d, log)
 	out = appendGovee(out, cfg, d, log)
+	out = appendClashRoyale(out, cfg, d, log)
 	return out
 }
 
@@ -132,6 +134,21 @@ func appendGovee(out []provider.Provider, cfg *config.Config, d provider.Deps, l
 		return govee.New(govee.Config{
 			BaseURL:   cfg.GoveeBaseURL,
 			RateLimit: cfg.GoveeRateLimit,
+		}, d)
+	})
+}
+
+// appendClashRoyale adds the Clash Royale provider behind its RoyaleAPI proxy
+// token, the same credential gate as urchin/hypixel. The key itself is created
+// on developer.clashroyale.com (Supercell) with RoyaleAPI's proxy egress IP
+// 45.79.218.79 whitelisted on it; the proxy then forwards Bearer-keyed calls
+// to api.clashroyale.com. A key in Doppler lights all four !cr commands.
+func appendClashRoyale(out []provider.Provider, cfg *config.Config, d provider.Deps, log *zap.Logger) []provider.Provider {
+	return appendIf(out, log, cfg.ClashRoyaleAPIKey == "", "clashroyale provider disabled: CLASHROYALE_API_KEY not set (!cr commands will not answer)", func() provider.Provider {
+		return clashroyale.New(clashroyale.Config{
+			BaseURL:   cfg.ClashRoyaleBaseURL,
+			APIKey:    cfg.ClashRoyaleAPIKey,
+			RateLimit: cfg.ClashRoyaleRateLimit,
 		}, d)
 	})
 }

--- a/app/gossip/internal/providers/clashroyale/clashroyale.go
+++ b/app/gossip/internal/providers/clashroyale/clashroyale.go
@@ -58,10 +58,10 @@ type api struct {
 func New(cfg Config, d provider.Deps) provider.Provider {
 	p := newAPI(cfg, d)
 	b := provider.NewProvider(providerName, d)
-	p.view(b, "stats", func(tag, msg string) any { return statsReply{Tag: tag, Error: msg} }, shapeStats)
-	p.view(b, "decks", func(tag, msg string) any { return decksReply{Tag: tag, Error: msg} }, shapeDecks)
-	p.view(b, "ranked", func(tag, msg string) any { return rankedReply{Tag: tag, Error: msg} }, shapeRanked)
-	p.view(b, "trophy_road", func(tag, msg string) any { return trophyRoadReply{Tag: tag, Error: msg} }, shapeTrophyRoad)
+	p.view(b, "stats", func(tag, msg string) any { return gossiprpc.ClashRoyaleStatsReply{Tag: tag, Error: msg} }, shapeStats)
+	p.view(b, "decks", func(tag, msg string) any { return gossiprpc.ClashRoyaleDecksReply{Tag: tag, Error: msg} }, shapeDecks)
+	p.view(b, "ranked", func(tag, msg string) any { return gossiprpc.ClashRoyaleRankedReply{Tag: tag, Error: msg} }, shapeRanked)
+	p.view(b, "trophy_road", func(tag, msg string) any { return gossiprpc.ClashRoyaleTrophyRoadReply{Tag: tag, Error: msg} }, shapeTrophyRoad)
 	return b.Build()
 }
 
@@ -159,133 +159,44 @@ func (t playerTag) String() string   { return "#" + string(t) }
 func (t playerTag) cacheKey() string { return strings.ToLower(string(t)) }
 
 // playerProfile is the current official player payload subset used by all
-// four views. Unknown upstream additions are ignored by encoding/json.
+// four views. Unknown upstream additions are ignored by encoding/json. Nested
+// values reuse the shared reply shapes: their JSON keys mirror the upstream's
+// own, so the profile decodes straight into them and shaping is projection
+// only.
 type playerProfile struct {
-	Tag                       string       `json:"tag"`
-	Name                      string       `json:"name"`
-	ExpLevel                  int          `json:"expLevel"`
-	ExpPoints                 int64        `json:"expPoints"`
-	StarPoints                int64        `json:"starPoints"`
-	Trophies                  int          `json:"trophies"`
-	BestTrophies              int          `json:"bestTrophies"`
-	Wins                      int          `json:"wins"`
-	Losses                    int          `json:"losses"`
-	BattleCount               int          `json:"battleCount"`
-	ThreeCrownWins            int          `json:"threeCrownWins"`
-	ChallengeCardsWon         int          `json:"challengeCardsWon"`
-	ChallengeMaxWins          int          `json:"challengeMaxWins"`
-	TournamentCardsWon        int          `json:"tournamentCardsWon"`
-	TournamentBattleCount     int          `json:"tournamentBattleCount"`
-	Donations                 int          `json:"donations"`
-	DonationsReceived         int          `json:"donationsReceived"`
-	TotalDonations            int          `json:"totalDonations"`
-	Arena                     arena        `json:"arena"`
-	Clan                      clan         `json:"clan"`
-	CurrentFavouriteCard      card         `json:"currentFavouriteCard"`
-	CurrentDeck               []card       `json:"currentDeck"`
-	CurrentDeckSupportCards   []card       `json:"currentDeckSupportCards"`
-	LeagueStatistics          leagueStats  `json:"leagueStatistics"`
-	CurrentPathOfLegendResult rankedResult `json:"currentPathOfLegendSeasonResult"`
-	LastPathOfLegendResult    rankedResult `json:"lastPathOfLegendSeasonResult"`
-	BestPathOfLegendResult    rankedResult `json:"bestPathOfLegendSeasonResult"`
-}
-
-type arena struct {
-	ID   int64  `json:"id"`
-	Name string `json:"name"`
-}
-
-type clan struct {
-	Tag     string `json:"tag"`
-	Name    string `json:"name"`
-	BadgeID int64  `json:"badgeId,omitempty"`
-}
-
-type iconURLs struct {
-	Medium    string `json:"medium,omitempty"`
-	Evolution string `json:"evolutionMedium,omitempty"`
-}
-
-type card struct {
-	ID                int64    `json:"id"`
-	Name              string   `json:"name"`
-	Level             int      `json:"level,omitempty"`
-	MaxLevel          int      `json:"maxLevel,omitempty"`
-	EvolutionLevel    int      `json:"evolutionLevel,omitempty"`
-	MaxEvolutionLevel int      `json:"maxEvolutionLevel,omitempty"`
-	ElixirCost        int      `json:"elixirCost,omitempty"`
-	Rarity            string   `json:"rarity,omitempty"`
-	IconURLs          iconURLs `json:"iconUrls,omitempty"`
-}
-
-// rankedResult covers both Path of Legends results and the legacy league
-// season records. Fields absent in one representation remain zero-valued.
-type rankedResult struct {
-	SeasonID     string `json:"id,omitempty"`
-	LeagueNumber int    `json:"leagueNumber,omitempty"`
-	Trophies     int    `json:"trophies,omitempty"`
-	BestTrophies int    `json:"bestTrophies,omitempty"`
-	Rank         int    `json:"rank,omitempty"`
+	Tag                       string                            `json:"tag"`
+	Name                      string                            `json:"name"`
+	ExpLevel                  int                               `json:"expLevel"`
+	ExpPoints                 int64                             `json:"expPoints"`
+	StarPoints                int64                             `json:"starPoints"`
+	Trophies                  int                               `json:"trophies"`
+	BestTrophies              int                               `json:"bestTrophies"`
+	Wins                      int                               `json:"wins"`
+	Losses                    int                               `json:"losses"`
+	BattleCount               int                               `json:"battleCount"`
+	ThreeCrownWins            int                               `json:"threeCrownWins"`
+	ChallengeCardsWon         int                               `json:"challengeCardsWon"`
+	ChallengeMaxWins          int                               `json:"challengeMaxWins"`
+	TournamentCardsWon        int                               `json:"tournamentCardsWon"`
+	TournamentBattleCount     int                               `json:"tournamentBattleCount"`
+	Donations                 int                               `json:"donations"`
+	DonationsReceived         int                               `json:"donationsReceived"`
+	TotalDonations            int                               `json:"totalDonations"`
+	Arena                     gossiprpc.ClashRoyaleArena        `json:"arena"`
+	Clan                      gossiprpc.ClashRoyaleClan         `json:"clan"`
+	CurrentFavouriteCard      gossiprpc.ClashRoyaleCard         `json:"currentFavouriteCard"`
+	CurrentDeck               []gossiprpc.ClashRoyaleCard       `json:"currentDeck"`
+	CurrentDeckSupportCards   []gossiprpc.ClashRoyaleCard       `json:"currentDeckSupportCards"`
+	LeagueStatistics          leagueStats                       `json:"leagueStatistics"`
+	CurrentPathOfLegendResult gossiprpc.ClashRoyaleRankedResult `json:"currentPathOfLegendSeasonResult"`
+	LastPathOfLegendResult    gossiprpc.ClashRoyaleRankedResult `json:"lastPathOfLegendSeasonResult"`
+	BestPathOfLegendResult    gossiprpc.ClashRoyaleRankedResult `json:"bestPathOfLegendSeasonResult"`
 }
 
 type leagueStats struct {
-	Current  rankedResult `json:"currentSeason"`
-	Previous rankedResult `json:"previousSeason"`
-	Best     rankedResult `json:"bestSeason"`
-}
-
-// Public endpoint replies live in the provider package intentionally: this
-// change adds only the gossip integration and no sesame-facing feature.
-type statsReply struct {
-	Player                string  `json:"player"`
-	Tag                   string  `json:"tag"`
-	KingLevel             int     `json:"king_level"`
-	ExperiencePoints      int64   `json:"experience_points"`
-	StarPoints            int64   `json:"star_points"`
-	Wins                  int     `json:"wins"`
-	Losses                int     `json:"losses"`
-	Draws                 int     `json:"draws"`
-	Battles               int     `json:"battles"`
-	WinRate               float64 `json:"win_rate"`
-	ThreeCrownWins        int     `json:"three_crown_wins"`
-	ChallengeCardsWon     int     `json:"challenge_cards_won"`
-	ChallengeMaxWins      int     `json:"challenge_max_wins"`
-	TournamentCardsWon    int     `json:"tournament_cards_won"`
-	TournamentBattleCount int     `json:"tournament_battle_count"`
-	Donations             int     `json:"donations"`
-	DonationsReceived     int     `json:"donations_received"`
-	TotalDonations        int     `json:"total_donations"`
-	Clan                  clan    `json:"clan"`
-	FavouriteCard         card    `json:"favourite_card"`
-	Error                 string  `json:"error,omitempty"`
-}
-
-type decksReply struct {
-	Player        string  `json:"player"`
-	Tag           string  `json:"tag"`
-	CurrentDeck   []card  `json:"current_deck"`
-	SupportCards  []card  `json:"support_cards"`
-	AverageElixir float64 `json:"average_elixir"`
-	Error         string  `json:"error,omitempty"`
-}
-
-type rankedReply struct {
-	Player   string       `json:"player"`
-	Tag      string       `json:"tag"`
-	Current  rankedResult `json:"current"`
-	Previous rankedResult `json:"previous"`
-	Best     rankedResult `json:"best"`
-	Unranked bool         `json:"unranked"`
-	Error    string       `json:"error,omitempty"`
-}
-
-type trophyRoadReply struct {
-	Player       string `json:"player"`
-	Tag          string `json:"tag"`
-	Trophies     int    `json:"trophies"`
-	BestTrophies int    `json:"best_trophies"`
-	Arena        arena  `json:"arena"`
-	Error        string `json:"error,omitempty"`
+	Current  gossiprpc.ClashRoyaleRankedResult `json:"currentSeason"`
+	Previous gossiprpc.ClashRoyaleRankedResult `json:"previousSeason"`
+	Best     gossiprpc.ClashRoyaleRankedResult `json:"bestSeason"`
 }
 
 func (p *api) profile(ctx context.Context, tag playerTag) (playerProfile, error) {
@@ -312,7 +223,7 @@ func shapeStats(profile playerProfile) any {
 	if profile.BattleCount > 0 {
 		winRate = float64(profile.Wins) * 100 / float64(profile.BattleCount)
 	}
-	return statsReply{
+	return gossiprpc.ClashRoyaleStatsReply{
 		Player: profile.Name, Tag: profile.Tag, KingLevel: profile.ExpLevel,
 		ExperiencePoints: profile.ExpPoints, StarPoints: profile.StarPoints,
 		Wins: profile.Wins, Losses: profile.Losses, Draws: draws,
@@ -335,17 +246,17 @@ func shapeDecks(profile playerProfile) any {
 	if len(profile.CurrentDeck) > 0 {
 		average = math.Round((float64(total)/float64(len(profile.CurrentDeck)))*100) / 100
 	}
-	return decksReply{
+	return gossiprpc.ClashRoyaleDecksReply{
 		Player: profile.Name, Tag: profile.Tag, CurrentDeck: profile.CurrentDeck,
 		SupportCards: profile.CurrentDeckSupportCards, AverageElixir: average,
 	}
 }
 
-func hasRankedResult(r rankedResult) bool {
+func hasRankedResult(r gossiprpc.ClashRoyaleRankedResult) bool {
 	return r.SeasonID != "" || r.LeagueNumber != 0 || r.Trophies != 0 || r.BestTrophies != 0 || r.Rank != 0
 }
 
-func preferRanked(primary, fallback rankedResult) rankedResult {
+func preferRanked(primary, fallback gossiprpc.ClashRoyaleRankedResult) gossiprpc.ClashRoyaleRankedResult {
 	if hasRankedResult(primary) {
 		return primary
 	}
@@ -356,14 +267,14 @@ func shapeRanked(profile playerProfile) any {
 	current := preferRanked(profile.CurrentPathOfLegendResult, profile.LeagueStatistics.Current)
 	previous := preferRanked(profile.LastPathOfLegendResult, profile.LeagueStatistics.Previous)
 	best := preferRanked(profile.BestPathOfLegendResult, profile.LeagueStatistics.Best)
-	return rankedReply{
+	return gossiprpc.ClashRoyaleRankedReply{
 		Player: profile.Name, Tag: profile.Tag, Current: current, Previous: previous, Best: best,
 		Unranked: !hasRankedResult(current),
 	}
 }
 
 func shapeTrophyRoad(profile playerProfile) any {
-	return trophyRoadReply{
+	return gossiprpc.ClashRoyaleTrophyRoadReply{
 		Player: profile.Name, Tag: profile.Tag, Trophies: profile.Trophies,
 		BestTrophies: profile.BestTrophies, Arena: profile.Arena,
 	}

--- a/app/gossip/internal/providers/clashroyale/clashroyale_test.go
+++ b/app/gossip/internal/providers/clashroyale/clashroyale_test.go
@@ -140,7 +140,7 @@ func TestEndpointsShareOneNormalizedPlayerFetch(t *testing.T) {
 		_, _ = w.Write([]byte(playerBody))
 	}))
 
-	stats := decodeReply[statsReply](t, endpoint(t, p, "stats")(context.Background(), gossiprpc.Request{Account: " #p2lq0gr "}))
+	stats := decodeReply[gossiprpc.ClashRoyaleStatsReply](t, endpoint(t, p, "stats")(context.Background(), gossiprpc.Request{Account: " #p2lq0gr "}))
 	require.Empty(t, stats.Error)
 	assert.Equal(t, "Bagel", stats.Player)
 	assert.Equal(t, "#P2LQ0GR", stats.Tag)
@@ -150,7 +150,7 @@ func TestEndpointsShareOneNormalizedPlayerFetch(t *testing.T) {
 	assert.Equal(t, "Bakery", stats.Clan.Name)
 	assert.Equal(t, "Knight", stats.FavouriteCard.Name)
 
-	decks := decodeReply[decksReply](t, endpoint(t, p, "decks")(context.Background(), gossiprpc.Request{Account: "P2LQ0GR"}))
+	decks := decodeReply[gossiprpc.ClashRoyaleDecksReply](t, endpoint(t, p, "decks")(context.Background(), gossiprpc.Request{Account: "P2LQ0GR"}))
 	require.Empty(t, decks.Error)
 	require.Len(t, decks.CurrentDeck, 8)
 	assert.Equal(t, "Knight", decks.CurrentDeck[0].Name)
@@ -158,7 +158,7 @@ func TestEndpointsShareOneNormalizedPlayerFetch(t *testing.T) {
 	assert.Len(t, decks.SupportCards, 1)
 	assert.InDelta(t, 3.75, decks.AverageElixir, 1e-9)
 
-	ranked := decodeReply[rankedReply](t, endpoint(t, p, "ranked")(context.Background(), gossiprpc.Request{Account: "#P2LQ0GR"}))
+	ranked := decodeReply[gossiprpc.ClashRoyaleRankedReply](t, endpoint(t, p, "ranked")(context.Background(), gossiprpc.Request{Account: "#P2LQ0GR"}))
 	require.Empty(t, ranked.Error)
 	assert.False(t, ranked.Unranked)
 	assert.Equal(t, 10, ranked.Current.LeagueNumber)
@@ -166,7 +166,7 @@ func TestEndpointsShareOneNormalizedPlayerFetch(t *testing.T) {
 	assert.Equal(t, 321, ranked.Current.Rank)
 	assert.Equal(t, 42, ranked.Best.Rank)
 
-	road := decodeReply[trophyRoadReply](t, endpoint(t, p, "trophy_road")(context.Background(), gossiprpc.Request{Account: "P2LQ0GR"}))
+	road := decodeReply[gossiprpc.ClashRoyaleTrophyRoadReply](t, endpoint(t, p, "trophy_road")(context.Background(), gossiprpc.Request{Account: "P2LQ0GR"}))
 	require.Empty(t, road.Error)
 	assert.Equal(t, 9123, road.Trophies)
 	assert.Equal(t, 9345, road.BestTrophies)
@@ -187,7 +187,7 @@ func TestRankedFallsBackToLeagueStatistics(t *testing.T) {
 		}`))
 	}))
 
-	reply := decodeReply[rankedReply](t, endpoint(t, p, "ranked")(context.Background(), gossiprpc.Request{Account: "P2LQ0GR"}))
+	reply := decodeReply[gossiprpc.ClashRoyaleRankedReply](t, endpoint(t, p, "ranked")(context.Background(), gossiprpc.Request{Account: "P2LQ0GR"}))
 	require.Empty(t, reply.Error)
 	assert.False(t, reply.Unranked)
 	assert.Equal(t, "2026-07", reply.Current.SeasonID)
@@ -201,10 +201,10 @@ func TestMissingAndInvalidTagsDoNotCallUpstream(t *testing.T) {
 		t.Fatal("no upstream request expected")
 	}))
 
-	missing := decodeReply[statsReply](t, endpoint(t, p, "stats")(context.Background(), gossiprpc.Request{}))
+	missing := decodeReply[gossiprpc.ClashRoyaleStatsReply](t, endpoint(t, p, "stats")(context.Background(), gossiprpc.Request{}))
 	assert.Equal(t, "missing account", missing.Error)
 
-	invalid := decodeReply[decksReply](t, endpoint(t, p, "decks")(context.Background(), gossiprpc.Request{Account: "#ABC123"}))
+	invalid := decodeReply[gossiprpc.ClashRoyaleDecksReply](t, endpoint(t, p, "decks")(context.Background(), gossiprpc.Request{Account: "#ABC123"}))
 	assert.Equal(t, "invalid player tag", invalid.Error)
 }
 
@@ -222,9 +222,9 @@ func TestNotFoundIsFriendlyAndNegativeCachedAcrossEndpoints(t *testing.T) {
 		_, _ = w.Write([]byte(`{"reason":"notFound"}`))
 	}))
 
-	stats := decodeReply[statsReply](t, endpoint(t, p, "stats")(context.Background(), gossiprpc.Request{Account: "P2LQ0GR"}))
+	stats := decodeReply[gossiprpc.ClashRoyaleStatsReply](t, endpoint(t, p, "stats")(context.Background(), gossiprpc.Request{Account: "P2LQ0GR"}))
 	assert.Equal(t, "player not found", stats.Error)
-	road := decodeReply[trophyRoadReply](t, endpoint(t, p, "trophy_road")(context.Background(), gossiprpc.Request{Account: "P2LQ0GR"}))
+	road := decodeReply[gossiprpc.ClashRoyaleTrophyRoadReply](t, endpoint(t, p, "trophy_road")(context.Background(), gossiprpc.Request{Account: "P2LQ0GR"}))
 	assert.Equal(t, "player not found", road.Error)
 	assert.Equal(t, 1, hits)
 }

--- a/app/sesame/modules/all.go
+++ b/app/sesame/modules/all.go
@@ -25,6 +25,7 @@ func All(d engine.Deps) []module.Module {
 		Urchin(d),
 		Mcsr(d),
 		Fortnite(d),
+		ClashRoyale(d),
 		// Raffle before Queue: both declare !join, and the registry's first-wins
 		// de-dup gives the earlier module the standalone spelling. A channel
 		// running both features joins raffles with !join and reaches the queue

--- a/app/sesame/modules/clashroyale.go
+++ b/app/sesame/modules/clashroyale.go
@@ -1,0 +1,283 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package modules
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"ItsBagelBot/app/sesame/engine"
+	"ItsBagelBot/app/sesame/module"
+	"ItsBagelBot/internal/domain/outgress"
+	gossiprpc "ItsBagelBot/internal/domain/rpc/gossip"
+)
+
+// clashroyaleModuleName is the ModuleView key; the console MODULE_CATALOG entry
+// and the dashboard module page use the same id.
+const clashroyaleModuleName = "clashroyale"
+
+// clashroyaleCooldown is the shared per-command window; gossip caches the one
+// shared player profile all four commands project, so this only shields chat
+// from command spam, not the API.
+const clashroyaleCooldown = 10 * time.Second
+
+// Default reply templates. The broadcaster customizes them per command on the
+// module page; blank falls back to these.
+const (
+	defaultClashStatsTemplate  = "{player} · level {level} · {wins}W/{losses}L · {winrate}% WR · {crowns} three-crowns · {clan}"
+	defaultClashDecksTemplate  = "{player}'s deck ({count}/8): {cards} · avg elixir {elixir}"
+	defaultClashRankedTemplate = "{player} Path of Legends: league {league} · {trophies} trophies · rank #{rank} · best {besttrophies}"
+	defaultClashRoadTemplate   = "{player}: {trophies} trophies · best {besttrophies} · {arena}"
+)
+
+// clashroyaleUnrankedText replaces !crranked's template when gossip answers
+// Unranked: every numeric token would render zero, so the default line says
+// why instead (the same shape as !fn session's no-snapshot case).
+const clashroyaleUnrankedText = "has no Path of Legends record this season"
+
+// clashroyaleConfig is the module's dashboard configuration. Account is the
+// linked player tag (blank = the broadcaster's own Twitch login, which the
+// provider almost always rejects — Clash Royale has no name lookup, so a tag
+// is required). The *Enabled toggles are stored "on"/"off" — empty means on,
+// matching the alerts module's semantics — and each *Message is a customized
+// template (blank = default).
+type clashroyaleConfig struct {
+	Account string `json:"account"`
+
+	StatsEnabled  string `json:"statsEnabled"`
+	StatsMessage  string `json:"statsMessage"`
+	DecksEnabled  string `json:"decksEnabled"`
+	DecksMessage  string `json:"decksMessage"`
+	RankedEnabled string `json:"rankedEnabled"`
+	RankedMessage string `json:"rankedMessage"`
+	RoadEnabled   string `json:"roadEnabled"`
+	RoadMessage   string `json:"roadMessage"`
+}
+
+// ClashRoyale owns the Clash Royale chat commands backed by the gossip
+// service. It is a named, opt-in module (KindOptIn): off by default, enabled
+// on the dashboard, where the broadcaster links their player tag. Viewers can
+// always target another player explicitly: "!cr #P2LQ0GR".
+//
+// The command surface mirrors fortnite's: one root with subcommands plus the
+// squashed forms as direct triggers.
+//
+//	!cr [tag]           lifetime profile (also !crstats)
+//	!cr decks [tag]     current battle deck (also !crdecks)
+//	!cr ranked [tag]    Path of Legends standing (also !crranked)
+//	!cr road [tag]      trophy-road standing (also !crroad)
+//
+// All four ride gossip's one shared profile cache, so a viewer reading several
+// views of the same player spends a single upstream request per 5 minutes.
+func ClashRoyale(d engine.Deps) module.Module {
+	rankedSpecial := func(reply any) (string, bool) {
+		r, ok := reply.(*gossiprpc.ClashRoyaleRankedReply)
+		if !ok || !r.Unranked {
+			return "", false
+		}
+		return unrankedText(r.Player), true
+	}
+	statsRun := clashRun(d, clashCommand{
+		endpoint: "stats",
+		enabled:  func(c clashroyaleConfig) string { return c.StatsEnabled },
+		message:  func(c clashroyaleConfig) string { return c.StatsMessage },
+		fallback: defaultClashStatsTemplate,
+		newReply: func() any { return &gossiprpc.ClashRoyaleStatsReply{} },
+		tokens:   clashStatsTokens(),
+	})
+	decksRun := clashRun(d, clashCommand{
+		endpoint: "decks",
+		enabled:  func(c clashroyaleConfig) string { return c.DecksEnabled },
+		message:  func(c clashroyaleConfig) string { return c.DecksMessage },
+		fallback: defaultClashDecksTemplate,
+		newReply: func() any { return &gossiprpc.ClashRoyaleDecksReply{} },
+		tokens:   clashDecksTokens(),
+	})
+	rankedRun := clashRun(d, clashCommand{
+		endpoint: "ranked",
+		enabled:  func(c clashroyaleConfig) string { return c.RankedEnabled },
+		message:  func(c clashroyaleConfig) string { return c.RankedMessage },
+		fallback: defaultClashRankedTemplate,
+		newReply: func() any { return &gossiprpc.ClashRoyaleRankedReply{} },
+		tokens:   clashRankedTokens(),
+		special:  rankedSpecial,
+	})
+	roadRun := clashRun(d, clashCommand{
+		endpoint: "trophy_road",
+		enabled:  func(c clashroyaleConfig) string { return c.RoadEnabled },
+		message:  func(c clashroyaleConfig) string { return c.RoadMessage },
+		fallback: defaultClashRoadTemplate,
+		newReply: func() any { return &gossiprpc.ClashRoyaleTrophyRoadReply{} },
+		tokens:   clashRoadTokens(),
+	})
+
+	m := module.NewModule(clashroyaleModuleName, module.KindOptIn)
+	m.Command("cr").Everyone().Cooldown(clashroyaleCooldown).
+		Run(clashDispatchRun(statsRun, decksRun, rankedRun, roadRun))
+	m.Command("crstats").Everyone().Cooldown(clashroyaleCooldown).Aliases("clashroyale").
+		Run(statsRun)
+	m.Command("crdecks").Everyone().Cooldown(clashroyaleCooldown).Aliases("crdeck").
+		Run(decksRun)
+	m.Command("crranked").Everyone().Cooldown(clashroyaleCooldown).Aliases("crpol").
+		Run(rankedRun)
+	m.Command("crroad").Everyone().Cooldown(clashroyaleCooldown).Aliases("crtrophy").
+		Run(roadRun)
+	return m.Build()
+}
+
+// clashCommand names one command's wiring: the gossip endpoint it queries,
+// where its toggle and template live in the config blob, an empty reply value
+// Call decodes into, and an optional post-decode override (ranked's
+// no-record answer replaces its template entirely).
+type clashCommand struct {
+	endpoint string
+	enabled  func(clashroyaleConfig) string
+	message  func(clashroyaleConfig) string
+	fallback string
+	newReply func() any
+	tokens   map[string]func(any) string
+	special  func(reply any) (string, bool)
+}
+
+// clashRun builds one command runner: resolve the target tag, call the
+// endpoint, expand the template over the reply. Tokens are declared against
+// `any` so one runner serves four reply types; each palette casts back.
+func clashRun(d engine.Deps, cmd clashCommand) module.RunFunc {
+	return func(ctx context.Context, c *module.Context, args string, emit module.Emit) error {
+		var cfg clashroyaleConfig
+		_ = c.Decode(&cfg)
+		if !alertOn(cmd.enabled(cfg)) || d.Gossip == nil {
+			return nil
+		}
+
+		tag := resolveAccount(accountSources{Arg: args, Linked: cfg.Account, BroadcasterLogin: c.Env.BroadcasterUserLogin})
+		req := gossiprpc.Request{Account: tag, IsPremium: c.Regress.IsPremium()}
+		reply := cmd.newReply()
+		if err := d.Gossip.Call(ctx, engine.GossipRoute{Provider: "clashroyale", Endpoint: cmd.endpoint}, req, reply); err != nil {
+			if chatReplyError(c, emit, tag, err) {
+				return nil
+			}
+			return err
+		}
+		if cmd.special != nil {
+			if text, ok := cmd.special(reply); ok {
+				emit(&module.Output{Type: outgress.TypeChat, BroadcasterID: c.Env.BroadcasterUserID, Text: text})
+				return nil
+			}
+		}
+
+		msg := module.ExpandString(orDefault(cmd.message(cfg), cmd.fallback), func(key string) (string, bool) {
+			if field, ok := cmd.tokens[key]; ok {
+				return field(reply), true
+			}
+			return module.ParseDynamic(key)
+		})
+		emit(&module.Output{Type: outgress.TypeChat, BroadcasterID: c.Env.BroadcasterUserID, Text: msg})
+		return nil
+	}
+}
+
+// clashDispatchRun routes !cr's first argument word onto the subcommand
+// runners: "decks"/"ranked"/"road" select one explicitly, and anything else —
+// nothing, or a player tag — is a profile lookup, so "!cr #P2LQ0GR" reads
+// naturally.
+func clashDispatchRun(statsRun, decksRun, rankedRun, roadRun module.RunFunc) module.RunFunc {
+	return func(ctx context.Context, c *module.Context, args string, emit module.Emit) error {
+		sub, rest, _ := strings.Cut(strings.TrimSpace(args), " ")
+		switch strings.ToLower(sub) {
+		case "decks", "deck":
+			return decksRun(ctx, c, rest, emit)
+		case "ranked", "pol":
+			return rankedRun(ctx, c, rest, emit)
+		case "road", "trophy", "trophies":
+			return roadRun(ctx, c, rest, emit)
+		default:
+			return statsRun(ctx, c, args, emit)
+		}
+	}
+}
+
+// clashStatsTokens is the !crstats template palette over the gossip reply.
+func clashStatsTokens() map[string]func(any) string {
+	type reply = gossiprpc.ClashRoyaleStatsReply
+	return map[string]func(any) string{
+		"player":         func(v any) string { return v.(*reply).Player },
+		"tag":            func(v any) string { return v.(*reply).Tag },
+		"level":          func(v any) string { return i64(int64(v.(*reply).KingLevel)) },
+		"wins":           func(v any) string { return i64(int64(v.(*reply).Wins)) },
+		"losses":         func(v any) string { return i64(int64(v.(*reply).Losses)) },
+		"draws":          func(v any) string { return i64(int64(v.(*reply).Draws)) },
+		"battles":        func(v any) string { return i64(int64(v.(*reply).Battles)) },
+		"winrate":        func(v any) string { return trimScore(v.(*reply).WinRate) },
+		"crowns":         func(v any) string { return i64(int64(v.(*reply).ThreeCrownWins)) },
+		"challengemax":   func(v any) string { return i64(int64(v.(*reply).ChallengeMaxWins)) },
+		"donations":      func(v any) string { return i64(int64(v.(*reply).Donations)) },
+		"totaldonations": func(v any) string { return i64(int64(v.(*reply).TotalDonations)) },
+		"clan": func(v any) string {
+			if clan := v.(*reply).Clan.Name; clan != "" {
+				return clan
+			}
+			return "no clan"
+		},
+		"favcard": func(v any) string { return v.(*reply).FavouriteCard.Name },
+	}
+}
+
+// clashDecksTokens is the !crdecks palette: the deck joined as names (bounded
+// by the game at 8 cards plus one tower troop, so no truncation budget is
+// needed), the elixir average gossip precomputed, and the count.
+func clashDecksTokens() map[string]func(any) string {
+	type reply = gossiprpc.ClashRoyaleDecksReply
+	names := func(cards []gossiprpc.ClashRoyaleCard) string {
+		parts := make([]string, len(cards))
+		for i, card := range cards {
+			parts[i] = card.Name
+		}
+		return strings.Join(parts, ", ")
+	}
+	return map[string]func(any) string{
+		"player":  func(v any) string { return v.(*reply).Player },
+		"tag":     func(v any) string { return v.(*reply).Tag },
+		"cards":   func(v any) string { return names(v.(*reply).CurrentDeck) },
+		"support": func(v any) string { return names(v.(*reply).SupportCards) },
+		"elixir":  func(v any) string { return trimScore(v.(*reply).AverageElixir) },
+		"count":   func(v any) string { return i64(int64(len(v.(*reply).CurrentDeck))) },
+	}
+}
+
+// clashRankedTokens is the !crranked palette over the PoL result (gossip
+// already fell back to legacy league seasons where they are the only record).
+func clashRankedTokens() map[string]func(any) string {
+	type reply = gossiprpc.ClashRoyaleRankedReply
+	return map[string]func(any) string{
+		"player":       func(v any) string { return v.(*reply).Player },
+		"tag":          func(v any) string { return v.(*reply).Tag },
+		"league":       func(v any) string { return i64(int64(v.(*reply).Current.LeagueNumber)) },
+		"trophies":     func(v any) string { return i64(int64(v.(*reply).Current.Trophies)) },
+		"rank":         func(v any) string { return i64(int64(v.(*reply).Current.Rank)) },
+		"prevleague":   func(v any) string { return i64(int64(v.(*reply).Previous.LeagueNumber)) },
+		"prevtrophies": func(v any) string { return i64(int64(v.(*reply).Previous.Trophies)) },
+		"bestleague":   func(v any) string { return i64(int64(v.(*reply).Best.LeagueNumber)) },
+		"besttrophies": func(v any) string { return i64(int64(v.(*reply).Best.Trophies)) },
+		"bestrank":     func(v any) string { return i64(int64(v.(*reply).Best.Rank)) },
+	}
+}
+
+// clashRoadTokens is the !crroad palette.
+func clashRoadTokens() map[string]func(any) string {
+	type reply = gossiprpc.ClashRoyaleTrophyRoadReply
+	return map[string]func(any) string{
+		"player":       func(v any) string { return v.(*reply).Player },
+		"tag":          func(v any) string { return v.(*reply).Tag },
+		"trophies":     func(v any) string { return i64(int64(v.(*reply).Trophies)) },
+		"besttrophies": func(v any) string { return i64(int64(v.(*reply).BestTrophies)) },
+		"arena":        func(v any) string { return v.(*reply).Arena.Name },
+	}
+}
+
+// unrankedText renders !crranked's answer when the player has no PoL record.
+func unrankedText(player string) string {
+	return player + " " + clashroyaleUnrankedText
+}

--- a/app/sesame/modules/clashroyale.go
+++ b/app/sesame/modules/clashroyale.go
@@ -155,28 +155,41 @@ func clashRun(d engine.Deps, cmd clashCommand) module.RunFunc {
 		tag := resolveAccount(accountSources{Arg: args, Linked: cfg.Account, BroadcasterLogin: c.Env.BroadcasterUserLogin})
 		req := gossiprpc.Request{Account: tag, IsPremium: c.Regress.IsPremium()}
 		reply := cmd.newReply()
-		if err := d.Gossip.Call(ctx, engine.GossipRoute{Provider: "clashroyale", Endpoint: cmd.endpoint}, req, reply); err != nil {
-			if chatReplyError(c, emit, tag, err) {
-				return nil
-			}
-			return err
+		route := engine.GossipRoute{Provider: "clashroyale", Endpoint: cmd.endpoint}
+		if err := d.Gossip.Call(ctx, route, req, reply); err != nil {
+			return clashCallErr(c, emit, tag, err)
 		}
-		if cmd.special != nil {
-			if text, ok := cmd.special(reply); ok {
-				emit(&module.Output{Type: outgress.TypeChat, BroadcasterID: c.Env.BroadcasterUserID, Text: text})
-				return nil
-			}
-		}
-
-		msg := module.ExpandString(orDefault(cmd.message(cfg), cmd.fallback), func(key string) (string, bool) {
-			if field, ok := cmd.tokens[key]; ok {
-				return field(reply), true
-			}
-			return module.ParseDynamic(key)
-		})
-		emit(&module.Output{Type: outgress.TypeChat, BroadcasterID: c.Env.BroadcasterUserID, Text: msg})
+		emit(&module.Output{Type: outgress.TypeChat, BroadcasterID: c.Env.BroadcasterUserID, Text: clashRender(cmd, cfg, reply)})
 		return nil
 	}
+}
+
+// clashCallErr maps a gossip failure onto the command's outcome:
+// reply-level errors (player not found, ...) were answered in chat and count
+// as handled; infrastructure errors also chat a retry hint but propagate so
+// the caller still logs them.
+func clashCallErr(c *module.Context, emit module.Emit, tag string, err error) error {
+	if chatReplyError(c, emit, tag, err) {
+		return nil
+	}
+	return err
+}
+
+// clashRender picks the final chat line: a command's special-case override
+// when it fires (ranked's no-record answer), otherwise the configured
+// template expanded over the gossip reply.
+func clashRender(cmd clashCommand, cfg clashroyaleConfig, reply any) string {
+	if cmd.special != nil {
+		if text, ok := cmd.special(reply); ok {
+			return text
+		}
+	}
+	return module.ExpandString(orDefault(cmd.message(cfg), cmd.fallback), func(key string) (string, bool) {
+		if field, ok := cmd.tokens[key]; ok {
+			return field(reply), true
+		}
+		return module.ParseDynamic(key)
+	})
 }
 
 // clashDispatchRun routes !cr's first argument word onto the subcommand

--- a/app/sesame/modules/clashroyale_test.go
+++ b/app/sesame/modules/clashroyale_test.go
@@ -1,0 +1,191 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package modules
+
+import (
+	"context"
+	"testing"
+
+	"ItsBagelBot/app/sesame/engine"
+	"ItsBagelBot/app/sesame/module"
+	"ItsBagelBot/internal/domain/outgress"
+	gossiprpc "ItsBagelBot/internal/domain/rpc/gossip"
+	"ItsBagelBot/pkg/bus"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func clashCmd(t *testing.T, gw engine.GossipCaller, name string) module.Command {
+	t.Helper()
+	m := ClashRoyale(engine.Deps{Gossip: gw, Log: zap.NewNop()})
+	assert.Equal(t, "clashroyale", m.Name)
+	assert.Equal(t, module.KindOptIn, m.Kind)
+	return findCmd(t, m, name)
+}
+
+func clashStatsReply() gossiprpc.ClashRoyaleStatsReply {
+	return gossiprpc.ClashRoyaleStatsReply{
+		Player: "Bagel", Tag: "#P2LQ0GR", KingLevel: 62,
+		Wins: 600, Losses: 300, Draws: 100, Battles: 1000, WinRate: 60,
+		ThreeCrownWins: 120,
+		Clan:           gossiprpc.ClashRoyaleClan{Tag: "#2Q0", Name: "Bakery"},
+		FavouriteCard:  gossiprpc.ClashRoyaleCard{Name: "Knight"},
+	}
+}
+
+func TestCrstatsDefaultTemplate(t *testing.T) {
+	gw := &fakeGossip{replies: map[string]any{"clashroyale.stats": clashStatsReply()}}
+	cmd := clashCmd(t, gw, "crstats")
+
+	var col collector
+	require.NoError(t, cmd.Run(context.Background(), urchinCtx(""), "", col.emit))
+	require.Len(t, col.out, 1)
+	assert.Equal(t, outgress.TypeChat, col.out[0].Type)
+	assert.Equal(t, "2", col.out[0].BroadcasterID)
+	assert.Equal(t,
+		"Bagel · level 62 · 600W/300L · 60% WR · 120 three-crowns · Bakery",
+		col.out[0].Text)
+
+	// No linked tag and no arg: falls back to the broadcaster's login, and the
+	// premium flag rides along for gossip's reserved bucket.
+	call := gw.lastCall(t)
+	assert.Equal(t, "streamer", call.req.Account)
+	assert.False(t, call.req.IsPremium)
+}
+
+func TestCrstatsLinkedTagAndArgPriority(t *testing.T) {
+	gw := &fakeGossip{replies: map[string]any{"clashroyale.stats": clashStatsReply()}}
+	cmd := clashCmd(t, gw, "crstats")
+
+	var col collector
+	cfg := `{"account":"#P2LQ0GR"}`
+	require.NoError(t, cmd.Run(context.Background(), urchinCtx(cfg), "", col.emit))
+	assert.Equal(t, "#P2LQ0GR", gw.lastCall(t).req.Account)
+
+	// An explicit argument beats the linked tag; '@' and trailing words strip.
+	require.NoError(t, cmd.Run(context.Background(), urchinCtx(cfg), "@#P9VQ0JR please", col.emit))
+	assert.Equal(t, "#P9VQ0JR", gw.lastCall(t).req.Account)
+}
+
+func TestCrDecksRankedRoadTemplates(t *testing.T) {
+	decks := gossiprpc.ClashRoyaleDecksReply{
+		Player: "Bagel", Tag: "#P2LQ0GR",
+		CurrentDeck: []gossiprpc.ClashRoyaleCard{
+			{Name: "Knight"}, {Name: "Archers"}, {Name: "Fireball"},
+		},
+		SupportCards:  []gossiprpc.ClashRoyaleCard{{Name: "Tower Troop"}},
+		AverageElixir: 3.75,
+	}
+	ranked := gossiprpc.ClashRoyaleRankedReply{
+		Player: "Bagel", Tag: "#P2LQ0GR",
+		Current: gossiprpc.ClashRoyaleRankedResult{LeagueNumber: 10, Trophies: 2100, Rank: 321},
+		Best:    gossiprpc.ClashRoyaleRankedResult{LeagueNumber: 10, Trophies: 2400, Rank: 42},
+	}
+	road := gossiprpc.ClashRoyaleTrophyRoadReply{
+		Player: "Bagel", Tag: "#P2LQ0GR", Trophies: 9123, BestTrophies: 9345,
+		Arena: gossiprpc.ClashRoyaleArena{Name: "Legendary Arena"},
+	}
+
+	cases := []struct {
+		name, trigger, endpoint, want string
+		reply                         any
+	}{
+		{"decks", "crdecks", "decks",
+			"Bagel's deck (3/8): Knight, Archers, Fireball · avg elixir 3.75", decks},
+		{"ranked", "crranked", "ranked",
+			"Bagel Path of Legends: league 10 · 2100 trophies · rank #321 · best 2400", ranked},
+		{"road", "crroad", "trophy_road",
+			"Bagel: 9123 trophies · best 9345 · Legendary Arena", road},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gw := &fakeGossip{replies: map[string]any{"clashroyale." + tc.endpoint: tc.reply}}
+			var col collector
+			require.NoError(t, clashCmd(t, gw, tc.trigger).Run(context.Background(), urchinCtx(""), "", col.emit))
+			require.Len(t, col.out, 1)
+			assert.Equal(t, tc.want, col.out[0].Text)
+			assert.Equal(t, tc.endpoint, gw.lastCall(t).endpoint)
+		})
+	}
+}
+
+// The !cr root routes its first argument word: bare/tag → profile stats,
+// decks/ranked/road select the subcommand, and the remainder is the tag arg.
+func TestCrDispatch(t *testing.T) {
+	cases := []struct {
+		name, args, endpoint string
+	}{
+		{"bare is stats", "", "stats"},
+		{"tag arg is stats", "@#P2LQ0GR extra", "stats"},
+		{"decks subcommand", "decks", "decks"},
+		{"deck alias with tag", "deck #P2LQ0GR", "decks"},
+		{"ranked subcommand", "ranked", "ranked"},
+		{"pol alias", "POL", "ranked"},
+		{"road subcommand", "road", "trophy_road"},
+		{"trophy alias", "trophies", "trophy_road"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gw := &fakeGossip{replies: map[string]any{
+				"clashroyale.stats":       clashStatsReply(),
+				"clashroyale.decks":       gossiprpc.ClashRoyaleDecksReply{Player: "Bagel"},
+				"clashroyale.ranked":      gossiprpc.ClashRoyaleRankedReply{Player: "Bagel"},
+				"clashroyale.trophy_road": gossiprpc.ClashRoyaleTrophyRoadReply{Player: "Bagel"},
+			}}
+			var col collector
+			require.NoError(t, clashCmd(t, gw, "cr").Run(context.Background(), urchinCtx(`{"account":"#P2LQ0GR"}`), tc.args, col.emit))
+			require.Len(t, col.out, 1)
+			assert.Equal(t, tc.endpoint, gw.lastCall(t).endpoint)
+			// A bare subcommand still targets the linked tag.
+			if tc.args == "decks" || tc.args == "ranked" || tc.args == "road" {
+				assert.Equal(t, "#P2LQ0GR", gw.lastCall(t).req.Account)
+			}
+		})
+	}
+}
+
+// A per-command "off" toggle keeps that command silent: no chat line and no
+// gossip call.
+func TestClashDisabledStaysSilent(t *testing.T) {
+	cases := []struct{ name, config string }{
+		{"cr", `{"statsEnabled":"off"}`},
+		{"crstats", `{"statsEnabled":"off"}`},
+		{"crdecks", `{"decksEnabled":"off"}`},
+		{"crranked", `{"rankedEnabled":"off"}`},
+		{"crroad", `{"roadEnabled":"off"}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gw := &fakeGossip{}
+			var col collector
+			require.NoError(t, clashCmd(t, gw, tc.name).Run(context.Background(), urchinCtx(tc.config), "", col.emit))
+			assert.Empty(t, col.out)
+			gw.mu.Lock()
+			assert.Empty(t, gw.calls)
+			gw.mu.Unlock()
+		})
+	}
+}
+
+func TestCrReplyErrorChats(t *testing.T) {
+	gw := &fakeGossip{err: bus.RPCReplyError{Message: "player not found"}}
+	var col collector
+	require.NoError(t, clashCmd(t, gw, "crstats").Run(context.Background(), urchinCtx(""), "#P0AAAAAA", col.emit))
+	require.Len(t, col.out, 1)
+	assert.Equal(t, "#P0AAAAAA: player not found", col.out[0].Text)
+}
+
+// An unranked player replaces the ranked template entirely: every numeric
+// token would render zero, so the default line says why instead.
+func TestCrrankedUnranked(t *testing.T) {
+	gw := &fakeGossip{replies: map[string]any{"clashroyale.ranked": gossiprpc.ClashRoyaleRankedReply{
+		Player: "Bagel", Unranked: true,
+	}}}
+	var col collector
+	require.NoError(t, clashCmd(t, gw, "crranked").Run(context.Background(), urchinCtx(""), "", col.emit))
+	require.Len(t, col.out, 1)
+	assert.Equal(t, "Bagel has no Path of Legends record this season", col.out[0].Text)
+}

--- a/app/sesame/modules/clashroyale_test.go
+++ b/app/sesame/modules/clashroyale_test.go
@@ -139,10 +139,9 @@ func TestCrDispatch(t *testing.T) {
 			require.NoError(t, clashCmd(t, gw, "cr").Run(context.Background(), urchinCtx(`{"account":"#P2LQ0GR"}`), tc.args, col.emit))
 			require.Len(t, col.out, 1)
 			assert.Equal(t, tc.endpoint, gw.lastCall(t).endpoint)
-			// A bare subcommand still targets the linked tag.
-			if tc.args == "decks" || tc.args == "ranked" || tc.args == "road" {
-				assert.Equal(t, "#P2LQ0GR", gw.lastCall(t).req.Account)
-			}
+			// Every case targets the same player: arg-bearing cases type the
+			// linked tag itself and bare subcommands fall back to it.
+			assert.Equal(t, "#P2LQ0GR", gw.lastCall(t).req.Account)
 		})
 	}
 }

--- a/console/shared/lib/types.ts
+++ b/console/shared/lib/types.ts
@@ -1233,6 +1233,88 @@ export const MODULE_CATALOG: readonly ModuleDef[] = [
     ]
   },
   {
+    // All four !cr views ride gossip's one shared Clash Royale profile cache,
+    // so their token palettes below mirror app/sesame/modules/clashroyale.go.
+    id: 'clashroyale',
+    label: 'Clash Royale Stats',
+    tagline: 'Clash Royale profiles, decks and Path of Legends standing in chat.',
+    description:
+      'One command, four looks: !cr shows a player\'s lifetime profile (level, win/loss record, win rate, three-crown wins, clan); !cr decks lists their current battle deck with the average elixir cost; !cr ranked shows their Path of Legends standing (falling back to legacy league seasons for older accounts); !cr road shows their trophy-road record and arena. The squashed forms !crstats, !crdecks, !crranked and !crroad work too. Link your player tag below — Clash Royale has no name lookup, so a tag like #P2LQ0GR is required. Viewers can also name any tag, e.g. "!cr #P2LQ0GR".',
+    icon: 'gamepad',
+    category: 'Games',
+    defaultEnabled: false,
+    replies: [
+      {
+        key: 'stats',
+        label: '!cr',
+        tagline: 'Lifetime profile — !cr, !cr stats or !crstats.',
+        event: '!cr',
+        command: 'cr',
+        enableKey: 'statsEnabled',
+        messageKey: 'statsMessage',
+        defaultMessage: '{player} · level {level} · {wins}W/{losses}L · {winrate}% WR · {crowns} three-crowns · {clan}',
+        tokens: ['player', 'tag', 'level', 'wins', 'losses', 'draws', 'battles', 'winrate', 'crowns', 'challengemax', 'donations', 'totaldonations', 'clan', 'favcard'],
+        previewSamples: {
+          player: 'Bagel', tag: '#P2LQ0GR', level: '62', wins: '600', losses: '300', draws: '100',
+          battles: '1000', winrate: '60', crowns: '120', challengemax: '12', donations: '50',
+          totaldonations: '10000', clan: 'Bakery', favcard: 'Knight'
+        }
+      },
+      {
+        key: 'decks',
+        label: '!cr decks',
+        tagline: "The current battle deck with its average elixir (also !crdecks).",
+        event: '!cr decks',
+        command: 'cr decks',
+        enableKey: 'decksEnabled',
+        messageKey: 'decksMessage',
+        defaultMessage: "{player}'s deck ({count}/8): {cards} · avg elixir {elixir}",
+        tokens: ['player', 'tag', 'cards', 'support', 'elixir', 'count'],
+        previewSamples: {
+          player: 'Bagel', tag: '#P2LQ0GR',
+          cards: 'Knight, Archers, Goblins, Giant, P.E.K.K.A, Minions, Fireball, Cannon',
+          support: 'Tower Troop', elixir: '3.75', count: '8'
+        }
+      },
+      {
+        key: 'ranked',
+        label: '!cr ranked',
+        tagline: 'Path of Legends standing (also !crranked); legacy league seasons fill in for older records.',
+        event: '!cr ranked',
+        command: 'cr ranked',
+        enableKey: 'rankedEnabled',
+        messageKey: 'rankedMessage',
+        defaultMessage: '{player} Path of Legends: league {league} · {trophies} trophies · rank #{rank} · best {besttrophies}',
+        tokens: ['player', 'tag', 'league', 'trophies', 'rank', 'prevleague', 'prevtrophies', 'bestleague', 'besttrophies', 'bestrank'],
+        previewSamples: {
+          player: 'Bagel', tag: '#P2LQ0GR', league: '10', trophies: '2100', rank: '321',
+          prevleague: '10', prevtrophies: '2050', bestleague: '10', besttrophies: '2400', bestrank: '42'
+        }
+      },
+      {
+        key: 'road',
+        label: '!cr road',
+        tagline: 'Trophy-road record and arena (also !crroad).',
+        event: '!cr road',
+        command: 'cr road',
+        enableKey: 'roadEnabled',
+        messageKey: 'roadMessage',
+        defaultMessage: '{player}: {trophies} trophies · best {besttrophies} · {arena}',
+        tokens: ['player', 'tag', 'trophies', 'besttrophies', 'arena'],
+        previewSamples: { player: 'Bagel', tag: '#P2LQ0GR', trophies: '9123', besttrophies: '9345', arena: 'Legendary Arena' }
+      }
+    ],
+    settings: [
+      {
+        key: 'account',
+        label: 'Linked player tag',
+        type: 'text',
+        placeholder: '#P2LQ0GR',
+        help: 'Default player for every command. Clash Royale has no name lookup, so this must be a player tag; leave blank only if you always type one.'
+      }
+    ]
+  },
+  {
     id: 'queue',
     label: 'Play Queue',
     tagline: 'Let viewers line up to play with you, first come first served.',

--- a/deploy/k8s/gossip.yaml
+++ b/deploy/k8s/gossip.yaml
@@ -17,6 +17,12 @@
 # (an api-fortnite.com key) additionally lights !fnstats. The "season" stats
 # window auto-resolves the season start from the stats upstream hourly;
 # FORTNITE_SEASON_START_UNIX optionally overrides it manually.
+# clashroyale (!cr / !crstats / !crdecks / !crranked / !crroad) needs a
+# Supercell key from developer.clashroyale.com with RoyaleAPI's proxy egress
+# IP 45.79.218.79 whitelisted on the key; set CLASHROYALE_API_KEY in Doppler
+# and calls ride proxy.royaleapi.dev. Without it the provider skips at boot
+# and the !cr commands time out at the caller like any disabled provider.
+# Lower CLASHROYALE_RATE_LIMIT from its default for a fresh key.
 apiVersion: secrets.doppler.com/v1alpha1
 kind: DopplerSecret
 metadata:

--- a/internal/domain/rpc/gossip/gossip.go
+++ b/internal/domain/rpc/gossip/gossip.go
@@ -508,3 +508,117 @@ type McsrWeeklyRaceReply struct {
 	Empty      bool   `json:"empty"`
 	Error      string `json:"error,omitempty"`
 }
+
+// --- clashroyale (Supercell Clash Royale via RoyaleAPI's proxy) --------------
+//
+// All four endpoints derive from the same GET /players/{tag} profile, so their
+// replies are projections of one cached payload; nested shapes below mirror the
+// upstream's own JSON keys where a chat template wants them verbatim.
+
+// ClashRoyaleArena is the arena a player currently sits in.
+type ClashRoyaleArena struct {
+	ID   int64  `json:"id"`
+	Name string `json:"name"`
+}
+
+// ClashRoyaleClan is the clan a player belongs to; zero-valued when clanless.
+type ClashRoyaleClan struct {
+	Tag     string `json:"tag"`
+	Name    string `json:"name"`
+	BadgeID int64  `json:"badgeId,omitempty"`
+}
+
+// ClashRoyaleCard is one card as it appears in a deck or favourite slot: the
+// bot-needed subset of the upstream card object, icon URLs included.
+type ClashRoyaleCardIconURLs struct {
+	Medium    string `json:"medium,omitempty"`
+	Evolution string `json:"evolutionMedium,omitempty"`
+}
+
+type ClashRoyaleCard struct {
+	ID                int64                   `json:"id"`
+	Name              string                  `json:"name"`
+	Level             int                     `json:"level,omitempty"`
+	MaxLevel          int                     `json:"maxLevel,omitempty"`
+	EvolutionLevel    int                     `json:"evolutionLevel,omitempty"`
+	MaxEvolutionLevel int                     `json:"maxEvolutionLevel,omitempty"`
+	ElixirCost        int                     `json:"elixirCost,omitempty"`
+	Rarity            string                  `json:"rarity,omitempty"`
+	IconURLs          ClashRoyaleCardIconURLs `json:"iconUrls,omitempty"`
+}
+
+// ClashRoyaleRankedResult covers both Path of Legends results and the legacy
+// league season records. Fields absent in one representation remain
+// zero-valued.
+type ClashRoyaleRankedResult struct {
+	SeasonID     string `json:"id,omitempty"`
+	LeagueNumber int    `json:"leagueNumber,omitempty"`
+	Trophies     int    `json:"trophies,omitempty"`
+	BestTrophies int    `json:"bestTrophies,omitempty"`
+	Rank         int    `json:"rank,omitempty"`
+}
+
+// ClashRoyaleStatsReply is the answer to clashroyale.stats (sesame's !crstats):
+// a player's lifetime profile. Draws is derived (battles minus wins and
+// losses) and WinRate is a percentage over battles.
+type ClashRoyaleStatsReply struct {
+	Player                string          `json:"player"`
+	Tag                   string          `json:"tag"`
+	KingLevel             int             `json:"king_level"`
+	ExperiencePoints      int64           `json:"experience_points"`
+	StarPoints            int64           `json:"star_points"`
+	Wins                  int             `json:"wins"`
+	Losses                int             `json:"losses"`
+	Draws                 int             `json:"draws"`
+	Battles               int             `json:"battles"`
+	WinRate               float64         `json:"win_rate"`
+	ThreeCrownWins        int             `json:"three_crown_wins"`
+	ChallengeCardsWon     int             `json:"challenge_cards_won"`
+	ChallengeMaxWins      int             `json:"challenge_max_wins"`
+	TournamentCardsWon    int             `json:"tournament_cards_won"`
+	TournamentBattleCount int             `json:"tournament_battle_count"`
+	Donations             int             `json:"donations"`
+	DonationsReceived     int             `json:"donations_received"`
+	TotalDonations        int             `json:"total_donations"`
+	Clan                  ClashRoyaleClan `json:"clan"`
+	FavouriteCard         ClashRoyaleCard `json:"favourite_card"`
+	Error                 string          `json:"error,omitempty"`
+}
+
+// ClashRoyaleDecksReply is the answer to clashroyale.decks (sesame's !crdecks):
+// the player's current battle deck and tower troop, with the elixir average
+// precomputed to two decimals.
+type ClashRoyaleDecksReply struct {
+	Player        string            `json:"player"`
+	Tag           string            `json:"tag"`
+	CurrentDeck   []ClashRoyaleCard `json:"current_deck"`
+	SupportCards  []ClashRoyaleCard `json:"support_cards"`
+	AverageElixir float64           `json:"average_elixir"`
+	Error         string            `json:"error,omitempty"`
+}
+
+// ClashRoyaleRankedReply is the answer to clashroyale.ranked (sesame's
+// !crranked): the player's Path of Legends standing, falling back to the
+// legacy league seasons for players without PoL records. Unranked is true when
+// neither source has a current result.
+type ClashRoyaleRankedReply struct {
+	Player   string                  `json:"player"`
+	Tag      string                  `json:"tag"`
+	Current  ClashRoyaleRankedResult `json:"current"`
+	Previous ClashRoyaleRankedResult `json:"previous"`
+	Best     ClashRoyaleRankedResult `json:"best"`
+	Unranked bool                    `json:"unranked"`
+	Error    string                  `json:"error,omitempty"`
+}
+
+// ClashRoyaleTrophyRoadReply is the answer to clashroyale.trophy_road
+// (sesame's !crtrophy): the player's trophy-road standing — current and best
+// trophies plus the arena they sit in.
+type ClashRoyaleTrophyRoadReply struct {
+	Player       string           `json:"player"`
+	Tag          string           `json:"tag"`
+	Trophies     int              `json:"trophies"`
+	BestTrophies int              `json:"best_trophies"`
+	Arena        ClashRoyaleArena `json:"arena"`
+	Error        string           `json:"error,omitempty"`
+}

--- a/pkg/bus/rpc_pool.go
+++ b/pkg/bus/rpc_pool.go
@@ -162,9 +162,9 @@ const (
 	//	than a slow one, so the ceiling stops where the budget stops.
 	//
 	// Pools are per subscription, so the process-wide worst case is this ceiling
-	// times the number of subjects. gossip registers fifteen: urchin 5, fortnite
-	// 4, mcsr 3, govee 2, hypixel 1 (clashroyale is written but not returned by
-	// providers.All, so it subscribes nothing). All fifteen saturated with
+	// times the number of subjects. gossip registers nineteen: urchin 5,
+	// fortnite 4, clashroyale 4, mcsr 3, govee 2, hypixel 1. All nineteen
+	// saturated with
 	// pathological 4MiB bodies is past the limit and is NOT defended by this
 	// ceiling; it is defended by the shape of the workload (chat commands, one or
 	// two hot endpoints at a time), by the per-upstream buckets, and by the fact

--- a/web/src/pages/fr/guides/modules.astro
+++ b/web/src/pages/fr/guides/modules.astro
@@ -224,7 +224,7 @@ const sections = [
 
         <Fragment slot="games">
             <p>
-                Trois intégrations mettent les stats de jeu dans le chat pour que personne ne quitte le
+                Quatre intégrations mettent les stats de jeu dans le chat pour que personne ne quitte le
                 stream. Liez votre compte une fois sur la page du module; chaque réponse est un modèle
                 réécrivable avec des variables propres au jeu.
             </p>
@@ -246,6 +246,11 @@ const sections = [
                             <td>Stats Fortnite</td>
                             <td><code>!fn</code> <code>!fn season</code> <code>!fn session</code> <code>!fn store</code></td>
                             <td>Stats à vie, de saison et du stream (victoires, K/D, taux de victoire), plus la boutique du jour.</td>
+                        </tr>
+                        <tr>
+                            <td>Stats Clash Royale</td>
+                            <td><code>!cr</code> <code>!cr decks</code> <code>!cr ranked</code> <code>!cr road</code></td>
+                            <td>Profil à vie (niveau, victoires/défaites, taux de victoire), le deck actuel avec son élixir moyen, le classement Path of Legends et le record trophée — par tag de joueur.</td>
                         </tr>
                     </tbody>
                 </table>

--- a/web/src/pages/guides/modules.astro
+++ b/web/src/pages/guides/modules.astro
@@ -214,7 +214,7 @@ const sections = [
 
         <Fragment slot="games">
             <p>
-                Three integrations put game stats in chat so nobody alt-tabs. Link your account once on
+                Four integrations put game stats in chat so nobody alt-tabs. Link your account once on
                 the module's page; every reply is a rewritable template with game-specific variables.
             </p>
             <div class="gtable-wrap">
@@ -235,6 +235,11 @@ const sections = [
                             <td>Fortnite Stats</td>
                             <td><code>!fn</code> <code>!fn season</code> <code>!fn session</code> <code>!fn store</code></td>
                             <td>Lifetime, season and this-stream stats (wins, K/D, win rate), plus today's item shop.</td>
+                        </tr>
+                        <tr>
+                            <td>Clash Royale Stats</td>
+                            <td><code>!cr</code> <code>!cr decks</code> <code>!cr ranked</code> <code>!cr road</code></td>
+                            <td>Lifetime profile (level, win/loss, win rate), the current battle deck with its average elixir, Path of Legends standing, and trophy-road record — by player tag.</td>
                         </tr>
                     </tbody>
                 </table>


### PR DESCRIPTION
## Summary
- Lights up the previously dormant clashroyale gossip provider (it subscribed nothing and wasn't compiled into the binary): config fields, credential-gated registration, four RPC subjects live.
- Moves the four endpoint replies into `internal/domain/rpc/gossip` per fleet convention — every JSON tag byte-identical, wire format pinned by the existing provider tests is unchanged.
- New sesame opt-in module: root `!cr [tag]` dispatching `decks/ranked/road` plus squashed `!crstats !crdecks !crranked !crroad`, per-command toggles + templates, linked player tag, premium bucket passthrough, fixed unranked line when PoL results are empty.
- Console MODULE_CATALOG entry (Clash Royale Stats / Games) with the four rewritable replies and linked-tag setting; stores through the generic modules table.
- Docs/deploy: guides tables en+fr gain the fourth game module; gossip.yaml header documents the key flow (Supercell key from developer.clashroyale.com whitelisting RoyaleAPI's proxy egress 45.79.218.79); rpc_pool memory-budget comment updated 15 → 19 subjects.

## Verification
- go build/vet/tests green for gossip, sesame/modules, rpc domain, bus
- console catalog test + svelte-check pass; astro check shows only pre-existing errors elsewhere
- Live-tested against proxy.royaleapi.dev with the prd Doppler key: 200 profile fetch mapped field-by-field onto playerProfile, 404 path maps to the friendly not-found reply

Branch contains only this feature — cherry-picked cleanly off main, none of the in-flight valorant work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in Clash Royale chat module.
  * Added commands for player statistics, decks, ranked standing, and trophy-road progress.
  * Added configurable response templates, linked player tags, aliases, cooldowns, and per-command enablement.
  * Added Clash Royale API integration with configurable rate limiting and setup options.

* **Documentation**
  * Added English and French guides covering Clash Royale commands and available data.
  * Documented provider setup and deployment requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->