### PR TITLE
fix(network): allow kubelet health probes for NATS monitor

### DIFF
--- a/deploy/messaging/network-policies.yaml
+++ b/deploy/messaging/network-policies.yaml
@@ -72,6 +72,14 @@ spec:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: tailscale
+        # WORKAROUND for cilium/cilium#43012 (v1.18.4+): kubelet health probes arrive
+        # from cilium_host misclassified as the "world" identity instead of "host".
+        # This ipBlock allows "world" (0.0.0.0/0) but excludes the cluster's pod CIDR,
+        # securely allowing kubelet probes while keeping pod-to-pod monitor access blocked.
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.42.0.0/16
       ports:
         - port: 8222
         - port: 8223


### PR DESCRIPTION
Added a workaround for cilium/cilium#43012 where kubelet health probes are dropped by default-deny because they're misclassified as 'world'. This explicitly allows 0.0.0.0/0 while excluding the cluster pod CIDR (10.42.0.0/16) to ensure NATS monitor ports remain protected from unauthorized pod-to-pod access.