### PR TITLE
fix(health): recover idle pull-lane health + active NATS heartbeat on readiness

### DIFF
--- a/app/commands/main.go
+++ b/app/commands/main.go
@@ -149,7 +149,7 @@ func main() {
 	// means the pool went cold and is paying the ~18ms handshake instead
 	// of reusing a conn.
 	health.Serve(env.Get("LISTEN_ADDR", ":8080"), serviceName,
-		health.Bool("nats", n.RPC.IsConnected),
+		health.NATS("nats", n.RPC),
 		health.Degrades(db.HealthCheck("mysql", driver.DB())))
 
 	log.Info("commands service ready",

--- a/app/gossip/main.go
+++ b/app/gossip/main.go
@@ -96,7 +96,7 @@ func main() {
 	}
 	subscribeRPCHealth(nc, queueGroup, log)
 
-	health.Serve(cfg.ListenAddr, serviceName, health.Bool("nats", nc.IsConnected))
+	health.Serve(cfg.ListenAddr, serviceName, health.NATS("nats", nc))
 
 	names := make([]string, 0, len(active))
 	for _, p := range active {

--- a/app/loyalty/main.go
+++ b/app/loyalty/main.go
@@ -181,7 +181,7 @@ func main() {
 	// went cold and is paying the ~18ms handshake instead of reusing a
 	// conn.
 	health.Serve(env.Get("LISTEN_ADDR", ":8080"), serviceName,
-		health.Bool("nats", nc.IsConnected),
+		health.NATS("nats", nc),
 		health.Degrades(db.HealthCheck("mysql", driver.DB())))
 
 	log.Info("loyalty service ready",

--- a/app/modules/main.go
+++ b/app/modules/main.go
@@ -71,7 +71,7 @@ func main() {
 	// means the pool went cold and is paying the ~18ms handshake instead
 	// of reusing a conn.
 	health.Serve(env.Get("LISTEN_ADDR", ":8080"), serviceName,
-		health.Bool("nats", n.RPC.IsConnected),
+		health.NATS("nats", n.RPC),
 		health.Degrades(db.HealthCheck("mysql", driver.DB())))
 
 	log.Info("modules service ready", zap.String("projection_subject", projectionSubject))

--- a/app/notifications/main.go
+++ b/app/notifications/main.go
@@ -136,7 +136,7 @@ func main() {
 	// much higher means the pool went cold and is paying the ~18ms
 	// handshake instead of reusing a conn.
 	health.Serve(env.Get("LISTEN_ADDR", ":8080"), serviceName,
-		health.Bool("nats", nc.IsConnected),
+		health.NATS("nats", nc),
 		health.Degrades(db.HealthCheck("mysql", driver.DB())))
 
 	log.Info("notifications service ready",

--- a/app/outgress/main.go
+++ b/app/outgress/main.go
@@ -180,7 +180,7 @@ func main() {
 	}
 	fatalIf(log, bus.SubscribeRPCHealth(nc, serviceName, "outgress-rpc"), "failed to subscribe rpc health")
 
-	health.Serve(env.Get("LISTEN_ADDR", ":8080"), serviceName, health.Bool("nats", nc.IsConnected))
+	health.Serve(env.Get("LISTEN_ADDR", ":8080"), serviceName, health.NATS("nats", nc))
 
 	d.logReady(tw)
 

--- a/app/projector/main.go
+++ b/app/projector/main.go
@@ -124,7 +124,7 @@ func main() {
 	}, topics)
 	fatalIf(log, bus.SubscribeRPCHealth(nc, serviceName, "projector-rpc"), "failed to subscribe rpc health")
 
-	health.Serve(env.Get("LISTEN_ADDR", ":8080"), serviceName, health.Bool("nats", nc.IsConnected))
+	health.Serve(env.Get("LISTEN_ADDR", ":8080"), serviceName, health.NATS("nats", nc))
 
 	log.Info("projector ready",
 		zap.String("status_subject", topics.status),

--- a/app/sesame/main.go
+++ b/app/sesame/main.go
@@ -132,7 +132,7 @@ func main() {
 	}
 
 	health.Serve(cfg.ListenAddr, serviceName,
-		health.Bool("nats", nc.IsConnected),
+		health.NATS("nats", nc),
 		health.Bool("bus_subscriber", func() bool { return bus.SubscriberHealthy(sub) }),
 	)
 	logReady(cfg, deps.Special.Len(), log)

--- a/app/transactions/main.go
+++ b/app/transactions/main.go
@@ -102,7 +102,7 @@ func main() {
 	handler := web.New(repo, web.Config{
 		WebhookSecret: env.Get("TEBEX_WEBHOOK_SECRET", ""),
 		Health: health.NewSet(serviceName,
-			health.Bool("nats", nc.IsConnected),
+			health.NATS("nats", nc),
 			health.Degrades(db.HealthCheck("mysql", driver.DB()))),
 		NotifyGift:   notifier.Notify,
 		ApplyBilling: billing.Apply,

--- a/app/users/main.go
+++ b/app/users/main.go
@@ -86,7 +86,7 @@ func main() {
 	// means the pool went cold and is paying the ~18ms handshake instead
 	// of reusing a conn.
 	health.Serve(env.Get("LISTEN_ADDR", ":8080"), serviceName,
-		health.Bool("nats", nc.IsConnected),
+		health.NATS("nats", nc),
 		health.Degrades(db.HealthCheck("mysql", dbPool)))
 	subjects.logReady(log)
 

--- a/pkg/bus/pull_consumer.go
+++ b/pkg/bus/pull_consumer.go
@@ -506,6 +506,12 @@ func (s *pullSubscriber) pumpIterator() bool {
 	}
 	release := s.stopIteratorOnClose(iter)
 	defer release()
+	// A successfully bound iterator IS fetch-loop progress: Next may legitimately
+	// block for hours on an idle lane. Clearing the health clock here — not only
+	// on message arrival — is what lets a lane recover from one transient error
+	// while idle; otherwise errSince ages past laneUnhealthyAfter and the pod
+	// reports itself unready until traffic happens to return.
+	s.noteFetchProgress()
 	sinceFloor := 0
 	for {
 		wire, err := iter.Next()

--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -75,6 +75,51 @@ func Degrades(c Check) Check {
 	return c
 }
 
+// Pinger is the slice of *nats.Conn the NATS check needs, so this package
+// never imports nats.go. Both methods are satisfied by *nats.Conn directly.
+type Pinger interface {
+	IsConnected() bool
+	FlushTimeout(time.Duration) error
+}
+
+// NATS verifies a NATS connection with a real heartbeat round trip instead of
+// only reading its cached state.
+//
+// IsConnected alone is a local flag: it flips false only when the client's own
+// machinery has noticed the loss, and a half-open partition (NAT drop, node
+// pause, pulled cable) leaves it true indefinitely while every publish drains
+// into the void. FlushTimeout sends a PING and blocks on the server's PONG, so
+// a probe either heard from a live server or failed within its remaining
+// budget — the same heartbeat the client library itself runs, on demand. The
+// flag is still checked first so a client that already knows it is down fails
+// without spending a round trip.
+//
+// A nil conn always passes (see Bool): a service that wired no connection has
+// no NATS dependency to report on.
+func NATS(name string, conn Pinger) Check {
+	return Check{Name: name, Probe: func(ctx context.Context) error {
+		if conn == nil {
+			return nil
+		}
+		if !conn.IsConnected() {
+			return errors.New("not connected")
+		}
+		wait := checkTimeout
+		if deadline, ok := ctx.Deadline(); ok {
+			if d := time.Until(deadline); d < wait {
+				wait = d
+			}
+		}
+		if wait <= 0 {
+			return errors.New("heartbeat: probe deadline exceeded")
+		}
+		if err := conn.FlushTimeout(wait); err != nil {
+			return fmt.Errorf("heartbeat: %w", err)
+		}
+		return nil
+	}}
+}
+
 // CheckResult is one check's outcome inside a Report.
 type CheckResult struct {
 	Name      string `json:"name"`

--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -107,6 +107,64 @@ func TestBoolNilAlwaysPasses(t *testing.T) {
 	}
 }
 
+// fakeConn records whether the probe spent a round trip, so the fast-path
+// (cached state already false) is distinguishable from the heartbeat itself.
+type fakeConn struct {
+	connected bool
+	flushErr  error
+	flushed   bool
+}
+
+func (f *fakeConn) IsConnected() bool { return f.connected }
+
+func (f *fakeConn) FlushTimeout(time.Duration) error {
+	f.flushed = true
+	return f.flushErr
+}
+
+func TestNATSHeartbeat(t *testing.T) {
+	cases := []struct {
+		name      string
+		conn      *fakeConn
+		ctx       context.Context
+		wantErr   bool
+		wantFlush bool
+	}{
+		{"disconnected fails without a round trip",
+			&fakeConn{connected: false}, context.Background(), true, false},
+		{"connected passes the round trip",
+			&fakeConn{connected: true}, context.Background(), false, true},
+		{"failed pong fails the check",
+			&fakeConn{connected: true, flushErr: errors.New("i/o timeout")}, context.Background(), true, true},
+		{"expired deadline fails before flushing",
+			&fakeConn{connected: true}, expiredCtx(), true, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := NATS("nats", tc.conn).Probe(tc.ctx)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("probe err = %v, wantErr %v", err, tc.wantErr)
+			}
+			if tc.conn.flushed != tc.wantFlush {
+				t.Fatalf("flushed = %v, want %v", tc.conn.flushed, tc.wantFlush)
+			}
+		})
+	}
+}
+
+func TestNATSNilConnAlwaysPasses(t *testing.T) {
+	if err := NATS("x", nil).Probe(context.Background()); err != nil {
+		t.Fatalf("nil conn: %v", err)
+	}
+}
+
+func expiredCtx() context.Context {
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	cancel()
+	return ctx
+}
+
 func TestProbeSeesDeadline(t *testing.T) {
 	s := NewSet("svc", Check{Name: "slow", Probe: func(ctx context.Context) error {
 		if _, ok := ctx.Deadline(); !ok {


### PR DESCRIPTION
## Summary
- A successfully bound pull iterator now clears the lane health clock (`noteFetchProgress()` right after `consumer.Messages()` succeeds): a fetch loop blocked in `Next()` on an empty lane is healthy progress, so one transient error can no longer flip a quiet lane sick forever — recovery no longer depends on traffic returning. Two sesame replicas sat NotReady for hours after a single missed heartbeat.
- The health endpoints stop trusting the cached `nc.IsConnected()` flag, which stays true through a half-open partition while publishes drain into the void. New `health.NATS` check fast-fails on the flag, then spends a real PING/PONG round trip (`FlushTimeout`) within the probe's remaining budget — `/readyz` and `/status` either heard from a live server or report down. All ten services switch to it; sesame keeps its complementary fetch-progress clock (a deleted durable holds a perfectly healthy connection).

## Test plan
- `go test ./pkg/health ./pkg/bus` — new cases cover disconnected fast-path (no round trip spent), failed pong, and expired probe deadline.
- `go vet` / `go build` across all ten touched services.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service health checks by actively verifying NATS connectivity and reporting clearer failures.
  * Health checks now respect probe timeouts and safely handle unavailable connections.
  * Fixed message consumer recovery so idle lanes can return to a healthy state sooner.
* **Reliability**
  * Preserved degraded MySQL health reporting while improving NATS readiness monitoring across services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->