### PR TITLE
fix(console): treat blank env overrides as absent in subject/connection fallbacks

### DIFF
--- a/console/admin/src/lib/server/feed.ts
+++ b/console/admin/src/lib/server/feed.ts
@@ -12,8 +12,10 @@ let dialing: Promise<NatsConnection> | null = null;
 
 // The status stream lives on the hub (like the shared client's bus role);
 // NATS_URL is the local-dev fallback only.
+// `||` chains, not `??` (same blank-as-absent rule as the SUB maps): a
+// set-but-blank var must fall through, or servers: '' dials nothing forever.
 function url(): string {
-  return process.env.NATS_HUB_URL ?? process.env.NATS_URL ?? 'nats://127.0.0.1:4222';
+  return process.env.NATS_HUB_URL || process.env.NATS_URL || 'nats://127.0.0.1:4222';
 }
 
 async function get(): Promise<NatsConnection> {
@@ -21,7 +23,7 @@ async function get(): Promise<NatsConnection> {
   if (dialing) return dialing;
   const opts: ConnectionOptions = {
     servers: url(),
-    name: (process.env.NATS_CLIENT_NAME ?? 'console') + '-feed',
+    name: (process.env.NATS_CLIENT_NAME || 'console') + '-feed',
     maxReconnectAttempts: -1,
     reconnectTimeWait: 500,
     pingInterval: 20_000,

--- a/console/admin/src/lib/server/services.ts
+++ b/console/admin/src/lib/server/services.ts
@@ -18,19 +18,24 @@ import { adminL1CacheCapacity } from './config-sanity';
 // SvelteKit's dynamic-env proxy at module-eval time during server.init()
 // deadlocks the handler import (unsettled top-level await -> exit 13). In
 // adapter-node process.env carries the same values.
+//
+// Env fallbacks use `||`, not `??` (same rule as dashboard/services.ts SUB): a
+// set-but-blank Doppler var through `??` collapses every subject here to a
+// leading-dot fragment and turns RPCs into silent timeouts. All defaults are
+// non-empty strings, so `||` discards nothing legitimate.
 const SUB = {
-  shards: process.env.NATS_ADMIN_SUBJECT ?? 'twitch.ingress.admin.shards.get',
-  scale: process.env.NATS_SHARD_SCALE_SUBJECT ?? 'twitch.ingress.admin.shards.scale',
-  autoscale: process.env.NATS_SHARD_AUTOSCALE_SUBJECT ?? 'twitch.ingress.admin.shards.autoscale',
-  status: process.env.NATS_STATUS_SUBJECT_PREFIX ?? 'twitch.ingress.status',
-  user: process.env.NATS_ADMIN_USER_SUBJECT_PREFIX ?? 'bagel.rpc.admin.user',
-  auth: process.env.NATS_ADMIN_AUTH_SUBJECT_PREFIX ?? 'bagel.rpc.admin.user.auth',
-  audit: process.env.NATS_ADMIN_AUDIT_SUBJECT_PREFIX ?? 'bagel.rpc.admin.user.audit',
-  outgress: process.env.NATS_OUTGRESS_SYSTEM_SUBJECT ?? 'twitch.outgress.system',
-  outgressRpc: process.env.NATS_OUTGRESS_RPC_PREFIX ?? 'bagel.rpc.outgress',
-  notifications: process.env.NATS_ADMIN_NOTIFICATIONS_SUBJECT_PREFIX ?? 'bagel.rpc.admin.notifications',
-  loyalty: process.env.NATS_LOYALTY_SUBJECT_PREFIX ?? 'bagel.rpc.loyalty',
-  health: process.env.NATS_RPC_HEALTH_PREFIX ?? 'bagel.rpc.health'
+  shards: process.env.NATS_ADMIN_SUBJECT || 'twitch.ingress.admin.shards.get',
+  scale: process.env.NATS_SHARD_SCALE_SUBJECT || 'twitch.ingress.admin.shards.scale',
+  autoscale: process.env.NATS_SHARD_AUTOSCALE_SUBJECT || 'twitch.ingress.admin.shards.autoscale',
+  status: process.env.NATS_STATUS_SUBJECT_PREFIX || 'twitch.ingress.status',
+  user: process.env.NATS_ADMIN_USER_SUBJECT_PREFIX || 'bagel.rpc.admin.user',
+  auth: process.env.NATS_ADMIN_AUTH_SUBJECT_PREFIX || 'bagel.rpc.admin.user.auth',
+  audit: process.env.NATS_ADMIN_AUDIT_SUBJECT_PREFIX || 'bagel.rpc.admin.user.audit',
+  outgress: process.env.NATS_OUTGRESS_SYSTEM_SUBJECT || 'twitch.outgress.system',
+  outgressRpc: process.env.NATS_OUTGRESS_RPC_PREFIX || 'bagel.rpc.outgress',
+  notifications: process.env.NATS_ADMIN_NOTIFICATIONS_SUBJECT_PREFIX || 'bagel.rpc.admin.notifications',
+  loyalty: process.env.NATS_LOYALTY_SUBJECT_PREFIX || 'bagel.rpc.loyalty',
+  health: process.env.NATS_RPC_HEALTH_PREFIX || 'bagel.rpc.health'
 };
 
 export const STATUS_PREFIX = SUB.status;

--- a/console/dashboard/src/lib/server/services.ts
+++ b/console/dashboard/src/lib/server/services.ts
@@ -20,24 +20,31 @@ import { dashboardL1CacheCapacity } from './config-sanity';
 // SvelteKit's dynamic-env proxy at module-eval time during server.init()
 // deadlocks the handler import (unsettled top-level await -> exit 13). In
 // adapter-node process.env carries the same values.
+//
+// Every env fallback below is `||`, never `??`: Doppler has shipped set-but-
+// blank vars before, and `??` passes one straight through, collapsing every
+// subject built from it to a leading-dot fragment ('.modules.get') that no
+// responder answers — a silent RPC timeout, not a config error. The identical
+// pattern once delivered a blank Valkey master name and took writes down; that
+// fix was also `||`. All defaults here are non-empty strings, so there is no
+// legitimate falsy value `||` could discard.
 export const SUB = {
-  broadcaster: process.env.NATS_BROADCASTER_STATUS_SUBJECT ?? 'bagel.rpc.broadcaster.status.get',
-  dashboard: process.env.NATS_DASHBOARD_SUBJECT_PREFIX ?? 'bagel.rpc.dashboard',
-  commands: process.env.NATS_COMMANDS_SUBJECT_PREFIX ?? 'bagel.rpc.commands',
-  modules: process.env.NATS_MODULES_SUBJECT_PREFIX ?? 'bagel.rpc.modules',
-  projector: process.env.NATS_PROJECTOR_DASHBOARD_SUBJECT_PREFIX ?? 'bagel.rpc.projector.dashboard',
-  outgress: process.env.NATS_OUTGRESS_SYSTEM_SUBJECT ?? 'twitch.outgress.system',
-  outgressRpc: process.env.NATS_OUTGRESS_RPC_PREFIX ?? 'bagel.rpc.outgress',
-  // Hard cutover from the gateway rename: no NATS_GATEWAY_SUBJECT_PREFIX fallback
-  // (the old account/user no longer exist). `||` so a blank Doppler value falls
-  // through to the default instead of resolving to an empty subject prefix.
+  broadcaster: process.env.NATS_BROADCASTER_STATUS_SUBJECT || 'bagel.rpc.broadcaster.status.get',
+  dashboard: process.env.NATS_DASHBOARD_SUBJECT_PREFIX || 'bagel.rpc.dashboard',
+  commands: process.env.NATS_COMMANDS_SUBJECT_PREFIX || 'bagel.rpc.commands',
+  modules: process.env.NATS_MODULES_SUBJECT_PREFIX || 'bagel.rpc.modules',
+  projector: process.env.NATS_PROJECTOR_DASHBOARD_SUBJECT_PREFIX || 'bagel.rpc.projector.dashboard',
+  outgress: process.env.NATS_OUTGRESS_SYSTEM_SUBJECT || 'twitch.outgress.system',
+  outgressRpc: process.env.NATS_OUTGRESS_RPC_PREFIX || 'bagel.rpc.outgress',
+  // Hard cutover from the gateway rename: no NATS_GATEWAY_SUBJECT_PREFIX
+  // fallback (the old account/user no longer exist).
   gossip: process.env.NATS_GOSSIP_SUBJECT_PREFIX || 'bagel.rpc.gossip',
-  loyalty: process.env.NATS_LOYALTY_SUBJECT_PREFIX ?? 'bagel.rpc.loyalty',
-  goveeKey: process.env.NATS_MODULES_GOVEE_SUBJECT_PREFIX ?? 'bagel.rpc.modules.govee',
-  audit: process.env.NATS_ADMIN_AUDIT_SUBJECT_PREFIX ?? 'bagel.rpc.admin.user.audit',
-  delegation: process.env.NATS_DELEGATION_SUBJECT_PREFIX ?? 'bagel.rpc.delegation',
-  notifications: process.env.NATS_NOTIFICATIONS_SUBJECT_PREFIX ?? 'bagel.rpc.notifications',
-  transactions: process.env.NATS_TRANSACTIONS_SUBJECT_PREFIX ?? 'bagel.rpc.transactions'
+  loyalty: process.env.NATS_LOYALTY_SUBJECT_PREFIX || 'bagel.rpc.loyalty',
+  goveeKey: process.env.NATS_MODULES_GOVEE_SUBJECT_PREFIX || 'bagel.rpc.modules.govee',
+  audit: process.env.NATS_ADMIN_AUDIT_SUBJECT_PREFIX || 'bagel.rpc.admin.user.audit',
+  delegation: process.env.NATS_DELEGATION_SUBJECT_PREFIX || 'bagel.rpc.delegation',
+  notifications: process.env.NATS_NOTIFICATIONS_SUBJECT_PREFIX || 'bagel.rpc.notifications',
+  transactions: process.env.NATS_TRANSACTIONS_SUBJECT_PREFIX || 'bagel.rpc.transactions'
 };
 
 function userPrefixes(id: string): string[] {

--- a/console/shared/lib/server/nats.ts
+++ b/console/shared/lib/server/nats.ts
@@ -84,8 +84,10 @@ export function enableLeafFailback(nc: NatsConnection): void {
   const intervalMs = positiveNumber(process.env.NATS_FAILBACK_INTERVAL_MS, 30_000);
   const required = positiveNumber(process.env.NATS_FAILBACK_SUCCESSES, 3);
   const timeoutMs = positiveNumber(process.env.NATS_FAILBACK_PROBE_TIMEOUT_MS, 1_000);
+  // `||` not `??`: a set-but-blank URL must fall through to the default, or
+  // the failback probe would fetch('') forever and never fire.
   const healthURL =
-    process.env.NATS_LOCAL_LEAF_HEALTH_URL ?? 'http://nats-leaf-local:8222/healthz';
+    process.env.NATS_LOCAL_LEAF_HEALTH_URL || 'http://nats-leaf-local:8222/healthz';
   let consecutive = 0;
   let running = false;
 
@@ -134,7 +136,9 @@ export function enableLeafFailback(nc: NatsConnection): void {
 }
 
 function fallbackServer(override: string | undefined): string {
-  return override ?? `nats://${process.env.NATS_HOST ?? '127.0.0.1'}:${process.env.NATS_PORT ?? '4222'}`;
+  // `||` not `??`: a blank override/host must fall through to the default —
+  // through `??` a blank NATS_HOST builds 'nats://:4222' and every dial fails.
+  return override || `nats://${process.env.NATS_HOST || '127.0.0.1'}:${process.env.NATS_PORT || '4222'}`;
 }
 
 // Ordered RPC pool. Legacy NATS_LEAF_URL values are intentionally ignored so
@@ -144,7 +148,7 @@ function rpcServerList(override: string | undefined): string[] {
 }
 
 function busServerList(override: string | undefined): string[] {
-  return [process.env.NATS_HUB_URL ?? fallbackServer(override)];
+  return [process.env.NATS_HUB_URL || fallbackServer(override)];
 }
 
 // Verify the NATS server's TLS cert against the fleet CA (NATS_CA_PEM, the
@@ -175,7 +179,7 @@ function options(role: Role): ConnectionOptions {
       : busServerList(process.env.NATS_URL),
     // RPC stays on the leaf tier; the Service handles cross-node leaf failover.
     noRandomize: true,
-    name: `${process.env.NATS_CLIENT_NAME ?? 'console'}-${role}`,
+    name: `${process.env.NATS_CLIENT_NAME || 'console'}-${role}`,
     maxReconnectAttempts: -1,
     reconnectTimeWait: 500,
     // Broker auth/config and Doppler-driven app restarts can briefly land out
@@ -188,9 +192,11 @@ function options(role: Role): ConnectionOptions {
     // a gateway "server connection error" the user has to refresh past.
     timeout: 3_000
   };
-  const user = isRpc ? (process.env.NATS_RPC_USER ?? process.env.NATS_USER) : process.env.NATS_USER;
+  // `||` chains, not `??`: a blank RPC credential must fall back to the shared
+  // one instead of authenticating with an empty string.
+  const user = isRpc ? (process.env.NATS_RPC_USER || process.env.NATS_USER) : process.env.NATS_USER;
   const pass = isRpc
-    ? (process.env.NATS_RPC_PASSWORD ?? process.env.NATS_PASSWORD)
+    ? (process.env.NATS_RPC_PASSWORD || process.env.NATS_PASSWORD)
     : process.env.NATS_PASSWORD;
   if (user) opts.user = user;
   if (pass) opts.pass = pass;

--- a/console/shared/lib/server/nats.ts
+++ b/console/shared/lib/server/nats.ts
@@ -171,6 +171,18 @@ function tlsOptions(): ConnectionOptions['tls'] | undefined {
   return { ca: caPem };
 }
 
+// Role-scoped env lookup: the RPC tier reads its dedicated variable with the
+// shared one as fallback; every other tier reads only the shared variable.
+// The fallback chain is `||`, not `??`: a set-but-blank Doppler var must fall
+// through, or through `??` the caller authenticates with an empty string.
+function roleEnv(
+  isRpc: boolean,
+  rpcVar: string | undefined,
+  sharedVar: string | undefined
+): string | undefined {
+  return isRpc ? rpcVar || sharedVar : sharedVar;
+}
+
 function options(role: Role): ConnectionOptions {
   const isRpc = role === 'rpc';
   const opts: ConnectionOptions = {
@@ -192,12 +204,8 @@ function options(role: Role): ConnectionOptions {
     // a gateway "server connection error" the user has to refresh past.
     timeout: 3_000
   };
-  // `||` chains, not `??`: a blank RPC credential must fall back to the shared
-  // one instead of authenticating with an empty string.
-  const user = isRpc ? (process.env.NATS_RPC_USER || process.env.NATS_USER) : process.env.NATS_USER;
-  const pass = isRpc
-    ? (process.env.NATS_RPC_PASSWORD || process.env.NATS_PASSWORD)
-    : process.env.NATS_PASSWORD;
+  const user = roleEnv(isRpc, process.env.NATS_RPC_USER, process.env.NATS_USER);
+  const pass = roleEnv(isRpc, process.env.NATS_RPC_PASSWORD, process.env.NATS_PASSWORD);
   if (user) opts.user = user;
   if (pass) opts.pass = pass;
   if (process.env.NATS_TOKEN) opts.token = process.env.NATS_TOKEN;


### PR DESCRIPTION
Fixes #536

## Problem

Every NATS subject prefix in the console's `SUB` maps resolved its env override with `??`, which only falls back on `null`/`undefined`. A set-but-blank Doppler var passes straight through: the prefix becomes `''` and every subject built from it collapses to a leading-dot fragment (`.modules.get`). Nothing throws — the RPC just never reaches a responder and surfaces as a silent timeout. The same pattern already caused a production outage once before (blank Valkey master name); the `gossip` entry was fixed to `||` during the gateway rename but the rest were left.

## Change

Swap `??` → `||` wherever a non-empty string is required — all defaults are non-empty strings, so nothing legitimate is discarded:

- `console/dashboard/src/lib/server/services.ts` — all 13 remaining `SUB` entries
- `console/admin/src/lib/server/services.ts` — all 12 `SUB` entries
- `console/shared/lib/server/nats.ts` — server URL fallback (`nats://:4222` on blank host), hub URL list (`servers: ''`), leaf failback health probe (`fetch('')` forever), client name, RPC credential chains (blank cred authenticating as `''`)
- `console/admin/src/lib/server/feed.ts` — hub URL chain and client name

Comments at each site record why `||` is the rule so it doesn't drift back to `??`.

Deliberately out of scope: `shared/lib/server/logger.ts` `LOG_LEVEL` — pino rejects a blank level loudly at boot, so it is not part of this silent-failure class.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved configuration handling when environment variables are blank.
  - Services now reliably use safe default endpoints, connection details, client names, and credentials.
  - Prevented empty configuration values from causing invalid connections, authentication issues, or service timeouts.
  - Updated messaging and health-check connections to fall back to configured defaults when values are missing or blank.
  - Applied consistent fallback behavior across administrative, dashboard, and shared service connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->