### PR TITLE
fix(security): red-team follow-ups

### DIFF
--- a/app/gossip/internal/providers/mcsr/mcsr.go
+++ b/app/gossip/internal/providers/mcsr/mcsr.go
@@ -207,9 +207,15 @@ func (p *api) admit(isPremium bool) func(context.Context) error {
 }
 
 // fetchUser loads a player's live standing straight from the API.
+//
+// Account is raw chat text and was proven live (red-team F2) to parse as URL
+// syntax when interpolated bare: "?x=1" became a query string, "#x" a
+// fragment, each forcing upstream calls with attacker-chosen shape while
+// carrying the provider's API-key headers. Every path segment below is
+// therefore escaped individually - a segment may never change the request.
 func (p *api) fetchUser(ctx context.Context, account string) (gossiprpc.McsrUserReply, error) {
 	var resp userResponse
-	if err := p.http.GetJSON(ctx, "/users/"+strings.TrimSpace(account), nil, &resp); err != nil {
+	if err := p.http.GetJSON(ctx, "/users/"+url.PathEscape(strings.TrimSpace(account)), nil, &resp); err != nil {
 		return gossiprpc.McsrUserReply{}, err
 	}
 	d := resp.Data
@@ -644,7 +650,7 @@ func (p *api) fetchLastMatch(ctx context.Context, account string, season int) (m
 	if season > 0 {
 		q.Set("season", strconv.Itoa(season))
 	}
-	if err := p.http.GetJSON(ctx, "/users/"+strings.TrimSpace(account)+"/matches", q, &resp); err != nil {
+	if err := p.http.GetJSON(ctx, "/users/"+url.PathEscape(strings.TrimSpace(account))+"/matches", q, &resp); err != nil {
 		return matchesResponse{}, err
 	}
 	return resp, nil
@@ -672,7 +678,7 @@ func (p *api) fetchVersus(ctx context.Context, q versusQuery) (versusResponse, e
 	if q.Season > 0 {
 		vals = url.Values{"season": {strconv.Itoa(q.Season)}}
 	}
-	path := "/users/" + strings.TrimSpace(q.A) + "/versus/" + strings.TrimSpace(q.B)
+	path := "/users/" + url.PathEscape(strings.TrimSpace(q.A)) + "/versus/" + url.PathEscape(strings.TrimSpace(q.B))
 	if err := p.http.GetJSON(ctx, path, vals, &resp); err != nil {
 		return versusResponse{}, err
 	}

--- a/app/sesame/engine/loyalty_config.go
+++ b/app/sesame/engine/loyalty_config.go
@@ -46,13 +46,22 @@ type LoyaltyModuleConfig struct {
 	WatchPointsPerTick int64 `json:"watchPointsPerTick"`
 }
 
-// rate applies the zero-default / negative-off convention.
+// maxRate caps any configured points rate. Downstream math multiplies rates
+// by per-event quantities (bits per cheer, months per sub); a broadcaster-set
+// config near MaxInt64 wraps that product negative — self-inflicted negative
+// balances, but still an int64 overflow class we can delete outright. 1e9
+// points per event is past any sane economy.
+const maxRate = int64(1_000_000_000)
+
+// rate applies the zero-default / negative-off convention, plus the ceiling.
 func rate(v, def int64) int64 {
 	switch {
 	case v == 0:
 		return def
 	case v < 0:
 		return 0
+	case v > maxRate:
+		return maxRate
 	default:
 		return v
 	}

--- a/console/admin/src/lib/server/demo-data.ts
+++ b/console/admin/src/lib/server/demo-data.ts
@@ -197,7 +197,7 @@ export function demoSecretsBundle(ids: readonly SecretServiceId[]): DemoSecretsB
       dbUser: `${id}_svc_r1demo00`,
       autoMigrate: 'false',
       canReadDoppler: true,
-      tokenSource: id === 'users' ? 'scoped' : 'legacy'
+      tokenSource: 'scoped'
     })),
     tokens: {
       users: [
@@ -213,13 +213,11 @@ export function demoSecretsBundle(ids: readonly SecretServiceId[]): DemoSecretsB
     scope: {
       sources: {
         users: 'scoped',
-        commands: 'legacy',
-        modules: 'legacy',
-        transactions: 'legacy',
-        notifications: 'legacy'
-      },
-      legacyInUse: true,
-      legacyExcessProjects: ['admin', 'dashboard', 'gossip']
+        commands: 'scoped',
+        modules: 'scoped',
+        transactions: 'scoped',
+        notifications: 'scoped'
+      }
     }
   };
 }

--- a/console/admin/src/lib/server/secrets.ts
+++ b/console/admin/src/lib/server/secrets.ts
@@ -4,11 +4,13 @@
 // Secrets console backend: per-service database credentials plus Doppler
 // service-token minting, on least-privileged Doppler access.
 //
-// Token model (least privilege):
-//   DOPPLER_TOKEN_<SERVICE>   — per-service Doppler token scoped to that one
-//                               project (users/commands/…). Preferred.
-//   DOPPLER_MANAGEMENT_TOKEN  — legacy broad token, used only as a fallback
-//                               and flagged as over-privileged in the UI.
+// Token model (least privilege): every service must resolve its own
+// DOPPLER_TOKEN_<SERVICE>, scoped to that one project (users/commands/…).
+// There is deliberately NO broad-token fallback — DOPPLER_MANAGEMENT_TOKEN /
+// generic DOPPLER_TOKEN used to be consulted when a scoped token was missing,
+// which turned any console-admin compromise into read access to all five DB
+// projects plus token minting (red-team finding F-secrets). Missing now means
+// missing: the UI reports it instead of silently escalating privilege.
 // Minted service tokens are always read-only and scoped to a single config —
 // the narrowest credential Doppler can issue.
 import { env } from '$env/dynamic/private';
@@ -44,19 +46,13 @@ export function serviceOf(raw: string): SecretServiceId | null {
 
 // ── Doppler token resolution ─────────────────────────────────────────────────
 
-export type TokenSource = 'scoped' | 'legacy' | 'missing';
-
-function legacyToken(): string {
-  return (env.DOPPLER_MANAGEMENT_TOKEN ?? env.DOPPLER_TOKEN ?? '').trim();
-}
+export type TokenSource = 'scoped' | 'missing';
 
 // tokenFor picks the narrowest credential available for a service and reports
 // which tier it came from, so the UI can tell the truth about privilege.
 export function tokenFor(svc: ServiceDef): { token: string; source: TokenSource } {
   const scoped = (env[`DOPPLER_TOKEN_${svc.id.toUpperCase()}`] ?? '').trim();
   if (scoped) return { token: scoped, source: 'scoped' };
-  const legacy = legacyToken();
-  if (legacy) return { token: legacy, source: 'legacy' };
   return { token: '', source: 'missing' };
 }
 
@@ -92,40 +88,15 @@ function dopplerBody(svc: ServiceDef, extra: Record<string, unknown>): RequestIn
 // ── Scope report ─────────────────────────────────────────────────────────────
 
 export interface ScopeReport {
-  // Which tier each service resolves to.
+  // Which tier each service resolves to ('scoped' or 'missing').
   sources: Record<SecretServiceId, TokenSource>;
-  // True when at least one service still falls back to the broad legacy token.
-  legacyInUse: boolean;
-  // Projects visible to the legacy token beyond the five service projects —
-  // concrete evidence of over-privilege ([] when unknown or clean).
-  legacyExcessProjects: string[];
-}
-
-async function visibleProjects(token: string): Promise<string[] | null> {
-  try {
-    const res = await dopplerFetch({ token, path: '/v3/projects?per_page=100' });
-    const body = (await res.json()) as { projects?: { slug?: string; name?: string }[] };
-    return (body.projects ?? []).map((p) => p.slug ?? p.name ?? '').filter(Boolean);
-  } catch {
-    // A properly scoped token often cannot list projects at all; that is not
-    // an error worth surfacing, just an unknown.
-    return null;
-  }
 }
 
 export async function scopeReport(): Promise<ScopeReport> {
   const sources = Object.fromEntries(
     serviceIds().map((id) => [id, tokenFor(services[id]).source])
   ) as Record<SecretServiceId, TokenSource>;
-
-  const legacyInUse = Object.values(sources).includes('legacy');
-  let legacyExcessProjects: string[] = [];
-  if (legacyInUse) {
-    const allowed = new Set(serviceIds().map((id) => services[id].project));
-    const visible = await visibleProjects(legacyToken());
-    legacyExcessProjects = (visible ?? []).filter((p) => !allowed.has(p));
-  }
-  return { sources, legacyInUse, legacyExcessProjects };
+  return { sources };
 }
 
 // ── Config secrets (DB credential status) ────────────────────────────────────

--- a/console/admin/src/routes/(admin)/secrets/+page.svelte
+++ b/console/admin/src/routes/(admin)/secrets/+page.svelte
@@ -8,7 +8,6 @@
     Icon,
     Button,
     PageHead,
-    AlertBanner,
     ConfirmDialog,
     Modal,
     Skeleton,
@@ -186,15 +185,7 @@
       <Skeleton variant="block" height="200px" />
     </div>
   {:else}
-    {#if scope?.legacyInUse}
-      <AlertBanner>
-        {Object.values(scope.sources).filter((s) => s === 'legacy').length} of {services.length}
-        services still use the broad legacy Doppler token
-        {#if scope.legacyExcessProjects.length}
-          — it can also reach {scope.legacyExcessProjects.join(', ')}
-        {/if}. Set DOPPLER_TOKEN_&lt;SERVICE&gt; per project to finish the least-privilege migration.
-      </AlertBanner>
-    {:else if scope}
+    {#if scope}
       <p class="scope-ok">
         <Icon name="check" size={13} /> Every service resolves a per-project scoped Doppler token.
       </p>

--- a/deploy/db/status-routes.yaml
+++ b/deploy/db/status-routes.yaml
@@ -103,6 +103,21 @@ spec:
     path: /status
 ---
 apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: status-ratelimit
+  namespace: db
+spec:
+  # Mirrors deploy/k8s/status-routes.yaml: the app half shipped this limiter,
+  # this copy didn't, leaving seven backends hammerable at line rate by anyone
+  # who can reach health.itsbagelbot.com (red-team finding F3b).
+  rateLimit:
+    average: 1
+    burst: 10
+    sourceCriterion:
+      requestHeaderName: CF-Connecting-IP
+---
+apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
   name: service-status
@@ -163,7 +178,7 @@ spec:
       middlewares: [{name: status-path}]
       services:
         - name: transactions
-          port: 80
+          port: 443
           scheme: https
           serversTransport: transactions-transport
           nativeLB: true
@@ -246,25 +261,6 @@ spec:
   serverName: users-status
   rootCAsSecrets:
     - users-tls
----
-# Tebex webhook + checkout callbacks; moved with the transactions pods.
-apiVersion: traefik.io/v1alpha1
-kind: IngressRoute
-metadata:
-  name: transactions-webhooks
-  namespace: db
-spec:
-  entryPoints: [websecure]
-  routes:
-    - match: Host(`webhooks.itsbagelbot.com`) && (PathPrefix(`/tebex`) || PathPrefix(`/webhooks/tebex`))
-      kind: Rule
-      services:
-        - name: transactions
-          port: 80
-          scheme: https
-          serversTransport: transactions-transport
-          nativeLB: true
-  tls: {}
 ---
 apiVersion: traefik.io/v1alpha1
 kind: ServersTransport

--- a/deploy/k8s/web-error-pages.yaml
+++ b/deploy/k8s/web-error-pages.yaml
@@ -2,20 +2,27 @@
 # Proprietary. No license granted. See LICENSE.md.
 
 # Unrouted hostnames at the traefik edge (anything the tunnel wildcard admits
-# that no router claims) proxy straight through to the marketing site, path
-# intact. An unknown path gets web/'s coded 404 page under a genuine 404
-# status — and because the path is NOT rewritten, the page's own assets
-# (/_astro/*, styles, fonts) resolve through the same catch-all to the real
-# files with the right MIME types. (The first cut rewrote every path to a
-# 404-forcing one, which turned each asset request into an HTML error page:
-# MIME refusals and CSP noise all the way down.)
+# that no router claims) get a 302 to the canonical branded 404:
+# https://itsbagelbot.com/404
 #
-# The marketing apex resolves to Cloudflare's static hosting directly (NOT back
-# through the tunnel — verified: the apex serves with no tunnel route present),
-# so proxying to it cannot loop into cloudflared.
+# History, so nobody re-litigates it blindly:
+#   v1 proxied every unmatched host straight to the apex, path intact — great
+#   branded pages, but ANY forgotten subdomain silently served production
+#   content publicly (wildcard DNS + tunnel admit Host(*)), and the route
+#   doubled as an origin-fetch primitive for whatever Host a client invented.
+#   v2 deleted the fallback entirely — failed closed, but lost the branded
+#   page. Owner call: the 404 must live at itsbagelbot.com/404.
+#   v3 (this): redirect-only. A redirect hands back a Location header and
+#   serves nothing from our origin on unclaimed names, and the attacker-
+#   supplied path is discarded rather than forwarded. Temporary (not
+#   permanent) so browsers never cache a mapping for a name we may later
+#   route deliberately.
 #
-# Requires providers.kubernetesCRD.allowExternalNameServices=true in the
-# traefik HelmChartConfig (deploy/infra/cluster/traefik-config.yaml).
+# The web-origin ExternalName + ServersTransport are kept as the route's
+# backend formality: the redirect middleware answers before any dial happens,
+# so nothing is ever fetched through them here. Requires
+# providers.kubernetesCRD.allowExternalNameServices=true in the traefik
+# HelmChartConfig (deploy/infra/cluster/traefik-config.yaml).
 apiVersion: v1
 kind: Service
 metadata:
@@ -40,6 +47,19 @@ spec:
   serverName: itsbagelbot.com
 ---
 apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: unrouted-host-404
+  namespace: app
+spec:
+  redirectRegex:
+    # Anything about the request beyond its presence is discarded: scheme,
+    # host and path all collapse to the one canonical URL.
+    regex: .*
+    replacement: https://itsbagelbot.com/404
+    permanent: false
+---
+apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
   name: unrouted-host-fallback
@@ -52,11 +72,12 @@ spec:
     - match: HostRegexp(`^.+$`)
       kind: Rule
       priority: 1
+      middlewares:
+        - name: unrouted-host-404
       services:
         - name: web-origin
           port: 443
           scheme: https
           serversTransport: web-origin-transport
-          # Host must be the marketing site for Cloudflare to route it.
           passHostHeader: false
   tls: {}

--- a/deploy/messaging/network-policies.yaml
+++ b/deploy/messaging/network-policies.yaml
@@ -1,0 +1,77 @@
+# Copyright (c) 2026 Adam Ousmer. All rights reserved.
+# Proprietary. No license granted. See LICENSE.md.
+
+# East-west gate for the messaging namespace (red-team finding F5). app/db ship
+# default-deny policies; messaging had none, so one popped pod anywhere could
+# enumerate the fleet over NATS's UNAUTHENTICATED monitor/profiling listeners —
+# connz/jsz/subsz leak account names, consumer lag and peer IPs.
+#
+# Shape mirrors deploy/k8s/network-policies.yaml: default-deny first, then
+# explicit allows (policies union). Data-plane ports stay reachable cluster-
+# wide on purpose — every service already holds NATS credentials by design;
+# the monitor ports are what needed gating.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-nats
+  namespace: messaging
+spec:
+  podSelector:
+    matchLabels:
+      app: nats
+  policyTypes: [Ingress]
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-nats-data-plane
+  namespace: messaging
+spec:
+  # Clients live across the app and db namespaces; leafnodes and cluster routes
+  # stay inside messaging itself. 7422 is the websocket listener.
+  podSelector:
+    matchLabels:
+      app: nats
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: app
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: db
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: messaging
+      ports:
+        - port: 4222
+        - port: 4223
+        - port: 6222
+        - port: 6223
+        - port: 7422
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-nats-monitor
+  namespace: messaging
+spec:
+  # Monitor/profiling only from namespaces with a reason to look: the
+  # observability stack, and the tailscale ProxyGroup fronting
+  # nats-monitoring.tail451e6d.ts.net.
+  podSelector:
+    matchLabels:
+      app: nats
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: observability
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: tailscale
+      ports:
+        - port: 8222
+        - port: 8223


### PR DESCRIPTION
Follow-ups from the authorized red-team engagement. White-box findings verified live where noted.

**Code**
- mcsr gossip provider: `url.PathEscape` every chat-controlled path segment (`!mcsr feinberg?cb=1` / `feinberg#x` confirmed live to parse as URL syntax upstream)
- console-admin secrets: removed the broad `DOPPLER_MANAGEMENT_TOKEN`/`DOPPLER_TOKEN` fallback — a missing scoped token now reports `missing` instead of silently escalating
- loyalty: configured rates capped at 1e9, deleting the broadcaster-settable int64 overflow class

**Deploy**
- unrouted-host fallback: 302 to `https://itsbagelbot.com/404` instead of proxying any wildcard-admitted hostname to the apex with attacker paths intact
- db status routes: rate limiter on the health surface (app half had one, db half didn't); duplicate dead `:80` transactions-webhooks route removed; `/transactions` repointed to :443
- messaging: NetworkPolicy — NATS data plane stays cluster-wide, unauth monitor/profiling ports pinned to observability + tailscale

Verified: go build/test (mcsr, sesame/engine), svelte-check 0/0, demo-gate verifier, YAML parse.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved handling of account identifiers in API requests.
  * Scoped service tokens are now required, with clearer secret-status reporting.
  * Added network protections for messaging services and request-rate limits for status endpoints.

* **Bug Fixes**
  * Prevented excessively high loyalty point rates from causing unexpected behavior.
  * Unmatched website requests now redirect to a consistent 404 page.

* **Administration**
  * Updated demo secret data and removed legacy-token warnings from the secrets dashboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->