### PR TITLE
feat(sesame): Valorant chat module

### DIFF
--- a/app/sesame/modules/all.go
+++ b/app/sesame/modules/all.go
@@ -26,6 +26,7 @@ func All(d engine.Deps) []module.Module {
 		Mcsr(d),
 		Fortnite(d),
 		ClashRoyale(d),
+		Valorant(d),
 		// Raffle before Queue: both declare !join, and the registry's first-wins
 		// de-dup gives the earlier module the standalone spelling. A channel
 		// running both features joins raffles with !join and reaches the queue

--- a/app/sesame/modules/valorant.go
+++ b/app/sesame/modules/valorant.go
@@ -86,37 +86,46 @@ type valorantConfig struct {
 // "!val eu Frosty#EUW1" and "!val lb console ap" read naturally. Every
 // account answer rides gossip's cache keyed on id+region+platform, and a
 // region-less lookup auto-detects the shard once per day fleet-wide.
-func Valorant(d engine.Deps) module.Module {
-	rankSpecial := func(reply any) (string, bool) {
-		r, ok := reply.(*gossiprpc.ValorantRankReply)
-		if !ok || !r.Unranked {
-			return "", false
-		}
-		return r.Player + " " + valUnrankedText, true
+// The four empty-state overrides. Each replaces its command's template
+// entirely when the reply carries no renderable content, because every
+// numeric token would print zero.
+func valRankSpecial(reply any) (string, bool) {
+	r, ok := reply.(*gossiprpc.ValorantRankReply)
+	if !ok || !r.Unranked {
+		return "", false
 	}
-	matchSpecial := func(reply any) (string, bool) {
-		r, ok := reply.(*gossiprpc.ValorantMatchesReply)
-		if !ok || !r.Empty {
-			return "", false
-		}
-		return r.Player + " " + valNoMatchesText, true
-	}
-	boardSpecial := func(reply any) (string, bool) {
-		r, ok := reply.(*gossiprpc.ValorantLeaderboardReply)
-		if !ok || !r.Empty {
-			return "", false
-		}
-		return r.Board + " " + valEmptyBoardText, true
-	}
-	shopSpecial := func(reply any) (string, bool) {
-		r, ok := reply.(*gossiprpc.ValorantShopReply)
-		if !ok || !r.Empty {
-			return "", false
-		}
-		return valEmptyShopText, true
-	}
+	return r.Player + " " + valUnrankedText, true
+}
 
-	runs := valRuns{
+func valMatchSpecial(reply any) (string, bool) {
+	r, ok := reply.(*gossiprpc.ValorantMatchesReply)
+	if !ok || !r.Empty {
+		return "", false
+	}
+	return r.Player + " " + valNoMatchesText, true
+}
+
+func valBoardSpecial(reply any) (string, bool) {
+	r, ok := reply.(*gossiprpc.ValorantLeaderboardReply)
+	if !ok || !r.Empty {
+		return "", false
+	}
+	return r.Board + " " + valEmptyBoardText, true
+}
+
+func valShopSpecial(reply any) (string, bool) {
+	r, ok := reply.(*gossiprpc.ValorantShopReply)
+	if !ok || !r.Empty {
+		return "", false
+	}
+	return valEmptyShopText, true
+}
+
+// newValRuns wires the five subcommand runners: each names its gossip
+// endpoint, where its toggle and template live in the config blob, and which
+// empty-state override applies.
+func newValRuns(d engine.Deps) valRuns {
+	return valRuns{
 		rank: valRun(d, valCommand{
 			endpoint: "rank",
 			enabled:  func(c valorantConfig) string { return c.RankEnabled },
@@ -124,7 +133,7 @@ func Valorant(d engine.Deps) module.Module {
 			fallback: defaultValRankTemplate,
 			newReply: func() any { return &gossiprpc.ValorantRankReply{} },
 			tokens:   valRankTokens(),
-			special:  rankSpecial,
+			special:  valRankSpecial,
 		}),
 		matches: valRun(d, valCommand{
 			endpoint: "matches",
@@ -133,7 +142,7 @@ func Valorant(d engine.Deps) module.Module {
 			fallback: defaultValMatchesTemplate,
 			newReply: func() any { return &gossiprpc.ValorantMatchesReply{} },
 			tokens:   valMatchTokens(),
-			special:  matchSpecial,
+			special:  valMatchSpecial,
 		}),
 		account: valRun(d, valCommand{
 			endpoint: "account",
@@ -150,7 +159,7 @@ func Valorant(d engine.Deps) module.Module {
 			fallback: defaultValBoardTemplate,
 			newReply: func() any { return &gossiprpc.ValorantLeaderboardReply{} },
 			tokens:   valBoardTokens(),
-			special:  boardSpecial,
+			special:  valBoardSpecial,
 			// A bare "!vallb" is a regional top-N ask, not a lookup of the
 			// broadcaster's own standing: falling back to their Twitch login
 			// (never a syntactically valid Riot ID) would only produce
@@ -164,11 +173,15 @@ func Valorant(d engine.Deps) module.Module {
 			fallback: defaultValShopTemplate,
 			newReply: func() any { return &gossiprpc.ValorantShopReply{} },
 			tokens:   valShopTokens(),
-			special:  shopSpecial,
+			special:  valShopSpecial,
 			// The rotation is global: no account scopes it, so none is resolved.
 			accountless: true,
 		}),
 	}
+}
+
+func Valorant(d engine.Deps) module.Module {
+	runs := newValRuns(d)
 
 	m := module.NewModule(valModuleName, module.KindOptIn)
 	m.Command("val").Everyone().Cooldown(valCooldown).

--- a/app/sesame/modules/valorant.go
+++ b/app/sesame/modules/valorant.go
@@ -116,72 +116,80 @@ func Valorant(d engine.Deps) module.Module {
 		return valEmptyShopText, true
 	}
 
-	rankRun := valRun(d, valCommand{
-		endpoint: "rank",
-		enabled:  func(c valorantConfig) string { return c.RankEnabled },
-		message:  func(c valorantConfig) string { return c.RankMessage },
-		fallback: defaultValRankTemplate,
-		newReply: func() any { return &gossiprpc.ValorantRankReply{} },
-		tokens:   valRankTokens(),
-		special:  rankSpecial,
-	})
-	matchRun := valRun(d, valCommand{
-		endpoint: "matches",
-		enabled:  func(c valorantConfig) string { return c.MatchEnabled },
-		message:  func(c valorantConfig) string { return c.MatchMessage },
-		fallback: defaultValMatchesTemplate,
-		newReply: func() any { return &gossiprpc.ValorantMatchesReply{} },
-		tokens:   valMatchTokens(),
-		special:  matchSpecial,
-	})
-	acctRun := valRun(d, valCommand{
-		endpoint: "account",
-		enabled:  func(c valorantConfig) string { return c.AcctEnabled },
-		message:  func(c valorantConfig) string { return c.AcctMessage },
-		fallback: defaultValAccountTemplate,
-		newReply: func() any { return &gossiprpc.ValorantAccountReply{} },
-		tokens:   valAccountTokens(),
-	})
-	boardRun := valRun(d, valCommand{
-		endpoint: "leaderboard",
-		enabled:  func(c valorantConfig) string { return c.BoardEnabled },
-		message:  func(c valorantConfig) string { return c.BoardMessage },
-		fallback: defaultValBoardTemplate,
-		newReply: func() any { return &gossiprpc.ValorantLeaderboardReply{} },
-		tokens:   valBoardTokens(),
-		special:  boardSpecial,
-		// A bare "!vallb" is a regional top-N ask, not a lookup of the
-		// broadcaster's own standing: falling back to their Twitch login
-		// (never a syntactically valid Riot ID) would only produce
-		// "invalid riot id" instead of the board they asked for.
-		noBroadcasterFallback: true,
-	})
-	shopRun := valRun(d, valCommand{
-		endpoint: "shop",
-		enabled:  func(c valorantConfig) string { return c.ShopEnabled },
-		message:  func(c valorantConfig) string { return c.ShopMessage },
-		fallback: defaultValShopTemplate,
-		newReply: func() any { return &gossiprpc.ValorantShopReply{} },
-		tokens:   valShopTokens(),
-		special:  shopSpecial,
-		// The rotation is global: no account scopes it, so none is resolved.
-		accountless: true,
-	})
+	runs := valRuns{
+		rank: valRun(d, valCommand{
+			endpoint: "rank",
+			enabled:  func(c valorantConfig) string { return c.RankEnabled },
+			message:  func(c valorantConfig) string { return c.RankMessage },
+			fallback: defaultValRankTemplate,
+			newReply: func() any { return &gossiprpc.ValorantRankReply{} },
+			tokens:   valRankTokens(),
+			special:  rankSpecial,
+		}),
+		matches: valRun(d, valCommand{
+			endpoint: "matches",
+			enabled:  func(c valorantConfig) string { return c.MatchEnabled },
+			message:  func(c valorantConfig) string { return c.MatchMessage },
+			fallback: defaultValMatchesTemplate,
+			newReply: func() any { return &gossiprpc.ValorantMatchesReply{} },
+			tokens:   valMatchTokens(),
+			special:  matchSpecial,
+		}),
+		account: valRun(d, valCommand{
+			endpoint: "account",
+			enabled:  func(c valorantConfig) string { return c.AcctEnabled },
+			message:  func(c valorantConfig) string { return c.AcctMessage },
+			fallback: defaultValAccountTemplate,
+			newReply: func() any { return &gossiprpc.ValorantAccountReply{} },
+			tokens:   valAccountTokens(),
+		}),
+		board: valRun(d, valCommand{
+			endpoint: "leaderboard",
+			enabled:  func(c valorantConfig) string { return c.BoardEnabled },
+			message:  func(c valorantConfig) string { return c.BoardMessage },
+			fallback: defaultValBoardTemplate,
+			newReply: func() any { return &gossiprpc.ValorantLeaderboardReply{} },
+			tokens:   valBoardTokens(),
+			special:  boardSpecial,
+			// A bare "!vallb" is a regional top-N ask, not a lookup of the
+			// broadcaster's own standing: falling back to their Twitch login
+			// (never a syntactically valid Riot ID) would only produce
+			// "invalid riot id" instead of the board they asked for.
+			noBroadcasterFallback: true,
+		}),
+		shop: valRun(d, valCommand{
+			endpoint: "shop",
+			enabled:  func(c valorantConfig) string { return c.ShopEnabled },
+			message:  func(c valorantConfig) string { return c.ShopMessage },
+			fallback: defaultValShopTemplate,
+			newReply: func() any { return &gossiprpc.ValorantShopReply{} },
+			tokens:   valShopTokens(),
+			special:  shopSpecial,
+			// The rotation is global: no account scopes it, so none is resolved.
+			accountless: true,
+		}),
+	}
 
 	m := module.NewModule(valModuleName, module.KindOptIn)
 	m.Command("val").Everyone().Cooldown(valCooldown).
-		Run(valDispatchRun(rankRun, matchRun, acctRun, boardRun, shopRun))
+		Run(valDispatchRun(runs))
 	m.Command("valrank").Everyone().Cooldown(valCooldown).
-		Run(rankRun)
+		Run(runs.rank)
 	m.Command("valmatches").Everyone().Cooldown(valCooldown).Aliases("valhistory").
-		Run(matchRun)
+		Run(runs.matches)
 	m.Command("valaccount").Everyone().Cooldown(valCooldown).Aliases("valwho").
-		Run(acctRun)
+		Run(runs.account)
 	m.Command("vallb").Everyone().Cooldown(valCooldown).Aliases("valleaderboard").
-		Run(boardRun)
+		Run(runs.board)
 	m.Command("valshop").Everyone().Cooldown(valCooldown).Aliases("valrotation").
-		Run(shopRun)
+		Run(runs.shop)
 	return m.Build()
+}
+
+// valRuns bundles the five subcommand runners so the root dispatcher takes one
+// argument instead of a positional list that grows with every new view.
+type valRuns struct {
+	rank, matches, account, board, shop module.RunFunc
 }
 
 // valCommand names one command's wiring: the gossip endpoint it queries,
@@ -202,10 +210,9 @@ type valCommand struct {
 	accountless           bool
 }
 
-// valRun builds one command runner: peel the scoping args, resolve the target
-// id, call the endpoint, expand the template over the reply. Tokens are
-// declared against `any` so one runner serves five reply types; each palette
-// casts back.
+// valRun builds one command runner: scope the request, call the endpoint,
+// expand the template over the reply. Tokens are declared against `any` so
+// one runner serves five reply types; each palette casts back.
 func valRun(d engine.Deps, cmd valCommand) module.RunFunc {
 	return func(ctx context.Context, c *module.Context, args string, emit module.Emit) error {
 		var cfg valorantConfig
@@ -214,46 +221,17 @@ func valRun(d engine.Deps, cmd valCommand) module.RunFunc {
 			return nil
 		}
 
-		req := gossiprpc.Request{IsPremium: c.Regress.IsPremium()}
-		if !cmd.accountless {
-			argAccount, argRegion, argPlatform := parseValArgs(args)
-			if argRegion != "" {
-				req.Region = argRegion
-			} else {
-				req.Region = cfg.Region
-			}
-			if argPlatform != "" {
-				req.Platform = argPlatform
-			} else {
-				req.Platform = cfg.Platform
-			}
-			if cmd.noBroadcasterFallback {
-				req.Account = argAccount
-				if req.Account == "" {
-					req.Account = cfg.Account
-				}
-			} else {
-				req.Account = resolveAccount(accountSources{Arg: argAccount, Linked: cfg.Account, BroadcasterLogin: c.Env.BroadcasterUserLogin})
-			}
-		}
-
+		req := valRequest(cmd, cfg, c, args)
 		reply := cmd.newReply()
-		subject := req.Account
-		if cmd.accountless {
-			// The rotation has no target player, so errors name the feature.
-			subject = "daily rotation"
-		}
 		if err := d.Gossip.Call(ctx, engine.GossipRoute{Provider: "valorant", Endpoint: cmd.endpoint}, req, reply); err != nil {
-			if chatReplyError(c, emit, subject, err) {
+			if chatReplyError(c, emit, valSubject(cmd, req), err) {
 				return nil
 			}
 			return err
 		}
-		if cmd.special != nil {
-			if text, ok := cmd.special(reply); ok {
-				emit(&module.Output{Type: outgress.TypeChat, BroadcasterID: c.Env.BroadcasterUserID, Text: text})
-				return nil
-			}
+		if text, ok := valSpecial(cmd.special, reply); ok {
+			emit(&module.Output{Type: outgress.TypeChat, BroadcasterID: c.Env.BroadcasterUserID, Text: text})
+			return nil
 		}
 
 		msg := module.ExpandString(orDefault(cmd.message(cfg), cmd.fallback), func(key string) (string, bool) {
@@ -267,26 +245,74 @@ func valRun(d engine.Deps, cmd valCommand) module.RunFunc {
 	}
 }
 
+// valRequest scopes one lookup: shard and ladder words peel off the typed args
+// first and dashboard config fills whatever remains; the target account then
+// resolves through the shared fallback chain — unless the command opts out,
+// because a board ask without an id is a regional top-N (the login fallback
+// would only mint "invalid riot id") and the shop has no target at all.
+func valRequest(cmd valCommand, cfg valorantConfig, c *module.Context, args string) gossiprpc.Request {
+	req := gossiprpc.Request{IsPremium: c.Regress.IsPremium()}
+	if cmd.accountless {
+		return req
+	}
+	argAccount, argRegion, argPlatform := parseValArgs(args)
+	req.Region, req.Platform = argRegion, argPlatform
+	if req.Region == "" {
+		req.Region = cfg.Region
+	}
+	if req.Platform == "" {
+		req.Platform = cfg.Platform
+	}
+
+	switch {
+	case cmd.noBroadcasterFallback:
+		req.Account = argAccount
+		if req.Account == "" {
+			req.Account = cfg.Account
+		}
+	default:
+		req.Account = resolveAccount(accountSources{Arg: argAccount, Linked: cfg.Account, BroadcasterLogin: c.Env.BroadcasterUserLogin})
+	}
+	return req
+}
+
+// valSubject names what a failure chats about: the rotation has no target
+// player, so its errors name the feature instead of an account.
+func valSubject(cmd valCommand, req gossiprpc.Request) string {
+	if cmd.accountless {
+		return "daily rotation"
+	}
+	return req.Account
+}
+
+// valSpecial applies a command's empty-state override, if one is wired.
+func valSpecial(special func(any) (string, bool), reply any) (string, bool) {
+	if special == nil {
+		return "", false
+	}
+	return special(reply)
+}
+
 // valDispatchRun routes !val's first argument word onto the subcommand
 // runners: "matches"/"account"/"lb"/"shop" select one explicitly, and anything
 // else — nothing, or a Riot ID — is a rank lookup, so "!val Frosty#EUW1" reads
 // naturally.
-func valDispatchRun(rankRun, matchRun, acctRun, boardRun, shopRun module.RunFunc) module.RunFunc {
+func valDispatchRun(runs valRuns) module.RunFunc {
 	return func(ctx context.Context, c *module.Context, args string, emit module.Emit) error {
 		sub, rest, _ := strings.Cut(strings.TrimSpace(args), " ")
 		switch strings.ToLower(sub) {
 		case "match", "matches", "history":
-			return matchRun(ctx, c, rest, emit)
+			return runs.matches(ctx, c, rest, emit)
 		case "account", "who":
-			return acctRun(ctx, c, rest, emit)
+			return runs.account(ctx, c, rest, emit)
 		case "lb", "leaderboard", "top":
-			return boardRun(ctx, c, rest, emit)
+			return runs.board(ctx, c, rest, emit)
 		case "shop", "rotation":
-			return shopRun(ctx, c, rest, emit)
+			return runs.shop(ctx, c, rest, emit)
 		case "rank", "standing":
-			return rankRun(ctx, c, rest, emit)
+			return runs.rank(ctx, c, rest, emit)
 		default:
-			return rankRun(ctx, c, args, emit)
+			return runs.rank(ctx, c, args, emit)
 		}
 	}
 }

--- a/app/sesame/modules/valorant.go
+++ b/app/sesame/modules/valorant.go
@@ -1,0 +1,443 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package modules
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"ItsBagelBot/app/sesame/engine"
+	"ItsBagelBot/app/sesame/module"
+	"ItsBagelBot/internal/domain/outgress"
+	gossiprpc "ItsBagelBot/internal/domain/rpc/gossip"
+)
+
+// valModuleName is the ModuleView key; the console MODULE_CATALOG entry and
+// the dashboard module page use the same id.
+const valModuleName = "valorant"
+
+// valCooldown is the shared per-command window; gossip caches every answer
+// (two minutes on rank and matches, a day on the shop rotation), so this only
+// shields chat from command spam, not the API.
+const valCooldown = 10 * time.Second
+
+// Default reply templates. The broadcaster customizes them per command on the
+// module page; blank falls back to these.
+const (
+	defaultValRankTemplate    = "{player} · {tier} · {rr} RR ({lastchange}) · peak {peaktier}"
+	defaultValMatchesTemplate = "{player}'s last {count}: {matches}"
+	defaultValAccountTemplate = "{player} · account level {level}"
+	defaultValBoardTemplate   = "{board}: {entries}"
+	defaultValShopTemplate    = "Daily rotation ({count}): {items} · resets in {reset}"
+)
+
+// Special-case lines that replace their template entirely, because every
+// numeric token would render zero (the same shape as !crranked's no-record
+// answer).
+const (
+	valUnrankedText   = "has no competitive record this act"
+	valNoMatchesText  = "has no recent competitive games"
+	valEmptyBoardText = "leaderboard has no entries yet"
+	valEmptyShopText  = "the daily rotation is empty today"
+)
+
+// valorantConfig is the module's dashboard configuration. Account is the
+// linked Riot ID ("Name#Tag"); Region and Platform scope it ("na", "console",
+// ...) — blank lets gossip detect the shard from the account and default to
+// PC. Chat args override all three per call. The *Enabled toggles are stored
+// "on"/"off" — empty means on, matching the alerts module's semantics — and
+// each *Message is a customized template (blank = default).
+type valorantConfig struct {
+	Account  string `json:"account"`
+	Region   string `json:"region"`
+	Platform string `json:"platform"`
+
+	RankEnabled  string `json:"rankEnabled"`
+	RankMessage  string `json:"rankMessage"`
+	MatchEnabled string `json:"matchesEnabled"`
+	MatchMessage string `json:"matchesMessage"`
+	AcctEnabled  string `json:"accountEnabled"`
+	AcctMessage  string `json:"accountMessage"`
+	BoardEnabled string `json:"boardEnabled"`
+	BoardMessage string `json:"boardMessage"`
+	ShopEnabled  string `json:"shopEnabled"`
+	ShopMessage  string `json:"shopMessage"`
+}
+
+// Valorant owns the Valorant chat commands backed by the gossip service. It
+// is a named, opt-in module (KindOptIn): off by default, enabled on the
+// dashboard, where the broadcaster links their Riot ID. Viewers can always
+// target another player explicitly: "!val Frosty#EUW1".
+//
+// The command surface mirrors clashroyale's: one root with subcommands plus
+// the squashed forms as direct triggers.
+//
+//	!val [id]            current competitive standing (also !valrank)
+//	!val matches [id]    the last few competitive games (also !valmatches)
+//	!val account [id]    who an ID resolves to, level/title (also !valaccount)
+//	!val lb [region]     the regional top 10 (also !vallb)
+//	!val shop            today's global skin rotation (also !valshop)
+//
+// An id is "Name#Tag"; any argument word naming a shard (na/eu/ap/kr/br/
+// latam) or a ladder (pc/console) scopes the lookup wherever it sits, so
+// "!val eu Frosty#EUW1" and "!val lb console ap" read naturally. Every
+// account answer rides gossip's cache keyed on id+region+platform, and a
+// region-less lookup auto-detects the shard once per day fleet-wide.
+func Valorant(d engine.Deps) module.Module {
+	rankSpecial := func(reply any) (string, bool) {
+		r, ok := reply.(*gossiprpc.ValorantRankReply)
+		if !ok || !r.Unranked {
+			return "", false
+		}
+		return r.Player + " " + valUnrankedText, true
+	}
+	matchSpecial := func(reply any) (string, bool) {
+		r, ok := reply.(*gossiprpc.ValorantMatchesReply)
+		if !ok || !r.Empty {
+			return "", false
+		}
+		return r.Player + " " + valNoMatchesText, true
+	}
+	boardSpecial := func(reply any) (string, bool) {
+		r, ok := reply.(*gossiprpc.ValorantLeaderboardReply)
+		if !ok || !r.Empty {
+			return "", false
+		}
+		return r.Board + " " + valEmptyBoardText, true
+	}
+	shopSpecial := func(reply any) (string, bool) {
+		r, ok := reply.(*gossiprpc.ValorantShopReply)
+		if !ok || !r.Empty {
+			return "", false
+		}
+		return valEmptyShopText, true
+	}
+
+	rankRun := valRun(d, valCommand{
+		endpoint: "rank",
+		enabled:  func(c valorantConfig) string { return c.RankEnabled },
+		message:  func(c valorantConfig) string { return c.RankMessage },
+		fallback: defaultValRankTemplate,
+		newReply: func() any { return &gossiprpc.ValorantRankReply{} },
+		tokens:   valRankTokens(),
+		special:  rankSpecial,
+	})
+	matchRun := valRun(d, valCommand{
+		endpoint: "matches",
+		enabled:  func(c valorantConfig) string { return c.MatchEnabled },
+		message:  func(c valorantConfig) string { return c.MatchMessage },
+		fallback: defaultValMatchesTemplate,
+		newReply: func() any { return &gossiprpc.ValorantMatchesReply{} },
+		tokens:   valMatchTokens(),
+		special:  matchSpecial,
+	})
+	acctRun := valRun(d, valCommand{
+		endpoint: "account",
+		enabled:  func(c valorantConfig) string { return c.AcctEnabled },
+		message:  func(c valorantConfig) string { return c.AcctMessage },
+		fallback: defaultValAccountTemplate,
+		newReply: func() any { return &gossiprpc.ValorantAccountReply{} },
+		tokens:   valAccountTokens(),
+	})
+	boardRun := valRun(d, valCommand{
+		endpoint: "leaderboard",
+		enabled:  func(c valorantConfig) string { return c.BoardEnabled },
+		message:  func(c valorantConfig) string { return c.BoardMessage },
+		fallback: defaultValBoardTemplate,
+		newReply: func() any { return &gossiprpc.ValorantLeaderboardReply{} },
+		tokens:   valBoardTokens(),
+		special:  boardSpecial,
+		// A bare "!vallb" is a regional top-N ask, not a lookup of the
+		// broadcaster's own standing: falling back to their Twitch login
+		// (never a syntactically valid Riot ID) would only produce
+		// "invalid riot id" instead of the board they asked for.
+		noBroadcasterFallback: true,
+	})
+	shopRun := valRun(d, valCommand{
+		endpoint: "shop",
+		enabled:  func(c valorantConfig) string { return c.ShopEnabled },
+		message:  func(c valorantConfig) string { return c.ShopMessage },
+		fallback: defaultValShopTemplate,
+		newReply: func() any { return &gossiprpc.ValorantShopReply{} },
+		tokens:   valShopTokens(),
+		special:  shopSpecial,
+		// The rotation is global: no account scopes it, so none is resolved.
+		accountless: true,
+	})
+
+	m := module.NewModule(valModuleName, module.KindOptIn)
+	m.Command("val").Everyone().Cooldown(valCooldown).
+		Run(valDispatchRun(rankRun, matchRun, acctRun, boardRun, shopRun))
+	m.Command("valrank").Everyone().Cooldown(valCooldown).
+		Run(rankRun)
+	m.Command("valmatches").Everyone().Cooldown(valCooldown).Aliases("valhistory").
+		Run(matchRun)
+	m.Command("valaccount").Everyone().Cooldown(valCooldown).Aliases("valwho").
+		Run(acctRun)
+	m.Command("vallb").Everyone().Cooldown(valCooldown).Aliases("valleaderboard").
+		Run(boardRun)
+	m.Command("valshop").Everyone().Cooldown(valCooldown).Aliases("valrotation").
+		Run(shopRun)
+	return m.Build()
+}
+
+// valCommand names one command's wiring: the gossip endpoint it queries,
+// where its toggle and template live in the config blob, an empty reply value
+// Call decodes into, an optional post-decode override (the three empty-state
+// answers replace their template entirely), and two account-resolution
+// deviations shared by !vallb and !valshop.
+type valCommand struct {
+	endpoint string
+	enabled  func(valorantConfig) string
+	message  func(valorantConfig) string
+	fallback string
+	newReply func() any
+	tokens   map[string]func(any) string
+	special  func(reply any) (string, bool)
+
+	noBroadcasterFallback bool
+	accountless           bool
+}
+
+// valRun builds one command runner: peel the scoping args, resolve the target
+// id, call the endpoint, expand the template over the reply. Tokens are
+// declared against `any` so one runner serves five reply types; each palette
+// casts back.
+func valRun(d engine.Deps, cmd valCommand) module.RunFunc {
+	return func(ctx context.Context, c *module.Context, args string, emit module.Emit) error {
+		var cfg valorantConfig
+		_ = c.Decode(&cfg)
+		if !alertOn(cmd.enabled(cfg)) || d.Gossip == nil {
+			return nil
+		}
+
+		req := gossiprpc.Request{IsPremium: c.Regress.IsPremium()}
+		if !cmd.accountless {
+			argAccount, argRegion, argPlatform := parseValArgs(args)
+			if argRegion != "" {
+				req.Region = argRegion
+			} else {
+				req.Region = cfg.Region
+			}
+			if argPlatform != "" {
+				req.Platform = argPlatform
+			} else {
+				req.Platform = cfg.Platform
+			}
+			if cmd.noBroadcasterFallback {
+				req.Account = argAccount
+				if req.Account == "" {
+					req.Account = cfg.Account
+				}
+			} else {
+				req.Account = resolveAccount(accountSources{Arg: argAccount, Linked: cfg.Account, BroadcasterLogin: c.Env.BroadcasterUserLogin})
+			}
+		}
+
+		reply := cmd.newReply()
+		subject := req.Account
+		if cmd.accountless {
+			// The rotation has no target player, so errors name the feature.
+			subject = "daily rotation"
+		}
+		if err := d.Gossip.Call(ctx, engine.GossipRoute{Provider: "valorant", Endpoint: cmd.endpoint}, req, reply); err != nil {
+			if chatReplyError(c, emit, subject, err) {
+				return nil
+			}
+			return err
+		}
+		if cmd.special != nil {
+			if text, ok := cmd.special(reply); ok {
+				emit(&module.Output{Type: outgress.TypeChat, BroadcasterID: c.Env.BroadcasterUserID, Text: text})
+				return nil
+			}
+		}
+
+		msg := module.ExpandString(orDefault(cmd.message(cfg), cmd.fallback), func(key string) (string, bool) {
+			if field, ok := cmd.tokens[key]; ok {
+				return field(reply), true
+			}
+			return module.ParseDynamic(key)
+		})
+		emit(&module.Output{Type: outgress.TypeChat, BroadcasterID: c.Env.BroadcasterUserID, Text: msg})
+		return nil
+	}
+}
+
+// valDispatchRun routes !val's first argument word onto the subcommand
+// runners: "matches"/"account"/"lb"/"shop" select one explicitly, and anything
+// else — nothing, or a Riot ID — is a rank lookup, so "!val Frosty#EUW1" reads
+// naturally.
+func valDispatchRun(rankRun, matchRun, acctRun, boardRun, shopRun module.RunFunc) module.RunFunc {
+	return func(ctx context.Context, c *module.Context, args string, emit module.Emit) error {
+		sub, rest, _ := strings.Cut(strings.TrimSpace(args), " ")
+		switch strings.ToLower(sub) {
+		case "match", "matches", "history":
+			return matchRun(ctx, c, rest, emit)
+		case "account", "who":
+			return acctRun(ctx, c, rest, emit)
+		case "lb", "leaderboard", "top":
+			return boardRun(ctx, c, rest, emit)
+		case "shop", "rotation":
+			return shopRun(ctx, c, rest, emit)
+		case "rank", "standing":
+			return rankRun(ctx, c, rest, emit)
+		default:
+			return rankRun(ctx, c, args, emit)
+		}
+	}
+}
+
+// parseValArgs splits a typed argument list into its scoping parts. Any word
+// naming a shard or ladder sets the region/platform wherever it sits ("!val
+// console ap" needs no account); the first remaining word is the account —
+// always a username-shaped Riot ID ("Name#Tag"), never a numeric id. The shard
+// set mirrors the provider's affinity table — adding one means touching both
+// places, since sesame prefers to pre-scope than to round-trip an upstream
+// rejection as a chat error.
+func parseValArgs(args string) (account, region, platform string) {
+	for _, f := range strings.Fields(args) {
+		switch w := strings.ToLower(f); w {
+		case "na", "eu", "ap", "kr", "br", "latam":
+			region = w
+		case "pc", "console":
+			platform = w
+		default:
+			if account == "" {
+				account = strings.TrimPrefix(f, "@")
+			}
+		}
+	}
+	return account, region, platform
+}
+
+// valRankTokens is the !valrank template palette over the gossip reply.
+func valRankTokens() map[string]func(any) string {
+	type reply = gossiprpc.ValorantRankReply
+	return map[string]func(any) string{
+		"player":     func(v any) string { return v.(*reply).Player },
+		"region":     func(v any) string { return v.(*reply).Region },
+		"tier":       func(v any) string { return v.(*reply).Tier },
+		"elo":        func(v any) string { return i64(int64(v.(*reply).Elo)) },
+		"rr":         func(v any) string { return i64(int64(v.(*reply).RR)) },
+		"lastchange": func(v any) string { return signed(v.(*reply).LastChange) },
+		"peaktier":   func(v any) string { return v.(*reply).PeakTier },
+		"placement":  func(v any) string { return i64(int64(v.(*reply).Placement)) },
+	}
+}
+
+// valMatchTokens is the !valmatches palette: the games joined as one-liners
+// (bounded by the upstream at five, so no truncation budget is needed) plus
+// the age of the most recent one.
+func valMatchTokens() map[string]func(any) string {
+	type reply = gossiprpc.ValorantMatchesReply
+	return map[string]func(any) string{
+		"player": func(v any) string { return v.(*reply).Player },
+		"region": func(v any) string { return v.(*reply).Region },
+		"count":  func(v any) string { return i64(int64(len(v.(*reply).Matches))) },
+		"matches": func(v any) string {
+			r := v.(*reply)
+			parts := make([]string, len(r.Matches))
+			for i, m := range r.Matches {
+				parts[i] = fmt.Sprintf("%s %d/%d/%d %s on %s", m.Agent, m.Kills, m.Deaths, m.Assists, m.Result, m.Map)
+			}
+			return strings.Join(parts, ", ")
+		},
+		"lastago": func(v any) string {
+			if m := v.(*reply).Matches; len(m) > 0 {
+				return valAgo(m[0].AgoSeconds)
+			}
+			return ""
+		},
+	}
+}
+
+// valAccountTokens is the !valaccount palette.
+func valAccountTokens() map[string]func(any) string {
+	type reply = gossiprpc.ValorantAccountReply
+	return map[string]func(any) string{
+		"player": func(v any) string { return v.(*reply).Player },
+		"puuid":  func(v any) string { return v.(*reply).Puuid },
+		"region": func(v any) string { return v.(*reply).Region },
+		"level":  func(v any) string { return i64(int64(v.(*reply).AccountLevel)) },
+		"card":   func(v any) string { return v.(*reply).Card },
+		"title":  func(v any) string { return v.(*reply).Title },
+	}
+}
+
+// valBoardTokens is the !vallb palette: the rows joined as "#rank player (RR)"
+// (bounded by the upstream at ten, so no truncation budget is needed).
+func valBoardTokens() map[string]func(any) string {
+	type reply = gossiprpc.ValorantLeaderboardReply
+	return map[string]func(any) string{
+		"player": func(v any) string { return v.(*reply).Player },
+		"board":  func(v any) string { return v.(*reply).Board },
+		"count":  func(v any) string { return i64(int64(len(v.(*reply).Entries))) },
+		"entries": func(v any) string {
+			entries := v.(*reply).Entries
+			parts := make([]string, len(entries))
+			for i, e := range entries {
+				parts[i] = "#" + i64(int64(e.Rank)) + " " + e.Player + " (" + i64(int64(e.RR)) + " RR)"
+			}
+			return strings.Join(parts, ", ")
+		},
+	}
+}
+
+// valShopTokens is the !valshop palette. The rotation is bounded by the game
+// itself (a handful of direct-purchase skins per day), so the joined list fits
+// a chat line without a truncation budget.
+func valShopTokens() map[string]func(any) string {
+	type reply = gossiprpc.ValorantShopReply
+	return map[string]func(any) string{
+		"count": func(v any) string { return i64(int64(v.(*reply).Count)) },
+		"items": func(v any) string {
+			items := v.(*reply).Items
+			parts := make([]string, len(items))
+			for i, item := range items {
+				parts[i] = item.Name + " (" + i64(item.Price) + " VP)"
+			}
+			return strings.Join(parts, ", ")
+		},
+		"reset": func(v any) string { return valResetIn(v.(*reply).ResetUnix) },
+	}
+}
+
+// valAgo renders a wall-clock age ("2h ago"); sub-minute reads as fresh
+// because a completed match younger than that is still being played out in
+// the client.
+func valAgo(seconds int64) string {
+	d := time.Duration(seconds) * time.Second
+	switch {
+	case d < time.Minute:
+		return "just now"
+	case d < time.Hour:
+		return fmt.Sprintf("%dm ago", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh ago", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd ago", int(d.Hours()/24))
+	}
+}
+
+// valResetIn renders the countdown to the next shop flip, rounded to the
+// minute so a template never prints "resets in 3h 59m" an hour early.
+func valResetIn(unix int64) string {
+	d := time.Until(time.Unix(unix, 0)).Round(time.Minute)
+	if d < 0 {
+		d = 0
+	}
+	h := int(d.Hours())
+	m := int(d.Minutes()) % 60
+	switch {
+	case h > 0 && m > 0:
+		return fmt.Sprintf("%dh %dm", h, m)
+	case h > 0:
+		return fmt.Sprintf("%dh", h)
+	default:
+		return fmt.Sprintf("%dm", m)
+	}
+}

--- a/app/sesame/modules/valorant_test.go
+++ b/app/sesame/modules/valorant_test.go
@@ -1,0 +1,263 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package modules
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"ItsBagelBot/app/sesame/engine"
+	"ItsBagelBot/app/sesame/module"
+	"ItsBagelBot/internal/domain/outgress"
+	gossiprpc "ItsBagelBot/internal/domain/rpc/gossip"
+	"ItsBagelBot/pkg/bus"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func valCmd(t *testing.T, gw engine.GossipCaller, name string) module.Command {
+	t.Helper()
+	m := Valorant(engine.Deps{Gossip: gw, Log: zap.NewNop()})
+	assert.Equal(t, "valorant", m.Name)
+	assert.Equal(t, module.KindOptIn, m.Kind)
+	return findCmd(t, m, name)
+}
+
+func valRankReply() gossiprpc.ValorantRankReply {
+	return gossiprpc.ValorantRankReply{
+		Player: "Frosty#EUW1", Region: "eu",
+		Tier: "Immortal 2", Elo: 1832, RR: 67, LastChange: -12,
+		PeakTier: "Immortal 1", Placement: 513,
+	}
+}
+
+func TestValrankDefaultTemplate(t *testing.T) {
+	gw := &fakeGossip{replies: map[string]any{"valorant.rank": valRankReply()}}
+	cmd := valCmd(t, gw, "valrank")
+
+	var col collector
+	require.NoError(t, cmd.Run(context.Background(), urchinCtx(""), "", col.emit))
+	require.Len(t, col.out, 1)
+	assert.Equal(t, outgress.TypeChat, col.out[0].Type)
+	assert.Equal(t, "2", col.out[0].BroadcasterID)
+	assert.Equal(t,
+		"Frosty#EUW1 · Immortal 2 · 67 RR (-12) · peak Immortal 1",
+		col.out[0].Text)
+
+	// No linked id and no arg: falls back to the broadcaster's login (which
+	// the provider rejects as an invalid Riot ID), and the premium flag rides
+	// along for gossip's reserved bucket.
+	call := gw.lastCall(t)
+	assert.Equal(t, "streamer", call.req.Account)
+	assert.False(t, call.req.IsPremium)
+}
+
+// Scoping inputs resolve in priority order: chat arg over dashboard config,
+// shard/ladder words wherever they sit around the id.
+func TestValScopingArgsAndConfig(t *testing.T) {
+	gw := &fakeGossip{replies: map[string]any{"valorant.rank": valRankReply()}}
+	cmd := valCmd(t, gw, "valrank")
+	var col collector
+
+	// Config alone scopes both axes.
+	cfg := `{"account":"Frosty#EUW1","region":"eu","platform":"pc"}`
+	require.NoError(t, cmd.Run(context.Background(), urchinCtx(cfg), "", col.emit))
+	call := gw.lastCall(t)
+	assert.Equal(t, "Frosty#EUW1", call.req.Account)
+	assert.Equal(t, "eu", call.req.Region)
+	assert.Equal(t, "pc", call.req.Platform)
+
+	// An explicit id beats the linked one; a shard word is peeled wherever it
+	// sits and overrides the configured region.
+	require.NoError(t, cmd.Run(context.Background(), urchinCtx(cfg), "console @Reyna#KR5 ap", col.emit))
+	call = gw.lastCall(t)
+	assert.Equal(t, "Reyna#KR5", call.req.Account)
+	assert.Equal(t, "ap", call.req.Region)
+	assert.Equal(t, "console", call.req.Platform)
+}
+
+// The !val root routes its first argument word onto the subcommand runners;
+// anything else targets rank, so "!val Frosty#EUW1" reads naturally.
+func TestValDispatch(t *testing.T) {
+	replies := map[string]any{
+		"valorant.rank":        gossiprpc.ValorantRankReply{Player: "Frosty#EUW1"},
+		"valorant.matches":     gossiprpc.ValorantMatchesReply{Player: "Frosty#EUW1"},
+		"valorant.account":     gossiprpc.ValorantAccountReply{Player: "Frosty#EUW1", AccountLevel: 142},
+		"valorant.leaderboard": gossiprpc.ValorantLeaderboardReply{Board: "ap/console"},
+		"valorant.shop":        gossiprpc.ValorantShopReply{},
+	}
+	cases := []struct {
+		name, args, endpoint string
+	}{
+		{"bare is rank", "", "rank"},
+		{"id arg is rank", "Frosty#EUW1", "rank"},
+		{"standing alias", "standing", "rank"},
+		{"matches subcommand", "matches", "matches"},
+		{"history alias with id", "history Frosty#EUW1", "matches"},
+		{"account subcommand", "account", "account"},
+		{"who alias", "WHO", "account"},
+		{"lb subcommand with shard", "lb console ap", "leaderboard"},
+		{"leaderboard alias", "leaderboard", "leaderboard"},
+		{"shop subcommand", "shop", "shop"},
+		{"rotation alias", "rotation", "shop"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gw := &fakeGossip{replies: replies}
+			var col collector
+			require.NoError(t, valCmd(t, gw, "val").Run(context.Background(),
+				urchinCtx(`{"account":"Frosty#EUW1","region":"eu"}`), tc.args, col.emit))
+			require.Len(t, col.out, 1)
+			assert.Equal(t, tc.endpoint, gw.lastCall(t).endpoint)
+		})
+	}
+}
+
+// A per-command "off" toggle keeps that command silent: no chat line and no
+// gossip call.
+func TestValDisabledStaysSilent(t *testing.T) {
+	cases := []struct{ name, config string }{
+		{"val", `{"rankEnabled":"off"}`},
+		{"valrank", `{"rankEnabled":"off"}`},
+		{"valmatches", `{"matchesEnabled":"off"}`},
+		{"valaccount", `{"accountEnabled":"off"}`},
+		{"vallb", `{"boardEnabled":"off"}`},
+		{"valshop", `{"shopEnabled":"off"}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gw := &fakeGossip{}
+			var col collector
+			require.NoError(t, valCmd(t, gw, tc.name).Run(context.Background(), urchinCtx(tc.config), "", col.emit))
+			assert.Empty(t, col.out)
+			gw.mu.Lock()
+			assert.Empty(t, gw.calls)
+			gw.mu.Unlock()
+		})
+	}
+}
+
+func TestValReplyErrorChats(t *testing.T) {
+	gw := &fakeGossip{err: bus.RPCReplyError{Message: "player not found"}}
+	var col collector
+	require.NoError(t, valCmd(t, gw, "valrank").Run(context.Background(), urchinCtx(""), "Frosty#EUW1", col.emit))
+	require.Len(t, col.out, 1)
+	assert.Equal(t, "Frosty#EUW1: player not found", col.out[0].Text)
+
+	// The accountless shop names the feature instead of a target player.
+	var shop collector
+	require.NoError(t, valCmd(t, gw, "valshop").Run(context.Background(), urchinCtx(""), "", shop.emit))
+	require.Len(t, shop.out, 1)
+	assert.Equal(t, "daily rotation: player not found", shop.out[0].Text)
+}
+
+// An unranked player replaces the rank template entirely: every numeric token
+// would render zero, so the default line says why instead.
+func TestValrankUnranked(t *testing.T) {
+	gw := &fakeGossip{replies: map[string]any{"valorant.rank": gossiprpc.ValorantRankReply{
+		Player: "Frosty#EUW1", Unranked: true,
+	}}}
+	var col collector
+	require.NoError(t, valCmd(t, gw, "valrank").Run(context.Background(), urchinCtx(""), "", col.emit))
+	require.Len(t, col.out, 1)
+	assert.Equal(t, "Frosty#EUW1 has no competitive record this act", col.out[0].Text)
+}
+
+func TestValmatchesTemplateAndEmpty(t *testing.T) {
+	full := gossiprpc.ValorantMatchesReply{
+		Player: "Frosty#EUW1", Region: "eu",
+		Matches: []gossiprpc.ValorantMatchEntry{
+			{Map: "Haven", Agent: "Jett", Result: "win", Kills: 20, Deaths: 14, Assists: 7, ACS: 231.4, AgoSeconds: 7200},
+			{Map: "Ascent", Agent: "Omen", Result: "loss", Kills: 9, Deaths: 17, Assists: 3, AgoSeconds: 60},
+		},
+	}
+	t.Run("default template", func(t *testing.T) {
+		gw := &fakeGossip{replies: map[string]any{"valorant.matches": full}}
+		var col collector
+		require.NoError(t, valCmd(t, gw, "valmatches").Run(context.Background(), urchinCtx(""), "", col.emit))
+		require.Len(t, col.out, 1)
+		assert.Equal(t,
+			"Frosty#EUW1's last 2: Jett 20/14/7 win on Haven, Omen 9/17/3 loss on Ascent",
+			col.out[0].Text)
+	})
+	t.Run("empty replaces the template", func(t *testing.T) {
+		gw := &fakeGossip{replies: map[string]any{"valorant.matches": gossiprpc.ValorantMatchesReply{
+			Player: "Frosty#EUW1", Empty: true,
+		}}}
+		var col collector
+		require.NoError(t, valCmd(t, gw, "valmatches").Run(context.Background(), urchinCtx(""), "", col.emit))
+		require.Len(t, col.out, 1)
+		assert.Equal(t, "Frosty#EUW1 has no recent competitive games", col.out[0].Text)
+	})
+}
+
+// A bare !vallb is a regional top-N ask: the board answers even though neither
+// an arg nor a linked id exists, because the Twitch-login fallback would only
+// mint an invalid-Riot-ID error.
+func TestVallbBareTopN(t *testing.T) {
+	gw := &fakeGossip{replies: map[string]any{"valorant.leaderboard": gossiprpc.ValorantLeaderboardReply{
+		Board: "ap/console",
+		Entries: []gossiprpc.ValorantLeaderboardEntry{
+			{Rank: 4, Player: "Zekken#5221", Tier: 25, RR: 431, Wins: 61},
+			{Rank: 5, Player: "Frosty#EUW1", Tier: 25, RR: 402},
+		},
+	}}}
+	var col collector
+	require.NoError(t, valCmd(t, gw, "vallb").Run(context.Background(),
+		urchinCtx(`{"region":"ap","platform":"console"}`), "", col.emit))
+	require.Len(t, col.out, 1)
+	assert.Equal(t,
+		"ap/console: #4 Zekken#5221 (431 RR), #5 Frosty#EUW1 (402 RR)",
+		col.out[0].Text)
+
+	call := gw.lastCall(t)
+	assert.Empty(t, call.req.Account)
+	assert.Equal(t, "ap", call.req.Region)
+	assert.Equal(t, "console", call.req.Platform)
+}
+
+// An explicit id still scopes a leaderboard ask ("is anyone I know on the
+// board?"), riding through as the request's account.
+func TestVallbWithID(t *testing.T) {
+	gw := &fakeGossip{replies: map[string]any{"valorant.leaderboard": gossiprpc.ValorantLeaderboardReply{
+		Player: "Frosty#EUW1", Board: "eu/pc",
+		Entries: []gossiprpc.ValorantLeaderboardEntry{{Rank: 513, Player: "Frosty#EUW1", Tier: 24, RR: 1832}},
+	}}}
+	var col collector
+	require.NoError(t, valCmd(t, gw, "vallb").Run(context.Background(),
+		urchinCtx(""), "eu Frosty#EUW1", col.emit))
+	require.Len(t, col.out, 1)
+	assert.Equal(t, "eu/pc: #513 Frosty#EUW1 (1832 RR)", col.out[0].Text)
+	assert.Equal(t, "Frosty#EUW1", gw.lastCall(t).req.Account)
+}
+
+func TestValaccountTemplate(t *testing.T) {
+	gw := &fakeGossip{replies: map[string]any{"valorant.account": gossiprpc.ValorantAccountReply{
+		Player: "Frosty#EUW1", Region: "eu", AccountLevel: 142, Title: "Radiant",
+	}}}
+	var col collector
+	require.NoError(t, valCmd(t, gw, "valaccount").Run(context.Background(), urchinCtx(""), "", col.emit))
+	require.Len(t, col.out, 1)
+	assert.Equal(t, "Frosty#EUW1 · account level 142", col.out[0].Text)
+}
+
+func TestValshopTemplate(t *testing.T) {
+	gw := &fakeGossip{replies: map[string]any{"valorant.shop": gossiprpc.ValorantShopReply{
+		ResetUnix: time.Now().Add(2*time.Hour + 30*time.Minute).Unix(),
+		Items: []gossiprpc.ValorantShopItem{
+			{Name: "Reaver Vandal", Price: 1775, Tier: "Exclusive"},
+			{Name: "Ion Frenzy", Price: 875},
+		},
+		Count: 2,
+	}}}
+	var col collector
+	require.NoError(t, valCmd(t, gw, "valshop").Run(context.Background(), urchinCtx(""), "", col.emit))
+	require.Len(t, col.out, 1)
+	assert.Equal(t,
+		"Daily rotation (2): Reaver Vandal (1775 VP), Ion Frenzy (875 VP) · resets in 2h 30m",
+		col.out[0].Text)
+}

--- a/console/shared/lib/catalog-valorant.ts
+++ b/console/shared/lib/catalog-valorant.ts
@@ -1,0 +1,124 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+// The Valorant module's catalog definition, split out of types.ts for the
+// same reason as catalog-games.ts: five customizable replies plus settings
+// make it one of the longest MODULE_CATALOG entries, and its token palettes
+// mirror app/sesame/modules/valorant.go (same config keys, same defaults).
+import type { ModuleDef } from './types';
+
+export const VALORANT_MODULE_DEF: ModuleDef = {
+  // All five !val views are gossip lookups, so their token palettes below
+  // mirror app/sesame/modules/valorant.go.
+  id: 'valorant',
+  label: 'Valorant Stats',
+  tagline: 'Valorant ranks, match history, leaderboards and the daily shop rotation in chat.',
+  description:
+    'One command, five looks: !val shows a player\'s competitive standing (tier, RR, last game\'s RR change, peak tier); !val matches lists their recent ranked games as agent K/D/A results; !val account shows who a Riot ID resolves to, with their account level; !val lb prints the top 10 of any regional leaderboard, PC or console; !val shop shows today\'s global skin rotation with VP prices and the reset countdown. The squashed forms !valrank, !valmatches, !valaccount, !vallb and !valshop work too. Link your Riot ID below ("Name#Tag") — viewers can also name any player, e.g. "!val Frosty#EUW1", and add a shard or ladder anywhere in the line to scope that one lookup ("!val eu Frosty#EUW1", "!val lb console ap"). Leave the region blank and the bot detects the shard from the account itself.',
+  icon: 'gamepad',
+  category: 'Games',
+  defaultEnabled: false,
+  replies: [
+    {
+      key: 'rank',
+      label: '!val',
+      tagline: 'Competitive standing — !val, !val rank or !valrank.',
+      event: '!val',
+      command: 'val',
+      enableKey: 'rankEnabled',
+      messageKey: 'rankMessage',
+      defaultMessage: '{player} · {tier} · {rr} RR ({lastchange}) · peak {peaktier}',
+      tokens: ['player', 'region', 'tier', 'elo', 'rr', 'lastchange', 'peaktier', 'placement'],
+      previewSamples: {
+        player: 'Frosty#EUW1', region: 'eu', tier: 'Immortal 2', elo: '1832', rr: '67',
+        lastchange: '-12', peaktier: 'Immortal 1', placement: '513'
+      }
+    },
+    {
+      key: 'matches',
+      label: '!val matches',
+      tagline: 'Recent ranked games (also !valmatches).',
+      event: '!val matches',
+      command: 'val matches',
+      enableKey: 'matchesEnabled',
+      messageKey: 'matchesMessage',
+      defaultMessage: "{player}'s last {count}: {matches}",
+      tokens: ['player', 'region', 'count', 'matches', 'lastago'],
+      previewSamples: {
+        player: 'Frosty#EUW1', region: 'eu', count: '2',
+        matches: 'Jett 20/14/7 win on Haven, Omen 9/17/3 loss on Ascent', lastago: '2h ago'
+      }
+    },
+    {
+      key: 'account',
+      label: '!val account',
+      tagline: 'Who an ID resolves to, with account level (also !valaccount).',
+      event: '!val account',
+      command: 'val account',
+      enableKey: 'accountEnabled',
+      messageKey: 'accountMessage',
+      defaultMessage: '{player} · account level {level}',
+      tokens: ['player', 'puuid', 'region', 'level', 'card', 'title'],
+      previewSamples: {
+        player: 'Frosty#EUW1', puuid: 'a1b2c3d4-05e6-47f8-89a0-b1c2d3e4f5a6',
+        region: 'eu', level: '142', card: 'Silver Card', title: 'Radiant'
+      }
+    },
+    {
+      key: 'board',
+      label: '!val lb',
+      tagline: 'Regional top 10, PC or console (also !vallb).',
+      event: '!val lb',
+      command: 'val lb',
+      enableKey: 'boardEnabled',
+      messageKey: 'boardMessage',
+      defaultMessage: '{board}: {entries}',
+      tokens: ['player', 'board', 'count', 'entries'],
+      previewSamples: {
+        player: 'Frosty#EUW1', board: 'ap/console', count: '2',
+        entries: '#4 Zekken#5221 (431 RR), #5 Frosty#EUW1 (402 RR)'
+      }
+    },
+    {
+      key: 'shop',
+      label: '!val shop',
+      tagline: "Today's global skin rotation with reset countdown (also !valshop).",
+      event: '!val shop',
+      command: 'val shop',
+      enableKey: 'shopEnabled',
+      messageKey: 'shopMessage',
+      defaultMessage: 'Daily rotation ({count}): {items} · resets in {reset}',
+      tokens: ['count', 'items', 'reset'],
+      previewSamples: {
+        count: '2', items: 'Reaver Vandal (1775 VP), Ion Frenzy (875 VP)', reset: '2h 30m'
+      }
+    }
+  ],
+  settings: [
+    {
+      key: 'account',
+      label: 'Linked Riot ID',
+      type: 'text',
+      placeholder: 'Frosty#EUW1',
+      help: 'Default player for every command, as "Name#Tag" — Valorant has no name-only lookup, so the #tag is required.'
+    },
+    {
+      key: 'region',
+      label: 'Region shard',
+      type: 'text',
+      placeholder: 'eu',
+      help: 'na, eu, ap, kr, br or latam. Leave blank and the bot detects the shard from the account itself.'
+    },
+    {
+      key: 'platform',
+      label: 'Ladder',
+      type: 'select',
+      placeholder: 'pc',
+      options: [
+        { value: 'pc', label: 'PC' },
+        { value: 'console', label: 'Console' }
+      ],
+      help: 'Ranks and leaderboards are tracked as separate ladders per platform; blank means PC.'
+    }
+  ]
+};

--- a/console/shared/lib/types.ts
+++ b/console/shared/lib/types.ts
@@ -3,6 +3,7 @@
 
 import type { IconName } from './icons';
 import { GAME_MODULE_DEFS } from './catalog-games';
+import { VALORANT_MODULE_DEF } from './catalog-valorant';
 // Wire types mirroring the Go NATS RPC contracts (JSON over core NATS).
 export type Perm = 'everyone' | 'sub' | 'vip' | 'mod' | 'lead_mod' | 'broadcaster';
 export type Tier = 'premium' | 'standard';
@@ -1327,121 +1328,7 @@ export const MODULE_CATALOG: readonly ModuleDef[] = [
       }
     ]
   },
-  {
-    // All five !val views are gossip lookups, so their token palettes below
-    // mirror app/sesame/modules/valorant.go.
-    id: 'valorant',
-    label: 'Valorant Stats',
-    tagline: 'Valorant ranks, match history, leaderboards and the daily shop rotation in chat.',
-    description:
-      'One command, five looks: !val shows a player\'s competitive standing (tier, RR, last game\'s RR change, peak tier); !val matches lists their recent ranked games as agent K/D/A results; !val account shows who a Riot ID resolves to, with their account level; !val lb prints the top 10 of any regional leaderboard, PC or console; !val shop shows today\'s global skin rotation with VP prices and the reset countdown. The squashed forms !valrank, !valmatches, !valaccount, !vallb and !valshop work too. Link your Riot ID below ("Name#Tag") — viewers can also name any player, e.g. "!val Frosty#EUW1", and add a shard or ladder anywhere in the line to scope that one lookup ("!val eu Frosty#EUW1", "!val lb console ap"). Leave the region blank and the bot detects the shard from the account itself.',
-    icon: 'gamepad',
-    category: 'Games',
-    defaultEnabled: false,
-    replies: [
-      {
-        key: 'rank',
-        label: '!val',
-        tagline: 'Competitive standing — !val, !val rank or !valrank.',
-        event: '!val',
-        command: 'val',
-        enableKey: 'rankEnabled',
-        messageKey: 'rankMessage',
-        defaultMessage: '{player} · {tier} · {rr} RR ({lastchange}) · peak {peaktier}',
-        tokens: ['player', 'region', 'tier', 'elo', 'rr', 'lastchange', 'peaktier', 'placement'],
-        previewSamples: {
-          player: 'Frosty#EUW1', region: 'eu', tier: 'Immortal 2', elo: '1832', rr: '67',
-          lastchange: '-12', peaktier: 'Immortal 1', placement: '513'
-        }
-      },
-      {
-        key: 'matches',
-        label: '!val matches',
-        tagline: 'Recent ranked games (also !valmatches).',
-        event: '!val matches',
-        command: 'val matches',
-        enableKey: 'matchesEnabled',
-        messageKey: 'matchesMessage',
-        defaultMessage: "{player}'s last {count}: {matches}",
-        tokens: ['player', 'region', 'count', 'matches', 'lastago'],
-        previewSamples: {
-          player: 'Frosty#EUW1', region: 'eu', count: '2',
-          matches: 'Jett 20/14/7 win on Haven, Omen 9/17/3 loss on Ascent', lastago: '2h ago'
-        }
-      },
-      {
-        key: 'account',
-        label: '!val account',
-        tagline: 'Who an ID resolves to, with account level (also !valaccount).',
-        event: '!val account',
-        command: 'val account',
-        enableKey: 'accountEnabled',
-        messageKey: 'accountMessage',
-        defaultMessage: '{player} · account level {level}',
-        tokens: ['player', 'puuid', 'region', 'level', 'card', 'title'],
-        previewSamples: {
-          player: 'Frosty#EUW1', puuid: 'a1b2c3d4-05e6-47f8-89a0-b1c2d3e4f5a6',
-          region: 'eu', level: '142', card: 'Silver Card', title: 'Radiant'
-        }
-      },
-      {
-        key: 'board',
-        label: '!val lb',
-        tagline: 'Regional top 10, PC or console (also !vallb).',
-        event: '!val lb',
-        command: 'val lb',
-        enableKey: 'boardEnabled',
-        messageKey: 'boardMessage',
-        defaultMessage: '{board}: {entries}',
-        tokens: ['player', 'board', 'count', 'entries'],
-        previewSamples: {
-          player: 'Frosty#EUW1', board: 'ap/console', count: '2',
-          entries: '#4 Zekken#5221 (431 RR), #5 Frosty#EUW1 (402 RR)'
-        }
-      },
-      {
-        key: 'shop',
-        label: '!val shop',
-        tagline: "Today's global skin rotation with reset countdown (also !valshop).",
-        event: '!val shop',
-        command: 'val shop',
-        enableKey: 'shopEnabled',
-        messageKey: 'shopMessage',
-        defaultMessage: 'Daily rotation ({count}): {items} · resets in {reset}',
-        tokens: ['count', 'items', 'reset'],
-        previewSamples: {
-          count: '2', items: 'Reaver Vandal (1775 VP), Ion Frenzy (875 VP)', reset: '2h 30m'
-        }
-      }
-    ],
-    settings: [
-      {
-        key: 'account',
-        label: 'Linked Riot ID',
-        type: 'text',
-        placeholder: 'Frosty#EUW1',
-        help: 'Default player for every command, as "Name#Tag" — Valorant has no name-only lookup, so the #tag is required.'
-      },
-      {
-        key: 'region',
-        label: 'Region shard',
-        type: 'text',
-        placeholder: 'eu',
-        help: 'na, eu, ap, kr, br or latam. Leave blank and the bot detects the shard from the account itself.'
-      },
-      {
-        key: 'platform',
-        label: 'Ladder',
-        type: 'select',
-        placeholder: 'pc',
-        options: [
-          { value: 'pc', label: 'PC' },
-          { value: 'console', label: 'Console' }
-        ],
-        help: 'Ranks and leaderboards are tracked as separate ladders per platform; blank means PC.'
-      }
-    ]
-  },
+  VALORANT_MODULE_DEF,
   {
     id: 'queue',
     label: 'Play Queue',

--- a/console/shared/lib/types.ts
+++ b/console/shared/lib/types.ts
@@ -1328,6 +1328,121 @@ export const MODULE_CATALOG: readonly ModuleDef[] = [
     ]
   },
   {
+    // All five !val views are gossip lookups, so their token palettes below
+    // mirror app/sesame/modules/valorant.go.
+    id: 'valorant',
+    label: 'Valorant Stats',
+    tagline: 'Valorant ranks, match history, leaderboards and the daily shop rotation in chat.',
+    description:
+      'One command, five looks: !val shows a player\'s competitive standing (tier, RR, last game\'s RR change, peak tier); !val matches lists their recent ranked games as agent K/D/A results; !val account shows who a Riot ID resolves to, with their account level; !val lb prints the top 10 of any regional leaderboard, PC or console; !val shop shows today\'s global skin rotation with VP prices and the reset countdown. The squashed forms !valrank, !valmatches, !valaccount, !vallb and !valshop work too. Link your Riot ID below ("Name#Tag") — viewers can also name any player, e.g. "!val Frosty#EUW1", and add a shard or ladder anywhere in the line to scope that one lookup ("!val eu Frosty#EUW1", "!val lb console ap"). Leave the region blank and the bot detects the shard from the account itself.',
+    icon: 'gamepad',
+    category: 'Games',
+    defaultEnabled: false,
+    replies: [
+      {
+        key: 'rank',
+        label: '!val',
+        tagline: 'Competitive standing — !val, !val rank or !valrank.',
+        event: '!val',
+        command: 'val',
+        enableKey: 'rankEnabled',
+        messageKey: 'rankMessage',
+        defaultMessage: '{player} · {tier} · {rr} RR ({lastchange}) · peak {peaktier}',
+        tokens: ['player', 'region', 'tier', 'elo', 'rr', 'lastchange', 'peaktier', 'placement'],
+        previewSamples: {
+          player: 'Frosty#EUW1', region: 'eu', tier: 'Immortal 2', elo: '1832', rr: '67',
+          lastchange: '-12', peaktier: 'Immortal 1', placement: '513'
+        }
+      },
+      {
+        key: 'matches',
+        label: '!val matches',
+        tagline: 'Recent ranked games (also !valmatches).',
+        event: '!val matches',
+        command: 'val matches',
+        enableKey: 'matchesEnabled',
+        messageKey: 'matchesMessage',
+        defaultMessage: "{player}'s last {count}: {matches}",
+        tokens: ['player', 'region', 'count', 'matches', 'lastago'],
+        previewSamples: {
+          player: 'Frosty#EUW1', region: 'eu', count: '2',
+          matches: 'Jett 20/14/7 win on Haven, Omen 9/17/3 loss on Ascent', lastago: '2h ago'
+        }
+      },
+      {
+        key: 'account',
+        label: '!val account',
+        tagline: 'Who an ID resolves to, with account level (also !valaccount).',
+        event: '!val account',
+        command: 'val account',
+        enableKey: 'accountEnabled',
+        messageKey: 'accountMessage',
+        defaultMessage: '{player} · account level {level}',
+        tokens: ['player', 'puuid', 'region', 'level', 'card', 'title'],
+        previewSamples: {
+          player: 'Frosty#EUW1', puuid: 'a1b2c3d4-05e6-47f8-89a0-b1c2d3e4f5a6',
+          region: 'eu', level: '142', card: 'Silver Card', title: 'Radiant'
+        }
+      },
+      {
+        key: 'board',
+        label: '!val lb',
+        tagline: 'Regional top 10, PC or console (also !vallb).',
+        event: '!val lb',
+        command: 'val lb',
+        enableKey: 'boardEnabled',
+        messageKey: 'boardMessage',
+        defaultMessage: '{board}: {entries}',
+        tokens: ['player', 'board', 'count', 'entries'],
+        previewSamples: {
+          player: 'Frosty#EUW1', board: 'ap/console', count: '2',
+          entries: '#4 Zekken#5221 (431 RR), #5 Frosty#EUW1 (402 RR)'
+        }
+      },
+      {
+        key: 'shop',
+        label: '!val shop',
+        tagline: "Today's global skin rotation with reset countdown (also !valshop).",
+        event: '!val shop',
+        command: 'val shop',
+        enableKey: 'shopEnabled',
+        messageKey: 'shopMessage',
+        defaultMessage: 'Daily rotation ({count}): {items} · resets in {reset}',
+        tokens: ['count', 'items', 'reset'],
+        previewSamples: {
+          count: '2', items: 'Reaver Vandal (1775 VP), Ion Frenzy (875 VP)', reset: '2h 30m'
+        }
+      }
+    ],
+    settings: [
+      {
+        key: 'account',
+        label: 'Linked Riot ID',
+        type: 'text',
+        placeholder: 'Frosty#EUW1',
+        help: 'Default player for every command, as "Name#Tag" — Valorant has no name-only lookup, so the #tag is required.'
+      },
+      {
+        key: 'region',
+        label: 'Region shard',
+        type: 'text',
+        placeholder: 'eu',
+        help: 'na, eu, ap, kr, br or latam. Leave blank and the bot detects the shard from the account itself.'
+      },
+      {
+        key: 'platform',
+        label: 'Ladder',
+        type: 'select',
+        placeholder: 'pc',
+        options: [
+          { value: 'pc', label: 'PC' },
+          { value: 'console', label: 'Console' }
+        ],
+        help: 'Ranks and leaderboards are tracked as separate ladders per platform; blank means PC.'
+      }
+    ]
+  },
+  {
     id: 'queue',
     label: 'Play Queue',
     tagline: 'Let viewers line up to play with you, first come first served.',

--- a/internal/domain/rpc/gossip/gossip.go
+++ b/internal/domain/rpc/gossip/gossip.go
@@ -636,3 +636,112 @@ type ClashRoyaleTrophyRoadReply struct {
 	Arena        ClashRoyaleArena `json:"arena"`
 	Error        string           `json:"error,omitempty"`
 }
+
+// --- valorant (HenrikDev community API lookups) -----------------------------
+
+// ValorantRankReply is the answer to valorant.rank (sesame's !valrank): the
+// account's current competitive standing. LastChange is the RR delta of the
+// most recent competitive game (negative on a loss); Placement is the current
+// act leaderboard position, 0 when unplaced. Unranked is true for accounts
+// without a act placement — Elo is zeroed alongside it so templates never
+// print "-23 elo, Unranked".
+type ValorantRankReply struct {
+	Player     string `json:"player"`
+	Region     string `json:"region"`
+	Tier       string `json:"tier"`
+	Elo        int    `json:"elo"`
+	RR         int    `json:"rr"`
+	LastChange int    `json:"last_change"`
+	PeakTier   string `json:"peak_tier"`
+	Placement  int    `json:"placement"`
+	Unranked   bool   `json:"unranked"`
+	Error      string `json:"error,omitempty"`
+}
+
+// ValorantMatchEntry summarizes one completed competitive game for a chat
+// line. ACS is precomputed upstream (score over team rounds, one decimal) and
+// AgoSeconds lets a template say how old the game is.
+type ValorantMatchEntry struct {
+	Map        string  `json:"map"`
+	Agent      string  `json:"agent"`
+	Result     string  `json:"result"` // "win" | "loss" | "draw"
+	Kills      int     `json:"kills"`
+	Deaths     int     `json:"deaths"`
+	Assists    int     `json:"assists"`
+	ACS        float64 `json:"acs"`
+	AgoSeconds int64   `json:"ago_seconds"`
+}
+
+// ValorantMatchesReply is the answer to valorant.matches (sesame's
+// !valmatches): the last few completed competitive games, newest first.
+// Incomplete games are skipped rather than shown as ghost rows. Empty is true
+// when the account simply has no ranked games in the retained window — a
+// normal answer, not an error.
+type ValorantMatchesReply struct {
+	Player  string               `json:"player"`
+	Region  string               `json:"region"`
+	Matches []ValorantMatchEntry `json:"matches"`
+	Empty   bool                 `json:"empty"`
+	Error   string               `json:"error,omitempty"`
+}
+
+// ValorantAccountReply is the answer to valorant.account (sesame's
+// !valaccount): who a Riot ID resolves to, plus the level/card/title flex. It
+// doubles as the cheapest correctness probe for a caller unsure of spelling or
+// region.
+type ValorantAccountReply struct {
+	Player       string `json:"player"`
+	Puuid        string `json:"puuid,omitempty"`
+	Region       string `json:"region,omitempty"`
+	AccountLevel int    `json:"account_level,omitempty"`
+	Card         string `json:"card,omitempty"`
+	Title        string `json:"title,omitempty"`
+	Error        string `json:"error,omitempty"`
+}
+
+// ValorantLeaderboardEntry is one ranked row of a regional board. Tier stays
+// the numeric competitive tier id (3 = Iron 1 up to 27 = Radiant) rather than a
+// spelled-out name, matching what every tracker renders from.
+type ValorantLeaderboardEntry struct {
+	Rank   int    `json:"rank"`
+	Player string `json:"player"`
+	Tier   int    `json:"tier"`
+	RR     int    `json:"rr"`
+	Wins   int    `json:"wins"`
+}
+
+// ValorantLeaderboardReply is the answer to valorant.leaderboard (sesame's
+// !vallb): the top slice of one regional board. Board echoes
+// "<region>/<platform>" so a template can say which board it printed; Player
+// echoes the account scoping it when one was given ("" for a bare top-N ask).
+type ValorantLeaderboardReply struct {
+	Player  string                     `json:"player,omitempty"`
+	Board   string                     `json:"board,omitempty"`
+	Entries []ValorantLeaderboardEntry `json:"entries"`
+	Empty   bool                       `json:"empty"`
+	Error   string                     `json:"error,omitempty"`
+}
+
+// ValorantShopItem is one rotated skin ready for rendering. Color is the
+// rarity's background hex straight from Riot's content CDN, so a renderer can
+// colour-code without owning a rarity table.
+type ValorantShopItem struct {
+	Name  string `json:"name"`
+	Price int64  `json:"price"`
+	Tier  string `json:"tier,omitempty"`
+	Color string `json:"color,omitempty"`
+	Icon  string `json:"icon,omitempty"`
+}
+
+// ValorantShopReply is the answer to valorant.shop (sesame's !valshop):
+// today's global skin rotation, priciest first. ResetUnix is the instant the
+// rotation turns over (03:00 UTC), so a template can print a countdown. Empty
+// is true on the rare days Riot rotates nothing — a normal answer, not an
+// error.
+type ValorantShopReply struct {
+	ResetUnix int64              `json:"reset_unix"`
+	Items     []ValorantShopItem `json:"items"`
+	Count     int                `json:"count"`
+	Empty     bool               `json:"empty"`
+	Error     string             `json:"error,omitempty"`
+}


### PR DESCRIPTION
## What

Wires the gossip Valorant provider (shipped in 43253a42) into sesame as an opt-in chat module, plus the shared contract types and the dashboard module page.

**Command surface** — one root with subcommands, squashed forms as direct triggers:

- `!val [Name#Tag]` — competitive standing (`!valrank`)
- `!val matches [id]` — recent ranked games as agent K/D/A (`!valmatches`)
- `!val account [id]` — identity + level flex (`!valaccount`)
- `!val lb [region]` — regional top 10, PC or console (`!vallb`)
- `!val shop` — daily skin rotation with reset countdown (`!valshop`)

Shard (`na/eu/ap/kr/br/latam`) and ladder (`pc/console`) words peel from anywhere in the argument line; region-less lookups ride gossip's day-long auto-detect entry. Deliberate behaviors: a bare `!vallb` answers the regional board instead of falling back to the broadcaster's Twitch login (never a valid Riot ID), and all four empty states replace their template entirely rather than rendering zeros.

**Contract**: seven typed replies in `internal/domain/rpc/gossip`, mirroring the provider's JSON exactly.

**Console**: `valorant` MODULE_CATALOG entry — five reply rows with token palettes and rehearsal samples matching the Go defaults verbatim; settings for linked Riot ID, region shard and PC/console ladder.

## Test plan

- `go build ./...`, `go vet`
- `go test ./app/sesame/... ./app/gossip/... ./internal/domain/rpc/...` — new valorant module tests cover default templates, scoping precedence (arg > config), root dispatch, per-command toggles, reply-error chatting, unranked/matches-empty/board-empty/shop-empty replacements, bare top-N board ask
- catalog uniqueness + rehearsal tests, dashboard `svelte-check` 0 errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in Valorant module with rank, recent matches, account, leaderboard, and daily shop commands.
  * Added Riot ID, region, platform, aliases, cooldowns, configurable templates, and per-command enablement.
  * Added support for account-free shop lookups and leaderboard account fallback.
  * Added clear responses for empty results, unranked accounts, errors, and shop reset times.
  * Added Valorant settings and message customization options to the configuration interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->