### PR TITLE
fix(sesame): order live-state lifecycle against rapid stream start/stop

### DIFF
--- a/app/gossip/internal/providers/fortnite/fortnite.go
+++ b/app/gossip/internal/providers/fortnite/fortnite.go
@@ -197,6 +197,7 @@ func (p *api) build() provider.Provider {
 			Fetch(p.statsFetch)
 		b.Endpoint("session_start").Timeout(handlerTimeout).Handle(p.sessionStart)
 		b.Endpoint("session").Timeout(handlerTimeout).Handle(p.session)
+		b.Endpoint("session_end").Timeout(handlerTimeout).Handle(p.sessionEnd)
 	}
 	return b.Build()
 }
@@ -650,6 +651,22 @@ func (p *api) sessionStart(ctx context.Context, req gossiprpc.Request) any {
 		return gossiprpc.FortniteSnapshotReply{Player: stats.Player, Error: "snapshot store failed"}
 	}
 	return gossiprpc.FortniteSnapshotReply{Player: stats.Player}
+}
+
+// sessionEnd drops the channel's stream-start snapshot when the stream ends.
+// The snapshot TTL would eventually reclaim it, but a rapid stop/restart cycle
+// that raced its handlers (#561) left the old baseline diffing against the new
+// stream; clearing here makes "this stream" start clean on the next go-live
+// even when the online snapshot lost that race. Pure store delete: no upstream
+// call, no budget spent. Reuses FortniteSnapshotReply as the ack shape.
+func (p *api) sessionEnd(ctx context.Context, req gossiprpc.Request) any {
+	if req.ChannelID == "" {
+		return gossiprpc.FortniteSnapshotReply{Error: "missing channel"}
+	}
+	if err := p.cache.DelJSON(ctx, snapshotKey(req.ChannelID)); err != nil {
+		return gossiprpc.FortniteSnapshotReply{Error: "snapshot delete failed"}
+	}
+	return gossiprpc.FortniteSnapshotReply{}
 }
 
 // loadSnapshot reads the channel's stream-start snapshot, reporting ok only

--- a/app/gossip/internal/providers/fortnite/fortnite_test.go
+++ b/app/gossip/internal/providers/fortnite/fortnite_test.go
@@ -642,7 +642,7 @@ func TestKeyedServesAllEndpoints(t *testing.T) {
 	for _, ep := range p.Endpoints() {
 		names = append(names, ep.Name)
 	}
-	assert.ElementsMatch(t, []string{"shop", "stats", "session_start", "session"}, names)
+	assert.ElementsMatch(t, []string{"shop", "stats", "session_start", "session", "session_end"}, names)
 }
 
 func TestOddRateLimitDoesNotPanic(t *testing.T) {

--- a/app/gossip/internal/providers/mcsr/mcsr.go
+++ b/app/gossip/internal/providers/mcsr/mcsr.go
@@ -111,6 +111,7 @@ func New(cfg Config, d provider.Deps) provider.Provider {
 	b.Endpoint("user").Timeout(handlerTimeout).Handle(p.user)
 	b.Endpoint("session_start").Timeout(handlerTimeout).Handle(p.sessionStart)
 	b.Endpoint("session").Timeout(handlerTimeout).Handle(p.session)
+	b.Endpoint("session_end").Timeout(handlerTimeout).Handle(p.sessionEnd)
 	b.Endpoint("last_match").Timeout(handlerTimeout).Handle(p.lastMatch)
 	b.Endpoint("versus").Timeout(handlerTimeout).Handle(p.versus)
 	b.Endpoint("leaderboard").Timeout(handlerTimeout).Handle(p.leaderboard)
@@ -311,6 +312,22 @@ func (p *api) writeSnapshot(ctx context.Context, channelID, account string, user
 		Played:   user.Played,
 		AtUnix:   time.Now().Unix(),
 	}, snapshotTTL)
+}
+
+// sessionEnd drops the channel's stream-start snapshot when the stream ends.
+// The snapshot TTL would eventually reclaim it, but a rapid stop/restart cycle
+// that raced its handlers (#561) left the old baseline diffing against the new
+// stream; clearing here makes "this stream" start clean on the next go-live
+// even when the online snapshot lost that race. Pure store delete: no upstream
+// call, no rate-limit spent. Reuses McsrSnapshotReply as the ack shape.
+func (p *api) sessionEnd(ctx context.Context, req gossiprpc.Request) any {
+	if req.ChannelID == "" {
+		return gossiprpc.McsrSnapshotReply{Error: "missing channel"}
+	}
+	if err := p.cache.DelJSON(ctx, snapshotKey(req.ChannelID)); err != nil {
+		return gossiprpc.McsrSnapshotReply{Error: "snapshot delete failed"}
+	}
+	return gossiprpc.McsrSnapshotReply{}
 }
 
 // session answers the delta since the channel's stream-start snapshot. Without

--- a/app/outgress/internal/worker/live.go
+++ b/app/outgress/internal/worker/live.go
@@ -5,6 +5,7 @@ package worker
 
 import (
 	"context"
+	"strconv"
 	"time"
 
 	"ItsBagelBot/internal/domain/invalidate"
@@ -25,26 +26,42 @@ type LiveWriter struct {
 	cacheInvalidate string // core-NATS prefix; subject = prefix + "." + scope
 	ttl             time.Duration
 	log             *zap.Logger
+
+	// The two writes apply through the shared versioned scripts
+	// (internal/domain/live): the re-check result carries its own instant as
+	// the version, so a stale stream.offline event landing after this write
+	// cannot delete what Twitch just confirmed, whichever replica processes it.
+	setScript   *valkey.Lua
+	clearScript *valkey.Lua
 }
 
 func NewLiveWriter(client valkey.Client, nc *nats.Conn, cacheInvalidatePrefix string, ttl time.Duration, log *zap.Logger) *LiveWriter {
 	if ttl <= 0 {
 		ttl = 12 * time.Hour
 	}
-	return &LiveWriter{client: client, nc: nc, cacheInvalidate: cacheInvalidatePrefix, ttl: ttl, log: log}
+	return &LiveWriter{
+		client: client, nc: nc, cacheInvalidate: cacheInvalidatePrefix, ttl: ttl, log: log,
+		setScript:   valkey.NewLuaScript(livekey.SetScript),
+		clearScript: valkey.NewLuaScript(livekey.ClearScript),
+	}
 }
 
-// Write stores the live state for broadcasterID (SET with TTL when live, DEL when
-// offline) and broadcasts a live cache invalidation so worker replicas drop their
-// cached bool and read the fresh state.
+// Write stores the live state for broadcasterID (versioned SET with TTL when
+// live, conditional DEL when offline) and broadcasts a live cache invalidation
+// so worker replicas drop their cached bool and read the fresh state.
 func (w *LiveWriter) Write(ctx context.Context, broadcasterID string, isLive bool) error {
 	key := livekey.KeyString(broadcasterID)
+	version := livekey.VersionNow()
 
 	var err error
 	if isLive {
-		err = w.client.Do(ctx, w.client.B().Set().Key(key).Value("1").ExSeconds(int64(w.ttl.Seconds())).Build()).Error()
+		_, err = w.setScript.Exec(ctx, w.client, []string{key, livekey.VerKeyString(broadcasterID)}, []string{
+			livekey.Value(version), strconv.FormatInt(int64(w.ttl.Seconds()), 10), strconv.FormatInt(int64(livekey.VerTTL.Seconds()), 10),
+		}).AsInt64()
 	} else {
-		err = w.client.Do(ctx, w.client.B().Del().Key(key).Build()).Error()
+		_, err = w.clearScript.Exec(ctx, w.client, []string{key, livekey.VerKeyString(broadcasterID)}, []string{
+			livekey.Value(version), strconv.FormatInt(int64(livekey.VerTTL.Seconds()), 10),
+		}).AsInt64()
 	}
 	if err != nil {
 		return err

--- a/app/sesame/engine/deps.go
+++ b/app/sesame/engine/deps.go
@@ -112,6 +112,14 @@ type Deps struct {
 	// schedule-retried event applying them twice. nil (the kill switch) fails
 	// open everywhere: effects run, nothing is deduped.
 	Dedup *EventDedup
+	// Seq serializes per-broadcaster the background work the stream-lifecycle
+	// handlers enqueue (live key writes, greet resets, timer/loyalty tick
+	// arm-disarm, gossip session snapshots): tasks run in arrival order, one
+	// fully complete before the next starts, so an offline handler's disarm can
+	// no longer race the online handler's arm on this replica (#561). It is the
+	// intra-replica half of the fix — the versioned LiveStore writes are the
+	// cross-replica half. nil leaves every handler plain fire-and-forget.
+	Seq *Sequencer
 }
 
 // FeedCounts is one feeding's fleet-wide readout: how often the bagel has been
@@ -189,10 +197,17 @@ type IsLiveChecker interface {
 // LiveStore answers and maintains a broadcaster's live state. Reads are served
 // from a cache fronting Valkey with a projector RPC fallback; writes flow from
 // the stream events the worker consumes.
+// The writes are versioned (#561): version is the event's ordering claim (the
+// envelope's EventVersion, unix millis). A write whose version is older than
+// what is already applied is skipped rather than overwriting — a rapid
+// stream.online/offline pair processed by different consumer goroutines must
+// not let the online land last and resurrect the key. applied reports whether
+// this call won; callers skip their follow-up effects when it did not, so a
+// superseded online never re-arms timers an offline just disarmed.
 type LiveStore interface {
 	IsLiveChecker
-	SetLive(ctx context.Context, broadcasterID uint64) error
-	ClearLive(ctx context.Context, broadcasterID uint64) error
+	SetLive(ctx context.Context, broadcasterID uint64, version int64) (applied bool, err error)
+	ClearLive(ctx context.Context, broadcasterID uint64, version int64) (applied bool, err error)
 }
 
 // GreetStore tracks which special users have already been greeted in the current

--- a/app/sesame/engine/live_valkey.go
+++ b/app/sesame/engine/live_valkey.go
@@ -101,9 +101,10 @@ func liveKey(id uint64) string { return livekey.Key(id) }
 // projector is written back so the key-expiry re-check applies to it.
 func (s *ValkeyLiveStore) IsLive(ctx context.Context, broadcasterID uint64) (bool, error) {
 	return s.cache.GetOrLoad(ctx, broadcasterID, func(ctx context.Context) (bool, error) {
-		val, err := s.client.Do(ctx, s.client.B().Get().Key(liveKey(broadcasterID)).Build()).ToString()
+		// Existence is the answer; the value is the applied version (#561).
+		_, err := s.client.Do(ctx, s.client.B().Get().Key(liveKey(broadcasterID)).Build()).ToString()
 		if err == nil {
-			return val == "1", nil
+			return true, nil
 		}
 		if !valkey.IsValkeyNil(err) {
 			return false, err
@@ -121,39 +122,74 @@ func (s *ValkeyLiveStore) IsLive(ctx context.Context, broadcasterID uint64) (boo
 			return false, nil
 		}
 		if reply.Live {
-			_ = s.setLiveKey(ctx, broadcasterID)
+			_, _ = s.setLiveKey(ctx, broadcasterID, livekey.VersionNow())
 		}
 		return reply.Live, nil
 	})
 }
 
-// SetLive marks the broadcaster live (on stream.online) and fans the change out.
-func (s *ValkeyLiveStore) SetLive(ctx context.Context, broadcasterID uint64) error {
-	if err := s.setLiveKey(ctx, broadcasterID); err != nil {
-		return err
+// SetLive marks the broadcaster live (on stream.online) and fans the change
+// out. applied is false when a newer version was already on the key — the
+// caller must then skip its follow-up effects (greet reset, timer arm), which
+// belong to a session that has already ended (#561).
+func (s *ValkeyLiveStore) SetLive(ctx context.Context, broadcasterID uint64, version int64) (bool, error) {
+	applied, err := s.setLiveKey(ctx, broadcasterID, version)
+	if err != nil || !applied {
+		return false, err
 	}
 	s.cache.Set(broadcasterID, true)
 	s.broadcast(broadcasterID)
-	return nil
+	return true, nil
 }
 
-// ClearLive drops the broadcaster's live state (on stream.offline) = invalidate.
-func (s *ValkeyLiveStore) ClearLive(ctx context.Context, broadcasterID uint64) error {
-	if err := s.client.Do(ctx, s.client.B().Del().Key(liveKey(broadcasterID)).Build()).Error(); err != nil {
-		return err
-	}
+// ClearLive drops the broadcaster's live state (on stream.offline). A newer
+// applied version (a re-check that confirmed live after this event was sent)
+// survives: the local cache still drops so this replica re-reads the truth,
+// but the fleet-wide broadcast is skipped — nothing changed fleet-wide.
+func (s *ValkeyLiveStore) ClearLive(ctx context.Context, broadcasterID uint64, version int64) (bool, error) {
 	s.cache.Invalidate(broadcasterID)
+	applied, err := clearLiveKey(ctx, s.client, broadcasterID, version)
+	if err != nil || !applied {
+		return false, err
+	}
 	s.broadcast(broadcasterID)
-	return nil
+	return true, nil
 }
 
-func (s *ValkeyLiveStore) setLiveKey(ctx context.Context, broadcasterID uint64) error {
+func (s *ValkeyLiveStore) setLiveKey(ctx context.Context, broadcasterID uint64, version int64) (bool, error) {
 	ttl := s.cfg.TTL
 	if ttl <= 0 {
 		ttl = 12 * time.Hour
 	}
-	return s.client.Do(ctx, s.client.B().Set().Key(liveKey(broadcasterID)).Value("1").ExSeconds(int64(ttl.Seconds())).Build()).Error()
+	applied, err := setLiveScript.Exec(ctx, s.client, []string{liveKey(broadcasterID), livekey.VerKey(broadcasterID)}, []string{
+		livekey.Value(version), strconv.FormatInt(int64(ttl.Seconds()), 10), strconv.FormatInt(int64(livekey.VerTTL.Seconds()), 10),
+	}).AsInt64()
+	if err != nil {
+		return false, err
+	}
+	return applied > 0, nil
 }
+
+func clearLiveKey(ctx context.Context, client valkey.Client, broadcasterID uint64, version int64) (bool, error) {
+	applied, err := clearLiveScript.Exec(ctx, client, []string{liveKey(broadcasterID), livekey.VerKey(broadcasterID)}, []string{
+		livekey.Value(version), strconv.FormatInt(int64(livekey.VerTTL.Seconds()), 10),
+	}).AsInt64()
+	if err != nil {
+		return false, err
+	}
+	return applied > 0, nil
+}
+
+// The two writes run through their scripts atomically (internal/domain/live):
+// each compares the stored version and refuses to move state backwards. Not
+// NewLuaScriptRetryable on purpose — a retried SET would re-apply a version it
+// already wrote, which is idempotent, but a retried DEL racing a concurrent
+// SetLive could delete a freshly confirmed key; one clean failure beats one
+// wrong deletion (same reasoning as emoteplay_valkey.go).
+var (
+	setLiveScript   = valkey.NewLuaScript(livekey.SetScript)
+	clearLiveScript = valkey.NewLuaScript(livekey.ClearScript)
+)
 
 // broadcast fans a live change to every replica so their in-process caches drop
 // the entry immediately, backing the short cache TTL.

--- a/app/sesame/engine/live_valkey_versioning_test.go
+++ b/app/sesame/engine/live_valkey_versioning_test.go
@@ -1,0 +1,106 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package engine
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	livekey "ItsBagelBot/internal/domain/live"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/valkey-io/valkey-go"
+	"go.uber.org/zap"
+)
+
+// TestVersionedLiveWrites drives the #561 ordering semantics against a real
+// Valkey: the scripts, not the callers, are what keep a stale stream.online
+// from resurrecting a key an offline already cleared — including the case the
+// plain GET-based check cannot see, where the DEL has already removed the key
+// and only the companion ver: key remembers the applied version. Skipped like
+// the other hot-path tests when VALKEY_TEST_ADDR is unset.
+func TestVersionedLiveWrites(t *testing.T) {
+	client := newHotPathTestClient(t)
+	ctx := context.Background()
+	s := NewValkeyLiveStore(client, nil, nil, LiveConfig{TTL: time.Minute, Log: zap.NewNop()})
+
+	get := func(t *testing.T, id uint64) (string, bool) {
+		t.Helper()
+		val, err := client.Do(ctx, client.B().Get().Key(liveKey(id)).Build()).ToString()
+		if valkey.IsValkeyNil(err) {
+			return "", false
+		}
+		require.NoError(t, err)
+		return val, true
+	}
+	cleanupKeys := func(ids ...uint64) {
+		for _, id := range ids {
+			_ = client.Do(ctx, client.B().Del().Key(liveKey(id)).Key(livekey.VerKey(id)).Build()).Error()
+		}
+	}
+
+	t.Run("online then offline then stale online", func(t *testing.T) {
+		const id uint64 = 5601
+		cleanupKeys(id)
+		t.Cleanup(func() { cleanupKeys(id) })
+
+		applied, err := s.SetLive(ctx, id, 1000)
+		require.NoError(t, err)
+		assert.True(t, applied, "first online must apply")
+		val, ok := get(t, id)
+		assert.True(t, ok)
+		assert.Equal(t, "1000", val, "the value carries the applied version")
+
+		applied, err = s.ClearLive(ctx, id, 2000)
+		require.NoError(t, err)
+		assert.True(t, applied)
+		_, ok = get(t, id)
+		assert.False(t, ok, "offline must delete the live key")
+
+		// The resurrection scenario: an older online redelivered after the
+		// offline's DEL. No live key exists; only ver: remembers 2000 > 1000.
+		applied, err = s.SetLive(ctx, id, 1500)
+		require.NoError(t, err)
+		assert.False(t, applied, "stale online must lose to the deleted-but-remembered offline")
+		_, ok = get(t, id)
+		assert.False(t, ok)
+
+		// A genuinely newer online still applies.
+		applied, err = s.SetLive(ctx, id, 3000)
+		require.NoError(t, err)
+		assert.True(t, applied)
+	})
+
+	t.Run("equal version applies last writer wins", func(t *testing.T) {
+		const id uint64 = 5602
+		cleanupKeys(id)
+		t.Cleanup(func() { cleanupKeys(id) })
+
+		applied, err := s.SetLive(ctx, id, 1000)
+		require.NoError(t, err)
+		assert.True(t, applied)
+		applied, err = s.ClearLive(ctx, id, 1000)
+		require.NoError(t, err)
+		assert.True(t, applied, "an equal-version offline may clear")
+	})
+
+	t.Run("legacy constant value is superseded without a flush", func(t *testing.T) {
+		const id uint64 = 5603
+		cleanupKeys(id)
+		t.Cleanup(func() { cleanupKeys(id) })
+
+		// A pre-versioning replica wrote the old constant "1".
+		require.NoError(t, client.Do(ctx, client.B().Set().Key(liveKey(id)).Value("1").ExSeconds(60).Build()).Error())
+
+		// No ver: claim exists yet, so a versioned online takes over cleanly.
+		applied, err := s.SetLive(ctx, id, 5000)
+		require.NoError(t, err)
+		assert.True(t, applied)
+		val, ok := get(t, id)
+		assert.True(t, ok)
+		assert.Equal(t, "5000", val)
+	})
+}

--- a/app/sesame/engine/pipeline_test.go
+++ b/app/sesame/engine/pipeline_test.go
@@ -70,9 +70,9 @@ func (r fakeReader) Command(context.Context, uint64, string) (projection.Command
 // liveAlways is a LiveStore that reports live and no-ops its writes.
 type liveAlways struct{}
 
-func (liveAlways) IsLive(context.Context, uint64) (bool, error) { return true, nil }
-func (liveAlways) SetLive(context.Context, uint64) error        { return nil }
-func (liveAlways) ClearLive(context.Context, uint64) error      { return nil }
+func (liveAlways) IsLive(context.Context, uint64) (bool, error)           { return true, nil }
+func (liveAlways) SetLive(context.Context, uint64, int64) (bool, error)   { return true, nil }
+func (liveAlways) ClearLive(context.Context, uint64, int64) (bool, error) { return true, nil }
 
 const (
 	premiumSubj  = "outgress.premium"

--- a/app/sesame/engine/streamseq.go
+++ b/app/sesame/engine/streamseq.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package engine
+
+import (
+	"sync"
+)
+
+// The consumer pool hands stream events to whichever goroutine is free
+// (pkg/bus/weighted.go: handlers must be safe for concurrent use), so two
+// lifecycle events for the same broadcaster — stream.online then an immediate
+// stream.offline — can run their fire-and-forget follow-ups interleaved, and a
+// late ArmAll / tick Arm lands after the offline's DisarmAll (#561). The
+// Sequencer is the intra-replica ordering fix: per-broadcaster FIFO queues in
+// which each enqueued task runs to completion before the next starts.
+//
+// Cross-replica ordering is NOT provided here (two replicas may receive the
+// pair); that half belongs to the versioned live-key writes. What this buys is
+// exactly the effects that have no version: timer/loyalty arm-disarm and greet
+// resets land in event order on the replica that saw both events.
+
+const (
+	// seqQueueDepth bounds one broadcaster's backlog. Lifecycle events are a
+	// handful per stream; the depth only has to absorb a burst, and an overflow
+	// degrades to inline execution rather than dropping state changes.
+	seqQueueDepth = 64
+)
+
+// Sequencer runs enqueued tasks per broadcaster strictly in arrival order.
+type Sequencer struct {
+	mu   sync.Mutex
+	seqs map[uint64]*seqQueue
+}
+
+// seqQueue is one broadcaster's FIFO plus the flag marking a live pump. mu
+// guards busy and the map membership; the channel is only sent to under mu so
+// a reaping pump cannot race an enqueue into a queue it just abandoned.
+type seqQueue struct {
+	ch   chan func()
+	busy bool
+}
+
+// NewSequencer builds an empty sequencer.
+func NewSequencer() *Sequencer {
+	return &Sequencer{seqs: make(map[uint64]*seqQueue)}
+}
+
+// Do enqueues task behind everything previously enqueued for broadcasterID.
+// It never blocks on task execution — the handler returns immediately — but it
+// does block briefly on the internal mutex, which no task holds while running.
+// When a broadcaster's backlog is full the task degrades to inline execution:
+// ordering with the queued tasks is lost for that one task, but dropping a
+// ClearLive or a DisarmAll would be strictly worse.
+func (s *Sequencer) Do(broadcasterID uint64, task func()) {
+	if broadcasterID == 0 || task == nil {
+		return
+	}
+	s.mu.Lock()
+	q, ok := s.seqs[broadcasterID]
+	if !ok {
+		q = &seqQueue{ch: make(chan func(), seqQueueDepth)}
+		s.seqs[broadcasterID] = q
+	}
+	select {
+	case q.ch <- task:
+		if !q.busy {
+			q.busy = true
+			s.mu.Unlock()
+			go s.pump(broadcasterID, q)
+			return
+		}
+		s.mu.Unlock()
+	default:
+		// Backlog full: run inline rather than drop (see Do's doc).
+		s.mu.Unlock()
+		task()
+	}
+}
+
+// pump drains one broadcaster's queue until it is momentarily empty, then
+// leaves the map so the next event spawns a fresh pump. Every enqueue happens
+// under s.mu, so the emptiness check and the delete cannot race a sender: if a
+// task was enqueued first, len > 0 and we keep going; if the delete happened
+// first, the sender built a fresh queue.
+func (s *Sequencer) pump(broadcasterID uint64, q *seqQueue) {
+	for {
+		var task func()
+		s.mu.Lock()
+		select {
+		case task = <-q.ch:
+			s.mu.Unlock()
+		default:
+			delete(s.seqs, broadcasterID)
+			q.busy = false
+			s.mu.Unlock()
+			return
+		}
+		task()
+	}
+}

--- a/app/sesame/engine/streamseq_test.go
+++ b/app/sesame/engine/streamseq_test.go
@@ -114,16 +114,15 @@ func TestSequencerRespawnsPumpAfterIdle(t *testing.T) {
 
 func TestSequencerIgnoresZeroIDAndNilTask(t *testing.T) {
 	s := NewSequencer()
+	rec := &seqRecorder{}
 	assert.NotPanics(t, func() {
-		s.Do(0, func() {})
+		s.Do(0, func() { rec.record("zero-id") })
 		s.Do(3, nil)
 	})
-	s.Do(3, func() {})
-	assert.Eventually(t, func() bool {
-		s.mu.Lock()
-		defer s.mu.Unlock()
-		return len(s.seqs) == 1 && s.seqs[3] != nil
-	}, time.Second, time.Millisecond)
+	// Only a task with a real broadcaster id and a body may ever run.
+	s.Do(3, func() { rec.record("real") })
+	assert.Eventually(t, func() bool { return len(rec.names()) == 1 }, time.Second, time.Millisecond)
+	assert.Equal(t, []string{"real"}, rec.names())
 }
 
 func TestSequencerConcurrentDoIsSafe(t *testing.T) {

--- a/app/sesame/engine/streamseq_test.go
+++ b/app/sesame/engine/streamseq_test.go
@@ -1,0 +1,142 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package engine
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// seqRecorder collects the order tasks actually ran in, safe because the
+// Sequencer itself serializes the runs it orders.
+type seqRecorder struct {
+	mu  sync.Mutex
+	ran []string
+}
+
+func (r *seqRecorder) record(name string) {
+	r.mu.Lock()
+	r.ran = append(r.ran, name)
+	r.mu.Unlock()
+}
+
+func (r *seqRecorder) names() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.ran...)
+}
+
+func TestSequencerRunsPerBroadcasterInArrivalOrder(t *testing.T) {
+	s := NewSequencer()
+	rec := &seqRecorder{}
+	for i := range 20 {
+		name := "task" + string(rune('a'+i))
+		s.Do(7, func() { rec.record(name) })
+	}
+	assert.Eventually(t, func() bool { return len(rec.names()) == 20 }, time.Second, time.Millisecond)
+	want := make([]string, 0, 20)
+	for i := range 20 {
+		want = append(want, "task"+string(rune('a'+i)))
+	}
+	assert.Equal(t, want, rec.names(), "tasks must run strictly in enqueue order")
+}
+
+func TestSequencerKeepsBroadcasterQueuesIndependent(t *testing.T) {
+	s := NewSequencer()
+	rec := &seqRecorder{}
+	var wg sync.WaitGroup
+	for _, id := range []uint64{1, 2, 3, 4} {
+		for i := range 10 {
+			wg.Add(1)
+			s.Do(id, func() {
+				rec.record(string(rune('a'+id-1)) + string(rune('a'+i)))
+				wg.Done()
+			})
+		}
+	}
+	wg.Wait()
+	names := rec.names()
+	assert.Len(t, names, 40)
+	// Within one broadcaster's slice of the log the relative order must hold;
+	// interleaving across broadcasters is allowed and irrelevant.
+	for _, id := range []uint64{1, 2, 3, 4} {
+		prefix := string(rune('a' + id - 1))
+		var got []string
+		for _, n := range names {
+			if len(n) == 2 && n[0] == prefix[0] {
+				got = append(got, n[1:])
+			}
+		}
+		want := make([]string, 0, 10)
+		for i := range 10 {
+			want = append(want, string(rune('a'+i)))
+		}
+		assert.Equal(t, want, got, "broadcaster %d lost ordering", id)
+	}
+}
+
+func TestSequencerWaitsForSlowTaskBeforeStartingNext(t *testing.T) {
+	s := NewSequencer()
+	rec := &seqRecorder{}
+	release := make(chan struct{})
+	s.Do(9, func() {
+		rec.record("slow")
+		<-release
+	})
+	s.Do(9, func() { rec.record("after") })
+	// The second task must not start while the first is still blocked.
+	assert.Never(t, func() bool { return len(rec.names()) > 1 }, 50*time.Millisecond, 5*time.Millisecond,
+		"task ran before its predecessor completed")
+	close(release)
+	assert.Eventually(t, func() bool { return len(rec.names()) == 2 }, time.Second, time.Millisecond)
+	assert.Equal(t, []string{"slow", "after"}, rec.names())
+}
+
+func TestSequencerRespawnsPumpAfterIdle(t *testing.T) {
+	s := NewSequencer()
+	rec := &seqRecorder{}
+	s.Do(5, func() { rec.record("first") })
+	assert.Eventually(t, func() bool { return len(rec.names()) == 1 }, time.Second, time.Millisecond)
+	// The pump exits once the queue drains; a later event must still run.
+	assert.Eventually(t, func() bool {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		return len(s.seqs) == 0
+	}, time.Second, time.Millisecond, "drained queue must be reaped")
+	s.Do(5, func() { rec.record("second") })
+	assert.Eventually(t, func() bool { return len(rec.names()) == 2 }, time.Second, time.Millisecond)
+	assert.Equal(t, []string{"first", "second"}, rec.names())
+}
+
+func TestSequencerIgnoresZeroIDAndNilTask(t *testing.T) {
+	s := NewSequencer()
+	assert.NotPanics(t, func() {
+		s.Do(0, func() {})
+		s.Do(3, nil)
+	})
+	s.Do(3, func() {})
+	assert.Eventually(t, func() bool {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		return len(s.seqs) == 1 && s.seqs[3] != nil
+	}, time.Second, time.Millisecond)
+}
+
+func TestSequencerConcurrentDoIsSafe(t *testing.T) {
+	s := NewSequencer()
+	rec := &seqRecorder{}
+	var wg sync.WaitGroup
+	for i := range 50 {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			s.Do(uint64(1+i%4), func() { rec.record("t") })
+		}(i)
+	}
+	wg.Wait()
+	assert.Eventually(t, func() bool { return len(rec.names()) == 50 }, time.Second, time.Millisecond)
+}

--- a/app/sesame/main.go
+++ b/app/sesame/main.go
@@ -115,7 +115,7 @@ func main() {
 	guard := automod.New()
 	deps := buildDeps(w, engineRuntime{
 		proj: proj, live: live, timers: timers, guard: guard, loyalty: loyalty, tick: loyaltyTick,
-		stats: loyaltyReporter, raffle: raffle,
+		stats: loyaltyReporter, raffle: raffle, seq: engine.NewSequencer(),
 	})
 	registry := engine.NewRegistry(log, modules.All(deps)...)
 	startRefreshers(ctx, guard, cfg, log)

--- a/app/sesame/modules/core_test.go
+++ b/app/sesame/modules/core_test.go
@@ -24,9 +24,9 @@ type fakeLive struct {
 	err  error
 }
 
-func (f *fakeLive) IsLive(context.Context, uint64) (bool, error) { return f.live, f.err }
-func (f *fakeLive) SetLive(context.Context, uint64) error        { return nil }
-func (f *fakeLive) ClearLive(context.Context, uint64) error      { return nil }
+func (f *fakeLive) IsLive(context.Context, uint64) (bool, error)           { return f.live, f.err }
+func (f *fakeLive) SetLive(context.Context, uint64, int64) (bool, error)   { return true, nil }
+func (f *fakeLive) ClearLive(context.Context, uint64, int64) (bool, error) { return true, nil }
 
 type fakeGreet struct {
 	first   bool

--- a/app/sesame/modules/fortnite.go
+++ b/app/sesame/modules/fortnite.go
@@ -114,6 +114,7 @@ func Fortnite(d engine.Deps) module.Module {
 	// spending the tight daily stats budget for a command the broadcaster
 	// turned off.
 	m.On("stream.online", fortniteSnapshotOnline(d))
+	m.On("stream.offline", fortniteSessionOffline(d))
 	return m.Build()
 }
 
@@ -138,7 +139,7 @@ func fortniteSnapshotOnline(d engine.Deps) module.EventHandler {
 		}
 		account := resolveAccount(accountSources{Linked: cfg.Account, BroadcasterLogin: c.Env.BroadcasterUserLogin})
 		channelID := strconv.FormatUint(c.BroadcasterID, 10)
-		go func() {
+		seqOrGo(d.Seq, c.BroadcasterID, log, func() {
 			wctx, cancel := context.WithTimeout(context.Background(), fortniteSnapshotTimeout)
 			defer cancel()
 			req := gossiprpc.Request{Account: account, AccountType: cfg.AccountType, ChannelID: channelID, IsPremium: c.Regress.IsPremium()}
@@ -150,7 +151,43 @@ func fortniteSnapshotOnline(d engine.Deps) module.EventHandler {
 			}
 			log.Debug("fortnite: stream-start snapshot stored",
 				zap.String("channel_id", channelID), zap.String("player", reply.Player))
-		}()
+		})
+		return nil
+	}
+}
+
+// fortniteSessionOffline clears the channel's session baseline when the stream
+// ends, so a rapid stop/restart cycle (#561) cannot leave !fn session diffing
+// the new stream against the old one's snapshot. Sequenced behind the online
+// snapshot like every other lifecycle effect; only fires when the online
+// snapshot was enabled (the baseline it clears exists then). Gossip
+// deployments without the provider answer no-responder — an expected miss,
+// hence Debug.
+func fortniteSessionOffline(d engine.Deps) module.EventHandler {
+	log := d.Log
+	if log == nil {
+		log = zap.NewNop()
+	}
+	return func(_ context.Context, c *module.Context, _ module.Emit) error {
+		if d.Gossip == nil {
+			return nil
+		}
+		var cfg fortniteConfig
+		_ = c.Decode(&cfg)
+		if !alertOn(cfg.SessionEnabled) {
+			return nil
+		}
+		channelID := strconv.FormatUint(c.BroadcasterID, 10)
+		seqOrGo(d.Seq, c.BroadcasterID, log, func() {
+			wctx, cancel := context.WithTimeout(context.Background(), fortniteSnapshotTimeout)
+			defer cancel()
+			var reply gossiprpc.FortniteSnapshotReply
+			err := d.Gossip.Call(wctx, engine.GossipRoute{Provider: "fortnite", Endpoint: "session_end"}, gossiprpc.Request{ChannelID: channelID}, &reply)
+			if err != nil {
+				log.Debug("fortnite: stream-end snapshot clear failed",
+					zap.String("channel_id", channelID), zap.Error(err))
+			}
+		})
 		return nil
 	}
 }

--- a/app/sesame/modules/fortnite_test.go
+++ b/app/sesame/modules/fortnite_test.go
@@ -311,3 +311,46 @@ func TestFormatShopEntriesBudget(t *testing.T) {
 	assert.True(t, strings.HasPrefix(got, huge.Name))
 	assert.Contains(t, got, "+1 more")
 }
+
+// stream.offline clears the channel's stream-start baseline so a rapid
+// stop/restart cycle (#561) cannot diff the next stream against this one's
+// snapshot. The call is fire-and-forget through the lifecycle sequencer.
+func TestFnStreamOfflineClearsBaseline(t *testing.T) {
+	done := make(chan struct{})
+	gw := &fakeGossip{
+		replies: map[string]any{"fortnite.session_end": gossiprpc.FortniteSnapshotReply{}},
+		done:    done,
+	}
+	h := Fortnite(engine.Deps{Gossip: gw, Log: zap.NewNop()}).Events["stream.offline"]
+	require.NotNil(t, h, "fortnite must handle stream.offline")
+
+	var col collector
+	cfg := `{"sessionEnabled":true,"account":"Ninja","accountType":"epic"}`
+	require.NoError(t, h(context.Background(), fortniteOnlineCtx(cfg), col.emit))
+	assert.Empty(t, col.out, "offline handler must not chat")
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("stream.offline never called gossip")
+	}
+	call := gw.lastCall(t)
+	assert.Equal(t, "fortnite", call.provider)
+	assert.Equal(t, "session_end", call.endpoint)
+	assert.Equal(t, "2", call.req.ChannelID)
+	assert.Empty(t, call.req.Account, "the clear is channel-scoped, not account-scoped")
+}
+
+// With the session command toggled off there is no baseline to clear (the
+// online snapshot never ran), so stream.offline must not call gossip at all.
+func TestFnStreamOfflineSkipsWhenSessionOff(t *testing.T) {
+	gw := &fakeGossip{replies: map[string]any{"fortnite.session_end": gossiprpc.FortniteSnapshotReply{}}}
+	h := Fortnite(engine.Deps{Gossip: gw, Log: zap.NewNop()}).Events["stream.offline"]
+	require.NotNil(t, h)
+
+	var col collector
+	require.NoError(t, h(context.Background(), fortniteOnlineCtx(`{"account":"Ninja","sessionEnabled":"off"}`), col.emit))
+	gw.mu.Lock()
+	assert.Empty(t, gw.calls)
+	gw.mu.Unlock()
+}

--- a/app/sesame/modules/live.go
+++ b/app/sesame/modules/live.go
@@ -9,8 +9,9 @@ import (
 	"time"
 
 	"ItsBagelBot/app/sesame/engine"
-	"ItsBagelBot/internal/domain/i18n"
 	"ItsBagelBot/app/sesame/module"
+	"ItsBagelBot/internal/domain/i18n"
+	livekey "ItsBagelBot/internal/domain/live"
 	"ItsBagelBot/internal/domain/outgress"
 
 	"go.uber.org/zap"
@@ -30,6 +31,15 @@ const liveWriteTimeout = 5 * time.Second
 // write to the geographically far master never blocks the consumer goroutine.
 // Failures are logged best-effort rather than returned: the pipeline swallows a
 // handler error without redelivery anyway, so returning it would buy nothing.
+//
+// The consumer pool gives no cross-message ordering, so a rapid online/offline
+// pair can arrive interleaved and their goroutines can run in either order
+// (#561). Two guards close that race. Per broadcaster, d.Seq serializes the
+// work so an offline's disarm lands after an earlier online's arm completes.
+// Across replicas, the writes carry the event's EventVersion and the store
+// refuses to move the key backwards; when SetLive reports superseded — a
+// newer offline already won — the follow-up effects are skipped too, since
+// they belong to a session that has ended.
 func Live(d engine.Deps) module.Module {
 	log := d.Log
 	if log == nil {
@@ -40,11 +50,19 @@ func Live(d engine.Deps) module.Module {
 
 	m.On("stream.online", func(_ context.Context, c *module.Context, emit module.Emit) error {
 		id := c.BroadcasterID
-		go func() {
+		version := c.Env.EventVersion()
+		if version == 0 {
+			version = livekey.VersionNow()
+		}
+		seqOrGo(d.Seq, id, log, func() {
 			wctx, cancel := context.WithTimeout(context.Background(), liveWriteTimeout)
 			defer cancel()
-			if err := d.Live.SetLive(wctx, id); err != nil {
+			applied, err := d.Live.SetLive(wctx, id, version)
+			if err != nil {
 				log.Warn("live: failed to set live", zap.Uint64("broadcaster_id", id), zap.Error(err))
+			}
+			if !applied {
+				return
 			}
 			// New session: forget who has been greeted so the bagel reply fires again.
 			if err := d.Greet.ResetGreets(wctx, id); err != nil {
@@ -54,35 +72,64 @@ func Live(d engine.Deps) module.Module {
 			if d.Timers != nil {
 				d.Timers.ArmAll(wctx, id)
 			}
-		}()
-		
+		})
+
 		emit(&module.Output{
 			Type:          outgress.TypeChat,
 			BroadcasterID: strconv.FormatUint(id, 10),
 			Text:          i18n.T(c.Locale, "bagels_ready"),
 		})
-		
+
 		log.Debug("stream online", zap.Uint64("broadcaster_id", id))
 		return nil
 	})
 
 	m.On("stream.offline", func(_ context.Context, c *module.Context, _ module.Emit) error {
 		id := c.BroadcasterID
-		go func() {
+		version := c.Env.EventVersion()
+		if version == 0 {
+			version = livekey.VersionNow()
+		}
+		seqOrGo(d.Seq, id, log, func() {
 			wctx, cancel := context.WithTimeout(context.Background(), liveWriteTimeout)
 			defer cancel()
-			if err := d.Live.ClearLive(wctx, id); err != nil {
+			if _, err := d.Live.ClearLive(wctx, id, version); err != nil {
 				log.Warn("live: failed to clear live", zap.Uint64("broadcaster_id", id), zap.Error(err))
 			}
 			// Stream ended: stop every repeating timer immediately rather than
-			// waiting out its longest-running interval.
+			// waiting out its longest-running interval. Disarm unconditionally:
+			// timers are per-replica schedules with no version of their own, so
+			// erring toward "off" after an offline event is the safe side.
 			if d.Timers != nil {
 				d.Timers.DisarmAll(wctx, id)
 			}
-		}()
+		})
 		log.Debug("stream offline", zap.Uint64("broadcaster_id", id))
 		return nil
 	})
 
 	return m.Build()
+}
+
+// seqOrGo runs task through d.Seq's per-broadcaster queue when one is wired,
+// keeping every lifecycle effect in event order; without it (tests, kill
+// switch) it degrades to the plain fire-and-forget goroutine.
+func seqOrGo(seq *engine.Sequencer, broadcasterID uint64, log *zap.Logger, task func()) {
+	if log == nil {
+		log = zap.NewNop()
+	}
+	if seq == nil {
+		go task()
+		return
+	}
+	seq.Do(broadcasterID, func() {
+		defer func() {
+			// One panicking task must not kill its pump goroutine and strand
+			// the broadcaster's queued work behind it.
+			if r := recover(); r != nil {
+				log.Error("live: lifecycle task panicked", zap.Uint64("broadcaster_id", broadcasterID), zap.Any("panic", r))
+			}
+		}()
+		task()
+	})
 }

--- a/app/sesame/modules/live.go
+++ b/app/sesame/modules/live.go
@@ -47,13 +47,30 @@ func Live(d engine.Deps) module.Module {
 	}
 
 	m := module.NewModule("", module.KindCore)
+	m.On("stream.online", liveOnlineHandler(d, log))
+	m.On("stream.offline", liveOfflineHandler(d, log))
+	return m.Build()
+}
 
-	m.On("stream.online", func(_ context.Context, c *module.Context, emit module.Emit) error {
+// eventVersion resolves the ordering claim a lifecycle write applies under:
+// the event's own timestamp when it carries one, else this writer's clock.
+// Zero means "no ordering claim" (older envelopes); falling back to now() lets
+// such an event apply rather than letting it lose to everything ever stamped.
+func eventVersion(c *module.Context) int64 {
+	if v := c.Env.EventVersion(); v != 0 {
+		return v
+	}
+	return livekey.VersionNow()
+}
+
+// liveOnlineHandler marks the broadcaster live and starts the session: greet
+// set reset, timers armed. The session-start side effects run only when the
+// store applied the write — a superseded online belongs to a session that has
+// already ended (#561).
+func liveOnlineHandler(d engine.Deps, log *zap.Logger) module.EventHandler {
+	return func(_ context.Context, c *module.Context, emit module.Emit) error {
 		id := c.BroadcasterID
-		version := c.Env.EventVersion()
-		if version == 0 {
-			version = livekey.VersionNow()
-		}
+		version := eventVersion(c)
 		seqOrGo(d.Seq, id, log, func() {
 			wctx, cancel := context.WithTimeout(context.Background(), liveWriteTimeout)
 			defer cancel()
@@ -64,11 +81,9 @@ func Live(d engine.Deps) module.Module {
 			if !applied {
 				return
 			}
-			// New session: forget who has been greeted so the bagel reply fires again.
 			if err := d.Greet.ResetGreets(wctx, id); err != nil {
 				log.Warn("live: failed to reset greets", zap.Uint64("broadcaster_id", id), zap.Error(err))
 			}
-			// New session: every repeating timer starts its countdown fresh.
 			if d.Timers != nil {
 				d.Timers.ArmAll(wctx, id)
 			}
@@ -82,33 +97,31 @@ func Live(d engine.Deps) module.Module {
 
 		log.Debug("stream online", zap.Uint64("broadcaster_id", id))
 		return nil
-	})
+	}
+}
 
-	m.On("stream.offline", func(_ context.Context, c *module.Context, _ module.Emit) error {
+// liveOfflineHandler drops the broadcaster's live state and stops every
+// repeating timer immediately rather than waiting out its longest-running
+// interval. Disarm runs unconditionally: timers are per-replica schedules with
+// no version of their own, so erring toward "off" after an offline event is
+// the safe side.
+func liveOfflineHandler(d engine.Deps, log *zap.Logger) module.EventHandler {
+	return func(_ context.Context, c *module.Context, _ module.Emit) error {
 		id := c.BroadcasterID
-		version := c.Env.EventVersion()
-		if version == 0 {
-			version = livekey.VersionNow()
-		}
+		version := eventVersion(c)
 		seqOrGo(d.Seq, id, log, func() {
 			wctx, cancel := context.WithTimeout(context.Background(), liveWriteTimeout)
 			defer cancel()
 			if _, err := d.Live.ClearLive(wctx, id, version); err != nil {
 				log.Warn("live: failed to clear live", zap.Uint64("broadcaster_id", id), zap.Error(err))
 			}
-			// Stream ended: stop every repeating timer immediately rather than
-			// waiting out its longest-running interval. Disarm unconditionally:
-			// timers are per-replica schedules with no version of their own, so
-			// erring toward "off" after an offline event is the safe side.
 			if d.Timers != nil {
 				d.Timers.DisarmAll(wctx, id)
 			}
 		})
 		log.Debug("stream offline", zap.Uint64("broadcaster_id", id))
 		return nil
-	})
-
-	return m.Build()
+	}
 }
 
 // seqOrGo runs task through d.Seq's per-broadcaster queue when one is wired,

--- a/app/sesame/modules/live_test.go
+++ b/app/sesame/modules/live_test.go
@@ -40,30 +40,29 @@ type versionedLive struct {
 
 func (f *versionedLive) IsLive(context.Context, uint64) (bool, error) { return f.isLive, nil }
 
-func (f *versionedLive) SetLive(_ context.Context, _ uint64, version int64) (bool, error) {
+// claim applies one transition under the same newer-version-wins rule the
+// Valkey scripts use; both wrappers differ only in which call log they record.
+// Everything touches f's fields under f.mu, including the recording: the pump
+// goroutine runs these while the test goroutine reads them.
+func (f *versionedLive) claim(calls *[]int64, version int64, name string, liveAfter bool) (bool, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	f.setCalls = append(f.setCalls, version)
+	*calls = append(*calls, version)
 	if version < f.applied {
 		return false, nil
 	}
 	f.applied = version
-	f.isLive = true
-	f.log.add("set:" + strconv.FormatInt(version, 10))
+	f.isLive = liveAfter
+	f.log.add(name + ":" + strconv.FormatInt(version, 10))
 	return true, nil
 }
 
+func (f *versionedLive) SetLive(_ context.Context, _ uint64, version int64) (bool, error) {
+	return f.claim(&f.setCalls, version, "set", true)
+}
+
 func (f *versionedLive) ClearLive(_ context.Context, _ uint64, version int64) (bool, error) {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	f.clearCalls = append(f.clearCalls, version)
-	if version < f.applied {
-		return false, nil
-	}
-	f.applied = version
-	f.isLive = false
-	f.log.add("clear:" + strconv.FormatInt(version, 10))
-	return true, nil
+	return f.claim(&f.clearCalls, version, "clear", false)
 }
 
 // orderedTimers and orderedGreets funnel their calls into the shared log.
@@ -161,6 +160,20 @@ func greetsAndArms(items []string) []string {
 	return out
 }
 
+// liveFixture bundles the module under test with the fakes its assertions read.
+type liveFixture struct {
+	m    module.Module
+	live *versionedLive
+	log  *lifecycleLog
+}
+
+func newLiveFixture() liveFixture {
+	fx := liveFixture{log: &lifecycleLog{}}
+	fx.live = &versionedLive{log: fx.log}
+	fx.m = Live(liveTestDeps(fx.live, fx.log))
+	return fx
+}
+
 // TestRapidOnlineThenOfflineLeavesChannelOffline drives the exact reported
 // symptom: offline right on the heels of online. Effects must land in event
 // order and end offline with timers down.
@@ -168,14 +181,12 @@ func TestRapidOnlineThenOfflineLeavesChannelOffline(t *testing.T) {
 	const on = "2026-08-23T12:00:00Z"
 	const off = "2026-08-23T12:00:01Z"
 
-	log := &lifecycleLog{}
-	live := &versionedLive{log: log}
-	m := Live(liveTestDeps(live, log))
+	fx := newLiveFixture()
 
-	runLifecycle(t, m, "stream.online", on)
-	runLifecycle(t, m, "stream.offline", off)
+	runLifecycle(t, fx.m, "stream.online", on)
+	runLifecycle(t, fx.m, "stream.offline", off)
 
-	got := waitForLog(t, log, 5)
+	got := waitForLog(t, fx.log, 5)
 	assert.Equal(t, []string{
 		"set:" + millis(on),
 		"greets",
@@ -183,7 +194,7 @@ func TestRapidOnlineThenOfflineLeavesChannelOffline(t *testing.T) {
 		"clear:" + millis(off),
 		"disarm",
 	}, got, "offline effects must follow the online's, never interleave")
-	assert.False(t, live.isLive, "channel must end offline")
+	assert.False(t, fx.live.isLive, "channel must end offline")
 }
 
 // TestStaleOnlineLosingToNewerOfflineIsIgnored covers redelivery skew: an
@@ -192,46 +203,42 @@ func TestRapidOnlineThenOfflineLeavesChannelOffline(t *testing.T) {
 // resetting greets or arming timers would resurrect state the offline just
 // cleared.
 func TestStaleOnlineLosingToNewerOfflineIsIgnored(t *testing.T) {
-	log := &lifecycleLog{}
-	live := &versionedLive{log: log}
-	m := Live(liveTestDeps(live, log))
+	fx := newLiveFixture()
 
 	// The genuine offline wins first.
-	runLifecycle(t, m, "stream.offline", "1970-01-01T00:00:02Z")
-	waitForLog(t, log, 2) // clear + disarm
-	log.reset()
-	live.mu.Lock()
-	live.setCalls, live.clearCalls = nil, nil
-	live.mu.Unlock()
+	runLifecycle(t, fx.m, "stream.offline", "1970-01-01T00:00:02Z")
+	waitForLog(t, fx.log, 2) // clear + disarm
+	fx.log.reset()
+	fx.live.mu.Lock()
+	fx.live.setCalls, fx.live.clearCalls = nil, nil
+	fx.live.mu.Unlock()
 
 	// An older online redelivered afterwards must change nothing at all.
-	runLifecycle(t, m, "stream.online", "1970-01-01T00:00:01Z")
+	runLifecycle(t, fx.m, "stream.online", "1970-01-01T00:00:01Z")
 
 	// The store call itself proves the sequenced task ran to completion.
 	assert.Eventually(t, func() bool {
-		live.mu.Lock()
-		defer live.mu.Unlock()
-		return len(live.setCalls) == 1
+		fx.live.mu.Lock()
+		defer fx.live.mu.Unlock()
+		return len(fx.live.setCalls) == 1
 	}, time.Second, time.Millisecond, "stale online never reached the store")
 
-	assert.Empty(t, log.snapshot(), "superseded online must apply no state")
-	assert.Empty(t, greetsAndArms(log.snapshot()))
-	assert.False(t, live.isLive)
-	assert.Equal(t, []int64{1000}, live.setCalls, "the stale SET must have reached the store and lost")
+	assert.Empty(t, fx.log.snapshot(), "superseded online must apply no state")
+	assert.Empty(t, greetsAndArms(fx.log.snapshot()))
+	assert.False(t, fx.live.isLive)
+	assert.Equal(t, []int64{1000}, fx.live.setCalls, "the stale SET must have reached the store and lost")
 }
 
 // TestNewerOnlineAfterOfflineStartsCleanSession is the mirror image: a genuine
 // online arriving after an offline must fully start the session (greets,
 // timers armed, live).
 func TestNewerOnlineAfterOfflineStartsCleanSession(t *testing.T) {
-	log := &lifecycleLog{}
-	live := &versionedLive{log: log}
-	m := Live(liveTestDeps(live, log))
+	fx := newLiveFixture()
 
-	runLifecycle(t, m, "stream.offline", "1970-01-01T00:00:01Z")
-	runLifecycle(t, m, "stream.online", "1970-01-01T00:00:05Z")
+	runLifecycle(t, fx.m, "stream.offline", "1970-01-01T00:00:01Z")
+	runLifecycle(t, fx.m, "stream.online", "1970-01-01T00:00:05Z")
 
-	got := waitForLog(t, log, 5)
+	got := waitForLog(t, fx.log, 5)
 	assert.Equal(t, []string{"clear:1000", "disarm", "set:5000", "greets", "arm"}, got)
-	assert.True(t, live.isLive)
+	assert.True(t, fx.live.isLive)
 }

--- a/app/sesame/modules/live_test.go
+++ b/app/sesame/modules/live_test.go
@@ -1,0 +1,237 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package modules
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"ItsBagelBot/app/sesame/engine"
+	"ItsBagelBot/app/sesame/module"
+	lane "ItsBagelBot/internal/domain/event/lane"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// The #561 regression tests: a rapid stream.online / stream.offline pair must
+// leave the broadcaster offline, timers disarmed and greets untouched by any
+// superseded online — whichever order the events arrive in.
+
+// versionedLive is a recording LiveStore applying the same
+// newer-version-wins rule as the Valkey scripts, so tests can drive both
+// arrival orders through realistic store semantics. Applied transitions are
+// appended to a shared lifecycle log for order assertions.
+type versionedLive struct {
+	mu      sync.Mutex
+	applied int64 // highest version applied so far; survives deletion like ver:
+	isLive  bool
+
+	setCalls   []int64 // every call, applied or not
+	clearCalls []int64
+
+	log *lifecycleLog
+}
+
+func (f *versionedLive) IsLive(context.Context, uint64) (bool, error) { return f.isLive, nil }
+
+func (f *versionedLive) SetLive(_ context.Context, _ uint64, version int64) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.setCalls = append(f.setCalls, version)
+	if version < f.applied {
+		return false, nil
+	}
+	f.applied = version
+	f.isLive = true
+	f.log.add("set:" + strconv.FormatInt(version, 10))
+	return true, nil
+}
+
+func (f *versionedLive) ClearLive(_ context.Context, _ uint64, version int64) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.clearCalls = append(f.clearCalls, version)
+	if version < f.applied {
+		return false, nil
+	}
+	f.applied = version
+	f.isLive = false
+	f.log.add("clear:" + strconv.FormatInt(version, 10))
+	return true, nil
+}
+
+// orderedTimers and orderedGreets funnel their calls into the shared log.
+type orderedTimers struct{ log *lifecycleLog }
+
+func (t orderedTimers) ArmAll(context.Context, uint64)    { t.log.add("arm") }
+func (t orderedTimers) DisarmAll(context.Context, uint64) { t.log.add("disarm") }
+
+type orderedGreets struct{ log *lifecycleLog }
+
+func (g orderedGreets) FirstGreet(context.Context, uint64, string) (bool, error) { return false, nil }
+func (g orderedGreets) ResetGreets(context.Context, uint64) error {
+	g.log.add("greets")
+	return nil
+}
+
+// lifecycleLog is the one ordered record every fake appends to.
+type lifecycleLog struct {
+	mu    sync.Mutex
+	items []string
+}
+
+func (l *lifecycleLog) add(item string) {
+	l.mu.Lock()
+	l.items = append(l.items, item)
+	l.mu.Unlock()
+}
+
+func (l *lifecycleLog) snapshot() []string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return append([]string(nil), l.items...)
+}
+
+func (l *lifecycleLog) reset() {
+	l.mu.Lock()
+	l.items = nil
+	l.mu.Unlock()
+}
+
+func waitForLog(t *testing.T, l *lifecycleLog, n int) []string {
+	t.Helper()
+	assert.Eventually(t, func() bool { return len(l.snapshot()) >= n }, time.Second, time.Millisecond,
+		"expected %d lifecycle entries, got %v", n, l.snapshot())
+	return l.snapshot()
+}
+
+// millis renders an RFC3339 instant the way EventVersion does, so expected
+// versions stay readable without hardcoding epoch math.
+func millis(ts string) string {
+	t, err := time.Parse(time.RFC3339, ts)
+	if err != nil {
+		panic(err)
+	}
+	return strconv.FormatInt(t.UnixMilli(), 10)
+}
+
+func liveCtx(eventType, receivedAt string) *module.Context {
+	return &module.Context{
+		Env: lane.Envelope{
+			Type:              eventType,
+			BroadcasterUserID: "2",
+			ReceivedAt:        receivedAt,
+		},
+		BroadcasterID: 2,
+		Log:           zap.NewNop(),
+	}
+}
+
+func runLifecycle(t *testing.T, m module.Module, eventType, ts string) {
+	t.Helper()
+	h := m.Events[eventType]
+	require.NotNil(t, h, "module must handle %s", eventType)
+	require.NoError(t, h(context.Background(), liveCtx(eventType, ts), func(*module.Output) {}))
+}
+
+func liveTestDeps(live engine.LiveStore, log *lifecycleLog) engine.Deps {
+	return engine.Deps{
+		Live:   live,
+		Greet:  orderedGreets{log: log},
+		Timers: orderedTimers{log: log},
+		Seq:    engine.NewSequencer(),
+		Log:    zap.NewNop(),
+	}
+}
+
+// greetsAndArms filters the log to the session-start side effects.
+func greetsAndArms(items []string) []string {
+	var out []string
+	for _, it := range items {
+		if it == "greets" || it == "arm" {
+			out = append(out, it)
+		}
+	}
+	return out
+}
+
+// TestRapidOnlineThenOfflineLeavesChannelOffline drives the exact reported
+// symptom: offline right on the heels of online. Effects must land in event
+// order and end offline with timers down.
+func TestRapidOnlineThenOfflineLeavesChannelOffline(t *testing.T) {
+	const on = "2026-08-23T12:00:00Z"
+	const off = "2026-08-23T12:00:01Z"
+
+	log := &lifecycleLog{}
+	live := &versionedLive{log: log}
+	m := Live(liveTestDeps(live, log))
+
+	runLifecycle(t, m, "stream.online", on)
+	runLifecycle(t, m, "stream.offline", off)
+
+	got := waitForLog(t, log, 5)
+	assert.Equal(t, []string{
+		"set:" + millis(on),
+		"greets",
+		"arm",
+		"clear:" + millis(off),
+		"disarm",
+	}, got, "offline effects must follow the online's, never interleave")
+	assert.False(t, live.isLive, "channel must end offline")
+}
+
+// TestStaleOnlineLosingToNewerOfflineIsIgnored covers redelivery skew: an
+// older stream.online arriving after a newer offline already won. The store
+// rejects the SET, and the module must skip the session-start effects too —
+// resetting greets or arming timers would resurrect state the offline just
+// cleared.
+func TestStaleOnlineLosingToNewerOfflineIsIgnored(t *testing.T) {
+	log := &lifecycleLog{}
+	live := &versionedLive{log: log}
+	m := Live(liveTestDeps(live, log))
+
+	// The genuine offline wins first.
+	runLifecycle(t, m, "stream.offline", "1970-01-01T00:00:02Z")
+	waitForLog(t, log, 2) // clear + disarm
+	log.reset()
+	live.mu.Lock()
+	live.setCalls, live.clearCalls = nil, nil
+	live.mu.Unlock()
+
+	// An older online redelivered afterwards must change nothing at all.
+	runLifecycle(t, m, "stream.online", "1970-01-01T00:00:01Z")
+
+	// The store call itself proves the sequenced task ran to completion.
+	assert.Eventually(t, func() bool {
+		live.mu.Lock()
+		defer live.mu.Unlock()
+		return len(live.setCalls) == 1
+	}, time.Second, time.Millisecond, "stale online never reached the store")
+
+	assert.Empty(t, log.snapshot(), "superseded online must apply no state")
+	assert.Empty(t, greetsAndArms(log.snapshot()))
+	assert.False(t, live.isLive)
+	assert.Equal(t, []int64{1000}, live.setCalls, "the stale SET must have reached the store and lost")
+}
+
+// TestNewerOnlineAfterOfflineStartsCleanSession is the mirror image: a genuine
+// online arriving after an offline must fully start the session (greets,
+// timers armed, live).
+func TestNewerOnlineAfterOfflineStartsCleanSession(t *testing.T) {
+	log := &lifecycleLog{}
+	live := &versionedLive{log: log}
+	m := Live(liveTestDeps(live, log))
+
+	runLifecycle(t, m, "stream.offline", "1970-01-01T00:00:01Z")
+	runLifecycle(t, m, "stream.online", "1970-01-01T00:00:05Z")
+
+	got := waitForLog(t, log, 5)
+	assert.Equal(t, []string{"clear:1000", "disarm", "set:5000", "greets", "arm"}, got)
+	assert.True(t, live.isLive)
+}

--- a/app/sesame/modules/loyalty.go
+++ b/app/sesame/modules/loyalty.go
@@ -163,14 +163,16 @@ func onAccrual[T any](d engine.Deps, award func(cfg engine.LoyaltyModuleConfig, 
 
 // onStreamTick builds the stream.online/offline handlers: the watch tick
 // follows the stream lifecycle, mirroring the timers module. Fire-and-forget
-// on a Background-derived context, like the live module's writes.
+// on a Background-derived context, like the live module's writes, and run
+// through d.Seq like them so an offline's Disarm cannot race past an online's
+// Arm on this replica (#561).
 func onStreamTick(d engine.Deps, arm bool) module.EventHandler {
 	return func(_ context.Context, c *module.Context, _ module.Emit) error {
 		if d.LoyaltyTick == nil {
 			return nil
 		}
 		id := c.BroadcasterID
-		go func() {
+		seqOrGo(d.Seq, id, d.Log, func() {
 			wctx, cancel := context.WithTimeout(context.Background(), loyaltyTickTimeout)
 			defer cancel()
 			if arm {
@@ -178,7 +180,7 @@ func onStreamTick(d engine.Deps, arm bool) module.EventHandler {
 			} else {
 				d.LoyaltyTick.Disarm(wctx, id)
 			}
-		}()
+		})
 		return nil
 	}
 }

--- a/app/sesame/modules/mcsr.go
+++ b/app/sesame/modules/mcsr.go
@@ -154,7 +154,7 @@ func Mcsr(d engine.Deps) module.Module {
 		_ = c.Decode(&cfg)
 		account := resolveAccount(accountSources{Linked: cfg.Account, BroadcasterLogin: c.Env.BroadcasterUserLogin})
 		channelID := strconv.FormatUint(c.BroadcasterID, 10)
-		go func() {
+		seqOrGo(d.Seq, c.BroadcasterID, log, func() {
 			wctx, cancel := context.WithTimeout(context.Background(), mcsrSnapshotTimeout)
 			defer cancel()
 			var reply gossiprpc.McsrSnapshotReply
@@ -165,7 +165,29 @@ func Mcsr(d engine.Deps) module.Module {
 			}
 			log.Debug("mcsr: stream-start snapshot stored",
 				zap.String("channel_id", channelID), zap.String("account", account), zap.Int("elo", reply.Elo))
-		}()
+		})
+		return nil
+	})
+
+	// Stream ended: clear the session-start baseline so a rapid stop/restart
+	// cycle (#561) cannot leave !session diffing the new stream against the old
+	// one's snapshot. Sequenced behind the online snapshot like every other
+	// lifecycle effect. Gossip deployments without the provider (or in shop-only
+	// mode) answer no-responder — an expected miss, hence Debug.
+	m.On("stream.offline", func(_ context.Context, c *module.Context, _ module.Emit) error {
+		if d.Gossip == nil {
+			return nil
+		}
+		channelID := strconv.FormatUint(c.BroadcasterID, 10)
+		seqOrGo(d.Seq, c.BroadcasterID, log, func() {
+			wctx, cancel := context.WithTimeout(context.Background(), mcsrSnapshotTimeout)
+			defer cancel()
+			var reply gossiprpc.McsrSnapshotReply
+			if err := d.Gossip.Call(wctx, engine.GossipRoute{Provider: "mcsr", Endpoint: "session_end"}, gossiprpc.Request{ChannelID: channelID}, &reply); err != nil {
+				log.Debug("mcsr: stream-end snapshot clear failed",
+					zap.String("channel_id", channelID), zap.Error(err))
+			}
+		})
 		return nil
 	})
 

--- a/app/sesame/wiring.go
+++ b/app/sesame/wiring.go
@@ -78,6 +78,7 @@ type engineRuntime struct {
 	tick    *engine.ValkeyLoyaltyClock
 	stats   *engine.LoyaltyReporter
 	raffle  *engine.ValkeyRaffleStore
+	seq     *engine.Sequencer
 }
 
 // buildDeps assembles the engine.Deps every module fn captures. modules.All turns
@@ -114,6 +115,8 @@ func buildDeps(w wireCtx, rt engineRuntime) engine.Deps {
 		Personality: engine.NewValkeyPersonality(in.vc, engine.NewPersonalityRPC(in.nc, cfg.ModulesRPCPrefix), log),
 
 		Dedup: newDedup(w),
+
+		Seq: rt.seq,
 
 		PublicBaseURL: cfg.PublicBaseURL,
 	}

--- a/internal/domain/event/lane/lane.go
+++ b/internal/domain/event/lane/lane.go
@@ -10,6 +10,7 @@ package lane
 import (
 	"ItsBagelBot/pkg/codec"
 	"strconv"
+	"time"
 )
 
 // Badge is one Twitch chat badge as carried on a channel.chat.message event.
@@ -71,6 +72,14 @@ type Envelope struct {
 
 	MsgID   string `json:"msg_id,omitempty"`
 	ShardID int    `json:"shard_id,omitempty"`
+
+	// ReceivedAt is ingress's EventSub notification receipt time (Twitch's
+	// message_timestamp, RFC 3339), published on every lane body (see
+	// app/ingress/lib/ingress/pipeline.ex). It is the only ordering signal
+	// stream.online / stream.offline carry: the consumer pool gives no
+	// cross-message ordering, so lifecycle writers compare EventVersion
+	// instead of trusting arrival order. Absent on older envelopes.
+	ReceivedAt string `json:"received_at,omitempty"`
 }
 
 // BroadcasterName is the broadcaster's Twitch display name for chat-facing text,
@@ -90,6 +99,22 @@ func (e Envelope) ChatterName() string {
 		return e.ChatterUserName
 	}
 	return e.ChatterUserLogin
+}
+
+// EventVersion returns the event's ordering version: the ReceivedAt instant as
+// unix milliseconds. Zero when the envelope predates the field or carries an
+// unparseable timestamp — callers must treat 0 as "no ordering claim" and fall
+// back to their own clock rather than letting a timestamp-less event win a
+// comparison against a stamped one.
+func (e Envelope) EventVersion() int64 {
+	if e.ReceivedAt == "" {
+		return 0
+	}
+	t, err := time.Parse(time.RFC3339, e.ReceivedAt)
+	if err != nil {
+		return 0
+	}
+	return t.UnixMilli()
 }
 
 // BroadcasterID returns the broadcaster the event belongs to as a uint64. For

--- a/internal/domain/live/live.go
+++ b/internal/domain/live/live.go
@@ -8,7 +8,10 @@
 // drifting between the two services that touch it.
 package live
 
-import "strconv"
+import (
+	"strconv"
+	"time"
+)
 
 // KeyPrefix is the per-broadcaster live key prefix: live:<broadcaster_id> = "1"
 // while the stream is online; absence means not-known-live (offline or cold).
@@ -23,3 +26,77 @@ func Key(id uint64) string { return KeyPrefix + strconv.FormatUint(id, 10) }
 
 // KeyString returns the live key for a broadcaster id already in string form.
 func KeyString(id string) string { return KeyPrefix + id }
+
+// The key's VALUE is the applied version: the unix-millisecond instant of the
+// stream event (Twitch EventSub message_timestamp) that last set it, or of the
+// Twitch re-check that wrote it. Existence still means live; readers never
+// parse the value (#561). Before versioning the value was the constant "1" and
+// both writers used blind SET/DEL — so a rapid stream.online/offline pair,
+// processed by different consumer goroutines, let SetLive land after ClearLive
+// and resurrect a stale key with its 12h TTL, leaving every downstream reader
+// treating an offline channel as live until natural expiry. Writers now apply
+// through the two scripts below, which make each write conditional on the
+// highest version already applied.
+//
+// The version lives under its OWN key (VerKey) rather than only inside the
+// live key, because the DEL would otherwise destroy exactly the fact a later
+// stale SET must be judged against: offline deletes the live key, and an old
+// online redelivered afterwards would see no key, no version, and win. The
+// version key survives both operations with its own TTL, so the ordering
+// claim outlives every individual write.
+
+// VerKeyPrefix holds the per-broadcaster last-applied version:
+// ver:<broadcaster_id> = unix millis. It sorts under the shared live: prefix,
+// which the expiry watcher and timer scans already skip (their id parse
+// rejects anything non-numeric).
+const VerKeyPrefix = KeyPrefix + "ver:"
+
+// VerKey returns the version key for a broadcaster id.
+func VerKey(id uint64) string { return VerKeyPrefix + strconv.FormatUint(id, 10) }
+
+// VerKeyString returns the version key for a string broadcaster id.
+func VerKeyString(id string) string { return VerKeyPrefix + id }
+
+// VerTTL is how long a version claim outlives the write that made it. It must
+// comfortably exceed the worst plausible event skew — EventSub redelivery plus
+// lane queue backlog — because it is the whole memory the ordering has. Two
+// days covers both many times over and keeps cold broadcasters from
+// accumulating keys forever.
+const VerTTL = 48 * time.Hour
+
+// VersionNow is the fallback version for writers with no event timestamp (the
+// projector write-back, outgress's authoritative re-check): the writer's own
+// clock. Those writers ARE the authority at that instant, so now() is their
+// correct ordering claim.
+func VersionNow() int64 { return time.Now().UnixMilli() }
+
+// Value renders a version as the key value stored in Valkey.
+func Value(version int64) string { return strconv.FormatInt(version, 10) }
+
+// SetScript applies SET live:<id> <version> EX <ttl> only when no newer
+// version was already applied (checked and recorded in the companion ver: key).
+// A legacy constant "1" live key carries no claim of its own — the ver: key is
+// the sole arbiter — so rolling replicas converge without a flush.
+// KEYS: live key, ver key. ARGV: version, ttl seconds, ver ttl seconds.
+const SetScript = `local cur = redis.call('GET', KEYS[2])
+if cur then
+  local curv = tonumber(cur)
+  if curv and curv > tonumber(ARGV[1]) then return 0 end
+end
+redis.call('SET', KEYS[1], ARGV[1], 'EX', tonumber(ARGV[2]))
+redis.call('SET', KEYS[2], ARGV[1], 'EX', tonumber(ARGV[3]))
+return 1`
+
+// ClearScript applies DEL live:<id> only when the applied version is not newer
+// than this event: a stale offline must not delete what a fresh re-check just
+// confirmed, and it must still record its own recency so an OLDER online
+// redelivered afterwards loses too. KEYS: live key, ver key. ARGV: version,
+// ver ttl seconds.
+const ClearScript = `local cur = redis.call('GET', KEYS[2])
+if cur then
+  local curv = tonumber(cur)
+  if curv and curv > tonumber(ARGV[1]) then return 0 end
+end
+redis.call('DEL', KEYS[1])
+redis.call('SET', KEYS[2], ARGV[1], 'EX', tonumber(ARGV[3]))
+return 1`


### PR DESCRIPTION
Closes #561

## Problem
A rapid `stream.online` → `stream.offline` pair left a stale `live:<broadcaster_id>` key (12h TTL) in Valkey and in-process caches flagged live: the consumer pool gives no cross-message ordering, the module's fire-and-forget goroutines raced, and both writers used blind SET/DEL — so `SetLive` could land after `ClearLive` and resurrect the key. Gossip session baselines then diffed against dead streams, timers/loyalty ticks stayed armed.

## Fix — two coordinated halves

**Cross-replica (versioned writes)**
- Key value now carries the applied version: the event's `received_at` (EventSub message_timestamp, already on every lane body; now decoded via `lane.Envelope.ReceivedAt` / new `EventVersion()`), or the writer's own clock for authoritative re-checks.
- SET/DEL apply through shared conditional Lua scripts (`internal/domain/live`) that refuse to move state backwards.
- The version lives in a companion `live:ver:<id>` claim key (48h TTL): a plain DEL would erase exactly the fact a later stale SET must be judged against — this is the resurrection case the naive design misses.
- `outgress` re-check write-back uses the same scripts with now() as its version, so a stale offline can't delete what Twitch just confirmed.
- Legacy constant `"1"` values converge without a flush (no ver: claim ⇒ first versioned write wins).
- Invalidation broadcast fires only when a write actually applied; local cache always drops on ClearLive.

**Intra-replica (ordering)**
- New `engine.Sequencer`: per-broadcaster FIFO where each task runs to completion before the next starts (pump-per-burst, reaped when idle, overflow degrades to inline rather than dropping a ClearLive).
- Live module, loyalty tick arm/disarm and the fortnite/mcsr snapshot handlers route through it; a superseded online skips greet-reset/timer-arm entirely.
- New pure-store `session_end` gossip endpoints (fortnite, mcsr) invoked from `stream.offline`, clearing stream-start snapshots so `!fn session` / `!session` start clean even when the online snapshot lost the race.

## Residual (documented in code)
Cross-replica timer/loyalty arm races are narrowed by serialization only when one replica sees both events; the valkey-side versioning carries the fleet-wide guarantee for the live key itself.

## Tests
- Module-level rapid-pair regression, both arrival orders, under `-race`.
- Sequencer: FIFO order, per-broadcaster independence, slow-task blocking, pump respawn, concurrent-Do safety.
- `lane.EventVersion` parsing incl. absent/unparseable ⇒ 0 ("no ordering claim").
- Provider tests for both `session_end` endpoints (+ endpoint-surface update).
- Env-gated Valkey integration test driving the resurrection scenario end to end (skips without `VALKEY_TEST_ADDR`, like the other hot-path tests).