### PR TITLE
chore(deps): move the console onto the scoped @nats-io clients

### DIFF
--- a/console/admin/package.json
+++ b/console/admin/package.json
@@ -12,8 +12,9 @@
   },
   "dependencies": {
     "@bagel/shared": "workspace:*",
+    "@nats-io/kv": "^3.4.0",
+    "@nats-io/transport-node": "^3.4.0",
     "nanoid": "^5.1.14",
-    "nats": "^2.29.2",
     "newrelic": "^12.11.0",
     "pino": "^9"
   },

--- a/console/admin/src/lib/server/feed.ts
+++ b/console/admin/src/lib/server/feed.ts
@@ -5,7 +5,12 @@
 // subscription that drives the SSE endpoint. Kept separate from the shared
 // request/reply client so a long-lived subscription never interferes with the
 // short-lived RPC requests (and vice versa).
-import { connect, type ConnectionOptions, type NatsConnection, type Subscription } from 'nats';
+import {
+  connect,
+  type ConnectionOptions,
+  type NatsConnection,
+  type Subscription
+} from '@nats-io/transport-node';
 
 let conn: NatsConnection | null = null;
 let dialing: Promise<NatsConnection> | null = null;

--- a/console/admin/src/lib/server/lanes.ts
+++ b/console/admin/src/lib/server/lanes.ts
@@ -3,7 +3,7 @@
 
 import { jsm, js } from '@bagel/shared/server/nats';
 import { logger } from '@bagel/shared/server/logger';
-import type { KV } from 'nats';
+import { Kvm, type KV } from '@nats-io/kv';
 import { dev } from '$app/environment';
 
 // Keep this boot-safe. Importing access.ts here pulls in services.ts, creating
@@ -54,10 +54,10 @@ async function getKV(): Promise<KV> {
         num_replicas: NATS_REPLICAS
       });
     }
-    kvStore = await client.views.kv(LANE_BUCKET, { history: 1, replicas: NATS_REPLICAS });
+    kvStore = await new Kvm(client).create(LANE_BUCKET, { history: 1, replicas: NATS_REPLICAS });
   } catch (err: any) {
     if (err.code === '404' || err.message?.includes('not found')) {
-      kvStore = await client.views.kv(LANE_BUCKET, {
+      kvStore = await new Kvm(client).create(LANE_BUCKET, {
         history: 1,
         replicas: NATS_REPLICAS,
         description: 'admin lane display aliases'

--- a/console/bun.lock
+++ b/console/bun.lock
@@ -23,8 +23,9 @@
       "name": "admin",
       "dependencies": {
         "@bagel/shared": "workspace:*",
+        "@nats-io/kv": "^3.4.0",
+        "@nats-io/transport-node": "^3.4.0",
         "nanoid": "^5.1.14",
-        "nats": "^2.29.2",
         "newrelic": "^12.11.0",
         "pino": "^9",
       },
@@ -38,7 +39,6 @@
       "dependencies": {
         "@bagel/shared": "workspace:*",
         "motion": "^12.0.0",
-        "nats": "^2.29.2",
         "newrelic": "^12.11.0",
         "pino": "^9",
       },
@@ -52,10 +52,11 @@
       "version": "0.0.0",
       "dependencies": {
         "@luzir/bolota": "0.1.6",
+        "@nats-io/jetstream": "^3.4.0",
+        "@nats-io/transport-node": "^3.4.0",
         "iovalkey": "^0.4.0",
         "lenis": "^1.3.18",
         "motion": "^12.0.0",
-        "nats": "^2.29.2",
         "oauth4webapi": "^3.8.7",
         "pino": "^9",
         "three": "^0.185.0",
@@ -106,6 +107,18 @@
     "@luzir/bolota": ["@luzir/bolota@0.1.6", "", {}, "sha512-xVadeemh1Y6aSjCGlzv93y8x4p1s8gufKR1abpWSbXAsatVICmoZDX34z+R5c15bYWrF0ZNDdsHT5d7jebxCSA=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
+
+    "@nats-io/jetstream": ["@nats-io/jetstream@3.4.0", "", { "dependencies": { "@nats-io/nats-core": "3.4.0" } }, "sha512-GzHQodNJ942+R5LRb8PuZ5ugVWVWMRiufxUYLLVWkXKfwDXYN+Owo0d7L/b9O7BPyrbYD7jQWAC6+ZVuXa9Gyw=="],
+
+    "@nats-io/kv": ["@nats-io/kv@3.4.0", "", { "dependencies": { "@nats-io/jetstream": "3.4.0", "@nats-io/nats-core": "3.4.0" } }, "sha512-168pcRJxWcIRHwdyczI3DaGk5r3CAj3CyKXuk4Nmx5KKj7N1znQOJPIxCoV0TPlAvoTidVb7eBv41J9imapMeQ=="],
+
+    "@nats-io/nats-core": ["@nats-io/nats-core@3.4.0", "", { "dependencies": { "@nats-io/nkeys": "2.0.3", "@nats-io/nuid": "3.0.0" } }, "sha512-QMDM86EUNm+wudlKC67HLar/KHHQUvJGLfb4jbahje3pUk3K9afeck9fwsxBZF0eUFox6T/TA6m/t+lQqf+QsQ=="],
+
+    "@nats-io/nkeys": ["@nats-io/nkeys@2.0.3", "", { "dependencies": { "tweetnacl": "^1.0.3" } }, "sha512-JVt56GuE6Z89KUkI4TXUbSI9fmIfAmk6PMPknijmuL72GcD+UgIomTcRWiNvvJKxA01sBbmIPStqJs5cMRBC3A=="],
+
+    "@nats-io/nuid": ["@nats-io/nuid@3.0.0", "", {}, "sha512-QbXZDrxmYlrn5AD06gYcUTmEHwxn96HBQMIk7XTjDlEcx6FPzVBBPjp4AMRh1lEv6B4iJ6Xb/Uz61JugPXFRQg=="],
+
+    "@nats-io/transport-node": ["@nats-io/transport-node@3.4.0", "", { "dependencies": { "@nats-io/nats-core": "3.4.0", "@nats-io/nkeys": "2.0.3", "@nats-io/nuid": "3.0.0" } }, "sha512-hH7u7ejIBTFEJIZ8rIcMrHJI6wl+HhpO5sVFs1+ppmXa8RuB2+Lh1+UwTzZ5xTNNm1TKcRkYy+2qCV56qp8RxA=="],
 
     "@newrelic/fn-inspect": ["@newrelic/fn-inspect@4.4.0", "", { "dependencies": { "nan": "^2.22.2", "node-gyp-build": "^4.8.1", "prebuildify": "^6.0.1" } }, "sha512-VgoXZp3zqP1167XvrA772EHDFUNuYGQh14whFq1d2sE6dC3ZL46tXI9JY0yZdAAeyCERi7mhq7CPx9BYiTOl/A=="],
 
@@ -575,11 +588,7 @@
 
     "nanoid": ["nanoid@5.1.16", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ=="],
 
-    "nats": ["nats@2.29.3", "", { "dependencies": { "nkeys.js": "1.1.0" } }, "sha512-tOQCRCwC74DgBTk4pWZ9V45sk4d7peoE2njVprMRCBXrhJ5q5cYM7i6W+Uvw2qUrcfOSnuisrX7bEx3b3Wx4QA=="],
-
     "newrelic": ["newrelic@12.25.1", "", { "dependencies": { "@grpc/grpc-js": "^1.13.2", "@grpc/proto-loader": "^0.7.5", "@newrelic/security-agent": "^2.4.4", "@opentelemetry/api": "^1.9.0", "@opentelemetry/core": "^2.0.0", "@opentelemetry/exporter-metrics-otlp-proto": "^0.201.1", "@opentelemetry/resources": "^2.0.1", "@opentelemetry/sdk-metrics": "^2.0.1", "@opentelemetry/sdk-trace-base": "^2.0.0", "@tyriar/fibonacci-heap": "^2.0.7", "concat-stream": "^2.0.0", "https-proxy-agent": "^7.0.1", "import-in-the-middle": "^1.13.0", "json-bigint": "^1.0.0", "json-stringify-safe": "^5.0.0", "module-details-from-path": "^1.0.3", "readable-stream": "^3.6.1", "require-in-the-middle": "^7.4.0", "semver": "^7.5.2", "winston-transport": "^4.5.0" }, "optionalDependencies": { "@newrelic/fn-inspect": "^4.4.0", "@newrelic/native-metrics": "^11.1.0", "@prisma/prisma-fmt-wasm": "^4.17.0-16.27eb2449f178cd9fe1a4b892d732cc4795f75085" }, "bin": { "newrelic-naming-rules": "bin/test-naming-rules.js" } }, "sha512-CcVkLRiVRhfiVQeGJ3bjpMfM6yhaK9gxG+jQCR5DhcG94hTgLCCND1xwdlVqZwPG5LMlPddkDXWmXY7jd6P5DQ=="],
-
-    "nkeys.js": ["nkeys.js@1.1.0", "", { "dependencies": { "tweetnacl": "1.0.3" } }, "sha512-tB/a0shZL5UZWSwsoeyqfTszONTt4k2YS0tuQioMOD180+MbombYVgzDUYHlx+gejYK6rgf08n/2Df99WY0Sxg=="],
 
     "node-abi": ["node-abi@3.94.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g=="],
 

--- a/console/dashboard/package.json
+++ b/console/dashboard/package.json
@@ -13,7 +13,6 @@
   "dependencies": {
     "@bagel/shared": "workspace:*",
     "motion": "^12.0.0",
-    "nats": "^2.29.2",
     "newrelic": "^12.11.0",
     "pino": "^9"
   },

--- a/console/shared/lib/server/nats-rpc-locality.test.ts
+++ b/console/shared/lib/server/nats-rpc-locality.test.ts
@@ -2,7 +2,7 @@
 // Proprietary. No license granted. See LICENSE.md.
 
 import { describe, expect, test } from 'bun:test';
-import { ErrorCode } from 'nats';
+import { NoRespondersError, RequestError, TimeoutError } from '@nats-io/transport-node';
 import { requestLocalFirst, rpcSubjectsForNode } from './nats-rpc-locality';
 
 describe('RPC node locality', () => {
@@ -23,7 +23,11 @@ describe('RPC node locality', () => {
     const called: string[] = [];
     const result = await requestLocalFirst(['rpc.get.node.node2', 'rpc.get'], async (subject) => {
       called.push(subject);
-      if (subject.endsWith('.node.node2')) throw { code: ErrorCode.NoResponders };
+      if (subject.endsWith('.node.node2')) {
+        throw new RequestError(`no responders for '${subject}'`, {
+          cause: new NoRespondersError(subject)
+        });
+      }
       return 'generic reply';
     });
     expect(result).toBe('generic reply');
@@ -35,9 +39,9 @@ describe('RPC node locality', () => {
     await expect(
       requestLocalFirst(['rpc.write.node.node2', 'rpc.write'], async (subject) => {
         called.push(subject);
-        throw { code: ErrorCode.Timeout };
+        throw new TimeoutError();
       })
-    ).rejects.toEqual({ code: ErrorCode.Timeout });
+    ).rejects.toBeInstanceOf(TimeoutError);
     expect(called).toEqual(['rpc.write.node.node2']);
   });
 });

--- a/console/shared/lib/server/nats-rpc-locality.ts
+++ b/console/shared/lib/server/nats-rpc-locality.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 Adam Ousmer. All rights reserved.
 // Proprietary. No license granted. See LICENSE.md.
 
-import { ErrorCode } from 'nats';
+import { RequestError } from '@nats-io/transport-node';
 
 const RPC_NODE_TOKEN = 'node';
 
@@ -10,13 +10,10 @@ export function rpcSubjectsForNode(subject: string, node: string | undefined): s
   return [`${subject}.${RPC_NODE_TOKEN}.${node}`, subject];
 }
 
+// v3 clients drop the ErrorCode enum: requests reject with a RequestError whose
+// cause is a NoRespondersError exactly when no local responder exists.
 function isNoResponders(error: unknown): boolean {
-  return (
-    typeof error === 'object' &&
-    error !== null &&
-    'code' in error &&
-    (error as { code?: string }).code === ErrorCode.NoResponders
-  );
+  return error instanceof RequestError && error.isNoResponders();
 }
 
 // A generic retry is safe only when NATS proves no local responder exists.

--- a/console/shared/lib/server/nats.ts
+++ b/console/shared/lib/server/nats.ts
@@ -7,16 +7,16 @@
 import newrelic from 'newrelic';
 import {
   connect,
-  JSONCodec,
   type ConnectionOptions,
-  type NatsConnection,
-  type JetStreamClient,
-  type JetStreamManager,
-  type JetStreamManagerOptions
-} from 'nats';
+  type NatsConnection
+} from '@nats-io/transport-node';
+import { jetstream, jetstreamManager } from '@nats-io/jetstream';
+import type {
+  JetStreamClient,
+  JetStreamManager,
+  JetStreamManagerOptions
+} from '@nats-io/jetstream';
 import { requestLocalFirst, rpcSubjectsForNode } from './nats-rpc-locality';
-
-const jc = JSONCodec();
 
 // Collapse numeric/id path tokens so per-subject RPC segments stay low-cardinality
 // in New Relic (e.g. `...status.12345` -> `...status.*`).
@@ -260,13 +260,13 @@ export function hubJetStreamOptions(): JetStreamManagerOptions {
 
 export async function js(): Promise<JetStreamClient> {
   const nc = await get('bus');
-  if (!jsClient) jsClient = nc.jetstream(hubJetStreamOptions());
+  if (!jsClient) jsClient = jetstream(nc, hubJetStreamOptions());
   return jsClient;
 }
 
 export async function jsm(): Promise<JetStreamManager> {
   const nc = await get('bus');
-  if (!jsManager) jsManager = await nc.jetstreamManager(hubJetStreamOptions());
+  if (!jsManager) jsManager = await jetstreamManager(nc, hubJetStreamOptions());
   return jsManager;
 }
 
@@ -318,11 +318,12 @@ export async function rpc<T>(subject: string, payload: unknown = {}, timeoutMs =
   return newrelic.startSegment(`NATS/request/${rpcSegment(subject)}`, true, async () => {
     const nc = await get('rpc');
     const subjects = rpcSubjectsForNode(subject, process.env.NODE_NAME);
-    const data = jc.encode(payload);
+    // v3 clients accept string payloads directly (JSONCodec was removed).
+    const data = JSON.stringify(payload);
     const msg = await requestLocalFirst(subjects, (routedSubject) =>
       nc.request(routedSubject, data, { timeout: timeoutMs })
     );
-    const reply = jc.decode(msg.data) as T & { error?: string };
+    const reply = msg.json<T & { error?: string }>();
     if (reply && typeof reply === 'object' && reply.error) throw new RpcError(reply.error);
     return reply as T;
   });
@@ -343,7 +344,7 @@ export async function publish(subject: string, payload: unknown = {}): Promise<v
     // JetStream streams and must use the bus connection; RPC + cache stay on rpc.
     const role: Role = subject.startsWith('twitch.') || subject.startsWith('data.') ? 'bus' : 'rpc';
     const nc = await get(role);
-    nc.publish(subject, jc.encode(payload));
+    nc.publish(subject, JSON.stringify(payload));
     await nc.flush();
   });
 }

--- a/console/shared/package.json
+++ b/console/shared/package.json
@@ -42,10 +42,11 @@
   },
   "dependencies": {
     "@luzir/bolota": "0.1.6",
+    "@nats-io/jetstream": "^3.4.0",
+    "@nats-io/transport-node": "^3.4.0",
     "iovalkey": "^0.4.0",
     "lenis": "^1.3.18",
     "motion": "^12.0.0",
-    "nats": "^2.29.2",
     "oauth4webapi": "^3.8.7",
     "pino": "^9",
     "three": "^0.185.0"


### PR DESCRIPTION
Closes the `nats` deprecation row on the [Dependency Dashboard](https://github.com/AdamOusmer/ItsBagelBot/issues/475).

The npm `nats` package is deprecated and frozen at 2.29.3; Renovate lists it under "Deprecations / Replacements" with no replacement PR it can open. This migrates all three console workspaces to the successor packages (`@nats-io/*` v3.4.0, published from the nats-io/nats.js monorepo):

| workspace | before | after |
|---|---|---|
| shared | `nats ^2.29.2` | `@nats-io/transport-node`, `@nats-io/jetstream` |
| admin | `nats ^2.29.2` | `@nats-io/transport-node`, `@nats-io/kv` |
| dashboard | `nats ^2.29.2` | *(direct dep dropped — only consumed shared's client)* |

## v3 API breaks handled

- `nc.jetstream()` / `nc.jetstreamManager()` → standalone `jetstream(nc, opts)` / `jetstreamManager(nc, opts)`
- `JetStreamClient#views.kv()` → `new Kvm(js).create()` (`@nats-io/kv`)
- `JSONCodec` removed → string payloads on publish/request, replies via `Msg.json<T>()`
- `ErrorCode` enum removed → no-responders detection via `RequestError.isNoResponders()`; the locality test now builds real `RequestError` / `NoRespondersError` / `TimeoutError` values

## Verification

- `bun test shared`: 159 pass, 0 fail
- `svelte-check` (admin + dashboard): 0 errors (one pre-existing CSS compat warning in dashboard)
- Production builds of both apps pass their demo-fixture gates
- Lockfile delta vs main is exactly the NATS swap — no other dependency drift

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated NATS connectivity and messaging support for improved compatibility with the latest client packages.
  * Preserved existing feed, key-value storage, RPC, publishing, and reply-handling behavior.
  * Improved handling of request failures, including no-responder and timeout conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->