### PR TITLE
feat(sesame): emote pyramids and streaks tracker

### DIFF
--- a/app/sesame/engine/deps.go
+++ b/app/sesame/engine/deps.go
@@ -108,6 +108,10 @@ type Deps struct {
 	// default. nil degrades gracefully: facts go random, the feed count is
 	// omitted and the mood re-rolls per message.
 	Personality PersonalityStore
+	// EmotePlay is the per-channel emote pyramid + streak tracker behind the
+	// emoteplay module; ValkeyEmotePlay is the default. nil leaves the module
+	// silent (it never emits without a store).
+	EmotePlay EmotePlayStore
 	// Dedup guards the non-idempotent effect sites against a redelivered or
 	// schedule-retried event applying them twice. nil (the kill switch) fails
 	// open everywhere: effects run, nothing is deduped.
@@ -177,6 +181,13 @@ type FeedTotalPersister interface {
 	FeedBump(ctx context.Context, broadcasterID uint64, name string) (FeedTotals, error)
 	// FeedBoard reads the leaderboard and the named channel's standing.
 	FeedBoard(ctx context.Context, broadcasterID uint64, limit int) (FeedBoard, error)
+}
+
+// EmotePlayStore advances a channel's emote chains by one candidate line. See
+// ValkeyEmotePlay (emoteplay_valkey.go) for the transition rules and the
+// race-safety reasoning; callers only feed lines and read back milestones.
+type EmotePlayStore interface {
+	Bump(ctx context.Context, u EmotePlayUpdate) (EmotePlayResult, error)
 }
 
 // IsLiveChecker is the read-only slice of the live store: just "is this

--- a/app/sesame/engine/emoteplay_valkey.go
+++ b/app/sesame/engine/emoteplay_valkey.go
@@ -1,0 +1,269 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package engine
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/valkey-io/valkey-go"
+)
+
+// Tuned windows. Both are gap tolerances, not stream boundaries: a chain dies
+// when the next candidate line takes longer than the window to arrive, and
+// ordinary prose never touches this store at all (the module gates on shape),
+// so nothing here can cost the chat hot path anything. Values are script
+// arguments, so a test can shrink them instead of sleeping out real windows.
+const (
+	// pyramidWindow is the max gap between two lines of one pyramid. Chat
+	// pyramids move at typing speed (~1-3s per line); 15s absorbs slow typists
+	// and a folded-cohort detour without keeping a dead attempt alive long
+	// enough for someone to "complete" a pyramid nobody was building.
+	pyramidWindow = 15 * time.Second
+	// streakWindow is the max gap between two single-emote messages of one
+	// streak. Streaks read as hype only while they are dense; 10s keeps the
+	// counter from creeping up across scattered messages.
+	streakWindow = 10 * time.Second
+)
+
+// streakLadder is the counts at which a streak is announced. A milestone fires
+// when the running count crosses a rung (a folded cohort may jump several), and
+// after the last rung the streak stays silent — past x1000 every further line
+// would be spam with no information. Crossing (not equality) so a 5-duplicate
+// cohort cannot step over a rung without celebrating it.
+var streakLadder = []int{5, 10, 25, 50, 100, 250, 500, 1000}
+
+// EmotePlayUpdate is one candidate line fed to the store: emote is the exact
+// repeated token (case matters — Kappa and kappa are different emotes), width
+// its repetition count in the line (>= 1), copies how many identical lines the
+// ingress squash folded into this envelope (>= 1 when none).
+type EmotePlayUpdate struct {
+	BroadcasterID uint64
+	MsgID         string
+	Emote         string
+	Width         int
+	Copies        int
+}
+
+// EmotePlayResult is what one accepted line did to the channel's chains.
+type EmotePlayResult struct {
+	// PyramidDone is true when this line landed the descent back at width 1;
+	// Apex is the height it reached.
+	PyramidDone bool
+	Apex        int
+	// StreakMilestone is true when the streak crossed a ladder rung; Streak is
+	// that rung's count (the announced number, not necessarily the raw count —
+	// a folded cohort can overshoot).
+	StreakMilestone bool
+	Streak          int
+}
+
+// EmotePlayStore itself is declared in deps.go alongside the other store
+// interfaces; ValkeyEmotePlay below is its implementation.
+
+// ValkeyEmotePlay is the race-safety story, which is the whole reason it lives
+// in valkey rather than pod-local memory: sesame runs 3 replicas sharing one
+// durable lane consumer, so consecutive lines of the same channel are routinely
+// handled by different pods, and JetStream redeliveries re-run handlers after a
+// nack. Every transition is therefore ONE Lua script call — read state, decide,
+// write state, all inside the interpreter's single-threaded atomicity — so the
+// second pod to touch a channel linearizes on top of the first pod's write.
+// There is deliberately no WATCH/MULTI retry loop and no GET-then-SET: the
+// script is one master round trip, which keeps the per-candidate-line cost at
+// exactly one RTT and closes the inter-pod races by construction.
+//
+// The script is not NewLuaScriptRetryable on purpose (same reasoning as
+// pkg/ratelimit): a connection failure mid-script could have applied the bump,
+// and replaying it would double-count a line. The module treats an error as
+// "line lost" and fails open silently.
+//
+// Replays of the SAME message id are absorbed in-script (the msg field): a
+// redelivered envelope re-runs this handler because the pipeline's EventDedup
+// deliberately does not claim plain-chat lines, and without the msg guard a
+// redelivery would double-count a streak line. One guard covers both
+// subsystems since they consume the same line.
+type ValkeyEmotePlay struct {
+	client valkey.Client
+	// The windows ride every Bump as script arguments rather than living only
+	// in the script source, so tests can shrink them to milliseconds instead
+	// of sleeping out production values.
+	pyrWin time.Duration
+	stkWin time.Duration
+}
+
+func NewValkeyEmotePlay(client valkey.Client) *ValkeyEmotePlay {
+	return &ValkeyEmotePlay{client: client, pyrWin: pyramidWindow, stkWin: streakWindow}
+}
+
+// emoteplayScript advances pyramid + streak state for one candidate line.
+//
+// KEYS[1] the channel's state hash (emoteplay:v1:<broadcaster>).
+// ARGV[1] emote, [2] width, [3] copies, [4] msgid,
+// [5] pyramid window ms, [6] streak window ms, [7] key ttl ms, [8] ladder csv.
+//
+// Returns {flags, milestone, apex}: flags bit0 (value 1) pyramid completed,
+// bit1 (value 2) streak milestone; milestone the rung crossed; apex the
+// completed pyramid's height. Integers only — raffle_claim.go documents why a
+// RESP2 bulk starting '-' would parse as an error.
+//
+// Pyramid rules. State: emote, width, apex, phase (0 ascending / 1 descending).
+// From any line: same width repeats are neutral no-ops (two chatters racing the
+// same step, or two pods delivering near-simultaneously, must not double-step);
+// width+1 ascends while phase=asc; width-1 descends, but only straight off the
+// apex (phase flips there); landing the descent at 1 completes and clears.
+// Anything else — different emote, a width jump, re-ascending mid-descent —
+// restarts the attempt anchored AT the offending line rather than clearing:
+// a troll wall should not erase the fun, it just becomes the new base. Window
+// expiry behaves like a clear.
+//
+// Streak rules. Only single-token lines (width==1) count; a wider pure-emote
+// line (someone building something else) breaks the current streak silently.
+// Same-emote lines add their copies (folded duplicates each count — they were
+// distinct chatters); a different emote restarts from that line's copies.
+var emoteplayScript = valkey.NewLuaScript(`
+local t = redis.call('TIME')
+local now = t[1] * 1000 + math.floor(t[2] / 1000)
+local emote, width, copies = ARGV[1], tonumber(ARGV[2]), tonumber(ARGV[3])
+local pwin, swin = tonumber(ARGV[5]), tonumber(ARGV[6])
+
+local st = redis.call('HMGET', KEYS[1],
+  'pem', 'pw', 'pa', 'pp', 'pts',
+  'sem', 'sn', 'sts',
+  'msg')
+local pem, pw, pa, pp, pts = st[1], tonumber(st[2]), tonumber(st[3]), tonumber(st[4]), tonumber(st[5])
+local sem, sn, sts = st[6], tonumber(st[7]), tonumber(st[8])
+
+-- Replay absorption runs before anything else, on its own unconditional
+-- field: neither subsystem's state may own this guard, because a completion
+-- clears the pyramid fields and would let a redelivery slip past a
+-- subsystem-owned guard and double-count into the streak.
+if ARGV[4] ~= '' and st[9] == ARGV[4] then
+  redis.call('PEXPIRE', KEYS[1], tonumber(ARGV[7]))
+  return {0, 0, 0}
+end
+
+local flags, milestone, done_apex = 0, 0, 0
+
+-- Pyramid.
+if pts == nil or now - pts > pwin then
+  pem, pw, pa, pp = emote, width, width, 0
+elseif pem ~= emote then
+  pem, pw, pa, pp = emote, width, width, 0
+elseif width == pw + 1 then
+  if pp == 1 then
+    pem, pw, pa, pp = emote, width, width, 0
+  else
+    pw, pa = width, width
+  end
+elseif width == pw - 1 then
+  -- Descending, either already under way or turning straight off the apex.
+  -- One branch for both so the landing-at-1 check can never be skipped: an
+  -- apex-2 attempt turns at its own top and must complete there too.
+  if pp == 1 or pw == pa then
+    pw = width
+    pp = 1
+    if pw <= 1 then
+      flags = flags + 1
+      done_apex = pa
+      pem, pw, pa, pp, pts = nil, nil, nil, nil, nil
+    end
+  else
+    pem, pw, pa, pp = emote, width, width, 0
+  end
+elseif width ~= pw then
+  pem, pw, pa, pp = emote, width, width, 0
+end
+-- width == pw falls through: duplicate step, neutral.
+
+if done_apex > 0 then
+  redis.call('HDEL', KEYS[1], 'pem', 'pw', 'pa', 'pp', 'pts')
+else
+  redis.call('HMSET', KEYS[1], 'pem', pem, 'pw', pw, 'pa', pa, 'pp', pp, 'pts', now)
+end
+
+-- Streak.
+if width == 1 then
+  if sts == nil or now - sts > swin then
+    sem, sn = nil, nil
+  end
+  local prev = sn
+  if sem == emote and sn then
+    sn = sn + copies
+  else
+    sem, sn, prev = emote, copies, 0
+  end
+  for v in string.gmatch(ARGV[8], '%d+') do
+    local rung = tonumber(v)
+    if prev < rung and rung <= sn and (milestone == 0 or rung < milestone) then
+      milestone = rung
+    end
+  end
+  if milestone > 0 then flags = flags + 2 end
+  redis.call('HMSET', KEYS[1], 'sem', sem, 'sn', sn, 'sts', now)
+else
+  redis.call('HDEL', KEYS[1], 'sem', 'sn', 'sts')
+end
+
+-- The replay marker is written unconditionally last, so it records exactly the
+-- line this call consumed no matter what either subsystem did above.
+redis.call('HSET', KEYS[1], 'msg', ARGV[4])
+redis.call('PEXPIRE', KEYS[1], tonumber(ARGV[7]))
+return {flags, milestone, done_apex}`)
+
+func emoteplayKey(broadcasterID uint64) string {
+	return "emoteplay:v1:" + strconv.FormatUint(broadcasterID, 10)
+}
+
+// Bump advances both chains for one line in a single master round trip. Pure
+// write script, so the default write-to-master routing is correct without a
+// Primary pin (nothing ever reads back through a replica).
+func (s *ValkeyEmotePlay) Bump(ctx context.Context, u EmotePlayUpdate) (EmotePlayResult, error) {
+	ladder := make([]string, len(streakLadder))
+	for i, r := range streakLadder {
+		ladder[i] = strconv.Itoa(r)
+	}
+	args := []string{
+		u.Emote,
+		strconv.Itoa(u.Width),
+		strconv.Itoa(u.Copies),
+		u.MsgID,
+		strconv.FormatInt(s.pyrWin.Milliseconds(), 10),
+		strconv.FormatInt(s.stkWin.Milliseconds(), 10),
+		// Twice the longest subsystem window, so an abandoned chain always
+		// expires server-side even if no further candidate line ever arrives.
+		// Nothing reads the key except this script, so the exact value only
+		// bounds memory.
+		strconv.FormatInt((2 * s.pyrWin).Milliseconds(), 10),
+		strings.Join(ladder, ","),
+	}
+	values, err := emoteplayScript.Exec(ctx, s.client,
+		[]string{emoteplayKey(u.BroadcasterID)}, args).ToArray()
+	if err != nil {
+		return EmotePlayResult{}, err
+	}
+	if len(values) != 3 {
+		return EmotePlayResult{}, errors.New("emoteplay: invalid script result")
+	}
+	flags, err := values[0].AsInt64()
+	if err != nil {
+		return EmotePlayResult{}, err
+	}
+	milestone, err := values[1].AsInt64()
+	if err != nil {
+		return EmotePlayResult{}, err
+	}
+	apex, err := values[2].AsInt64()
+	if err != nil {
+		return EmotePlayResult{}, err
+	}
+	return EmotePlayResult{
+		PyramidDone:     flags&1 != 0,
+		Apex:            int(apex),
+		StreakMilestone: flags&2 != 0,
+		Streak:          int(milestone),
+	}, nil
+}

--- a/app/sesame/engine/emoteplay_valkey_test.go
+++ b/app/sesame/engine/emoteplay_valkey_test.go
@@ -1,0 +1,179 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package engine
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// These tests are opt-in because the pyramid and streak transitions are a Lua
+// state machine whose semantics only exist inside a real Valkey interpreter.
+// They use the same VALKEY_TEST_ADDR convention as valkey_hotpath_test.go. The
+// script's windows are plain arguments, so expiry is exercised with millisecond
+// windows rather than sleeping out the production values.
+func TestEmotePlayScriptIntegration(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+	client := newHotPathTestClient(t)
+	store := NewValkeyEmotePlay(client)
+
+	// step feeds one candidate line to a fresh-namespaced store and requires no
+	// error; each subtest builds its own channel id so state never collides.
+	channel := 0
+	step := func(t *testing.T, msgID, emote string, width, copies int) EmotePlayResult {
+		t.Helper()
+		res, err := store.Bump(ctx, EmotePlayUpdate{
+			BroadcasterID: uint64(channel), MsgID: msgID, Emote: emote, Width: width, Copies: copies,
+		})
+		require.NoError(t, err)
+		return res
+	}
+	nextChannel := func() { channel++ }
+
+	t.Run("full pyramid completes once at the base", func(t *testing.T) {
+		nextChannel()
+		for _, w := range []int{1, 2} {
+			require.False(t, step(t, "m"+strconv.Itoa(w), "Kappa", w, 1).PyramidDone)
+		}
+		r3 := step(t, "m3", "Kappa", 3, 1)
+		require.False(t, r3.PyramidDone)
+		require.Equal(t, 0, r3.Apex, "apex is only reported on completion")
+		require.False(t, step(t, "m2d", "Kappa", 2, 1).PyramidDone)
+		done := step(t, "m1d", "Kappa", 1, 1)
+		require.True(t, done.PyramidDone)
+		require.Equal(t, 3, done.Apex)
+		// After completion the state is cleared: repeating the base line starts
+		// a fresh attempt, it does not complete again.
+		require.False(t, step(t, "after", "Kappa", 1, 1).PyramidDone)
+	})
+
+	t.Run("same-width duplicates never double-step", func(t *testing.T) {
+		nextChannel()
+		step(t, "a", "Kappa", 1, 1)
+		step(t, "b", "Kappa", 2, 1)
+		// Two chatters racing the same step (or two pods delivering one line
+		// near-simultaneously): the second must be neutral.
+		step(t, "c", "Kappa", 2, 1)
+		step(t, "d", "Kappa", 3, 1)
+		require.False(t, step(t, "e", "Kappa", 3, 1).PyramidDone)
+		require.False(t, step(t, "f", "Kappa", 4, 1).PyramidDone)
+	})
+
+	t.Run("foreign emote restarts, apex turn still descends", func(t *testing.T) {
+		nextChannel()
+		step(t, "a", "Kappa", 1, 1)
+		step(t, "b", "Kappa", 2, 1)
+		// Different emote mid-pyramid: the old attempt is abandoned and the new
+		// attempt anchors at this line (width 2).
+		step(t, "c", "PogChamp", 2, 1)
+		done := step(t, "d", "PogChamp", 1, 1)
+		require.True(t, done.PyramidDone, "a fresh attempt may descend straight off its anchor")
+		require.Equal(t, 2, done.Apex)
+	})
+
+	t.Run("width jump restarts instead of completing", func(t *testing.T) {
+		nextChannel()
+		step(t, "a", "Kappa", 1, 1)
+		step(t, "b", "Kappa", 2, 1)
+		step(t, "c", "Kappa", 5, 1) // jump: attempt restarts anchored at 5
+		// Descending from that anchor would complete a 5-tall pyramid nobody
+		// built — but it IS the anchored apex, so this is legal by the rules;
+		// what matters is that the jump did not preserve the old ascent.
+		done := step(t, "d", "Kappa", 4, 1)
+		require.False(t, done.PyramidDone)
+	})
+
+	t.Run("replayed message id applies nothing", func(t *testing.T) {
+		nextChannel()
+		first := step(t, "same", "Kappa", 1, 1)
+		require.False(t, first.StreakMilestone)
+		for i := 0; i < 3; i++ {
+			replay := step(t, "same", "Kappa", 1, 1)
+			require.False(t, replay.StreakMilestone, "redelivery must not recount")
+			require.False(t, replay.PyramidDone)
+		}
+		next := step(t, "other", "Kappa", 1, 1)
+		require.False(t, next.StreakMilestone, "count is 2, under the first rung")
+	})
+
+	t.Run("streak ladder crossing with folded cohorts", func(t *testing.T) {
+		nextChannel()
+		step(t, "s1", "Kappa", 1, streakLadder[0]-1) // one below the first rung
+		crossed := step(t, "s2", "Kappa", 1, 2)
+		require.True(t, crossed.StreakMilestone, "the cohort steps over the rung")
+		require.Equal(t, streakLadder[0], crossed.Streak, "the announced value is the rung, not the raw count")
+		silent := step(t, "s3", "Kappa", 1, 1)
+		require.False(t, silent.StreakMilestone, "between rungs")
+		switched := step(t, "s4", "PogChamp", 1, 1)
+		require.False(t, switched.StreakMilestone, "a new emote restarts from 1")
+	})
+
+	t.Run("wide line breaks the streak silently", func(t *testing.T) {
+		nextChannel()
+		step(t, "w1", "Kappa", 1, streakLadder[0]-1)
+		step(t, "w2", "Kappa", 3, 1) // someone starts building: the streak resets
+		wide := step(t, "w3", "Kappa", 1, 1)
+		require.False(t, wide.StreakMilestone)
+	})
+
+	t.Run("expired window restarts both chains", func(t *testing.T) {
+		short := &ValkeyEmotePlay{client: client, pyrWin: 40 * time.Millisecond, stkWin: 40 * time.Millisecond}
+		bumpShort := func(msgID string, width int) EmotePlayResult {
+			res, err := short.Bump(ctx, EmotePlayUpdate{MsgID: msgID, Emote: "Kappa", Width: width, Copies: 1})
+			require.NoError(t, err)
+			return res
+		}
+		require.False(t, bumpShort("t1", 1).PyramidDone)
+		require.False(t, bumpShort("t2", 2).PyramidDone)
+		time.Sleep(60 * time.Millisecond) // one window + slack, well inside any redelivery scale
+		require.False(t, bumpShort("t3", 1).StreakMilestone, "the streak expired with the window")
+		require.False(t, bumpShort("t4", 2).PyramidDone,
+			"the pyramid expired: width 2 starts a fresh attempt instead of ascending the dead one")
+	})
+
+	t.Run("concurrent replicas complete the pyramid exactly once", func(t *testing.T) {
+		const replicas = 16
+		racing := &ValkeyEmotePlay{client: client, pyrWin: time.Minute, stkWin: time.Minute}
+		// Build to descending-through-2, then race every replica at the final
+		// width-1 line with distinct message ids — the shape of two pods plus a
+		// redelivery all seeing the same chat moment.
+		for _, w := range []struct {
+			msgID string
+			width int
+		}{{"p1", 1}, {"p2", 2}, {"p3", 3}, {"p4", 2}} {
+			res, err := racing.Bump(ctx, EmotePlayUpdate{MsgID: w.msgID, Emote: "Kappa", Width: w.width, Copies: 1})
+			require.NoError(t, err)
+			require.False(t, res.PyramidDone)
+		}
+		var (
+			wg          sync.WaitGroup
+			mu          sync.Mutex
+			completions int
+		)
+		wg.Add(replicas)
+		for i := 0; i < replicas; i++ {
+			go func(i int) {
+				defer wg.Done()
+				res, err := racing.Bump(ctx, EmotePlayUpdate{
+					MsgID: "race-" + strconv.Itoa(i), Emote: "Kappa", Width: 1, Copies: 1,
+				})
+				require.NoError(t, err)
+				if res.PyramidDone {
+					mu.Lock()
+					completions++
+					mu.Unlock()
+				}
+			}(i)
+		}
+		wg.Wait()
+		require.Equal(t, 1, completions,
+			"exactly one replica may observe the completion; every other racer must linearize behind it")
+	})
+}

--- a/app/sesame/engine/emoteplay_valkey_test.go
+++ b/app/sesame/engine/emoteplay_valkey_test.go
@@ -194,32 +194,34 @@ func TestEmotePlayConcurrentReplicasCompleteExactlyOnce(t *testing.T) {
 // chat moment — and reports how many observed the completion.
 func raceWidthOneLines(t *testing.T, ctx context.Context, store *ValkeyEmotePlay, replicas int) int {
 	t.Helper()
-	results := make(chan EmotePlayResult, replicas)
+	outcomes := make(chan bumpOutcome, replicas)
 	var wg sync.WaitGroup
 	wg.Add(replicas)
 	for i := 0; i < replicas; i++ {
 		go func(i int) {
 			defer wg.Done()
-			// t.Error rather than require: FailNow must stay on the test
-			// goroutine, workers report and drain instead.
 			res, err := store.Bump(ctx, EmotePlayUpdate{
 				MsgID: "race-" + strconv.Itoa(i), Emote: "Kappa", Width: 1, Copies: 1,
 			})
-			if err != nil {
-				t.Errorf("racer %d: %v", i, err)
-				results <- EmotePlayResult{}
-				return
-			}
-			results <- res
+			outcomes <- bumpOutcome{res: res, err: err}
 		}(i)
 	}
 	wg.Wait()
-	close(results)
+	close(outcomes)
 	completions := 0
-	for res := range results {
-		if res.PyramidDone {
+	for out := range outcomes {
+		require.NoError(t, out.err)
+		if out.res.PyramidDone {
 			completions++
 		}
 	}
 	return completions
+}
+
+// bumpOutcome carries one racer's result through the channel so the worker
+// closure stays a straight line and every assertion lands on the test
+// goroutine.
+type bumpOutcome struct {
+	res EmotePlayResult
+	err error
 }

--- a/app/sesame/engine/emoteplay_valkey_test.go
+++ b/app/sesame/engine/emoteplay_valkey_test.go
@@ -41,17 +41,24 @@ func (f *emoteplayFixture) channel() int {
 	return f.seq
 }
 
-func (f *emoteplayFixture) bump(channel int, msgID string, width, copies int) EmotePlayResult {
-	f.t.Helper()
-	return f.storeBumpEmote(channel, msgID, "Kappa", width, copies)
+// emoteBump names one candidate line a test feeds the store. A struct keeps
+// the helper at one argument and reads as a table row.
+type emoteBump struct {
+	channel int
+	msgID   string
+	emote   string // defaults to "Kappa" when blank
+	width   int
+	copies  int
 }
 
-// storeBumpEmote is bump with the emote spelled out; most tests only ever use
-// one token, so bump keeps their bodies quiet.
-func (f *emoteplayFixture) storeBumpEmote(channel int, msgID, emote string, width, copies int) EmotePlayResult {
+func (f *emoteplayFixture) bump(b emoteBump) EmotePlayResult {
 	f.t.Helper()
+	emote := b.emote
+	if emote == "" {
+		emote = "Kappa"
+	}
 	res, err := f.store.Bump(f.ctx, EmotePlayUpdate{
-		BroadcasterID: uint64(channel), MsgID: msgID, Emote: emote, Width: width, Copies: copies,
+		BroadcasterID: uint64(b.channel), MsgID: b.msgID, Emote: emote, Width: b.width, Copies: b.copies,
 	})
 	require.NoError(f.t, err)
 	return res
@@ -61,42 +68,42 @@ func TestEmotePlayPyramidCompletesOnceAtTheBase(t *testing.T) {
 	f := newEmotePlayFixture(t)
 	ch := f.channel()
 	for _, w := range []int{1, 2} {
-		require.False(t, f.bump(ch, "m"+strconv.Itoa(w), w, 1).PyramidDone)
+		require.False(t, f.bump(emoteBump{channel: ch, msgID: "m" + strconv.Itoa(w), width: w, copies: 1}).PyramidDone)
 	}
-	r3 := f.bump(ch, "m3", 3, 1)
+	r3 := f.bump(emoteBump{channel: ch, msgID: "m3", width: 3, copies: 1})
 	require.False(t, r3.PyramidDone)
 	require.Equal(t, 0, r3.Apex, "apex is only reported on completion")
-	require.False(t, f.bump(ch, "m2d", 2, 1).PyramidDone)
-	done := f.bump(ch, "m1d", 1, 1)
+	require.False(t, f.bump(emoteBump{channel: ch, msgID: "m2d", width: 2, copies: 1}).PyramidDone)
+	done := f.bump(emoteBump{channel: ch, msgID: "m1d", width: 1, copies: 1})
 	require.True(t, done.PyramidDone)
 	require.Equal(t, 3, done.Apex)
 	// After completion the state is cleared: repeating the base line starts a
 	// fresh attempt, it does not complete again.
-	require.False(t, f.bump(ch, "after", 1, 1).PyramidDone)
+	require.False(t, f.bump(emoteBump{channel: ch, msgID: "after", width: 1, copies: 1}).PyramidDone)
 }
 
 func TestEmotePlaySameWidthDuplicatesNeverDoubleStep(t *testing.T) {
 	f := newEmotePlayFixture(t)
 	ch := f.channel()
-	f.bump(ch, "a", 1, 1)
-	f.bump(ch, "b", 2, 1)
+	f.bump(emoteBump{channel: ch, msgID: "a", width: 1, copies: 1})
+	f.bump(emoteBump{channel: ch, msgID: "b", width: 2, copies: 1})
 	// Two chatters racing the same step (or two pods delivering one line
 	// near-simultaneously): the second must be neutral.
-	f.bump(ch, "c", 2, 1)
-	f.bump(ch, "d", 3, 1)
-	require.False(t, f.bump(ch, "e", 3, 1).PyramidDone)
-	require.False(t, f.bump(ch, "f", 4, 1).PyramidDone)
+	f.bump(emoteBump{channel: ch, msgID: "c", width: 2, copies: 1})
+	f.bump(emoteBump{channel: ch, msgID: "d", width: 3, copies: 1})
+	require.False(t, f.bump(emoteBump{channel: ch, msgID: "e", width: 3, copies: 1}).PyramidDone)
+	require.False(t, f.bump(emoteBump{channel: ch, msgID: "f", width: 4, copies: 1}).PyramidDone)
 }
 
 func TestEmotePlayForeignEmoteRestartsAndApexTurnStillDescends(t *testing.T) {
 	f := newEmotePlayFixture(t)
 	ch := f.channel()
-	f.bump(ch, "a", 1, 1)
-	f.bump(ch, "b", 2, 1)
+	f.bump(emoteBump{channel: ch, msgID: "a", width: 1, copies: 1})
+	f.bump(emoteBump{channel: ch, msgID: "b", width: 2, copies: 1})
 	// Different emote mid-pyramid: the old attempt is abandoned and the new
 	// attempt anchors at this line (width 2).
-	f.bump(ch, "c", 2, 1)
-	done := f.bump(ch, "d", 1, 1)
+	f.bump(emoteBump{channel: ch, msgID: "c", width: 2, copies: 1})
+	done := f.bump(emoteBump{channel: ch, msgID: "d", width: 1, copies: 1})
 	require.True(t, done.PyramidDone, "a fresh attempt may descend straight off its anchor")
 	require.Equal(t, 2, done.Apex)
 }
@@ -104,47 +111,47 @@ func TestEmotePlayForeignEmoteRestartsAndApexTurnStillDescends(t *testing.T) {
 func TestEmotePlayWidthJumpRestartsInsteadOfCompleting(t *testing.T) {
 	f := newEmotePlayFixture(t)
 	ch := f.channel()
-	f.bump(ch, "a", 1, 1)
-	f.bump(ch, "b", 2, 1)
-	f.bump(ch, "c", 5, 1) // jump: attempt restarts anchored at 5
+	f.bump(emoteBump{channel: ch, msgID: "a", width: 1, copies: 1})
+	f.bump(emoteBump{channel: ch, msgID: "b", width: 2, copies: 1})
+	f.bump(emoteBump{channel: ch, msgID: "c", width: 5, copies: 1}) // jump: attempt restarts anchored at 5
 	// Descending from that anchor is legal by the apex-turn rule; what matters
 	// is that the jump did not preserve the old ascent as a taller pyramid.
-	require.False(t, f.bump(ch, "d", 4, 1).PyramidDone)
+	require.False(t, f.bump(emoteBump{channel: ch, msgID: "d", width: 4, copies: 1}).PyramidDone)
 }
 
 func TestEmotePlayReplayedMessageIDAppliesNothing(t *testing.T) {
 	f := newEmotePlayFixture(t)
 	ch := f.channel()
-	first := f.bump(ch, "same", 1, 1)
+	first := f.bump(emoteBump{channel: ch, msgID: "same", width: 1, copies: 1})
 	require.False(t, first.StreakMilestone)
 	for i := 0; i < 3; i++ {
-		replay := f.bump(ch, "same", 1, 1)
+		replay := f.bump(emoteBump{channel: ch, msgID: "same", width: 1, copies: 1})
 		require.False(t, replay.StreakMilestone, "redelivery must not recount")
 		require.False(t, replay.PyramidDone)
 	}
-	next := f.bump(ch, "other", 1, 1)
+	next := f.bump(emoteBump{channel: ch, msgID: "other", width: 1, copies: 1})
 	require.False(t, next.StreakMilestone, "count is 2, under the first rung")
 }
 
 func TestEmotePlayStreakLadderCrossingWithFoldedCohorts(t *testing.T) {
 	f := newEmotePlayFixture(t)
 	ch := f.channel()
-	f.bump(ch, "s1", 1, streakLadder[0]-1) // one below the first rung
-	crossed := f.bump(ch, "s2", 1, 2)
+	f.bump(emoteBump{channel: ch, msgID: "s1", width: 1, copies: streakLadder[0] - 1}) // one below the first rung
+	crossed := f.bump(emoteBump{channel: ch, msgID: "s2", width: 1, copies: 2})
 	require.True(t, crossed.StreakMilestone, "the cohort steps over the rung")
 	require.Equal(t, streakLadder[0], crossed.Streak, "the announced value is the rung, not the raw count")
-	silent := f.bump(ch, "s3", 1, 1)
+	silent := f.bump(emoteBump{channel: ch, msgID: "s3", width: 1, copies: 1})
 	require.False(t, silent.StreakMilestone, "between rungs")
-	switched := f.storeBumpEmote(ch, "s4", "PogChamp", 1, 1)
+	switched := f.bump(emoteBump{channel: ch, msgID: "s4", emote: "PogChamp", width: 1, copies: 1})
 	require.False(t, switched.StreakMilestone, "a new emote restarts from 1")
 }
 
 func TestEmotePlayWideLineBreaksTheStreakSilently(t *testing.T) {
 	f := newEmotePlayFixture(t)
 	ch := f.channel()
-	f.bump(ch, "w1", 1, streakLadder[0]-1)
-	f.bump(ch, "w2", 3, 1) // someone starts building: the streak resets
-	wide := f.storeBumpEmote(ch, "w3", "Kappa", 1, 1)
+	f.bump(emoteBump{channel: ch, msgID: "w1", width: 1, copies: streakLadder[0] - 1})
+	f.bump(emoteBump{channel: ch, msgID: "w2", width: 3, copies: 1}) // someone starts building: the streak resets
+	wide := f.bump(emoteBump{channel: ch, msgID: "w3", width: 1, copies: 1})
 	require.False(t, wide.StreakMilestone)
 }
 
@@ -169,9 +176,6 @@ func TestEmotePlayConcurrentReplicasCompleteExactlyOnce(t *testing.T) {
 	const replicas = 16
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	t.Cleanup(cancel)
-	// Build to descending-through-2, then race every replica at the final
-	// width-1 line with distinct message ids — the shape of two pods plus a
-	// redelivery all seeing the same chat moment.
 	racing := &ValkeyEmotePlay{client: newHotPathTestClient(t), pyrWin: time.Minute, stkWin: time.Minute}
 	for _, w := range []struct {
 		msgID string
@@ -181,27 +185,41 @@ func TestEmotePlayConcurrentReplicasCompleteExactlyOnce(t *testing.T) {
 		require.NoError(t, err)
 		require.False(t, res.PyramidDone)
 	}
-	var (
-		wg          sync.WaitGroup
-		mu          sync.Mutex
-		completions int
-	)
+	require.Equal(t, 1, raceWidthOneLines(t, ctx, racing, replicas),
+		"exactly one replica may observe the completion; every other racer must linearize behind it")
+}
+
+// raceWidthOneLines fires replicas concurrent final width-1 lines with distinct
+// message ids — the shape of two pods plus a redelivery all seeing the same
+// chat moment — and reports how many observed the completion.
+func raceWidthOneLines(t *testing.T, ctx context.Context, store *ValkeyEmotePlay, replicas int) int {
+	t.Helper()
+	results := make(chan EmotePlayResult, replicas)
+	var wg sync.WaitGroup
 	wg.Add(replicas)
 	for i := 0; i < replicas; i++ {
 		go func(i int) {
 			defer wg.Done()
-			res, err := racing.Bump(ctx, EmotePlayUpdate{
+			// t.Error rather than require: FailNow must stay on the test
+			// goroutine, workers report and drain instead.
+			res, err := store.Bump(ctx, EmotePlayUpdate{
 				MsgID: "race-" + strconv.Itoa(i), Emote: "Kappa", Width: 1, Copies: 1,
 			})
-			require.NoError(t, err)
-			if res.PyramidDone {
-				mu.Lock()
-				completions++
-				mu.Unlock()
+			if err != nil {
+				t.Errorf("racer %d: %v", i, err)
+				results <- EmotePlayResult{}
+				return
 			}
+			results <- res
 		}(i)
 	}
 	wg.Wait()
-	require.Equal(t, 1, completions,
-		"exactly one replica may observe the completion; every other racer must linearize behind it")
+	close(results)
+	completions := 0
+	for res := range results {
+		if res.PyramidDone {
+			completions++
+		}
+	}
+	return completions
 }

--- a/app/sesame/engine/emoteplay_valkey_test.go
+++ b/app/sesame/engine/emoteplay_valkey_test.go
@@ -18,162 +18,190 @@ import (
 // They use the same VALKEY_TEST_ADDR convention as valkey_hotpath_test.go. The
 // script's windows are plain arguments, so expiry is exercised with millisecond
 // windows rather than sleeping out the production values.
-func TestEmotePlayScriptIntegration(t *testing.T) {
+
+// emoteplayFixture hands each test a real client and its own channel id space,
+// so state never collides across tests.
+type emoteplayFixture struct {
+	t     *testing.T
+	ctx   context.Context
+	store *ValkeyEmotePlay
+	seq   int
+}
+
+func newEmotePlayFixture(t *testing.T) *emoteplayFixture {
+	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	t.Cleanup(cancel)
-	client := newHotPathTestClient(t)
-	store := NewValkeyEmotePlay(client)
+	return &emoteplayFixture{t: t, ctx: ctx, store: NewValkeyEmotePlay(newHotPathTestClient(t))}
+}
 
-	// step feeds one candidate line to a fresh-namespaced store and requires no
-	// error; each subtest builds its own channel id so state never collides.
-	channel := 0
-	step := func(t *testing.T, msgID, emote string, width, copies int) EmotePlayResult {
-		t.Helper()
-		res, err := store.Bump(ctx, EmotePlayUpdate{
-			BroadcasterID: uint64(channel), MsgID: msgID, Emote: emote, Width: width, Copies: copies,
-		})
+// channel returns a fresh broadcaster id per call; the key namespace is the id.
+func (f *emoteplayFixture) channel() int {
+	f.seq++
+	return f.seq
+}
+
+func (f *emoteplayFixture) bump(channel int, msgID string, width, copies int) EmotePlayResult {
+	f.t.Helper()
+	return f.storeBumpEmote(channel, msgID, "Kappa", width, copies)
+}
+
+// storeBumpEmote is bump with the emote spelled out; most tests only ever use
+// one token, so bump keeps their bodies quiet.
+func (f *emoteplayFixture) storeBumpEmote(channel int, msgID, emote string, width, copies int) EmotePlayResult {
+	f.t.Helper()
+	res, err := f.store.Bump(f.ctx, EmotePlayUpdate{
+		BroadcasterID: uint64(channel), MsgID: msgID, Emote: emote, Width: width, Copies: copies,
+	})
+	require.NoError(f.t, err)
+	return res
+}
+
+func TestEmotePlayPyramidCompletesOnceAtTheBase(t *testing.T) {
+	f := newEmotePlayFixture(t)
+	ch := f.channel()
+	for _, w := range []int{1, 2} {
+		require.False(t, f.bump(ch, "m"+strconv.Itoa(w), w, 1).PyramidDone)
+	}
+	r3 := f.bump(ch, "m3", 3, 1)
+	require.False(t, r3.PyramidDone)
+	require.Equal(t, 0, r3.Apex, "apex is only reported on completion")
+	require.False(t, f.bump(ch, "m2d", 2, 1).PyramidDone)
+	done := f.bump(ch, "m1d", 1, 1)
+	require.True(t, done.PyramidDone)
+	require.Equal(t, 3, done.Apex)
+	// After completion the state is cleared: repeating the base line starts a
+	// fresh attempt, it does not complete again.
+	require.False(t, f.bump(ch, "after", 1, 1).PyramidDone)
+}
+
+func TestEmotePlaySameWidthDuplicatesNeverDoubleStep(t *testing.T) {
+	f := newEmotePlayFixture(t)
+	ch := f.channel()
+	f.bump(ch, "a", 1, 1)
+	f.bump(ch, "b", 2, 1)
+	// Two chatters racing the same step (or two pods delivering one line
+	// near-simultaneously): the second must be neutral.
+	f.bump(ch, "c", 2, 1)
+	f.bump(ch, "d", 3, 1)
+	require.False(t, f.bump(ch, "e", 3, 1).PyramidDone)
+	require.False(t, f.bump(ch, "f", 4, 1).PyramidDone)
+}
+
+func TestEmotePlayForeignEmoteRestartsAndApexTurnStillDescends(t *testing.T) {
+	f := newEmotePlayFixture(t)
+	ch := f.channel()
+	f.bump(ch, "a", 1, 1)
+	f.bump(ch, "b", 2, 1)
+	// Different emote mid-pyramid: the old attempt is abandoned and the new
+	// attempt anchors at this line (width 2).
+	f.bump(ch, "c", 2, 1)
+	done := f.bump(ch, "d", 1, 1)
+	require.True(t, done.PyramidDone, "a fresh attempt may descend straight off its anchor")
+	require.Equal(t, 2, done.Apex)
+}
+
+func TestEmotePlayWidthJumpRestartsInsteadOfCompleting(t *testing.T) {
+	f := newEmotePlayFixture(t)
+	ch := f.channel()
+	f.bump(ch, "a", 1, 1)
+	f.bump(ch, "b", 2, 1)
+	f.bump(ch, "c", 5, 1) // jump: attempt restarts anchored at 5
+	// Descending from that anchor is legal by the apex-turn rule; what matters
+	// is that the jump did not preserve the old ascent as a taller pyramid.
+	require.False(t, f.bump(ch, "d", 4, 1).PyramidDone)
+}
+
+func TestEmotePlayReplayedMessageIDAppliesNothing(t *testing.T) {
+	f := newEmotePlayFixture(t)
+	ch := f.channel()
+	first := f.bump(ch, "same", 1, 1)
+	require.False(t, first.StreakMilestone)
+	for i := 0; i < 3; i++ {
+		replay := f.bump(ch, "same", 1, 1)
+		require.False(t, replay.StreakMilestone, "redelivery must not recount")
+		require.False(t, replay.PyramidDone)
+	}
+	next := f.bump(ch, "other", 1, 1)
+	require.False(t, next.StreakMilestone, "count is 2, under the first rung")
+}
+
+func TestEmotePlayStreakLadderCrossingWithFoldedCohorts(t *testing.T) {
+	f := newEmotePlayFixture(t)
+	ch := f.channel()
+	f.bump(ch, "s1", 1, streakLadder[0]-1) // one below the first rung
+	crossed := f.bump(ch, "s2", 1, 2)
+	require.True(t, crossed.StreakMilestone, "the cohort steps over the rung")
+	require.Equal(t, streakLadder[0], crossed.Streak, "the announced value is the rung, not the raw count")
+	silent := f.bump(ch, "s3", 1, 1)
+	require.False(t, silent.StreakMilestone, "between rungs")
+	switched := f.storeBumpEmote(ch, "s4", "PogChamp", 1, 1)
+	require.False(t, switched.StreakMilestone, "a new emote restarts from 1")
+}
+
+func TestEmotePlayWideLineBreaksTheStreakSilently(t *testing.T) {
+	f := newEmotePlayFixture(t)
+	ch := f.channel()
+	f.bump(ch, "w1", 1, streakLadder[0]-1)
+	f.bump(ch, "w2", 3, 1) // someone starts building: the streak resets
+	wide := f.storeBumpEmote(ch, "w3", "Kappa", 1, 1)
+	require.False(t, wide.StreakMilestone)
+}
+
+func TestEmotePlayExpiredWindowRestartsBothChains(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+	short := &ValkeyEmotePlay{client: newHotPathTestClient(t), pyrWin: 40 * time.Millisecond, stkWin: 40 * time.Millisecond}
+	bumpShort := func(msgID string, width int) EmotePlayResult {
+		res, err := short.Bump(ctx, EmotePlayUpdate{MsgID: msgID, Emote: "Kappa", Width: width, Copies: 1})
 		require.NoError(t, err)
 		return res
 	}
-	nextChannel := func() { channel++ }
+	require.False(t, bumpShort("t1", 1).PyramidDone)
+	require.False(t, bumpShort("t2", 2).PyramidDone)
+	time.Sleep(60 * time.Millisecond) // one window + slack, well inside any redelivery scale
+	require.False(t, bumpShort("t3", 1).StreakMilestone, "the streak expired with the window")
+	require.False(t, bumpShort("t4", 2).PyramidDone,
+		"the pyramid expired: width 2 starts a fresh attempt instead of ascending the dead one")
+}
 
-	t.Run("full pyramid completes once at the base", func(t *testing.T) {
-		nextChannel()
-		for _, w := range []int{1, 2} {
-			require.False(t, step(t, "m"+strconv.Itoa(w), "Kappa", w, 1).PyramidDone)
-		}
-		r3 := step(t, "m3", "Kappa", 3, 1)
-		require.False(t, r3.PyramidDone)
-		require.Equal(t, 0, r3.Apex, "apex is only reported on completion")
-		require.False(t, step(t, "m2d", "Kappa", 2, 1).PyramidDone)
-		done := step(t, "m1d", "Kappa", 1, 1)
-		require.True(t, done.PyramidDone)
-		require.Equal(t, 3, done.Apex)
-		// After completion the state is cleared: repeating the base line starts
-		// a fresh attempt, it does not complete again.
-		require.False(t, step(t, "after", "Kappa", 1, 1).PyramidDone)
-	})
-
-	t.Run("same-width duplicates never double-step", func(t *testing.T) {
-		nextChannel()
-		step(t, "a", "Kappa", 1, 1)
-		step(t, "b", "Kappa", 2, 1)
-		// Two chatters racing the same step (or two pods delivering one line
-		// near-simultaneously): the second must be neutral.
-		step(t, "c", "Kappa", 2, 1)
-		step(t, "d", "Kappa", 3, 1)
-		require.False(t, step(t, "e", "Kappa", 3, 1).PyramidDone)
-		require.False(t, step(t, "f", "Kappa", 4, 1).PyramidDone)
-	})
-
-	t.Run("foreign emote restarts, apex turn still descends", func(t *testing.T) {
-		nextChannel()
-		step(t, "a", "Kappa", 1, 1)
-		step(t, "b", "Kappa", 2, 1)
-		// Different emote mid-pyramid: the old attempt is abandoned and the new
-		// attempt anchors at this line (width 2).
-		step(t, "c", "PogChamp", 2, 1)
-		done := step(t, "d", "PogChamp", 1, 1)
-		require.True(t, done.PyramidDone, "a fresh attempt may descend straight off its anchor")
-		require.Equal(t, 2, done.Apex)
-	})
-
-	t.Run("width jump restarts instead of completing", func(t *testing.T) {
-		nextChannel()
-		step(t, "a", "Kappa", 1, 1)
-		step(t, "b", "Kappa", 2, 1)
-		step(t, "c", "Kappa", 5, 1) // jump: attempt restarts anchored at 5
-		// Descending from that anchor would complete a 5-tall pyramid nobody
-		// built — but it IS the anchored apex, so this is legal by the rules;
-		// what matters is that the jump did not preserve the old ascent.
-		done := step(t, "d", "Kappa", 4, 1)
-		require.False(t, done.PyramidDone)
-	})
-
-	t.Run("replayed message id applies nothing", func(t *testing.T) {
-		nextChannel()
-		first := step(t, "same", "Kappa", 1, 1)
-		require.False(t, first.StreakMilestone)
-		for i := 0; i < 3; i++ {
-			replay := step(t, "same", "Kappa", 1, 1)
-			require.False(t, replay.StreakMilestone, "redelivery must not recount")
-			require.False(t, replay.PyramidDone)
-		}
-		next := step(t, "other", "Kappa", 1, 1)
-		require.False(t, next.StreakMilestone, "count is 2, under the first rung")
-	})
-
-	t.Run("streak ladder crossing with folded cohorts", func(t *testing.T) {
-		nextChannel()
-		step(t, "s1", "Kappa", 1, streakLadder[0]-1) // one below the first rung
-		crossed := step(t, "s2", "Kappa", 1, 2)
-		require.True(t, crossed.StreakMilestone, "the cohort steps over the rung")
-		require.Equal(t, streakLadder[0], crossed.Streak, "the announced value is the rung, not the raw count")
-		silent := step(t, "s3", "Kappa", 1, 1)
-		require.False(t, silent.StreakMilestone, "between rungs")
-		switched := step(t, "s4", "PogChamp", 1, 1)
-		require.False(t, switched.StreakMilestone, "a new emote restarts from 1")
-	})
-
-	t.Run("wide line breaks the streak silently", func(t *testing.T) {
-		nextChannel()
-		step(t, "w1", "Kappa", 1, streakLadder[0]-1)
-		step(t, "w2", "Kappa", 3, 1) // someone starts building: the streak resets
-		wide := step(t, "w3", "Kappa", 1, 1)
-		require.False(t, wide.StreakMilestone)
-	})
-
-	t.Run("expired window restarts both chains", func(t *testing.T) {
-		short := &ValkeyEmotePlay{client: client, pyrWin: 40 * time.Millisecond, stkWin: 40 * time.Millisecond}
-		bumpShort := func(msgID string, width int) EmotePlayResult {
-			res, err := short.Bump(ctx, EmotePlayUpdate{MsgID: msgID, Emote: "Kappa", Width: width, Copies: 1})
+func TestEmotePlayConcurrentReplicasCompleteExactlyOnce(t *testing.T) {
+	const replicas = 16
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+	// Build to descending-through-2, then race every replica at the final
+	// width-1 line with distinct message ids — the shape of two pods plus a
+	// redelivery all seeing the same chat moment.
+	racing := &ValkeyEmotePlay{client: newHotPathTestClient(t), pyrWin: time.Minute, stkWin: time.Minute}
+	for _, w := range []struct {
+		msgID string
+		width int
+	}{{"p1", 1}, {"p2", 2}, {"p3", 3}, {"p4", 2}} {
+		res, err := racing.Bump(ctx, EmotePlayUpdate{MsgID: w.msgID, Emote: "Kappa", Width: w.width, Copies: 1})
+		require.NoError(t, err)
+		require.False(t, res.PyramidDone)
+	}
+	var (
+		wg          sync.WaitGroup
+		mu          sync.Mutex
+		completions int
+	)
+	wg.Add(replicas)
+	for i := 0; i < replicas; i++ {
+		go func(i int) {
+			defer wg.Done()
+			res, err := racing.Bump(ctx, EmotePlayUpdate{
+				MsgID: "race-" + strconv.Itoa(i), Emote: "Kappa", Width: 1, Copies: 1,
+			})
 			require.NoError(t, err)
-			return res
-		}
-		require.False(t, bumpShort("t1", 1).PyramidDone)
-		require.False(t, bumpShort("t2", 2).PyramidDone)
-		time.Sleep(60 * time.Millisecond) // one window + slack, well inside any redelivery scale
-		require.False(t, bumpShort("t3", 1).StreakMilestone, "the streak expired with the window")
-		require.False(t, bumpShort("t4", 2).PyramidDone,
-			"the pyramid expired: width 2 starts a fresh attempt instead of ascending the dead one")
-	})
-
-	t.Run("concurrent replicas complete the pyramid exactly once", func(t *testing.T) {
-		const replicas = 16
-		racing := &ValkeyEmotePlay{client: client, pyrWin: time.Minute, stkWin: time.Minute}
-		// Build to descending-through-2, then race every replica at the final
-		// width-1 line with distinct message ids — the shape of two pods plus a
-		// redelivery all seeing the same chat moment.
-		for _, w := range []struct {
-			msgID string
-			width int
-		}{{"p1", 1}, {"p2", 2}, {"p3", 3}, {"p4", 2}} {
-			res, err := racing.Bump(ctx, EmotePlayUpdate{MsgID: w.msgID, Emote: "Kappa", Width: w.width, Copies: 1})
-			require.NoError(t, err)
-			require.False(t, res.PyramidDone)
-		}
-		var (
-			wg          sync.WaitGroup
-			mu          sync.Mutex
-			completions int
-		)
-		wg.Add(replicas)
-		for i := 0; i < replicas; i++ {
-			go func(i int) {
-				defer wg.Done()
-				res, err := racing.Bump(ctx, EmotePlayUpdate{
-					MsgID: "race-" + strconv.Itoa(i), Emote: "Kappa", Width: 1, Copies: 1,
-				})
-				require.NoError(t, err)
-				if res.PyramidDone {
-					mu.Lock()
-					completions++
-					mu.Unlock()
-				}
-			}(i)
-		}
-		wg.Wait()
-		require.Equal(t, 1, completions,
-			"exactly one replica may observe the completion; every other racer must linearize behind it")
-	})
+			if res.PyramidDone {
+				mu.Lock()
+				completions++
+				mu.Unlock()
+			}
+		}(i)
+	}
+	wg.Wait()
+	require.Equal(t, 1, completions,
+		"exactly one replica may observe the completion; every other racer must linearize behind it")
 }

--- a/app/sesame/modules/all.go
+++ b/app/sesame/modules/all.go
@@ -39,5 +39,6 @@ func All(d engine.Deps) []module.Module {
 		Govee(d),
 		TimeOfDay(d),
 		Triggers(d),
+		EmotePlay(d),
 	}
 }

--- a/app/sesame/modules/emoteplay.go
+++ b/app/sesame/modules/emoteplay.go
@@ -139,6 +139,20 @@ func emotePlayAnnounce(c *module.Context, emit module.Emit, emote string, res en
 //   - Lines wider than maxPyramidWidth are rejected here (not by the store), so
 //     copypasta walls never produce a valkey call at all.
 func emoteShape(text string) (token string, width int, ok bool) {
+	token, i := firstToken(text)
+	if token == "" {
+		return "", 0, false
+	}
+	width, ok = countRepeatedToken(text, i, token)
+	if !ok || !emoteTokenish(token) {
+		return "", 0, false
+	}
+	return token, width, true
+}
+
+// firstToken returns the leading whitespace-delimited token of text plus the
+// offset just past it ("" when text is blank).
+func firstToken(text string) (string, int) {
 	i, n := 0, len(text)
 	for i < n && isASCIISpace(text[i]) {
 		i++
@@ -147,10 +161,14 @@ func emoteShape(text string) (token string, width int, ok bool) {
 	for i < n && !isASCIISpace(text[i]) {
 		i++
 	}
-	token = text[start:i]
-	if token == "" {
-		return "", 0, false
-	}
+	return text[start:i], i
+}
+
+// countRepeatedToken walks the tokens after offset i and returns how many
+// times in total (first occurrence included) token occurs, ok=false the moment
+// any token differs or the pyramid-width cap is exceeded.
+func countRepeatedToken(text string, i int, token string) (width int, ok bool) {
+	n := len(text)
 	width = 1
 	for i < n {
 		for i < n && isASCIISpace(text[i]) {
@@ -164,17 +182,14 @@ func emoteShape(text string) (token string, width int, ok bool) {
 			i++
 		}
 		if i-j != len(token) || text[j:i] != token {
-			return "", 0, false
+			return 0, false
 		}
 		width++
 		if width > maxPyramidWidth {
-			return "", 0, false
+			return 0, false
 		}
 	}
-	if !emoteTokenish(token) {
-		return "", 0, false
-	}
-	return token, width, true
+	return width, true
 }
 
 // emoteTokenish requires at least one letter or digit, so punctuation spam

--- a/app/sesame/modules/emoteplay.go
+++ b/app/sesame/modules/emoteplay.go
@@ -79,13 +79,20 @@ func emotePlayOnChat(d engine.Deps) module.EventHandler {
 			Copies:        copies,
 		})
 		if err != nil {
-			if c.Log != nil {
-				c.Log.Debug("emoteplay: bump failed", zap.Uint64("broadcaster_id", c.BroadcasterID), zap.Error(err))
-			}
+			logBumpFailure(c, err)
 			return nil
 		}
 		emotePlayAnnounce(c, emit, emote, res)
 		return nil
+	}
+}
+
+// logBumpFailure keeps the handler branch-light: a valkey outage during emote
+// spam must not grow the handler's shape, so the Debug sink lives here.
+func logBumpFailure(c *module.Context, err error) {
+	if c.Log != nil {
+		c.Log.Debug("emoteplay: bump failed",
+			zap.Uint64("broadcaster_id", c.BroadcasterID), zap.Error(err))
 	}
 }
 
@@ -202,12 +209,19 @@ func skipNonSpaces(text string, i int) int {
 // ("...", "???") never registers as an emote. Any non-ASCII rune counts: emote
 // codes exist in CJK scripts, and decoding one short token is cheap.
 func emoteTokenish(token string) bool {
-	for _, r := range token {
-		if r >= utf8.RuneSelf || unicode.IsLetter(r) || unicode.IsDigit(r) {
-			return true
-		}
+	return strings.ContainsFunc(token, emoteRuneOK)
+}
+
+// emoteRuneOK is emoteTokenish's predicate, kept operator-free: each acceptance
+// reason is its own plain branch.
+func emoteRuneOK(r rune) bool {
+	if r >= utf8.RuneSelf {
+		return true
 	}
-	return false
+	if unicode.IsLetter(r) {
+		return true
+	}
+	return unicode.IsDigit(r)
 }
 
 func isASCIISpace(b byte) bool {

--- a/app/sesame/modules/emoteplay.go
+++ b/app/sesame/modules/emoteplay.go
@@ -153,43 +153,49 @@ func emoteShape(text string) (token string, width int, ok bool) {
 // firstToken returns the leading whitespace-delimited token of text plus the
 // offset just past it ("" when text is blank).
 func firstToken(text string) (string, int) {
-	i, n := 0, len(text)
-	for i < n && isASCIISpace(text[i]) {
-		i++
+	start := skipSpaces(text, 0)
+	end := skipNonSpaces(text, start)
+	if start == end {
+		return "", end
 	}
-	start := i
-	for i < n && !isASCIISpace(text[i]) {
-		i++
-	}
-	return text[start:i], i
+	return text[start:end], end
 }
 
 // countRepeatedToken walks the tokens after offset i and returns how many
 // times in total (first occurrence included) token occurs, ok=false the moment
 // any token differs or the pyramid-width cap is exceeded.
 func countRepeatedToken(text string, i int, token string) (width int, ok bool) {
-	n := len(text)
 	width = 1
-	for i < n {
-		for i < n && isASCIISpace(text[i]) {
-			i++
+	for width <= maxPyramidWidth {
+		i = skipSpaces(text, i)
+		if i >= len(text) {
+			return width, true
 		}
-		if i >= n {
-			break
-		}
-		j := i
-		for i < n && !isASCIISpace(text[i]) {
-			i++
-		}
-		if i-j != len(token) || text[j:i] != token {
+		next := skipNonSpaces(text, i)
+		if text[i:next] != token {
 			return 0, false
 		}
+		i = next
 		width++
-		if width > maxPyramidWidth {
-			return 0, false
-		}
 	}
-	return width, true
+	return 0, false
+}
+
+// skipSpaces advances past ASCII whitespace; skipNonSpaces past everything
+// else. The pair is the whole tokenizer: byte-index arithmetic keeps the scan
+// allocation-free on the hot path.
+func skipSpaces(text string, i int) int {
+	for i < len(text) && isASCIISpace(text[i]) {
+		i++
+	}
+	return i
+}
+
+func skipNonSpaces(text string, i int) int {
+	for i < len(text) && !isASCIISpace(text[i]) {
+		i++
+	}
+	return i
 }
 
 // emoteTokenish requires at least one letter or digit, so punctuation spam

--- a/app/sesame/modules/emoteplay.go
+++ b/app/sesame/modules/emoteplay.go
@@ -131,66 +131,57 @@ func emotePlayAnnounce(c *module.Context, emit module.Emit, emote string, res en
 	}
 }
 
-// emoteShape reports whether text is exactly one token repeated (width >= 1),
-// ASCII-whitespace separated, and returns the token and its count. It scans
-// bytes with no allocation: this runs on EVERY chat line, so it must stay
+// tokenWalker walks text one whitespace-delimited token at a time, returning ""
+// once exhausted. Byte-index arithmetic keeps the walk allocation-free: this is
+// the hot path behind every chat line the module screens, so it must stay
 // cheaper than the valkey call it gates.
+type tokenWalker struct {
+	text string
+	i    int
+}
+
+func (w *tokenWalker) next() string {
+	start := skipSpaces(w.text, w.i)
+	end := skipNonSpaces(w.text, start)
+	w.i = end
+	return w.text[start:end]
+}
+
+// emoteShape reports whether text is exactly one token repeated (width >= 1),
+// ASCII-whitespace separated, and returns the token and its count.
 //
 // Deliberate limits, chosen for the hot path:
-//   - ASCII whitespace only. Twitch chat separates tokens with plain spaces in
-//     practice; exotic U+00A0-style separators just fail the shape check and
-//     cost nothing, which beats paying rune-decoding on every line to handle
-//     them.
 //   - Case-sensitive comparison. Kappa and kappa render different emotes, and
 //     mixing them mid-pyramid should break the shape, not blend it.
 //   - Lines wider than maxPyramidWidth are rejected here (not by the store), so
 //     copypasta walls never produce a valkey call at all.
 func emoteShape(text string) (token string, width int, ok bool) {
-	token, i := firstToken(text)
+	w := tokenWalker{text: text}
+	token = w.next()
 	if token == "" {
 		return "", 0, false
 	}
-	width, ok = countRepeatedToken(text, i, token)
-	if !ok || !emoteTokenish(token) {
-		return "", 0, false
-	}
-	return token, width, true
-}
-
-// firstToken returns the leading whitespace-delimited token of text plus the
-// offset just past it ("" when text is blank).
-func firstToken(text string) (string, int) {
-	start := skipSpaces(text, 0)
-	end := skipNonSpaces(text, start)
-	if start == end {
-		return "", end
-	}
-	return text[start:end], end
-}
-
-// countRepeatedToken walks the tokens after offset i and returns how many
-// times in total (first occurrence included) token occurs, ok=false the moment
-// any token differs or the pyramid-width cap is exceeded.
-func countRepeatedToken(text string, i int, token string) (width int, ok bool) {
-	width = 1
-	for width <= maxPyramidWidth {
-		i = skipSpaces(text, i)
-		if i >= len(text) {
-			return width, true
+	for width = 1; width <= maxPyramidWidth; width++ {
+		switch next := w.next(); {
+		case next == "":
+			if !emoteTokenish(token) {
+				return "", 0, false
+			}
+			return token, width, true
+		case next != token:
+			return "", 0, false
 		}
-		next := skipNonSpaces(text, i)
-		if text[i:next] != token {
-			return 0, false
-		}
-		i = next
-		width++
 	}
-	return 0, false
+	return "", 0, false
 }
 
 // skipSpaces advances past ASCII whitespace; skipNonSpaces past everything
-// else. The pair is the whole tokenizer: byte-index arithmetic keeps the scan
-// allocation-free on the hot path.
+// else. The pair is the whole tokenizer.
+//
+// Deliberate limits: ASCII whitespace only. Twitch chat separates tokens with
+// plain spaces in practice; exotic U+00A0-style separators just fail the shape
+// check and cost nothing, which beats paying rune-decoding on every line to
+// handle them.
 func skipSpaces(text string, i int) int {
 	for i < len(text) && isASCIISpace(text[i]) {
 		i++

--- a/app/sesame/modules/emoteplay.go
+++ b/app/sesame/modules/emoteplay.go
@@ -1,0 +1,198 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package modules
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"ItsBagelBot/app/sesame/engine"
+	"ItsBagelBot/app/sesame/module"
+	"ItsBagelBot/internal/domain/i18n"
+	"ItsBagelBot/internal/domain/outgress"
+
+	"go.uber.org/zap"
+)
+
+// emoteplayModuleName is the ModuleView key; it matches the console
+// MODULE_CATALOG entry id (console/shared/lib/types.ts).
+const emoteplayModuleName = "emoteplay"
+
+// maxPyramidWidth caps how wide a line the tracker will even look at. A line
+// wider than this is ignored WITHOUT touching valkey and without resetting any
+// chain: 50-token copypasta walls are not pyramid material, and letting them
+// clear state would hand every troll a one-line kill switch against an active
+// pyramid. Abandoned chains expire through the store's windows instead.
+const maxPyramidWidth = 10
+
+// EmotePlay celebrates chat-built emote structures: pyramids (the same emote
+// stacked 1, 2, 3… and back down to 1) and streaks (a run of single-emote
+// messages). It is a named opt-in module (KindOptIn): unlike the commands, it
+// speaks without being asked, so broadcasters switch it on deliberately from
+// its dashboard module page.
+//
+// Speed contract: ordinary prose never reaches valkey. The handler screens each
+// line in-process with a zero-allocation shape scan and only a line that IS one
+// repeated token pays the single atomic store round trip that advances both
+// chains. Announcements fire only on milestones, so the steady-state cost of an
+// idle channel is a few byte compares per message.
+//
+// Cross-replica correctness lives entirely in the store (see ValkeyEmotePlay):
+// sesame's replicas share one lane consumer, so consecutive lines of a pyramid
+// routinely arrive at different pods, and the store's single Lua round trip is
+// what makes the second pod see the first pod's step instead of racing it.
+func EmotePlay(d engine.Deps) module.Module {
+	m := module.NewModule(emoteplayModuleName, module.KindOptIn)
+	m.On("channel.chat.message", emotePlayOnChat(d))
+	return m.Build()
+}
+
+// emotePlayOnChat feeds candidate lines to the store and announces milestones.
+// A store error is swallowed at Debug level rather than returned on purpose:
+// returning it would make the pipeline log at Error and notice New Relic for
+// every candidate line during a valkey outage, and emote-spam channels would
+// turn one cache hiccup into an alert storm. This store is best-effort hype
+// state, not money — the line is lost, chat moves on, and the Debug sink is
+// there if anyone goes looking.
+func emotePlayOnChat(d engine.Deps) module.EventHandler {
+	return func(ctx context.Context, c *module.Context, emit module.Emit) error {
+		if d.EmotePlay == nil || c.Env.Text == "" {
+			return nil
+		}
+		emote, width, ok := emoteShape(c.Env.Text)
+		if !ok {
+			return nil
+		}
+		copies := len(c.Env.Senders)
+		if copies < 1 {
+			copies = 1
+		}
+		res, err := d.EmotePlay.Bump(ctx, engine.EmotePlayUpdate{
+			BroadcasterID: c.BroadcasterID,
+			MsgID:         c.Env.MsgID,
+			Emote:         emote,
+			Width:         width,
+			Copies:        copies,
+		})
+		if err != nil {
+			if c.Log != nil {
+				c.Log.Debug("emoteplay: bump failed", zap.Uint64("broadcaster_id", c.BroadcasterID), zap.Error(err))
+			}
+			return nil
+		}
+		emotePlayAnnounce(c, emit, emote, res)
+		return nil
+	}
+}
+
+// emotePlayAnnounce renders the milestone replies. When one line lands both a
+// completion and a streak rung (the final width-1 descent line also counts as a
+// streak message), only the pyramid speaks: two overlapping celebrations of the
+// same line read as noise, and the streak's next rung is never far away.
+func emotePlayAnnounce(c *module.Context, emit module.Emit, emote string, res engine.EmotePlayResult) {
+	switch {
+	case res.PyramidDone:
+		text := module.ExpandString(i18n.T(c.Locale, "emoteplay.pyramid"), func(key string) (string, bool) {
+			switch key {
+			case "user":
+				return strings.TrimPrefix(c.Env.ChatterName(), "@"), true
+			case "emote":
+				return emote, true
+			case "height":
+				return strconv.Itoa(res.Apex), true
+			default:
+				return module.ParseDynamic(key)
+			}
+		})
+		emit(&module.Output{Type: outgress.TypeChat, BroadcasterID: c.Env.BroadcasterUserID, Text: text})
+	case res.StreakMilestone:
+		text := module.ExpandString(i18n.T(c.Locale, "emoteplay.streak"), func(key string) (string, bool) {
+			switch key {
+			case "emote":
+				return emote, true
+			case "count":
+				return strconv.Itoa(res.Streak), true
+			default:
+				return module.ParseDynamic(key)
+			}
+		})
+		emit(&module.Output{Type: outgress.TypeChat, BroadcasterID: c.Env.BroadcasterUserID, Text: text})
+	}
+}
+
+// emoteShape reports whether text is exactly one token repeated (width >= 1),
+// ASCII-whitespace separated, and returns the token and its count. It scans
+// bytes with no allocation: this runs on EVERY chat line, so it must stay
+// cheaper than the valkey call it gates.
+//
+// Deliberate limits, chosen for the hot path:
+//   - ASCII whitespace only. Twitch chat separates tokens with plain spaces in
+//     practice; exotic U+00A0-style separators just fail the shape check and
+//     cost nothing, which beats paying rune-decoding on every line to handle
+//     them.
+//   - Case-sensitive comparison. Kappa and kappa render different emotes, and
+//     mixing them mid-pyramid should break the shape, not blend it.
+//   - Lines wider than maxPyramidWidth are rejected here (not by the store), so
+//     copypasta walls never produce a valkey call at all.
+func emoteShape(text string) (token string, width int, ok bool) {
+	i, n := 0, len(text)
+	for i < n && isASCIISpace(text[i]) {
+		i++
+	}
+	start := i
+	for i < n && !isASCIISpace(text[i]) {
+		i++
+	}
+	token = text[start:i]
+	if token == "" {
+		return "", 0, false
+	}
+	width = 1
+	for i < n {
+		for i < n && isASCIISpace(text[i]) {
+			i++
+		}
+		if i >= n {
+			break
+		}
+		j := i
+		for i < n && !isASCIISpace(text[i]) {
+			i++
+		}
+		if i-j != len(token) || text[j:i] != token {
+			return "", 0, false
+		}
+		width++
+		if width > maxPyramidWidth {
+			return "", 0, false
+		}
+	}
+	if !emoteTokenish(token) {
+		return "", 0, false
+	}
+	return token, width, true
+}
+
+// emoteTokenish requires at least one letter or digit, so punctuation spam
+// ("...", "???") never registers as an emote. Any non-ASCII rune counts: emote
+// codes exist in CJK scripts, and decoding one short token is cheap.
+func emoteTokenish(token string) bool {
+	for _, r := range token {
+		if r >= utf8.RuneSelf || unicode.IsLetter(r) || unicode.IsDigit(r) {
+			return true
+		}
+	}
+	return false
+}
+
+func isASCIISpace(b byte) bool {
+	switch b {
+	case ' ', '\t', '\n', '\v', '\f', '\r':
+		return true
+	}
+	return false
+}

--- a/app/sesame/modules/emoteplay_test.go
+++ b/app/sesame/modules/emoteplay_test.go
@@ -1,0 +1,165 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package modules
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"ItsBagelBot/app/sesame/engine"
+	"ItsBagelBot/app/sesame/module"
+	"ItsBagelBot/internal/domain/event/lane"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// stubEmotePlay records every Bump and replays a canned result, so handler
+// tests never need valkey.
+type stubEmotePlay struct {
+	updates []engine.EmotePlayUpdate
+	result  engine.EmotePlayResult
+	err     error
+}
+
+func (s *stubEmotePlay) Bump(_ context.Context, u engine.EmotePlayUpdate) (engine.EmotePlayResult, error) {
+	s.updates = append(s.updates, u)
+	return s.result, s.err
+}
+
+func emotePlayDeps(store *stubEmotePlay) engine.Deps {
+	return engine.Deps{Log: zap.NewNop(), EmotePlay: store}
+}
+
+func runEmotePlay(t *testing.T, d engine.Deps, env lane.Envelope) []module.Output {
+	t.Helper()
+	m := EmotePlay(d)
+	require.Equal(t, emoteplayModuleName, m.Name)
+	assert.Equal(t, module.KindOptIn, m.Kind, "the module speaks unprompted; it must ship disabled")
+	handler := m.Events["channel.chat.message"]
+	require.NotNil(t, handler)
+	var col collector
+	c := &module.Context{Env: env, BroadcasterID: 42, Log: zap.NewNop()}
+	require.NoError(t, handler(context.Background(), c, col.emit))
+	return col.out
+}
+
+func TestEmoteShape(t *testing.T) {
+	cases := []struct {
+		name  string
+		text  string
+		token string
+		width int
+		ok    bool
+	}{
+		{"single emote", "Kappa", "Kappa", 1, true},
+		{"pyramid line", "Kappa Kappa Kappa", "Kappa", 3, true},
+		{"extra inner spaces", "  Kappa   Kappa  ", "Kappa", 2, true},
+		{"prose", "hello there friends", "", 0, false},
+		{"mixed emotes", "Kappa PogChamp", "", 0, false},
+		{"prefix blend", "Kappa KappaKappa", "", 0, false},
+		{"case differs", "Kappa kappa", "", 0, false},
+		{"punctuation spam", ". . . .", "", 0, false},
+		{"wall over cap", repeatToken("Kappa", maxPyramidWidth+1), "", 0, false},
+		{"exactly at cap", repeatToken("Kappa", maxPyramidWidth), "Kappa", maxPyramidWidth, true},
+		{"empty", "", "", 0, false},
+		{"cjk token", "全員 全員 全員", "全員", 3, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tok, w, ok := emoteShape(tc.text)
+			assert.Equal(t, tc.ok, ok)
+			assert.Equal(t, tc.token, tok)
+			assert.Equal(t, tc.width, w)
+		})
+	}
+}
+
+// repeatToken joins n copies of s with single spaces (test helper).
+func repeatToken(s string, n int) string {
+	out := s
+	for i := 1; i < n; i++ {
+		out += " " + s
+	}
+	return out
+}
+
+func TestEmotePlayCandidateFeedsStoreOnce(t *testing.T) {
+	store := &stubEmotePlay{}
+	runEmotePlay(t, emotePlayDeps(store), lane.Envelope{
+		Type: "channel.chat.message", MsgID: "m1", Text: "Kappa Kappa",
+	})
+	require.Len(t, store.updates, 1)
+	u := store.updates[0]
+	assert.Equal(t, uint64(42), u.BroadcasterID)
+	assert.Equal(t, "m1", u.MsgID)
+	assert.Equal(t, "Kappa", u.Emote)
+	assert.Equal(t, 2, u.Width)
+	assert.Equal(t, 1, u.Copies)
+}
+
+func TestEmotePlayProseNeverTouchesStore(t *testing.T) {
+	store := &stubEmotePlay{}
+	for _, text := range []string{"", "just chatting", "Kappa PogChamp Kappa"} {
+		runEmotePlay(t, emotePlayDeps(store), lane.Envelope{Text: text})
+	}
+	assert.Empty(t, store.updates, "prose must cost zero store round trips")
+}
+
+func TestEmotePlayCohortCountsCopies(t *testing.T) {
+	store := &stubEmotePlay{}
+	line := lane.Sender{ChatterUserID: "2"}
+	runEmotePlay(t, emotePlayDeps(store), lane.Envelope{
+		Text: "Kappa", Senders: []lane.Sender{line, line, line},
+	})
+	require.Len(t, store.updates, 1)
+	assert.Equal(t, 3, store.updates[0].Copies)
+}
+
+func TestEmotePlayAnnouncements(t *testing.T) {
+	base := lane.Envelope{Type: "channel.chat.message", BroadcasterUserID: "42", Text: "Kappa"}
+
+	t.Run("pyramid completion announces height", func(t *testing.T) {
+		store := &stubEmotePlay{result: engine.EmotePlayResult{PyramidDone: true, Apex: 4}}
+		out := runEmotePlay(t, emotePlayDeps(store), base)
+		require.Len(t, out, 1)
+		assert.Contains(t, out[0].Text, "Kappa")
+		assert.Contains(t, out[0].Text, "4")
+	})
+
+	t.Run("streak milestone announces rung", func(t *testing.T) {
+		store := &stubEmotePlay{result: engine.EmotePlayResult{StreakMilestone: true, Streak: 10}}
+		out := runEmotePlay(t, emotePlayDeps(store), base)
+		require.Len(t, out, 1)
+		assert.Contains(t, out[0].Text, "Kappa")
+		assert.Contains(t, out[0].Text, "10")
+	})
+
+	t.Run("completion wins over same-line streak rung", func(t *testing.T) {
+		store := &stubEmotePlay{result: engine.EmotePlayResult{
+			PyramidDone: true, Apex: 3, StreakMilestone: true, Streak: 5}}
+		out := runEmotePlay(t, emotePlayDeps(store), base)
+		require.Len(t, out, 1, "one line must not be celebrated twice")
+		assert.Contains(t, out[0].Text, "pyramid")
+	})
+
+	t.Run("silent advance emits nothing", func(t *testing.T) {
+		store := &stubEmotePlay{}
+		out := runEmotePlay(t, emotePlayDeps(store), base)
+		assert.Empty(t, out)
+	})
+}
+
+func TestEmotePlayStoreErrorFailsOpenSilently(t *testing.T) {
+	store := &stubEmotePlay{err: errors.New("valkey down")}
+	out := runEmotePlay(t, emotePlayDeps(store), lane.Envelope{Text: "Kappa"})
+	assert.Empty(t, out, "an outage must never emit, block or nack chat")
+}
+
+func TestEmotePlayNilStoreInert(t *testing.T) {
+	out := runEmotePlay(t, engine.Deps{Log: zap.NewNop()}, lane.Envelope{Text: "Kappa"})
+	assert.Empty(t, out)
+}

--- a/app/sesame/wiring.go
+++ b/app/sesame/wiring.go
@@ -113,6 +113,8 @@ func buildDeps(w wireCtx, rt engineRuntime) engine.Deps {
 
 		Personality: engine.NewValkeyPersonality(in.vc, engine.NewPersonalityRPC(in.nc, cfg.ModulesRPCPrefix), log),
 
+		EmotePlay: engine.NewValkeyEmotePlay(in.vc),
+
 		Dedup: newDedup(w),
 
 		PublicBaseURL: cfg.PublicBaseURL,

--- a/console/shared/lib/module-catalog.test.ts
+++ b/console/shared/lib/module-catalog.test.ts
@@ -17,4 +17,19 @@ describe('module catalog', () => {
     expect(counters?.toggleable).toBe(false);
     expect(moduleDelegateSections(counters!)).toEqual(['modules']);
   });
+
+  // The emoteplay tile must stay a plain opt-in toggle: no bespoke page, no
+  // delegation grant of its own, and an id matching the sesame module name the
+  // engine gates on (app/sesame/modules/emoteplay.go). Its announcements are
+  // system text, so there are no editable replies to configure.
+  test('emoteplay is a toggle-only opt-in module keyed by its sesame name', () => {
+    const def = moduleDef('emoteplay');
+    expect(def).toBeDefined();
+    expect(def?.href).toBeUndefined();
+    expect(def?.hidden).toBeFalsy();
+    expect(def?.toggleable).not.toBe(false);
+    expect(def?.defaultEnabled).toBe(false);
+    expect(def?.replies).toHaveLength(0);
+    expect(def?.icon).toBe('pulse');
+  });
 });

--- a/console/shared/lib/types.ts
+++ b/console/shared/lib/types.ts
@@ -594,6 +594,17 @@ export const MODULE_CATALOG: readonly ModuleDef[] = [
     ]
   },
   {
+    id: 'emoteplay',
+    label: 'Emote Pyramids & Streaks',
+    tagline: 'Celebrate chat-built emote pyramids and emote streaks.',
+    description:
+      'Watch chat build emote pyramids (the same emote stacked 1, 2, 3 and back down to 1) and emote streaks (a run of single-emote messages), and let the bot cheer when they land. Fully automatic: no commands, no setup. A pyramid only counts when it is built cleanly, line by line, with nothing else posted in between.',
+    icon: 'pulse',
+    category: 'Chat Tools',
+    defaultEnabled: false,
+    replies: []
+  },
+  {
     id: 'automod',
     label: 'AutoMod',
     tagline: 'Catch scams, IP-grabbers and raid spam before your mods do.',

--- a/internal/domain/i18n/locales/en.json
+++ b/internal/domain/i18n/locales/en.json
@@ -10,6 +10,8 @@
   "cmd.link": "@{user} browse {channel}'s commands here: {url}",
   "cmd.modified": "@{user} the command {command} has been modified",
   "cmd.removed": "@{user} the command {command} has been removed",
+  "emoteplay.pyramid": "{user} completed the {emote} pyramid! ({height} tall)",
+  "emoteplay.streak": "{emote} streak ×{count}!",
   "external.retry": "still looking that up, try again in a moment",
   "feed.board": "Bagel leaderboard: {places}. {standing}",
   "feed.board.empty": "Nobody has fed the bagel yet. Say \"feed the bagel\" and take first place.",

--- a/internal/domain/i18n/locales/fr.json
+++ b/internal/domain/i18n/locales/fr.json
@@ -10,6 +10,8 @@
   "cmd.link": "@{user} parcourez les commandes de {channel} ici : {url}",
   "cmd.modified": "@{user} la commande {command} a été modifiée",
   "cmd.removed": "@{user} la commande {command} a été supprimée",
+  "emoteplay.pyramid": "{user} vient de finir la pyramide {emote} ! ({height} de haut)",
+  "emoteplay.streak": "Série {emote} ×{count} !",
   "external.retry": "recherche en cours, réessayez dans un instant",
   "feed.board": "Classement bagel : {places}. {standing}",
   "feed.board.empty": "Personne n'a encore nourri le bagel. Dites « feed the bagel » et prenez la première place.",


### PR DESCRIPTION
## What

One opt-in sesame module, `emoteplay`, that tracks two chat structures and celebrates them:

- **Pyramids** — the same emote stacked 1, 2, 3… and back down to 1. Strict shape rules: ±1 steps only, descent must turn at the apex, re-ascending mid-descent or a foreign emote restarts the attempt anchored at the offending line (a troll wall becomes a new base instead of erasing progress).
- **Streaks** — consecutive single-emote messages; announced on a ladder (5/10/25/50/100/250/500/1000), silent past it. Folded duplicate cohorts count every sender.

## Race safety (why valkey, and how)

Sesame runs 3 replicas sharing one durable lane consumer, so consecutive lines of one pyramid routinely land on different pods, and JetStream redeliveries re-run handlers after a nack. Pod-local memory cannot work here. Every transition is therefore ONE Lua script per candidate line — read state, decide, write state inside the interpreter's atomicity — so the second pod linearizes on top of the first pod's write:

- no WATCH/MULTI retry loop, no read-then-write;
- deliberately NOT `NewLuaScriptRetryable` (a mid-script connection failure may have applied the bump; replaying would double-count);
- redeliveries: an unconditional `msg` field absorbs a replayed message id — owned by neither subsystem, since a completion clears pyramid state and would let a subsystem-owned guard slip;
- cross-pod near-ties: same-width repeats are neutral no-ops, so two pods delivering "Kappa Kappa" cannot double-step;
- fleet clock via `redis.call('TIME')`; windows expire server-side, idle keys via TTL — abandoning a chain costs nothing.

## Speed contract

Prose never reaches valkey. A zero-allocation byte scan gates every chat line in-process (`emoteShape`); only emote-shaped lines pay exactly one master RTT that advances both chains. Lines wider than 10 tokens are rejected at the door — copypasta walls cost nothing and cannot reset active pyramids. Emission is milestone-only. The pipeline alloc-ceiling tests still pass untouched.

## Surfaces

- `engine/emoteplay_valkey.go` — store + script; `Deps.EmotePlayStore`
- `modules/emoteplay.go` — handler, gate, i18n announcements (en/fr)
- console MODULE_CATALOG entry (opt-in toggle); wiring + registration

## Tests

- unit: shape gate table, cohort copies, announcement mapping, fail-open on store errors
- integration (VALKEY_TEST_ADDR-gated, like the other script tests): full pyramid, apex-turn, restarts, replay absorption, ladder crossing with cohort jumps, window expiry via ms-scale windows, and a 16-way concurrent race asserting exactly one completion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in Emote Pyramids & Streaks chat tool, disabled by default.
  * Detects repeated emotes, tracks pyramid progress and streak milestones, and announces achievements.
  * Added English and French localized notifications.
  * Added persistent state handling with automatic expiration and duplicate-event protection.

* **Tests**
  * Added coverage for progression, resets, concurrency, localization, filtering, and failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->