### PR TITLE
feat(gossip): Valorant provider — rank, matches, leaderboard, account, featured bundle

### DIFF
--- a/app/gossip/internal/config/config.go
+++ b/app/gossip/internal/config/config.go
@@ -80,8 +80,8 @@ type Config struct {
 	FortniteSeasonStart    int64
 
 	// Valorant provider (rank/MMR, recent matches, leaderboards, account
-	// lookups, daily offer rotation) riding the community HenrikDev API. Key
-	// empty = provider disabled. The offer rotation additionally reads Riot's
+	// lookups, featured-bundle viewer) riding the community HenrikDev API. Key
+	// empty = provider disabled. The bundle viewer additionally reads Riot's
 	// keyless content CDN (valorant-api.com) to turn item UUIDs into names,
 	// icons and rarity colours — a second host with its own budget because it
 	// meters per source IP while HenrikDev meters per key.

--- a/app/gossip/internal/config/config.go
+++ b/app/gossip/internal/config/config.go
@@ -79,6 +79,18 @@ type Config struct {
 	FortniteStatsRateLimit float64
 	FortniteSeasonStart    int64
 
+	// Valorant provider (rank/MMR, recent matches, leaderboards, account
+	// lookups, daily offer rotation) riding the community HenrikDev API. Key
+	// empty = provider disabled. The offer rotation additionally reads Riot's
+	// keyless content CDN (valorant-api.com) to turn item UUIDs into names,
+	// icons and rarity colours — a second host with its own budget because it
+	// meters per source IP while HenrikDev meters per key.
+	ValorantBaseURL          string
+	ValorantContentBaseURL   string
+	ValorantAPIKey           string
+	ValorantRateLimit        float64
+	ValorantContentRateLimit float64
+
 	// Govee smart-light provider. It holds no service key (each broadcaster
 	// brings their own, fetched from the modules service). GoveeKeySubjectPrefix
 	// is that internal RPC's subject prefix; empty disables the provider.
@@ -158,6 +170,19 @@ func Load() *Config {
 		// day; the default leaves headroom.
 		FortniteStatsRateLimit: env.GetFloat("FORTNITE_STATS_RATE_LIMIT", 9000.0),
 		FortniteSeasonStart:    int64(env.GetInt("FORTNITE_SEASON_START_UNIX", 0)),
+
+		ValorantBaseURL:        env.Get("VALORANT_BASE_URL", "https://api.henrikdev.xyz"),
+		ValorantContentBaseURL: env.Get("VALORANT_CONTENT_BASE_URL", "https://valorant-api.com"),
+		ValorantAPIKey:         env.Get("VALORANT_API_KEY", ""),
+		// HenrikDev's enhanced tier allows 90 requests/min for public bots
+		// (basic is 30); the default sits under the enhanced ceiling so bursts
+		// deny locally instead of tripping the upstream limiter, which also
+		// poisons any cache fill in flight. A basic-tier key MUST set
+		// VALORANT_RATE_LIMIT=30 or it will 429 constantly.
+		ValorantRateLimit: env.GetFloat("VALORANT_RATE_LIMIT", 80.0),
+		// valorant-api.com publishes no hard per-client limit; 60/min is
+		// conservative for a multi-MB skins payload that caches for a day.
+		ValorantContentRateLimit: env.GetFloat("VALORANT_CONTENT_RATE_LIMIT", 60.0),
 
 		GoveeBaseURL:          env.Get("GOVEE_BASE_URL", "https://openapi.api.govee.com"),
 		GoveeRateLimit:        env.GetFloat("GOVEE_RATE_LIMIT", 8.0),

--- a/app/gossip/internal/config/config.go
+++ b/app/gossip/internal/config/config.go
@@ -174,12 +174,13 @@ func Load() *Config {
 		ValorantBaseURL:        env.Get("VALORANT_BASE_URL", "https://api.henrikdev.xyz"),
 		ValorantContentBaseURL: env.Get("VALORANT_CONTENT_BASE_URL", "https://valorant-api.com"),
 		ValorantAPIKey:         env.Get("VALORANT_API_KEY", ""),
-		// HenrikDev's enhanced tier allows 90 requests/min for public bots
-		// (basic is 30); the default sits under the enhanced ceiling so bursts
-		// deny locally instead of tripping the upstream limiter, which also
-		// poisons any cache fill in flight. A basic-tier key MUST set
-		// VALORANT_RATE_LIMIT=30 or it will 429 constantly.
-		ValorantRateLimit: env.GetFloat("VALORANT_RATE_LIMIT", 80.0),
+		// The fleet runs HenrikDev's instant Basic tier: 30 requests/min. The
+		// default sits AT the ceiling because every gossip pod shares one key,
+		// and the local bucket denying at 30 is strictly cheaper than the
+		// upstream's own 429 poisoning any cache fill in flight. Upgrading the
+		// Doppler key to Enhanced (90/min) MUST be paired with raising this to
+		// ~80, or a third of the paid allowance goes unused.
+		ValorantRateLimit: env.GetFloat("VALORANT_RATE_LIMIT", 30.0),
 		// valorant-api.com publishes no hard per-client limit; 60/min is
 		// conservative for a multi-MB skins payload that caches for a day.
 		ValorantContentRateLimit: env.GetFloat("VALORANT_CONTENT_RATE_LIMIT", 60.0),

--- a/app/gossip/internal/providers/all.go
+++ b/app/gossip/internal/providers/all.go
@@ -43,64 +43,58 @@ func All(cfg *config.Config, d provider.Deps) []provider.Provider {
 	return out
 }
 
-// appendIf is the shape every appendX helper below shares: gate on a
-// condition, log why and leave out unchanged when it skips, otherwise build
-// the provider and append it. Factoring this once means adding a provider
-// with the same "one credential/flag gates it" shape is writing a gate
-// condition, a skip reason and a constructor closure — not a fifth copy of
-// this whole sequence (the duplication CodeScene flagged once appendPaceman
-// made the third near-identical copy).
-func appendIf(out []provider.Provider, log *zap.Logger, skip bool, skipReason string, build func() provider.Provider) []provider.Provider {
-	if skip {
+// gated registers one provider behind its single disable condition: when the
+// gate trips, log why and leave out unchanged (a skipped provider's subjects
+// simply time out at the caller, the same failure mode as the upstream being
+// down); otherwise run the constructor lazily and append it. Factoring this
+// once means adding a provider with the same "one credential/flag gates it"
+// shape is writing a flag expression, a skip reason and an env-to-Config
+// mapping below — not a seventh copy of the whole sequence (the duplication
+// CodeScene flagged once appendPaceman made the third near-identical copy of
+// what began as an inline if/warn/append in every helper).
+func gated[T any](out []provider.Provider, log *zap.Logger, disabled bool, skipReason string, build func(T, provider.Deps) provider.Provider, cfg T, d provider.Deps) []provider.Provider {
+	if disabled {
 		log.Warn(skipReason)
 		return out
 	}
-	return append(out, build())
+	return append(out, build(cfg, d))
 }
 
 func appendUrchin(out []provider.Provider, cfg *config.Config, d provider.Deps, log *zap.Logger) []provider.Provider {
-	return appendIf(out, log, cfg.UrchinAPIKey == "", "urchin provider disabled: URCHIN_API_KEY not set", func() provider.Provider {
-		return urchin.New(urchin.Config{
-			BaseURL:   cfg.UrchinBaseURL,
-			APIKey:    cfg.UrchinAPIKey,
-			RateLimit: cfg.UrchinRateLimit,
-		}, d)
-	})
+	return gated(out, log, cfg.UrchinAPIKey == "", "urchin provider disabled: URCHIN_API_KEY not set", urchin.New, urchin.Config{
+		BaseURL:   cfg.UrchinBaseURL,
+		APIKey:    cfg.UrchinAPIKey,
+		RateLimit: cfg.UrchinRateLimit,
+	}, d)
 }
 
 func appendHypixel(out []provider.Provider, cfg *config.Config, d provider.Deps, log *zap.Logger) []provider.Provider {
-	return appendIf(out, log, cfg.HypixelAPIKey == "", "hypixel provider disabled: HYPIXEL_API_KEY not set (!bwstats will not answer)", func() provider.Provider {
-		return hypixel.New(hypixel.Config{
-			BaseURL:         cfg.HypixelBaseURL,
-			MojangBaseURL:   cfg.MojangBaseURL,
-			APIKey:          cfg.HypixelAPIKey,
-			RateLimit:       cfg.HypixelRateLimit,
-			MojangRateLimit: cfg.MojangRateLimit,
-		}, d)
-	})
+	return gated(out, log, cfg.HypixelAPIKey == "", "hypixel provider disabled: HYPIXEL_API_KEY not set (!bwstats will not answer)", hypixel.New, hypixel.Config{
+		BaseURL:         cfg.HypixelBaseURL,
+		MojangBaseURL:   cfg.MojangBaseURL,
+		APIKey:          cfg.HypixelAPIKey,
+		RateLimit:       cfg.HypixelRateLimit,
+		MojangRateLimit: cfg.MojangRateLimit,
+	}, d)
 }
 
 func appendMcsr(out []provider.Provider, cfg *config.Config, d provider.Deps, log *zap.Logger) []provider.Provider {
-	return appendIf(out, log, !cfg.McsrEnabled, "mcsr provider disabled: MCSR_ENABLED=false", func() provider.Provider {
-		return mcsr.New(mcsr.Config{
-			BaseURL:   cfg.McsrBaseURL,
-			APIKey:    cfg.McsrAPIKey,
-			RateLimit: cfg.McsrRateLimit,
-		}, d)
-	})
+	return gated(out, log, !cfg.McsrEnabled, "mcsr provider disabled: MCSR_ENABLED=false", mcsr.New, mcsr.Config{
+		BaseURL:   cfg.McsrBaseURL,
+		APIKey:    cfg.McsrAPIKey,
+		RateLimit: cfg.McsrRateLimit,
+	}, d)
 }
 
 // appendPaceman adds the paceman provider. Its public API needs no key, so
-// unlike appendUrchin/appendHypixel there is no credential to gate on — the
+// unlike the credential-gated providers there is nothing to gate on — the
 // only switch is the operator-controlled PacemanEnabled kill switch.
 func appendPaceman(out []provider.Provider, cfg *config.Config, d provider.Deps, log *zap.Logger) []provider.Provider {
-	return appendIf(out, log, !cfg.PacemanEnabled, "paceman provider disabled: PACEMAN_ENABLED=false", func() provider.Provider {
-		return paceman.New(paceman.Config{
-			BaseURL:     cfg.PacemanBaseURL,
-			UserBaseURL: cfg.PacemanUserBaseURL,
-			RateLimit:   cfg.PacemanRateLimit,
-		}, d)
-	})
+	return gated(out, log, !cfg.PacemanEnabled, "paceman provider disabled: PACEMAN_ENABLED=false", paceman.New, paceman.Config{
+		BaseURL:     cfg.PacemanBaseURL,
+		UserBaseURL: cfg.PacemanUserBaseURL,
+		RateLimit:   cfg.PacemanRateLimit,
+	}, d)
 }
 
 // appendFortnite adds the fortnite provider behind the FORTNITE_ENABLED flag
@@ -132,12 +126,10 @@ func appendFortnite(out []provider.Provider, cfg *config.Config, d provider.Deps
 // them; without it (the modules internal key RPC unwired) there is nothing to
 // authenticate with, so it is skipped like any credential-less provider.
 func appendGovee(out []provider.Provider, cfg *config.Config, d provider.Deps, log *zap.Logger) []provider.Provider {
-	return appendIf(out, log, d.GoveeKeys == nil, "govee provider disabled: no key resolver (modules govee RPC unwired)", func() provider.Provider {
-		return govee.New(govee.Config{
-			BaseURL:   cfg.GoveeBaseURL,
-			RateLimit: cfg.GoveeRateLimit,
-		}, d)
-	})
+	return gated(out, log, d.GoveeKeys == nil, "govee provider disabled: no key resolver (modules govee RPC unwired)", govee.New, govee.Config{
+		BaseURL:   cfg.GoveeBaseURL,
+		RateLimit: cfg.GoveeRateLimit,
+	}, d)
 }
 
 // appendClashRoyale adds the Clash Royale provider behind its RoyaleAPI proxy
@@ -146,13 +138,11 @@ func appendGovee(out []provider.Provider, cfg *config.Config, d provider.Deps, l
 // 45.79.218.79 whitelisted on it; the proxy then forwards Bearer-keyed calls
 // to api.clashroyale.com. A key in Doppler lights all four !cr commands.
 func appendClashRoyale(out []provider.Provider, cfg *config.Config, d provider.Deps, log *zap.Logger) []provider.Provider {
-	return appendIf(out, log, cfg.ClashRoyaleAPIKey == "", "clashroyale provider disabled: CLASHROYALE_API_KEY not set (!cr commands will not answer)", func() provider.Provider {
-		return clashroyale.New(clashroyale.Config{
-			BaseURL:   cfg.ClashRoyaleBaseURL,
-			APIKey:    cfg.ClashRoyaleAPIKey,
-			RateLimit: cfg.ClashRoyaleRateLimit,
-		}, d)
-	})
+	return gated(out, log, cfg.ClashRoyaleAPIKey == "", "clashroyale provider disabled: CLASHROYALE_API_KEY not set (!cr commands will not answer)", clashroyale.New, clashroyale.Config{
+		BaseURL:   cfg.ClashRoyaleBaseURL,
+		APIKey:    cfg.ClashRoyaleAPIKey,
+		RateLimit: cfg.ClashRoyaleRateLimit,
+	}, d)
 }
 
 // appendValorant adds the Valorant provider behind its HenrikDev key, the same
@@ -161,13 +151,11 @@ func appendClashRoyale(out []provider.Provider, cfg *config.Config, d provider.D
 // viewer prices itself through HenrikDev (only its name/icon join rides the
 // keyless content CDN), so a missing key leaves every !val command dark.
 func appendValorant(out []provider.Provider, cfg *config.Config, d provider.Deps, log *zap.Logger) []provider.Provider {
-	return appendIf(out, log, cfg.ValorantAPIKey == "", "valorant provider disabled: VALORANT_API_KEY not set (!val commands will not answer)", func() provider.Provider {
-		return valorant.New(valorant.Config{
-			BaseURL:          cfg.ValorantBaseURL,
-			ContentBaseURL:   cfg.ValorantContentBaseURL,
-			APIKey:           cfg.ValorantAPIKey,
-			RateLimit:        cfg.ValorantRateLimit,
-			ContentRateLimit: cfg.ValorantContentRateLimit,
-		}, d)
-	})
+	return gated(out, log, cfg.ValorantAPIKey == "", "valorant provider disabled: VALORANT_API_KEY not set (!val commands will not answer)", valorant.New, valorant.Config{
+		BaseURL:          cfg.ValorantBaseURL,
+		ContentBaseURL:   cfg.ValorantContentBaseURL,
+		APIKey:           cfg.ValorantAPIKey,
+		RateLimit:        cfg.ValorantRateLimit,
+		ContentRateLimit: cfg.ValorantContentRateLimit,
+	}, d)
 }

--- a/app/gossip/internal/providers/all.go
+++ b/app/gossip/internal/providers/all.go
@@ -151,11 +151,15 @@ func appendClashRoyale(out []provider.Provider, cfg *config.Config, d provider.D
 			BaseURL:   cfg.ClashRoyaleBaseURL,
 			APIKey:    cfg.ClashRoyaleAPIKey,
 			RateLimit: cfg.ClashRoyaleRateLimit,
+		}, d)
+	})
+}
+
 // appendValorant adds the Valorant provider behind its HenrikDev key, the same
 // credential gate as urchin/hypixel/clashroyale. The key gates everything:
-// unlike fortnite there is no keyless fallback mode — even the offer rotation
-// prices itself through HenrikDev (only its name/icon join rides the keyless
-// content CDN), so a missing key leaves every !val command dark.
+// unlike fortnite there is no keyless fallback mode — even the featured-bundle
+// viewer prices itself through HenrikDev (only its name/icon join rides the
+// keyless content CDN), so a missing key leaves every !val command dark.
 func appendValorant(out []provider.Provider, cfg *config.Config, d provider.Deps, log *zap.Logger) []provider.Provider {
 	return appendIf(out, log, cfg.ValorantAPIKey == "", "valorant provider disabled: VALORANT_API_KEY not set (!val commands will not answer)", func() provider.Provider {
 		return valorant.New(valorant.Config{

--- a/app/gossip/internal/providers/all.go
+++ b/app/gossip/internal/providers/all.go
@@ -16,6 +16,7 @@ import (
 	"ItsBagelBot/app/gossip/internal/providers/mcsr"
 	"ItsBagelBot/app/gossip/internal/providers/paceman"
 	"ItsBagelBot/app/gossip/internal/providers/urchin"
+	"ItsBagelBot/app/gossip/internal/providers/valorant"
 
 	"go.uber.org/zap"
 )
@@ -38,6 +39,7 @@ func All(cfg *config.Config, d provider.Deps) []provider.Provider {
 	out = appendFortnite(out, cfg, d, log)
 	out = appendGovee(out, cfg, d, log)
 	out = appendClashRoyale(out, cfg, d, log)
+	out = appendValorant(out, cfg, d, log)
 	return out
 }
 
@@ -149,6 +151,19 @@ func appendClashRoyale(out []provider.Provider, cfg *config.Config, d provider.D
 			BaseURL:   cfg.ClashRoyaleBaseURL,
 			APIKey:    cfg.ClashRoyaleAPIKey,
 			RateLimit: cfg.ClashRoyaleRateLimit,
+// appendValorant adds the Valorant provider behind its HenrikDev key, the same
+// credential gate as urchin/hypixel/clashroyale. The key gates everything:
+// unlike fortnite there is no keyless fallback mode — even the offer rotation
+// prices itself through HenrikDev (only its name/icon join rides the keyless
+// content CDN), so a missing key leaves every !val command dark.
+func appendValorant(out []provider.Provider, cfg *config.Config, d provider.Deps, log *zap.Logger) []provider.Provider {
+	return appendIf(out, log, cfg.ValorantAPIKey == "", "valorant provider disabled: VALORANT_API_KEY not set (!val commands will not answer)", func() provider.Provider {
+		return valorant.New(valorant.Config{
+			BaseURL:          cfg.ValorantBaseURL,
+			ContentBaseURL:   cfg.ValorantContentBaseURL,
+			APIKey:           cfg.ValorantAPIKey,
+			RateLimit:        cfg.ValorantRateLimit,
+			ContentRateLimit: cfg.ValorantContentRateLimit,
 		}, d)
 	})
 }

--- a/app/gossip/internal/providers/valorant/live_test.go
+++ b/app/gossip/internal/providers/valorant/live_test.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+// Live upstream probe, gated behind VALORANT_LIVE=1 plus a real
+// VALORANT_API_KEY (injected from Doppler, never logged). It exercises the
+// actual wire path — headers, paths, envelopes, shaping — against the real
+// HenrikDev and content hosts, spending about six requests of the key's
+// budget. Everything it prints is public game data.
+
+package valorant
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"ItsBagelBot/app/gossip/internal/core"
+	"ItsBagelBot/app/gossip/internal/provider"
+	gossiprpc "ItsBagelBot/internal/domain/rpc/gossip"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestLiveUpstream(t *testing.T) {
+	if os.Getenv("VALORANT_LIVE") != "1" || os.Getenv("VALORANT_API_KEY") == "" {
+		t.Skip("live probe: needs VALORANT_LIVE=1 and a real VALORANT_API_KEY")
+	}
+	p := New(Config{}, provider.Deps{Cache: core.NewCache(newMemStore()), Log: zap.NewNop()})
+	ctx := context.Background()
+
+	board := decodeReply[leaderboardReply](t, endpoint(t, p, "leaderboard")(ctx,
+		gossiprpc.Request{Region: "eu", Platform: "pc"}))
+	require.Empty(t, board.Error, "leaderboard probe failed")
+	require.NotEmpty(t, board.Entries, "eu/pc board empty")
+	top := board.Entries[0]
+	fmt.Printf("leaderboard: %s top=%s tier=%d rr=%d\n", board.Board, top.Player, top.Tier, top.RR)
+	require.Contains(t, top.Player, "#", "board row missing tagline")
+
+	// No Region on the player probes: this deliberately exercises the
+	// auto-detect path (one shared identity resolve feeding all three).
+	player := gossiprpc.Request{Account: top.Player}
+
+	account := decodeReply[accountReply](t, endpoint(t, p, "account")(ctx, player))
+	assert.Empty(t, account.Error)
+	fmt.Printf("account: %s region=%s level=%d card=%v\n", account.Player, account.Region, account.AccountLevel, account.Card != "")
+
+	rank := decodeReply[rankReply](t, endpoint(t, p, "rank")(ctx, player))
+	assert.Empty(t, rank.Error)
+	fmt.Printf("rank: %s tier=%q rr=%d delta=%d peak=%q unranked=%v\n",
+		rank.Region, rank.Tier, rank.RR, rank.LastChange, rank.PeakTier, rank.Unranked)
+
+	matches := decodeReply[matchesReply](t, endpoint(t, p, "matches")(ctx, player))
+	assert.Empty(t, matches.Error)
+	for i, m := range matches.Matches {
+		fmt.Printf("match[%d]: %s on %s as %s %d/%d/%d acs=%.1f\n",
+			i, m.Result, m.Map, m.Agent, m.Kills, m.Deaths, m.Assists, m.ACS)
+	}
+
+	shop := decodeReply[shopReply](t, endpoint(t, p, "shop")(ctx, gossiprpc.Request{}))
+	assert.Empty(t, shop.Error)
+	if shop.Count > 0 {
+		fmt.Printf("shop: %d items, first=%q price=%d tier=%q\n", shop.Count, shop.Items[0].Name, shop.Items[0].Price, shop.Items[0].Tier)
+	} else {
+		fmt.Println("shop: empty rotation")
+	}
+}

--- a/app/gossip/internal/providers/valorant/live_test.go
+++ b/app/gossip/internal/providers/valorant/live_test.go
@@ -28,7 +28,8 @@ func TestLiveUpstream(t *testing.T) {
 	if os.Getenv("VALORANT_LIVE") != "1" || os.Getenv("VALORANT_API_KEY") == "" {
 		t.Skip("live probe: needs VALORANT_LIVE=1 and a real VALORANT_API_KEY")
 	}
-	p := New(Config{}, provider.Deps{Cache: core.NewCache(newMemStore()), Log: zap.NewNop()})
+	p := New(Config{APIKey: os.Getenv("VALORANT_API_KEY")},
+		provider.Deps{Cache: core.NewCache(newMemStore()), Log: zap.NewNop()})
 	ctx := context.Background()
 
 	board := decodeReply[leaderboardReply](t, endpoint(t, p, "leaderboard")(ctx,
@@ -62,8 +63,10 @@ func TestLiveUpstream(t *testing.T) {
 	shop := decodeReply[shopReply](t, endpoint(t, p, "shop")(ctx, gossiprpc.Request{}))
 	assert.Empty(t, shop.Error)
 	if shop.Count > 0 {
-		fmt.Printf("shop: %d items, first=%q price=%d tier=%q\n", shop.Count, shop.Items[0].Name, shop.Items[0].Price, shop.Items[0].Tier)
+		fmt.Printf("shop: bundle=%q (%.1f%% off) price=%d vp items=%d first=%q expires_in=%.1fd\n",
+			shop.Bundle, shop.DiscountPct, shop.Price, shop.Count, shop.Items[0].Name,
+			float64(shop.ExpiresSeconds)/86400)
 	} else {
-		fmt.Println("shop: empty rotation")
+		fmt.Println("shop: no featured bundle payload")
 	}
 }

--- a/app/gossip/internal/providers/valorant/sharing_test.go
+++ b/app/gossip/internal/providers/valorant/sharing_test.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+// This file tests the relationship *between* endpoints, not any one of them:
+// which lookups share the day-long identity resolve and which deliberately do
+// not. That contract is invisible in any single endpoint's test, and it is
+// exactly what a future refactor of resolveAccount could silently break.
+
+package valorant
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+
+	gossiprpc "ItsBagelBot/internal/domain/rpc/gossip"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAutoRegionResolveIsSharedAcrossEndpoints(t *testing.T) {
+	var mu sync.Mutex
+	accountHits := 0
+	henrik := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/valorant/v2/account/"):
+			mu.Lock()
+			accountHits++
+			mu.Unlock()
+			fmt.Fprint(w, accountBody)
+		case strings.HasPrefix(r.URL.Path, "/valorant/v4/matches/"):
+			fmt.Fprint(w, `{"status":200,"data":[]}`)
+		default:
+			fmt.Fprint(w, mmrBody)
+		}
+	})
+	p := newTestProvider(t, henrik, noUpstream(t, "content"))
+	rank := endpoint(t, p, "rank")
+	matches := endpoint(t, p, "matches")
+	ctx := context.Background()
+	auto := gossiprpc.Request{Account: "Frosty#EUW1"}
+
+	assert.Empty(t, decodeReply[rankReply](t, rank(ctx, auto)).Error)
+	assert.Empty(t, decodeReply[matchesReply](t, matches(ctx, auto)).Error)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, 1, accountHits,
+		"both auto-region lookups ride one identity entry; a second account read here means the shared resolve was lost")
+
+	secondRank := decodeReply[rankReply](t, rank(ctx, gossiprpc.Request{Account: "Frosty#EUW1", Region: "eu"}))
+	assert.Empty(t, secondRank.Error)
+	assert.Equal(t, 1, accountHits,
+		"an explicit region never touches the resolve at all")
+}
+
+func TestAccountEndpointKeepsItsOwnCacheEntry(t *testing.T) {
+	// The account endpoint answers with level/card/title, which drift within
+	// the identity resolve's 24h window; it intentionally reads upstream under
+	// its own hour-long byte-flow entry instead of the resolve's. The sequence
+	// below pins the deliberate duplication: warming the resolve first does
+	// not spare the account endpoint one upstream read, and the account
+	// endpoint's own second call is served from its flow cache.
+	var mu sync.Mutex
+	accountHits := 0
+	henrik := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/valorant/v2/account/") {
+			mu.Lock()
+			accountHits++
+			mu.Unlock()
+			fmt.Fprint(w, accountBody)
+			return
+		}
+		fmt.Fprint(w, mmrBody)
+	})
+	p := newTestProvider(t, henrik, noUpstream(t, "content"))
+	ctx := context.Background()
+
+	assert.Empty(t, decodeReply[rankReply](t, endpoint(t, p, "rank")(ctx,
+		gossiprpc.Request{Account: "Frosty#EUW1"})).Error, "warms the identity resolve")
+
+	req := gossiprpc.Request{Account: "Frosty#EUW1"}
+	assert.Empty(t, decodeReply[accountReply](t, endpoint(t, p, "account")(ctx, req)).Error,
+		"must not ride the still-warm resolve entry")
+
+	mu.Lock()
+	hitsAfterFirst := accountHits
+	mu.Unlock()
+	assert.Equal(t, 2, hitsAfterFirst)
+
+	assert.Empty(t, decodeReply[accountReply](t, endpoint(t, p, "account")(ctx, req)).Error)
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, 2, accountHits, "the account endpoint's own byte-flow cache absorbs the repeat")
+}

--- a/app/gossip/internal/providers/valorant/shop.go
+++ b/app/gossip/internal/providers/valorant/shop.go
@@ -1,0 +1,231 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+// This file is the daily offer rotation: HenrikDev prices item UUIDs, Riot's
+// content CDN names them. The two upstreams are joined here rather than at the
+// caller because the join is what makes the endpoint useful — a rotation of
+// bare UUIDs is a shop nobody can read.
+//
+// What is intentionally absent: personal shops and night markets need the
+// viewer's own Riot credentials, which HenrikDev bans products for collecting
+// (see the package comment). Bundles are also out: store-featured carries its
+// own bundle metadata and deserves its own endpoint when someone wants it,
+// not a half-join bolted onto this one.
+
+package valorant
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"time"
+
+	"ItsBagelBot/app/gossip/internal/core"
+	"ItsBagelBot/app/gossip/internal/provider"
+	gossiprpc "ItsBagelBot/internal/domain/rpc/gossip"
+
+	"golang.org/x/sync/errgroup"
+)
+
+// These two UUIDs are schema-level constants of the game's economy model, not
+// data that rotates: every skin offer prices itself in VP under the first and
+// identifies its reward kind under the second. They have been stable since
+// open beta (they are how SkinPeek, ValoDex and every community shop tracker
+// decode the same payload), so hardcoding them trades one config knob nobody
+// would ever set correctly for constants nothing has ever shaken.
+const (
+	valorantPointsTypeID = "85ad13f7-3d1b-5128-9eb2-7cd8ee0b5741"
+	skinItemTypeID       = "e5c1dd93-8875-4a96-8f30-6a9b17da1ce4"
+)
+
+// The shop flips over at 20:00 America/Los_Angeles — 03:00 UTC during PDT.
+// Winter PST pushes that to 04:00 UTC, so the day after the clocks change the
+// window runs an hour long and stale-while-revalidate covers the gap: the
+// half-window sizing in the flow means the last pre-flip build expires right
+// on 03:00, and the first read past it refreshes against the same deadline
+// instead of serving yesterday's rotation from the physical tail. Computing
+// "next 20:00 Pacific" exactly needs a location database on every pod for a
+// boundary that self-heals anyway; 03:00 fixed is the deliberate trade.
+func nextShopRotation(now time.Time) time.Time {
+	today := time.Date(now.Year(), now.Month(), now.Day(), 3, 0, 0, 0, time.UTC)
+	if !now.Before(today) {
+		return today.Add(24 * time.Hour)
+	}
+	return today
+}
+
+// offersWire is the priced half of the join. Cost keys currency type UUIDs to
+// amounts; Rewards carries what the offer actually grants, filtered down to
+// skins below so agent-contract points and radianite never masquerade as shop
+// rows.
+type offersWire struct {
+	Data struct {
+		Offers []offerEntry `json:"Offers"`
+	} `json:"data"`
+}
+
+type offerEntry struct {
+	OfferID string           `json:"OfferID"`
+	Cost    map[string]int64 `json:"Cost"`
+	Rewards []offerReward    `json:"Rewards"`
+}
+
+type offerReward struct {
+	ItemID     string `json:"ItemID"`
+	ItemTypeID string `json:"ItemTypeID"`
+}
+
+// skinsWire is the catalogue half. One payload lists every skin ever shipped
+// (a few MB); it changes only at patches, so it is cached under one key all
+// pods share for a full day rather than refetched per request.
+type skinsWire struct {
+	Data []skinAsset `json:"data"`
+}
+
+type skinAsset struct {
+	UUID            string `json:"uuid"`
+	DisplayName     string `json:"displayName"`
+	DisplayIcon     string `json:"displayIcon"`
+	ContentTierUUID string `json:"contentTierUuid"`
+}
+
+// tiersWire maps content tier UUIDs to their display names and rarity colours.
+type tiersWire struct {
+	Data []tierAsset `json:"data"`
+}
+
+type tierAsset struct {
+	UUID            string `json:"uuid"`
+	DisplayName     string `json:"displayName"`
+	BackgroundColor string `json:"backgroundColor"`
+}
+
+// skinTTL bounds both catalogue entries. Patches land roughly fortnightly;
+// 24 hours means a patch day serves old names for at most a day — visible as
+// a renamed skin keeping its old label, never as a missing or wrong-priced
+// item, because prices come fresh from the offers leg every window.
+const skinTTL = 24 * time.Hour
+
+func (p *api) skinCatalogue(ctx context.Context) (map[string]skinAsset, error) {
+	key := core.Key(providerName, "skins", "catalogue")
+	return core.Cached(ctx, p.cache, key, skinTTL, negativeTTL, nil, func(ctx context.Context) (map[string]skinAsset, error) {
+		var wire skinsWire
+		if err := p.content.GetJSON(ctx, "/v1/weapons/skins", nil, &wire); err != nil {
+			return nil, err
+		}
+		catalogue := make(map[string]skinAsset, len(wire.Data))
+		for _, asset := range wire.Data {
+			catalogue[asset.UUID] = asset
+		}
+		return catalogue, nil
+	})
+}
+
+func (p *api) contentTiers(ctx context.Context) (map[string]tierAsset, error) {
+	key := core.Key(providerName, "tiers", "content")
+	return core.Cached(ctx, p.cache, key, skinTTL, negativeTTL, nil, func(ctx context.Context) (map[string]tierAsset, error) {
+		var wire tiersWire
+		if err := p.content.GetJSON(ctx, "/v1/contenttiers", nil, &wire); err != nil {
+			return nil, err
+		}
+		tiers := make(map[string]tierAsset, len(wire.Data))
+		for _, asset := range wire.Data {
+			tiers[asset.UUID] = asset
+		}
+		return tiers, nil
+	})
+}
+
+// shopItem is one rotated skin ready for rendering. Color is the rarity's
+// background hex ("#0f1923"-style) straight from the content tiers, so the
+// module can colour-code without owning a rarity table.
+type shopItem struct {
+	Name  string `json:"name"`
+	Price int64  `json:"price"`
+	Tier  string `json:"tier,omitempty"`
+	Color string `json:"color,omitempty"`
+	Icon  string `json:"icon,omitempty"`
+}
+
+// shopReply is the answer to valorant.shop: today's global skin rotation.
+// ResetUnix is the instant the rotation turns over, so a template can print a
+// countdown. Empty is true on the rare days Riot rotates nothing — a normal
+// answer, not an error.
+type shopReply struct {
+	ResetUnix int64      `json:"reset_unix"`
+	Items     []shopItem `json:"items"`
+	Count     int        `json:"count"`
+	Empty     bool       `json:"empty"`
+	Error     string     `json:"error,omitempty"`
+}
+
+// shopFetch joins three legs concurrently: prices from HenrikDev, the skin
+// catalogue and rarity tiers from the content CDN. Each leg is independently
+// cached (the catalogues for a day), so steady state costs exactly one Henrik
+// call per rotation window and zero content calls.
+func (p *api) shopFetch(ctx context.Context, _ gossiprpc.Request, _ provider.ID) (any, error) {
+	var wire offersWire
+	var catalogue map[string]skinAsset
+	var tiers map[string]tierAsset
+
+	group, groupCtx := errgroup.WithContext(ctx)
+	group.Go(func() error {
+		return p.http.GetJSON(groupCtx, "/valorant/v1/store-offers", nil, &wire)
+	})
+	group.Go(func() error {
+		var err error
+		catalogue, err = p.skinCatalogue(groupCtx)
+		return err
+	})
+	group.Go(func() error {
+		var err error
+		tiers, err = p.contentTiers(groupCtx)
+		return err
+	})
+	if err := group.Wait(); err != nil {
+		return nil, err
+	}
+
+	items := make([]shopItem, 0, len(wire.Data.Offers))
+	for _, offer := range wire.Data.Offers {
+		if !isSkinOffer(offer) {
+			continue
+		}
+		price := offer.Cost[valorantPointsTypeID]
+		skin, ok := catalogue[offer.OfferID]
+		// Unknown skins are skipped rather than rendered as blank rows. The
+		// catalogue lags a new act's items by at most a patch cycle; a rowless
+		// shop that day reads as "smaller rotation", which is true-ish, while
+		// "Unknown item — 1800VP" five times reads as breakage.
+		if !ok || price <= 0 {
+			continue
+		}
+		item := shopItem{Name: skin.DisplayName, Price: price, Icon: skin.DisplayIcon}
+		if tier, ok := tiers[skin.ContentTierUUID]; ok {
+			item.Tier = tier.DisplayName
+			item.Color = tier.BackgroundColor
+		}
+		items = append(items, item)
+	}
+	// Priciest first: the rotation is read top-down as "what's worth looking
+	// at", and Ultra editions bury cheap accessories when left in upstream
+	// offer order.
+	sort.SliceStable(items, func(i, j int) bool { return items[i].Price > items[j].Price })
+	return shopReply{
+		ResetUnix: nextShopRotation(time.Now()).Unix(),
+		Items:     items,
+		Count:     len(items),
+		Empty:     len(items) == 0,
+	}, nil
+}
+
+// isSkinOffer filters to single-skin direct purchases. Bundle offers carry the
+// same shape with a bundle-level reward set; they are excluded here because
+// their OfferID is not in the weapons-skins catalogue and their pricing model
+// (bundle discount over sum-of-parts) is its own feature.
+func isSkinOffer(offer offerEntry) bool {
+	if len(offer.Rewards) != 1 {
+		return false
+	}
+	return strings.EqualFold(offer.Rewards[0].ItemTypeID, skinItemTypeID)
+}

--- a/app/gossip/internal/providers/valorant/shop.go
+++ b/app/gossip/internal/providers/valorant/shop.go
@@ -1,21 +1,25 @@
 // Copyright (c) 2026 Adam Ousmer. All rights reserved.
 // Proprietary. No license granted. See LICENSE.md.
 
-// This file is the daily offer rotation: HenrikDev prices item UUIDs, Riot's
-// content CDN names them. The two upstreams are joined here rather than at the
-// caller because the join is what makes the endpoint useful — a rotation of
-// bare UUIDs is a shop nobody can read.
+// This file is the featured-bundle viewer: HenrikDev carries Riot's own store
+// payload (prices, discounts, per-item breakdown, remaining rotation time),
+// and Riot's content CDN names it. The two upstreams are joined here rather
+// than at the caller because the join is what makes the endpoint useful — a
+// bundle of bare UUIDs is a shop nobody can read.
 //
-// What is intentionally absent: personal shops and night markets need the
-// viewer's own Riot credentials, which HenrikDev bans products for collecting
-// (see the package comment). Bundles are also out: store-featured carries its
-// own bundle metadata and deserves its own endpoint when someone wants it,
-// not a half-join bolted onto this one.
+// Why bundles and not the daily skin rotation: HenrikDev's global
+// store-offers endpoint returns 404 code 46 ("Riot has removed this
+// implementation") at every version — Riot killed the public rotation feed,
+// and the per-player views (personal store, night market) need viewer
+// credentials HenrikDev bans products for collecting. The featured bundle is
+// what survives globally, and it is the piece players actually ask bots to
+// announce anyway.
 
 package valorant
 
 import (
 	"context"
+	"net/url"
 	"sort"
 	"strings"
 	"time"
@@ -27,57 +31,70 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-// These two UUIDs are schema-level constants of the game's economy model, not
-// data that rotates: every skin offer prices itself in VP under the first and
-// identifies its reward kind under the second. They have been stable since
-// open beta (they are how SkinPeek, ValoDex and every community shop tracker
-// decode the same payload), so hardcoding them trades one config knob nobody
-// would ever set correctly for constants nothing has ever shaken.
-const (
-	valorantPointsTypeID = "85ad13f7-3d1b-5128-9eb2-7cd8ee0b5741"
-	skinItemTypeID       = "e5c1dd93-8875-4a96-8f30-6a9b17da1ce4"
-)
+// Bundle items are joined by catalogue membership alone, not by an item-type
+// allowlist: the live store payload types its five skin entries with a
+// per-level UUID (e7c63390...) that matches nothing in the offers feed this
+// file originally targeted — whose EquippableSkin id (e5c1dd93...) died along
+// with that endpoint. Only weapon-skin level UUIDs exist in the weapons-skins
+// catalogue, so "resolves" and "is a skin" are the same test; buddies, cards
+// and sprays fall out on their own without us hardcoding another generation
+// of Riot's type constants.
 
-// The shop flips over at 20:00 America/Los_Angeles — 03:00 UTC during PDT.
-// Winter PST pushes that to 04:00 UTC, so the day after the clocks change the
-// window runs an hour long and stale-while-revalidate covers the gap: the
-// half-window sizing in the flow means the last pre-flip build expires right
-// on 03:00, and the first read past it refreshes against the same deadline
-// instead of serving yesterday's rotation from the physical tail. Computing
-// "next 20:00 Pacific" exactly needs a location database on every pod for a
-// boundary that self-heals anyway; 03:00 fixed is the deliberate trade.
-func nextShopRotation(now time.Time) time.Time {
-	today := time.Date(now.Year(), now.Month(), now.Day(), 3, 0, 0, 0, time.UTC)
-	if !now.Before(today) {
-		return today.Add(24 * time.Hour)
-	}
-	return today
-}
-
-// offersWire is the priced half of the join. Cost keys currency type UUIDs to
-// amounts; Rewards carries what the offer actually grants, filtered down to
-// skins below so agent-contract points and radianite never masquerade as shop
-// rows.
-type offersWire struct {
+// featuredWire is HenrikDev's /valorant/v1/store-featured. Only the headline
+// bundle is decoded: Bundles[] repeats the same shape for sub-bundles and
+// BundleRemainingDurationInSeconds duplicates the per-bundle countdown.
+type featuredWire struct {
 	Data struct {
-		Offers []offerEntry `json:"Offers"`
+		FeaturedBundle struct {
+			Bundle featuredBundle `json:"Bundle"`
+		} `json:"FeaturedBundle"`
 	} `json:"data"`
 }
 
-type offerEntry struct {
-	OfferID string           `json:"OfferID"`
-	Cost    map[string]int64 `json:"Cost"`
-	Rewards []offerReward    `json:"Rewards"`
+type featuredBundle struct {
+	ID          string `json:"ID"`
+	DataAssetID string `json:"DataAssetID"`
+	// Whole-bundle discount as a fraction (0.451 = 45.1% off).
+	TotalDiscountPercent float64 `json:"TotalDiscountPercent"`
+	// Riot's own countdown to when this bundle leaves the store.
+	DurationRemainingInSeconds float64        `json:"DurationRemainingInSeconds"`
+	Items                      []featuredItem `json:"Items"`
 }
 
-type offerReward struct {
-	ItemID     string `json:"ItemID"`
-	ItemTypeID string `json:"ItemTypeID"`
+// Prices arrive as JSON floats even when whole ("DiscountedPrice":0.0), so
+// they decode as float64 and are truncated only at the reply boundary. A
+// plain int64 field hard-fails the entire store decode on the first
+// fractional zero (observed live), not merely loses precision.
+type featuredItem struct {
+	Item struct {
+		ItemTypeID string  `json:"ItemTypeID"`
+		ItemID     string  `json:"ItemID"`
+		Amount     float64 `json:"Amount"`
+	} `json:"Item"`
+	BasePrice       float64 `json:"BasePrice"`
+	DiscountPercent float64 `json:"DiscountPercent"`
+	DiscountedPrice float64 `json:"DiscountedPrice"`
 }
 
-// skinsWire is the catalogue half. One payload lists every skin ever shipped
-// (a few MB); it changes only at patches, so it is cached under one key all
-// pods share for a full day rather than refetched per request.
+// bundleMetaWire is the content CDN's catalogue entry for one bundle, keyed by
+// the DataAssetID the store payload carries.
+type bundleMetaWire struct {
+	Data struct {
+		UUID        string `json:"uuid"`
+		DisplayName string `json:"displayName"`
+		// SubText is the edition suffix ("2.0", "Collection") rendered under
+		// the name in-game.
+		SubText     string `json:"displayNameSubText"`
+		Description string `json:"description"`
+		DisplayIcon string `json:"displayIcon"`
+	} `json:"data"`
+}
+
+// skinsWire is the catalogue half of the item join. One payload lists every
+// skin ever shipped (a few MB); it changes only at patches, so it is cached
+// under one key all pods share for a full day rather than refetched per
+// request. Bundle items reference skin LEVEL uuids, not the parent skin uuid,
+// so every level uuid indexes back to its skin too.
 type skinsWire struct {
 	Data []skinAsset `json:"data"`
 }
@@ -87,6 +104,9 @@ type skinAsset struct {
 	DisplayName     string `json:"displayName"`
 	DisplayIcon     string `json:"displayIcon"`
 	ContentTierUUID string `json:"contentTierUuid"`
+	Levels          []struct {
+		UUID string `json:"uuid"`
+	} `json:"levels"`
 }
 
 // tiersWire maps content tier UUIDs to their display names and rarity colours.
@@ -100,10 +120,11 @@ type tierAsset struct {
 	BackgroundColor string `json:"backgroundColor"`
 }
 
-// skinTTL bounds both catalogue entries. Patches land roughly fortnightly;
-// 24 hours means a patch day serves old names for at most a day — visible as
-// a renamed skin keeping its old label, never as a missing or wrong-priced
-// item, because prices come fresh from the offers leg every window.
+// skinTTL bounds all three catalogue entries. Patches land roughly
+// fortnightly; 24 hours means a patch day serves old names for at most a day
+// — visible as a renamed skin keeping its old label, never as a missing or
+// wrong-priced item, because prices come fresh from the store payload every
+// window.
 const skinTTL = 24 * time.Hour
 
 func (p *api) skinCatalogue(ctx context.Context) (map[string]skinAsset, error) {
@@ -113,9 +134,12 @@ func (p *api) skinCatalogue(ctx context.Context) (map[string]skinAsset, error) {
 		if err := p.content.GetJSON(ctx, "/v1/weapons/skins", nil, &wire); err != nil {
 			return nil, err
 		}
-		catalogue := make(map[string]skinAsset, len(wire.Data))
+		catalogue := make(map[string]skinAsset, len(wire.Data)*4)
 		for _, asset := range wire.Data {
 			catalogue[asset.UUID] = asset
+			for _, level := range asset.Levels {
+				catalogue[level.UUID] = asset
+			}
 		}
 		return catalogue, nil
 	})
@@ -136,9 +160,31 @@ func (p *api) contentTiers(ctx context.Context) (map[string]tierAsset, error) {
 	})
 }
 
-// shopItem is one rotated skin ready for rendering. Color is the rarity's
-// background hex ("#0f1923"-style) straight from the content tiers, so the
-// module can colour-code without owning a rarity table.
+// bundleMeta resolves one bundle's display identity. Cached under its data
+// asset UUID: the same bundle reappears on re-rerun rotations, so repeat
+// features cost nothing after the first.
+func (p *api) bundleMeta(ctx context.Context, dataAssetID string) (bundleMetaWire, error) {
+	key := core.Key(providerName, "bundle", dataAssetID)
+	return core.Cached(ctx, p.cache, key, skinTTL, negativeTTL, nil, func(ctx context.Context) (bundleMetaWire, error) {
+		var meta bundleMetaWire
+		if err := p.content.GetJSON(ctx, "/v1/bundles/"+url.PathEscape(dataAssetID), nil, &meta); err != nil {
+			return bundleMetaWire{}, err
+		}
+		if strings.TrimSpace(meta.Data.DisplayName) == "" {
+			// A catalogue miss here means the bundle predates or postdates the
+			// cached weapons/skins-style index; without this guard the reply
+			// would carry an empty name and look broken rather than unknown.
+			return bundleMetaWire{}, &core.UpstreamError{Status: 404, Message: "bundle not found in catalogue"}
+		}
+		return meta, nil
+	})
+}
+
+// shopItem is one weapon skin inside the featured bundle, ready for
+// rendering. Color is the rarity's background hex straight from the content
+// tiers, so the module can colour-code without owning a rarity table. Price
+// is what the bundle charges for it today — the discounted price when one
+// applies, the base price otherwise.
 type shopItem struct {
 	Name  string `json:"name"`
 	Price int64  `json:"price"`
@@ -147,30 +193,48 @@ type shopItem struct {
 	Icon  string `json:"icon,omitempty"`
 }
 
-// shopReply is the answer to valorant.shop: today's global skin rotation.
-// ResetUnix is the instant the rotation turns over, so a template can print a
-// countdown. Empty is true on the rare days Riot rotates nothing — a normal
-// answer, not an error.
+// shopReply is the answer to valorant.shop: the current featured bundle.
+// ExpiresSeconds is Riot's own countdown to the next rotation, so a template
+// can print an exact deadline instead of a guess. Price sums the listed skin
+// items' effective prices — the bundle may also carry cards, sprays or VP,
+// which render nowhere but are included in Riot's own checkout total.
 type shopReply struct {
-	ResetUnix int64      `json:"reset_unix"`
-	Items     []shopItem `json:"items"`
-	Count     int        `json:"count"`
-	Empty     bool       `json:"empty"`
-	Error     string     `json:"error,omitempty"`
+	Bundle         string     `json:"bundle"`
+	Subtitle       string     `json:"subtitle,omitempty"`
+	Description    string     `json:"description,omitempty"`
+	Icon           string     `json:"icon,omitempty"`
+	DiscountPct    float64    `json:"discount_pct,omitempty"`
+	Price          int64      `json:"price"`
+	ExpiresSeconds int64      `json:"expires_in_seconds"`
+	Items          []shopItem `json:"items"`
+	Count          int        `json:"count"`
+	Error          string     `json:"error,omitempty"`
 }
 
-// shopFetch joins three legs concurrently: prices from HenrikDev, the skin
-// catalogue and rarity tiers from the content CDN. Each leg is independently
-// cached (the catalogues for a day), so steady state costs exactly one Henrik
-// call per rotation window and zero content calls.
+// shopFetch joins three legs concurrently: the priced store payload from
+// HenrikDev, plus the skin catalogue and rarity tiers from the content CDN.
+// Each leg is independently cached (the catalogues for a day), so steady state
+// costs exactly one Henrik call per window and zero content calls.
+//
+// Caching is a fixed six hours rather than a deadline pinned to the bundle's
+// remaining seconds: the flow sizes windows before fetching, so the upstream
+// countdown cannot inform them — and it does not need to, because the reply
+// echoes ExpiresSeconds for exact rendering while six hours keeps any served
+// copy within a rounding error of Riot's own schedule.
 func (p *api) shopFetch(ctx context.Context, _ gossiprpc.Request, _ provider.ID) (any, error) {
-	var wire offersWire
+	var wire featuredWire
+	var meta bundleMetaWire
 	var catalogue map[string]skinAsset
 	var tiers map[string]tierAsset
 
 	group, groupCtx := errgroup.WithContext(ctx)
 	group.Go(func() error {
-		return p.http.GetJSON(groupCtx, "/valorant/v1/store-offers", nil, &wire)
+		if err := p.http.GetJSON(groupCtx, "/valorant/v1/store-featured", nil, &wire); err != nil {
+			return err
+		}
+		var err error
+		meta, err = p.bundleMeta(groupCtx, wire.Data.FeaturedBundle.Bundle.DataAssetID)
+		return err
 	})
 	group.Go(func() error {
 		var err error
@@ -186,46 +250,39 @@ func (p *api) shopFetch(ctx context.Context, _ gossiprpc.Request, _ provider.ID)
 		return nil, err
 	}
 
-	items := make([]shopItem, 0, len(wire.Data.Offers))
-	for _, offer := range wire.Data.Offers {
-		if !isSkinOffer(offer) {
+	bundle := wire.Data.FeaturedBundle.Bundle
+	items := make([]shopItem, 0, len(bundle.Items))
+	var price int64
+	for _, entry := range bundle.Items {
+		skin, ok := catalogue[entry.Item.ItemID]
+		// Unknown skins are skipped rather than rendered as blank rows: a
+		// catalogue lagging a patch shows a smaller list with an honest Count,
+		// never "Unknown item — 1800VP" five times.
+		if !ok {
 			continue
 		}
-		price := offer.Cost[valorantPointsTypeID]
-		skin, ok := catalogue[offer.OfferID]
-		// Unknown skins are skipped rather than rendered as blank rows. The
-		// catalogue lags a new act's items by at most a patch cycle; a rowless
-		// shop that day reads as "smaller rotation", which is true-ish, while
-		// "Unknown item — 1800VP" five times reads as breakage.
-		if !ok || price <= 0 {
-			continue
+		effective := entry.BasePrice
+		if entry.DiscountedPrice > 0 {
+			effective = entry.DiscountedPrice
 		}
-		item := shopItem{Name: skin.DisplayName, Price: price, Icon: skin.DisplayIcon}
+		item := shopItem{Name: skin.DisplayName, Price: int64(effective), Icon: skin.DisplayIcon}
 		if tier, ok := tiers[skin.ContentTierUUID]; ok {
 			item.Tier = tier.DisplayName
 			item.Color = tier.BackgroundColor
 		}
 		items = append(items, item)
+		price += int64(effective)
 	}
-	// Priciest first: the rotation is read top-down as "what's worth looking
-	// at", and Ultra editions bury cheap accessories when left in upstream
-	// offer order.
 	sort.SliceStable(items, func(i, j int) bool { return items[i].Price > items[j].Price })
 	return shopReply{
-		ResetUnix: nextShopRotation(time.Now()).Unix(),
-		Items:     items,
-		Count:     len(items),
-		Empty:     len(items) == 0,
+		Bundle:         meta.Data.DisplayName,
+		Subtitle:       meta.Data.SubText,
+		Description:    meta.Data.Description,
+		Icon:           meta.Data.DisplayIcon,
+		DiscountPct:    bundle.TotalDiscountPercent * 100,
+		Price:          price,
+		ExpiresSeconds: int64(bundle.DurationRemainingInSeconds),
+		Items:          items,
+		Count:          len(items),
 	}, nil
-}
-
-// isSkinOffer filters to single-skin direct purchases. Bundle offers carry the
-// same shape with a bundle-level reward set; they are excluded here because
-// their OfferID is not in the weapons-skins catalogue and their pricing model
-// (bundle discount over sum-of-parts) is its own feature.
-func isSkinOffer(offer offerEntry) bool {
-	if len(offer.Rewards) != 1 {
-		return false
-	}
-	return strings.EqualFold(offer.Rewards[0].ItemTypeID, skinItemTypeID)
 }

--- a/app/gossip/internal/providers/valorant/shop_test.go
+++ b/app/gossip/internal/providers/valorant/shop_test.go
@@ -2,9 +2,10 @@
 // Proprietary. No license granted. See LICENSE.md.
 
 // Shop tests are their own file for the same reason fortnite's shop_test.go
-// is: the offer rotation is a deadline-cached join of two upstreams, and its
-// failure modes (boundary math, unknown items, currency filtering) share
-// nothing with the per-player lookups the other tests cover.
+// is: the featured bundle is a three-upstream join (store payload, skin
+// catalogue, rarity tiers) and its failure modes — unknown items, currency
+// filtering, catalogue lag — share nothing with the per-player lookups the
+// other tests cover.
 
 package valorant
 
@@ -16,7 +17,6 @@ import (
 	"strings"
 	"sync"
 	"testing"
-	"time"
 
 	"ItsBagelBot/app/gossip/internal/core"
 	"ItsBagelBot/app/gossip/internal/provider"
@@ -27,41 +27,58 @@ import (
 	"go.uber.org/zap"
 )
 
-func TestNextShopRotation(t *testing.T) {
-	// The shop flips at 20:00 Pacific, pinned here as 03:00 UTC (the PDT
-	// mapping). The table pins both sides of the boundary plus the instant
-	// itself: at exactly 03:00 the new rotation is already live, so the
-	// deadline is tomorrow, not "now" — a zero-length window would make the
-	// flow answer uncached all day.
-	day := func(day int, h, m int) time.Time {
-		return time.Date(2026, time.August, day, h, m, 0, 0, time.UTC)
-	}
-	cases := []struct {
-		now  time.Time
-		want time.Time
-	}{
-		{now: day(20, 2, 59), want: day(20, 3, 0)}, // minutes before the flip
-		{now: day(20, 3, 0), want: day(21, 3, 0)},  // the flip instant: next window
-		{now: day(20, 12, 0), want: day(21, 3, 0)}, // midday
-	}
-	for _, tc := range cases {
-		got := nextShopRotation(tc.now)
-		assert.Equal(t, tc.want, got, "now=%s", tc.now)
-		assert.Equal(t, time.UTC, got.Location())
-	}
-}
+const testBundleAssetID = "d087f4fd-4942-d782-c76c-5e84dc307a66"
 
-func newShopProvider(t *testing.T) (provider.Provider, func() [3]int) {
+const (
+	skinsBody = `{"status":200,"data":[
+	  {"uuid":"skin-a","displayName":"Reaver Vandal","displayIcon":"https://media.test/reaver.png","contentTierUuid":"tier-ultra",
+	   "levels":[{"uuid":"level-a1","displayName":"Reaver Vandal Level 1"},{"uuid":"level-a2","displayName":"Reaver Vandal Level 2"}]},
+	  {"uuid":"skin-b","displayName":"Prime Phantom","displayIcon":"https://media.test/prime.png","contentTierUuid":"tier-deluxe",
+	   "levels":[{"uuid":"level-b1","displayName":"Prime Phantom Level 1"}]}
+	]}`
+	tiersBody = `{"status":200,"data":[
+	  {"uuid":"tier-ultra","displayName":"ULTRA Edition","backgroundColor":"#b8903ce6"},
+	  {"uuid":"tier-deluxe","displayName":"Deluxe Edition","backgroundColor":"#fd7d02e6"}
+	]}`
+	bundleBody = `{"status":200,"data":{
+	  "uuid":"` + testBundleAssetID + `",
+	  "displayName":"Aeris",
+	  "displayNameSubText":"Collection",
+	  "description":"Make every angle yours.",
+	  "displayIcon":"https://media.test/aeris.png"
+	}}`
+)
+
+var featuredBody = fmt.Sprintf(`{"status":200,"data":{"FeaturedBundle":{"Bundle":{
+  "ID":"69f5f8ea-3022-40f0-9d62-aefb7d09dcaf",
+  "DataAssetID":%q,
+  "CurrencyID":"85ad13f7-3d1b-5128-9eb2-7cd8ee0b5741",
+  "TotalDiscountPercent":0.451,
+  "DurationRemainingInSeconds":874496,
+  "Items":[
+    {"Item":{"ItemTypeID":"e7c63390-97b1-4a2a-8a2b-0b5cbbde9697","ItemID":"level-a1","Amount":1},
+     "BasePrice":4350.0,"DiscountPercent":0.45,"DiscountedPrice":2393},
+    {"Item":{"ItemTypeID":"e7c63390-97b1-4a2a-8a2b-0b5cbbde9697","ItemID":"level-b1","Amount":1},
+     "BasePrice":2175.0,"DiscountPercent":0.45,"DiscountedPrice":1196},
+    {"Item":{"ItemTypeID":"dd3bf334-87f3-405d-8fd7-ac8064ae2756","ItemID":"buddy-1","Amount":1},
+     "BasePrice":325.0,"DiscountPercent":0.0,"DiscountedPrice":0},
+    {"Item":{"ItemTypeID":"e7c63390-97b1-4a2a-8a2b-0b5cbbde9697","ItemID":"level-unknown","Amount":1},
+     "BasePrice":900.0,"DiscountPercent":0.0,"DiscountedPrice":0}
+  ]
+}}}}`,
+	testBundleAssetID)
+
+func newShopProvider(t *testing.T) (provider.Provider, func() [4]int) {
 	t.Helper()
 	var mu sync.Mutex
-	skinHits, tierHits, offerHits := 0, 0, 0
+	skinHits, tierHits, bundleHits, storeHits := 0, 0, 0, 0
 
 	henrik := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		mu.Lock()
 		defer mu.Unlock()
-		require.Equal(t, "/valorant/v1/store-offers", r.URL.Path)
-		offerHits++
-		fmt.Fprint(w, offersBody)
+		require.Equal(t, "/valorant/v1/store-featured", r.URL.Path)
+		storeHits++
+		fmt.Fprint(w, featuredBody)
 	}))
 	content := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		mu.Lock()
@@ -73,6 +90,9 @@ func newShopProvider(t *testing.T) (provider.Provider, func() [3]int) {
 		case "/v1/contenttiers":
 			tierHits++
 			fmt.Fprint(w, tiersBody)
+		case "/v1/bundles/" + testBundleAssetID:
+			bundleHits++
+			fmt.Fprint(w, bundleBody)
 		default:
 			t.Errorf("unexpected content path %s", r.URL.Path)
 			w.WriteHeader(http.StatusNotFound)
@@ -88,80 +108,46 @@ func newShopProvider(t *testing.T) (provider.Provider, func() [3]int) {
 		Cache: core.NewCache(newMemStore()),
 		Log:   zap.NewNop(),
 	})
-	hits := func() [3]int {
+	hits := func() [4]int {
 		mu.Lock()
 		defer mu.Unlock()
-		return [3]int{skinHits, tierHits, offerHits}
+		return [4]int{skinHits, tierHits, bundleHits, storeHits}
 	}
 	return p, hits
 }
 
-const (
-	skinsBody = `{"status":200,"data":[
-	  {"uuid":"skin-a","displayName":"Reaver Vandal","displayIcon":"https://media.test/reaver.png","contentTierUuid":"tier-ultra"},
-	  {"uuid":"skin-b","displayName":"Prime Phantom","displayIcon":"https://media.test/prime.png","contentTierUuid":"tier-deluxe"},
-	  {"uuid":"skin-b-lvl1","displayName":"Standard Phantom","displayIcon":"","contentTierUuid":""}
-	]}`
-	tiersBody = `{"status":200,"data":[
-	  {"uuid":"tier-ultra","displayName":"ULTRA Edition","backgroundColor":"#b8903ce6"},
-	  {"uuid":"tier-deluxe","displayName":"Deluxe Edition","backgroundColor":"#fd7d02e6"}
-	]}`
-)
-
-var offersBody = fmt.Sprintf(`{"status":200,"data":{"Offers":[
-  {"OfferID":"skin-a","IsDirectPurchase":true,
-   "Cost":{%q:3550},
-   "Rewards":[{"ItemTypeID":%q,"ItemID":"lvl-a","Quantity":1}]},
-  {"OfferID":"skin-b","IsDirectPurchase":true,
-   "Cost":{%q:1775},
-   "Rewards":[{"ItemTypeID":%q,"ItemID":"lvl-b","Quantity":1}]},
-  {"OfferID":"rad-offer","IsDirectPurchase":true,
-   "Cost":{"8579f7d4-2fbe-4a3d-a814-10e6e9e53c48":100},
-   "Rewards":[{"ItemTypeID":"d06b97d2-4db6-469a-9067-89a957badc47","ItemID":"rad","Quantity":50}]},
-  {"OfferID":"skin-unknown","IsDirectPurchase":true,
-   "Cost":{%q:900},
-   "Rewards":[{"ItemTypeID":%q,"ItemID":"lvl-u","Quantity":1}]},
-  {"OfferID":"no-vp","IsDirectPurchase":true,
-   "Cost":{"8579f7d4-2fbe-4a3d-a814-10e6e9e53c48":400},
-   "Rewards":[{"ItemTypeID":%q,"ItemID":"lvl-nv","Quantity":1}]}
-]}}`,
-	valorantPointsTypeID, skinItemTypeID,
-	valorantPointsTypeID, skinItemTypeID,
-	valorantPointsTypeID, skinItemTypeID,
-	skinItemTypeID)
-
-func TestShopJoinsPricesAgainstTheCatalogue(t *testing.T) {
+func TestShopJoinsTheFeaturedBundleAgainstTheCatalogue(t *testing.T) {
 	p, hits := newShopProvider(t)
 	handle := endpoint(t, p, "shop")
 
 	reply := decodeReply[shopReply](t, handle(context.Background(), gossiprpc.Request{}))
 
 	assert.Empty(t, reply.Error)
-	require.Len(t, reply.Items, 2, "radianite offers, VP-less offers and catalogue misses never render")
+	assert.Equal(t, "Aeris", reply.Bundle)
+	assert.Equal(t, "Collection", reply.Subtitle)
+	assert.Equal(t, "https://media.test/aeris.png", reply.Icon)
+	assert.InDelta(t, 45.1, reply.DiscountPct, 0.001)
+	assert.Equal(t, int64(874496), reply.ExpiresSeconds, "Riot's own countdown rides through")
+	assert.Equal(t, int64(2393+1196), reply.Price, "only the listed skins sum; sprays stay out")
 
+	require.Len(t, reply.Items, 2, "non-skin items and catalogue misses never render")
 	first := reply.Items[0]
-	assert.Equal(t, "Reaver Vandal", first.Name, "priciest first")
-	assert.Equal(t, int64(3550), first.Price)
+	assert.Equal(t, "Reaver Vandal", first.Name, "bundle items key on level uuids, resolved to the parent skin")
+	assert.Equal(t, int64(2393), first.Price, "discounted price wins over base")
 	assert.Equal(t, "ULTRA Edition", first.Tier)
 	assert.Equal(t, "#b8903ce6", first.Color)
-	assert.Equal(t, "https://media.test/reaver.png", first.Icon)
-	assert.Equal(t, int64(1775), reply.Items[1].Price)
+	assert.Equal(t, int64(1196), reply.Items[1].Price)
 
-	resetIn := time.Unix(reply.ResetUnix, 0).Sub(time.Now())
-	assert.Greater(t, resetIn, time.Duration(0))
-	assert.LessOrEqual(t, resetIn, 24*time.Hour, "reset lands inside the coming rotation day")
-	assert.False(t, reply.Empty)
-
-	require.Equal(t, [3]int{1, 1, 1}, hits(), "catalogues cache for a day; one offer fetch serves the window")
+	require.Equal(t, [4]int{1, 1, 1, 1}, hits(), "catalogues cache for a day; one store fetch serves the window")
 
 	again := decodeReply[shopReply](t, handle(context.Background(), gossiprpc.Request{}))
 	assert.Equal(t, reply, again)
-	require.Equal(t, [3]int{1, 1, 1}, hits(), "nothing re-fetches inside the same rotation window")
+	require.Equal(t, [4]int{1, 1, 1, 1}, hits(), "nothing re-fetches inside the six-hour window")
 }
 
-func TestUnknownSkinsAreSkippedButCountedHonestly(t *testing.T) {
+func TestShopUnknownSkinsAreSkippedButCountedHonestly(t *testing.T) {
 	// A catalogue miss mid-patch shrinks Count rather than padding rows with
-	// blank names; Empty stays false because real items did render.
+	// blank names.
 	p, _ := newShopProvider(t)
 	reply := decodeReply[shopReply](t, endpoint(t, p, "shop")(context.Background(), gossiprpc.Request{}))
 	assert.Equal(t, 2, reply.Count)

--- a/app/gossip/internal/providers/valorant/shop_test.go
+++ b/app/gossip/internal/providers/valorant/shop_test.go
@@ -1,0 +1,173 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+// Shop tests are their own file for the same reason fortnite's shop_test.go
+// is: the offer rotation is a deadline-cached join of two upstreams, and its
+// failure modes (boundary math, unknown items, currency filtering) share
+// nothing with the per-player lookups the other tests cover.
+
+package valorant
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"ItsBagelBot/app/gossip/internal/core"
+	"ItsBagelBot/app/gossip/internal/provider"
+	gossiprpc "ItsBagelBot/internal/domain/rpc/gossip"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestNextShopRotation(t *testing.T) {
+	// The shop flips at 20:00 Pacific, pinned here as 03:00 UTC (the PDT
+	// mapping). The table pins both sides of the boundary plus the instant
+	// itself: at exactly 03:00 the new rotation is already live, so the
+	// deadline is tomorrow, not "now" — a zero-length window would make the
+	// flow answer uncached all day.
+	day := func(day int, h, m int) time.Time {
+		return time.Date(2026, time.August, day, h, m, 0, 0, time.UTC)
+	}
+	cases := []struct {
+		now  time.Time
+		want time.Time
+	}{
+		{now: day(20, 2, 59), want: day(20, 3, 0)}, // minutes before the flip
+		{now: day(20, 3, 0), want: day(21, 3, 0)},  // the flip instant: next window
+		{now: day(20, 12, 0), want: day(21, 3, 0)}, // midday
+	}
+	for _, tc := range cases {
+		got := nextShopRotation(tc.now)
+		assert.Equal(t, tc.want, got, "now=%s", tc.now)
+		assert.Equal(t, time.UTC, got.Location())
+	}
+}
+
+func newShopProvider(t *testing.T) (provider.Provider, func() [3]int) {
+	t.Helper()
+	var mu sync.Mutex
+	skinHits, tierHits, offerHits := 0, 0, 0
+
+	henrik := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		require.Equal(t, "/valorant/v1/store-offers", r.URL.Path)
+		offerHits++
+		fmt.Fprint(w, offersBody)
+	}))
+	content := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		switch r.URL.Path {
+		case "/v1/weapons/skins":
+			skinHits++
+			fmt.Fprint(w, skinsBody)
+		case "/v1/contenttiers":
+			tierHits++
+			fmt.Fprint(w, tiersBody)
+		default:
+			t.Errorf("unexpected content path %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(func() { henrik.Close(); content.Close() })
+
+	p := New(Config{
+		BaseURL:        henrik.URL,
+		ContentBaseURL: content.URL,
+		APIKey:         "val-key",
+	}, provider.Deps{
+		Cache: core.NewCache(newMemStore()),
+		Log:   zap.NewNop(),
+	})
+	hits := func() [3]int {
+		mu.Lock()
+		defer mu.Unlock()
+		return [3]int{skinHits, tierHits, offerHits}
+	}
+	return p, hits
+}
+
+const (
+	skinsBody = `{"status":200,"data":[
+	  {"uuid":"skin-a","displayName":"Reaver Vandal","displayIcon":"https://media.test/reaver.png","contentTierUuid":"tier-ultra"},
+	  {"uuid":"skin-b","displayName":"Prime Phantom","displayIcon":"https://media.test/prime.png","contentTierUuid":"tier-deluxe"},
+	  {"uuid":"skin-b-lvl1","displayName":"Standard Phantom","displayIcon":"","contentTierUuid":""}
+	]}`
+	tiersBody = `{"status":200,"data":[
+	  {"uuid":"tier-ultra","displayName":"ULTRA Edition","backgroundColor":"#b8903ce6"},
+	  {"uuid":"tier-deluxe","displayName":"Deluxe Edition","backgroundColor":"#fd7d02e6"}
+	]}`
+)
+
+var offersBody = fmt.Sprintf(`{"status":200,"data":{"Offers":[
+  {"OfferID":"skin-a","IsDirectPurchase":true,
+   "Cost":{%q:3550},
+   "Rewards":[{"ItemTypeID":%q,"ItemID":"lvl-a","Quantity":1}]},
+  {"OfferID":"skin-b","IsDirectPurchase":true,
+   "Cost":{%q:1775},
+   "Rewards":[{"ItemTypeID":%q,"ItemID":"lvl-b","Quantity":1}]},
+  {"OfferID":"rad-offer","IsDirectPurchase":true,
+   "Cost":{"8579f7d4-2fbe-4a3d-a814-10e6e9e53c48":100},
+   "Rewards":[{"ItemTypeID":"d06b97d2-4db6-469a-9067-89a957badc47","ItemID":"rad","Quantity":50}]},
+  {"OfferID":"skin-unknown","IsDirectPurchase":true,
+   "Cost":{%q:900},
+   "Rewards":[{"ItemTypeID":%q,"ItemID":"lvl-u","Quantity":1}]},
+  {"OfferID":"no-vp","IsDirectPurchase":true,
+   "Cost":{"8579f7d4-2fbe-4a3d-a814-10e6e9e53c48":400},
+   "Rewards":[{"ItemTypeID":%q,"ItemID":"lvl-nv","Quantity":1}]}
+]}}`,
+	valorantPointsTypeID, skinItemTypeID,
+	valorantPointsTypeID, skinItemTypeID,
+	valorantPointsTypeID, skinItemTypeID,
+	skinItemTypeID)
+
+func TestShopJoinsPricesAgainstTheCatalogue(t *testing.T) {
+	p, hits := newShopProvider(t)
+	handle := endpoint(t, p, "shop")
+
+	reply := decodeReply[shopReply](t, handle(context.Background(), gossiprpc.Request{}))
+
+	assert.Empty(t, reply.Error)
+	require.Len(t, reply.Items, 2, "radianite offers, VP-less offers and catalogue misses never render")
+
+	first := reply.Items[0]
+	assert.Equal(t, "Reaver Vandal", first.Name, "priciest first")
+	assert.Equal(t, int64(3550), first.Price)
+	assert.Equal(t, "ULTRA Edition", first.Tier)
+	assert.Equal(t, "#b8903ce6", first.Color)
+	assert.Equal(t, "https://media.test/reaver.png", first.Icon)
+	assert.Equal(t, int64(1775), reply.Items[1].Price)
+
+	resetIn := time.Unix(reply.ResetUnix, 0).Sub(time.Now())
+	assert.Greater(t, resetIn, time.Duration(0))
+	assert.LessOrEqual(t, resetIn, 24*time.Hour, "reset lands inside the coming rotation day")
+	assert.False(t, reply.Empty)
+
+	require.Equal(t, [3]int{1, 1, 1}, hits(), "catalogues cache for a day; one offer fetch serves the window")
+
+	again := decodeReply[shopReply](t, handle(context.Background(), gossiprpc.Request{}))
+	assert.Equal(t, reply, again)
+	require.Equal(t, [3]int{1, 1, 1}, hits(), "nothing re-fetches inside the same rotation window")
+}
+
+func TestUnknownSkinsAreSkippedButCountedHonestly(t *testing.T) {
+	// A catalogue miss mid-patch shrinks Count rather than padding rows with
+	// blank names; Empty stays false because real items did render.
+	p, _ := newShopProvider(t)
+	reply := decodeReply[shopReply](t, endpoint(t, p, "shop")(context.Background(), gossiprpc.Request{}))
+	assert.Equal(t, 2, reply.Count)
+	require.Len(t, reply.Items, reply.Count)
+	for _, item := range reply.Items {
+		assert.NotEmpty(t, strings.TrimSpace(item.Name))
+		assert.Positive(t, item.Price)
+	}
+}

--- a/app/gossip/internal/providers/valorant/valorant.go
+++ b/app/gossip/internal/providers/valorant/valorant.go
@@ -4,13 +4,14 @@
 // Package valorant exposes Riot's Valorant through the community HenrikDev API
 // (api.henrikdev.xyz), joined where it matters with Riot's public content CDN
 // (valorant-api.com). It answers rank/MMR, recent competitive matches,
-// regional leaderboards, account lookups and the daily offer rotation.
+// regional leaderboards, account lookups and the current featured bundle.
 //
-// Two deliberate gaps: the personal store and the night market have no
-// endpoint here. Both are per-account views Riot only exposes behind a user's
-// own credentials (cookies or RSO), and HenrikDev explicitly bans products
-// that collect those credentials — so this provider serves only the global
-// offer rotation, which is key-authed and safe to share.
+// Three deliberate gaps: the personal store and the night market have no
+// endpoint here because both are per-account views Riot only exposes behind a
+// user's own credentials, and HenrikDev explicitly bans products that collect
+// those. The daily skin rotation is gone for good — Riot removed the global
+// offers feed this provider would have needed (see shop.go) — so the closest
+// surviving global surface, the featured bundle, is what ships.
 //
 // The upstream meters per API key over a rolling minute and its v4 match
 // endpoints additionally bill background Riot fetches against the caller, so
@@ -63,6 +64,15 @@ const (
 	// absorbs the boundary.
 	boardTTL = 30 * time.Minute
 
+	// The featured bundle turns over on Riot's staggered store schedule with
+	// no published UTC boundary, and its payload carries an exact remaining-
+	// seconds countdown that renders fresher than any window we could derive.
+	// Six hours keeps a served copy within a rounding error of that schedule
+	// at ~4 upstream reads per day. The old offers feed had a hard 03:00 UTC
+	// boundary worth pinning CachedUntil to; Riot removed it entirely (see
+	// shop.go), so the deadline machinery has nothing real to pin to here.
+	bundleTTL = 6 * time.Hour
+
 	negativeTTL = 5 * time.Minute
 
 	httpTimeout    = 10 * time.Second
@@ -80,7 +90,7 @@ const (
 
 // Config carries both upstream hosts and their per-minute budgets. APIKey must
 // be non-empty; providers.All skips this provider otherwise. The content CDN
-// needs no credential of its own — it exists to turn the offer rotation's item
+// needs no credential of its own — it exists to turn the store payload's item
 // UUIDs into names, icons and rarity colours.
 type Config struct {
 	BaseURL          string
@@ -108,8 +118,8 @@ type api struct {
 }
 
 // New builds the Valorant provider: four keyed byte-flow views over HenrikDev
-// plus the daily offer rotation, which joins HenrikDev's prices against the
-// content CDN's catalogue under one deadline window.
+// plus the featured-bundle viewer, which joins HenrikDev's store payload
+// against the content CDN's catalogue.
 func New(cfg Config, d provider.Deps) provider.Provider {
 	p := newAPI(cfg, d)
 	b := provider.NewProvider(providerName, d)
@@ -147,8 +157,8 @@ func New(cfg Config, d provider.Deps) provider.Provider {
 		Fetch(p.boardFetch)
 
 	b.Endpoint("shop").Timeout(handlerTimeout).
-		CachedUntil(nextShopRotation, negativeTTL).
-		ID(provider.StaticID("offers")).
+		Cached(bundleTTL, negativeTTL).
+		ID(provider.StaticID("featured")).
 		Reply(func(_, msg string) any { return shopReply{Error: msg} }).
 		Budget(p.shopBudget).
 		Fallback("shop lookup failed").
@@ -400,15 +410,17 @@ func scoped(req gossiprpc.Request) (id riotIDValue, region, platform string) {
 
 // --- rank -------------------------------------------------------------------
 
-// mmrWire covers HenrikDev MMR v3. Peak arrives as one entry per season with
-// that season's ranking schema; only tier id/name and RR matter here.
+// mmrWire covers HenrikDev MMR v3. Peak arrives here as ONE object — the
+// account's highest recorded seasonal standing — though the published OpenAPI
+// spec documents an array; the live payload wins (verified against a Radiant
+// account, where an array-typed decode failed and cost every rank lookup).
 type mmrWire struct {
 	Data mmrData `json:"data"`
 }
 
 type mmrData struct {
 	Current currentMMR `json:"current"`
-	Peak    []peakMMR  `json:"peak"`
+	Peak    peakMMR    `json:"peak"`
 }
 
 type currentMMR struct {
@@ -481,21 +493,14 @@ func (p *api) rankFetch(ctx context.Context, req gossiprpc.Request, id provider.
 	return reply, nil
 }
 
-// peakTier picks the highest seasonal peak. Tier ids are global across acts
-// (3 = Iron 1 up to 27 = Radiant), so max-by-id is max-by-rank; RR breaks ties
-// within a tier because a peak at 150 RR outranks a peak at 10.
-func peakTier(peaks []peakMMR) string {
-	best := -1
-	rr := -1
-	name := ""
-	for _, peak := range peaks {
-		if peak.Tier.ID > best || (peak.Tier.ID == best && peak.RR > rr) {
-			best = peak.Tier.ID
-			rr = peak.RR
-			name = peak.Tier.Name
-		}
+// peakTier reads the account's all-time peak standing. Tier id 0 (unplaced in
+// any recorded season) renders as empty rather than the upstream's placeholder
+// name, so templates can omit the line entirely.
+func peakTier(peak peakMMR) string {
+	if peak.Tier.ID == 0 {
+		return ""
 	}
-	return name
+	return peak.Tier.Name
 }
 
 // --- matches ----------------------------------------------------------------

--- a/app/gossip/internal/providers/valorant/valorant.go
+++ b/app/gossip/internal/providers/valorant/valorant.go
@@ -1,0 +1,807 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+// Package valorant exposes Riot's Valorant through the community HenrikDev API
+// (api.henrikdev.xyz), joined where it matters with Riot's public content CDN
+// (valorant-api.com). It answers rank/MMR, recent competitive matches,
+// regional leaderboards, account lookups and the daily offer rotation.
+//
+// Two deliberate gaps: the personal store and the night market have no
+// endpoint here. Both are per-account views Riot only exposes behind a user's
+// own credentials (cookies or RSO), and HenrikDev explicitly bans products
+// that collect those credentials — so this provider serves only the global
+// offer rotation, which is key-authed and safe to share.
+//
+// The upstream meters per API key over a rolling minute and its v4 match
+// endpoints additionally bill background Riot fetches against the caller, so
+// everything here reads through the shared cache aggressively: one warm entry
+// answers every caller in the fleet for the TTL.
+package valorant
+
+import (
+	"context"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"ItsBagelBot/app/gossip/internal/core"
+	"ItsBagelBot/app/gossip/internal/provider"
+	gossiprpc "ItsBagelBot/internal/domain/rpc/gossip"
+
+	"ItsBagelBot/pkg/ratelimit"
+)
+
+const (
+	defaultBaseURL        = "https://api.henrikdev.xyz"
+	defaultContentBaseURL = "https://valorant-api.com"
+
+	// Rank and matches change per game played; two minutes keeps an RR delta
+	// honest across a session without letting a squad of viewers fan out into
+	// upstream calls (they collapse onto one flight instead). Clash Royale's
+	// five minutes fits a profile that moves daily; a competitive ladder that
+	// moves per match does not.
+	rankTTL    = 2 * time.Minute
+	matchesTTL = 2 * time.Minute
+
+	// The account reply carries slow-drifting cosmetics (level, card, title);
+	// an hour of staleness is invisible next to how often any of it changes.
+	accountTTL = time.Hour
+
+	// The resolve leg backs auto-region detection. PUUID and shard are
+	// immutable for an account's life, so this is cached a full day — the
+	// point is that after one caller pays for detection, nobody in the fleet
+	// pays again for 24 hours. Renames do go stale inside that window, but
+	// nothing rendered from this entry comes out of it (replies echo the
+	// caller's input); only the region rides forward.
+	resolveTTL = 24 * time.Hour
+
+	// HenrikDev rebuilds leaderboards roughly hourly (the payload says so via
+	// last_update/next_update); thirty minutes is half that cadence, so a
+	// served board is at worst one rebuild behind and stale-while-revalidate
+	// absorbs the boundary.
+	boardTTL = 30 * time.Minute
+
+	negativeTTL = 5 * time.Minute
+
+	httpTimeout    = 10 * time.Second
+	handlerTimeout = 15 * time.Second
+
+	// RateLimit is configured as requests per minute.
+	rateWindowSeconds = 60.0
+
+	// How many recent competitive matches a lookup reports and how deep the
+	// leaderboard slice goes. Both are chat-render sized: five results fill a
+	// message without truncation, ten names fit a leaderboard post.
+	matchCount   = 5
+	boardEntries = 10
+)
+
+// Config carries both upstream hosts and their per-minute budgets. APIKey must
+// be non-empty; providers.All skips this provider otherwise. The content CDN
+// needs no credential of its own — it exists to turn the offer rotation's item
+// UUIDs into names, icons and rarity colours.
+type Config struct {
+	BaseURL          string
+	ContentBaseURL   string
+	APIKey           string
+	RateLimit        float64
+	ContentRateLimit float64
+}
+
+// providerName is the subject token this provider answers under.
+const providerName = "valorant"
+
+// api holds the provider's runtime pieces; the declared endpoints capture it.
+type api struct {
+	// http dials HenrikDev; content dials the keyless Riot content CDN.
+	http    *core.HTTPClient
+	content *core.HTTPClient
+	cache   *core.Cache
+	limiter *ratelimit.Limiter
+	// buckets spends the HenrikDev key allowance; contentBuckets spends the
+	// CDN's. They are separate budgets because they meter separately: the key
+	// is per-account, the CDN meters per source IP fleet-wide.
+	buckets        core.Buckets
+	contentBuckets core.Buckets
+}
+
+// New builds the Valorant provider: four keyed byte-flow views over HenrikDev
+// plus the daily offer rotation, which joins HenrikDev's prices against the
+// content CDN's catalogue under one deadline window.
+func New(cfg Config, d provider.Deps) provider.Provider {
+	p := newAPI(cfg, d)
+	b := provider.NewProvider(providerName, d)
+
+	b.Endpoint("rank").Timeout(handlerTimeout).
+		Cached(rankTTL, negativeTTL).
+		ID(riotID).
+		Reply(func(id, msg string) any { return rankReply{Player: id, Error: msg} }).
+		Budget(p.budget).
+		Fallback("rank lookup failed").
+		Fetch(p.rankFetch)
+
+	b.Endpoint("matches").Timeout(handlerTimeout).
+		Cached(matchesTTL, negativeTTL).
+		ID(riotID).
+		Reply(func(id, msg string) any { return matchesReply{Player: id, Error: msg} }).
+		Budget(p.budget).
+		Fallback("match history lookup failed").
+		Fetch(p.matchesFetch)
+
+	b.Endpoint("account").Timeout(handlerTimeout).
+		Cached(accountTTL, negativeTTL).
+		ID(riotID).
+		Reply(func(id, msg string) any { return accountReply{Player: id, Error: msg} }).
+		Budget(p.budget).
+		Fallback("account lookup failed").
+		Fetch(p.accountFetch)
+
+	b.Endpoint("leaderboard").Timeout(handlerTimeout).
+		Cached(boardTTL, negativeTTL).
+		ID(boardID).
+		Reply(func(id, msg string) any { return leaderboardReply{Player: id, Error: msg} }).
+		Budget(p.budget).
+		Fallback("leaderboard lookup failed").
+		Fetch(p.boardFetch)
+
+	b.Endpoint("shop").Timeout(handlerTimeout).
+		CachedUntil(nextShopRotation, negativeTTL).
+		ID(provider.StaticID("offers")).
+		Reply(func(_, msg string) any { return shopReply{Error: msg} }).
+		Budget(p.shopBudget).
+		Fallback("shop lookup failed").
+		Fetch(p.shopFetch)
+
+	return b.Build()
+}
+
+func newAPI(cfg Config, d provider.Deps) *api {
+	base := strings.TrimSuffix(cfg.BaseURL, "/")
+	if base == "" {
+		base = defaultBaseURL
+	}
+	content := strings.TrimSuffix(cfg.ContentBaseURL, "/")
+	if content == "" {
+		content = defaultContentBaseURL
+	}
+	// HenrikDev's enhanced tier allows 90 requests/min for public bots; the
+	// default stays under it so a burst never trips the upstream's own limiter
+	// (a 429 there costs more than a local deny — it poisons the cache fill).
+	if cfg.RateLimit <= 0 {
+		cfg.RateLimit = 80
+	}
+	// valorant-api.com publishes no hard limit; 60/min is conservative for a
+	// payload this size, and the skins catalogue caches for a day anyway.
+	if cfg.ContentRateLimit <= 0 {
+		cfg.ContentRateLimit = 60
+	}
+	return &api{
+		// HenrikDev takes the raw key in Authorization — no "Bearer" prefix.
+		// Its auth scheme is a bare token (sending Bearer yields 401), unlike
+		// the Supercell proxy clashroyale uses.
+		http: core.NewHTTPClient(base, map[string]string{
+			"Authorization": cfg.APIKey,
+		}, httpTimeout),
+		content:        core.NewHTTPClient(content, nil, httpTimeout),
+		cache:          d.Cache,
+		limiter:        d.Limiter,
+		buckets:        core.NewBuckets("ratelimit:gossip:valorant", cfg.RateLimit, rateWindowSeconds),
+		contentBuckets: core.NewBuckets("ratelimit:gossip:valorant:content", cfg.ContentRateLimit, rateWindowSeconds),
+	}
+}
+
+// budget spends one request's share of the HenrikDev allowance in that
+// request's own lane. Every endpoint shares one allowance because every call
+// bills the same key, so it is declared on each endpoint rather than written
+// inside any fetch: a check there runs once per singleflight flight, is
+// charged to whichever caller won it, and hands that verdict to everyone
+// joined — which let a drained standard bucket deny premium callers the
+// reserve they are entitled to.
+func (p *api) budget(ctx context.Context, req gossiprpc.Request) error {
+	return p.buckets.Enforce(ctx, p.limiter, req.IsPremium)
+}
+
+// shopBudget debits both upstreams the shop leg touches, in call order:
+// content first (the likely-cached catalogue read), then the priced offers.
+func (p *api) shopBudget(ctx context.Context, req gossiprpc.Request) error {
+	if err := p.contentBuckets.Enforce(ctx, p.limiter, req.IsPremium); err != nil {
+		return err
+	}
+	return p.buckets.Enforce(ctx, p.limiter, req.IsPremium)
+}
+
+// riotIDValue is the canonical Riot ID split at "#". Tags are case-insensitive
+// per Riot but conventionally uppercase; the display form preserves the name
+// exactly as typed while the cache key folds both halves lowercased, so
+// "Frosty#EUW1" and "frosty#euw1" share one entry.
+type riotIDValue struct {
+	name string
+	tag  string
+}
+
+func parseRiotID(account string) (riotIDValue, string) {
+	raw := strings.TrimSpace(account)
+	name, tag, ok := strings.Cut(raw, "#")
+	if !ok || strings.TrimSpace(name) == "" || strings.TrimSpace(tag) == "" {
+		return riotIDValue{}, "invalid riot id (want name#tag)"
+	}
+	// Bounds mirror Riot's own limits (16-char name, 3-5 char tag) with slack;
+	// anything past these cannot exist, so it is rejected before spending a
+	// cache slot or an upstream call on it.
+	if len(name) > 32 || len(tag) > 8 {
+		return riotIDValue{}, "invalid riot id (want name#tag)"
+	}
+	return riotIDValue{name: name, tag: strings.ToUpper(tag)}, ""
+}
+
+func (r riotIDValue) String() string { return r.name + "#" + r.tag }
+
+func (r riotIDValue) cacheKey() string {
+	return strings.ToLower(r.name) + "#" + strings.ToLower(r.tag)
+}
+
+// affinities are the Valorant shards HenrikDev serves. There is no "es": Spain
+// players belong to eu, despite what old bot folklore says.
+var affinities = map[string]struct{}{
+	"na": {}, "eu": {}, "ap": {}, "kr": {}, "br": {}, "latam": {},
+}
+
+// normalizeRegion maps the caller's region to its canonical lowercase form.
+// Empty means "detect it from the account", returned as the sentinel "auto".
+func normalizeRegion(region string) (string, string) {
+	r := strings.ToLower(strings.TrimSpace(region))
+	if r == "" {
+		return "auto", ""
+	}
+	if _, ok := affinities[r]; ok {
+		return r, ""
+	}
+	return "", "unknown region (want na, eu, ap, kr, br or latam)"
+}
+
+// normalizePlatform maps the ladder split; pc is the default because it is
+// where the overwhelmingly larger player base sits.
+func normalizePlatform(platform string) (string, string) {
+	switch p := strings.ToLower(strings.TrimSpace(platform)); p {
+	case "":
+		return "pc", ""
+	case "pc", "console":
+		return p, ""
+	default:
+		return "", "unknown platform (want pc or console)"
+	}
+}
+
+// riotID validates the account plus its scoping inputs and keys the cache on
+// all three: the same Riot ID answers differently per region (and per
+// platform), so the key must fold them even when the caller left them unset —
+// folding the normalized defaults rather than raw input means "na" and "NA"
+// share one entry, and unset-vs-"pc" do too.
+func riotID(req gossiprpc.Request) (provider.ID, string) {
+	id, msg := parseRiotID(req.Account)
+	if msg != "" {
+		return provider.ID{Display: strings.TrimSpace(req.Account)}, msg
+	}
+	region, msg := normalizeRegion(req.Region)
+	if msg != "" {
+		return provider.ID{Display: id.String()}, msg
+	}
+	platform, msg := normalizePlatform(req.Platform)
+	if msg != "" {
+		return provider.ID{Display: id.String()}, msg
+	}
+	return provider.ID{
+		Display: id.String(),
+		Key:     id.cacheKey() + ":" + region + ":" + platform,
+	}, ""
+}
+
+// boardID scopes a leaderboard request. Unlike player endpoints, the account
+// here is optional — a bare top-10 ask has no Riot ID — but then the region
+// must be explicit, since there is nothing to detect it from.
+func boardID(req gossiprpc.Request) (provider.ID, string) {
+	display := strings.TrimSpace(req.Account)
+	region, msg := normalizeRegion(req.Region)
+	if msg != "" {
+		return provider.ID{}, msg
+	}
+	platform, msg := normalizePlatform(req.Platform)
+	if msg != "" {
+		return provider.ID{}, msg
+	}
+	if display == "" && region == "auto" {
+		return provider.ID{}, "missing region (no account to detect it from)"
+	}
+	return provider.ID{Display: display, Key: strings.ToLower(display) + ":" + region + ":" + platform}, ""
+}
+
+// accountInfo is the v2 account subset every consumer needs. Region comes back
+// normalized from the upstream already ("na", not "NORTH AMERICA"); it is
+// lowercased again defensively because the whole auto-detect path keys off it.
+//
+// This one struct feeds both the public account endpoint and the identity
+// resolve behind auto-region, deliberately: they hit the same upstream path,
+// and keeping one wire type means a shape change upstream breaks loudly in one
+// place instead of silently diverging between two.
+type accountInfo struct {
+	Puuid        string `json:"puuid"`
+	Region       string `json:"region"`
+	Name         string `json:"name"`
+	Tag          string `json:"tag"`
+	AccountLevel int    `json:"account_level"`
+	Card         string `json:"card"`
+	Title        string `json:"title"`
+}
+
+// accountWire is HenrikDev's response envelope: every reply is {"status",
+// "data"}, unlike RoyaleAPI's bare objects.
+type accountWire struct {
+	Data accountInfo `json:"data"`
+}
+
+// effectiveRegion returns the affinity a lookup must run against: the
+// caller's explicit one, or the account's own shard resolved through the
+// shared day-long identity entry. Auto costs one extra upstream read on a cold
+// cache and none afterwards, which is what makes region-less commands viable
+// at all.
+func (p *api) effectiveRegion(ctx context.Context, id riotIDValue, region string) (string, error) {
+	if region != "auto" {
+		return region, nil
+	}
+	info, err := p.resolveAccount(ctx, id)
+	if err != nil {
+		return "", err
+	}
+	shard := strings.ToLower(strings.TrimSpace(info.Region))
+	if shard == "" {
+		// Observed for brand-new accounts before their first game; without
+		// this guard the lookup would proceed as "/mmr//" and fail opaquely.
+		return "", &core.UpstreamError{Status: 404, Message: "could not detect region"}
+	}
+	return shard, nil
+}
+
+// resolveAccount reads the identity entry backing auto-region. Only
+// successes cache positively, and only genuine misses reach the upstream: the
+// day-long TTL is the whole economy of the feature.
+func (p *api) resolveAccount(ctx context.Context, id riotIDValue) (accountInfo, error) {
+	key := core.Key(providerName, "resolve", id.cacheKey())
+	return core.Cached(ctx, p.cache, key, resolveTTL, negativeTTL, nil, func(ctx context.Context) (accountInfo, error) {
+		var wire accountWire
+		path := "/valorant/v2/account/" + url.PathEscape(id.name) + "/" + url.PathEscape(id.tag)
+		if err := p.http.GetJSON(ctx, path, nil, &wire); err != nil {
+			return accountInfo{}, err
+		}
+		info := wire.Data
+		// A 200 with no puuid happens when Riot's index has not settled on a
+		// freshly renamed account; minting the 404 here lets negative caching
+		// absorb the retry storm that would otherwise follow.
+		if strings.TrimSpace(info.Puuid) == "" {
+			return accountInfo{}, &core.UpstreamError{Status: 404, Message: "player not found"}
+		}
+		return info, nil
+	})
+}
+
+// scoped unpacks what riotID validated. The ID funcs may not thread their
+// parsed values through provider.ID beyond Display/Key, so fetches re-run the
+// normalizers on the request — cheap pure functions whose verdicts are already
+// known good by the time a fetch runs.
+func scoped(req gossiprpc.Request) (id riotIDValue, region, platform string) {
+	id, _ = parseRiotID(req.Account)
+	region, _ = normalizeRegion(req.Region)
+	platform, _ = normalizePlatform(req.Platform)
+	return id, region, platform
+}
+
+// --- rank -------------------------------------------------------------------
+
+// mmrWire covers HenrikDev MMR v3. Peak arrives as one entry per season with
+// that season's ranking schema; only tier id/name and RR matter here.
+type mmrWire struct {
+	Data mmrData `json:"data"`
+}
+
+type mmrData struct {
+	Current currentMMR `json:"current"`
+	Peak    []peakMMR  `json:"peak"`
+}
+
+type currentMMR struct {
+	Elo        int       `json:"elo"`
+	RR         int       `json:"rr"`
+	LastChange int       `json:"last_change"`
+	Tier       tierCombo `json:"tier"`
+	Placement  placement `json:"leaderboard_placement"`
+}
+
+type tierCombo struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+type placement struct {
+	Rank int `json:"rank"`
+}
+
+type peakMMR struct {
+	Tier tierCombo `json:"tier"`
+	RR   int       `json:"rr"`
+}
+
+// rankReply is the answer to valorant.rank: the standing a viewer asks about
+// first, and the reason this provider exists. LastChange is the RR delta of
+// the most recent competitive game (negative on a loss) — the single number
+// players screenshot most. Placement is the current act leaderboard position,
+// 0 when unplaced. Tier ids are 0 for unranked accounts, which drives
+// Unranked; Elo still arrives for them but is meaningless, so it is zeroed
+// alongside to keep templates from printing "-23 elo, Unranked".
+type rankReply struct {
+	Player     string `json:"player"`
+	Region     string `json:"region"`
+	Tier       string `json:"tier"`
+	Elo        int    `json:"elo"`
+	RR         int    `json:"rr"`
+	LastChange int    `json:"last_change"`
+	PeakTier   string `json:"peak_tier"`
+	Placement  int    `json:"placement"`
+	Unranked   bool   `json:"unranked"`
+	Error      string `json:"error,omitempty"`
+}
+
+func (p *api) rankFetch(ctx context.Context, req gossiprpc.Request, id provider.ID) (any, error) {
+	rid, region, platform := scoped(req)
+	eff, err := p.effectiveRegion(ctx, rid, region)
+	if err != nil {
+		return nil, err
+	}
+	var wire mmrWire
+	path := "/valorant/v3/mmr/" + eff + "/" + platform + "/" + url.PathEscape(rid.name) + "/" + url.PathEscape(rid.tag)
+	if err := p.http.GetJSON(ctx, path, nil, &wire); err != nil {
+		return nil, err
+	}
+	mmr := wire.Data
+	reply := rankReply{
+		Player:     rid.String(),
+		Region:     eff,
+		Tier:       mmr.Current.Tier.Name,
+		RR:         mmr.Current.RR,
+		LastChange: mmr.Current.LastChange,
+		PeakTier:   peakTier(mmr.Peak),
+		Placement:  mmr.Current.Placement.Rank,
+		Unranked:   mmr.Current.Tier.ID == 0,
+	}
+	if !reply.Unranked {
+		reply.Elo = mmr.Current.Elo
+	}
+	return reply, nil
+}
+
+// peakTier picks the highest seasonal peak. Tier ids are global across acts
+// (3 = Iron 1 up to 27 = Radiant), so max-by-id is max-by-rank; RR breaks ties
+// within a tier because a peak at 150 RR outranks a peak at 10.
+func peakTier(peaks []peakMMR) string {
+	best := -1
+	rr := -1
+	name := ""
+	for _, peak := range peaks {
+		if peak.Tier.ID > best || (peak.Tier.ID == best && peak.RR > rr) {
+			best = peak.Tier.ID
+			rr = peak.RR
+			name = peak.Tier.Name
+		}
+	}
+	return name
+}
+
+// --- matches ----------------------------------------------------------------
+
+// matchesWire covers Matches v4 list entries. The full payload includes rounds
+// and kills arrays used by deep-analysis tools; neither survives decoding
+// here because chat wants summaries, and dropping them keeps a five-match
+// decode allocation small.
+type matchesWire struct {
+	Data []matchV4 `json:"data"`
+}
+
+type matchV4 struct {
+	Metadata matchMeta     `json:"metadata"`
+	Players  []matchPlayer `json:"players"`
+	Teams    []matchTeam   `json:"teams"`
+}
+
+type matchMeta struct {
+	Map         mapCombo  `json:"map"`
+	StartedAt   time.Time `json:"started_at"`
+	IsCompleted bool      `json:"is_completed"`
+}
+
+type mapCombo struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type matchPlayer struct {
+	Puuid      string     `json:"puuid"`
+	Name       string     `json:"name"`
+	Tag        string     `json:"tag"`
+	TeamID     string     `json:"team_id"`
+	Agent      agentCombo `json:"agent"`
+	Statistics matchStats `json:"stats"`
+}
+
+type agentCombo struct {
+	Name string `json:"name"`
+}
+
+type matchStats struct {
+	Kills   int `json:"kills"`
+	Deaths  int `json:"deaths"`
+	Assists int `json:"assists"`
+	Score   int `json:"score"`
+}
+
+type matchTeam struct {
+	TeamID string     `json:"team_id"`
+	Won    bool       `json:"won"`
+	Rounds teamRounds `json:"rounds"`
+}
+
+type teamRounds struct {
+	Won  int `json:"won"`
+	Lost int `json:"lost"`
+}
+
+// matchEntry summarizes one game for a chat line. ACS is computed here rather
+// than echoed because the upstream ships a per-round score total, not a rate:
+// score divided by the player's team rounds, rounded to a whole number the way
+// trackers render it.
+type matchEntry struct {
+	Map        string  `json:"map"`
+	Agent      string  `json:"agent"`
+	Result     string  `json:"result"` // "win" | "loss" | "draw"
+	Kills      int     `json:"kills"`
+	Deaths     int     `json:"deaths"`
+	Assists    int     `json:"assists"`
+	ACS        float64 `json:"acs"`
+	AgoSeconds int64   `json:"ago_seconds"`
+}
+
+// matchesReply is the answer to valorant.matches: the last few completed
+// competitive games, newest first. Incomplete games (someone dodged in lobby)
+// are skipped rather than shown as ghost rows. Empty is true when the account
+// simply has no ranked games in the upstream's retained window — a normal
+// answer, not an error.
+type matchesReply struct {
+	Player  string       `json:"player"`
+	Region  string       `json:"region"`
+	Matches []matchEntry `json:"matches"`
+	Empty   bool         `json:"empty"`
+	Error   string       `json:"error,omitempty"`
+}
+
+func (p *api) matchesFetch(ctx context.Context, req gossiprpc.Request, id provider.ID) (any, error) {
+	rid, region, platform := scoped(req)
+	eff, err := p.effectiveRegion(ctx, rid, region)
+	if err != nil {
+		return nil, err
+	}
+	var history matchesWire
+	path := "/valorant/v4/matches/" + eff + "/" + platform + "/" + url.PathEscape(rid.name) + "/" + url.PathEscape(rid.tag)
+	query := url.Values{"mode": {"competitive"}, "size": {strconv.Itoa(matchCount)}}
+	if err := p.http.GetJSON(ctx, path, query, &history); err != nil {
+		return nil, err
+	}
+	now := time.Now()
+	entries := make([]matchEntry, 0, len(history.Data))
+	for _, match := range history.Data {
+		if !match.Metadata.IsCompleted {
+			continue
+		}
+		player, ok := findSelf(match.Players, rid)
+		if !ok {
+			// The queried player must appear in their own match list; a miss
+			// means Riot's name index lags a rename, and rendering a rowless
+			// shell would lie about the game existing.
+			continue
+		}
+		entry := matchEntry{
+			Map:     match.Metadata.Map.Name,
+			Agent:   player.Agent.Name,
+			Result:  matchResult(match.Teams, player.TeamID),
+			Kills:   player.Statistics.Kills,
+			Deaths:  player.Statistics.Deaths,
+			Assists: player.Statistics.Assists,
+		}
+		if rounds := teamRoundsPlayed(match.Teams, player.TeamID); rounds > 0 {
+			entry.ACS = float64(player.Statistics.Score) / float64(rounds)
+		}
+		entry.ACS = float64(int(entry.ACS*10+0.5)) / 10
+		entry.AgoSeconds = int64(now.Sub(match.Metadata.StartedAt).Seconds())
+		if entry.AgoSeconds < 0 {
+			entry.AgoSeconds = 0
+		}
+		entries = append(entries, entry)
+	}
+	return matchesReply{
+		Player:  rid.String(),
+		Region:  eff,
+		Matches: entries,
+		Empty:   len(entries) == 0,
+	}, nil
+}
+
+// findSelf locates the queried player among the ten in a match. Name+tag is
+// the join key because fetching by puuid would force the resolve leg on every
+// matches call; Riot IDs are unique enough for the player's own history.
+func findSelf(players []matchPlayer, rid riotIDValue) (matchPlayer, bool) {
+	for _, player := range players {
+		if strings.EqualFold(player.Name, rid.name) && strings.EqualFold(player.Tag, rid.tag) {
+			return player, true
+		}
+	}
+	return matchPlayer{}, false
+}
+
+func teamRoundsPlayed(teams []matchTeam, teamID string) int {
+	for _, team := range teams {
+		if team.TeamID == teamID {
+			return team.Rounds.Won + team.Rounds.Lost
+		}
+	}
+	return 0
+}
+
+// matchResult classifies from the won flags alone: a side that won is a win,
+// a loss is any other side having won, and neither flag set (forfeits resolved
+// as draws, rare) falls through to draw rather than guessing.
+func matchResult(teams []matchTeam, teamID string) string {
+	mine, theirs := false, false
+	for _, team := range teams {
+		if !team.Won {
+			continue
+		}
+		if team.TeamID == teamID {
+			mine = true
+		} else {
+			theirs = true
+		}
+	}
+	switch {
+	case mine:
+		return "win"
+	case theirs:
+		return "loss"
+	default:
+		return "draw"
+	}
+}
+
+// --- account ----------------------------------------------------------------
+
+// accountReply is the answer to valorant.account: who a Riot ID resolves to,
+// plus the level/card/title flex. It is also the cheapest correctness probe —
+// a caller unsure of spelling or region gets one definitive answer here.
+type accountReply struct {
+	Player       string `json:"player"`
+	Puuid        string `json:"puuuid,omitempty"`
+	Region       string `json:"region,omitempty"`
+	AccountLevel int    `json:"account_level,omitempty"`
+	Card         string `json:"card,omitempty"`
+	Title        string `json:"title,omitempty"`
+	Error        string `json:"error,omitempty"`
+}
+
+func (p *api) accountFetch(ctx context.Context, req gossiprpc.Request, id provider.ID) (any, error) {
+	rid, _, _ := scoped(req)
+	var wire accountWire
+	path := "/valorant/v2/account/" + url.PathEscape(rid.name) + "/" + url.PathEscape(rid.tag)
+	if err := p.http.GetJSON(ctx, path, nil, &wire); err != nil {
+		return nil, err
+	}
+	info := wire.Data
+	// Same 200-but-empty mint as resolveAccount: renames mid-propagation come
+	// back complete-looking but hollow.
+	if strings.TrimSpace(info.Puuid) == "" {
+		return nil, &core.UpstreamError{Status: 404, Message: "player not found"}
+	}
+	return accountReply{
+		Player:       rid.String(),
+		Puuid:        info.Puuid,
+		Region:       strings.ToLower(info.Region),
+		AccountLevel: info.AccountLevel,
+		Card:         info.Card,
+		Title:        info.Title,
+	}, nil
+}
+
+// --- leaderboard ------------------------------------------------------------
+
+// boardWire covers Leaderboard v3, the platform-aware variant. V2 predates
+// console splits; asking it for a console board silently returns PC data,
+// which is exactly the kind of quiet wrongness the extra version segment buys
+// out of.
+type boardWire struct {
+	Data struct {
+		Players []boardPlayer `json:"players"`
+	} `json:"data"`
+}
+
+type boardPlayer struct {
+	LeaderboardRank int    `json:"leaderboard_rank"`
+	Name            string `json:"name"`
+	Tag             string `json:"tag"`
+	Wins            int    `json:"wins"`
+	RR              int    `json:"rr"`
+	Tier            int    `json:"tier"`
+}
+
+// lbEntry is one ranked row. Tier stays the numeric competitive tier id rather
+// than a spelled-out name: the module rendering this owns a static id→icon
+// table already (every Valorant tracker does), and threading names through
+// would mean a second content-CDN join per board for no gain.
+type lbEntry struct {
+	Rank   int    `json:"rank"`
+	Player string `json:"player"`
+	Tier   int    `json:"tier"`
+	RR     int    `json:"rr"`
+	Wins   int    `json:"wins"`
+}
+
+// leaderboardReply is the answer to valorant.leaderboard: the top slice of one
+// regional board. Board echoes "<region>/<platform>" so a template can say
+// which board it printed; Player echoes the account scoping it when one was
+// given ("" for a bare top-N ask). Anonymized rows arrive with placeholder
+// names from the upstream itself and are passed through as-is — hiding them
+// would shift everyone's rank and lie about the board's composition.
+type leaderboardReply struct {
+	Player  string    `json:"player,omitempty"`
+	Board   string    `json:"board,omitempty"`
+	Entries []lbEntry `json:"entries"`
+	Empty   bool      `json:"empty"`
+	Error   string    `json:"error,omitempty"`
+}
+
+func (p *api) boardFetch(ctx context.Context, req gossiprpc.Request, id provider.ID) (any, error) {
+	_, region, platform := scoped(req)
+	eff := region
+	if region == "auto" {
+		// boardID guarantees an account exists whenever region is auto.
+		rid, _, _ := scoped(req)
+		resolved, err := p.effectiveRegion(ctx, rid, region)
+		if err != nil {
+			return nil, err
+		}
+		eff = resolved
+	}
+	var board boardWire
+	path := "/valorant/v3/leaderboard/" + eff + "/" + platform
+	if err := p.http.GetJSON(ctx, path, nil, &board); err != nil {
+		return nil, err
+	}
+	players := board.Data.Players
+	sort.SliceStable(players, func(i, j int) bool {
+		return players[i].LeaderboardRank < players[j].LeaderboardRank
+	})
+	if len(players) > boardEntries {
+		players = players[:boardEntries]
+	}
+	entries := make([]lbEntry, 0, len(players))
+	for _, player := range players {
+		entries = append(entries, lbEntry{
+			Rank:   player.LeaderboardRank,
+			Player: player.Name + "#" + player.Tag,
+			Tier:   player.Tier,
+			RR:     player.RR,
+			Wins:   player.Wins,
+		})
+	}
+	return leaderboardReply{
+		Player:  id.Display,
+		Board:   eff + "/" + platform,
+		Entries: entries,
+		Empty:   len(entries) == 0,
+	}, nil
+}

--- a/app/gossip/internal/providers/valorant/valorant.go
+++ b/app/gossip/internal/providers/valorant/valorant.go
@@ -166,11 +166,13 @@ func newAPI(cfg Config, d provider.Deps) *api {
 	if content == "" {
 		content = defaultContentBaseURL
 	}
-	// HenrikDev's enhanced tier allows 90 requests/min for public bots; the
-	// default stays under it so a burst never trips the upstream's own limiter
-	// (a 429 there costs more than a local deny — it poisons the cache fill).
+	// HenrikDev's Basic tier allows 30 requests/min and that is what the
+	// fleet runs; the default sits AT the ceiling so bursts deny locally
+	// instead of tripping the upstream limiter (a 429 there costs more than a
+	// local deny — it poisons the cache fill). An Enhanced key (90/min) must
+	// raise VALORANT_RATE_LIMIT to match, or the paid headroom is wasted.
 	if cfg.RateLimit <= 0 {
-		cfg.RateLimit = 80
+		cfg.RateLimit = 30
 	}
 	// valorant-api.com publishes no hard limit; 60/min is conservative for a
 	// payload this size, and the skins catalogue caches for a day anyway.

--- a/app/gossip/internal/providers/valorant/valorant.go
+++ b/app/gossip/internal/providers/valorant/valorant.go
@@ -235,17 +235,20 @@ type riotIDValue struct {
 
 func parseRiotID(account string) (riotIDValue, string) {
 	raw := strings.TrimSpace(account)
-	name, tag, ok := strings.Cut(raw, "#")
-	if !ok || strings.TrimSpace(name) == "" || strings.TrimSpace(tag) == "" {
-		return riotIDValue{}, "invalid riot id (want name#tag)"
-	}
-	// Bounds mirror Riot's own limits (16-char name, 3-5 char tag) with slack;
-	// anything past these cannot exist, so it is rejected before spending a
-	// cache slot or an upstream call on it.
-	if len(name) > 32 || len(tag) > 8 {
+	name, tag, found := strings.Cut(raw, "#")
+	name, tag = strings.TrimSpace(name), strings.TrimSpace(tag)
+	if !wellFormedRiotID(name, tag, found) {
 		return riotIDValue{}, "invalid riot id (want name#tag)"
 	}
 	return riotIDValue{name: name, tag: strings.ToUpper(tag)}, ""
+}
+
+// wellFormedRiotID carries every fault condition a split Riot ID can have so
+// parseRiotID spends one branch on them. The bounds mirror Riot's own limits
+// (16-char name, 3-5 char tag) with slack; anything past these cannot exist,
+// so it is rejected before spending a cache slot or an upstream call on it.
+func wellFormedRiotID(name, tag string, found bool) bool {
+	return found && name != "" && tag != "" && len(name) <= 32 && len(tag) <= 8
 }
 
 func (r riotIDValue) String() string { return r.name + "#" + r.tag }

--- a/app/gossip/internal/providers/valorant/valorant_test.go
+++ b/app/gossip/internal/providers/valorant/valorant_test.go
@@ -117,10 +117,12 @@ const mmrBody = `{
       "tier":{"id":23,"name":"Immortal 1"},
       "leaderboard_placement":{"rank":812,"updated_at":"2026-08-22T00:00:00Z"}
     },
-    "peak":[
-      {"season":{"id":"ab57","short":"S25"},"ranking_schema":"Competitive","tier":{"id":21,"name":"Ascendant 2"},"rr":80},
-      {"season":{"id":"cd68","short":"S26"},"ranking_schema":"Competitive","tier":{"id":23,"name":"Immortal 1"},"rr":10}
-    ]
+    "peak":{
+      "season":{"id":"ab57","short":"S25"},
+      "ranking_schema":"Competitive",
+      "tier":{"id":21,"name":"Ascendant 2"},
+      "rr":80
+    }
   }
 }`
 
@@ -162,7 +164,7 @@ func TestRankFetchesMMRWithPlainAuthorizationHeader(t *testing.T) {
 	assert.Equal(t, -12, reply.LastChange)
 	assert.Equal(t, 812, reply.Placement)
 	assert.False(t, reply.Unranked)
-	assert.Equal(t, "Immortal 1", reply.PeakTier, "peak picks highest tier id, not newest season")
+	assert.Equal(t, "Ascendant 2", reply.PeakTier, "the single peak object reads directly")
 	assert.Equal(t, "val-key", gotAuth)
 }
 
@@ -221,7 +223,7 @@ func TestRankNegativeCacheStopsRepeatUpstreamHits(t *testing.T) {
 }
 
 func TestUnrankedZeroesEloButKeepsRRShape(t *testing.T) {
-	unrankedBody := `{"status":200,"data":{"current":{"elo":0,"rr":0,"last_change":0,"tier":{"id":0,"name":"UNRANKED"},"leaderboard_placement":{"rank":0}},"peak":[]}}`
+	unrankedBody := `{"status":200,"data":{"current":{"elo":0,"rr":0,"last_change":0,"tier":{"id":0,"name":"UNRANKED"},"leaderboard_placement":{"rank":0}},"peak":{"tier":{"id":0,"name":"UNRANKED"},"rr":0}}}`
 	henrik := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, unrankedBody)
 	})

--- a/app/gossip/internal/providers/valorant/valorant_test.go
+++ b/app/gossip/internal/providers/valorant/valorant_test.go
@@ -1,0 +1,458 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package valorant
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"ItsBagelBot/app/gossip/internal/core"
+	"ItsBagelBot/app/gossip/internal/provider"
+	gossiprpc "ItsBagelBot/internal/domain/rpc/gossip"
+	"ItsBagelBot/pkg/codec"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+type memStore struct {
+	mu sync.Mutex
+	m  map[string][]byte
+}
+
+func newMemStore() *memStore { return &memStore{m: map[string][]byte{}} }
+
+func (s *memStore) Get(_ context.Context, key string) ([]byte, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	b, ok := s.m[key]
+	return append([]byte(nil), b...), ok, nil
+}
+
+func (s *memStore) Set(_ context.Context, key string, value []byte, _ time.Duration) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.m[key] = append([]byte(nil), value...)
+	return nil
+}
+
+func (s *memStore) Del(_ context.Context, key string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.m, key)
+	return nil
+}
+
+func (s *memStore) SetNX(_ context.Context, key string, val []byte, _ time.Duration) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.m[key]; ok {
+		return false, nil
+	}
+	s.m[key] = append([]byte(nil), val...)
+	return true, nil
+}
+
+func newTestProvider(t *testing.T, henrik, content http.Handler) provider.Provider {
+	t.Helper()
+	henrikSrv := httptest.NewServer(henrik)
+	t.Cleanup(henrikSrv.Close)
+	contentSrv := httptest.NewServer(content)
+	t.Cleanup(contentSrv.Close)
+	return New(Config{
+		BaseURL:        henrikSrv.URL,
+		ContentBaseURL: contentSrv.URL,
+		APIKey:         "val-key",
+	}, provider.Deps{
+		Cache: core.NewCache(newMemStore()),
+		Log:   zap.NewNop(),
+	})
+}
+
+func noUpstream(t *testing.T, name string) http.Handler {
+	t.Helper()
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("unexpected %s request: %s", name, r.URL.Path)
+		w.WriteHeader(http.StatusTeapot)
+	})
+}
+
+func endpoint(t *testing.T, p provider.Provider, name string) func(context.Context, gossiprpc.Request) any {
+	t.Helper()
+	for _, ep := range p.Endpoints() {
+		if ep.Name == name {
+			return ep.Handle
+		}
+	}
+	t.Fatalf("endpoint %q not found", name)
+	return nil
+}
+
+func decodeReply[T any](t *testing.T, value any) T {
+	t.Helper()
+	if typed, ok := value.(T); ok {
+		return typed
+	}
+	raw, ok := value.(codec.RawMessage)
+	require.True(t, ok, "unexpected result type %T", value)
+	var reply T
+	require.NoError(t, codec.Unmarshal(raw, &reply))
+	return reply
+}
+
+const mmrBody = `{
+  "status":200,
+  "data":{
+    "account":{"puuid":"puuid-1","name":"Frosty","tag":"EUW1"},
+    "current":{
+      "elo":1849,"rr":63,"last_change":-12,
+      "tier":{"id":23,"name":"Immortal 1"},
+      "leaderboard_placement":{"rank":812,"updated_at":"2026-08-22T00:00:00Z"}
+    },
+    "peak":[
+      {"season":{"id":"ab57","short":"S25"},"ranking_schema":"Competitive","tier":{"id":21,"name":"Ascendant 2"},"rr":80},
+      {"season":{"id":"cd68","short":"S26"},"ranking_schema":"Competitive","tier":{"id":23,"name":"Immortal 1"},"rr":10}
+    ]
+  }
+}`
+
+const accountBody = `{
+  "status":200,
+  "data":{
+    "puuid":"puuid-1","region":"eu","name":"Frosty","tag":"EUW1",
+    "account_level":231,
+    "card":"https://media.test/card.png",
+    "title":"Vanquisher",
+    "updated_at":"2026-08-20T00:00:00Z",
+    "platforms":["pc"]
+  }
+}`
+
+func TestRankFetchesMMRWithPlainAuthorizationHeader(t *testing.T) {
+	// HenrikDev takes the raw key, not "Bearer <key>"; this pins the exact
+	// header because a Bearer prefix yields a 401 that looks like a bad key.
+	var gotAuth string
+	henrik := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		assert.Equal(t, "/valorant/v3/mmr/na/pc/Frosty/EUW1", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, mmrBody)
+	})
+	p := newTestProvider(t, henrik, noUpstream(t, "content"))
+
+	reply := decodeReply[rankReply](t, endpoint(t, p, "rank")(context.Background(), gossiprpc.Request{
+		Account: "Frosty#EUW1",
+		Region:  "NA",
+	}))
+
+	assert.Empty(t, reply.Error)
+	assert.Equal(t, "Frosty#EUW1", reply.Player, "display preserves name case, canonical tag")
+	assert.Equal(t, "na", reply.Region, "region normalizes to canonical form")
+	assert.Equal(t, "Immortal 1", reply.Tier)
+	assert.Equal(t, 1849, reply.Elo)
+	assert.Equal(t, 63, reply.RR)
+	assert.Equal(t, -12, reply.LastChange)
+	assert.Equal(t, 812, reply.Placement)
+	assert.False(t, reply.Unranked)
+	assert.Equal(t, "Immortal 1", reply.PeakTier, "peak picks highest tier id, not newest season")
+	assert.Equal(t, "val-key", gotAuth)
+}
+
+func TestRankAutoRegionResolvesThroughSharedAccountEntry(t *testing.T) {
+	var mu sync.Mutex
+	accountHits, mmrHits := 0, 0
+	henrik := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/valorant/v2/account/"):
+			accountHits++
+			fmt.Fprint(w, accountBody)
+		case strings.HasPrefix(r.URL.Path, "/valorant/v3/mmr/"):
+			mmrHits++
+			assert.Equal(t, "/valorant/v3/mmr/eu/pc/Frosty/EUW1", r.URL.Path,
+				"detected region must route the mmr leg")
+			fmt.Fprint(w, mmrBody)
+		default:
+			t.Errorf("unexpected path %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	p := newTestProvider(t, henrik, noUpstream(t, "content"))
+	handle := endpoint(t, p, "rank")
+	req := gossiprpc.Request{Account: "Frosty#EUW1"}
+
+	for i := 0; i < 3; i++ {
+		reply := decodeReply[rankReply](t, handle(context.Background(), req))
+		assert.Empty(t, reply.Error)
+		assert.Equal(t, "eu", reply.Region)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, 1, accountHits, "identity resolve is paid once, then cached for the day")
+	assert.Equal(t, 1, mmrHits, "rank replies collapse onto one cached flight")
+}
+
+func TestRankNegativeCacheStopsRepeatUpstreamHits(t *testing.T) {
+	hits := 0
+	henrik := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, `{"status":404,"errors":[{"code":"NO_ACCOUNT","message":"No account found"}]}`)
+	})
+	p := newTestProvider(t, henrik, noUpstream(t, "content"))
+
+	handle := endpoint(t, p, "rank")
+	req := gossiprpc.Request{Account: "Ghost404#0000", Region: "ap"}
+	first := decodeReply[rankReply](t, handle(context.Background(), req))
+	second := decodeReply[rankReply](t, handle(context.Background(), req))
+
+	assert.Equal(t, "player not found", first.Error)
+	assert.Equal(t, first.Error, second.Error)
+	assert.Equal(t, 1, hits, "404s are negatively cached for the window")
+}
+
+func TestUnrankedZeroesEloButKeepsRRShape(t *testing.T) {
+	unrankedBody := `{"status":200,"data":{"current":{"elo":0,"rr":0,"last_change":0,"tier":{"id":0,"name":"UNRANKED"},"leaderboard_placement":{"rank":0}},"peak":[]}}`
+	henrik := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, unrankedBody)
+	})
+	p := newTestProvider(t, henrik, noUpstream(t, "content"))
+
+	reply := decodeReply[rankReply](t, endpoint(t, p, "rank")(context.Background(), gossiprpc.Request{
+		Account: "Newbie#EUW", Region: "eu",
+	}))
+	assert.True(t, reply.Unranked)
+	assert.Zero(t, reply.Elo, "elo of an unranked account is noise; templates should never see it")
+	assert.Empty(t, reply.PeakTier)
+}
+
+const matchesBody = `{
+  "status":200,
+  "data":[
+    {
+      "metadata":{"map":{"id":"7eaecc1b","name":"Ascent"},"started_at":"%s","is_completed":true},
+      "players":[
+        {"puuid":"p-self","name":"Frosty","tag":"EUW1","team_id":"Red","agent":{"name":"Jett"},
+         "stats":{"kills":24,"deaths":15,"assists":7,"score":4563}},
+        {"puuid":"p-other","name":"Rival","tag":"2222","team_id":"Blue","agent":{"name":"Brimstone"},
+         "stats":{"kills":10,"deaths":20,"assists":3,"score":2100}}
+      ],
+      "teams":[
+        {"team_id":"Red","won":true,"rounds":{"won":14,"lost":10}},
+        {"team_id":"Blue","won":false,"rounds":{"won":10,"lost":14}}
+      ]
+    },
+    {
+      "metadata":{"map":{"id":"e219598c","name":"Bind"},"started_at":"%s","is_completed":false},
+      "players":[
+        {"puuid":"p-self","name":"Frosty","tag":"EUW1","team_id":"Blue","agent":{"name":"Omen"},
+         "stats":{"kills":5,"deaths":2,"assists":1,"score":800}}
+      ],
+      "teams":[{"team_id":"Blue","won":false,"rounds":{"won":3,"lost":4}}]
+    },
+    {
+      "metadata":{"map":{"id":"2bee0cdc","name":"Pearl"},"started_at":"%s","is_completed":true},
+      "players":[
+        {"puuid":"p-self","name":"Frosty","tag":"EUW1","team_id":"Blue","agent":{"name":"Sova"},
+         "stats":{"kills":11,"deaths":17,"assists":4,"score":2412}}
+      ],
+      "teams":[
+        {"team_id":"Blue","won":false,"rounds":{"won":6,"lost":13}},
+        {"team_id":"Red","won":true,"rounds":{"won":13,"lost":6}}
+      ]
+    }
+  ]
+}`
+
+func TestMatchesSummarizesCompletedGamesOnly(t *testing.T) {
+	anHourAgo := time.Now().UTC().Add(-time.Hour).Format(time.RFC3339)
+	body := fmt.Sprintf(matchesBody, anHourAgo, anHourAgo, anHourAgo)
+	var gotQuery string
+	henrik := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		assert.Equal(t, "/valorant/v4/matches/na/pc/Frosty/EUW1", r.URL.Path)
+		fmt.Fprint(w, body)
+	})
+	p := newTestProvider(t, henrik, noUpstream(t, "content"))
+
+	reply := decodeReply[matchesReply](t, endpoint(t, p, "matches")(context.Background(), gossiprpc.Request{
+		Account: "Frosty#EUW1", Region: "na",
+	}))
+
+	assert.Empty(t, reply.Error)
+	assert.Equal(t, "mode=competitive&size=5", gotQuery,
+		"the competitive-only filter rides the upstream query, not client-side guessing")
+	require.Len(t, reply.Matches, 2, "an incomplete game is skipped, not shown as a ghost row")
+
+	win := reply.Matches[0]
+	assert.Equal(t, "Ascent", win.Map)
+	assert.Equal(t, "Jett", win.Agent)
+	assert.Equal(t, "win", win.Result)
+	assert.Equal(t, 24, win.Kills)
+	assert.InDelta(t, 190.1, win.ACS, 0.001, "score 4563 over 24 rounds, rounded to one decimal")
+	assert.GreaterOrEqual(t, win.AgoSeconds, int64(3590))
+
+	loss := reply.Matches[1]
+	assert.Equal(t, "loss", loss.Result)
+	assert.InDelta(t, 126.9, loss.ACS, 0.001, "score 2412 over 19 rounds")
+}
+
+func TestMatchesEmptyHistoryIsAnAnswerNotAnError(t *testing.T) {
+	henrik := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"status":200,"data":[]}`)
+	})
+	p := newTestProvider(t, henrik, noUpstream(t, "content"))
+
+	reply := decodeReply[matchesReply](t, endpoint(t, p, "matches")(context.Background(), gossiprpc.Request{
+		Account: "Quiet#EUW", Region: "eu",
+	}))
+	assert.Empty(t, reply.Error)
+	assert.True(t, reply.Empty)
+}
+
+func TestAccountEchoesResolvedIdentity(t *testing.T) {
+	henrik := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/valorant/v2/account/Frosty/EUW1", r.URL.Path)
+		fmt.Fprint(w, accountBody)
+	})
+	p := newTestProvider(t, henrik, noUpstream(t, "content"))
+
+	reply := decodeReply[accountReply](t, endpoint(t, p, "account")(context.Background(), gossiprpc.Request{
+		Account: "Frosty#EUW1",
+	}))
+	assert.Empty(t, reply.Error)
+	assert.Equal(t, "Frosty#EUW1", reply.Player)
+	assert.Equal(t, "puuid-1", reply.Puuid)
+	assert.Equal(t, "eu", reply.Region)
+	assert.Equal(t, 231, reply.AccountLevel)
+	assert.Equal(t, "https://media.test/card.png", reply.Card)
+}
+
+const leaderboardBody = `{
+  "status":200,
+  "data":{
+    "players":[
+      {"leaderboard_rank":5,"name":"Five","tag":"5555","wins":30,"rr":700,"tier":25,"is_anonymized":false},
+      {"leaderboard_rank":1,"name":"One","tag":"1111","wins":42,"rr":910,"tier":27,"is_anonymized":false},
+      {"leaderboard_rank":11,"name":"Eleven","tag":"eeee","wins":9,"rr":420,"tier":24,"is_anonymized":false},
+      {"leaderboard_rank":3,"name":"Three","tag":"3333","wins":33,"rr":750,"tier":26,"is_anonymized":false}
+    ]
+  }
+}`
+
+func TestLeaderboardSortsAndCapsTheSlice(t *testing.T) {
+	henrik := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/valorant/v3/leaderboard/ap/console", r.URL.Path,
+			"v3 is the platform-aware board; v2 would silently return PC data")
+		fmt.Fprint(w, leaderboardBody)
+	})
+	p := newTestProvider(t, henrik, noUpstream(t, "content"))
+
+	reply := decodeReply[leaderboardReply](t, endpoint(t, p, "leaderboard")(context.Background(), gossiprpc.Request{
+		Region:   "AP",
+		Platform: "Console",
+	}))
+
+	assert.Empty(t, reply.Error)
+	assert.Equal(t, "ap/console", reply.Board)
+	ranks := make([]int, 0, len(reply.Entries))
+	for _, entry := range reply.Entries {
+		ranks = append(ranks, entry.Rank)
+	}
+	assert.Equal(t, []int{1, 3, 5, 11}, ranks, "upstream order is not trusted")
+	assert.Equal(t, "One#1111", reply.Entries[0].Player)
+}
+
+func TestLeaderboardRequiresRegionWithoutAccount(t *testing.T) {
+	p := newTestProvider(t, noUpstream(t, "henrik"), noUpstream(t, "content"))
+
+	reply := decodeReply[leaderboardReply](t, endpoint(t, p, "leaderboard")(context.Background(), gossiprpc.Request{}))
+	assert.Contains(t, reply.Error, "missing region")
+}
+
+func TestIdentityValidationAndCacheKeys(t *testing.T) {
+	t.Run("parseRiotID", func(t *testing.T) {
+		cases := []struct {
+			in     string
+			wantID string
+			reject string
+		}{
+			{in: "Frosty#EUW1", wantID: "Frosty#EUW1"},
+			{in: " frosty#euw1 ", wantID: "frosty#EUW1"},
+			{in: "", reject: "invalid riot id"},
+			{in: "NoTag", reject: "invalid riot id"},
+			{in: "#EUW1", reject: "invalid riot id"},
+			{in: "Name#", reject: "invalid riot id"},
+			{in: strings.Repeat("n", 33) + "#tag", reject: "invalid riot id"},
+		}
+		for _, tc := range cases {
+			id, msg := parseRiotID(tc.in)
+			if tc.reject != "" {
+				assert.NotEmpty(t, msg, tc.in)
+				continue
+			}
+			assert.Empty(t, msg, tc.in)
+			assert.Equal(t, tc.wantID, id.String(), tc.in)
+		}
+	})
+
+	t.Run("normalizeRegion", func(t *testing.T) {
+		region, msg := normalizeRegion(" NA ")
+		assert.Equal(t, "na", region)
+		assert.Empty(t, msg)
+
+		region, msg = normalizeRegion("")
+		assert.Equal(t, "auto", region, "empty means detect-from-account")
+		assert.Empty(t, msg)
+
+		for _, bad := range []string{"es", "north america", "euw"} {
+			_, msg = normalizeRegion(bad)
+			assert.NotEmpty(t, msg, bad)
+		}
+	})
+
+	t.Run("normalizePlatform", func(t *testing.T) {
+		platform, msg := normalizePlatform("")
+		assert.Equal(t, "pc", platform, "pc is the default split")
+		assert.Empty(t, msg)
+		platform, msg = normalizePlatform("Console")
+		assert.Equal(t, "console", platform)
+		assert.Empty(t, msg)
+		_, msg = normalizePlatform("mobile")
+		assert.NotEmpty(t, msg)
+	})
+
+	t.Run("riotID folds scoping into the cache key", func(t *testing.T) {
+		id, msg := riotID(gossiprpc.Request{Account: "Frosty#EUW1", Region: "NA"})
+		assert.Empty(t, msg)
+		assert.Equal(t, "frosty#euw1:na:pc", id.Key,
+			"same player, different spelling and region casing must share one entry")
+
+		id, msg = riotID(gossiprpc.Request{Account: "Frosty#EUW1"})
+		assert.Empty(t, msg)
+		assert.Equal(t, "frosty#euw1:auto:pc", id.Key,
+			"unset region keys separately from an explicit one; detection fills the gap")
+
+		_, msg = riotID(gossiprpc.Request{Account: "Frosty#EUW1", Platform: "stadia"})
+		assert.NotEmpty(t, msg)
+	})
+}
+
+func TestEndpointSurface(t *testing.T) {
+	p := newTestProvider(t, noUpstream(t, "henrik"), noUpstream(t, "content"))
+	assert.Equal(t, "valorant", p.Name())
+	names := make([]string, 0, 5)
+	for _, ep := range p.Endpoints() {
+		names = append(names, ep.Name)
+	}
+	assert.ElementsMatch(t, []string{"rank", "matches", "account", "leaderboard", "shop"}, names)
+}

--- a/deploy/k8s/gossip.yaml
+++ b/deploy/k8s/gossip.yaml
@@ -23,6 +23,12 @@
 # and calls ride proxy.royaleapi.dev. Without it the provider skips at boot
 # and the !cr commands time out at the caller like any disabled provider.
 # Lower CLASHROYALE_RATE_LIMIT from its default for a fresh key.
+# valorant (!valrank / !valmatches / !vallb / !valaccount / !valshop) needs
+# VALORANT_API_KEY in Doppler: a HenrikDev key from api.henrikdev.xyz/dashboard
+# (Discord join required). The instant Basic key is 30 req/min, which the
+# rate-limit default is sized to; an Enhanced key (90/min) must raise
+# VALORANT_RATE_LIMIT to ~80 to use it. Without the key the provider skips at
+# boot and every !val command times out at the caller.
 apiVersion: secrets.doppler.com/v1alpha1
 kind: DopplerSecret
 metadata:

--- a/internal/domain/rpc/gossip/gossip.go
+++ b/internal/domain/rpc/gossip/gossip.go
@@ -94,6 +94,20 @@ type Request struct {
 	// code. The upstream record-leaderboard has no such filter, so the
 	// provider drops it silently on that board rather than erroring.
 	Country string `json:"country,omitempty"`
+
+	// --- valorant (HenrikDev community API lookups) --------------------------
+
+	// Region is the Valorant shard a lookup targets: "na", "eu", "ap", "kr",
+	// "br" or "latam". Empty lets the provider detect it from the account
+	// itself through one extra cached account lookup, so callers that don't
+	// know their shard stay one upstream read behind explicit ones only on the
+	// first ask of the day. Zero on every non-valorant request.
+	Region string `json:"region,omitempty"`
+	// Platform selects which ladder split answers: "pc" (the provider's
+	// default when empty) or "console". Leaderboards and MMR are tracked as
+	// separate ladders per platform, so this folds into cache keys rather
+	// than being normalized away. Zero on every non-valorant request.
+	Platform string `json:"platform,omitempty"`
 }
 
 // Subject builds the NATS subject for one provider endpoint under prefix.


### PR DESCRIPTION
## What

Five gossip endpoints under `bagel.rpc.gossip.valorant.*`, served by a new provider riding the community HenrikDev API joined with Riot's keyless content CDN:

| Endpoint | Serves |
|---|---|
| `rank` | MMR v3: tier, elo, RR, last RR change, peak tier, act leaderboard placement |
| `matches` | Last 5 completed competitive games — map, agent, result, KDA, ACS |
| `leaderboard` | Platform-aware v3 board slice (v2 silently returns PC data for console) |
| `account` | Riot ID → puuid / region / level / card / title |
| `shop` | Current featured bundle: prices + discount + Riot's own countdown from HenrikDev; names, icons and rarity colours joined from the content CDN |

Auto-region: an empty `Request.Region` resolves the account's shard through a day-long shared identity entry, so callers without a shard pay one extra upstream read on first ask only.

Deliberately absent: personal store and night market (need viewer credentials HenrikDev bans products for collecting) and the daily skin rotation (Riot removed the global offers feed entirely — 404 code 46 at every version).

## Built-in systems used

- Byte-flow builder (`Cached`/`ID`/`Reply`/`Budget`/`Fetch`) over the fleet SWR cache + singleflight
- Two bucket sets: HenrikDev per-key (default at the Basic tier's 30/min ceiling) and content CDN per-IP, debited sequentially on shop
- Budget checks declared on endpoints, never inside fetches (singleflight lane rule)
- Negative caching of minted 404s; typed `UpstreamError` → friendly reply mapping
- Deadline-free fixed windows with decision-record comments on every tuned constant

## Verification

`VALORANT_LIVE=1` probe (`live_test.go`) exercises all five endpoints against the real upstreams using the Doppler-stored key. It caught three spec-vs-reality divergences, fixed here:

- MMR v3 `peak` is a single object, not the documented array
- store-offers is dead → shop pivoted to featured bundles
- bundle skins use per-level item UUIDs → join is catalogue membership alone

Live run against production data passes (Radiant #1 EU account, real match KDA/ACS, Aeris bundle at 45.1% off).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Valorant support for account details, ranks/MMR, recent competitive matches, leaderboards, and featured bundle shops.
  * Added support for selecting Valorant regions and platforms, including automatic region resolution.
  * Added caching and improved handling for repeated requests, unavailable accounts, and upstream errors.
* **Documentation**
  * Documented Valorant setup, API key requirements, rate limits, and optional configuration.
* **Bug Fixes**
  * Improved shop results with accurate item details, pricing, rarity, sorting, and expiration data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->