### PR TITLE
perf(console): edge-cache anonymous public pages at Cloudflare, compress the tunnel leg

### DIFF
--- a/console/dashboard/src/hooks.server.ts
+++ b/console/dashboard/src/hooks.server.ts
@@ -113,6 +113,59 @@ function resolveLocale(event: Parameters<Handle>[0]['event']): ReturnType<typeof
   });
 }
 
+// Anonymous renders of the public surfaces are identical for every visitor,
+// so they can be served straight from Cloudflare's edge instead of crossing
+// cloudflared -> traefik -> pod on every view (crawlers and drive-by traffic
+// are exactly the load that never needs to reach the cluster). [edgeTtlSec,
+// swrSec] keyed by route id; /login is near-static, /stats is a live snapshot
+// kept tight because its numbers are the point, channel pages change only
+// when a streamer edits settings.
+const EDGE_CACHE: Record<string, readonly [number, number]> = {
+  '/login': [600, 86_400],
+  '/(public)/stats': [30, 300],
+  '/(public)/[user]': [60, 300],
+  '/user/[channel]': [60, 300]
+};
+
+// Returns the Cache-Control that replaces harden()'s blanket HTML no-store
+// when this request provably produced the shared default render, else null.
+//
+// The gates exist because Cloudflare's cache key ignores cookies and
+// Accept-Language: anything request-specific must be excluded at origin
+// rather than varied at the edge.
+//   * anonymous only — an authed render must never be replayed to another
+//     user; guard.ts has already settled locals.session above.
+//   * locale 'en' only — detectLocale falls back to Accept-Language, so
+//     otherwise the first visitor's language would win the cache entry for
+//     every subsequent visitor for the whole TTL.
+//   * no ?lang param — it pins the locale cookie, and Set-Cookie responses
+//     must never be shared from a CDN.
+//   * cursor cookie not '0' — the opt-out flips markup server-side; any other
+//     value renders byte-identical to no cookie.
+//
+// max-age=0 keeps browsers revalidating each navigation (kit ETag -> cheap
+// 304) while the edge serves HITs for s-maxage; stale-while-revalidate lets
+// Cloudflare serve its stale copy during background revalidation, so TTL
+// expiry never stampedes origin. Edge hits bypass traefik and the pods
+// entirely, which also means they bypass the per-IP rate limits — intended:
+// abuse of these paths is absorbed by Cloudflare before it reaches us.
+//
+// CSP nonces: SvelteKit mints one per request into both the header and the
+// inline scripts, so a cached page replays a single nonce on every hit; on
+// these public pages anyone can read the nonce by fetching the URL, so
+// sharing it costs nothing. Authenticated pages keep harden()'s no-store.
+function edgeCacheControl(event: Parameters<Handle>[0]['event'], res: Response): string | null {
+  const ttl = EDGE_CACHE[event.route.id ?? ''];
+  if (!ttl) return null;
+  if (event.request.method !== 'GET' && event.request.method !== 'HEAD') return null;
+  if (res.status !== 200 || !res.headers.get('content-type')?.includes('text/html')) return null;
+  if (event.locals.session) return null;
+  if (event.locals.locale !== 'en') return null;
+  if (event.url.searchParams.has('lang')) return null;
+  if (event.cookies.get(CURSOR_COOKIE) === '0') return null;
+  return `public, max-age=0, s-maxage=${ttl[0]}, stale-while-revalidate=${ttl[1]}`;
+}
+
 const PERMISSIONS_POLICY =
   'camera=(), microphone=(), geolocation=(), payment=(), join-ad-interest-group=(), run-ad-auction=(), shared-storage=(), browsing-topics=()';
 
@@ -160,6 +213,8 @@ export const handle: Handle = async ({ event, resolve }) => {
   });
 
   harden(res, PERMISSIONS_POLICY);
+  const cacheControl = edgeCacheControl(event, res);
+  if (cacheControl) res.headers.set('Cache-Control', cacheControl);
   return res;
 };
 

--- a/console/dashboard/src/routes/(public)/stats/+page.server.ts
+++ b/console/dashboard/src/routes/(public)/stats/+page.server.ts
@@ -10,10 +10,11 @@ import { publicBoards } from '$lib/server/public-boards';
 // resolved locale to the i18n context. Signed-out, signed-in and banned
 // sessions all render the same numbers.
 //
-// no-store because the payload is a live counter snapshot: a CDN or browser
-// cache holding it would show a frozen "live" page.
-export const load: PageServerLoad = async ({ setHeaders }) => {
-  setHeaders({ 'cache-control': 'no-store' });
+// Freshness after load belongs to the /stats/stream SSE subscription in the
+// page component, not to SSR: the SSR numbers may sit up to s-maxage behind
+// real time when served from the CF edge (see edgeCacheControl in
+// hooks.server.ts), and hydration snaps them live within a beat.
+export const load: PageServerLoad = async () => {
   const [stats, boards] = await Promise.all([publicStats(), publicBoards()]);
   return { stats, boards };
 };

--- a/deploy/cloudflare/cache-rules.sh
+++ b/deploy/cloudflare/cache-rules.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Adam Ousmer. All rights reserved.
+# Proprietary. No license granted. See LICENSE.md.
+#
+# Applies the zone-level http_request_cache_settings ruleset (Cache Rules) for
+# the console hostnames. Run after deploying any dashboard change that touches
+# edgeCacheControl in console/dashboard/src/hooks.server.ts.
+#
+# Design: ONE broad eligibility rule for all four console hosts with Edge and
+# Browser TTL both "respect origin". Cloudflare never caches HTML by default
+# and its cache key ignores Vary, so caching policy lives entirely in origin
+# Cache-Control headers: edgeCacheControl marks anonymous default-render pages
+# cacheable, everything else sends no-store/private and bypasses on its own.
+# Broad eligibility is therefore safe by construction -- a path becomes
+# cacheable exactly when the app says so, and a future public page needs no
+# rule change here. There is deliberately no explicit /_app/immutable override:
+# sirv's immutable header + respect_origin gives the year-long edge TTL without
+# ever pinning a stale or error body for a year if something upstream strips
+# headers. Default extension-based caching already covers those assets either
+# way (verified live: cf-cache-status MISS -> HIT before this ruleset existed).
+#
+# The bagel_session bypass is defense-in-depth: even if the origin gate in
+# edgeCacheControl ever regressed, a request carrying a session cookie can
+# neither populate nor hit the edge cache. Cache rules are first-match-wins,
+# so it must stay above the eligibility rule.
+#
+# This script OWNS the phase: the PUT replaces the whole ruleset. Foreign rules
+# added through the dashboard will not survive a re-run of this script -- treat
+# this file as the source of truth for the phase.
+#
+# Needs: CF_API_TOKEN (Zone > Cache Rules > Edit) and CF_ZONE_ID. Idempotent.
+set -euo pipefail
+
+: "${CF_API_TOKEN:?Set CF_API_TOKEN (Zone.Cache Rules:Edit)}"
+: "${CF_ZONE_ID:?Set CF_ZONE_ID}"
+
+API="https://api.cloudflare.com/client/v4/zones/${CF_ZONE_ID}/rulesets/phases/http_request_cache_settings/entrypoint"
+
+PAYLOAD=$(cat <<'JSON'
+{
+  "rules": [
+    {
+      "description": "[bagelbot] bypass edge cache for session-bearing requests",
+      "expression": "(http.cookie contains \"bagel_session=\")",
+      "action": "set_cache_settings",
+      "action_parameters": { "cache": false },
+      "enabled": true
+    },
+    {
+      "description": "[bagelbot] console hosts: eligibility on, TTLs from origin headers",
+      "expression": "(http.host in {\"dashboard.itsbagelbot.com\" \"stats.itsbagelbot.com\" \"commands.itsbagelbot.com\" \"leaderboard.itsbagelbot.com\"})",
+      "action": "set_cache_settings",
+      "action_parameters": {
+        "cache": true,
+        "edge_ttl": { "mode": "respect_origin" },
+        "browser_ttl": { "mode": "respect_origin" }
+      },
+      "enabled": true
+    }
+  ]
+}
+JSON
+)
+
+auth=(-H "Authorization: Bearer ${CF_API_TOKEN}" -H 'Content-Type: application/json')
+
+echo '--- current phase entrypoint (empty phase is fine):'
+curl -sS "${auth[@]}" "$API" | python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+if not d.get("success"):
+    print(json.dumps(d.get("errors"), indent=2))
+elif d.get("result"):
+    print(json.dumps(d["result"].get("rules", []), indent=2))
+else:
+    print("(phase has no entrypoint yet)")'
+
+echo '--- applying:'
+RESULT=$(curl -sS "${auth[@]}" -X PUT "$API" -d "$PAYLOAD")
+
+python3 - "$RESULT" <<'PY'
+import json, sys
+d = json.loads(sys.argv[1])
+if not d.get("success"):
+    print(json.dumps(d.get("errors"), indent=2))
+    sys.exit(1)
+print(f"applied {len(d['result'].get('rules', []))} rule(s), version {d['result'].get('version')}")
+PY
+
+echo '--- verify a public page picks up HIT within its s-maxage:'
+echo "    curl -sI https://stats.itsbagelbot.com/ | grep -iE 'cf-cache-status|cache-control'"

--- a/deploy/k8s/console-dashboard.yaml
+++ b/deploy/k8s/console-dashboard.yaml
@@ -410,7 +410,7 @@ spec:
         Host(`dashboard.itsbagelbot.com`) || Host(`stats.itsbagelbot.com`) ||
         Host(`commands.itsbagelbot.com`)
       kind: Rule
-      middlewares: [{name: dashboard-ratelimit}]
+      middlewares: [{name: dashboard-ratelimit}, {name: dashboard-compress}]
       services:
         - name: console-dashboard
           port: 443
@@ -474,6 +474,34 @@ spec:
     burst: 10
     sourceCriterion:
       requestHeaderName: CF-Connecting-IP
+---
+# Compresses compressible responses on the origin leg of the tunnel. Browsers
+# already receive brotli compressed at the Cloudflare edge regardless of what
+# the origin sends, but everything between CF and the pod travels uncompressed
+# today: every uncached HTML page, __data.json and JSON endpoint leaves the
+# nodes at full size. gzip here cuts that leg roughly 70%, which is the whole
+# point given the goal of reducing node outgress.
+#
+# text/event-stream MUST stay excluded: /events and /stats/stream stream
+# indefinitely, and the compression middleware buffers responses, which turns
+# both into a broken stream that never flushes. Pre-compressed formats are
+# excluded because compressing them again costs CPU for ~0% size gain.
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: dashboard-compress
+  namespace: app
+spec:
+  compress:
+    excludedContentTypes:
+      - text/event-stream
+      - application/grpc
+      - font/woff2
+      - image/png
+      - image/jpeg
+      - image/webp
+      - image/avif
+      - video/mp4
 ---
 apiVersion: traefik.io/v1alpha1
 kind: ServersTransport


### PR DESCRIPTION
## What

Three pieces of the CDN-offload pass for the console:

1. **Origin-controlled edge caching of public HTML.** `edgeCacheControl()` in hooks swaps `harden()`'s blanket no-store for `s-maxage` + `stale-while-revalidate` on `/login`, `/stats`, root `[user]`, and `/user/[channel]` — but only when the response provably is the shared render: anonymous, locale `en`, no `?lang`, cursor cookie not `0`, 200, GET/HEAD. The gates are strict because Cloudflare's cache key ignores cookies and Accept-Language.
2. **Tunnel-leg compression.** New `dashboard-compress` traefik middleware gzips everything compressible between CF and the pod (~70% off uncached text egress from the nodes). `text/event-stream` excluded so SSE keeps streaming.
3. **deploy/cloudflare/cache-rules.sh** applies the zone `http_request_cache_settings` ruleset: a first-match `bagel_session` cookie bypass (defense-in-depth) above one broad eligibility rule with Edge/Browser TTL = respect origin, so cacheability stays decided entirely by origin headers.

Assets needed no change: sirv already sends `immutable` and CF extension caching picks it up (verified live MISS→HIT).

## Rollout order

Dashboard image → `kubectl apply` middleware → run the CF script. Order-safe: `respect_origin` bypasses until the new headers exist.

## Verification

- `svelte-check`: 0 errors (1 pre-existing css warning)
- YAML parses; middleware wired on the public-host router
- `bash -n` clean