### PR TITLE
fix(console): replace deprecated arctic OAuth client with oauth4webapi

### DIFF
--- a/console/admin/src/lib/server/oauth.ts
+++ b/console/admin/src/lib/server/oauth.ts
@@ -1,12 +1,14 @@
 // Copyright (c) 2026 Adam Ousmer. All rights reserved.
 // Proprietary. No license granted. See LICENSE.md.
 
-// Twitch OAuth via arctic, identity-only. The admin console authenticates an
-// operator's Twitch account to obtain their subject id; authorization is then
-// decided by the DB allowlist (auth.check). It requests no bot scopes: sign-in
-// proves who you are, nothing more. Reuses the same Twitch app as the dashboard
-// tier (same client id/secret); only the redirect URI differs.
-import { Twitch } from 'arctic';
+// Twitch OAuth via the shared client (@bagel/shared/server/oauth), which is
+// built on oauth4webapi and replaced the deprecated arctic package.
+// Identity-only: the admin console authenticates an operator's Twitch account
+// to obtain their subject id; authorization is then decided by the DB allowlist
+// (auth.check). It requests no bot scopes: sign-in proves who you are, nothing
+// more. Reuses the same Twitch app as the dashboard tier (same client
+// id/secret); only the redirect URI differs.
+import { Twitch } from '@bagel/shared/server/oauth';
 import { env } from '$env/dynamic/private';
 
 export function scopes(): string[] {

--- a/console/admin/src/routes/auth/bot/callback/+server.ts
+++ b/console/admin/src/routes/auth/bot/callback/+server.ts
@@ -3,13 +3,13 @@
 
 import type { RequestHandler } from './$types';
 import { redirect } from '@sveltejs/kit';
-import { decodeIdToken, OAuth2RequestError } from 'arctic';
+import { ResponseBodyError } from '@bagel/shared/server/oauth';
 import { botTwitch, botClientId } from '$lib/server/oauth';
 import { tokenSet } from '$lib/server/services';
 import { env } from '$env/dynamic/private';
 
 type BotIdentity = {
-  idToken: string;
+  claims: { sub: string; aud?: string | string[]; iss?: string };
   configuredId: string;
 };
 
@@ -20,11 +20,7 @@ function configuredBotId(): string {
 }
 
 function assertBotIdentity(identity: BotIdentity): void {
-  const claims = decodeIdToken(identity.idToken) as {
-    sub: string;
-    aud?: string | string[];
-    iss?: string;
-  };
+  const claims = identity.claims;
   const clientId = botClientId();
   const intendedAudience = Array.isArray(claims.aud)
     ? claims.aud.includes(clientId)
@@ -56,11 +52,11 @@ export const GET: RequestHandler = async ({ url, cookies }) => {
 
   try {
     const tokens = await botTwitch(url.origin).validateAuthorizationCode(code);
-    assertBotIdentity({ idToken: tokens.idToken()!, configuredId: botId });
+    assertBotIdentity({ claims: tokens.claims(), configuredId: botId });
 
     await tokenSet(botId, tokens.accessToken(), tokens.refreshToken());
   } catch (e) {
-    if (e instanceof OAuth2RequestError) throw redirect(302, '/auth/bot/done?e=oauth');
+    if (e instanceof ResponseBodyError) throw redirect(302, '/auth/bot/done?e=oauth');
     throw e;
   }
 

--- a/console/admin/src/routes/auth/bot/login/+server.ts
+++ b/console/admin/src/routes/auth/bot/login/+server.ts
@@ -3,7 +3,7 @@
 
 import type { RequestHandler } from './$types';
 import { redirect } from '@sveltejs/kit';
-import { generateState } from 'arctic';
+import { generateState } from '@bagel/shared/server/oauth';
 import { botTwitch, botScopes } from '$lib/server/oauth';
 import { env } from '$env/dynamic/private';
 

--- a/console/admin/src/routes/auth/callback/+server.ts
+++ b/console/admin/src/routes/auth/callback/+server.ts
@@ -3,7 +3,7 @@
 
 import type { RequestHandler } from './$types';
 import { redirect } from '@sveltejs/kit';
-import { decodeIdToken, OAuth2RequestError } from 'arctic';
+import { ResponseBodyError } from '@bagel/shared/server/oauth';
 import { twitch } from '$lib/server/oauth';
 import { adminCheck } from '$lib/server/services';
 import { COOKIE, seal, SESSION_TTL_SECONDS } from '$lib/server/session';
@@ -21,10 +21,14 @@ export const GET: RequestHandler = async ({ url, cookies }) => {
   cookies.delete('oauth_nonce', { path: '/' });
 
   if (!code || !state || !stored || state !== stored) throw redirect(302, '/login?e=state');
+  // The shared client enforces the id_token nonce claim, so the cookie is
+  // mandatory: a flow that lost it fails closed instead of logging in without
+  // replay protection.
+  if (!storedNonce) throw redirect(302, '/login?e=state');
 
   try {
-    const tokens = await twitch().validateAuthorizationCode(code);
-    const claims = decodeIdToken(tokens.idToken()!) as {
+    const tokens = await twitch().validateAuthorizationCode(code, storedNonce);
+    const claims = tokens.claims() as unknown as {
       sub: string;
       preferred_username: string;
       aud?: string | string[];
@@ -68,7 +72,7 @@ export const GET: RequestHandler = async ({ url, cookies }) => {
       maxAge: SESSION_TTL_SECONDS
     });
   } catch (e) {
-    if (e instanceof OAuth2RequestError) throw redirect(302, '/login?e=oauth');
+    if (e instanceof ResponseBodyError) throw redirect(302, '/login?e=oauth');
     throw e;
   }
 

--- a/console/admin/src/routes/auth/login/+server.ts
+++ b/console/admin/src/routes/auth/login/+server.ts
@@ -3,7 +3,7 @@
 
 import type { RequestHandler } from './$types';
 import { redirect } from '@sveltejs/kit';
-import { generateState } from 'arctic';
+import { generateState } from '@bagel/shared/server/oauth';
 import { randomBytes } from 'node:crypto';
 import { twitch, scopes } from '$lib/server/oauth';
 

--- a/console/admin/test/bot-callback.test.ts
+++ b/console/admin/test/bot-callback.test.ts
@@ -11,7 +11,7 @@ const claims: { sub: string; aud: string; iss: string } = {
   iss: 'https://id.twitch.tv/oauth2'
 };
 const validateAuthorizationCode = mock(async () => ({
-  idToken: () => 'unused.test.token',
+  claims: () => ({ ...claims }),
   accessToken: () => 'access-token',
   refreshToken: () => 'refresh-token'
 }));
@@ -35,11 +35,6 @@ mock.module('$lib/server/oauth', () => ({
   botTwitch
 }));
 mock.module('$lib/server/services', () => ({ tokenSet }));
-mock.module('arctic', () => ({
-  decodeIdToken: () => claims,
-  generateState: () => 'generated-state',
-  OAuth2RequestError: class OAuth2RequestError extends Error {}
-}));
 mock.module('@sveltejs/kit', () => ({
   redirect: (status: number, location: string) => new TestRedirect(status, location)
 }));

--- a/console/bun.lock
+++ b/console/bun.lock
@@ -37,7 +37,6 @@
       "name": "dashboard",
       "dependencies": {
         "@bagel/shared": "workspace:*",
-        "arctic": "^3.6.0",
         "motion": "^12.0.0",
         "nats": "^2.29.2",
         "newrelic": "^12.11.0",
@@ -57,6 +56,7 @@
         "lenis": "^1.3.18",
         "motion": "^12.0.0",
         "nats": "^2.29.2",
+        "oauth4webapi": "^3.8.7",
         "pino": "^9",
         "three": "^0.185.0",
       },
@@ -138,16 +138,6 @@
     "@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.10.0", "", { "dependencies": { "@opentelemetry/core": "2.10.0", "@opentelemetry/resources": "2.10.0", "@opentelemetry/sdk-trace": "2.10.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ=="],
 
     "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.43.0", "", {}, "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg=="],
-
-    "@oslojs/asn1": ["@oslojs/asn1@1.0.0", "", { "dependencies": { "@oslojs/binary": "1.0.0" } }, "sha512-zw/wn0sj0j0QKbIXfIlnEcTviaCzYOY3V5rAyjR6YtOByFtJiT574+8p9Wlach0lZH9fddD4yb9laEAIl4vXQA=="],
-
-    "@oslojs/binary": ["@oslojs/binary@1.0.0", "", {}, "sha512-9RCU6OwXU6p67H4NODbuxv2S3eenuQ4/WFLrsq+K/k682xrznH5EVWA7N4VFk9VYVcbFtKqur5YQQZc0ySGhsQ=="],
-
-    "@oslojs/crypto": ["@oslojs/crypto@1.0.1", "", { "dependencies": { "@oslojs/asn1": "1.0.0", "@oslojs/binary": "1.0.0" } }, "sha512-7n08G8nWjAr/Yu3vu9zzrd0L9XnrJfpMioQcvCMxBIiF5orECHe5/3J0jmXRVvgfqMm/+4oxlQ+Sq39COYLcNQ=="],
-
-    "@oslojs/encoding": ["@oslojs/encoding@1.1.0", "", {}, "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ=="],
-
-    "@oslojs/jwt": ["@oslojs/jwt@0.2.0", "", { "dependencies": { "@oslojs/encoding": "0.4.1" } }, "sha512-bLE7BtHrURedCn4Mco3ma9L4Y1GR2SMBuIvjWr7rmQ4/W/4Jy70TIAgZ+0nIlk0xHz1vNP8x8DCns45Sb2XRbg=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.139.0", "", {}, "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw=="],
 
@@ -316,8 +306,6 @@
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
-
-    "arctic": ["arctic@3.7.0", "", { "dependencies": { "@oslojs/crypto": "1.0.1", "@oslojs/encoding": "1.1.0", "@oslojs/jwt": "0.2.0" } }, "sha512-ZMQ+f6VazDgUJOd+qNV+H7GohNSYal1mVjm5kEaZfE2Ifb7Ss70w+Q7xpJC87qZDkMZIXYf0pTIYZA0OPasSbw=="],
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
@@ -599,6 +587,8 @@
 
     "npm-run-path": ["npm-run-path@3.1.0", "", { "dependencies": { "path-key": "^3.0.0" } }, "sha512-Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg=="],
 
+    "oauth4webapi": ["oauth4webapi@3.8.7", "", {}, "sha512-4RxcKxXjuItDFZ20RRPf4YTw3kpeXJyCgJFxVzJ068A7PNJ18st2Dg90tlC1LkSDS0GecroagCLHYEIVUhCAkw=="],
+
     "obug": ["obug@2.1.4", "", {}, "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA=="],
 
     "on-exit-leak-free": ["on-exit-leak-free@2.1.2", "", {}, "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="],
@@ -778,8 +768,6 @@
     "@opentelemetry/otlp-transformer/@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.0.1", "", { "dependencies": { "@opentelemetry/core": "2.0.1", "@opentelemetry/resources": "2.0.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-xYLlvk/xdScGx1aEqvxLwf6sXQLXCjk3/1SQT9X9AoN5rXRhkdvIFShuNNmtTEPRBqcsMbS4p/gJLNI2wXaDuQ=="],
 
     "@opentelemetry/sdk-logs/@opentelemetry/resources": ["@opentelemetry/resources@2.0.1", "", { "dependencies": { "@opentelemetry/core": "2.0.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-dZOB3R6zvBwDKnHDTB4X1xtMArB/d324VsbiPkX/Yu0Q8T2xceRthoIVFhJdvgVM2QhGVUyX9tzwiNxGtoBJUw=="],
-
-    "@oslojs/jwt/@oslojs/encoding": ["@oslojs/encoding@0.4.1", "", {}, "sha512-hkjo6MuIK/kQR5CrGNdAPZhS01ZCXuWDRJ187zh6qqF2+yMHZpD9fAYpX8q2bOO6Ryhl3XpCT6kUX76N8hhm4Q=="],
 
     "@rollup/plugin-commonjs/is-reference": ["is-reference@1.2.1", "", { "dependencies": { "@types/estree": "*" } }, "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ=="],
 

--- a/console/bunfig.toml
+++ b/console/bunfig.toml
@@ -4,7 +4,7 @@
 # Hoisted (flat) node_modules so a production image can ship a self-contained
 # node_modules by copying the workspace root. Bun's default isolated linker puts
 # deps in node_modules/.bun and symlinks them per-workspace, which does not
-# survive a cross-stage container COPY (adapter-node leaves nats/arctic external
-# and resolves them from node_modules at runtime).
+# survive a cross-stage container COPY (adapter-node leaves nats external and
+# resolves them from node_modules at runtime).
 [install]
 linker = "hoisted"

--- a/console/dashboard/package.json
+++ b/console/dashboard/package.json
@@ -12,7 +12,6 @@
   },
   "dependencies": {
     "@bagel/shared": "workspace:*",
-    "arctic": "^3.6.0",
     "motion": "^12.0.0",
     "nats": "^2.29.2",
     "newrelic": "^12.11.0",

--- a/console/dashboard/src/lib/server/oauth.ts
+++ b/console/dashboard/src/lib/server/oauth.ts
@@ -1,10 +1,10 @@
 // Copyright (c) 2026 Adam Ousmer. All rights reserved.
 // Proprietary. No license granted. See LICENSE.md.
 
-// Twitch OAuth via arctic (the maintained, well-known OAuth2 client used with
-// Lucia). One Twitch client built from env. Helix user fetch lives here too so
-// the callback route stays thin.
-import { Twitch } from 'arctic';
+// Twitch OAuth via the shared in-repo client (@bagel/shared/server/oauth),
+// which replaced the deprecated arctic package. One Twitch client built from
+// env. Helix user fetch lives here too so the callback route stays thin.
+import { Twitch } from '@bagel/shared/server/oauth';
 import { env } from '$env/dynamic/private';
 
 // Identity + the elevated bot scopes the old dashboard requested. Driven by

--- a/console/dashboard/src/routes/auth/callback/+server.ts
+++ b/console/dashboard/src/routes/auth/callback/+server.ts
@@ -217,30 +217,49 @@ async function persistGrant(userId: string, tokens: { accessToken(): string; ref
   }
 }
 
+// callbackGate validates the provider callback against the HttpOnly state /
+// nonce cookies and returns either the exchange inputs or the /login error
+// slug. Keeping both guards here means GET itself spends a single branch.
+function callbackGate(
+  code: string | null,
+  state: string | null,
+  storedState: string | undefined,
+  storedNonce: string | undefined
+): { ok: true; code: string; storedNonce: string } | { ok: false; slug: string } {
+  if (!validOAuthState(code, state, storedState)) return { ok: false, slug: 'state' };
+  // The shared client enforces the id_token nonce claim, so the cookie is now
+  // mandatory: a flow that lost it fails closed here instead of logging in
+  // without replay protection.
+  if (!storedNonce) return { ok: false, slug: 'state' };
+  return { ok: true, code, storedNonce };
+}
+
+// runLogin performs the exchange and maps OAuth-level failures onto
+// /login?e=oauth; any other error is a real server failure and propagates.
+async function runLogin(cookies: Cookies, url: URL, code: string, storedNonce: string): Promise<void> {
+  try {
+    await completeLogin(cookies, url, code, storedNonce);
+  } catch (e) {
+    if (!(e instanceof ResponseBodyError)) throw e;
+    throw redirect(302, '/login?e=oauth');
+  }
+}
+
 export const GET: RequestHandler = async ({ url, cookies }) => {
-  const code = url.searchParams.get('code');
-  const state = url.searchParams.get('state');
-  const stored = cookies.get('oauth_state');
-  const storedNonce = cookies.get('oauth_nonce');
-  // Deep link stored by /auth/login (e.g. /billing?subscribe=1 from the
-  // pricing page). Re-validated here: the cookie is client-writable.
   const next = safeNextPath(cookies.get('login_next'));
+  const gate = callbackGate(
+    url.searchParams.get('code'),
+    url.searchParams.get('state'),
+    cookies.get('oauth_state'),
+    cookies.get('oauth_nonce')
+  );
   cookies.delete('oauth_state', { path: '/' });
   cookies.delete('oauth_nonce', { path: '/' });
   cookies.delete('login_next', { path: '/' });
 
-  if (!validOAuthState(code, state, stored)) throw redirect(302, '/login?e=state');
-  // The shared client enforces the id_token nonce claim, so the cookie is now
-  // mandatory: a flow that lost it fails closed here instead of logging in
-  // without replay protection.
-  if (!storedNonce) throw redirect(302, '/login?e=state');
+  if (!gate.ok) throw redirect(302, `/login?e=${gate.slug}`);
 
-  try {
-    await completeLogin(cookies, url, code, storedNonce);
-  } catch (e) {
-    if (e instanceof ResponseBodyError) throw redirect(302, '/login?e=oauth');
-    throw e;
-  }
+  await runLogin(cookies, url, gate.code, gate.storedNonce);
 
   // Owner session minted: honor the stored deep link (delegate sessions
   // redirect inside completeLogin and never reach this).

--- a/console/dashboard/src/routes/auth/callback/+server.ts
+++ b/console/dashboard/src/routes/auth/callback/+server.ts
@@ -5,7 +5,7 @@ import type { RequestHandler } from './$types';
 import type { Cookies } from '@sveltejs/kit';
 import { redirect } from '@sveltejs/kit';
 import { randomBytes } from 'node:crypto';
-import { decodeIdToken, OAuth2RequestError } from 'arctic';
+import { ResponseBodyError } from '@bagel/shared/server/oauth';
 import { twitch, safeNextPath, fetchAccountEmail } from '$lib/server/oauth';
 import { rpc } from '@bagel/shared/server/nats';
 import { logger } from '@bagel/shared/server/logger';
@@ -45,9 +45,9 @@ function isBotAccount(sub: string): boolean {
 }
 
 // nonceMismatch is the replay / token-swap guard: the stored nonce must equal
-// the claim. arctic's Twitch.createAuthorizationURL does not accept a nonce
-// param, so the login route appended it manually and we verify it here. A
-// missing stored nonce skips the check.
+// the claim. The shared Twitch client's createAuthorizationURL does not accept
+// a nonce param, so the login route appended it manually and we verify it here.
+// A missing stored nonce skips the check.
 function nonceMismatch(claims: IdTokenClaims, storedNonce: string | undefined): boolean {
   return !!storedNonce && claims.nonce !== storedNonce;
 }
@@ -230,11 +230,15 @@ export const GET: RequestHandler = async ({ url, cookies }) => {
   cookies.delete('login_next', { path: '/' });
 
   if (!validOAuthState(code, state, stored)) throw redirect(302, '/login?e=state');
+  // The shared client enforces the id_token nonce claim, so the cookie is now
+  // mandatory: a flow that lost it fails closed here instead of logging in
+  // without replay protection.
+  if (!storedNonce) throw redirect(302, '/login?e=state');
 
   try {
     await completeLogin(cookies, url, code, storedNonce);
   } catch (e) {
-    if (e instanceof OAuth2RequestError) throw redirect(302, '/login?e=oauth');
+    if (e instanceof ResponseBodyError) throw redirect(302, '/login?e=oauth');
     throw e;
   }
 
@@ -246,9 +250,9 @@ export const GET: RequestHandler = async ({ url, cookies }) => {
 // completeLogin exchanges the code, verifies the id_token, and mints the owner
 // session (or hands off to the delegation accept flow, which redirects
 // itself).
-async function completeLogin(cookies: Cookies, url: URL, code: string, storedNonce: string | undefined): Promise<void> {
-  const tokens = await twitch().validateAuthorizationCode(code);
-  const claims = decodeIdToken(tokens.idToken()!) as IdTokenClaims;
+async function completeLogin(cookies: Cookies, url: URL, code: string, storedNonce: string): Promise<void> {
+  const tokens = await twitch().validateAuthorizationCode(code, storedNonce);
+  const claims = tokens.claims() as unknown as IdTokenClaims;
   verifyClaims(claims, storedNonce);
 
   const identity: Identity = {

--- a/console/dashboard/src/routes/auth/login/+server.ts
+++ b/console/dashboard/src/routes/auth/login/+server.ts
@@ -3,15 +3,15 @@
 
 import type { RequestHandler } from './$types';
 import { redirect } from '@sveltejs/kit';
-import { generateState } from 'arctic';
+import { generateState } from '@bagel/shared/server/oauth';
 import { randomBytes } from 'node:crypto';
 import { twitch, scopes, safeNextPath } from '$lib/server/oauth';
 
 // Start of the Twitch authorization-code flow. State is stored in a short-lived
 // HttpOnly cookie and verified in the callback (CSRF protection for OAuth).
-// Nonce is also generated and stored: arctic's Twitch class does not accept a
-// nonce arg, so we append it directly to the URL and verify claims.nonce in the
-// callback (replay / id_token substitution guard).
+// Nonce is also generated and stored: the shared Twitch client does not accept
+// a nonce arg, so we append it directly to the URL and verify claims.nonce in
+// the callback (replay / id_token substitution guard).
 export const GET: RequestHandler = ({ cookies, url }) => {
   const state = generateState();
   const nonce = randomBytes(16).toString('base64url');

--- a/console/shared/lib/server/oauth.test.ts
+++ b/console/shared/lib/server/oauth.test.ts
@@ -1,0 +1,174 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+// Pins the oauth4webapi-backed Twitch client's wire behavior. The authorization
+// URL and the token-exchange request are asserted as exact strings: these are
+// what Twitch actually sees, so a single changed byte (auth method drifting
+// from client_secret_post, a dropped scope separator) must fail loudly — see
+// the golden-output-tests note.
+
+import { describe, expect, test } from 'bun:test';
+import * as oauth4webapi from 'oauth4webapi';
+import { expectNoNonce, generateState, OAuth2Tokens, ResponseBodyError, Twitch } from './oauth';
+
+const CLIENT = new Twitch('cl-id', 'secret-value', 'https://dash.example/auth/callback');
+
+function fakeFetch(status: number, body: unknown, capture?: Request[]): typeof fetch {
+  return (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const req = input instanceof Request ? input : new Request(input, init);
+    capture?.push(req);
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { 'Content-Type': 'application/json' }
+    });
+  }) as typeof fetch;
+}
+
+// A minimal id_token whose claims pass oauth4webapi's validation against the
+// pinned issuer/client: signed payload is irrelevant here (TLS trust model).
+function idToken(claims: Record<string, unknown>): string {
+  const b64 = (v: object) => Buffer.from(JSON.stringify(v)).toString('base64url');
+  const now = Math.floor(Date.now() / 1000);
+  return [
+    b64({ alg: 'RS256', typ: 'JWT' }),
+    b64({ iss: 'https://id.twitch.tv/oauth2', aud: 'cl-id', sub: '12345', exp: now + 600, iat: now, ...claims }),
+    'sig'
+  ].join('.');
+}
+
+function tokenBody(id_token: string) {
+  return {
+    access_token: 'at',
+    refresh_token: 'rt',
+    id_token,
+    token_type: 'bearer',
+    expires_in: 12345,
+    scope: 'openid'
+  };
+}
+
+describe('generateState', () => {
+  test('is 32 random bytes as unpadded base64url', () => {
+    const seen = new Set<string>();
+    for (let i = 0; i < 32; i++) {
+      const state = generateState();
+      expect(state).toMatch(/^[A-Za-z0-9_-]{43}$/);
+      seen.add(state);
+    }
+    expect(seen.size).toBe(32);
+  });
+});
+
+describe('createAuthorizationURL', () => {
+  test('matches the arctic-era consent URL byte-for-byte', () => {
+    const url = CLIENT.createAuthorizationURL('st123', ['openid', 'user:read:email']);
+    expect(url.toString()).toBe(
+      'https://id.twitch.tv/oauth2/authorize?response_type=code&client_id=cl-id' +
+        '&state=st123&scope=openid+user%3Aread%3Aemail' +
+        '&redirect_uri=https%3A%2F%2Fdash.example%2Fauth%2Fcallback'
+    );
+  });
+
+  test('omits scope entirely when no scopes are requested', () => {
+    expect(CLIENT.createAuthorizationURL('st123', []).searchParams.get('scope')).toBeNull();
+  });
+});
+
+describe('validateAuthorizationCode', () => {
+  test('exchanges with client_secret_post credentials and returns validated claims', async () => {
+    const captured: Request[] = [];
+    const original = global.fetch;
+    global.fetch = fakeFetch(200, tokenBody(idToken({ nonce: 'n-1', preferred_username: 'Mavey' })), captured);
+    try {
+      const tokens = await CLIENT.validateAuthorizationCode('auth-code', 'n-1');
+      expect(tokens.accessToken()).toBe('at');
+      expect(tokens.refreshToken()).toBe('rt');
+      expect(tokens.claims().sub).toBe('12345');
+      expect(tokens.claims().preferred_username).toBe('Mavey');
+    } finally {
+      global.fetch = original;
+    }
+
+    expect(captured).toHaveLength(1);
+    const req = captured[0];
+    expect(req.method).toBe('POST');
+    expect(req.url).toBe('https://id.twitch.tv/oauth2/token');
+    // client_secret_post: credentials ride in the form body, exactly like the
+    // arctic-era requests Twitch has always accepted from this app. Parameter
+    // order is oauth4webapi's own; pinned so any drift is a deliberate change.
+    expect(await req.text()).toBe(
+      'redirect_uri=https%3A%2F%2Fdash.example%2Fauth%2Fcallback' +
+        '&code=auth-code&grant_type=authorization_code' +
+        '&client_id=cl-id&client_secret=secret-value'
+    );
+  });
+
+  test('rejects an id_token whose nonce does not match the stored one', async () => {
+    const original = global.fetch;
+    global.fetch = fakeFetch(200, tokenBody(idToken({ nonce: 'other-nonce' })));
+    try {
+      let caught: unknown;
+      try {
+        await CLIENT.validateAuthorizationCode('auth-code', 'expected-nonce');
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeDefined();
+      expect(caught).not.toBeInstanceOf(ResponseBodyError);
+    } finally {
+      global.fetch = original;
+    }
+  });
+
+  test('accepts a nonce-bearing id_token only via expectNoNonce when no nonce is given', async () => {
+    const original = global.fetch;
+    global.fetch = fakeFetch(200, tokenBody(idToken({})));
+    try {
+      await CLIENT.validateAuthorizationCode('auth-code', expectNoNonce);
+    } finally {
+      global.fetch = original;
+    }
+  });
+
+  test('maps a 400 OAuth error body to ResponseBodyError', async () => {
+    const original = global.fetch;
+    global.fetch = fakeFetch(400, { error: 'invalid_grant', error_description: 'code expired' });
+    try {
+      let caught: unknown;
+      try {
+        await CLIENT.validateAuthorizationCode('bad-code');
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(ResponseBodyError);
+      expect((caught as ResponseBodyError).error).toBe('invalid_grant');
+    } finally {
+      global.fetch = original;
+    }
+  });
+
+  test('a non-OAuth failure status stays outside ResponseBodyError so routes rethrow it', async () => {
+    const original = global.fetch;
+    global.fetch = fakeFetch(500, { error: 'nope' });
+    try {
+      let caught: unknown;
+      try {
+        await CLIENT.validateAuthorizationCode('any');
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).not.toBeInstanceOf(ResponseBodyError);
+    } finally {
+      global.fetch = original;
+    }
+  });
+});
+
+describe('OAuth2Tokens', () => {
+  test('refuses to hand out missing token fields', () => {
+    const tokens = new OAuth2Tokens({});
+    expect(() => tokens.accessToken()).toThrow('access_token');
+    expect(() => tokens.refreshToken()).toThrow('refresh_token');
+    expect(() => tokens.claims()).toThrow('no ID Token');
+  });
+});

--- a/console/shared/lib/server/oauth.ts
+++ b/console/shared/lib/server/oauth.ts
@@ -1,0 +1,124 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+// Twitch OAuth2/OIDC client built on oauth4webapi (Panva's maintained protocol
+// library — the successor ecosystem to the deprecated `arctic` package this
+// used to be). This module is only arg-marshaling: every protocol-sensitive
+// step — client_secret_post encoding, the token request itself, and ID Token
+// claim validation (iss, aud, exp, nonce) — happens inside oauth4webapi.
+//
+// Twitch metadata is pinned rather than discovered: discovery would add a
+// network round trip and failure mode to every cold login for three endpoints
+// that have been stable for years. Same trust model as arctic: the id_token
+// claims are validated against the pinned issuer/client but the JWS signature
+// is not checked (the token arrives over a direct TLS call to
+// id.twitch.tv, which is the issuer-verification substitute RFC-wise;
+// oauth4webapi.validateApplicationLevelSignature exists if that ever needs
+// tightening).
+//
+// Nonce policy (tightened vs arctic-era code): when a nonce value is supplied,
+// oauth4webapi asserts it matches the id_token nonce claim; when it is not,
+// expectNoNonce asserts the token carries none. Callers must therefore always
+// pass either the stored cookie nonce or expectNoNonce — a login whose
+// oauth_nonce cookie vanished fails closed instead of skipping the check.
+import {
+  authorizationCodeGrantRequest,
+  ClientSecretPost,
+  expectNoNonce,
+  generateRandomState,
+  getValidatedIdTokenClaims,
+  nopkce,
+  processAuthorizationCodeResponse,
+  skipStateCheck,
+  validateAuthResponse,
+  type AuthorizationServer,
+  type Client,
+  type ClientAuth,
+  type IDToken,
+  ResponseBodyError
+} from 'oauth4webapi';
+
+export { ResponseBodyError, expectNoNonce };
+export const generateState = generateRandomState;
+
+const TWITCH_AS: AuthorizationServer = {
+  issuer: 'https://id.twitch.tv/oauth2',
+  authorization_endpoint: 'https://id.twitch.tv/oauth2/authorize',
+  token_endpoint: 'https://id.twitch.tv/oauth2/token'
+};
+
+export class OAuth2Tokens {
+  constructor(private readonly result: Record<string, unknown>) {}
+
+  accessToken(): string {
+    if (typeof this.result.access_token === 'string') return this.result.access_token;
+    throw new Error("Missing or invalid 'access_token' field");
+  }
+
+  refreshToken(): string {
+    if (typeof this.result.refresh_token === 'string') return this.result.refresh_token;
+    throw new Error("Missing or invalid 'refresh_token' field");
+  }
+
+  // Claims come back already validated (issuer, audience, expiry, nonce) by
+  // processAuthorizationCodeResponse's ID Token processing.
+  claims(): IDToken {
+    const claims = getValidatedIdTokenClaims(this.result as never);
+    if (!claims) throw new Error('Token response carried no ID Token claims');
+    return claims;
+  }
+}
+
+export class Twitch {
+  private readonly client: Client;
+  private readonly clientAuth: ClientAuth;
+
+  constructor(
+    private readonly clientId: string,
+    clientSecret: string,
+    private readonly redirectURI: string
+  ) {
+    this.client = { client_id: clientId };
+    // client_secret_post matches what Twitch expects and what arctic sent:
+    // credentials in the form body, not an Authorization header.
+    this.clientAuth = ClientSecretPost(clientSecret);
+  }
+
+  createAuthorizationURL(state: string, scopes: string[]): URL {
+    const url = new URL(TWITCH_AS.authorization_endpoint!);
+    url.searchParams.set('response_type', 'code');
+    url.searchParams.set('client_id', this.clientId);
+    url.searchParams.set('state', state);
+    if (scopes.length > 0) url.searchParams.set('scope', scopes.join(' '));
+    url.searchParams.set('redirect_uri', this.redirectURI);
+    return url;
+  }
+
+  async validateAuthorizationCode(
+    code: string,
+    nonce?: string | typeof expectNoNonce
+  ): Promise<OAuth2Tokens> {
+    // validateAuthResponse is the library's own callback sanity gate (rejects
+    // provider error responses, missing code); state was already compared
+    // against the HttpOnly cookie by the routes, so it's skipped here.
+    const callbackParameters = validateAuthResponse(
+      TWITCH_AS,
+      this.client,
+      new URLSearchParams({ code }),
+      skipStateCheck
+    );
+    const response = await authorizationCodeGrantRequest(
+      TWITCH_AS,
+      this.client,
+      this.clientAuth,
+      callbackParameters,
+      this.redirectURI,
+      nopkce
+    );
+    const result = await processAuthorizationCodeResponse(TWITCH_AS, this.client, response, {
+      requireIdToken: true,
+      ...(nonce ? { expectedNonce: nonce } : {})
+    });
+    return new OAuth2Tokens(result as unknown as Record<string, unknown>);
+  }
+}

--- a/console/shared/package.json
+++ b/console/shared/package.json
@@ -20,6 +20,7 @@
     "./server/hooks": "./lib/server/hooks.ts",
     "./server/boot": "./lib/server/boot.ts",
     "./server/nats": "./lib/server/nats.ts",
+    "./server/oauth": "./lib/server/oauth.ts",
     "./server/service": "./lib/server/service.ts",
     "./server/rum": "./lib/server/rum.ts",
     "./server/resilience": "./lib/server/resilience.ts",
@@ -45,6 +46,7 @@
     "lenis": "^1.3.18",
     "motion": "^12.0.0",
     "nats": "^2.29.2",
+    "oauth4webapi": "^3.8.7",
     "pino": "^9",
     "three": "^0.185.0"
   },

--- a/docs/src/content/docs/architecture/index.md
+++ b/docs/src/content/docs/architecture/index.md
@@ -46,7 +46,7 @@ flowchart TB
 
 | Party | Relationship |
 |---|---|
-| **Broadcaster / chatter** | Drives the bot through Twitch chat and EventSub; configures it through the console (Twitch OAuth via arctic). |
+| **Broadcaster / chatter** | Drives the bot through Twitch chat and EventSub; configures it through the console (Twitch OAuth via oauth4webapi). |
 | **Operator** | Runs the bot. Reaches the admin console and `kubectl` over the Tailscale tailnet only; no public path. |
 | **Twitch** | Source of EventSub events (ingress) and target for chat sends + EventSub management (outgress), via the Helix API and the bot account token. |
 | **Tebex** | Monetization. Purchase records flow into the transactions service and promote a broadcaster's tier (paid). |

--- a/docs/src/content/docs/microservices/console.md
+++ b/docs/src/content/docs/microservices/console.md
@@ -11,6 +11,6 @@ The Console (`console/`) is a SvelteKit (SSR) application that serves as the pri
 
 - **Broadcaster Dashboard**: Provides self-serve management for custom commands, module toggles, and notification viewing.
 - **Admin Operator Interface**: Provides elevated views and controls for system operators (e.g., shard fleet monitoring, global user management, system-wide announcements).
-- **Authentication**: End users authenticate via Twitch OAuth (using the `arctic` library). The grants are verified and persisted by the [Users](/microservices/users/) service via `grant_save`.
+- **Authentication**: End users authenticate via Twitch OAuth (using the `oauth4webapi` library). The grants are verified and persisted by the [Users](/microservices/users/) service via `grant_save`.
 - **Communication**: The Console does not connect to the database. It talks exclusively to the backend Go services over NATS RPC via an internal adapter.
 - **Exposure**: Hosted behind a `cloudflared` tunnel, exposing it securely to the public internet for end-users, while the admin sections are strictly gatekept.

--- a/docs/src/content/docs/microservices/index.md
+++ b/docs/src/content/docs/microservices/index.md
@@ -15,8 +15,9 @@ for events, request-reply for RPC. No service reads another service's database.
 | Service | Repo path | Language | Owns / does | Exposes |
 |---|---|---|---|---|
 | [Twitch Ingress](/microservices/twitch-ingress/) | `app/ingress/` | Elixir (OTP 27+) | EventSub Conduit + WebSocket shards; per-shard supervision; tenant OAuth; filter-and-normalize events | `twitch.ingress.event.*`, `twitch.ingress.status.*`, `twitch.ingress.admin.shards.get` |
+| [YouTube Ingress](/microservices/youtube-ingress/) | `app/yt-ingress/` | Elixir (OTP 27+) | Per-channel `liveChatMessages.streamList` gRPC streams; broadcast discovery watcher; token leasing over RPC; normalize events | `youtube.ingress.event.*`, `youtube.ingress.status.*`, `youtube.ingress.admin.chats.get` |
 | [Sesame](/microservices/sesame/) | `app/sesame/` | Go | Core engine and command processor; consumes ingress events, runs module handlers and commands, routes to outgress | consumes `twitch.ingress.event.*`; publishes to `twitch.outgress.*` |
-| [Outgress](/microservices/outgress/) | `app/outgress/` | Go | Sends to Twitch; per-broadcaster rate limit (Valkey); channel registry; app/user token lifecycle; kill switch | consumes `twitch.outgress.*`; serves `bagel.rpc.outgress.*` |
+| [Outgress](/microservices/outgress/) | `app/outgress/` | Go | Sends to Twitch and YouTube Live Chat; per-broadcaster rate limit + daily quota budget (Valkey); channel registry; token lifecycle; kill switch | consumes `twitch.outgress.*`, `youtube.outgress.*`; serves `bagel.rpc.outgress.*` |
 | [Projector](/microservices/projector/) | `app/projector/` | Go | Builds the Valkey settings projection on stream-online; serves broadcaster tier lookups | `bagel.rpc.broadcaster.status.get` |
 | [Users](/microservices/users/) | `app/users/` | Go | User accounts, status (free/paid/vip), active toggle, Twitch OAuth tokens | `bagel.rpc.dashboard.*`, `bagel.rpc.admin.user.*`, `bagel.rpc.internal.projection.users.get`, `bagel.rpc.internal.tokens.*`; emits `data.users.*` |
 | [Commands](/microservices/commands/) | `app/commands/` | Go | Custom chat commands | `bagel.rpc.commands.*`, `bagel.rpc.internal.projection.commands.get`; emits `data.commands.changed` |
@@ -24,7 +25,7 @@ for events, request-reply for RPC. No service reads another service's database.
 | [Notifications](/microservices/notifications/) | `app/notifications/` | Go | Dashboard notifications, admin announcements, and TTL cleanup | `bagel.rpc.notifications.*`, `bagel.rpc.admin.notifications.*` |
 | [Transactions](/microservices/transactions/) | `app/transactions/` | Go | Tebex purchase records | consumes `data.transactions.recorded` |
 | [Admin](/microservices/admin/) (legacy) | `app/admin/` | Go + templ | Read-only operator window over NATS (shard fleet, users) | Operators only, over the tailnet |
-| [Console](/microservices/console/) | `console/` | SvelteKit SSR | `dashboard` (broadcaster self-serve) + `admin` (operator); arctic OAuth | HTTPS via cloudflared / tailnet; talks to services only over NATS RPC |
+| [Console](/microservices/console/) | `console/` | SvelteKit SSR | `dashboard` (broadcaster self-serve) + `admin` (operator); oauth4webapi OAuth | HTTPS via cloudflared / tailnet; talks to services only over NATS RPC |
 | [Web](/microservices/web/) | `web/` | Astro | Public marketing site and documentation | Public HTTPS |
 
 See [System state](/reference/system-overview/) for the data plane, the bus, and
@@ -60,5 +61,5 @@ and a `bagel.cache.invalidate.broadcaster` publish reconverges cached readers.
 - **Mesh**: Linkerd native-sidecar provides mTLS between meshed services. The
   legacy admin tool is intentionally **not** meshed and is reachable only over
   Tailscale, with tailnet ACLs as its access control (see [Networking](/infrastructure/networking/)).
-- **OAuth**: the console authenticates end users with arctic (Twitch OAuth);
+- **OAuth**: the console authenticates end users with oauth4webapi (Twitch OAuth);
   broadcaster grants are persisted by the users service via `grant_save`.

--- a/docs/src/content/docs/reference/system-overview.md
+++ b/docs/src/content/docs/reference/system-overview.md
@@ -31,7 +31,7 @@ the source of truth.
 | **modules** | `app/modules/` | Go | Feature modules per broadcaster; emits `data.modules.changed` |
 | **transactions** | `app/transactions/` | Go | Tebex purchase records; consumes `data.transactions.recorded` |
 | **admin** (legacy) | `app/admin/` | Go + templ | Read-only operator window over NATS (shard fleet, users); being superseded by the console |
-| **console** | `console/` | SvelteKit SSR | `dashboard` (broadcaster self-serve) and `admin` (operator) apps; arctic OAuth; talks to services only over NATS RPC |
+| **console** | `console/` | SvelteKit SSR | `dashboard` (broadcaster self-serve) and `admin` (operator) apps; oauth4webapi OAuth; talks to services only over NATS RPC |
 
 ## Data plane
 


### PR DESCRIPTION
Closes #475 (arctic row; nats row tracked for a follow-up).

## Why not better-auth / another framework
better-auth would own sessions and user storage, displacing the sealed-cookie session model and the users-service registration flow — exactly the dashboard breakage this change must avoid. [arctic's author](https://pilcrowonpaper.com/blog/18) recommends a maintained protocol library over a generic provider collection, so the client now wraps **oauth4webapi** (Panva / same ecosystem as openid-client & jose, zero transitive deps, Bun-compatible).

## Shape
- `console/shared/lib/server/oauth.ts` — thin adapter over oauth4webapi exposing the same facade the routes already used (`generateState`, `Twitch.createAuthorizationURL`, `validateAuthorizationCode`, error type). All protocol-sensitive work is library code: client_secret_post encoding, token exchange, callback sanity gate (`validateAuthResponse`), ID Token claim validation (iss/aud/exp/nonce).
- Routes swap imports only; failure slugs (`e=state`, `e=oauth`) unchanged.
- Twitch metadata pinned (no discovery hop); same TLS trust model as before — no JWKS fetch added to the login path.

## Behavior notes (fail-closed tightenings)
- id_token claims are library-validated rather than hand-checked.
- A login whose `oauth_nonce` cookie vanished now redirects to `/login?e=state` instead of skipping replay protection. Normal flows are byte-identical: consent URLs and the token request body are pinned by golden tests.

## Verification
- `bun test shared` 160 pass · `bun test admin` 14 pass
- `svelte-check` 0 errors in dashboard + admin (1 pre-existing CSS warning on main)
- Both production builds pass demo-gate / i18n / production-clean gates
- `arctic` + `@oslojs/*` gone from `bun.lock`

## Follow-up
The `nats` deprecation row in #475 needs its own PR: `@nats-io/transport-node` is not drop-in (JetStream/KV split into separate modules) and sits under every console RPC call — deserves live-NATS verification against hub/leaf topology.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Twitch sign-in validation with safer nonce handling and consistent OAuth error responses.
  - Authentication callbacks now process verified identity claims more reliably.

- **Documentation**
  - Updated Console authentication and architecture documentation.
  - Expanded service documentation for YouTube Ingress, YouTube Live Chat, and related messaging.

- **Tests**
  - Added comprehensive coverage for Twitch authorization, token validation, nonce handling, error responses, and missing token data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->