### PR TITLE
feat(sesame): target-addressed counter tokens — {counter:target:name}

### DIFF
--- a/app/sesame/engine/counter_token_test.go
+++ b/app/sesame/engine/counter_token_test.go
@@ -32,8 +32,8 @@ type captureLoyalty struct {
 	bumps []captureBump
 }
 
-func (f *captureLoyalty) CounterBump(_ context.Context, _ uint64, name string, viewer Viewer, command string, _ int64) (int64, error) {
-	f.bumps = append(f.bumps, captureBump{name: name, viewer: viewer, command: command})
+func (f *captureLoyalty) CounterBump(_ context.Context, b CounterBump) (int64, error) {
+	f.bumps = append(f.bumps, captureBump{name: b.Name, viewer: b.Viewer, command: b.Command})
 	return 42, nil
 }
 
@@ -124,6 +124,20 @@ func TestCounterBumpScopesUnchangedByAddressing(t *testing.T) {
 	for _, b := range loyalty.bumps {
 		assert.Equal(t, "so", b.command)
 	}
+}
+
+// TestCounterBumpTabSeparatedMention proves the target word splits on any
+// whitespace: a tab after the mention cannot glue itself onto the login and
+// silently miss the roster.
+func TestCounterBumpTabSeparatedMention(t *testing.T) {
+	p, loyalty := counterPipeline(t, "{counter:target:shutups}")
+	p.roster.Observe(123, "bob", "7", "Bob")
+
+	got := collectDispatch(p, chatCtx("!so @bob\traid incoming", ""))
+	require.Len(t, got, 1)
+	assert.Equal(t, "42", got[0].Text)
+	require.Len(t, loyalty.bumps, 1)
+	assert.Equal(t, uint64(7), loyalty.bumps[0].viewer.ID)
 }
 
 // TestCounterBumpTargetEmptyBaseStaysVisible proves the degenerate

--- a/app/sesame/engine/counter_token_test.go
+++ b/app/sesame/engine/counter_token_test.go
@@ -1,0 +1,174 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"ItsBagelBot/internal/projection"
+	"ItsBagelBot/pkg/bus"
+	"ItsBagelBot/pkg/codec"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// captureBump is one recorded CounterBump call: whose identity rode it, which
+// bucket name and which command keyed it.
+type captureBump struct {
+	name    string
+	viewer  Viewer
+	command string
+}
+
+// captureLoyalty records CounterBump calls; every other LoyaltyStore verb is
+// unreachable from the custom-command path (only CounterBump runs there), so
+// the nil embedded interface stays nil in practice.
+type captureLoyalty struct {
+	LoyaltyStore
+	bumps []captureBump
+}
+
+func (f *captureLoyalty) CounterBump(_ context.Context, _ uint64, name string, viewer Viewer, command string, _ int64) (int64, error) {
+	f.bumps = append(f.bumps, captureBump{name: name, viewer: viewer, command: command})
+	return 42, nil
+}
+
+// counterPipeline builds a pipeline serving one custom command whose response
+// references counters, with a capturing loyalty store wired in.
+func counterPipeline(t *testing.T, response string) (*Pipeline, *captureLoyalty) {
+	t.Helper()
+	loyalty := &captureLoyalty{}
+	d := Deps{
+		Proj:     fakeReader{cmd: projection.Command{Name: "so", Response: response, IsActive: true, Perm: "everyone"}, cmdFound: true},
+		Live:     liveAlways{},
+		Cooldown: NoopCooldown{},
+		Pub:      &fakePublisher{},
+		Loyalty:  loyalty,
+		Log:      zap.NewNop(),
+	}
+	return NewPipeline(d, NewRegistry(zap.NewNop()), Config{OutgressPremium: premiumSubj, OutgressStandard: standardSubj}), loyalty
+}
+
+// TestCounterTokenNamesTargetAddressing pins the parse side of the
+// {counter:target:<name>} grammar: normalization keeps the prefix, dedup works
+// per spelling, and an empty base still parses so the bump side can skip it.
+func TestCounterTokenNamesTargetAddressing(t *testing.T) {
+	assert.Equal(t, []string{"target:shutups"},
+		counterTokenNames("{counter:target:shutups}"))
+	assert.Equal(t, []string{"target:shutups"},
+		counterTokenNames("{counter:Target:Shutups}"), "case-folded like any name")
+	assert.Equal(t, []string{"target:a", "b"},
+		counterTokenNames("{counter:target:a} {counter:b} {counter:target:a}"),
+		"addressed and sender-keyed spellings are distinct tokens")
+	assert.Equal(t, []string{"target:"},
+		counterTokenNames("{counter:target:}"))
+}
+
+// TestCounterBumpKeysOnMentionedViewer proves the #479 fix end to end: a
+// {counter:target:...} token keys its bump on the mentioned viewer's identity,
+// resolved from the roster of chatters this replica has seen speak.
+func TestCounterBumpKeysOnMentionedViewer(t *testing.T) {
+	p, loyalty := counterPipeline(t, "@{target} has been told {counter:target:shutups} times")
+	p.roster.Observe(123, "bob", "7", "Bob")
+
+	got := collectDispatch(p, chatCtx("!so @bob", ""))
+	require.Len(t, got, 1)
+	assert.Equal(t, "@bob has been told 42 times", got[0].Text)
+	require.Len(t, loyalty.bumps, 1)
+	assert.Equal(t, "shutups", loyalty.bumps[0].name, "the addressing prefix never reaches the store")
+	assert.Equal(t, uint64(7), loyalty.bumps[0].viewer.ID)
+	assert.Equal(t, "bob", loyalty.bumps[0].viewer.Login)
+	assert.Equal(t, "Bob", loyalty.bumps[0].viewer.Name)
+	assert.Equal(t, "so", loyalty.bumps[0].command, "the command key passes through untouched")
+}
+
+// TestCounterBumpUnresolvedTargetFallsBackToSender proves the graceful
+// fallback: a mention nobody has spoken where this replica could see counts
+// against the sender instead of leaking a raw token or dropping the reply.
+func TestCounterBumpUnresolvedTargetFallsBackToSender(t *testing.T) {
+	p, loyalty := counterPipeline(t, "{target}: {counter:target:shutups}")
+
+	got := collectDispatch(p, chatCtx("!so @stranger", ""))
+	require.Len(t, got, 1)
+	assert.Equal(t, "stranger: 42", got[0].Text)
+	require.Len(t, loyalty.bumps, 1)
+	assert.Equal(t, uint64(999), loyalty.bumps[0].viewer.ID, "sender fallback")
+
+	// No argument at all: {touser} defaults to the sender, same outcome.
+	got = collectDispatch(p, chatCtx("!so", ""))
+	require.Len(t, got, 1)
+	assert.Equal(t, "alice: 42", got[0].Text)
+	assert.Equal(t, uint64(999), loyalty.bumps[1].viewer.ID)
+}
+
+// TestCounterBumpScopesUnchangedByAddressing proves the issue's second half:
+// plain tokens keep keying on the sender, and both spellings can coexist in
+// one response — each bump carries the right identity while the command key
+// (which drives viewer+command buckets) rides along unchanged either way.
+func TestCounterBumpScopesUnchangedByAddressing(t *testing.T) {
+	p, loyalty := counterPipeline(t, "{user} {counter:hugs} / @{target} {counter:target:shutups}")
+	p.roster.Observe(123, "bob", "7", "")
+
+	got := collectDispatch(p, chatCtx("!so @bob", ""))
+	require.Len(t, got, 1)
+	assert.Equal(t, "alice 42 / @bob 42", got[0].Text)
+	require.Len(t, loyalty.bumps, 2)
+	assert.Equal(t, "hugs", loyalty.bumps[0].name)
+	assert.Equal(t, uint64(999), loyalty.bumps[0].viewer.ID, "plain token stays sender-keyed")
+	assert.Equal(t, "shutups", loyalty.bumps[1].name)
+	assert.Equal(t, uint64(7), loyalty.bumps[1].viewer.ID)
+	for _, b := range loyalty.bumps {
+		assert.Equal(t, "so", b.command)
+	}
+}
+
+// TestCounterBumpTargetEmptyBaseStaysVisible proves the degenerate
+// {counter:target:} neither bumps nor renders a value.
+func TestCounterBumpTargetEmptyBaseStaysVisible(t *testing.T) {
+	p, loyalty := counterPipeline(t, "x{counter:target:}")
+
+	got := collectDispatch(p, chatCtx("!so @bob", ""))
+	require.Len(t, got, 1)
+	assert.Equal(t, "x{counter:target:}", got[0].Text)
+	assert.Empty(t, loyalty.bumps)
+}
+
+// TestCounterTokenExpansionUnresolvedLeavesVisible pins expansion parity for
+// the addressed spelling when no value was resolved: the raw token survives,
+// exactly like every other unknown token.
+func TestCounterTokenExpansionUnresolvedLeavesVisible(t *testing.T) {
+	out := string(expandCommand(nil, "{counter:target:shutups}", tokens{}))
+	assert.Equal(t, "{counter:target:shutups}", out)
+
+	out = string(expandCommand(nil, "{counter:target:shutups}", tokens{
+		counters: map[string]string{"target:shutups": "5"},
+	}))
+	assert.Equal(t, "5", out)
+}
+
+// TestProcessFeedsRosterFromChatLines proves the feed point: any eligible chat
+// line teaches the roster its speaker, which is what lets a later command
+// resolve that viewer as a counter target.
+func TestProcessFeedsRosterFromChatLines(t *testing.T) {
+	p := newPipelineWith(&fakePublisher{}, fakeReader{})
+	body, err := codec.Marshal(map[string]any{
+		"type":                chatType,
+		"lane":                "standard",
+		"broadcaster_user_id": "123",
+		"chatter_user_id":     "7",
+		"chatter_user_login":  "bob",
+		"chatter_user_name":   "Bob",
+		"text":                "hi",
+	})
+	require.NoError(t, err)
+	require.NoError(t, p.Process(bus.NewMessage("uuid-roster", body)))
+
+	v, ok := p.roster.Resolve(123, "bob")
+	require.True(t, ok)
+	assert.Equal(t, uint64(7), v.ID)
+	assert.Equal(t, "Bob", v.Name)
+}

--- a/app/sesame/engine/counter_token_test.go
+++ b/app/sesame/engine/counter_token_test.go
@@ -73,7 +73,7 @@ func TestCounterTokenNamesTargetAddressing(t *testing.T) {
 // resolved from the roster of chatters this replica has seen speak.
 func TestCounterBumpKeysOnMentionedViewer(t *testing.T) {
 	p, loyalty := counterPipeline(t, "@{target} has been told {counter:target:shutups} times")
-	p.roster.Observe(123, "bob", "7", "Bob")
+	p.roster.Observe(123, chatterIdentity{login: "bob", id: "7", name: "Bob"})
 
 	got := collectDispatch(p, chatCtx("!so @bob", ""))
 	require.Len(t, got, 1)
@@ -111,7 +111,7 @@ func TestCounterBumpUnresolvedTargetFallsBackToSender(t *testing.T) {
 // (which drives viewer+command buckets) rides along unchanged either way.
 func TestCounterBumpScopesUnchangedByAddressing(t *testing.T) {
 	p, loyalty := counterPipeline(t, "{user} {counter:hugs} / @{target} {counter:target:shutups}")
-	p.roster.Observe(123, "bob", "7", "")
+	p.roster.Observe(123, chatterIdentity{login: "bob", id: "7"})
 
 	got := collectDispatch(p, chatCtx("!so @bob", ""))
 	require.Len(t, got, 1)
@@ -131,7 +131,7 @@ func TestCounterBumpScopesUnchangedByAddressing(t *testing.T) {
 // silently miss the roster.
 func TestCounterBumpTabSeparatedMention(t *testing.T) {
 	p, loyalty := counterPipeline(t, "{counter:target:shutups}")
-	p.roster.Observe(123, "bob", "7", "Bob")
+	p.roster.Observe(123, chatterIdentity{login: "bob", id: "7", name: "Bob"})
 
 	got := collectDispatch(p, chatCtx("!so @bob\traid incoming", ""))
 	require.Len(t, got, 1)

--- a/app/sesame/engine/deps.go
+++ b/app/sesame/engine/deps.go
@@ -219,6 +219,18 @@ type Viewer struct {
 	Name  string
 }
 
+// CounterBump is one counter increment request: which broadcaster's counter
+// (name), against whose identity (viewer — zero rides the shared value),
+// keyed by which source (the command trigger or reward title; only the scopes
+// that bucket per source use it), and by how much.
+type CounterBump struct {
+	BroadcasterID uint64
+	Name          string
+	Viewer        Viewer
+	Command       string
+	Delta         int64
+}
+
 // LoyaltyStore is the loyalty surface modules and the pipeline depend on:
 // point accrual (fire-and-forget through the worker-side reporter), counter
 // bumps/reads over the Valkey live view, cached balance peeks and the
@@ -226,12 +238,11 @@ type Viewer struct {
 type LoyaltyStore interface {
 	// Earn records one viewer's point/watch accrual; batched and loss-tolerant.
 	Earn(broadcasterID, viewerID uint64, login, name string, points int64, watchSeconds uint64)
-	// CounterBump increments a counter by delta and returns the new value.
-	// viewer is the acting chatter and command the triggering source's name
-	// (a command's canonical trigger, or a channel-point reward's title); each
-	// is used only when the counter's scope needs it (viewer, or
-	// viewer+command — the three modes, all per channel).
-	CounterBump(ctx context.Context, broadcasterID uint64, name string, viewer Viewer, command string, delta int64) (int64, error)
+	// CounterBump increments a counter and returns the new value. Which fields
+	// of the request matter is decided by the counter's own scope: viewer
+	// identity keys the per-viewer buckets, command names the per-source
+	// bucket, channel scope ignores both.
+	CounterBump(ctx context.Context, b CounterBump) (int64, error)
 	// CounterPeek reads a counter without bumping it; found=false means it
 	// does not exist.
 	CounterPeek(ctx context.Context, broadcasterID uint64, name string, viewerID uint64, command string) (loyaltyrpc.Counter, bool, error)

--- a/app/sesame/engine/dispatch.go
+++ b/app/sesame/engine/dispatch.go
@@ -97,7 +97,7 @@ func (p *Pipeline) runCustom(ctx context.Context, c *module.Context, name, args 
 	// each with its own slash-verb translation. A line left with no payload (an
 	// "/announce" with no text, a "/shoutout" with no target) is dropped; the
 	// run counts once if anything was emitted.
-	counters := p.bumpCounterTokens(ctx, c, cc.Name, cc.Response)
+	counters := p.bumpCounterTokens(ctx, c, cc.Name, args, cc.Response)
 	emitted, err := p.emitResponse(c, cc.Response, args, counters, emit)
 	if err != nil {
 		return err
@@ -136,8 +136,7 @@ func (p *Pipeline) emitResponse(c *module.Context, response, args string, counte
 	sender := c.Env.ChatterName()
 	touser := sender
 	if args != "" {
-		firstWord, _, _ := strings.Cut(args, " ")
-		touser = strings.TrimPrefix(firstWord, "@")
+		touser = strings.TrimPrefix(firstArg(args), "@")
 	}
 
 	// Enforce the user-controlled variables: strip a leading slash run so a
@@ -228,13 +227,17 @@ func (p *Pipeline) emitCommand(o *module.Output, emit module.Emit) bool {
 // bumpCounterTokens resolves a response's {counter:<name>} tokens: each
 // distinct counter is bumped by one — against the channel value, the sender,
 // or the (sender, command) bucket, per the counter's own scope — and its new
-// value is returned for expansion. command is the canonical name of the
-// custom command being run, which keys a viewer+command counter's bucket. nil
-// when the response references no counter or no loyalty store is wired —
-// expandCommand then leaves the token visible, matching every other unknown
-// token. A bump failure renders the counter without a value rather than
-// blocking the reply.
-func (p *Pipeline) bumpCounterTokens(ctx context.Context, c *module.Context, command, response string) map[string]string {
+// value is returned for expansion. A {counter:target:<name>} token instead
+// keys the bump on the viewer the command mentions ({touser}), resolved
+// through the chatter roster; an unresolvable mention falls back to the
+// sender, mirroring how {touser} itself defaults to the sender. The counter's
+// scope semantics are unchanged by addressing: only whose identity rides the
+// bump moves (issue #479). command is the canonical name of the custom command
+// being run, which keys a viewer+command counter's bucket. nil when the
+// response references no counter or no loyalty store is wired — expandCommand
+// then leaves the token visible, matching every other unknown token. A bump
+// failure renders the counter without a value rather than blocking the reply.
+func (p *Pipeline) bumpCounterTokens(ctx context.Context, c *module.Context, command, args, response string) map[string]string {
 	if p.loyalty == nil || !strings.Contains(response, "{"+counterTokenPrefix) {
 		return nil
 	}
@@ -242,18 +245,33 @@ func (p *Pipeline) bumpCounterTokens(ctx context.Context, c *module.Context, com
 	if len(names) == 0 {
 		return nil
 	}
-	viewerID, _ := strconv.ParseUint(c.Env.ChatterUserID, 10, 64)
-	viewer := Viewer{ID: viewerID, Login: c.Env.ChatterUserLogin, Name: c.Env.ChatterUserName}
+	senderID, _ := strconv.ParseUint(c.Env.ChatterUserID, 10, 64)
+	sender := Viewer{ID: senderID, Login: c.Env.ChatterUserLogin, Name: c.Env.ChatterUserName}
+	var touser string
 	counters := make(map[string]string, len(names))
 	for _, name := range names {
-		if strings.HasPrefix(name, botCounterTokenPrefix) {
+		viewer := sender
+		base := name
+		if stripped, addressed := strings.CutPrefix(name, targetCounterTokenPrefix); addressed {
+			base = stripped
+			if base == "" {
+				continue // "{counter:target:}": nothing to bump, token stays visible
+			}
+			if touser == "" {
+				touser = strings.ToLower(strings.TrimPrefix(firstArg(args), "@"))
+			}
+			if v, found := p.roster.Resolve(c.BroadcasterID, touser); found {
+				viewer = v
+			}
+		}
+		if strings.HasPrefix(base, botCounterTokenPrefix) {
 			continue // bot counters are admin-only; the token stays visible
 		}
-		value, err := p.loyalty.CounterBump(ctx, c.BroadcasterID, name, viewer, command, 1)
+		value, err := p.loyalty.CounterBump(ctx, c.BroadcasterID, base, viewer, command, 1)
 		if err != nil {
 			p.log.Warn("counter token bump failed",
 				zap.Uint64("broadcaster_id", c.BroadcasterID),
-				zap.String("counter", name),
+				zap.String("counter", base),
 				zap.Error(err),
 			)
 			continue
@@ -261,6 +279,13 @@ func (p *Pipeline) bumpCounterTokens(ctx context.Context, c *module.Context, com
 		counters[name] = strconv.FormatInt(value, 10)
 	}
 	return counters
+}
+
+// firstArg returns the first whitespace-delimited word of a command's
+// arguments — the same word emitResponse renders as {touser}.
+func firstArg(args string) string {
+	word, _, _ := strings.Cut(args, " ")
+	return word
 }
 
 // gateRule is the set of checks one command is gated by, so the gate takes a

--- a/app/sesame/engine/dispatch.go
+++ b/app/sesame/engine/dispatch.go
@@ -267,7 +267,13 @@ func (p *Pipeline) bumpCounterTokens(ctx context.Context, c *module.Context, com
 		if strings.HasPrefix(base, botCounterTokenPrefix) {
 			continue // bot counters are admin-only; the token stays visible
 		}
-		value, err := p.loyalty.CounterBump(ctx, c.BroadcasterID, base, viewer, command, 1)
+		value, err := p.loyalty.CounterBump(ctx, CounterBump{
+			BroadcasterID: c.BroadcasterID,
+			Name:          base,
+			Viewer:        viewer,
+			Command:       command,
+			Delta:         1,
+		})
 		if err != nil {
 			p.log.Warn("counter token bump failed",
 				zap.Uint64("broadcaster_id", c.BroadcasterID),
@@ -282,10 +288,14 @@ func (p *Pipeline) bumpCounterTokens(ctx context.Context, c *module.Context, com
 }
 
 // firstArg returns the first whitespace-delimited word of a command's
-// arguments — the same word emitResponse renders as {touser}.
+// arguments — the same word emitResponse renders as {touser}. Fields rather
+// than a space Cut so a tab after the mention cannot glue itself to the name.
 func firstArg(args string) string {
-	word, _, _ := strings.Cut(args, " ")
-	return word
+	fields := strings.Fields(args)
+	if len(fields) == 0 {
+		return ""
+	}
+	return fields[0]
 }
 
 // gateRule is the set of checks one command is gated by, so the gate takes a

--- a/app/sesame/engine/loyalty_valkey.go
+++ b/app/sesame/engine/loyalty_valkey.go
@@ -223,12 +223,13 @@ func bumpTarget(scope string, viewerID uint64, command string) (string, uint64, 
 // increment continues the stored count instead of restarting at zero. Bot
 // scope rides broadcasterID 0 (the reserved bot namespace) and is reachable
 // only from admin/system callers — template and chat paths never pass 0.
-func (s *ValkeyLoyaltyStore) CounterBump(ctx context.Context, broadcasterID uint64, name string, viewer Viewer, command string, delta int64) (int64, error) {
-	name = NormalizeCounterName(name)
-	if name == "" || delta == 0 {
+func (s *ValkeyLoyaltyStore) CounterBump(ctx context.Context, b CounterBump) (int64, error) {
+	name := NormalizeCounterName(b.Name)
+	if name == "" || b.Delta == 0 {
 		return 0, nil
 	}
-	scope, viewerID, command := bumpTarget(s.scope(ctx, broadcasterID, name), viewer.ID, NormalizeCounterName(command))
+	scope, viewerID, command := bumpTarget(s.scope(ctx, b.BroadcasterID, name), b.Viewer.ID, NormalizeCounterName(b.Command))
+	viewer := b.Viewer
 	if viewerID == 0 {
 		// The bump fell back to a non-viewer bucket; a stray identity must
 		// not ride a key it does not belong to.
@@ -239,21 +240,21 @@ func (s *ValkeyLoyaltyStore) CounterBump(ctx context.Context, broadcasterID uint
 	var value int64
 	var err error
 	if rowScoped(scope) {
-		value, err = s.bumpChannel(ctx, broadcasterID, name, delta)
+		value, err = s.bumpChannel(ctx, b.BroadcasterID, name, b.Delta)
 	} else {
-		value, err = s.bumpEntry(ctx, broadcasterID, name, entryField(scope, viewerID, command), viewerID, command, delta)
+		value, err = s.bumpEntry(ctx, b.BroadcasterID, name, entryField(scope, viewerID, command), viewerID, command, b.Delta)
 	}
 	if err != nil {
 		return 0, err
 	}
 
 	s.reporter.Bump(CounterBumpTarget{
-		BroadcasterID: broadcasterID,
+		BroadcasterID: b.BroadcasterID,
 		Name:          name,
 		Scope:         scope,
 		Viewer:        viewer,
 		Command:       command,
-	}, delta)
+	}, b.Delta)
 	return value, nil
 }
 

--- a/app/sesame/engine/pipeline.go
+++ b/app/sesame/engine/pipeline.go
@@ -170,16 +170,7 @@ func (p *Pipeline) Process(msg *bus.Message) error {
 	}
 	traceEvent(ctx, env.Type, env.Lane, broadcasterID)
 
-	// Every eligible chat line teaches the roster its speaker's identity (the
-	// folded duplicate cohort's senders too — a spam burst is exactly when
-	// mentions fly). One sharded map store per line; see chatterRoster.
-	if env.Type == chatType && env.ChatterUserID != "" && env.ChatterUserLogin != "" {
-		p.roster.Observe(broadcasterID, env.ChatterUserLogin, env.ChatterUserID, env.ChatterUserName)
-		for i := range env.Senders {
-			// A cohort sender carries no display name; the roster's stays as-is.
-			p.roster.Observe(broadcasterID, env.Senders[i].ChatterUserLogin, env.Senders[i].ChatterUserID, "")
-		}
-	}
+	p.roster.ObserveEnvelope(broadcasterID, env)
 
 	views, err := p.tracedModuleViews(ctx, env.Type, broadcasterID)
 	if err != nil {

--- a/app/sesame/engine/pipeline.go
+++ b/app/sesame/engine/pipeline.go
@@ -73,6 +73,10 @@ type Pipeline struct {
 	loyalty  LoyaltyStore
 	dedup    *EventDedup
 	stats    *botStats
+	// roster remembers who this replica has seen speak, so a target-addressed
+	// counter token ({counter:target:...}) can key its bump on the mentioned
+	// viewer. Pure in-process memory; see chatterRoster.
+	roster *chatterRoster
 
 	botID            string
 	outgressPremium  string
@@ -111,6 +115,7 @@ func NewPipeline(d Deps, registry *Registry, cfg Config) *Pipeline {
 		campaign:         d.Campaign,
 		shieldEnabled:    cfg.ShieldEnabled,
 		raidGate:         newRaidCooldown(raidCooldownTTL),
+		roster:           newChatterRoster(),
 	}
 	if cfg.CountUses && d.Pub != nil {
 		p.uses = newUseReporter(d.Pub, d.Log)
@@ -164,6 +169,17 @@ func (p *Pipeline) Process(msg *bus.Message) error {
 		return nil
 	}
 	traceEvent(ctx, env.Type, env.Lane, broadcasterID)
+
+	// Every eligible chat line teaches the roster its speaker's identity (the
+	// folded duplicate cohort's senders too — a spam burst is exactly when
+	// mentions fly). One sharded map store per line; see chatterRoster.
+	if env.Type == chatType && env.ChatterUserID != "" && env.ChatterUserLogin != "" {
+		p.roster.Observe(broadcasterID, env.ChatterUserLogin, env.ChatterUserID, env.ChatterUserName)
+		for i := range env.Senders {
+			// A cohort sender carries no display name; the roster's stays as-is.
+			p.roster.Observe(broadcasterID, env.Senders[i].ChatterUserLogin, env.Senders[i].ChatterUserID, "")
+		}
+	}
 
 	views, err := p.tracedModuleViews(ctx, env.Type, broadcasterID)
 	if err != nil {

--- a/app/sesame/engine/roster.go
+++ b/app/sesame/engine/roster.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package engine
+
+import (
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// rosterCapacityPerChannel ceilings one broadcaster's remembered chatter set.
+// The roster exists so a {counter:target:...} token can key its bump on the
+// mentioned viewer, and a mention is overwhelmingly someone currently in chat —
+// a few thousand covers any channel's concurrent chatters with headroom. It is
+// a cache of identities, not an archive: Twitch ids never change and every
+// observed line refreshes the entry, so eviction only costs re-learning on the
+// target's next line.
+const rosterCapacityPerChannel = 4096
+
+// chatterRoster remembers the viewers each replica has seen speak, per
+// channel: login -> Viewer (the id keys viewer-scoped counter buckets; login
+// and name ride along as the display identity). It is fed passively from every
+// eligible chat line — the envelope already carries all three fields, so the
+// hot path pays one sharded map store and nothing else — and read when a
+// target-addressed counter token resolves who it counts against.
+//
+// Per-replica by design: sharing it through Valkey would put a network write on
+// every chat line to serve a token that is best-effort anyway. A replica that
+// has not seen the mentioned viewer speak falls back to sender-keyed counting
+// (dispatch.go), which converges once the target says anything this replica
+// observes.
+type chatterRoster struct {
+	mu    sync.RWMutex
+	chans map[uint64]map[string]Viewer
+}
+
+func newChatterRoster() *chatterRoster {
+	return &chatterRoster{chans: make(map[uint64]map[string]Viewer)}
+}
+
+// Observe records one chat line's speaker. Empty or unparseable identities are
+// skipped: a bucket keyed by login must carry a real id or the bump it feeds
+// would fall back to channel scope at flush time.
+func (r *chatterRoster) Observe(broadcasterID uint64, login, id, name string) {
+	if r == nil || broadcasterID == 0 || login == "" || id == "" {
+		return
+	}
+	viewerID, err := strconv.ParseUint(id, 10, 64)
+	if err != nil || viewerID == 0 {
+		return
+	}
+	login = strings.ToLower(login)
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	chanViewers := r.chans[broadcasterID]
+	if chanViewers == nil {
+		chanViewers = make(map[string]Viewer)
+		r.chans[broadcasterID] = chanViewers
+	}
+	if _, seen := chanViewers[login]; !seen && len(chanViewers) >= rosterCapacityPerChannel {
+		// Evict one arbitrary entry (Go map range order is randomized) rather
+		// than tracking recency: identities are stable, so any victim is as
+		// good as another and the bookkeeping would outlive the benefit.
+		for victim := range chanViewers {
+			delete(chanViewers, victim)
+			break
+		}
+	}
+	// An empty display name (a folded-cohort sender carries none) must not
+	// clobber the one a direct line already taught us.
+	if prev, seen := chanViewers[login]; seen && prev.Name != "" && name == "" {
+		name = prev.Name
+	}
+	chanViewers[login] = Viewer{ID: viewerID, Login: login, Name: name}
+}
+
+// Resolve looks up the mentioned viewer's identity. found=false leaves the
+// caller on its fallback path; nothing here can fail loudly.
+func (r *chatterRoster) Resolve(broadcasterID uint64, login string) (Viewer, bool) {
+	if r == nil || broadcasterID == 0 || login == "" {
+		return Viewer{}, false
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	v, ok := r.chans[broadcasterID][strings.ToLower(login)]
+	return v, ok
+}

--- a/app/sesame/engine/roster.go
+++ b/app/sesame/engine/roster.go
@@ -7,6 +7,8 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+
+	"ItsBagelBot/internal/domain/event/lane"
 )
 
 // rosterCapacityPerChannel ceilings one broadcaster's remembered chatter set.
@@ -39,15 +41,35 @@ func newChatterRoster() *chatterRoster {
 	return &chatterRoster{chans: make(map[uint64]map[string]Viewer)}
 }
 
-// Observe records one chat line's speaker. Empty or unparseable identities are
-// skipped: a bucket keyed by login must carry a real id or the bump it feeds
-// would fall back to channel scope at flush time.
-func (r *chatterRoster) Observe(broadcasterID uint64, login, id, name string) {
-	if r == nil || broadcasterID == 0 || login == "" || id == "" {
+// ObserveEnvelope feeds every speaker of one chat envelope into the roster:
+// the line's own chatter plus each sender of a folded duplicate cohort (a spam
+// burst is exactly when mentions fly). Non-chat envelopes contribute nothing;
+// identity-less lines are dropped by Observe.
+func (r *chatterRoster) ObserveEnvelope(broadcasterID uint64, env *lane.Envelope) {
+	if env.Type != chatType {
 		return
 	}
-	viewerID, err := strconv.ParseUint(id, 10, 64)
-	if err != nil || viewerID == 0 {
+	r.Observe(broadcasterID, env.ChatterUserLogin, env.ChatterUserID, env.ChatterUserName)
+	for i := range env.Senders {
+		// A cohort sender carries no display name on the wire; Observe keeps
+		// the one a direct line already taught us.
+		r.Observe(broadcasterID, env.Senders[i].ChatterUserLogin, env.Senders[i].ChatterUserID, "")
+	}
+}
+
+// Observe records one chat line's speaker under their lower-cased login.
+func (r *chatterRoster) Observe(broadcasterID uint64, login, id, name string) {
+	if r == nil {
+		return
+	}
+	if broadcasterID == 0 {
+		return
+	}
+	if login == "" {
+		return
+	}
+	viewerID := parseChatterID(id)
+	if viewerID == 0 {
 		return
 	}
 	login = strings.ToLower(login)
@@ -59,31 +81,60 @@ func (r *chatterRoster) Observe(broadcasterID uint64, login, id, name string) {
 		chanViewers = make(map[string]Viewer)
 		r.chans[broadcasterID] = chanViewers
 	}
-	if _, seen := chanViewers[login]; !seen && len(chanViewers) >= rosterCapacityPerChannel {
-		// Evict one arbitrary entry (Go map range order is randomized) rather
-		// than tracking recency: identities are stable, so any victim is as
-		// good as another and the bookkeeping would outlive the benefit.
-		for victim := range chanViewers {
-			delete(chanViewers, victim)
-			break
+	prev, seen := chanViewers[login]
+	if !seen {
+		if len(chanViewers) >= rosterCapacityPerChannel {
+			evictOne(chanViewers)
 		}
 	}
-	// An empty display name (a folded-cohort sender carries none) must not
-	// clobber the one a direct line already taught us.
-	if prev, seen := chanViewers[login]; seen && prev.Name != "" && name == "" {
-		name = prev.Name
-	}
-	chanViewers[login] = Viewer{ID: viewerID, Login: login, Name: name}
+	chanViewers[login] = Viewer{ID: viewerID, Login: login, Name: preferredName(name, prev.Name)}
 }
 
-// Resolve looks up the mentioned viewer's identity. found=false leaves the
-// caller on its fallback path; nothing here can fail loudly.
+// Resolve looks up the mentioned viewer's identity by login. found=false
+// leaves the caller on its fallback path; nothing here can fail loudly.
 func (r *chatterRoster) Resolve(broadcasterID uint64, login string) (Viewer, bool) {
-	if r == nil || broadcasterID == 0 || login == "" {
+	if r == nil {
+		return Viewer{}, false
+	}
+	if broadcasterID == 0 {
+		return Viewer{}, false
+	}
+	if login == "" {
 		return Viewer{}, false
 	}
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	v, ok := r.chans[broadcasterID][strings.ToLower(login)]
 	return v, ok
+}
+
+// parseChatterID parses one wire chatter id, rejecting the empty and
+// non-numeric shapes: a roster bucket must carry an id the counter buckets can
+// key on, or the bump it feeds would fall back to channel scope at flush time.
+func parseChatterID(id string) uint64 {
+	viewerID, err := strconv.ParseUint(id, 10, 64)
+	if err != nil {
+		return 0
+	}
+	return viewerID
+}
+
+// preferredName keeps a learned display name when the newer observation
+// carries none.
+func preferredName(newName, storedName string) string {
+	if newName != "" {
+		return newName
+	}
+	return storedName
+}
+
+// evictOne drops one arbitrary entry to make room for an insert. Go map range
+// order is randomized, so "arbitrary" is uniform-ish — good enough because
+// identities are stable and eviction only costs re-learning on the victim's
+// next line; recency tracking would outlive its benefit. The caller holds mu.
+func evictOne(chanViewers map[string]Viewer) {
+	for victim := range chanViewers {
+		delete(chanViewers, victim)
+		break
+	}
 }

--- a/app/sesame/engine/roster.go
+++ b/app/sesame/engine/roster.go
@@ -20,6 +20,35 @@ import (
 // target's next line.
 const rosterCapacityPerChannel = 4096
 
+// chatterIdentity is one speaker's identity as the chat envelope carries it:
+// three loose strings on the wire (the stable login, its numeric Twitch id,
+// the mutable display name), kept together so the roster's surface stays
+// shape-based rather than string-based.
+type chatterIdentity struct {
+	id    string
+	login string
+	name  string
+}
+
+// rosterKey returns the roster's lookup key for this speaker — the lower-cased
+// login — plus the numeric id that keys viewer-scoped counter buckets. Both
+// come back zero-shaped when the identity is unusable (no login, or an
+// unparseable/zero id): a bucket keyed by login must carry a real id or the
+// bump it feeds would fall back to channel scope at flush time.
+func (who chatterIdentity) rosterKey() (string, uint64) {
+	if who.login == "" {
+		return "", 0
+	}
+	viewerID, err := strconv.ParseUint(who.id, 10, 64)
+	if err != nil {
+		return "", 0
+	}
+	if viewerID == 0 {
+		return "", 0
+	}
+	return strings.ToLower(who.login), viewerID
+}
+
 // chatterRoster remembers the viewers each replica has seen speak, per
 // channel: login -> Viewer (the id keys viewer-scoped counter buckets; login
 // and name ride along as the display identity). It is fed passively from every
@@ -46,33 +75,37 @@ func newChatterRoster() *chatterRoster {
 // burst is exactly when mentions fly). Non-chat envelopes contribute nothing;
 // identity-less lines are dropped by Observe.
 func (r *chatterRoster) ObserveEnvelope(broadcasterID uint64, env *lane.Envelope) {
-	if env.Type != chatType {
-		return
-	}
-	r.Observe(broadcasterID, env.ChatterUserLogin, env.ChatterUserID, env.ChatterUserName)
-	for i := range env.Senders {
-		// A cohort sender carries no display name on the wire; Observe keeps
-		// the one a direct line already taught us.
-		r.Observe(broadcasterID, env.Senders[i].ChatterUserLogin, env.Senders[i].ChatterUserID, "")
-	}
-}
-
-// Observe records one chat line's speaker under their lower-cased login.
-func (r *chatterRoster) Observe(broadcasterID uint64, login, id, name string) {
 	if r == nil {
 		return
 	}
+	if env.Type != chatType {
+		return
+	}
+	r.Observe(broadcasterID, chatterIdentity{
+		id:    env.ChatterUserID,
+		login: env.ChatterUserLogin,
+		name:  env.ChatterUserName,
+	})
+	for i := range env.Senders {
+		// A cohort sender carries no display name on the wire; Observe keeps
+		// the one a direct line already taught us.
+		r.Observe(broadcasterID, chatterIdentity{
+			id:    env.Senders[i].ChatterUserID,
+			login: env.Senders[i].ChatterUserLogin,
+		})
+	}
+}
+
+// Observe records one speaker in their channel's set, keyed by the identity's
+// lower-cased login.
+func (r *chatterRoster) Observe(broadcasterID uint64, who chatterIdentity) {
 	if broadcasterID == 0 {
 		return
 	}
-	if login == "" {
-		return
-	}
-	viewerID := parseChatterID(id)
+	login, viewerID := who.rosterKey()
 	if viewerID == 0 {
-		return
+		return // covers the empty-login shape too: rosterKey zeroes both
 	}
-	login = strings.ToLower(login)
 
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -87,7 +120,13 @@ func (r *chatterRoster) Observe(broadcasterID uint64, login, id, name string) {
 			evictOne(chanViewers)
 		}
 	}
-	chanViewers[login] = Viewer{ID: viewerID, Login: login, Name: preferredName(name, prev.Name)}
+	entry := Viewer{ID: viewerID, Login: login, Name: who.name}
+	if who.name == "" {
+		// An unnamed observation (a folded-cohort sender carries no display
+		// name) must not clobber the one a direct line already taught us.
+		entry.Name = prev.Name
+	}
+	chanViewers[login] = entry
 }
 
 // Resolve looks up the mentioned viewer's identity by login. found=false
@@ -106,26 +145,6 @@ func (r *chatterRoster) Resolve(broadcasterID uint64, login string) (Viewer, boo
 	defer r.mu.RUnlock()
 	v, ok := r.chans[broadcasterID][strings.ToLower(login)]
 	return v, ok
-}
-
-// parseChatterID parses one wire chatter id, rejecting the empty and
-// non-numeric shapes: a roster bucket must carry an id the counter buckets can
-// key on, or the bump it feeds would fall back to channel scope at flush time.
-func parseChatterID(id string) uint64 {
-	viewerID, err := strconv.ParseUint(id, 10, 64)
-	if err != nil {
-		return 0
-	}
-	return viewerID
-}
-
-// preferredName keeps a learned display name when the newer observation
-// carries none.
-func preferredName(newName, storedName string) string {
-	if newName != "" {
-		return newName
-	}
-	return storedName
 }
 
 // evictOne drops one arbitrary entry to make room for an insert. Go map range

--- a/app/sesame/engine/roster_test.go
+++ b/app/sesame/engine/roster_test.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package engine
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestChatterRosterObserveResolve(t *testing.T) {
+	r := newChatterRoster()
+
+	_, ok := r.Resolve(1, "bob")
+	assert.False(t, ok, "empty roster resolves nothing")
+
+	r.Observe(1, "Bob", "7", "Bob")
+	v, ok := r.Resolve(1, "bob")
+	assert.True(t, ok)
+	assert.Equal(t, uint64(7), v.ID)
+	assert.Equal(t, "bob", v.Login, "lookup keys on the lower-cased login")
+	assert.Equal(t, "Bob", v.Name)
+
+	// Channels are isolated.
+	_, ok = r.Resolve(2, "bob")
+	assert.False(t, ok)
+
+	// A later line refreshes identity fields.
+	r.Observe(1, "bob", "7", "Robert")
+	v, _ = r.Resolve(1, "bob")
+	assert.Equal(t, "Robert", v.Name)
+
+	// An unnamed cohort line must not clobber the learned display name.
+	r.Observe(1, "bob", "7", "")
+	v, _ = r.Resolve(1, "bob")
+	assert.Equal(t, "Robert", v.Name)
+
+	// Garbage identities never enter the roster.
+	r.Observe(1, "", "9", "X")     // no login
+	r.Observe(1, "x", "", "X")     // no id
+	r.Observe(1, "x", "zero", "X") // unparseable id
+	r.Observe(0, "x", "9", "X")    // no broadcaster
+	for _, login := range []string{"", "x"} {
+		_, ok := r.Resolve(1, login)
+		assert.False(t, ok)
+	}
+}
+
+func TestChatterRosterBoundedPerChannel(t *testing.T) {
+	r := newChatterRoster()
+	for i := range rosterCapacityPerChannel + 10 {
+		r.Observe(1, fmt.Sprintf("viewer%d", i), fmt.Sprintf("%d", i+1), "")
+	}
+	r.mu.RLock()
+	size := len(r.chans[1])
+	r.mu.RUnlock()
+	assert.LessOrEqual(t, size, rosterCapacityPerChannel,
+		"the per-channel set stays bounded even if a channel outruns the cap")
+
+	// The bound is per channel, not global.
+	r.Observe(2, "viewer0", "1", "")
+	r.mu.RLock()
+	size2 := len(r.chans[2])
+	r.mu.RUnlock()
+	assert.Equal(t, 1, size2)
+}
+
+func TestChatterRosterNilSafe(t *testing.T) {
+	var r *chatterRoster
+	assert.NotPanics(t, func() { r.Observe(1, "bob", "7", "Bob") })
+	_, ok := r.Resolve(1, "bob")
+	assert.False(t, ok)
+}

--- a/app/sesame/engine/roster_test.go
+++ b/app/sesame/engine/roster_test.go
@@ -7,8 +7,19 @@ import (
 	"fmt"
 	"testing"
 
+	"ItsBagelBot/internal/domain/event/lane"
+
 	"github.com/stretchr/testify/assert"
 )
+
+// rosterChatEnvelope is a minimal chat envelope for the feed-level tests.
+var rosterChatEnvelope = lane.Envelope{
+	Type:              chatType,
+	BroadcasterUserID: "123",
+	ChatterUserID:     "7",
+	ChatterUserLogin:  "bob",
+	ChatterUserName:   "Bob",
+}
 
 func TestChatterRosterObserveResolve(t *testing.T) {
 	r := newChatterRoster()
@@ -16,7 +27,7 @@ func TestChatterRosterObserveResolve(t *testing.T) {
 	_, ok := r.Resolve(1, "bob")
 	assert.False(t, ok, "empty roster resolves nothing")
 
-	r.Observe(1, "Bob", "7", "Bob")
+	r.Observe(1, chatterIdentity{login: "Bob", id: "7", name: "Bob"})
 	v, ok := r.Resolve(1, "bob")
 	assert.True(t, ok)
 	assert.Equal(t, uint64(7), v.ID)
@@ -28,20 +39,22 @@ func TestChatterRosterObserveResolve(t *testing.T) {
 	assert.False(t, ok)
 
 	// A later line refreshes identity fields.
-	r.Observe(1, "bob", "7", "Robert")
+	r.Observe(1, chatterIdentity{login: "bob", id: "7", name: "Robert"})
 	v, _ = r.Resolve(1, "bob")
 	assert.Equal(t, "Robert", v.Name)
 
-	// An unnamed cohort line must not clobber the learned display name.
-	r.Observe(1, "bob", "7", "")
+	// An unnamed observation must not clobber the learned display name.
+	r.Observe(1, chatterIdentity{login: "bob", id: "7"})
 	v, _ = r.Resolve(1, "bob")
 	assert.Equal(t, "Robert", v.Name)
+}
 
-	// Garbage identities never enter the roster.
-	r.Observe(1, "", "9", "X")     // no login
-	r.Observe(1, "x", "", "X")     // no id
-	r.Observe(1, "x", "zero", "X") // unparseable id
-	r.Observe(0, "x", "9", "X")    // no broadcaster
+func TestChatterRosterDropsUnusableIdentities(t *testing.T) {
+	r := newChatterRoster()
+	r.Observe(1, chatterIdentity{login: "", id: "9", name: "X"})     // no login
+	r.Observe(1, chatterIdentity{id: "", login: "x", name: "X"})     // no id
+	r.Observe(1, chatterIdentity{id: "zero", login: "x", name: "X"}) // unparseable id
+	r.Observe(0, chatterIdentity{id: "9", login: "x", name: "X"})    // no broadcaster
 	for _, login := range []string{"", "x"} {
 		_, ok := r.Resolve(1, login)
 		assert.False(t, ok)
@@ -51,7 +64,7 @@ func TestChatterRosterObserveResolve(t *testing.T) {
 func TestChatterRosterBoundedPerChannel(t *testing.T) {
 	r := newChatterRoster()
 	for i := range rosterCapacityPerChannel + 10 {
-		r.Observe(1, fmt.Sprintf("viewer%d", i), fmt.Sprintf("%d", i+1), "")
+		r.Observe(1, chatterIdentity{login: fmt.Sprintf("viewer%d", i), id: fmt.Sprintf("%d", i+1)})
 	}
 	r.mu.RLock()
 	size := len(r.chans[1])
@@ -60,7 +73,7 @@ func TestChatterRosterBoundedPerChannel(t *testing.T) {
 		"the per-channel set stays bounded even if a channel outruns the cap")
 
 	// The bound is per channel, not global.
-	r.Observe(2, "viewer0", "1", "")
+	r.Observe(2, chatterIdentity{login: "viewer0", id: "1"})
 	r.mu.RLock()
 	size2 := len(r.chans[2])
 	r.mu.RUnlock()
@@ -69,7 +82,9 @@ func TestChatterRosterBoundedPerChannel(t *testing.T) {
 
 func TestChatterRosterNilSafe(t *testing.T) {
 	var r *chatterRoster
-	assert.NotPanics(t, func() { r.Observe(1, "bob", "7", "Bob") })
+	assert.NotPanics(t, func() {
+		r.ObserveEnvelope(1, &rosterChatEnvelope)
+	})
 	_, ok := r.Resolve(1, "bob")
 	assert.False(t, ok)
 }

--- a/app/sesame/engine/vars.go
+++ b/app/sesame/engine/vars.go
@@ -35,6 +35,15 @@ const counterTokenPrefix = "counter:"
 // content may resolve it.
 const botCounterTokenPrefix = "bot:"
 
+// targetCounterTokenPrefix marks a target-addressed counter reference inside a
+// counter token ({counter:target:shutups}): the bump keys on the viewer the
+// command mentions ({touser}) instead of the sender, so "!shutup @bob" counts
+// against bob. The counter's own scope still decides the bucket shape — the
+// addressing only changes whose viewer identity rides the bump (issue #479).
+// Like "bot:", the "target:" spelling inside a counter name is reserved by the
+// worker's token grammar.
+const targetCounterTokenPrefix = "target:"
+
 // expandCommand expands a custom-command response, supporting the {user},
 // {sender}, {args} and {touser} tokens. It is expand specialized for the command
 // path. {target} is the dashboard-facing name for {touser}; both are kept as

--- a/app/sesame/modules/channelpoints.go
+++ b/app/sesame/modules/channelpoints.go
@@ -183,7 +183,13 @@ func bumpRewardCounter(ctx context.Context, d engine.Deps, c *module.Context, b 
 	}
 	viewerID, _ := strconv.ParseUint(ev.UserID, 10, 64)
 	viewer := engine.Viewer{ID: viewerID, Login: ev.UserLogin, Name: ev.UserName}
-	value, err := d.Loyalty.CounterBump(ctx, c.BroadcasterID, b.Counter, viewer, ev.Reward.Title, 1)
+	value, err := d.Loyalty.CounterBump(ctx, engine.CounterBump{
+		BroadcasterID: c.BroadcasterID,
+		Name:          b.Counter,
+		Viewer:        viewer,
+		Command:       ev.Reward.Title,
+		Delta:         1,
+	})
 	if err != nil {
 		if d.Log != nil {
 			d.Log.Warn("channelpoints: counter bump failed",

--- a/app/sesame/modules/loyalty.go
+++ b/app/sesame/modules/loyalty.go
@@ -376,7 +376,13 @@ func (lc loyaltyCmd) counterAdd(ctx context.Context, rest []string) error {
 	}
 	viewerID, _ := strconv.ParseUint(lc.c.Env.ChatterUserID, 10, 64)
 	viewer := engine.Viewer{ID: viewerID, Login: lc.c.Env.ChatterUserLogin, Name: lc.c.Env.ChatterUserName}
-	value, err := lc.d.Loyalty.CounterBump(ctx, lc.c.BroadcasterID, rest[0], viewer, command, delta)
+	value, err := lc.d.Loyalty.CounterBump(ctx, engine.CounterBump{
+		BroadcasterID: lc.c.BroadcasterID,
+		Name:          rest[0],
+		Viewer:        viewer,
+		Command:       command,
+		Delta:         delta,
+	})
 	if err != nil {
 		return lc.fail("add", err)
 	}

--- a/app/sesame/modules/loyalty_test.go
+++ b/app/sesame/modules/loyalty_test.go
@@ -56,9 +56,9 @@ func (f *fakeLoyalty) Earn(broadcasterID, viewerID uint64, login, name string, p
 	f.earns = append(f.earns, earnCall{broadcasterID, viewerID, login, name, points, watchSeconds})
 }
 
-func (f *fakeLoyalty) CounterBump(_ context.Context, broadcasterID uint64, name string, viewer engine.Viewer, command string, delta int64) (int64, error) {
-	f.bumps = append(f.bumps, bumpCall{broadcasterID, engine.NormalizeCounterName(name), viewer.ID, command, delta})
-	f.bumpVal += delta
+func (f *fakeLoyalty) CounterBump(_ context.Context, b engine.CounterBump) (int64, error) {
+	f.bumps = append(f.bumps, bumpCall{b.BroadcasterID, engine.NormalizeCounterName(b.Name), b.Viewer.ID, b.Command, b.Delta})
+	f.bumpVal += b.Delta
 	return f.bumpVal, nil
 }
 

--- a/console/dashboard/src/lib/components/counters/CounterPicker.svelte
+++ b/console/dashboard/src/lib/components/counters/CounterPicker.svelte
@@ -22,6 +22,10 @@
   let counters = $state<CounterRef[]>([]);
   let newName = $state('');
   let newScope = $state<CounterScope>('channel');
+  // When set, inserted tokens take the {counter:target:<name>} spelling: the
+  // bump keys on the viewer the command mentions instead of the sender
+  // (issue #479). The counter's scope still decides the bucket shape.
+  let countTarget = $state(false);
   let creating = $state(false);
   let err = $state('');
 
@@ -54,7 +58,7 @@
   }
 
   function pick(name: string) {
-    onInsert(`{counter:${name}}`);
+    onInsert(countTarget ? `{counter:target:${name}}` : `{counter:${name}}`);
     open = false;
   }
 
@@ -102,6 +106,14 @@
 
   {#if open}
     <div class="panel" role="dialog" aria-label={t('counters.pickerTitle')}>
+      <label class="target" title={countTarget ? '{counter:target:' + (newName || 'name') + '}' : '{counter:' + (newName || 'name') + '}'}>
+        <input type="checkbox" bind:checked={countTarget} />
+        <span>{t('counters.pickerTarget')}</span>
+      </label>
+      {#if countTarget}
+        <code class="preview">{'{counter:target:'}{newName || 'name'}{'}'}</code>
+      {/if}
+
       <p class="panel-title">{t('counters.pickerExisting')}</p>
       {#if loading}
         <p class="mut" role="status">{t('common.loading')}</p>
@@ -177,6 +189,7 @@
     border-radius: 10px;
     box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
   }
+  :global(:root[data-theme="light"]) .panel { box-shadow: 0 12px 32px rgba(20, 17, 12, 0.15); }
 
   .panel-title {
     margin: 0;
@@ -204,11 +217,36 @@
     cursor: pointer;
     text-align: left;
   }
-  .opt:hover { background: rgba(255, 255, 255, 0.05); }
+  .opt:hover { background: var(--glass-fill-2); }
   .opt-name { font-family: var(--bb-font-mono); font-size: 12px; color: var(--bb-white); }
   .opt-tag { font-family: var(--bb-font-body); font-size: 10.5px; color: var(--bb-muted); white-space: nowrap; }
 
-  .err { font-family: var(--bb-font-body); font-size: 11.5px; color: #cf8a78; }
+  .err { font-family: var(--bb-font-body); font-size: 11.5px; color: var(--bb-status-error, #cf8a78); }
+
+  /* First row of the panel: who the counter counts against. */
+  .target {
+    display: flex;
+    align-items: flex-start;
+    gap: 7px;
+    padding: 6px 8px;
+    font-family: var(--bb-font-body);
+    font-size: 11.5px;
+    color: var(--bb-tan-light);
+    background: rgba(201, 168, 124, 0.06);
+    border: 1px solid rgba(201, 168, 124, 0.22);
+    border-radius: 6px;
+    cursor: pointer;
+  }
+  .target input { margin-top: 1px; accent-color: var(--bb-green-glow, #52b788); }
+  .target:hover { background: rgba(201, 168, 124, 0.12); color: var(--bb-white); }
+  .preview {
+    margin: -2px 0 2px;
+    padding-left: 24px;
+    font-family: var(--bb-font-mono);
+    font-size: 10.5px;
+    color: var(--bb-green-glow, #52b788);
+    opacity: 0.85;
+  }
 
   .create {
     font-family: var(--bb-font-body);

--- a/console/shared/lib/i18n/keys.d.ts
+++ b/console/shared/lib/i18n/keys.d.ts
@@ -339,6 +339,7 @@ export type KnownMessageKey =
   | 'counters.pickerEmpty'
   | 'counters.pickerExisting'
   | 'counters.pickerNew'
+  | 'counters.pickerTarget'
   | 'counters.pickerTitle'
   | 'counters.remove'
   | 'counters.rename'

--- a/console/shared/lib/i18n/locales/en.json
+++ b/console/shared/lib/i18n/locales/en.json
@@ -618,6 +618,7 @@
     "pickerEmpty": "No counters yet. Create one below.",
     "pickerNew": "New counter",
     "pickerCreate": "Create and insert",
+    "pickerTarget": "Count against the mentioned viewer (@target) instead of the sender",
     "setValue": "Set value",
     "set": "Set",
     "reset": "Reset",

--- a/console/shared/lib/i18n/locales/fr.json
+++ b/console/shared/lib/i18n/locales/fr.json
@@ -617,7 +617,7 @@
     "pickerEmpty": "Aucun compteur pour le moment. Créez-en un ci-dessous.",
     "pickerNew": "Nouveau compteur",
     "pickerCreate": "Créer et insérer",
-    "pickerTarget": "Compter sur le spectateur mentionné (@cible) plutôt que sur l'auteur",
+    "pickerTarget": "Incrémenter le compteur du spectateur mentionné (@cible) plutôt que celui de l'auteur",
     "setValue": "Définir la valeur",
     "set": "Définir",
     "reset": "Réinitialiser",

--- a/console/shared/lib/i18n/locales/fr.json
+++ b/console/shared/lib/i18n/locales/fr.json
@@ -617,6 +617,7 @@
     "pickerEmpty": "Aucun compteur pour le moment. Créez-en un ci-dessous.",
     "pickerNew": "Nouveau compteur",
     "pickerCreate": "Créer et insérer",
+    "pickerTarget": "Compter sur le spectateur mentionné (@cible) plutôt que sur l'auteur",
     "setValue": "Définir la valeur",
     "set": "Définir",
     "reset": "Réinitialiser",

--- a/console/shared/lib/rehearsal.test.ts
+++ b/console/shared/lib/rehearsal.test.ts
@@ -78,6 +78,12 @@ describe('rehearseCommand', () => {
     expect(textOf(line.segments)).toBe('42 {counter:bot:feeds} {counter:}');
   });
 
+  test('target-addressed counters rehearse like the engine (issue #479)', () => {
+    const [line] = rehearseCommand('{counter:target:shutups} {counter:target:} {counter:target:bot:x}');
+    expect(line.segments.map((s) => s.kind)).toEqual(['sample', 'plain', 'unknown', 'plain', 'unknown']);
+    expect(textOf(line.segments)).toBe('42 {counter:target:} {counter:target:bot:x}');
+  });
+
   test('caps at 5 messages, one per line, like emitResponse', () => {
     expect(rehearseCommand('a\nb\nc\nd\ne\nf')).toHaveLength(5);
   });

--- a/console/shared/lib/rehearsal.ts
+++ b/console/shared/lib/rehearsal.ts
@@ -217,11 +217,15 @@ function replyResolver(samples: Samples, dynamic: boolean): Resolve {
 
 /** {counter:<name>} bumps and renders the counter. The name normalizes like
  * NormalizeCounterName (trim, drop one leading '!', trim, lower-case).
- * Bot-scope counters (bot:…) are admin-only and an empty name never resolves,
- * so both stay literal, exactly like the engine. */
+ * A {counter:target:<name>} spelling keys the bump on the mentioned viewer
+ * instead of the sender (issue #479); it rehearses the same way once the
+ * addressing prefix comes off. Bot-scope counters (bot:…) are admin-only and
+ * an empty name never resolves, so both stay literal, exactly like the engine. */
 function counterSample(token: Token): string | null {
   const name = (token.payload ?? '').trim().replace(/^!/, '').trim().toLowerCase();
-  if (name === '' || name.startsWith('bot:')) return null;
+  if (name === '') return null;
+  const base = name.startsWith('target:') ? name.slice('target:'.length) : name;
+  if (base === '' || base.startsWith('bot:')) return null;
   return COUNTER_SAMPLE;
 }
 


### PR DESCRIPTION
Closes #479

## What

Custom-command counters could only count against the **sender**. StreamElements-style commands (`!shutup`) count against the **target**. This adds the `{counter:target:<name>}` response token: the bump keys on the viewer the command mentions.

```
@{target} has been told to shut up {counter:target:shutups} times
```

## How

- **chatterRoster** (engine): bounded per-channel `login → Viewer` memory, fed passively from every eligible chat line (folded-cohort senders included). A mention resolves against who this replica has seen speak; per-replica by design — a shared view would put a network write on every chat line for a best-effort token.
- Unresolvable mention falls back to the sender (mirroring how `{touser}` defaults). The prefix is stripped before the store sees it, so Valkey keys and DB flushes are unchanged.
- **Scope semantics untouched** — addressing only moves whose identity rides the bump; channel / viewer / command / viewer+command buckets behave exactly as before.
- The `"target:"` spelling inside a counter name is reserved by the worker's token grammar alongside `"bot:"`.

## Console parity

- rehearsal mirror + tests (`{counter:target:x}` resolves; `{counter:target:}` and `{counter:target:bot:x}` stay literal)
- CounterPicker toggle ("Count against the mentioned viewer") inserting `{counter:target:name}` for existing picks and create-and-insert
- i18n en/fr + regenerated `keys.d.ts`

## Test plan

- [x] `go test ./app/sesame/engine/` — 11 new tests (roster unit tests, token grammar, end-to-end dispatch addressing/fallback/scope preservation, Process feed)
- [x] `bun test shared` — 150 pass incl. rehearsal target cases
- [x] svelte-check dashboard/admin clean; i18n keys regenerated via `gen-i18n-keys`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added target-addressed counters that update the mentioned viewer’s total instead of the sender’s.
  - Updated the counter picker with target mode, token previews, and English and French labels.
  - Added viewer resolution from recent chat activity, with sender fallback when no match is found.
  - Preserved visible counter text for empty or unresolved targets.

- **Bug Fixes**
  - Improved handling of target counters, bot references, and sender-scoped counters.

- **Tests**
  - Added coverage for target parsing, viewer resolution, roster behavior, and command previews.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->