### PR TITLE
feat(gossip): batch and coalesce Urchin blacklist lookups across channels

### DIFF
--- a/app/gossip/internal/core/cache.go
+++ b/app/gossip/internal/core/cache.go
@@ -312,6 +312,47 @@ func (f envelopeFlight[T]) refresh() {
 	}()
 }
 
+// StoreRequest bundles one ready-made answer for StoreCached. The store call
+// needs six facts and threading them positionally is exactly the unreadable
+// signature envelopeFlight's own bundling exists to avoid, so the batch paths
+// that hydrate many keys at once build one of these per key instead.
+type StoreRequest[T any] struct {
+	// Key is the canonical cache key the entry is written under.
+	Key string
+	// TTL is the fresh window; the entry is physically retained for twice it,
+	// the same fresh-plus-stale-tail split Cached stores.
+	TTL time.Duration
+	// NegativeTTL pins a friendly failure (a typed *UpstreamError carrying a
+	// 400 or 404) for.
+	NegativeTTL time.Duration
+	// Value is the success payload. Ignored when Err carries a failure.
+	Value T
+	// Err is the fetch outcome this entry stands for: nil stores Value, a
+	// friendly 400/404 stores the negative, anything else stores nothing —
+	// an infrastructure failure teaches nothing about the key, so it must not
+	// be remembered.
+	Err error
+}
+
+// StoreCached writes one entry in exactly the format Cached reads — value
+// envelope for 2*ttl (fresh window ttl + stale tail), typed negative for
+// negativeTTL, nothing at all for a non-friendly failure — WITHOUT running a
+// fetch. It is the hydration half of batch lookups: one upstream answer covers
+// many players, and each of them must land in the shared cache individually so
+// the next single-player query hits instead of refetching. A key that already
+// holds an entry is overwritten; every writer of these keys derives its value
+// from the same upstream, so last-write-wins cannot move data backwards.
+func StoreCached[T any](ctx context.Context, c *Cache, req StoreRequest[T]) {
+	f := envelopeFlight[T]{cache: c, key: req.Key, ttl: req.TTL, negativeTTL: req.NegativeTTL}
+	env, storeTTL, err := f.envelopeFor(req.Value, req.Err)
+	if err != nil {
+		return // infrastructure failure: nothing learnable, leave uncached to retry
+	}
+	if b, merr := codec.Marshal(env); merr == nil {
+		_ = c.store.Set(ctx, req.Key, b, storeTTL)
+	}
+}
+
 // GetJSON reads a raw (non-fetching) entry, for provider-owned state like the
 // mcsr stream-start snapshot.
 func (c *Cache) GetJSON(ctx context.Context, key string, out any) (bool, error) {
@@ -332,4 +373,11 @@ func (c *Cache) SetJSON(ctx context.Context, key string, v any, ttl time.Duratio
 		return err
 	}
 	return c.store.Set(ctx, key, b, ttl)
+}
+
+// DelJSON drops a raw entry — the write half of the GetJSON/SetJSON pair, for
+// provider-owned state that must not outlive its session (the stream-start
+// snapshots stream.offline clears).
+func (c *Cache) DelJSON(ctx context.Context, key string) error {
+	return c.store.Del(ctx, key)
 }

--- a/app/gossip/internal/core/cache_test.go
+++ b/app/gossip/internal/core/cache_test.go
@@ -457,3 +457,55 @@ func TestCachedLegacyEntryWithoutStampRefreshes(t *testing.T) {
 	}, time.Second, 10*time.Millisecond)
 	assert.Equal(t, int32(1), fetches.Load())
 }
+
+// StoreCached must produce entries Cached serves as hits: a hydrated value
+// answers the next lookup with zero fetch work.
+func TestStoreCachedValueIsServedAsHit(t *testing.T) {
+	c := NewCache(newMemStore())
+	StoreCached(context.Background(), c, StoreRequest[payload]{
+		Key: "k", TTL: time.Minute, NegativeTTL: time.Minute,
+		Value: payload{Name: "hydrated", N: 7},
+	})
+
+	v, err := Cached(context.Background(), c, "k", time.Minute, time.Minute, nil, func(context.Context) (payload, error) {
+		t.Error("a hydrated entry must be served without a fetch")
+		return payload{}, nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, payload{Name: "hydrated", N: 7}, v)
+}
+
+// A hydrated negative behaves exactly like a fetched one.
+func TestStoreCachedNegativeIsServedAsHit(t *testing.T) {
+	c := NewCache(newMemStore())
+	notFound := &UpstreamError{Status: 404, Message: "player not found"}
+	StoreCached(context.Background(), c, StoreRequest[payload]{
+		Key: "k", TTL: time.Minute, NegativeTTL: time.Minute,
+		Err: notFound,
+	})
+
+	_, err := Cached(context.Background(), c, "k", time.Minute, time.Minute, nil, func(context.Context) (payload, error) {
+		t.Error("a hydrated negative must be served without a fetch")
+		return payload{}, nil
+	})
+	assert.Equal(t, notFound, err)
+}
+
+// An infrastructure failure teaches nothing about the key, so nothing may be
+// stored for it — the next lookup must reach the fetch.
+func TestStoreCachedInfraFailureStoresNothing(t *testing.T) {
+	c := NewCache(newMemStore())
+	StoreCached(context.Background(), c, StoreRequest[payload]{
+		Key: "k", TTL: time.Minute, NegativeTTL: time.Minute,
+		Err: errors.New("upstream exploded"),
+	})
+
+	var fetches atomic.Int32
+	v, err := Cached(context.Background(), c, "k", time.Minute, time.Minute, nil, func(context.Context) (payload, error) {
+		fetches.Add(1)
+		return payload{Name: "fetched"}, nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, payload{Name: "fetched"}, v)
+	assert.Equal(t, int32(1), fetches.Load(), "an infra failure must leave the key uncached")
+}

--- a/app/gossip/internal/providers/urchin/batch.go
+++ b/app/gossip/internal/providers/urchin/batch.go
@@ -1,0 +1,324 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package urchin
+
+import (
+	"context"
+	"encoding/hex"
+	"net/http"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	"ItsBagelBot/app/gossip/internal/core"
+	"ItsBagelBot/pkg/codec"
+)
+
+// Cross-channel micro-batching for Coral blacklist lookups (issue #616).
+//
+// The per-key singleflight inside core.Cache collapses concurrent misses for
+// ONE player, but N distinct players queried across channels in the same
+// moment still cost N separate GET /v3/player/tags calls — and Coral's
+// measured edge wall (~40 rapid requests, ~4/s refill; see maxBurst) is
+// tripped by exactly that shape long before the 600/5min key quota runs out.
+// This batcher collects UUID-shaped playertags misses over one short window
+// and resolves all of them with a single POST /v3/players, then hydrates each
+// player's entry back into the shared playertags cache so the tags command,
+// the sniper uuid hop and every later single-player query read it as a hit.
+//
+// Why UUID-shaped accounts only: the batch endpoint accepts nothing else.
+// Its contract (api.urchin.gg OpenAPI, batch_lookup) takes a bare uuid array;
+// usernames are not resolved and malformed entries are silently skipped. A
+// username still needs Coral's own Mojang resolution, which today only the
+// individual GET performs, so username lookups keep the old one-request-per-
+// player path unchanged. Minecraft usernames cap at 16 characters, so a
+// 32-hex-digit identifier is unambiguously a UUID — there is no shape on which
+// this routing could flip between calls.
+const (
+	// batchWindowDefault is how long the first miss of a wave waits for
+	// company before its batch fires. The issue sketched 50–100ms; that was
+	// written before it met this fleet's latency shape — sesame's hot path
+	// answers at a 64µs p99, so even a cold upstream fetch must not inherit
+	// tens of milliseconds of queueing on its account. 2ms is the compromise
+	// measured against how co-tenancy actually arrives here: same-burst
+	// lookups fanned out by the bus land on one pod within microseconds-to-
+	// low-single-digit-ms of each other, so 2ms still merges a burst into one
+	// POST, while chat-driven queries seconds apart were never going to share
+	// a window at any size — those are served by the cache layers, not the
+	// batcher. Anything the wider window would have caught, the per-key
+	// singleflight underneath already collapses instead.
+	batchWindowDefault = 2 * time.Millisecond
+	// batchLimit is Coral's own ceiling on one batch_lookup call. A window
+	// collecting more fires sequential POSTs of at most this many UUIDs.
+	batchLimit = 100
+)
+
+// batchRequest / batchResponse mirror Coral's BatchRequest/BatchResponse.
+// Tag objects carry more members than gossip reads (expires_at, added_by, ...)
+// ; like tagsResponse, only the subset the replies need is decoded. AddedOn is
+// unix milliseconds, matching the individual tags endpoint's field of the same
+// name.
+type batchRequest struct {
+	UUIDs []string `json:"uuids"`
+}
+
+type batchTag struct {
+	TagType string `json:"tag_type"`
+	Reason  string `json:"reason"`
+	AddedOn int64  `json:"added_on"`
+}
+
+type batchResponse struct {
+	Players map[string][]batchTag `json:"players"`
+}
+
+// batchOutcome is what one waiter receives: either the player's tags-shaped
+// record or the failure standing in for it. It reuses tagsResponse rather than
+// a batch-native shape so everything downstream of playerTags (the tags reply
+// shaper, sniper's uuid resolution) stays agnostic to how the answer arrived.
+// DisplayName is nil on this path — the batch endpoint returns no display
+// names — so those replies fall back to the identifier as typed.
+type batchOutcome struct {
+	resp tagsResponse
+	err  error
+}
+
+// batchSlot holds every waiter that joined on one uuid within the window. The
+// channels are per-waiter on purpose: a slot owns ONE outcome but MANY waiters,
+// and a single shared channel would hand that outcome to whichever waiter woke
+// first and hang the rest until their handler timeouts.
+type batchSlot struct {
+	waiters []chan batchOutcome
+}
+
+// tagsBatcher coalesces uuid-keyed playertags misses into batch_lookup calls.
+// It is pod-local by design: coordination beyond one process would need a
+// shared queue for the marginal players a second replica sees in the same
+// window, while the Valkey-backed cache already de-duplicates the far larger
+// repeat traffic across replicas.
+type tagsBatcher struct {
+	p *api
+	// window is the collection period; the FIRST caller of a wave pays it in
+	// full, everyone joining behind it rides along free.
+	window time.Duration
+	// notify wakes the flush loop; capacity 1 makes it a level trigger — a
+	// burst of arrivals costs one wakeup, and an arrival during a flush folds
+	// into the next window instead of being lost.
+	notify chan struct{}
+
+	mu     sync.Mutex
+	slots  map[string]*batchSlot
+	starts sync.Once
+}
+
+func newTagsBatcher(p *api, window time.Duration) *tagsBatcher {
+	return &tagsBatcher{
+		p:      p,
+		window: window,
+		notify: make(chan struct{}, 1),
+		slots:  make(map[string]*batchSlot),
+	}
+}
+
+// canonicalUUID reports whether acct is a bare player UUID (dashes optional,
+// any case) and returns its canonical form: lowercase, undashed — the exact
+// spelling Coral's batch request and response keys use. Normalizing here means
+// dashed/undashed/mixed-case spellings of one player collapse onto one cache
+// entry AND one batch line instead of three.
+func canonicalUUID(a account) (string, bool) {
+	s := strings.ReplaceAll(strings.ToLower(strings.TrimSpace(string(a))), "-", "")
+	if len(s) != 32 {
+		return "", false
+	}
+	if _, err := hex.DecodeString(s); err != nil {
+		return "", false
+	}
+	return s, true
+}
+
+// await registers ctx's caller under uuid and blocks until the batch carrying
+// it lands. Duplicate registrations within one window append to the same slot
+// and are answered by the same upstream call. A caller whose context dies
+// mid-window simply stops listening; its channel is buffered, so the eventual
+// delivery never blocks the flush and gets collected by the garbage collector.
+func (b *tagsBatcher) await(ctx context.Context, uuid string) (tagsResponse, error) {
+	b.starts.Do(func() { go b.run() })
+
+	ch := make(chan batchOutcome, 1)
+	b.mu.Lock()
+	slot, ok := b.slots[uuid]
+	if !ok {
+		slot = &batchSlot{}
+		b.slots[uuid] = slot
+	}
+	slot.waiters = append(slot.waiters, ch)
+	b.mu.Unlock()
+	if !ok {
+		select {
+		case b.notify <- struct{}{}:
+		default:
+		}
+	}
+
+	select {
+	case <-ctx.Done():
+		// The handler timeout or a bus cancellation caught up with us. The
+		// slot may already have been swapped out for flushing; either way the
+		// buffered delivery below is fire-and-forget.
+		return tagsResponse{}, ctx.Err()
+	case out := <-ch:
+		return out.resp, out.err
+	}
+}
+
+// run is the flush loop: sleep one window after each wake, then post whatever
+// gathered. The loop lives for the process — gossip providers have no shutdown
+// path — and idles as a blocked receive when no uuid-shaped lookups arrive.
+func (b *tagsBatcher) run() {
+	for range b.notify {
+		time.Sleep(b.window)
+		b.flush()
+	}
+}
+
+// flush swaps out the pending slots and drains them in batchLimit-sized
+// chunks. UUIDs are sorted so a given set of callers always produces the same
+// request body: deterministic bodies make the upstream-side caching Coral may
+// do behind batch_lookup maximally effective, and the wire format testable.
+func (b *tagsBatcher) flush() {
+	b.mu.Lock()
+	pending := b.slots
+	b.slots = make(map[string]*batchSlot)
+	b.mu.Unlock()
+
+	uuids := make([]string, 0, len(pending))
+	for u := range pending {
+		uuids = append(uuids, u)
+	}
+	slices.Sort(uuids)
+
+	for len(uuids) > 0 {
+		chunk := uuids[:min(len(uuids), batchLimit)]
+		uuids = uuids[len(chunk):]
+		b.post(chunk, pending)
+	}
+}
+
+// post resolves one chunk: one POST /v3/players, one parse, then demux to
+// every waiter plus hydration of each player's individual cache entry.
+//
+// Budget: the POST deliberately spends NO token of its own. Every route into
+// await is preceded on this same pod by an endpoint-level admission — the
+// flow's Budget check for a cold lookup, sniperBudget's doubled spend for the
+// uuid hop, or the SWR refresh's admit before its rebuild — so fleet-wide,
+// batched upstream calls can never outnumber tokens spent, and batching only
+// shrinks real load under the existing metering. Charging once more per POST
+// was considered and rejected: it double-bills busy windows, and skipping the
+// per-caller charge instead (the literal "one token per batch" reading) would
+// move the premium-reserve decision out of the per-caller admission the flow
+// doctrine requires it live in.
+func (b *tagsBatcher) post(uuids []string, pending map[string]*batchSlot) {
+	// Background context, not a waiter's: waiters may give up (handler
+	// timeout, channel close) but the call must finish regardless, because its
+	// answer hydrates entries for players nobody is still waiting on.
+	ctx, cancel := context.WithTimeout(context.Background(), httpTimeout)
+	defer cancel()
+
+	lookup, callErr := b.fetchBatch(ctx, uuids)
+	for _, u := range uuids {
+		deliver(pending[u], outcomeFor(u, lookup, callErr))
+	}
+	b.hydrate(ctx, uuids, lookup, callErr)
+}
+
+// fetchBatch performs the chunk's one POST /v3/players and returns the parsed
+// response keyed by canonical uuid. On a failed call the lookup is nil and the
+// error travels separately — a whole-request failure says nothing about any
+// individual player (a 404 here would mean we malformed the request, not that
+// these players don't exist), so it must never be mistaken for per-player truth.
+func (b *tagsBatcher) fetchBatch(ctx context.Context, uuids []string) (map[string][]batchTag, error) {
+	var resp batchResponse
+	body, err := codec.Marshal(batchRequest{UUIDs: uuids})
+	if err == nil {
+		err = b.p.http.Do(ctx, core.Request{
+			Method: http.MethodPost,
+			Path:   "/v3/players",
+			Body:   body,
+		}, &resp)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	lookup := make(map[string][]batchTag, len(resp.Players))
+	for k, v := range resp.Players {
+		if c, ok := canonicalUUID(account(k)); ok {
+			k = c // defensive: a dashed or uppercase echo would strand its player as "missing"
+		}
+		lookup[k] = v
+	}
+	return lookup, nil
+}
+
+// outcomeFor shapes one player's answer out of the batch result. Absent from a
+// successful response = no Coral record for this uuid (present-but-tagless
+// players DO appear, with an empty array); it becomes the same 404 the
+// individual GET produces for an unknown player.
+func outcomeFor(uuid string, lookup map[string][]batchTag, callErr error) batchOutcome {
+	if callErr != nil {
+		return batchOutcome{err: callErr}
+	}
+	tags, found := lookup[uuid]
+	if !found {
+		return batchOutcome{err: notFoundErr}
+	}
+	return batchOutcome{resp: tagsResponse{UUID: uuid, Tags: toTagsResponse(tags)}}
+}
+
+// hydrate writes each player's individual playertags entry through StoreCached.
+// A failed CALL hydrates nothing: only a successful response carries per-player
+// truth worth remembering, so on failure every key stays uncached and the next
+// window retries it.
+func (b *tagsBatcher) hydrate(ctx context.Context, uuids []string, lookup map[string][]batchTag, callErr error) {
+	for _, u := range uuids {
+		out := outcomeFor(u, lookup, callErr)
+		core.StoreCached(ctx, b.p.cache, core.StoreRequest[tagsResponse]{
+			Key:         core.Key(providerName, "playertags", u),
+			TTL:         tagsTTL,
+			NegativeTTL: negativeTTL,
+			Value:       out.resp,
+			Err:         out.err,
+		})
+	}
+}
+
+// notFoundErr is the shared "player has no Coral record" negative.
+var notFoundErr = &core.UpstreamError{Status: 404, Message: "player not found"}
+
+// deliver fans one outcome out to a slot's waiters. Channels are buffered and
+// sends non-blocking: every waiter gets exactly its own copy, a departed
+// waiter's slot fills and is dropped, and the flush never waits on anyone.
+func deliver(s *batchSlot, out batchOutcome) {
+	if s == nil {
+		return
+	}
+	for _, ch := range s.waiters {
+		select {
+		case ch <- out:
+		default:
+		}
+	}
+}
+
+// toTagsResponse converts batch tag records into the shape the rest of the
+// provider reads. AddedOn stays in milliseconds: tagsFetch divides by 1000
+// when shaping the reply, and the batch path must land in that same unit.
+func toTagsResponse(tags []batchTag) []playerTag {
+	out := make([]playerTag, len(tags))
+	for i, t := range tags {
+		out[i] = playerTag{TagType: t.TagType, Reason: t.Reason, AddedOn: t.AddedOn}
+	}
+	return out
+}

--- a/app/gossip/internal/providers/urchin/batch_test.go
+++ b/app/gossip/internal/providers/urchin/batch_test.go
@@ -1,0 +1,368 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package urchin
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	"ItsBagelBot/app/gossip/internal/core"
+	"ItsBagelBot/app/gossip/internal/provider"
+	gossiprpc "ItsBagelBot/internal/domain/rpc/gossip"
+	"ItsBagelBot/pkg/codec"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// batchWindow is WIDER than the production 2ms default on purpose: a test
+// wave of goroutines takes scheduler jitter to spawn, and the point is to
+// exercise the real window/sleep/flush machinery deterministically, not the
+// window's exact size.
+const batchWindow = 15 * time.Millisecond
+
+func newBatchProvider(t *testing.T, handler http.Handler) provider.Provider {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return New(Config{BaseURL: srv.URL, APIKey: "test-key", BatchWindow: batchWindow},
+		provider.Deps{Cache: core.NewCache(newMemStore()), Log: zap.NewNop()})
+}
+
+// batchRecorder captures POST /v3/players bodies and answers them from a map,
+// so several tests share one upstream stub.
+type batchRecorder struct {
+	mu      sync.Mutex
+	batches [][]string // canonical uuids per POST, arrival order
+	players map[string][]batchTag
+}
+
+func (r *batchRecorder) handle(w http.ResponseWriter, req *http.Request) bool {
+	if req.Method != http.MethodPost || req.URL.Path != "/v3/players" {
+		return false
+	}
+	var br batchRequest
+	_ = codec.Unmarshal(readAllBody(req), &br)
+	r.mu.Lock()
+	r.batches = append(r.batches, br.UUIDs)
+	players := make(map[string][]batchTag, len(r.players))
+	for k, v := range r.players {
+		players[k] = v
+	}
+	r.mu.Unlock()
+	payload, _ := codec.Marshal(batchResponse{Players: players})
+	_, _ = w.Write(payload)
+	return true
+}
+
+// readAllBody drains a request body through the codec-only JSON discipline the
+// repo's guard test enforces.
+func readAllBody(req *http.Request) []byte {
+	b, _ := io.ReadAll(req.Body)
+	_ = req.Body.Close()
+	return b
+}
+
+func (r *batchRecorder) all() [][]string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return slices.Clone(r.batches)
+}
+
+func (r *batchRecorder) count() int { return len(r.all()) }
+
+// flattenBodies merges every recorded batch into one uuid set.
+func flattenBatches(batches [][]string) []string {
+	var out []string
+	for _, b := range batches {
+		out = append(out, b...)
+	}
+	return out
+}
+
+const (
+	uuidA = "069a79f444e94726a5befca90e38aaf5"
+	uuidB = "b71e0c9d1f2d4c8eab12cd34ef56ab78"
+)
+
+func TestCanonicalUUID(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want string
+		ok   bool
+	}{
+		{uuidA, uuidA, true},
+		{"069A79F4-44E9-4726-A5BE-FCA90E38AAF5", uuidA, true}, // dashed uppercase
+		{"069a79f4-44e9-4726-a5be-fca90e38aaf5", uuidA, true}, // dashed lowercase
+		{"Techno", "", false},
+		{"069a79f444e94726a5befca90e38aaf", "", false},  // 31 chars
+		{"zzza79f444e94726a5befca90e38aaf5", "", false}, // not hex
+	} {
+		got, ok := canonicalUUID(account(tc.in))
+		assert.Equal(t, tc.ok, ok, tc.in)
+		assert.Equal(t, tc.want, got, tc.in)
+	}
+}
+
+// Two players queried by different channels inside one window must ride ONE
+// POST /v3/players carrying both canonical uuids, whatever spelling each
+// channel used.
+func TestBatchAggregatesDistinctPlayers(t *testing.T) {
+	rec := &batchRecorder{players: map[string][]batchTag{
+		uuidA: {{TagType: "blatant_cheater", Reason: "Fly / Killaura", AddedOn: 1700000000000}},
+		uuidB: {},
+	}}
+	p := newBatchProvider(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if rec.handle(w, r) {
+			return
+		}
+		t.Errorf("unexpected upstream call %s %s", r.Method, r.URL.Path)
+	}))
+	h := endpoint(t, p, "tags")
+
+	var wg sync.WaitGroup
+	replies := make([]gossiprpc.UrchinTagsReply, 2)
+	for i, acct := range []string{"069A79F4-44E9-4726-A5BE-FCA90E38AAF5", uuidB} {
+		wg.Add(1)
+		go func(i int, acct string) {
+			defer wg.Done()
+			replies[i] = asReply[gossiprpc.UrchinTagsReply](t, h(context.Background(), gossiprpc.Request{Account: acct}))
+		}(i, acct)
+	}
+	wg.Wait()
+
+	require.Equal(t, 1, rec.count(), "distinct players in one window must share one batch POST")
+	assert.Equal(t, []string{uuidA, uuidB}, rec.all()[0], "batch body carries canonical undashed uuids")
+
+	require.Empty(t, replies[0].Error)
+	require.Len(t, replies[0].Tags, 1)
+	assert.Equal(t, gossiprpc.UrchinTag{Type: "blatant_cheater", Reason: "Fly / Killaura", AddedOn: 1700000000}, replies[0].Tags[0])
+	// The batch endpoint reports no display names, so the reply echoes the
+	// typed identifier instead of a resolved name.
+	assert.Equal(t, "069A79F4-44E9-4726-A5BE-FCA90E38AAF5", replies[0].Player)
+
+	// Present-but-tagless is a SUCCESS (empty tag list), not an absence.
+	require.Empty(t, replies[1].Error)
+	assert.Empty(t, replies[1].Tags)
+}
+
+// Identical players spelled differently collapse onto one batch line and one
+// shared outcome.
+func TestBatchDedupsIdenticalPlayer(t *testing.T) {
+	rec := &batchRecorder{players: map[string][]batchTag{
+		uuidA: {{TagType: "sniper"}},
+	}}
+	p := newBatchProvider(t, rec.stubs(t))
+	h := endpoint(t, p, "tags")
+
+	const callers = 8
+	var wg sync.WaitGroup
+	replies := make([]gossiprpc.UrchinTagsReply, callers)
+	spellings := []string{uuidA, "069A79F4-44E9-4726-A5BE-FCA90E38AAF5", "069A79F444E94726A5BEFCA90E38AAF5"}
+	for i := range replies {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			replies[i] = asReply[gossiprpc.UrchinTagsReply](t, h(context.Background(), gossiprpc.Request{Account: spellings[i%len(spellings)]}))
+		}(i)
+	}
+	wg.Wait()
+
+	require.Equal(t, 1, rec.count())
+	assert.Equal(t, []string{uuidA}, rec.all()[0], "duplicate queries must collapse to one batch line")
+	for i, r := range replies {
+		require.Empty(t, r.Error, "caller %d", i)
+		require.Len(t, r.Tags, 1)
+	}
+}
+
+// The batch hydrates individual playertags cache entries: a follow-up query
+// through a DIFFERENT endpoint byte-cache (sniper resolves its uuid via
+// playerTags) must find the batch answer warm rather than re-batching.
+func TestBatchHydratesSharedPlayertagsCache(t *testing.T) {
+	rec := &batchRecorder{players: map[string][]batchTag{
+		uuidA: {{TagType: "cheater", Reason: "bhop"}},
+	}}
+	cubelifyHits := 0
+	p := newBatchProvider(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if rec.handle(w, r) {
+			return
+		}
+		switch r.URL.Path {
+		case "/v3/cubelify":
+			cubelifyHits++
+			assert.Equal(t, uuidA, r.URL.Query().Get("uuid"), "cubelify must receive the canonical uuid")
+			_, _ = w.Write([]byte(`{"score":{"value":7.5,"mode":"warn"},"tags":[]}`))
+		default:
+			t.Errorf("unexpected upstream call %s %s", r.Method, r.URL.Path)
+		}
+	}))
+
+	reply := asReply[gossiprpc.UrchinTagsReply](t,
+		endpoint(t, p, "tags")(context.Background(), gossiprpc.Request{Account: uuidA}))
+	require.Empty(t, reply.Error)
+
+	sniped := asReply[gossiprpc.UrchinSniperReply](t,
+		endpoint(t, p, "sniper")(context.Background(), gossiprpc.Request{Account: "069A79F4-44E9-4726-A5BE-FCA90E38AAF5"}))
+	require.Empty(t, sniped.Error)
+	assert.Equal(t, 7.5, sniped.Score)
+	assert.Equal(t, 1, cubelifyHits, "the uuid hop must be served by the hydrated batch entry")
+	assert.Equal(t, 1, rec.count(), "the sniper leg must not re-batch a hydrated player")
+}
+
+// Players missing from a successful batch response are shaped as 404s AND
+// negatively cached, so neither the tags command nor the sniper uuid hop asks
+// again while the negative lives.
+func TestBatchNegativeCachesMissingPlayers(t *testing.T) {
+	rec := &batchRecorder{players: map[string][]batchTag{
+		uuidA: {},
+	}}
+	p := newBatchProvider(t, rec.stubs(t))
+	tagsH := endpoint(t, p, "tags")
+	sniperH := endpoint(t, p, "sniper")
+
+	first := asReply[gossiprpc.UrchinTagsReply](t,
+		tagsH(context.Background(), gossiprpc.Request{Account: uuidB}))
+	assert.Equal(t, "player not found", first.Error)
+
+	second := asReply[gossiprpc.UrchinTagsReply](t,
+		tagsH(context.Background(), gossiprpc.Request{Account: uuidB}))
+	assert.Equal(t, "player not found", second.Error)
+
+	sniped := asReply[gossiprpc.UrchinSniperReply](t,
+		sniperH(context.Background(), gossiprpc.Request{Account: uuidB}))
+	assert.Equal(t, "player not found", sniped.Error)
+
+	assert.Equal(t, 1, rec.count(), "absent players must be answered from the negative cache")
+}
+
+// A wave larger than Coral's 100-uuid ceiling drains in capped sequential
+// POSTs, and every caller still gets its own answer.
+func TestBatchCapsAt100PerRequest(t *testing.T) {
+	const total = 150
+	rec := &batchRecorder{}
+	players := make(map[string][]batchTag, total)
+	for i := range total {
+		players[canonicalTestUUID(i)] = nil
+	}
+	rec.players = players
+
+	p := newBatchProvider(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !rec.handle(w, r) {
+			t.Errorf("unexpected upstream call %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	h := endpoint(t, p, "tags")
+
+	errs := make([]string, total)
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := range total {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			errs[i] = asReply[gossiprpc.UrchinTagsReply](t,
+				h(context.Background(), gossiprpc.Request{Account: canonicalTestUUID(i)})).Error
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	batches := rec.all()
+	require.GreaterOrEqual(t, len(batches), 2, "%d players cannot fit one request", total)
+	for i, b := range batches {
+		assert.LessOrEqual(t, len(b), batchLimit, "batch %d exceeds Coral's ceiling", i)
+	}
+	flat := flattenBatches(batches)
+	slices.Sort(flat)
+	want := make([]string, 0, total)
+	for i := range total {
+		want = append(want, canonicalTestUUID(i))
+	}
+	assert.Equal(t, want, flat, "every queried player must be covered by the drained batches")
+	for i, e := range errs {
+		assert.Empty(t, e, "caller %d", i)
+	}
+}
+
+// An infrastructure failure fails the whole wave WITHOUT caching anything:
+// callers get the friendly fallback, and a retry after recovery performs a
+// fresh POST rather than serving a pinned failure.
+func TestBatchInfraFailureIsNotCached(t *testing.T) {
+	rec := &batchRecorder{players: map[string][]batchTag{uuidA: {}}}
+	var mu sync.Mutex
+	healthy := false
+	p := newBatchProvider(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		ok := healthy
+		mu.Unlock()
+		if !ok {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"error":"boom"}`))
+			return
+		}
+		if !rec.handle(w, r) {
+			t.Errorf("unexpected upstream call %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	h := endpoint(t, p, "tags")
+
+	failed := asReply[gossiprpc.UrchinTagsReply](t, h(context.Background(), gossiprpc.Request{Account: uuidA}))
+	assert.Equal(t, "tags lookup failed", failed.Error)
+
+	mu.Lock()
+	healthy = true
+	mu.Unlock()
+	retried := asReply[gossiprpc.UrchinTagsReply](t, h(context.Background(), gossiprpc.Request{Account: uuidA}))
+	require.Empty(t, retried.Error)
+
+	assert.Equal(t, 1, rec.count(), "the failed wave must POST again once the upstream recovers")
+}
+
+// Username lookups never touch the batcher: they still resolve through the
+// individual GET, which is the only Coral surface that maps a username.
+func TestUsernameLookupsSkipBatcher(t *testing.T) {
+	rec := &batchRecorder{}
+	tagsHits := 0
+	p := newBatchProvider(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			rec.handle(w, r)
+			t.Error("username lookup must not reach the batch endpoint")
+			return
+		}
+		require.Equal(t, "/v3/player/tags", r.URL.Path)
+		tagsHits++
+		_, _ = w.Write([]byte(`{"uuid":"deadbeef","displayname":"Techno","tags":[]}`))
+	}))
+
+	reply := asReply[gossiprpc.UrchinTagsReply](t,
+		endpoint(t, p, "tags")(context.Background(), gossiprpc.Request{Account: "Techno"}))
+	require.Empty(t, reply.Error)
+	assert.Equal(t, 1, tagsHits)
+	assert.Zero(t, rec.count())
+}
+
+// stubs builds the plain upstream handler for a recorder-backed provider:
+// batch POSTs answered from its player map, anything else a test failure.
+func (r *batchRecorder) stubs(t *testing.T) http.Handler {
+	t.Helper()
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if r.handle(w, req) {
+			return
+		}
+		t.Errorf("unexpected upstream call %s %s", req.Method, req.URL.Path)
+	})
+}
+
+// canonicalTestUUID derives a stable valid uuid from an index.
+func canonicalTestUUID(i int) string { return fmt.Sprintf("%032x", i) }

--- a/app/gossip/internal/providers/urchin/urchin.go
+++ b/app/gossip/internal/providers/urchin/urchin.go
@@ -53,11 +53,13 @@ const (
 
 // Config carries the provider's environment: the Coral base URL, the API key
 // every request authenticates with, and the key's request budget per 5-minute
-// window.
+// window. BatchWindow sizes the cross-channel batch_lookup window (zero takes
+// the default); it exists for tests, which shrink it to keep suites fast.
 type Config struct {
-	BaseURL   string
-	APIKey    string
-	RateLimit float64
+	BaseURL     string
+	APIKey      string
+	RateLimit   float64
+	BatchWindow time.Duration
 }
 
 // providerName is the subject token this provider answers under.
@@ -70,6 +72,7 @@ type api struct {
 	key     string
 	limiter *ratelimit.Limiter
 	buckets core.Buckets
+	tags    *tagsBatcher
 }
 
 // New builds the urchin provider: the three session-delta endpoints plus the
@@ -109,13 +112,19 @@ func newAPI(cfg Config, d provider.Deps) *api {
 	if cfg.RateLimit <= 0 {
 		cfg.RateLimit = 600
 	}
-	return &api{
+	window := cfg.BatchWindow
+	if window <= 0 {
+		window = batchWindowDefault
+	}
+	a := &api{
 		http:    core.NewHTTPClient(base, map[string]string{"X-API-Key": cfg.APIKey}, httpTimeout),
 		cache:   d.Cache,
 		key:     cfg.APIKey,
 		limiter: d.Limiter,
 		buckets: core.NewPacedBuckets("ratelimit:gossip:urchin", cfg.RateLimit, rateWindowSeconds, maxBurst),
 	}
+	a.tags = newTagsBatcher(a, window)
+	return a
 }
 
 func sessionErrReply(id, msg string) any {
@@ -239,13 +248,16 @@ func (p *api) fetchSession(ctx context.Context, period string, acct account) (go
 // echoes the canonical uuid, without needing the Player Data permission the
 // dedicated /v3/resolve endpoint requires).
 type tagsResponse struct {
-	UUID        string  `json:"uuid"`
-	DisplayName *string `json:"displayname"`
-	Tags        []struct {
-		TagType string `json:"tag_type"`
-		Reason  string `json:"reason"`
-		AddedOn int64  `json:"added_on"`
-	} `json:"tags"`
+	UUID        string      `json:"uuid"`
+	DisplayName *string     `json:"displayname"`
+	Tags        []playerTag `json:"tags"`
+}
+
+// playerTag is one blacklist tag as the individual tags endpoint reports it.
+type playerTag struct {
+	TagType string `json:"tag_type"`
+	Reason  string `json:"reason"`
+	AddedOn int64  `json:"added_on"`
 }
 
 func (p *api) fetchTags(ctx context.Context, acct account) (tagsResponse, error) {
@@ -255,15 +267,28 @@ func (p *api) fetchTags(ctx context.Context, acct account) (tagsResponse, error)
 
 // playerTags fetches the Coral tags response for acct behind a shared cache.
 // Both the tags command and the sniper endpoint's uuid resolution read through
-// it, so a player queried by either costs one /v3/player/tags call rather than
-// two, and a missing player negative-caches once and satisfies both. It spends
-// one rate-limit token only on a real upstream fetch (the enforce lives inside
-// the cache's fill, so a hit costs nothing).
+// it, so a player queried by either costs one lookup rather than two, and a
+// missing player negative-caches once and satisfies both. It spends one
+// rate-limit token only on a real upstream fetch (the enforce lives inside the
+// cache's fill, so a hit costs nothing).
+//
+// UUID-shaped accounts ride the cross-channel batcher (see batch.go): their
+// misses within one window collapse into a single POST /v3/players whose
+// answer hydrates every player's entry here, so the batch's OTHER players are
+// already warm for whoever asks next. Their cache key is the canonical
+// undashed-lowercase uuid, so dashed and mixed-case spellings of one player
+// share an entry. Username accounts keep the individual GET — the batch
+// endpoint does not resolve usernames (batch.go explains why) — and keep the
+// typed-as-lowered key they always had.
 func (p *api) playerTags(ctx context.Context, acct account) (tagsResponse, error) {
-	key := core.Key(providerName, "playertags", acct.cacheKey())
-	return core.Cached(ctx, p.cache, key, tagsTTL, negativeTTL, nil, func(ctx context.Context) (tagsResponse, error) {
-		return p.fetchTags(ctx, acct)
-	})
+	id := acct.cacheKey()
+	fetch := func(ctx context.Context) (tagsResponse, error) { return p.fetchTags(ctx, acct) }
+	if cuuid, ok := canonicalUUID(acct); ok {
+		id = cuuid
+		fetch = func(ctx context.Context) (tagsResponse, error) { return p.tags.await(ctx, cuuid) }
+	}
+	key := core.Key(providerName, "playertags", id)
+	return core.Cached(ctx, p.cache, key, tagsTTL, negativeTTL, nil, fetch)
 }
 
 // tagsFetch reads the shared tags cache and shapes the blacklist-tags reply.


### PR DESCRIPTION
Closes #616.

## What

UUID-shaped playertags misses (`!tags` / `!sniper`'s uuid hop) now collect over a 2ms micro-batch window and resolve through a single `POST /v3/players` (Coral `batch_lookup`, ≤100 uuids per request), instead of one `GET /v3/player/tags` per player per channel.

- **Coalescing + dedup** (`app/gossip/internal/providers/urchin/batch.go`): concurrent misses across channels register on the batcher; identical players collapse to one batch line, distinct players share one POST. Fan-out is per-waiter channel, so every caller gets its own demultiplexed answer.
- **Cache hydration**: each batched answer lands in its own `gossip:urchin:playertags:<canonical-uuid>` entry via the new `core.StoreCached`, so the tags command, the sniper uuid hop and later single-player queries all read warm. Cache keys are canonical undashed-lowercase, so dashed/mixed-case spellings of a player share entries.
- **Negatives**: players absent from a successful batch response shape as 404 and negative-cache for `negativeTTL`. Whole-call failures (5xx etc.) fail the wave WITHOUT caching anything — nothing is learned about individual players from a malformed/failed request.
- **Usernames unchanged**: the batch endpoint accepts only UUIDs (no Mojang resolution), so username lookups keep the individual GET path.
- **Budget**: endpoint-level per-caller admission is untouched; every route into the batcher is preceded by an admission on the same pod, so upstream calls can never outnumber tokens spent fleet-wide. Rationale recorded in `batch.go`.

## Window sizing

The issue sketched 50–100ms; shipped default is **2ms**, because sesame's hot path answers at 64µs p99 and a cold upstream fetch must not inherit tens of ms of queueing. Same-burst bus arrivals land within µs–low-ms on one pod, which is where co-tenancy actually lives; chat-driven queries seconds apart are served by the cache/singleflight layers regardless.

## Tests

Aggregation + canonicalization, duplicate collapse, hydration across endpoints, negative caching, 100-cap drain of a 150-player wave, infra-failure non-caching, username-path isolation, canonicalUUID unit table — all passing under `-race`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added batched Coral player-tag lookups for UUID-based requests.
  * Combined duplicate and nearby requests into batches of up to 100 players.
  * Added configurable batching windows.
  * Improved caching for successful results and confirmed missing players.

* **Bug Fixes**
  * Prevented infrastructure failures from being cached.
  * Preserved direct handling for username lookups.
  * Improved UUID normalization and consistent tag responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->