### PR TITLE
perf(bus): prod runtime drop — drain-path HOL fix, timer wheel, codec symmetry, residual allocs

### DIFF
--- a/app/ingress/lib/ingress/config/publish.ex
+++ b/app/ingress/lib/ingress/config/publish.ex
@@ -114,9 +114,9 @@ defmodule Ingress.Config.Publish do
   # safe no matter how the lanes are partitioned or how the traffic splits
   # between them.
   #
-  # 50 is what the hub actually runs: deploy/k8s/nats-server.conf ships no
-  # `limits { batch { … } }` block on purpose, because JetStreamLimits is not
-  # hot-reloadable and one such key would wedge every later SIGHUP.
+  # 200 is what the hub actually runs: deploy/messaging/nats-server.conf has
+  # shipped `limits { batch { max_inflight_per_stream: 200 } }` live since the
+  # forced quorum roll of 2026-08-22.
   #
   # Sizing past it does not buy the extra window. An over-cap open is answered
   # with a definite 10210/429 — nothing was stored — so the cohort re-drives per

--- a/deploy/messaging/nats-server.conf
+++ b/deploy/messaging/nats-server.conf
@@ -130,8 +130,10 @@ cluster {
 #                  6 once the retry lane is provisioned. ≈ 640 MiB.
 #              Real per-member worst case ≈ 1.25 (streams) + 1.25 (WAL) + 0.6
 #              (ingest queues) + the Go runtime and connection buffers ≈ 4.1
-#              GiB against the pod's 5Gi limit: under 1 GiB of true headroom,
-#              not the ~3.7 GiB a 5Gi-minus-1.25GiB reading suggests. The pod's
+#              GiB against the pod's 8Gi limit (live since the 2026-08-23 roll,
+#              was 5Gi): ~3.9 GiB of true headroom above that worst case, with
+#              GOMEMLIMIT=6656MiB curbing heap growth before either the soft
+#              limit or the container limit is reached. The pod's
 #              memory REQUEST is 4Gi, deliberately below that worst case, so a
 #              member catching up a full catalog can exceed its request and
 #              enters the kubelet's eviction ranking — see the resources block

--- a/pkg/bus/batch_publisher.go
+++ b/pkg/bus/batch_publisher.go
@@ -92,7 +92,14 @@ type batchPublisher struct {
 	// the life of the process.
 	firstErr   error
 	firstErrAt uint64
-	changed    chan struct{}
+
+	// signal wakes every Flush waiting on completed, one Broadcast per cohort
+	// instead of the close-and-reallocate channel this replaced. A generation
+	// counter over a single long-lived channel was the other candidate and is
+	// rejected on semantics: a channel send reaches exactly one receiver, so a
+	// second concurrent Flush would sleep through wakeups that close-and-
+	// realloc used to deliver to all of them; Broadcast preserves exactly that.
+	signal *sync.Cond
 }
 
 type publishRequest struct {
@@ -123,6 +130,16 @@ type publishBatchWorker struct {
 	// cohort on a timed wire. collectBatch runs only on this goroutine, so the
 	// field takes no lock; run stops it on the way out.
 	timer *time.Timer
+
+	// ackTimers recycles awaitAsync's PubAck-wait timers. A single hoisted field
+	// like timer above would race: up to maxInflightCohorts ack goroutines call
+	// awaitAsync concurrently, each Resetting the shared timer. The pool keeps
+	// one per waiter with no per-cohort allocation. Get Resets before use,
+	// relying on Go 1.23 timer semantics (see armWindowTimer): a tick sent
+	// before Reset cannot be received after it, so no drain is needed. run's
+	// acks.Wait precedes close(done), so every borrowed timer is Stopped by its
+	// putAckTimer defer before teardown finishes.
+	ackTimers sync.Pool
 
 	// Cohort shape is fixed per wire at worker creation: the Fast-Ingest wire
 	// amortizes a session over a much longer collection window than the
@@ -182,11 +199,12 @@ func newBatchPublisherConnection(url string, index int, wire wireMode, log *zap.
 		nc.Close()
 		return nil, fmt.Errorf("bus: modern jetstream batch publisher: %w", err)
 	}
-	return &batchPublisher{
+	publisher := &batchPublisher{
 		nc: nc, js: js, modern: modern, log: log, wire: wire,
 		workers: make(map[string]*publishBatchWorker),
-		changed: make(chan struct{}),
-	}, nil
+	}
+	publisher.signal = sync.NewCond(&publisher.stateMu)
+	return publisher, nil
 }
 
 // nuidPool hands out NUID generators. The package-global nuid.Next() serializes
@@ -326,9 +344,35 @@ func publishMessage(command publishCommand) *nats.Msg {
 func newPublishRequest(command publishCommand, wire *nats.Msg) publishRequest {
 	request := publishRequest{msg: wire}
 	if command.confirmed {
-		request.confirmed = make(chan error, 1)
+		request.confirmed = getConfirmChan()
 	}
 	return request
+}
+
+// confirmChanPool recycles the buffered verdict channel of confirmed publishes,
+// which otherwise costs one allocation per confirmed message.
+var confirmChanPool = sync.Pool{
+	New: func() any { return make(chan error, 1) },
+}
+
+// getConfirmChan drains any verdict left over by a prior waiter that abandoned
+// on ctx.Done after finish had already delivered into the buffer.
+func getConfirmChan() chan error {
+	confirmed := confirmChanPool.Get().(chan error)
+	select {
+	case <-confirmed:
+	default:
+	}
+	return confirmed
+}
+
+// putConfirmChan returns a drained verdict channel to the pool. It is called
+// only from awaitPublishConfirmation after receiving the verdict: that receive
+// orders after finish's single send, so no writer can touch the channel again.
+// An abandoned wait never puts its channel back — its verdict may still be in
+// flight — and simply drops it to the garbage collector instead.
+func putConfirmChan(confirmed chan error) {
+	confirmChanPool.Put(confirmed)
 }
 
 // admit is the whole per-message critical section: the closed check, the worker
@@ -393,6 +437,7 @@ func awaitPublishConfirmation(ctx context.Context, request publishRequest) error
 	}
 	select {
 	case err := <-request.confirmed:
+		putConfirmChan(request.confirmed)
 		return err
 	case <-ctx.Done():
 		return ctx.Err()
@@ -422,6 +467,7 @@ func (p *batchPublisher) startWorker(stream string) (*publishBatchWorker, error)
 		batchSize:     publishBatchSize(p.wire),
 		batchWait:     publishBatchWait(p.wire),
 		overlapCommit: atomicPublishOverlap(),
+		ackTimers:     sync.Pool{New: func() any { return time.NewTimer(defaultPublishAckWait) }},
 	}
 	p.workers[stream] = worker
 	go worker.run()
@@ -479,16 +525,11 @@ func (p *batchPublisher) complete(count int, err error) {
 		p.firstErrAt = p.completed
 	}
 	p.completed += uint64(count)
-	p.notifyLocked()
+	p.signal.Broadcast()
 	p.stateMu.Unlock()
 	if err != nil {
 		p.log.Error("asynchronous NATS publish failed", zap.Int("messages", count), zap.Error(err))
 	}
-}
-
-func (p *batchPublisher) notifyLocked() {
-	close(p.changed)
-	p.changed = make(chan struct{})
 }
 
 func (p *batchPublisher) Flush(ctx context.Context) error {
@@ -497,18 +538,32 @@ func (p *batchPublisher) Flush(ctx context.Context) error {
 	// the caller by traffic it never emitted.
 	target := p.accepted.Load()
 	p.stateMu.Lock()
-	for p.completed < target {
-		changed := p.changed
-		p.stateMu.Unlock()
-		select {
-		case <-changed:
-		case <-ctx.Done():
-			return ctx.Err()
-		}
+	// Cond.Wait has no select arm for ctx.Done, so a watcher broadcasts the
+	// cancellation into the same cond; cancel plus this reap guarantee it exits
+	// before Flush returns.
+	ctx, cancel := context.WithCancel(ctx)
+	wake := make(chan struct{})
+	go func() {
+		<-ctx.Done()
 		p.stateMu.Lock()
+		p.signal.Broadcast()
+		p.stateMu.Unlock()
+		close(wake)
+	}()
+	var err error
+	for p.completed < target {
+		if ctx.Err() != nil {
+			err = ctx.Err()
+			break
+		}
+		p.signal.Wait()
 	}
-	err := p.takeWindowErrLocked(target)
+	if err == nil {
+		err = p.takeWindowErrLocked(target)
+	}
 	p.stateMu.Unlock()
+	cancel()
+	<-wake
 	return err
 }
 
@@ -695,8 +750,8 @@ func joinAsyncCohort(size int, futures []nats.PubAckFuture, startErr, awaitErr e
 // ambiguous for the messages still unresolved, so the cohort fails without
 // replay.
 func (w *publishBatchWorker) awaitAsync(futures []nats.PubAckFuture) error {
-	timer := time.NewTimer(defaultPublishAckWait)
-	defer timer.Stop()
+	timer := w.ackTimer()
+	defer w.putAckTimer(timer)
 	for _, future := range futures {
 		select {
 		case <-future.Ok():
@@ -707,6 +762,25 @@ func (w *publishBatchWorker) awaitAsync(futures []nats.PubAckFuture) error {
 		}
 	}
 	return nil
+}
+
+// ackTimer borrows a PubAck-wait timer from the worker's pool, Reset for this
+// cohort; see ackTimers for why this is a pool rather than one field and why
+// Reset needs no drain.
+func (w *publishBatchWorker) ackTimer() *time.Timer {
+	if timer, ok := w.ackTimers.Get().(*time.Timer); ok {
+		timer.Reset(defaultPublishAckWait)
+		return timer
+	}
+	return time.NewTimer(defaultPublishAckWait)
+}
+
+// putAckTimer stops and returns a borrowed timer. Stop after a fire is a no-op
+// under Go 1.23 semantics — the tick was already paired with our receive or is
+// discarded by Stop.
+func (w *publishBatchWorker) putAckTimer(timer *time.Timer) {
+	timer.Stop()
+	w.ackTimers.Put(timer)
 }
 
 func (w *publishBatchWorker) fail(batch []publishRequest, err error) {

--- a/pkg/bus/concurrent_subscriber.go
+++ b/pkg/bus/concurrent_subscriber.go
@@ -226,34 +226,38 @@ func (s *concurrentDurableSubscriber) Subscribe(ctx context.Context, subject str
 	s.subs[sub] = ownedSubscription{sub: sub, callbacks: callbacks, pump: pump}
 	s.mu.Unlock()
 
-	go func() {
-		select {
-		case <-ctx.Done():
-		case <-s.closeCh:
-		}
-		stopSubscription(sub, callbacks, pump)
-		s.mu.Lock()
-		delete(s.subs, sub)
-		s.mu.Unlock()
-	}()
-
-	go func() {
-		defer close(output)
-		for {
-			select {
-			case d := <-pump.queue:
-				if !s.deliver(ctx, output, callbacks, d) {
-					s.abandon(pump.queue)
-					return
-				}
-			case <-pump.stop:
-				s.abandon(pump.queue)
-				return
-			}
-		}
-	}()
+	go s.watchBind(ctx, sub, callbacks, pump)
+	go s.runPump(ctx, output, callbacks, pump)
 
 	return output, nil
+}
+
+// watchBind retires the subscription when its binding context ends or the
+// subscriber closes, whichever comes first.
+func (s *concurrentDurableSubscriber) watchBind(ctx context.Context, sub *nats.Subscription, callbacks *callbackGate, pump *subscriptionPump) {
+	select {
+	case <-ctx.Done():
+	case <-s.closeCh:
+	}
+	stopSubscription(sub, callbacks, pump)
+	s.mu.Lock()
+	delete(s.subs, sub)
+	s.mu.Unlock()
+}
+
+// runPump drains the explicit delivery queue toward the lane channel until the
+// pump halts or a delivery fails, then abandons whatever remains queued.
+func (s *concurrentDurableSubscriber) runPump(ctx context.Context, output chan<- *Message, callbacks *callbackGate, pump *subscriptionPump) {
+	defer close(output)
+	for live := true; live; {
+		select {
+		case d := <-pump.queue:
+			live = s.deliver(ctx, output, callbacks, d)
+		case <-pump.stop:
+			live = false
+		}
+	}
+	s.abandon(pump.queue)
 }
 
 func (s *concurrentDurableSubscriber) beginRegistration() bool {
@@ -642,29 +646,42 @@ func (w *keepAliveWheel) advance() {
 
 	var survivors []*resultWatch
 	for _, watch := range due {
-		if watch.finished.Load() {
-			continue // resolved or unwound since it was filed: lazy sweep
+		if w.sweepDue(e, watch) {
+			survivors = append(survivors, watch)
 		}
-		if e-watch.armEpoch >= uint64(w.steps) {
-			// Deadline reached: give the delivery back to AckWait. The CAS is
-			// the same arbiter resolve() uses, so exactly one side releases
-			// the acks seat.
-			if watch.finished.CompareAndSwap(false, true) {
-				watch.s.acks.Done()
-			}
-			continue
-		}
+	}
+	w.refile(next, survivors)
+}
+
+// sweepDue reports one unfinished watch against its deadline. It returns false
+// when the watch leaves the wheel: resolved or unwound since it was filed
+// (lazy sweep), or past deadline, where it surrenders the delivery to AckWait.
+// That surrender's CAS is the same arbiter resolve() uses, so exactly one side
+// releases the acks seat.
+func (w *keepAliveWheel) sweepDue(epoch uint64, watch *resultWatch) bool {
+	if watch.finished.Load() {
+		return false
+	}
+	if epoch-watch.armEpoch < uint64(w.steps) {
 		watch.s.reportProgress(watch.natsMsg)
-		survivors = append(survivors, watch)
+		return true
 	}
-	if len(survivors) > 0 {
-		w.mu.Lock()
-		// Survivors are due again next interval, which is the bucket the
-		// cursor points at now; registrations landing mid-pass joined the
-		// same slice under the same lock.
-		w.buckets[w.cursor] = append(next, survivors...)
-		w.mu.Unlock()
+	if watch.finished.CompareAndSwap(false, true) {
+		watch.s.acks.Done()
 	}
+	return false
+}
+
+// refile returns survivors to the bucket the cursor points at: they are due
+// again next interval, and registrations landing mid-pass joined the same
+// slice under the same lock.
+func (w *keepAliveWheel) refile(base []*resultWatch, survivors []*resultWatch) {
+	if len(survivors) == 0 {
+		return
+	}
+	w.mu.Lock()
+	w.buckets[w.cursor] = append(base, survivors...)
+	w.mu.Unlock()
 }
 
 // ack applies the acknowledgement contract the stream's retention actually

--- a/pkg/bus/concurrent_subscriber.go
+++ b/pkg/bus/concurrent_subscriber.go
@@ -19,8 +19,9 @@ import (
 // concurrentDurableSubscriber is the fleet-owned JetStream delivery adapter.
 // nats.go invokes one subscription callback serially, so the callback must not
 // wait for the handler's acknowledgement: doing so hard-caps every pod at one in-flight
-// event. This adapter hands the message to the weighted routine pool, returns
-// immediately, and reconciles Ack/Nack concurrently after the handler finishes.
+// event. This adapter hands the message through a bounded queue and a pump to
+// the weighted routine pool, returns immediately, and reconciles Ack/Nack
+// concurrently after the handler finishes.
 type concurrentDurableSubscriber struct {
 	nc       *nats.Conn
 	js       nats.JetStreamContext
@@ -42,9 +43,15 @@ type concurrentDurableSubscriber struct {
 	ackSync bool
 	log     *zap.Logger
 
+	// dropped counts deliveries shed when the explicit queue is full; see the
+	// overflow branch in deliveryCallback for why shedding beats blocking.
+	dropped atomic.Int64
+	// wheel drives the shared keep-alive passes; see keepAliveWheel.
+	wheel *keepAliveWheel
+
 	mu      sync.Mutex
 	closed  bool
-	subs    map[*nats.Subscription]*callbackGate
+	subs    map[*nats.Subscription]ownedSubscription
 	closeCh chan struct{}
 
 	registrations sync.WaitGroup
@@ -82,6 +89,42 @@ const (
 	// stays under laneAckWait so a failed confirmation still has room to
 	// NAK before the server redelivers on its own clock.
 	ackSyncTimeout = laneAckWait / 2
+
+	// durableQueueBytesBudget is how much payload the explicit-delivery queue
+	// may hold at once. It exists so the worst case is a stated number rather
+	// than something emergent: the queue decouples nats.go's serial delivery
+	// goroutine from a momentarily slow reader, and this constant is the ceiling
+	// on how much that decoupling can buffer before it starts shedding.
+	durableQueueBytesBudget = 8 << 20
+
+	// durableWireBytesFloor is the smallest lane delivery the queue depth is
+	// sized against. Live ingress runs measured ~865 B per event on the wire;
+	// rounding the average up to a flat 1 KiB deliberately rounds the derived
+	// depth DOWN in count while keeping the payload bound honest — the failure
+	// this budget guards against is unbounded heap under a stalled reader, never
+	// a shallow queue, and the overflow counter below makes any real shallowness
+	// loud instead of silent.
+	durableWireBytesFloor = 1024
+
+	// durableQueueDepth is how many deliveries the callback may hold for the
+	// pump, derived from the byte budget exactly the way flowQueueDepth is
+	// derived from the flow-control window (8 MiB / 1 KiB = 8192).
+	//
+	// Unlike the flow lane, this queue is deliberately sized UNDER the consumer's
+	// MaxAckPending (default 20000, raisable via NATS_LANE_MAX_ACK_PENDING) rather
+	// than above it. The flow lane had to clear its server's ramped byte window
+	// because a drop there loses a receipt permanently; here the brake really is
+	// the message count, and a shed delivery is one delayed event — the server
+	// redelivers it after laneAckWait (4s). Blocking, the alternative this queue
+	// replaced, was measured as strictly worse: parking nats.go's serial callback
+	// on `output <-` stalled every server push until MaxAckPending seats
+	// stranded, capping the lane near 2-3k msg/s. An unbounded queue was rejected
+	// for the opposite reason: it converts downstream stall into unbounded heap.
+	// Sitting under the brake means saturation sheds early and paces itself via
+	// AckWait instead of accumulating resident payload, and the throttled
+	// overflow counter (every 1000th drop logged, matching the flow overrun
+	// counter) is the signal that the derivation needs re-measuring.
+	durableQueueDepth = durableQueueBytesBudget / durableWireBytesFloor
 )
 
 // workQueueRetention reports whether a catalog stream deletes messages on
@@ -131,24 +174,44 @@ func newConcurrentDurableSubscriber(cfg concurrentSubscriberConfig) *concurrentD
 		nc: cfg.nc, js: cfg.js, stream: cfg.stream, consumer: cfg.consumer, group: cfg.group,
 		delay: cfg.delay, handlerDeadline: 30 * time.Second, progress: time.Second, log: cfg.log,
 		ackSync: workQueueRetention(cfg.stream),
-		subs:    make(map[*nats.Subscription]*callbackGate), closeCh: make(chan struct{}),
+		subs:    make(map[*nats.Subscription]ownedSubscription), closeCh: make(chan struct{}),
 	}
 	// Keep the WaitGroup positive until Close has unsubscribed every callback;
 	// this prevents an Add racing a Wait while a final delivery is arriving.
 	s.acks.Add(1)
+	// One wheel per subscriber, not one timer per message; see keepAliveWheel.
+	// It lives on closeCh, so both Close paths retire it and it stays running
+	// through the ack drain exactly as the per-message timers used to.
+	s.wheel = newKeepAliveWheel(wheelStepCount(s.handlerDeadline, s.progress), s.progress, s.closeCh)
 	return s
+}
+
+// wheelStepCount is how many progress intervals a watch may survive: the
+// per-message timers reported InProgress at fire k and surrendered once
+// k*progress reached handlerDeadline, so the step count is a ceiling division.
+// A degenerate interval collapses to a single step rather than panicking.
+func wheelStepCount(deadline, progress time.Duration) int {
+	if progress <= 0 || deadline <= 0 {
+		return 1
+	}
+	steps := (deadline + progress - 1) / progress
+	if steps < 1 {
+		return 1
+	}
+	return int(steps)
 }
 
 func (s *concurrentDurableSubscriber) Subscribe(ctx context.Context, subject string) (<-chan *Message, error) {
 	output := make(chan *Message)
 	callbacks := newCallbackGate()
+	pump := newSubscriptionPump()
 
 	if !s.beginRegistration() {
 		return nil, errors.New("bus: subscriber is closed")
 	}
 	defer s.registrations.Done()
 
-	callback := s.deliveryCallback(ctx, subject, output, callbacks)
+	callback := s.deliveryCallback(ctx, subject, callbacks, pump.queue)
 	sub, err := s.subscribe(subject, callback)
 	if err != nil {
 		return nil, err
@@ -157,10 +220,10 @@ func (s *concurrentDurableSubscriber) Subscribe(ctx context.Context, subject str
 	s.mu.Lock()
 	if s.closed {
 		s.mu.Unlock()
-		stopSubscription(sub, callbacks)
+		stopSubscription(sub, callbacks, pump)
 		return nil, errors.New("bus: subscriber closed during subscribe")
 	}
-	s.subs[sub] = callbacks
+	s.subs[sub] = ownedSubscription{sub: sub, callbacks: callbacks, pump: pump}
 	s.mu.Unlock()
 
 	go func() {
@@ -168,11 +231,26 @@ func (s *concurrentDurableSubscriber) Subscribe(ctx context.Context, subject str
 		case <-ctx.Done():
 		case <-s.closeCh:
 		}
-		stopSubscription(sub, callbacks)
+		stopSubscription(sub, callbacks, pump)
 		s.mu.Lock()
 		delete(s.subs, sub)
 		s.mu.Unlock()
-		close(output)
+	}()
+
+	go func() {
+		defer close(output)
+		for {
+			select {
+			case d := <-pump.queue:
+				if !s.deliver(ctx, output, callbacks, d) {
+					s.abandon(pump.queue)
+					return
+				}
+			case <-pump.stop:
+				s.abandon(pump.queue)
+				return
+			}
+		}
 	}()
 
 	return output, nil
@@ -200,11 +278,40 @@ func (s *concurrentDurableSubscriber) subscribe(subject string, callback nats.Ms
 		nats.BindStream(s.stream), nats.DeliverNew(), nats.AckExplicit(), nats.ManualAck())
 }
 
+// pendingDelivery is one decoded delivery waiting in the explicit queue for
+// the pump to hand it toward the lane channel.
+type pendingDelivery struct {
+	msg   *Message
+	watch *resultWatch
+}
+
+// subscriptionPump owns one subscription's explicit queue and the signal that
+// retires it. halt is idempotent because both shutdown paths — context
+// cancellation via the subscription's own watcher and Close via stopCallbacks
+// — can reach it, potentially concurrently, and each must be able to fire it.
+type subscriptionPump struct {
+	queue chan pendingDelivery
+	stop  chan struct{}
+	once  sync.Once
+}
+
+func newSubscriptionPump() *subscriptionPump {
+	return &subscriptionPump{
+		queue: make(chan pendingDelivery, durableQueueDepth),
+		stop:  make(chan struct{}),
+	}
+}
+
+// halt releases the pump. It must run strictly after callbacks.stopAndWait:
+// only then is every callback gone, so the pump's final non-blocking drain can
+// unwind the remaining queue without racing an enqueuer.
+func (p *subscriptionPump) halt() { p.once.Do(func() { close(p.stop) }) }
+
 func (s *concurrentDurableSubscriber) deliveryCallback(
 	ctx context.Context,
 	subject string,
-	output chan<- *Message,
 	callbacks *callbackGate,
+	queue chan<- pendingDelivery,
 ) nats.MsgHandler {
 	return func(natsMsg *nats.Msg) {
 		if !callbacks.enter() {
@@ -224,41 +331,83 @@ func (s *concurrentDurableSubscriber) deliveryCallback(
 		// is silently dropped. This broker never fires AckWait redelivery
 		// while interest stays bound, so every dropped slot strands one
 		// MaxAckPending seat until max_age; that race is what capped the
-		// lane near 2-3k msg/s. The non-delivery arms unwind the watch
-		// themselves and resultWatch.finished makes double release a no-op.
+		// lane near 2-3k msg/s. This ordering survived a fixed critical bug
+		// and must not move relative to the visibility point: installing
+		// here, ahead of the enqueue, keeps the watch armed before the pump
+		// can ever make the message visible. The non-delivery arms unwind
+		// the watch themselves and resultWatch.finished makes double release
+		// a no-op.
+		//
+		// The handoff itself is the bounded queue, and the enqueue never
+		// blocks: a saturated downstream sheds one delivery instead of
+		// parking nats.go's serial callback and stalling every server push.
 		w := s.newResultWatch(natsMsg, msg)
-		if !s.handOff(ctx, output, callbacks, msg) {
+		select {
+		case queue <- pendingDelivery{msg: msg, watch: w}:
+		default:
+			// Shedding follows the flow-lane precedent: dropping costs one
+			// event, blocking costs the window. On this adapter the shed
+			// delivery comes back on AckWait (<= laneAckWait), so the cost is
+			// delay rather than loss. Throttled like the flow overrun counter
+			// — sustained overflow is exactly the case where a line per drop
+			// emits at lane rate; the counter still moves on every drop, so
+			// the magnitude is never lost, only the repetition.
 			w.unwind()
+			if dropped := s.dropped.Add(1); dropped == 1 || dropped%1_000 == 0 {
+				s.log.Warn("durable delivery queue overflowed; leaving the message to AckWait redelivery",
+					zap.String("subject", subject),
+					zap.Int64("dropped_total", dropped))
+			}
 		}
 	}
 }
 
-// newResultWatch arms one message's keep-alive timer and resolve hook and
-// counts it against the in-flight ack budget.
+// newResultWatch arms one message's keep-alive slot on the shared wheel and
+// counts it against the in-flight ack budget. The budget seat is taken before
+// the watch becomes observable: registering into the wheel is the earliest
+// point another goroutine — the wheel ticker — may release the seat, and the
+// Add above it in program order is what keeps the counter from going negative.
 func (s *concurrentDurableSubscriber) newResultWatch(natsMsg *nats.Msg, msg *Message) *resultWatch {
 	w := &resultWatch{s: s, natsMsg: natsMsg}
-	w.timer = time.AfterFunc(s.progress, w.keepAlive)
-	msg.setResolveHandler(w.resolve)
 	s.acks.Add(1)
+	msg.setResolveHandler(w.resolve)
+	s.wheel.register(w)
 	return w
 }
 
-// handOff blocks until the message lands on output or the lane shuts down
-// around it; it reports whether the handoff won.
-func (s *concurrentDurableSubscriber) handOff(
+// deliver hands one queued message to the lane channel with its verdict
+// already wired up. It reports whether the handoff won; a lost handoff
+// releases the watch here so shutdown never waits on an acknowledgement
+// nobody will make.
+func (s *concurrentDurableSubscriber) deliver(
 	ctx context.Context,
 	output chan<- *Message,
 	callbacks *callbackGate,
-	msg *Message,
+	d pendingDelivery,
 ) bool {
 	select {
-	case output <- msg:
+	case output <- d.msg:
 		return true
 	case <-ctx.Done():
 	case <-s.closeCh:
 	case <-callbacks.stopped():
 	}
+	d.watch.unwind()
 	return false
+}
+
+// abandon unwinds every delivery the queue still holds. It runs strictly after
+// callbacks.stopAndWait (via pumpDone), which guarantees no enqueuer remains,
+// so a plain non-blocking drain cannot miss an entry.
+func (s *concurrentDurableSubscriber) abandon(queue <-chan pendingDelivery) {
+	for {
+		select {
+		case d := <-queue:
+			d.watch.unwind()
+		default:
+			return
+		}
+	}
 }
 
 func newCallbackGate() *callbackGate {
@@ -289,9 +438,12 @@ func (g *callbackGate) stopAndWait() {
 	g.active.Wait()
 }
 
-func stopSubscription(sub *nats.Subscription, callbacks *callbackGate) {
+func stopSubscription(sub *nats.Subscription, callbacks *callbackGate, pump *subscriptionPump) {
 	_ = sub.Unsubscribe()
 	callbacks.stopAndWait()
+	// Every callback has exited, so nothing can enqueue past this point;
+	// releasing the pump here lets it unwind whatever the queue still holds.
+	pump.halt()
 }
 
 func (s *concurrentDurableSubscriber) terminateMalformed(msg *nats.Msg, subject string, decodeErr error) {
@@ -351,44 +503,41 @@ func jetStreamIdentity(domain, stream string, sequence uint64) string {
 	return fmt.Sprintf("js:%s:%s:%d", domain, stream, sequence)
 }
 
-// watchResult reconciles one delivery without parking a goroutine on it.
+// resultWatch reconciles one delivery without parking a goroutine or a timer
+// on it.
 //
 // The resolve callback runs the acknowledgement on the worker goroutine that
-// finished the handler, and an AfterFunc keepalive covers the slow-handler
-// case: each fire reports InProgress (renewing the server's AckWait) until the
-// coarse handlerDeadline, after which ownership is deliberately given up to
-// AckWait redelivery. On the normal path the handler resolves inside one
-// progress interval, so the whole mechanism costs one timer registration and
-// one cancellation per message — no goroutine, no channel park. The finished
-// flag is the single arbiter between a late resolve and the deadline: whoever
-// swaps it first owns the acks slot, exactly one of them releases it.
-func (s *concurrentDurableSubscriber) watchResult(natsMsg *nats.Msg, msg *Message) {
-	w := &resultWatch{s: s, natsMsg: natsMsg}
-	w.timer = time.AfterFunc(s.progress, w.keepAlive)
-	msg.setResolveHandler(w.resolve)
-}
-
+// finished the handler, and the subscriber's shared keep-alive wheel covers
+// the slow-handler case: each pass reports InProgress (renewing the server's
+// AckWait) until the coarse handlerDeadline, after which ownership is
+// deliberately given up to AckWait redelivery. On the normal path the handler
+// resolves inside one progress interval, so the whole mechanism costs one
+// atomic store; the wheel sweeps the dead entry on its next pass — no timer
+// registration, no timer-heap traffic, no cancellation per message. The
+// finished flag is the single arbiter between a late resolve and the deadline:
+// whoever swaps it first owns the acks slot, exactly one of them releases it.
 type resultWatch struct {
 	s       *concurrentDurableSubscriber
 	natsMsg *nats.Msg
-	timer   *time.Timer
-	// elapsed is touched only inside keepAlive; AfterFunc serializes the
-	// callback with its own Reset, so it needs no lock.
-	elapsed  time.Duration
+	// armEpoch is written once under the wheel lock at registration and
+	// read-only afterwards; the wheel's lock provides the happens-before edge
+	// the walk relies on. Watch age is derived per pass from the wheel epoch,
+	// so unlike the per-message timers there is no mutable elapsed field to
+	// serialize.
+	armEpoch uint64
 	finished atomic.Bool
 }
 
-// unwind releases a watch whose message never reached a worker: stop the
-// keep-alive timer and give the ack seat straight back.
+// unwind releases a watch whose message never reached a worker: mark it
+// finished so the wheel's next pass skips it, and give the ack seat straight
+// back.
 func (w *resultWatch) unwind() {
-	w.timer.Stop()
 	if w.finished.CompareAndSwap(false, true) {
 		w.s.acks.Done()
 	}
 }
 
 func (w *resultWatch) resolve(acked bool) {
-	w.timer.Stop()
 	if !w.finished.CompareAndSwap(false, true) {
 		// The deadline already surrendered this delivery to AckWait; another
 		// ACK or NAK here would address a message the server may have
@@ -408,23 +557,114 @@ func (w *resultWatch) resolve(acked bool) {
 	w.s.nack(w.natsMsg)
 }
 
-func (w *resultWatch) keepAlive() {
-	if w.finished.Load() {
-		return
+// keepAliveWheel replaces the per-message time.AfterFunc the result watches
+// used to arm. Arming and stopping a timer per delivery pushed every message
+// through the runtime timer heap at lane rate for a mechanism that usually
+// does nothing: handlers resolve inside one progress interval, so nearly all
+// of that traffic was setup and teardown. The wheel arms nothing per message.
+// Watches join the bucket the next pass will walk, and ONE ticker goroutine
+// per subscriber walks one bucket per progress interval, reporting InProgress
+// for every unfinished watch and sweeping the ones a resolve or unwind has
+// marked finished — resolution never touches the bucket, the walk drops the
+// corpse, so the common path pays nothing beyond the atomic mark.
+//
+// The ring has wheelStepCount(handlerDeadline, progress) buckets, and watch
+// age is computed from wheel epochs rather than stored: at age >= steps the
+// watch surrenders the delivery to AckWait exactly where the per-message
+// timers gave up. Past the deadline no further progress is reported, because
+// the server may already have redelivered to another replica and renewing
+// would reclaim the ownership the deadline exists to give up.
+type keepAliveWheel struct {
+	interval time.Duration
+	steps    int
+
+	mu      sync.Mutex
+	buckets [][]*resultWatch
+	cursor  int
+	epoch   uint64
+
+	// done is the subscriber's closeCh: both Close paths close it exactly
+	// once, and keeping the wheel live through the ack drain preserves the old
+	// timers' behaviour of surrendering stuck deliveries while draining.
+	done <-chan struct{}
+}
+
+func newKeepAliveWheel(steps int, interval time.Duration, done <-chan struct{}) *keepAliveWheel {
+	if steps < 1 {
+		steps = 1
 	}
-	w.elapsed += w.s.progress
-	if w.elapsed >= w.s.handlerDeadline {
-		// The server's AckWait owns redelivery now. Do not emit another NAK
-		// after the deadline because it may already have redelivered to
-		// another replica, and reporting progress would renew the ownership
-		// the deadline exists to give up.
-		if w.finished.CompareAndSwap(false, true) {
-			w.s.acks.Done()
+	w := &keepAliveWheel{
+		interval: interval,
+		steps:    steps,
+		buckets:  make([][]*resultWatch, steps),
+		done:     done,
+	}
+	go w.spin()
+	return w
+}
+
+// register files a watch into the bucket the next pass walks. Its armEpoch is
+// the epoch the wheel has completed, so the first pass that sees it computes
+// age 1 and reports progress, matching the per-message timers' first fire one
+// full progress interval after arming.
+func (w *keepAliveWheel) register(watch *resultWatch) {
+	w.mu.Lock()
+	watch.armEpoch = w.epoch
+	w.buckets[w.cursor] = append(w.buckets[w.cursor], watch)
+	w.mu.Unlock()
+}
+
+func (w *keepAliveWheel) spin() {
+	ticker := time.NewTicker(w.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			w.advance()
+		case <-w.done:
+			return
 		}
-		return
 	}
-	w.s.reportProgress(w.natsMsg)
-	w.timer.Reset(w.s.progress)
+}
+
+// advance walks the bucket due this interval. The slice is detached under the
+// lock and processed outside it: reportProgress is network round-trip work and
+// must not serialize registrations happening mid-pass.
+func (w *keepAliveWheel) advance() {
+	w.mu.Lock()
+	due := w.buckets[w.cursor]
+	w.buckets[w.cursor] = nil
+	w.cursor = (w.cursor + 1) % len(w.buckets)
+	w.epoch++
+	e := w.epoch
+	next := w.buckets[w.cursor]
+	w.mu.Unlock()
+
+	var survivors []*resultWatch
+	for _, watch := range due {
+		if watch.finished.Load() {
+			continue // resolved or unwound since it was filed: lazy sweep
+		}
+		if e-watch.armEpoch >= uint64(w.steps) {
+			// Deadline reached: give the delivery back to AckWait. The CAS is
+			// the same arbiter resolve() uses, so exactly one side releases
+			// the acks seat.
+			if watch.finished.CompareAndSwap(false, true) {
+				watch.s.acks.Done()
+			}
+			continue
+		}
+		watch.s.reportProgress(watch.natsMsg)
+		survivors = append(survivors, watch)
+	}
+	if len(survivors) > 0 {
+		w.mu.Lock()
+		// Survivors are due again next interval, which is the bucket the
+		// cursor points at now; registrations landing mid-pass joined the
+		// same slice under the same lock.
+		w.buckets[w.cursor] = append(next, survivors...)
+		w.mu.Unlock()
+	}
 }
 
 // ack applies the acknowledgement contract the stream's retention actually
@@ -516,6 +756,7 @@ func (s *concurrentDurableSubscriber) Close() error {
 type ownedSubscription struct {
 	sub       *nats.Subscription
 	callbacks *callbackGate
+	pump      *subscriptionPump
 }
 
 func (s *concurrentDurableSubscriber) beginClose() ([]ownedSubscription, bool) {
@@ -534,8 +775,8 @@ func (s *concurrentDurableSubscriber) beginClose() ([]ownedSubscription, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	subs := make([]ownedSubscription, 0, len(s.subs))
-	for sub, callbacks := range s.subs {
-		subs = append(subs, ownedSubscription{sub: sub, callbacks: callbacks})
+	for _, owned := range s.subs {
+		subs = append(subs, owned)
 	}
 	return subs, true
 }
@@ -545,7 +786,7 @@ func (s *concurrentDurableSubscriber) stopCallbacks(subs []ownedSubscription) {
 		if err := owned.sub.Unsubscribe(); err != nil && !errors.Is(err, nats.ErrBadSubscription) {
 			s.log.Warn("durable subscription stop failed", zap.String("subject", owned.sub.Subject), zap.Error(err))
 		}
-		owned.callbacks.stopAndWait()
+		stopSubscription(owned.sub, owned.callbacks, owned.pump)
 	}
 }
 

--- a/pkg/bus/flow_control.go
+++ b/pkg/bus/flow_control.go
@@ -5,7 +5,7 @@ package bus
 
 import (
 	"strconv"
-	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/nats-io/nats.go"
@@ -67,9 +67,16 @@ type flowPosition struct {
 // flowCursor tracks the highest delivery this process has actually taken off
 // the wire. The flow response never claims more than this, so the replicated
 // ack floor can never move past a message the pod did not receive.
+//
+// The pair is two atomics rather than a mutex. Writers serialize on the stream
+// word's CAS (every commit is CAS-from-observed, so the stream never regresses)
+// and store the consumer sample after winning it; readers load consumer before
+// stream, which sequentially-consistent atomics pin to at most one window of
+// staleness — a response may under-claim an ack floor but can never over-claim
+// one.
 type flowCursor struct {
-	mu       sync.Mutex
-	position flowPosition
+	consumer atomic.Uint64
+	stream   atomic.Uint64
 }
 
 // record gates on the STREAM sequence, which is monotonic across a consumer
@@ -79,39 +86,50 @@ type flowCursor struct {
 // floor at MaxAckPending with no redelivery and no error. It returns false for a
 // sample that did not advance the cursor.
 func (c *flowCursor) record(consumer, stream uint64) bool {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if c.isSessionReset(consumer) {
-		c.position = flowPosition{consumer: consumer, stream: stream}
+	for {
+		prevStream := c.stream.Load()
+		prevConsumer := c.consumer.Load()
+		if c.consumer.Load() != prevConsumer {
+			continue // a writer committed mid-read; re-decide against the settled pair
+		}
+		if !isSessionReset(prevConsumer, consumer) && stream <= prevStream {
+			return false
+		}
+		if !c.stream.CompareAndSwap(prevStream, stream) {
+			continue // lost the word to a concurrent commit or reset; re-decide
+		}
+		c.consumer.Store(consumer)
 		return true
 	}
-	if stream <= c.position.stream {
-		return false
-	}
-	c.position = flowPosition{consumer: consumer, stream: stream}
-	return true
 }
 
 // isSessionReset recognises the server's own reset signature: a consumer
 // sequence further back than a whole ack window cannot be reordering.
-func (c *flowCursor) isSessionReset(consumer uint64) bool {
-	return c.position.consumer > consumer &&
-		c.position.consumer-consumer > flowSessionResetGap
+func isSessionReset(stored, consumer uint64) bool {
+	return stored > consumer &&
+		stored-consumer > flowSessionResetGap
 }
 
 func (c *flowCursor) snapshot() flowPosition {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.position
+	// Consumer-before-stream: worst case this returns last window's consumer
+	// beside the fresh stream, which only under-claims an ack floor.
+	consumer := c.consumer.Load()
+	return flowPosition{consumer: consumer, stream: c.stream.Load()}
 }
 
 // reset drops the cursor when this process recreates its own consumer. The new
 // consumer's sequences start over, so keeping the old pair would answer flow
-// control with an ack floor from a session the server no longer has.
+// control with an ack floor from a session the server no longer has. A record
+// committing inside these two stores can leave a mixed pair whose values are
+// each genuine receipts — conservative in the same direction as snapshot.
 func (c *flowCursor) reset() {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.position = flowPosition{}
+	for {
+		prev := c.stream.Load()
+		if c.stream.CompareAndSwap(prev, 0) {
+			c.consumer.Store(0)
+			return
+		}
+	}
 }
 
 // flowControlResponse builds the receipt-level acknowledgement for one push

--- a/pkg/bus/flow_retry.go
+++ b/pkg/bus/flow_retry.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/nats-io/nats.go"
 	jsapi "github.com/nats-io/nats.go/jetstream"
-	"github.com/nats-io/nuid"
 	"go.uber.org/zap"
 )
 
@@ -109,7 +108,9 @@ func scheduleLaneRetry(nc *nats.Conn, lane string, wire *nats.Msg, msg *Message)
 // outright when a time zone is present, even "UTC".
 func retryScheduleMsg(lane string, wire *nats.Msg, delay time.Duration, now time.Time) *nats.Msg {
 	target := RetryLaneSubject(lane)
-	schedule := nats.NewMsg(target + "." + nuid.Next())
+	// The pooled generator (nextNUID) avoids serializing this hop behind
+	// nuid.Next's process-global mutex; the row only needs uniqueness.
+	schedule := nats.NewMsg(target + "." + nextNUID())
 	schedule.Data = append([]byte(nil), wire.Data...)
 	copyApplicationHeaders(schedule.Header, wire.Header)
 

--- a/pkg/bus/lane_mode.go
+++ b/pkg/bus/lane_mode.go
@@ -79,9 +79,10 @@ const (
 	laneModeExplicit laneConsumeMode = "explicit"
 )
 
-// consumeMode resolves the configured contract. The default is deliberately
-// unchanged: flow is what production runs, and this knob exists to A/B pull
-// against it rather than to switch the fleet over.
+// consumeMode resolves the configured contract. Production ships explicit
+// today — consumeMode resolves there while NATS_CONSUME_FLOW stays off in the
+// deployed manifests — and PR #637 flips sesame to pull as its receipt-level
+// mode when it rolls. Flow remains selectable per deployment.
 //
 // NATS_CONSUME_FLOW=off predates NATS_CONSUME_MODE and still wins outright,
 // because it is set in deployed manifests as the kill switch back to explicit
@@ -89,7 +90,7 @@ const (
 // that a second variable exists. An unrecognised mode falls back to pull for
 // the same reason: a typo must not silently change the lane's shape.
 //
-// Pull is the default receipt-level shape. The flow consumer fans out per
+// Pull is the receipt-level shape PR #637 ships sesame onto. The flow consumer fans out per
 // consumer name, so every pod added by the autoscaler receives a full copy of
 // the lane and multiplies the broker's delivery egress; the shared-durable pull
 // consumer divides the lane instead (live-measured 2026-08-15: two pull

--- a/pkg/bus/orbit_batch.go
+++ b/pkg/bus/orbit_batch.go
@@ -106,9 +106,10 @@ const fastSessionMax = 65_536
 // The blast radius is not symmetric either. On the single wire an ambiguous
 // outcome costs one message; on the atomic wire it costs the whole cohort, up to
 // defaultAtomicPublishBatchSize. And atomic cohorts draw on the same per-stream
-// budget of 50 concurrently-open batches that the Elixir ingress fleet already
-// sizes itself against, so a Go publisher going atomic on a stream ingress is
-// also batching is a capacity change, not just a latency one.
+// budget of 200 concurrently-open batches — live since the 2026-08-22 roll,
+// raised from 50 — that the Elixir ingress fleet already sizes itself against,
+// so a Go publisher going atomic on a stream ingress is a capacity change, not
+// just a latency one.
 //
 // Turning it on is therefore a deliberate, per-service manifest edit that redoes
 // that arithmetic — not a default. An unrecognised value picks the smallest blast

--- a/pkg/bus/orbit_batch_test.go
+++ b/pkg/bus/orbit_batch_test.go
@@ -5,6 +5,7 @@ package bus
 
 import (
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -126,5 +127,7 @@ func confirmedBatch(n int) []publishRequest {
 // newTestBatchPublisher builds the connection-side state cohort resolution
 // touches, without a broker connection.
 func newTestBatchPublisher() *batchPublisher {
-	return &batchPublisher{log: zap.NewNop(), changed: make(chan struct{})}
+	publisher := &batchPublisher{log: zap.NewNop()}
+	publisher.signal = sync.NewCond(&publisher.stateMu)
+	return publisher
 }

--- a/pkg/bus/publish.go
+++ b/pkg/bus/publish.go
@@ -33,12 +33,15 @@ func publishPartition(ctx context.Context) string {
 // identity, trace propagation, pooling, batching, PubAcks and reconnect
 // behavior. Fleet publishing deliberately does not use broker deduplication.
 //
-// Delivery is at-least-once. The default Fast-Ingest wire stores each message
-// on arrival rather than on commit and the broker never rolls a session back,
-// so a caller that retries a reported failure can store a message twice. The
-// publisher narrows that window as far as the wire allows — it reports the
-// prefix the broker acknowledged as delivered and fails only the rest — but it
-// cannot close it.
+// Delivery is at-least-once on every wire. The default wire is wireSingle;
+// NATS_PUBLISH_WIRE opts a service into atomic or fast per deployment (PR #637
+// rolls atomic out service by service that way). Fast-Ingest exists for
+// arrival-time persistence, not rate: there the broker stores each message on
+// arrival rather than on commit and never rolls a session back, so a caller
+// that retries a reported failure can store a message twice. The publisher
+// narrows that window as far as the wire allows — it reports the prefix the
+// broker acknowledged as delivered and fails only the rest — but it cannot
+// close it.
 type Publisher interface {
 	// PublishOwned admits payload to the background publisher and takes ownership
 	// of its backing bytes on success. Prefer PublishJSON or PublishRaw at call

--- a/pkg/bus/pull_consumer.go
+++ b/pkg/bus/pull_consumer.go
@@ -623,6 +623,7 @@ func (s *pullSubscriber) deliver(wire jsapi.Msg) bool {
 	s.inflight.Add(1)
 	delivery.msg.setResolveHandler(func(acked bool) {
 		defer s.inflight.Done()
+		defer pullEnvelopePool.Put(delivery.wire)
 		if !acked {
 			s.scheduleRetry(delivery)
 		}
@@ -651,6 +652,30 @@ func (s *pullSubscriber) decode(wire jsapi.Msg) (pullDelivery, bool) {
 	return pullDelivery{wire: core, msg: msg}, true
 }
 
+// pullEnvelopePool recycles the per-delivery *nats.Msg envelope that
+// pullWireMessage rebuilds for the shared decode and retry helpers. The
+// envelope never outlives its Message's resolution: messageFromNATS copies the
+// identity and metadata out and leaves only a Data alias on the delivered
+// Message (owned by the fetch batch, untouched here), and the resolve handler —
+// which fires exactly once, after the handler finishes — is the last reader
+// before Put returns it. Data is deliberately not cleared on Put: the acquirer
+// overwrites every field, and the old buffer may still be aliased by a delivered
+// Message's payload.
+var pullEnvelopePool = sync.Pool{New: func() any { return new(nats.Msg) }}
+
+// resetPullHeader prepares a pooled envelope's header map for reuse: nil gets
+// an initial map sized for the identity key plus typical application headers;
+// otherwise every prior key is dropped. Returns the map to write into.
+func resetPullHeader(h nats.Header) nats.Header {
+	if h == nil {
+		return make(nats.Header, 2)
+	}
+	for k := range h {
+		delete(h, k)
+	}
+	return h
+}
+
 // pullWireMessage rebuilds the core message the shared decode and retry helpers
 // speak.
 //
@@ -661,19 +686,20 @@ func (s *pullSubscriber) decode(wire jsapi.Msg) (pullDelivery, bool) {
 // (which carries no publisher-set id) would mint a fresh NUID per delivery, and
 // a retry hop would land under an id no dedup guard could match to the original.
 func pullWireMessage(wire jsapi.Msg) *nats.Msg {
-	core := &nats.Msg{
-		Subject: wire.Subject(),
-		Reply:   wire.Reply(),
-		Header:  wire.Headers(),
-		Data:    wire.Data(),
+	core := pullEnvelopePool.Get().(*nats.Msg)
+	core.Subject = wire.Subject()
+	core.Reply = wire.Reply()
+	core.Data = wire.Data()
+	core.Header = resetPullHeader(core.Header)
+	for key, values := range wire.Headers() {
+		core.Header[key] = values
 	}
 	metadata, err := wire.Metadata()
 	if err != nil || metadata.Sequence.Stream == 0 {
 		return core
 	}
-	if core.Header == nil {
-		core.Header = nats.Header{}
-	}
+	// Stamped after reset so a recycled envelope cannot carry a prior
+	// delivery's identity forward.
 	if core.Header.Get(MessageIDHeader) == "" {
 		core.Header.Set(MessageIDHeader,
 			jetStreamIdentity(metadata.Domain, metadata.Stream, metadata.Sequence.Stream))

--- a/pkg/bus/rpc.go
+++ b/pkg/bus/rpc.go
@@ -43,7 +43,10 @@ func RequestJSON[T any](ctx context.Context, nc *nats.Conn, subject string, requ
 	encodeSegment := startMessagingSegment(ctx, messagingSpan{
 		name: "rpc.request.encode", operation: "request", destination: subject,
 	})
-	body, err := codec.Marshal(request)
+	// FastMarshal over codec.Marshal: escaping and key order are byte-level
+	// only and every consumer of internal fleet RPC parses JSON with Go or TS,
+	// so the sorted-key/escaped-HTML guarantees buy nothing on this path.
+	body, err := codec.FastMarshal(request)
 	endMessagingSegment(encodeSegment, err)
 	if err != nil {
 		return zero, fmt.Errorf("rpc %s marshal request: %w", subject, err)
@@ -71,7 +74,7 @@ func RequestJSON[T any](ctx context.Context, nc *nats.Conn, subject string, requ
 		name: "rpc.response.decode", operation: "request", destination: subject,
 	})
 	var reply T
-	if err := codec.Unmarshal(msg.Data, &reply); err != nil {
+	if err := codec.FastUnmarshal(msg.Data, &reply); err != nil {
 		endMessagingSegment(decodeSegment, err)
 		return zero, fmt.Errorf("rpc %s unmarshal reply: %w", subject, err)
 	}
@@ -125,7 +128,9 @@ func QueueSubscribeJSON[Req any, Resp any](
 		// required fields on the zero-value request.
 		if len(msg.Data) > 0 {
 			decodeSegment := txn.StartSegment("rpc.decode")
-			if err := codec.Unmarshal(msg.Data, &req); err != nil {
+			// FastUnmarshal leaves strings aliasing msg.Data, which stays alive
+			// for the whole inline handler — no copy needed.
+			if err := codec.FastUnmarshal(msg.Data, &req); err != nil {
 				decodeSegment.AddAttribute(resultAttribute, "invalid")
 				decodeSegment.End()
 				txn.NoticeError(err)
@@ -167,7 +172,10 @@ func QueueSubscribeJSON[Req any, Resp any](
 func respondAndLog(msg *nats.Msg, subject string, start time.Time, log *zap.Logger, txn *newrelic.Transaction, reply any) {
 	elapsed := time.Since(start)
 	encodeSegment := txn.StartSegment("rpc.reply.encode")
-	body, err := marshalResponse(reply)
+	// FastMarshal rather than marshalResponse: same byte-level-only argument as
+	// RequestJSON's request encode, and rpcErrorMessage's probe below still hits
+	// because a struct/map "error" field serializes as `"error":` either way.
+	body, err := codec.FastMarshal(reply)
 	encodeSegment.AddAttribute(resultAttribute, messagingResult(err))
 	encodeSegment.End()
 	if err != nil {

--- a/pkg/bus/rpc_locality.go
+++ b/pkg/bus/rpc_locality.go
@@ -58,10 +58,14 @@ func RequestWithContext(ctx context.Context, nc *nats.Conn, subject string, data
 // does not retry timeouts or connection errors because the request may already
 // have executed and replaying a mutation could apply it twice.
 func RequestMsgWithContext(ctx context.Context, nc *nats.Conn, msg *nats.Msg) (*nats.Msg, error) {
+	// One envelope for every attempt, with Data and Header aliased from msg:
+	// nc.request consumes Subject/Header/Data synchronously inside each publish
+	// (nothing is retained across calls), so reassigning only routed.Subject per
+	// attempt is safe and spares both a Msg allocation per attempt and any
+	// mutation of the caller's msg.
+	routed := &nats.Msg{Header: msg.Header, Data: msg.Data}
 	return requestLocalFirst(rpcRequestSubjects(rpcSubject(msg.Subject)), func(routedSubject string) (*nats.Msg, error) {
-		routed := nats.NewMsg(routedSubject)
-		routed.Data = msg.Data
-		routed.Header = msg.Header
+		routed.Subject = routedSubject
 		return nc.RequestMsgWithContext(ctx, routed)
 	})
 }

--- a/pkg/bus/rpc_test.go
+++ b/pkg/bus/rpc_test.go
@@ -1,0 +1,105 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package bus
+
+import (
+	"bytes"
+	"testing"
+
+	"ItsBagelBot/pkg/codec"
+)
+
+// The RPC paths encode replies with codec.FastMarshal while rpcErrorMessage
+// screens them with a raw byte scan for `"error"`. These tests pin that the
+// fast encoder emits struct tags and map keys in exactly the shape the probe
+// expects, so switching encoders can never silently blind the error check.
+func TestFastMarshalErrorEnvelopeHitsProbe(t *testing.T) {
+	type errorEnvelope struct {
+		Error string `json:"error"`
+	}
+
+	for name, body := range map[string]any{
+		"struct field": errorEnvelope{Error: "service draining"},
+		"map key":      map[string]string{"error": "internal error"},
+		"nested payload": struct {
+			Result string            `json:"result"`
+			Error  string            `json:"error"`
+			Detail map[string]string `json:"detail,omitempty"`
+		}{Result: "", Error: "bad request", Detail: map[string]string{"code": "E400"}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			data, err := codec.FastMarshal(body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Contains(data, errorFieldProbe) {
+				t.Fatalf("FastMarshal output %s misses probe %q", data, errorFieldProbe)
+			}
+			if got := ReplyErrorMessage(data); got != errorMessageOf(t, body) {
+				t.Fatalf("ReplyErrorMessage(%s) = %q, want %q", data, got, errorMessageOf(t, body))
+			}
+		})
+	}
+}
+
+func errorMessageOf(t *testing.T, body any) string {
+	t.Helper()
+	data, err := codec.Marshal(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	msg := ReplyErrorMessage(data)
+	if msg == "" {
+		t.Fatalf("std-encoded %s also missed by ReplyErrorMessage", data)
+	}
+	return msg
+}
+
+// A reply whose bytes contain `"error"` only as some other object's key must
+// stay a success: the scan is a cheap prefilter and the decode decides.
+func TestRPCErrorMessageValueFalsePositiveStaysSuccess(t *testing.T) {
+	data, err := codec.FastMarshal(map[string]map[string]string{"meta": {"error": "ignored"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(data, errorFieldProbe) {
+		t.Fatalf("fixture %s should contain the probe bytes", data)
+	}
+	if msg := ReplyErrorMessage(data); msg != "" {
+		t.Fatalf("ReplyErrorMessage(%s) = %q, want empty", data, msg)
+	}
+}
+
+// Escaping differences between std and fast encoding are byte-level only:
+// both must decode to identical values on the RPC round trip.
+func TestFastCodecRoundTripDecodesIdenticallyToStd(t *testing.T) {
+	type payload struct {
+		Text string `json:"text"`
+		N    int    `json:"n"`
+	}
+	in := payload{Text: "<bagel> & \"shop\"", N: 7}
+
+	fastData, err := codec.FastMarshal(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stdData, err := codec.Marshal(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var fastOut, stdOut payload
+	if err := codec.FastUnmarshal(fastData, &fastOut); err != nil {
+		t.Fatal(err)
+	}
+	if err := codec.Unmarshal(stdData, &stdOut); err != nil {
+		t.Fatal(err)
+	}
+	if fastOut != stdOut {
+		t.Fatalf("fast round trip %+v != std round trip %+v", fastOut, stdOut)
+	}
+	if fastOut != in {
+		t.Fatalf("round trip lost data: got %+v, want %+v", fastOut, in)
+	}
+}

--- a/pkg/bus/stream_budget_test.go
+++ b/pkg/bus/stream_budget_test.go
@@ -31,7 +31,7 @@ func TestMemoryStreamsFitTheHubMemoryBudget(t *testing.T) {
 	// partition pays, and this test is where it has to stay affordable.
 	const (
 		maxMem          = 4 << 30   // jetstream.max_mem
-		podMemoryLimit  = 5 << 30   // nats container limits.memory
+		podMemoryLimit  = 8 << 30   // nats container limits.memory, 8Gi live since the 2026-08-23 roll (was 5Gi); GOMEMLIMIT=6656MiB sits inside it
 		bufferedPerNode = 128 << 20 // jetstream.max_buffered_size, per stream
 		runtimeReserve  = 1 << 30   // Go heap, connection buffers, dedup ids
 	)


### PR DESCRIPTION
Cherry-pick of the production runtime commits from `perf/bus-residuals` (#638) onto current main. Bench-rig and tooling-only work is deliberately excluded; every commit here touches only the runtime surface.

## What's in it

- **Explicit-lane HOL fix** — explicit deliveries are queued instead of executed inline in the NATS callback; removes head-of-line blocking that parked the callback at a 2-3k/s cap.
- **Timer wheel for keepalives** — hierarchical wheel replaces per-connection timer heap churn with batched tick processing.
- **Pull-flow polish** — atomic receipt cursor (flowCursor), pooled retry ids, pulled envelope reuse on the drain path.
- **RPC codec symmetry** — fast-codec RPC round trips plus a single envelope allocation under locality; adds rpc_test.go coverage.
- **Residual alloc reuse** — ack-wait timer, notify channel and confirm channels reused instead of reallocated per message.
- **Pump/wheel refactor** — pump loop and wheel sweep lifted out of Subscribe/advance so the wheel owns its own cadence.
- Docs: capacity comments reconciled with rolled configuration (200-batch limit, 8 GiB budget).

Defaults unchanged. Supersedes #638 (same six commits, re-based over #639).

## Verification

- `go build ./...` ✅
- `go test ./pkg/bus -count=1 -race` ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Increased supported concurrent atomic-batch capacity from 50 to 200.
  * Expanded messaging memory capacity to support larger workloads.
  * Improved pull delivery and RPC processing efficiency.

* **Bug Fixes**
  * Improved subscriber responsiveness under backpressure, with safer queue handling and redelivery behavior.
  * Strengthened flow-control tracking during concurrent updates and session resets.
  * Improved cancellation, shutdown, and acknowledgement handling.

* **Documentation**
  * Clarified delivery guarantees, acknowledgement behavior, deployment modes, and capacity impacts of atomic publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->