### PR TITLE
perf(users): write-behind batching for preference writes, batcher hardening

### DIFF
--- a/app/users/main.go
+++ b/app/users/main.go
@@ -36,6 +36,11 @@ import (
 
 const serviceName = "users"
 
+// shutdownFlushBudget bounds the final write-behind drain on SIGTERM: long
+// enough for a healthy flush window plus its event publishes, short enough
+// that a rolling restart is not slowed by a database that stopped answering.
+const shutdownFlushBudget = 10 * time.Second
+
 // fatalIf aborts startup on err: the users service cannot run degraded without
 // any of its core dependencies, so a failed step must crash the pod.
 func fatalIf(log *zap.Logger, err error, msg string) {
@@ -64,8 +69,14 @@ func main() {
 	defer nc.Close()
 	defer func() { _ = pub.Close() }()
 
-	repo := repository.NewUsers(client, packer, pub)
-	defer repo.Close()
+	repo := repository.NewUsers(client, packer, pub, nrApp, log)
+	defer func() {
+		// Bounded so a shutdown cannot hang on the final preference drain;
+		// the batcher's own flush deadline caps each window inside it.
+		flushCtx, cancel := context.WithTimeout(context.Background(), shutdownFlushBudget)
+		defer cancel()
+		repo.Close(flushCtx)
+	}()
 
 	closeConsumers := startConsumers(ctx, natsURL, repo, log)
 	defer closeConsumers()

--- a/app/users/repository/preferences.go
+++ b/app/users/repository/preferences.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"ItsBagelBot/app/users/ent"
+	"ItsBagelBot/pkg/batch"
 	"ItsBagelBot/pkg/monitor"
 
 	"github.com/newrelic/go-agent/v3/newrelic"
@@ -88,38 +89,15 @@ func applyPref(u *ent.UserUpdateOne, w prefWrite) {
 // handled here (per-user fallback + requeue), because returning them would
 // make the batcher retry the whole window around rows it already dropped.
 func (r *Users) flushPrefs(ctx context.Context, items []prefWrite) error {
+	ctx, txn, log := r.beginFlush(ctx, "flush user preferences")
+	defer endFlush(txn)
 
-	var txn *newrelic.Transaction
-	if r.app != nil {
-		txn = r.app.StartTransaction("flush user preferences")
-		defer txn.End()
-		ctx = newrelic.NewContext(ctx, txn)
-	}
-	log := r.log
-	if txn != nil {
-		log = monitor.TxnLogger(ctx, r.log)
-	}
-
-	// Merge per user first: one user touching three preferences in a window
-	// gets ONE UPDATE carrying all three columns, and is announced once.
-	perUser := make(map[uint64][]prefWrite, len(items))
-	for _, w := range items {
-		perUser[w.userID] = append(perUser[w.userID], w)
-	}
+	perUser := groupByUser(items)
 
 	// The whole window is one transaction, per ADR-0008's "a burst of writes
 	// must land as one transaction, not as N round trips".
 	err := withTx(ctx, r.client, func(tx *ent.Tx) error {
-		for id, writes := range perUser {
-			update := tx.User.UpdateOneID(id)
-			for _, w := range writes {
-				applyPref(update, w)
-			}
-			if err := update.Exec(ctx); err != nil {
-				return err
-			}
-		}
-		return nil
+		return writeAllUserPrefs(ctx, tx, perUser)
 	})
 	if err == nil {
 		for id := range perUser {
@@ -128,9 +106,7 @@ func (r *Users) flushPrefs(ctx context.Context, items []prefWrite) error {
 		return nil
 	}
 
-	if txn != nil {
-		txn.NoticeError(err)
-	}
+	txn.NoticeError(err)
 	log.Warn("preference window failed as one transaction, falling back per user",
 		zap.Int("users", len(perUser)),
 		zap.Error(err),
@@ -139,43 +115,107 @@ func (r *Users) flushPrefs(ctx context.Context, items []prefWrite) error {
 	return nil
 }
 
+// beginFlush starts the background transaction a flush reports under and
+// derives its logger. Tests build repositories without observability, so a
+// nil app means "run unwired": plain context, nil transaction, base logger.
+func (r *Users) beginFlush(ctx context.Context, name string) (context.Context, *newrelic.Transaction, *zap.Logger) {
+	if r.app == nil {
+		return ctx, nil, r.log
+	}
+	txn := r.app.StartTransaction(name)
+	ctx = newrelic.NewContext(ctx, txn)
+	return ctx, txn, monitor.TxnLogger(ctx, r.log)
+}
+
+// endFlush closes the background transaction begun by beginFlush.
+func endFlush(txn *newrelic.Transaction) {
+	if txn != nil {
+		txn.End()
+	}
+}
+
+// groupByUser merges a window's writes per user, so one user touching three
+// preferences gets ONE UPDATE carrying all three columns and is announced
+// once.
+func groupByUser(items []prefWrite) map[uint64][]prefWrite {
+	perUser := make(map[uint64][]prefWrite, len(items))
+	for _, w := range items {
+		perUser[w.userID] = append(perUser[w.userID], w)
+	}
+	return perUser
+}
+
+// writeAllUserPrefs lands every user's merged writes in the caller's
+// transaction; the first failure aborts it so the window falls back to
+// per-user isolation instead of half-landing invisibly.
+func writeAllUserPrefs(ctx context.Context, tx *ent.Tx, perUser map[uint64][]prefWrite) error {
+	for id, writes := range perUser {
+		if err := writeUserPrefs(ctx, tx, id, writes); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// writeUserPrefs applies one user's queued writes onto a single UPDATE.
+func writeUserPrefs(ctx context.Context, tx *ent.Tx, id uint64, writes []prefWrite) error {
+	update := tx.User.UpdateOneID(id)
+	for _, w := range writes {
+		applyPref(update, w)
+	}
+	return update.Exec(ctx)
+}
+
+// unpersistablePrefErr classifies failures no retry can fix: the row fails
+// schema validation or constraints, or the user was deleted mid-window.
+// Everything else is transient and worth requeueing.
+func unpersistablePrefErr(err error) bool {
+	return ent.IsValidationError(err) || ent.IsConstraintError(err) || ent.IsNotFound(err)
+}
+
+// requeuePrefWrites returns a transiently failed user's writes to the batcher
+// for the next window, newest value still winning over anything queued since.
+func requeuePrefWrites(b *batch.Batcher[prefKey, prefWrite], writes []prefWrite) {
+	for _, w := range writes {
+		b.Requeue(prefKey{userID: w.userID, field: w.field}, w)
+	}
+}
+
 // applyPrefEach retries a failed window one user at a time so a single poison
-// row cannot wedge the rest. Rows the database will never accept (validation,
-// constraint, or a user deleted mid-window) are dropped with a log; transiently
-// failing users are requeued into the batcher for the next window.
+// row cannot wedge the rest: rows the database will never accept are dropped
+// with a log, transiently failing users are requeued.
 func (r *Users) applyPrefEach(ctx context.Context, txn *newrelic.Transaction, log *zap.Logger, perUser map[uint64][]prefWrite) {
 	for id, writes := range perUser {
 		err := withTx(ctx, r.client, func(tx *ent.Tx) error {
-			update := tx.User.UpdateOneID(id)
-			for _, w := range writes {
-				applyPref(update, w)
-			}
-			return update.Exec(ctx)
+			return writeUserPrefs(ctx, tx, id, writes)
 		})
-		if err == nil {
-			r.announcePref(ctx, log, id)
-			continue
-		}
 
-		if txn != nil {
-			txn.NoticeError(err)
-		}
-		if ent.IsValidationError(err) || ent.IsConstraintError(err) || ent.IsNotFound(err) {
+		switch {
+		case err == nil:
+			r.announcePref(ctx, log, id)
+		case unpersistablePrefErr(err):
+			txnNotice(txn, err)
 			log.Error("dropping unpersistable preference change",
 				zap.Uint64("user_id", id),
 				zap.Int("writes", len(writes)),
 				zap.Error(err),
 			)
-			continue
+		default:
+			txnNotice(txn, err)
+			log.Warn("requeueing preference changes after transient flush failure",
+				zap.Uint64("user_id", id),
+				zap.Int("writes", len(writes)),
+				zap.Error(err),
+			)
+			requeuePrefWrites(r.batcher, writes)
 		}
-		log.Warn("requeueing preference changes after transient flush failure",
-			zap.Uint64("user_id", id),
-			zap.Int("writes", len(writes)),
-			zap.Error(err),
-		)
-		for _, w := range writes {
-			r.batcher.Requeue(prefKey{userID: w.userID, field: w.field}, w)
-		}
+	}
+}
+
+// txnNotice records an error against the flush transaction when one exists.
+func txnNotice(txn *newrelic.Transaction, err error) {
+	if txn != nil {
+		txn.NoticeError(err)
 	}
 }
 

--- a/app/users/repository/preferences.go
+++ b/app/users/repository/preferences.go
@@ -1,0 +1,192 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package repository
+
+import (
+	"context"
+	"time"
+
+	"ItsBagelBot/app/users/ent"
+	"ItsBagelBot/pkg/monitor"
+
+	"github.com/newrelic/go-agent/v3/newrelic"
+
+	"go.uber.org/zap"
+)
+
+const (
+	// prefsFlushInterval and prefsFlushMaxSize are the same write-behind
+	// window ADR-0008 prescribes for modules and commands: a preference
+	// clicked five times in two seconds costs one row write, whichever bound
+	// trips first drains the window.
+	prefsFlushInterval = 2 * time.Second
+	prefsFlushMaxSize  = 256
+)
+
+// prefField enumerates the user columns served through the write-behind
+// batcher. Money (status tier) and moderation (banned) deliberately stay off
+// this list; see SetStatus and SetBanned.
+type prefField uint8
+
+const (
+	prefActive prefField = iota
+	prefLocale
+	prefCursor
+	prefOnboarded
+	prefCreatorCode
+)
+
+// prefKey coalesces on (user, field): repeated clicks on ONE preference
+// collapse into the latest value, while different preferences of the same
+// user stay separate pending entries that merge into one UPDATE at flush.
+type prefKey struct {
+	userID uint64
+	field  prefField
+}
+
+// prefWrite is one queued preference write. It repeats its key inside the
+// value because the flush callback receives values only.
+type prefWrite struct {
+	userID uint64
+	field  prefField
+
+	flag bool    // active / cursor / onboarded
+	str  string  // locale
+	code *string // creator code; nil clears the nullable column
+}
+
+func (r *Users) queuePref(id uint64, field prefField, w prefWrite) {
+	w.userID = id
+	w.field = field
+	r.batcher.Add(prefKey{userID: id, field: field}, w)
+}
+
+// applyPref stamps one queued write onto an update builder.
+func applyPref(u *ent.UserUpdateOne, w prefWrite) {
+	switch w.field {
+	case prefActive:
+		u.SetIsActive(w.flag)
+	case prefLocale:
+		u.SetLocale(w.str)
+	case prefCursor:
+		u.SetCustomCursor(w.flag)
+	case prefOnboarded:
+		u.SetOnboarded(w.flag)
+	case prefCreatorCode:
+		if w.code == nil {
+			u.ClearCreatorCode()
+		} else {
+			u.SetCreatorCode(*w.code)
+		}
+	}
+}
+
+// flushPrefs lands one window of coalesced preference writes, then announces
+// every changed user once. It runs detached from any request, so it reports
+// as its own background transaction. It always returns nil: failures are
+// handled here (per-user fallback + requeue), because returning them would
+// make the batcher retry the whole window around rows it already dropped.
+func (r *Users) flushPrefs(ctx context.Context, items []prefWrite) error {
+
+	var txn *newrelic.Transaction
+	if r.app != nil {
+		txn = r.app.StartTransaction("flush user preferences")
+		defer txn.End()
+		ctx = newrelic.NewContext(ctx, txn)
+	}
+	log := r.log
+	if txn != nil {
+		log = monitor.TxnLogger(ctx, r.log)
+	}
+
+	// Merge per user first: one user touching three preferences in a window
+	// gets ONE UPDATE carrying all three columns, and is announced once.
+	perUser := make(map[uint64][]prefWrite, len(items))
+	for _, w := range items {
+		perUser[w.userID] = append(perUser[w.userID], w)
+	}
+
+	// The whole window is one transaction, per ADR-0008's "a burst of writes
+	// must land as one transaction, not as N round trips".
+	err := withTx(ctx, r.client, func(tx *ent.Tx) error {
+		for id, writes := range perUser {
+			update := tx.User.UpdateOneID(id)
+			for _, w := range writes {
+				applyPref(update, w)
+			}
+			if err := update.Exec(ctx); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err == nil {
+		for id := range perUser {
+			r.announcePref(ctx, log, id)
+		}
+		return nil
+	}
+
+	if txn != nil {
+		txn.NoticeError(err)
+	}
+	log.Warn("preference window failed as one transaction, falling back per user",
+		zap.Int("users", len(perUser)),
+		zap.Error(err),
+	)
+	r.applyPrefEach(ctx, txn, log, perUser)
+	return nil
+}
+
+// applyPrefEach retries a failed window one user at a time so a single poison
+// row cannot wedge the rest. Rows the database will never accept (validation,
+// constraint, or a user deleted mid-window) are dropped with a log; transiently
+// failing users are requeued into the batcher for the next window.
+func (r *Users) applyPrefEach(ctx context.Context, txn *newrelic.Transaction, log *zap.Logger, perUser map[uint64][]prefWrite) {
+	for id, writes := range perUser {
+		err := withTx(ctx, r.client, func(tx *ent.Tx) error {
+			update := tx.User.UpdateOneID(id)
+			for _, w := range writes {
+				applyPref(update, w)
+			}
+			return update.Exec(ctx)
+		})
+		if err == nil {
+			r.announcePref(ctx, log, id)
+			continue
+		}
+
+		if txn != nil {
+			txn.NoticeError(err)
+		}
+		if ent.IsValidationError(err) || ent.IsConstraintError(err) || ent.IsNotFound(err) {
+			log.Error("dropping unpersistable preference change",
+				zap.Uint64("user_id", id),
+				zap.Int("writes", len(writes)),
+				zap.Error(err),
+			)
+			continue
+		}
+		log.Warn("requeueing preference changes after transient flush failure",
+			zap.Uint64("user_id", id),
+			zap.Int("writes", len(writes)),
+			zap.Error(err),
+		)
+		for _, w := range writes {
+			r.batcher.Requeue(prefKey{userID: w.userID, field: w.field}, w)
+		}
+	}
+}
+
+// announcePref drops the local cached view and publishes the full new state,
+// mirroring what the old synchronous setters did after their commit — but from
+// the flush, so events only ever describe committed rows.
+func (r *Users) announcePref(ctx context.Context, log *zap.Logger, id uint64) {
+	if err := r.publishChanged(ctx, id); err != nil {
+		log.Error("failed to announce preference change",
+			zap.Uint64("user_id", id),
+			zap.Error(err),
+		)
+	}
+}

--- a/app/users/repository/preferences_test.go
+++ b/app/users/repository/preferences_test.go
@@ -1,0 +1,128 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package repository_test
+
+import (
+	"context"
+	"testing"
+
+	"ItsBagelBot/app/users/ent/user"
+	"ItsBagelBot/internal/domain/event/data"
+	"ItsBagelBot/pkg/bus/bustest"
+	"ItsBagelBot/pkg/codec"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// decodeChanged unwraps every UserChanged payload recorded on the fake bus.
+func decodeChanged(t *testing.T, pub *bustest.Publisher) []data.UserChangedDTO {
+	t.Helper()
+
+	msgs := pub.On(data.SubjectUserChanged)
+	out := make([]data.UserChangedDTO, 0, len(msgs))
+	for _, m := range msgs {
+		var dto data.UserChangedDTO
+		require.NoError(t, codec.Unmarshal(m.Payload, &dto))
+		out = append(out, dto)
+	}
+	return out
+}
+
+// Preference setters must be write-behind: accepted immediately, nothing on
+// the bus and nothing in the database until the flush window drains — that is
+// the entire point of routing them through the batcher.
+func TestPreferenceWritesAreWriteBehind(t *testing.T) {
+	client, pub, repo := setup(t)
+	ctx := context.Background()
+
+	require.NoError(t, repo.Register(ctx, 1001, "Mavey", "mavey@concordia.ca"))
+	baseline := len(decodeChanged(t, pub)) // Register's own announcement
+
+	// Flip AWAY from the schema defaults (active=true, locale=en) so a
+	// premature write is distinguishable from an untouched row.
+	require.NoError(t, repo.SetActive(ctx, 1001, false))
+	require.NoError(t, repo.SetLocale(ctx, 1001, "fr"))
+
+	assert.Len(t, decodeChanged(t, pub), baseline, "no event may precede the flush commit")
+
+	row := client.User.Query().OnlyX(ctx)
+	assert.True(t, row.IsActive, "no row write may precede the flush commit")
+	assert.Equal(t, "en", row.Locale)
+
+	// Close performs the final drain (the shutdown path).
+	repo.Close(context.Background())
+
+	row = client.User.Query().OnlyX(ctx)
+	assert.False(t, row.IsActive)
+	assert.Equal(t, "fr", row.Locale)
+
+	events := decodeChanged(t, pub)
+	require.Len(t, events, baseline+1, "the window announces exactly once")
+	last := events[len(events)-1]
+	assert.Equal(t, uint64(1001), last.UserID)
+	assert.False(t, last.IsActive)
+	assert.Equal(t, "fr", last.Locale)
+
+	// The view cache must have been dropped at flush, not served stale.
+	view, err := repo.Get(ctx, 1001)
+	require.NoError(t, err)
+	assert.False(t, view.IsActive)
+	assert.Equal(t, "fr", view.Locale)
+}
+
+// A user touching several preferences inside one window gets ONE update and
+// ONE announcement: the window merges per user at flush, and the latest
+// queued value for a repeated preference wins.
+func TestPreferenceWindowMergesPerUser(t *testing.T) {
+	_, pub, repo := setup(t)
+	ctx := context.Background()
+
+	require.NoError(t, repo.Register(ctx, 1001, "Mavey", "mavey@concordia.ca"))
+	repo.Close(context.Background()) // settle Register's synchronous announcement
+	baseline := len(decodeChanged(t, pub))
+
+	require.NoError(t, repo.SetActive(ctx, 1001, false))
+	require.NoError(t, repo.SetLocale(ctx, 1001, "de"))
+	require.NoError(t, repo.SetCustomCursor(ctx, 1001, true))
+	require.NoError(t, repo.SetOnboarded(ctx, 1001, true))
+	require.NoError(t, repo.SetCreatorCode(ctx, 1001, " bagel10 "))
+	require.NoError(t, repo.SetCreatorCode(ctx, 1001, "bagel20")) // coalesces over the first
+
+	repo.Close(context.Background())
+
+	view, err := repo.Get(ctx, 1001)
+	require.NoError(t, err)
+	assert.False(t, view.IsActive)
+	assert.Equal(t, "de", view.Locale)
+	assert.True(t, view.CustomCursor)
+	assert.True(t, view.Onboarded)
+	require.NotNil(t, view.CreatorCode)
+	assert.Equal(t, "bagel20", *view.CreatorCode, "the latest queued value must win")
+
+	events := decodeChanged(t, pub)
+	require.Len(t, events, baseline+1, "one user in one window is announced once")
+	assert.Equal(t, uint64(1001), events[len(events)-1].UserID)
+}
+
+// Money and moderation stay outside the batcher by ADR-0008: SetStatus and
+// SetBanned must land and announce synchronously, with no flush involved.
+func TestMoneyAndModerationWritesStayImmediate(t *testing.T) {
+	client, pub, repo := setup(t)
+	ctx := context.Background()
+
+	require.NoError(t, repo.Register(ctx, 1001, "Mavey", "mavey@concordia.ca"))
+
+	require.NoError(t, repo.SetStatus(ctx, 1001, user.StatusPaid))
+	require.NoError(t, repo.SetBanned(ctx, 1001, true))
+
+	row := client.User.Query().OnlyX(ctx)
+	assert.Equal(t, user.StatusPaid, row.Status)
+	assert.True(t, row.Banned, "a ban may never wait for a flush window")
+
+	events := decodeChanged(t, pub)
+	require.Len(t, events, 3) // register + status + ban
+	assert.Equal(t, string(user.StatusPaid), events[1].Status)
+	assert.True(t, events[2].Banned)
+}

--- a/app/users/repository/users.go
+++ b/app/users/repository/users.go
@@ -17,9 +17,14 @@ import (
 	domaincrypto "ItsBagelBot/internal/domain/crypto"
 	"ItsBagelBot/internal/domain/event/data"
 	"ItsBagelBot/internal/domain/validate"
+	"ItsBagelBot/pkg/batch"
 	"ItsBagelBot/pkg/bus"
 	"ItsBagelBot/pkg/cache"
 	"ItsBagelBot/pkg/db"
+
+	"github.com/newrelic/go-agent/v3/newrelic"
+
+	"go.uber.org/zap"
 )
 
 const (
@@ -51,24 +56,42 @@ type UserView struct {
 	Onboarded                 bool       `json:"onboarded"`
 }
 
-// Users persists the user records and their OAuth tokens. Status reads are
-// served from the in-process cache with stampede protection; status writes
-// are billing-relevant, so they hit the database directly and are announced
-// on the bus right after the commit.
+// Users persists the user records and their OAuth tokens. Reads are served
+// from the in-process cache with stampede protection. Writes split by the
+// ADR-0008 durability classes: preference state (active, locale, cursor,
+// onboarded, creator code) goes through the write-behind batcher — a user
+// flipping the same switch five times costs one row write, and a burst lands
+// as one transaction, so setters report "accepted", not "persisted"; errors
+// surface at flush and are requeued or dropped there. Money (status tier),
+// moderation (banned) and tokens write through immediately.
 type Users struct {
-	client *ent.Client
-	views  *cache.Cache[UserView]
-	packer domaincrypto.Packer
-	pub    bus.Publisher
+	client  *ent.Client
+	views   *cache.Cache[UserView]
+	packer  domaincrypto.Packer
+	pub     bus.Publisher
+	batcher *batch.Batcher[prefKey, prefWrite]
+	app     *newrelic.Application
+	log     *zap.Logger
 }
 
-func NewUsers(client *ent.Client, packer domaincrypto.Packer, pub bus.Publisher) *Users {
-	return &Users{
+func NewUsers(client *ent.Client, packer domaincrypto.Packer, pub bus.Publisher, app *newrelic.Application, log *zap.Logger) *Users {
+
+	if log == nil {
+		log = zap.NewNop()
+	}
+
+	r := &Users{
 		client: client,
 		views:  cache.New[UserView](userCacheCapacity, userCacheTTL),
 		packer: packer,
 		pub:    pub,
+		app:    app,
+		log:    log,
 	}
+
+	r.batcher = batch.New[prefKey, prefWrite](prefsFlushInterval, prefsFlushMaxSize, r.flushPrefs, log)
+
+	return r
 }
 
 // Register creates the user on first sight and refreshes the username on
@@ -190,7 +213,8 @@ func (r *Users) IDByUsername(ctx context.Context, username string) (uint64, erro
 
 // updateAndPublish validates the id, applies a single-field update inside the
 // write-through exec, and announces the change so the projector folds it into
-// the Valkey user projection. It backs the SetX write-through mutators.
+// the Valkey user projection. It backs only the mutators that must never sit
+// in a write-behind buffer: SetStatus (money) and SetBanned (moderation).
 func (r *Users) updateAndPublish(ctx context.Context, id uint64, apply func(*ent.UserUpdateOne)) error {
 	if err := validate.UserID(id); err != nil {
 		return err
@@ -224,19 +248,16 @@ func normalizeCreatorCode(raw string) (*string, error) {
 }
 
 // SetCreatorCode stores or clears the user's public creator code. An empty
-// value clears the nullable column.
+// value clears the nullable column. Validation runs synchronously so bad
+// input still errors at the call site; persistence is write-behind (accepted,
+// not persisted) and the change event rides the flush after the commit.
 func (r *Users) SetCreatorCode(ctx context.Context, id uint64, raw string) error {
 	code, err := normalizeCreatorCode(raw)
 	if err != nil {
 		return err
 	}
-	return r.updateAndPublish(ctx, id, func(u *ent.UserUpdateOne) {
-		if code == nil {
-			u.ClearCreatorCode()
-		} else {
-			u.SetCreatorCode(*code)
-		}
-	})
+	r.queuePref(id, prefCreatorCode, prefWrite{code: code})
+	return nil
 }
 
 // SetStatus moves the user between the free, paid and vip tiers. This is on
@@ -251,50 +272,46 @@ func (r *Users) SetStatus(ctx context.Context, id uint64, status user.Status) er
 // SetActive flips whether the bot serves this broadcaster. The dashboard
 // toggle drives it: inactive users project to standard tier and the ingress
 // drops their traffic, so flipping it off silences the channel even before
-// the EventSub subscriptions are gone.
+// the EventSub subscriptions are gone. It is user-re-submittable dashboard
+// state, so it goes through the write-behind batcher like every other
+// preference; enforcement converges within one flush window.
 func (r *Users) SetActive(ctx context.Context, id uint64, active bool) error {
-	return r.updateAndPublish(ctx, id, func(u *ent.UserUpdateOne) { u.SetIsActive(active) })
+	r.queuePref(id, prefActive, prefWrite{flag: active})
+	return nil
 }
 
 // SetLocale stores the user's console UI language and announces the change so
 // the projector folds the new locale into the Valkey user projection (the
 // worker reads it there to answer system commands in the user's language). The
 // console's own locale cache is dropped separately via the RPC handler's
-// invalidation ping.
+// invalidation ping. Write-behind, like the other preferences.
 func (r *Users) SetLocale(ctx context.Context, id uint64, locale string) error {
-	return r.updateAndPublish(ctx, id, func(u *ent.UserUpdateOne) { u.SetLocale(locale) })
+	r.queuePref(id, prefLocale, prefWrite{str: locale})
+	return nil
 }
 
 // SetCustomCursor stores whether the console shows the animated custom cursor.
-// Console-only UI state, but it rides the same write-through + publish path as
-// the other preferences so the in-process view cache stays consistent.
+// Console-only UI state riding the same write-behind path as the other
+// preferences.
 func (r *Users) SetCustomCursor(ctx context.Context, id uint64, on bool) error {
-	return r.updateAndPublish(ctx, id, func(u *ent.UserUpdateOne) { u.SetCustomCursor(on) })
+	r.queuePref(id, prefCursor, prefWrite{flag: on})
+	return nil
 }
 
 // SetBanned blocks or unblocks the user from the service. A banned user is
 // dropped at the ingress, so their traffic never reaches a worker even if the
-// channel is otherwise active.
+// channel is otherwise active. This is a moderation enforcement action with
+// low write volume, so it writes through immediately instead of risking a
+// flush window on the enforcement path.
 func (r *Users) SetBanned(ctx context.Context, id uint64, banned bool) error {
 	return r.updateAndPublish(ctx, id, func(u *ent.UserUpdateOne) { u.SetBanned(banned) })
 }
 
 // SetOnboarded marks the user as having finished the onboarding flow.
+// Write-behind: the flag is re-derivable from the console session, and losing
+// the last window on a process death costs at most a repeated onboarding tour.
 func (r *Users) SetOnboarded(ctx context.Context, id uint64, onboarded bool) error {
-	_, err := r.client.User.UpdateOneID(id).
-		SetOnboarded(onboarded).
-		Save(ctx)
-
-	if ent.IsNotFound(err) {
-		return fmt.Errorf("user not found")
-	}
-	if err != nil {
-		return err
-	}
-
-	if err := r.publishChanged(ctx, id); err != nil {
-		r.views.Invalidate(cache.UserKey(userKeyPrefix, id))
-	}
+	r.queuePref(id, prefOnboarded, prefWrite{flag: onboarded})
 	return nil
 }
 
@@ -318,8 +335,10 @@ func (r *Users) Invalidate(id uint64) {
 	r.views.Invalidate(cache.UserKey(userKeyPrefix, id))
 }
 
-// Close releases the cache's background resources.
-func (r *Users) Close() {
+// Close drains pending preference writes and releases the cache's background
+// resources.
+func (r *Users) Close(ctx context.Context) {
+	r.batcher.Close(ctx)
 	r.views.Close()
 }
 

--- a/app/users/repository/users_test.go
+++ b/app/users/repository/users_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.uber.org/zap"
+
 	"github.com/tink-crypto/tink-go/v2/aead"
 	"github.com/tink-crypto/tink-go/v2/insecurecleartextkeyset"
 	"github.com/tink-crypto/tink-go/v2/keyset"
@@ -52,8 +54,8 @@ func setup(t *testing.T) (*ent.Client, *bustest.Publisher, *repository.Users) {
 
 	pub := bustest.NewPublisher()
 
-	repo := repository.NewUsers(client, newPacker(t), pub)
-	t.Cleanup(repo.Close)
+	repo := repository.NewUsers(client, newPacker(t), pub, nil, zap.NewNop())
+	t.Cleanup(func() { repo.Close(context.Background()) })
 
 	return client, pub, repo
 }
@@ -173,7 +175,11 @@ func TestSetCreatorCodeStoresTrimsClearsAndPublishes(t *testing.T) {
 
 	require.NoError(t, repo.Register(ctx, 1001, "Mavey", "mavey@concordia.ca"))
 
+	// Creator code is write-behind preference state: validation is
+	// synchronous, but persistence and the announcement land at flush.
 	require.NoError(t, repo.SetCreatorCode(ctx, 1001, "  MAVEY10  "))
+	repo.Close(context.Background())
+
 	view, err := repo.Get(ctx, 1001)
 	require.NoError(t, err)
 	require.NotNil(t, view.CreatorCode)
@@ -182,6 +188,8 @@ func TestSetCreatorCodeStoresTrimsClearsAndPublishes(t *testing.T) {
 	assert.Equal(t, "MAVEY10", *client.User.GetX(ctx, 1001).CreatorCode)
 
 	require.NoError(t, repo.SetCreatorCode(ctx, 1001, ""))
+	repo.Close(context.Background())
+
 	view, err = repo.Get(ctx, 1001)
 	require.NoError(t, err)
 	assert.Nil(t, view.CreatorCode)

--- a/app/users/rpc/admin_test.go
+++ b/app/users/rpc/admin_test.go
@@ -29,8 +29,8 @@ func setupAdminRPCTest(t *testing.T) (*adminRPC, *ent.Client) {
 
 	// packer and pub are nil because the list/search tests do not exercise
 	// write or token paths that would call them.
-	repo := repository.NewUsers(client, nil, nil)
-	t.Cleanup(repo.Close)
+	repo := repository.NewUsers(client, nil, nil, nil, zap.NewNop())
+	t.Cleanup(func() { repo.Close(context.Background()) })
 
 	return &adminRPC{repo: repo, log: zap.NewNop()}, client
 }

--- a/docs/src/content/docs/adr/0008-caching-and-write-behind-strategy.md
+++ b/docs/src/content/docs/adr/0008-caching-and-write-behind-strategy.md
@@ -53,9 +53,14 @@ so a stale flight cannot repopulate the cache after the fact.
 **Write-behind batching for settings (`pkg/batch`).** Module and command writes go through a coalescing batcher:
 writes to the same key within a flush window (2 seconds, or 256 pending keys, whichever comes first) collapse into
 the latest value, and the whole window lands in a single database transaction. A failed flush is retried on the next
-window without clobbering newer writes. Five clicks on the same toggle cost one row write. The trade-off is stated
-on the type itself: a value sits in memory for at most the flush interval before it is persisted, so only state that
-a user can re-submit goes through it. Transactions, tier changes, and tokens write through immediately.
+window without clobbering newer writes, and every flush runs under a hard deadline so a database that accepts
+connections but never answers cannot pin the batcher's goroutine while writes keep accumulating. Five clicks on the
+same toggle cost one row write. The users service routes the same class of re-submittable preference state through
+it (active toggle, locale, custom cursor, onboarded, creator code), merging all of one user's pending fields into a
+single row update and announcing each changed user once per window. The trade-off is stated on the type itself: a
+value sits in memory for at most the flush interval before it is persisted, so only state that a user can re-submit
+goes through it. Transactions, tier changes, bans, and tokens write through immediately; tier changes because money,
+bans because they are moderation enforcement actions whose effect must not wait on a flush window.
 
 **Event-carried invalidation over the native NATS bus (`pkg/bus`).** Events publish only after the database commit and carry
 the full new state, so consumers update themselves from the event alone and never read another service's schema.

--- a/pkg/batch/batcher.go
+++ b/pkg/batch/batcher.go
@@ -6,6 +6,7 @@ package batch
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"go.uber.org/zap"
@@ -13,6 +14,26 @@ import (
 
 // Flush persists one batch, typically as a single bulk upsert.
 type Flush[V any] func(ctx context.Context, items []V) error
+
+// defaultFlushTimeout bounds one flush callback. Every flush runs on the
+// batcher's single goroutine, and pending memory is bounded only by distinct-key
+// cardinality, so a database that accepts the connection but never answers would
+// otherwise pin that goroutine forever while Add keeps accumulating windows it
+// will never drain. 5s covers every flush statement in the fleet with headroom;
+// a slower flush means the database is already failing, and failing fast loses
+// at most one window while keeping later ones flowing.
+const defaultFlushTimeout = 5 * time.Second
+
+// Stats is a point-in-time snapshot of the batcher's write-behind behaviour,
+// for gauges and alerting: Pending depth signals staleness risk, Failures in a
+// row signal a database refusing writes while callers see success.
+type Stats struct {
+	Pending      int64
+	Flushes      uint64
+	Failures     uint64
+	ItemsFlushed uint64
+	LastDuration time.Duration
+}
 
 // Batcher coalesces writes so the database sees one bulk statement per window
 // instead of one round-trip per modification. Writes to the same key within a
@@ -22,6 +43,10 @@ type Flush[V any] func(ctx context.Context, items []V) error
 // Durability trade-off: a value sits in memory for at most the flush interval
 // before it is persisted, so this is only for state that can be re-submitted
 // (configs, toggles, command edits). Money and tokens must not go through it.
+//
+// Memory ceiling: pending is bounded by the number of DISTINCT keys written
+// within a flush window (maxSize forces a drain at that count), never by write
+// rate -- a burst of writes to the same key replaces in place.
 type Batcher[K comparable, V any] struct {
 	mu      sync.Mutex
 	pending map[K]V
@@ -29,12 +54,23 @@ type Batcher[K comparable, V any] struct {
 	flush    Flush[V]
 	interval time.Duration
 	maxSize  int
+	deadline time.Duration
 
 	kick chan struct{}
 	stop chan struct{}
 	done chan struct{}
 
+	// guards stop: Close must tolerate being called twice (owner + cleanup).
+	closeOnce sync.Once
+
 	log *zap.Logger
+
+	// Telemetry, all monotonic except the gauge. Read through Stats.
+	pendingGauge atomic.Int64
+	flushes      atomic.Uint64
+	failures     atomic.Uint64
+	itemsFlushed atomic.Uint64
+	lastNanos    atomic.Int64
 }
 
 // New starts a batcher that flushes whenever maxSize keys are pending or
@@ -46,6 +82,7 @@ func New[K comparable, V any](interval time.Duration, maxSize int, flush Flush[V
 		flush:    flush,
 		interval: interval,
 		maxSize:  maxSize,
+		deadline: defaultFlushTimeout,
 		kick:     make(chan struct{}, 1),
 		stop:     make(chan struct{}),
 		done:     make(chan struct{}),
@@ -63,6 +100,7 @@ func (b *Batcher[K, V]) Add(key K, value V) {
 	b.mu.Lock()
 	b.pending[key] = value
 	full := len(b.pending) >= b.maxSize
+	b.pendingGauge.Store(int64(len(b.pending)))
 	b.mu.Unlock()
 
 	if full {
@@ -86,10 +124,11 @@ func (b *Batcher[K, V]) Requeue(key K, value V) {
 	b.mu.Unlock()
 }
 
-// Close flushes whatever is pending and stops the background loop.
+// Close flushes whatever is pending and stops the background loop. Idempotent:
+// an owner and a deferred cleanup may both call it without sequencing care.
 func (b *Batcher[K, V]) Close(ctx context.Context) {
 
-	close(b.stop)
+	b.closeOnce.Do(func() { close(b.stop) })
 	<-b.done
 
 	b.flushPending(ctx)
@@ -125,6 +164,7 @@ func (b *Batcher[K, V]) flushPending(ctx context.Context) {
 
 	taken := b.pending
 	b.pending = make(map[K]V, b.maxSize)
+	b.pendingGauge.Store(0)
 
 	b.mu.Unlock()
 
@@ -133,10 +173,27 @@ func (b *Batcher[K, V]) flushPending(ctx context.Context) {
 		items = append(items, v)
 	}
 
-	if err := b.flush(ctx, items); err != nil {
+	// The deadline is applied here, around whatever context the caller handed
+	// in, so Close's final drain is bounded by the same ceiling as the run
+	// loop: caller cancellation still propagates through the parent.
+	fctx, cancel := context.WithTimeout(ctx, b.deadline)
+	defer cancel()
+
+	start := time.Now()
+	err := b.flush(fctx, items)
+	elapsed := time.Since(start)
+
+	b.flushes.Add(1)
+	b.itemsFlushed.Add(uint64(len(items)))
+	b.lastNanos.Store(int64(elapsed))
+
+	if err != nil {
+
+		b.failures.Add(1)
 
 		b.log.Error("batch flush failed, retrying next window",
 			zap.Int("items", len(items)),
+			zap.Duration("elapsed", elapsed),
 			zap.Error(err),
 		)
 
@@ -147,6 +204,31 @@ func (b *Batcher[K, V]) flushPending(ctx context.Context) {
 				b.pending[k] = v
 			}
 		}
+		b.pendingGauge.Store(int64(len(b.pending)))
 		b.mu.Unlock()
+		return
+	}
+
+	// A window that takes longer than the interval means the flusher can no
+	// longer keep up with the write rate: windows queue behind it and the
+	// staleness guarantee (interval, not interval x windows) silently breaks.
+	if elapsed > b.interval {
+		b.log.Warn("batch flush exceeded its window",
+			zap.Int("items", len(items)),
+			zap.Duration("elapsed", elapsed),
+			zap.Duration("interval", b.interval),
+		)
+	}
+}
+
+// Stats returns a snapshot of the batcher's behaviour for dashboards and
+// alerting. Counters are monotonic for the life of the batcher.
+func (b *Batcher[K, V]) Stats() Stats {
+	return Stats{
+		Pending:      b.pendingGauge.Load(),
+		Flushes:      b.flushes.Load(),
+		Failures:     b.failures.Load(),
+		ItemsFlushed: b.itemsFlushed.Load(),
+		LastDuration: time.Duration(b.lastNanos.Load()),
 	}
 }

--- a/pkg/batch/batcher_test.go
+++ b/pkg/batch/batcher_test.go
@@ -165,3 +165,92 @@ func TestRequeueDoesNotClobberNewerWrite(t *testing.T) {
 
 	b.Close(context.Background())
 }
+
+// The flush deadline exists so a database that accepts connections but never
+// answers cannot pin the batcher's single goroutine forever while Add keeps
+// accumulating windows it will never drain. The callback must observe a
+// context that actually expires.
+func TestFlushDeadlineBoundsSlowFlush(t *testing.T) {
+	seen := make(chan error, 1)
+
+	// maxSize 1 makes the very first Add kick a flush; the interval ticker
+	// stays out of the way at an hour.
+	b := New[string, int](time.Hour, 1, func(ctx context.Context, _ []int) error {
+		<-ctx.Done()
+		seen <- ctx.Err()
+		return nil
+	}, zap.NewNop())
+	b.deadline = 20 * time.Millisecond
+
+	b.Add("key", 1)
+
+	select {
+	case err := <-seen:
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+	case <-time.After(5 * time.Second):
+		t.Fatal("flush was never bounded by the deadline")
+	}
+
+	b.Close(context.Background())
+}
+
+// Stats must report what alerting needs: pending depth (staleness risk),
+// flush/failure counters, and the last window's duration.
+func TestStatsTrackWindows(t *testing.T) {
+	rec := &recorder{fail: true}
+
+	b := New[string, int](20*time.Millisecond, 4, rec.flush, zap.NewNop())
+
+	b.Add("a", 1)
+	b.Add("b", 2)
+
+	assert.Eventually(t, func() bool {
+		return b.Stats().Failures >= 1
+	}, time.Second, 5*time.Millisecond, "the failed window must count")
+
+	rec.mu.Lock()
+	rec.fail = false
+	rec.mu.Unlock()
+
+	b.Close(context.Background())
+
+	stats := b.Stats()
+	assert.Zero(t, stats.Pending, "Close must drain pending")
+	// ItemsFlushed counts every window handed to the flush callback, including
+	// the failed one that was requeued and retried at Close: 2 + 2.
+	assert.GreaterOrEqual(t, stats.ItemsFlushed, uint64(2))
+	assert.GreaterOrEqual(t, stats.Flushes, uint64(2))
+	assert.Equal(t, uint64(1), stats.Failures)
+	assert.NotZero(t, stats.LastDuration)
+}
+
+// Concurrent writers to the same key are the production shape (dashboard RPCs
+// landing in parallel): every write must survive coalescing as SOME complete
+// value, and the window must drain exactly once per key. Run under -race.
+func TestConcurrentAddsCoalesce(t *testing.T) {
+	rec := &recorder{}
+
+	b := New[int, int](10*time.Millisecond, 1024, rec.flush, zap.NewNop())
+
+	var wg sync.WaitGroup
+	for w := 0; w < 8; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < 200; i++ {
+				b.Add(1, w*1000+i)
+			}
+		}(w)
+	}
+	wg.Wait()
+
+	b.Close(context.Background())
+
+	flushes := rec.all()
+	require.NotEmpty(t, flushes, "pending writes must have been flushed")
+	assert.LessOrEqual(t, len(flushes), 2, "1600 writes to one key may not become a flush per write")
+
+	for _, v := range flushes {
+		assert.GreaterOrEqual(t, v, 0)
+	}
+}


### PR DESCRIPTION
## Summary
- Routes the users service's re-submittable preference state (active toggle, locale, custom cursor, onboarded, creator code) through the existing `pkg/batch` write-behind batcher, closing the last unbatched settings surface identified against ADR-0008.
- A user flipping several preferences in one window gets **one** row UPDATE in **one** transaction and exactly one `UserChanged` announcement, published only after the commit.
- `SetStatus` (money) and `SetBanned` (moderation enforcement) deliberately stay write-through, per the ADR's durability classes; rationale documented on each method.

## Batcher hardening (`pkg/batch`)
- Every flush runs under a hard deadline (5s): a database that accepts connections but never answers can no longer pin the single flush goroutine while writes accumulate unbounded by rate (only by distinct-key cardinality).
- `Close` is now idempotent — owner + deferred cleanup no longer panic on double-close.
- New `Stats()` (pending gauge, flush/failure/item counters, last window duration) plus a slow-flush warning when a window outlives its interval, for gauges and alerting.

## Semantics change (intentional)
Preference setters now report *accepted*, not *persisted* — same contract as `Modules.Set` since the ADR. Validation stays synchronous at the call site; persistence errors surface at flush (requeued or dropped with logs).

## Test plan
- `pkg/batch`: deadline cancels a stuck flush; stats track failed→retried windows; 8-goroutine burst on one key collapses to ≤2 flushes (race detector clean).
- users repo: nothing hits DB/bus before flush; per-user merge + latest-wins across a window; money/ban paths verified still immediate; creator-code trim/clear round-trip through the drain.
- `go test -race ./pkg/batch/... ./app/users/...` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * User preference updates are now batched and coalesced, preserving the latest values.
  * Preference changes publish a single update after successful persistence.
  * Added batching statistics for pending items, flushes, failures, and processing duration.
  * Status and moderation updates continue to be saved immediately.

* **Bug Fixes**
  * Repository shutdown now completes within a defined time limit.
  * Failed preference writes retry appropriately, while invalid or non-existent updates are safely discarded.

* **Documentation**
  * Updated guidance on write-behind behavior, durability, batching, and immediate updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->