### PR TITLE
chore(deploy): trafficDistribution PreferClose -> PreferSameZone

### DIFF
--- a/deploy/k8s/console-admin.yaml
+++ b/deploy/k8s/console-admin.yaml
@@ -15,7 +15,7 @@
 #
 # Region spread: replicas spread across the 3 cities (see console-dashboard.yaml
 # for the required node region/zone labels); the operator proxy prefers the
-# in-region admin pod via the Service's PreferClose.
+# in-region admin pod via the Service's PreferSameZone.
 apiVersion: secrets.doppler.com/v1alpha1
 kind: DopplerSecret
 metadata:
@@ -366,7 +366,7 @@ metadata:
   namespace: app
 spec:
   # No sessionAffinity: stateless sessions make every pod interchangeable.
-  # PreferClose keeps the operator proxy on the in-region admin pod.
+  # PreferSameZone keeps the operator proxy on the in-region admin pod.
   trafficDistribution: PreferSameNode
   selector:
     app: console-admin

--- a/deploy/k8s/console-dashboard.yaml
+++ b/deploy/k8s/console-dashboard.yaml
@@ -17,10 +17,10 @@
 #     kubectl label node <n> topology.kubernetes.io/region=<city> \
 #                            topology.kubernetes.io/zone=<city> --overwrite
 #   Path: Cloudflare edge -> closest cloudflared connector (per-node DaemonSet)
-#   -> node-local traefik (per-node DaemonSet, Service PreferClose). traefik then
+#   -> node-local traefik (per-node DaemonSet, Service PreferSameZone). traefik then
 #   routes to THIS Service's ClusterIP (nativeLB: true below) instead of load-
 #   balancing pod endpoints directly, so it inherits trafficDistribution:
-#   PreferClose and keeps the request inside the entry city, spilling to another
+#   PreferSameZone and keeps the request inside the entry city, spilling to another
 #   city only when the local pods are gone.
 #
 # Secrets: uses the Doppler-synced `dashboard-env` secret (project dashboard /
@@ -424,7 +424,7 @@ spec:
           scheme: https
           serversTransport: console-dashboard-transport
           # Route to the Service ClusterIP (not pod endpoints) so traefik
-          # inherits the Service's PreferClose region routing. No sticky cookie:
+          # inherits the Service's PreferSameZone region routing. No sticky cookie:
           # sessions are stateless, so any in-region pod is interchangeable.
           nativeLB: true
   tls: {}

--- a/deploy/messaging/nats-leaf.yaml
+++ b/deploy/messaging/nats-leaf.yaml
@@ -258,7 +258,7 @@ metadata:
   namespace: messaging
 spec:
   # Same-node first, then same-zone, then cluster-wide. Unlike Local this keeps
-  # applications available while their node's leaf is down; unlike PreferClose
+  # applications available while their node's leaf is down; unlike PreferSameZone
   # it makes node locality explicit on Kubernetes 1.34+. Short ClientIP
   # affinity keeps one pod's independent RPC/cache connections on the same
   # fallback leaf, but expires before the controlled 90s failback check.


### PR DESCRIPTION
Renamed synonym in k8s 1.33+, same semantics (same-zone preference).
Fixes the two live fields in the traefik chart values that triggered the
deprecation warning on every helm reconcile, and updates the comments
that referenced the old name so the docs stay truthful. valkey.yaml
keeps its mention: it deliberately contrasts PreferSameNode against the
deprecated term.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deployment documentation to accurately describe same-zone traffic routing and distribution behavior.
  * Applied consistent terminology across console administration, dashboard, and messaging services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->