### PR TITLE
fix(batch,users): close-drain retries, post-commit announce budget

### DIFF
--- a/app/users/repository/preferences.go
+++ b/app/users/repository/preferences.go
@@ -100,19 +100,35 @@ func (r *Users) flushPrefs(ctx context.Context, items []prefWrite) error {
 		return writeAllUserPrefs(ctx, tx, perUser)
 	})
 	if err == nil {
-		for id := range perUser {
-			r.announcePref(ctx, log, id)
-		}
+		r.announcePrefs(ctx, log, perUser)
 		return nil
 	}
 
-	txn.NoticeError(err)
+	txnNotice(txn, err)
 	log.Warn("preference window failed as one transaction, falling back per user",
 		zap.Int("users", len(perUser)),
 		zap.Error(err),
 	)
 	r.applyPrefEach(ctx, txn, log, perUser)
 	return nil
+}
+
+// prefAnnounceTimeout budgets post-commit event publication independently of
+// the flush deadline: the deadline protects the database window, but an
+// announcement racing its expiry must not inherit a spent context — the row
+// would be committed while its UserChanged event is lost.
+const prefAnnounceTimeout = 5 * time.Second
+
+// announcePrefs publishes one change event per affected user after a commit.
+// It derives a fresh bounded context (cancellation dropped, values kept so
+// announcements still report inside the flush transaction).
+func (r *Users) announcePrefs(ctx context.Context, log *zap.Logger, perUser map[uint64][]prefWrite) {
+	actx, cancel := context.WithTimeout(context.WithoutCancel(ctx), prefAnnounceTimeout)
+	defer cancel()
+
+	for id := range perUser {
+		r.announcePref(actx, log, id)
+	}
 }
 
 // beginFlush starts the background transaction a flush reports under and
@@ -192,7 +208,7 @@ func (r *Users) applyPrefEach(ctx context.Context, txn *newrelic.Transaction, lo
 
 		switch {
 		case err == nil:
-			r.announcePref(ctx, log, id)
+			r.announcePrefs(ctx, log, map[uint64][]prefWrite{id: writes})
 		case unpersistablePrefErr(err):
 			txnNotice(txn, err)
 			log.Error("dropping unpersistable preference change",

--- a/pkg/batch/batcher.go
+++ b/pkg/batch/batcher.go
@@ -121,17 +121,51 @@ func (b *Batcher[K, V]) Requeue(key K, value V) {
 	if _, exists := b.pending[key]; !exists {
 		b.pending[key] = value
 	}
+	// A failed flush requeues through here after flushPending zeroed the
+	// gauge; without this, Stats reports an empty backlog while retries sit
+	// in pending and staleness alerts stay silent.
+	b.pendingGauge.Store(int64(len(b.pending)))
 	b.mu.Unlock()
 }
 
+// closeRetryBackoff spaces out final-drain retries in Close so a database
+// that stopped answering is not hammered in a tight loop for the whole
+// shutdown budget.
+const closeRetryBackoff = 100 * time.Millisecond
+
 // Close flushes whatever is pending and stops the background loop. Idempotent:
 // an owner and a deferred cleanup may both call it without sequencing care.
+//
+// The final drain retries until the caller's context is spent: once stop has
+// fired, no later window can consume requeued items, so a transient failure
+// here would otherwise drop accepted writes at process exit. If the budget
+// runs out first, what remains is logged as lost — never returned silently.
 func (b *Batcher[K, V]) Close(ctx context.Context) {
 
 	b.closeOnce.Do(func() { close(b.stop) })
 	<-b.done
 
-	b.flushPending(ctx)
+	for b.pendingCount() > 0 {
+		b.flushPending(ctx)
+
+		if b.pendingCount() == 0 {
+			return
+		}
+
+		select {
+		case <-ctx.Done():
+			b.log.Error("batcher closed before pending writes landed; writes lost",
+				zap.Int("items", b.pendingCount()))
+			return
+		case <-time.After(closeRetryBackoff):
+		}
+	}
+}
+
+func (b *Batcher[K, V]) pendingCount() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return len(b.pending)
 }
 
 func (b *Batcher[K, V]) run() {

--- a/pkg/batch/batcher_test.go
+++ b/pkg/batch/batcher_test.go
@@ -254,3 +254,47 @@ func TestConcurrentAddsCoalesce(t *testing.T) {
 		assert.GreaterOrEqual(t, v, 0)
 	}
 }
+
+// After the run loop stops, nothing else consumes requeued items: a transient
+// failure during Close's final drain must be retried until it lands, or the
+// accepted writes die with the process.
+func TestCloseRetriesFailedFinalDrain(t *testing.T) {
+	rec := &recorder{fail: true}
+
+	b := New[string, int](time.Hour, 1, rec.flush, zap.NewNop())
+
+	b.Add("key", 1) // flushes immediately via kick, fails, returns to pending
+
+	assert.Eventually(t, func() bool {
+		return b.pendingCount() == 1 && rec.attemptCount() == 1
+	}, time.Second, 5*time.Millisecond, "the failing window must be back in pending")
+
+	rec.mu.Lock()
+	rec.fail = false
+	rec.mu.Unlock()
+
+	b.Close(context.Background())
+
+	require.Equal(t, []int{1}, rec.all(), "Close must retry the final drain to success")
+	assert.Zero(t, b.Stats().Pending)
+}
+
+// When the shutdown budget expires before a stuck database answers, Close
+// must give up and say what was lost — after visibly retrying, not after one
+// silent attempt.
+func TestCloseExpiryGivesUpAfterRetries(t *testing.T) {
+	rec := &recorder{fail: true}
+
+	b := New[string, int](time.Hour, 100, rec.flush, zap.NewNop())
+	b.Add("key", 1)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+	defer cancel()
+
+	started := time.Now()
+	b.Close(ctx)
+
+	assert.GreaterOrEqual(t, rec.attemptCount(), 2, "Close must retry, not drain once and quit")
+	assert.Less(t, time.Since(started), 5*time.Second, "an expired budget must end the drain promptly")
+	assert.Equal(t, 1, b.pendingCount(), "undrained writes stay visible for the loss log")
+}


### PR DESCRIPTION
Follow-ups to #625 from the CodeRabbit review — all four findings verified against code and fixed:

| Finding | Fix |
|---|---|
| `txn.NoticeError` dereferences nil when observability is disabled | fallback path uses the existing `txnNotice` helper |
| Post-commit announcements inherit the flush deadline; a commit racing expiry loses its `UserChanged` event | announcements run under a fresh 5s budget via `context.WithoutCancel` (values kept, so they still report inside the flush transaction) |
| Close's final drain requeued into the void after the run loop stopped — accepted writes could die at process exit on one transient error | final drain retries with 100ms backoff until the caller's context is spent; expiry logs the lost item count explicitly |
| `Requeue` left the pending gauge at zero after a failed window, blinding staleness alerts | gauge resynced under the mutex |

## Test plan
- `TestCloseRetriesFailedFinalDrain`: transient failure during shutdown is retried to success.
- `TestCloseExpiryGivesUpAfterRetries`: expired budget ends promptly after visible retries, undrained state stays countable.
- Full `go test -race ./pkg/batch/... ./app/users/...` green.