### PR TITLE
chore(deploy): atomic publish wire on hub publishers + sesame pull-consume tunables

### DIFF
--- a/deploy/k8s/commands.yaml
+++ b/deploy/k8s/commands.yaml
@@ -133,6 +133,10 @@ spec:
               value: tls://nats.messaging:4222
             - name: NATS_HUB_PUBLISH_URL
               value: tls://nats.messaging:4222
+            - name: NATS_PUBLISH_WIRE
+              value: atomic
+            - name: NATS_ATOMIC_PUBLISH_BATCH_SIZE
+              value: "1000"
             # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS
             # server's native-TLS cert; read as RootCAs by pkg/bus (Go services)
             # and the console nats lib (TS).

--- a/deploy/k8s/loyalty.yaml
+++ b/deploy/k8s/loyalty.yaml
@@ -131,6 +131,10 @@ spec:
               value: tls://nats-leaf.messaging:4222
             - name: NATS_HUB_URL
               value: tls://nats.messaging:4222
+            - name: NATS_PUBLISH_WIRE
+              value: atomic
+            - name: NATS_ATOMIC_PUBLISH_BATCH_SIZE
+              value: "1000"
             # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS
             # server's native-TLS cert; read as RootCAs by pkg/bus (Go services)
             # and the console nats lib (TS).

--- a/deploy/k8s/modules.yaml
+++ b/deploy/k8s/modules.yaml
@@ -133,6 +133,10 @@ spec:
               value: tls://nats.messaging:4222
             - name: NATS_HUB_PUBLISH_URL
               value: tls://nats.messaging:4222
+            - name: NATS_PUBLISH_WIRE
+              value: atomic
+            - name: NATS_ATOMIC_PUBLISH_BATCH_SIZE
+              value: "1000"
             # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS
             # server's native-TLS cert; read as RootCAs by pkg/bus (Go services)
             # and the console nats lib (TS).

--- a/deploy/k8s/outgress.yaml
+++ b/deploy/k8s/outgress.yaml
@@ -144,6 +144,10 @@ spec:
               value: tls://nats-leaf.messaging:4222
             - name: NATS_HUB_URL
               value: tls://nats.messaging:4222
+            - name: NATS_PUBLISH_WIRE
+              value: atomic
+            - name: NATS_ATOMIC_PUBLISH_BATCH_SIZE
+              value: "1000"
             # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS
             # server's native-TLS cert; read as RootCAs by pkg/bus (Go services)
             # and the console nats lib (TS).

--- a/deploy/k8s/projector.yaml
+++ b/deploy/k8s/projector.yaml
@@ -143,6 +143,10 @@ spec:
               value: tls://nats.messaging:4222
             - name: NATS_HUB_PUBLISH_URL
               value: tls://nats.messaging:4222
+            - name: NATS_PUBLISH_WIRE
+              value: atomic
+            - name: NATS_ATOMIC_PUBLISH_BATCH_SIZE
+              value: "1000"
             # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS
             # server's native-TLS cert; read as RootCAs by pkg/bus (Go services)
             # and the console nats lib (TS).

--- a/deploy/k8s/sesame.yaml
+++ b/deploy/k8s/sesame.yaml
@@ -151,6 +151,10 @@ spec:
               value: tls://nats.messaging:4222
             - name: NATS_HUB_PUBLISH_URL
               value: tls://nats.messaging:4222
+            - name: NATS_PUBLISH_WIRE
+              value: atomic
+            - name: NATS_ATOMIC_PUBLISH_BATCH_SIZE
+              value: "1000"
             # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS
             # server's native-TLS cert; read as RootCAs by pkg/bus (Go services)
             # and the console nats lib (TS).
@@ -220,6 +224,12 @@ spec:
               value: "on"
             - name: NATS_CONSUME_MODE
               value: pull
+            - name: NATS_PULL_FETCH_LOOPS
+              value: "8"
+            - name: NATS_PULL_MAX_ACK_PENDING
+              value: "200000"
+            - name: NATS_PULL_FETCH_BATCH
+              value: "1000"
             # PARTITION FLAG. "on" reshapes the ingress lane catalog to the
             # two-stream partition (narrow TWITCH_INGRESS, create
             # TWITCH_INGRESS_STANDARD) on the next sesame reconcile. Ships off

--- a/deploy/k8s/users.yaml
+++ b/deploy/k8s/users.yaml
@@ -139,6 +139,10 @@ spec:
               value: tls://nats.messaging:4222
             - name: NATS_HUB_PUBLISH_URL
               value: tls://nats.messaging:4222
+            - name: NATS_PUBLISH_WIRE
+              value: atomic
+            - name: NATS_ATOMIC_PUBLISH_BATCH_SIZE
+              value: "1000"
             # Fleet CA (trust-manager fleet-ca ConfigMap) to verify the NATS
             # server's native-TLS cert; read as RootCAs by pkg/bus (Go services)
             # and the console nats lib (TS).


### PR DESCRIPTION
## Summary

Env-only rollout manifests — no code defaults touched:

1. **Atomic publish wire** on the seven hub-publisher services: `NATS_PUBLISH_WIRE=atomic`, `NATS_ATOMIC_PUBLISH_BATCH_SIZE=1000` → sesame, outgress, users, commands, loyalty, modules, projector.
2. **Pull-mode consumption** on sesame only (it owns the hot ingress lanes): `NATS_PULL_FETCH_LOOPS=8`, `NATS_PULL_MAX_ACK_PENDING=200000`, `NATS_PULL_FETCH_BATCH=1000`. `NATS_CONSUME_FLOW=on` / `NATS_CONSUME_MODE=pull` were already pinned in sesame.yaml.

**Exclusions (verified by manifest evidence):** twitch-ingress is Elixir and already atomic; gossip, notifications, transactions carry no hub publisher env (their manifests state "RPC-only … no NATS_HUB_URL", "never touches JetStream"); console-admin/console-dashboard lack the hub publisher env.

## Prerequisites verified

- Retry lane provisioning: app/sesame/main.go:80 reconciles it when flow is on:
  `owned = append(owned, bus.TwitchIngressRetryStream)`
- Pull health recovery fix is on main via #635 ("install the result watch before the delivery handoff" — pkg/bus/concurrent_subscriber.go).
- Broker ACL grant for `$JS.API.CONSUMER.MSG.NEXT` on worker_bus must already be live (nats-auth.conf) — sesame's manifest flags it as a hard prerequisite for pull fetches.

## ⚠️ Staged rollout order

**Merge ≠ flip everything at once.**

1. Roll **sesame first** — it provisions TWITCH_INGRESS_RETRY plus the pull durables on its next reconcile.
2. Then roll the remaining publishers (they are independent of the consume side).

**Rollback:** remove the two `NATS_CONSUME_*`… i.e. set `NATS_CONSUME_FLOW=off` (one-word diff back); publishers roll back independently by dropping the `NATS_PUBLISH_WIRE` env.

## Measured expectations

- Publish: ~117k/s stored on a single stream with atomic cohorts.
- Drain scales per-pod from the 59k/s baseline.
- Commit RTT ≤10ms below saturation.

## Test plan

- [x] `go build ./pkg/bus ./deploy/...`
- [x] `go test ./pkg/bus -count=1`
- [x] `go test ./deploy/... -count=1` (manifest locality/auth tests)
- [x] All seven manifests parse as multi-doc YAML, zero duplicate env names


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Enabled atomic message publishing across core services, using batches of up to 1,000 messages.
  * Tuned message consumption for improved throughput, including parallel fetch loops and larger fetch batches.
  * Increased the maximum number of pending acknowledgements supported by the message consumer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->