### PR TITLE
fix(ui): drop hand-written -webkit-backdrop-filter, dead since Chrome 151

### DIFF
--- a/console/admin/src/routes/login/+page.svelte
+++ b/console/admin/src/routes/login/+page.svelte
@@ -64,7 +64,6 @@
     border: 1px solid var(--glass-border);
     border-radius: 8px;
     backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-sat, 180%));
-    -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-sat, 180%));
     box-shadow: var(--glass-rim), var(--glass-shadow);
   }
   .panel img {

--- a/console/dashboard/src/lib/components/public/PublicNav.svelte
+++ b/console/dashboard/src/lib/components/public/PublicNav.svelte
@@ -68,7 +68,6 @@
     border-bottom: 1px solid var(--bb-border);
     z-index: 50;
     backdrop-filter: blur(12px);
-    -webkit-backdrop-filter: blur(12px);
     background: rgba(10, 10, 10, 0.7);
   }
   .site-nav__inner {

--- a/console/dashboard/src/routes/user/[channel]/+page.svelte
+++ b/console/dashboard/src/routes/user/[channel]/+page.svelte
@@ -381,7 +381,6 @@
       0 18px 42px rgba(0,0,0,0.34),
       0 0 28px rgba(82,183,136,0.08);
     backdrop-filter: blur(12px);
-    -webkit-backdrop-filter: blur(12px);
   }
   .creator-strip__signal {
     width: 8px;

--- a/console/shared/components/Drawer.svelte
+++ b/console/shared/components/Drawer.svelte
@@ -80,7 +80,7 @@
     position: absolute; inset: 0;
     padding: 0; border: 0; cursor: pointer;
     background: rgba(0, 0, 0, 0.5);
-    backdrop-filter: blur(2px); -webkit-backdrop-filter: blur(2px);
+    backdrop-filter: blur(2px);
     animation: fade var(--bb-dur-fast, 160ms) var(--bb-ease-out-expo, ease) both;
   }
   @keyframes fade { from { opacity: 0; } to { opacity: 1; } }
@@ -93,7 +93,7 @@
       linear-gradient(var(--glass-fill), var(--glass-fill)),
       var(--bb-bg-1, #111);
     border-left: 1px solid var(--glass-border);
-    backdrop-filter: blur(var(--glass-blur)); -webkit-backdrop-filter: blur(var(--glass-blur));
+    backdrop-filter: blur(var(--glass-blur));
     box-shadow: -16px 0 48px rgba(0, 0, 0, 0.45);
     transform: translateX(100%);
     animation: slide-in var(--bb-dur-med, 320ms) var(--bb-ease-out-expo, cubic-bezier(.16,1,.3,1)) forwards;

--- a/console/shared/components/MobileNav.svelte
+++ b/console/shared/components/MobileNav.svelte
@@ -28,7 +28,6 @@
       background: rgba(10, 10, 10, 0.7);
       border-top: 1px solid var(--glass-border);
       backdrop-filter: blur(var(--glass-blur)) saturate(150%);
-      -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(150%);
     }
     .mobile-nav form { flex: 1; display: flex; }
     .mobile-nav a, .mobile-nav button {

--- a/console/shared/components/Modal.svelte
+++ b/console/shared/components/Modal.svelte
@@ -96,14 +96,14 @@
     position: absolute; inset: 0;
     padding: 0; border: 0; cursor: pointer;
     background: rgba(0, 0, 0, 0.55);
-    backdrop-filter: blur(4px); -webkit-backdrop-filter: blur(4px);
+    backdrop-filter: blur(4px);
   }
   .modal-card {
     position: relative;
     background: var(--bb-bg-1, #111);
     border: 1px solid var(--glass-border);
     border-radius: 8px;
-    backdrop-filter: blur(var(--glass-blur)); -webkit-backdrop-filter: blur(var(--glass-blur));
+    backdrop-filter: blur(var(--glass-blur));
     padding: 28px 28px 24px; max-width: 420px; width: 100%;
     max-height: calc(100dvh - 32px); overflow-y: auto; overscroll-behavior: contain;
     -webkit-overflow-scrolling: touch;

--- a/docs/src/components/MermaidStyles.astro
+++ b/docs/src/components/MermaidStyles.astro
@@ -538,7 +538,6 @@ pre.mermaid[data-processed].mermaid-interactive-ready:hover {
     border-radius: 999px;
     cursor: pointer;
     backdrop-filter: blur(6px);
-    -webkit-backdrop-filter: blur(6px);
     opacity: 0;
     transform: translateY(4px);
     transition: opacity 160ms ease, transform 160ms ease,
@@ -616,7 +615,6 @@ pre.mermaid[data-processed]:focus-within .mermaid-fullscreen-btn,
             rgb(var(--bb-bg-rgb) / 0.97) 75%
         );
     backdrop-filter: blur(14px) saturate(160%);
-    -webkit-backdrop-filter: blur(14px) saturate(160%);
     animation: bb-modal-fade 220ms ease-out;
 }
 :root[data-theme="light"] .mermaid-modal__backdrop {
@@ -717,7 +715,6 @@ pre.mermaid[data-processed]:focus-within .mermaid-fullscreen-btn,
     border: 1px solid rgb(var(--bb-green-glow-rgb) / 0.35);
     border-radius: 999px;
     backdrop-filter: blur(8px);
-    -webkit-backdrop-filter: blur(8px);
     box-shadow: 0 6px 24px rgb(var(--bb-shadow-rgb) / 0.45);
     animation: bb-modal-rise 220ms cubic-bezier(0.2, 0.7, 0.2, 1);
 }

--- a/docs/src/styles/theme.css
+++ b/docs/src/styles/theme.css
@@ -400,7 +400,6 @@ samp {
 
 header.header {
     backdrop-filter: saturate(180%) blur(14px);
-    -webkit-backdrop-filter: saturate(180%) blur(14px);
     border-bottom: 1px solid var(--sl-color-hairline-shade);
 }
 

--- a/web/src/components/layout/MobileMenu.astro
+++ b/web/src/components/layout/MobileMenu.astro
@@ -51,7 +51,6 @@ const getAppHref = `https://dashboard.itsbagelbot.com/?install=1${lang === defau
         padding: 16px;
         background: rgba(10, 10, 10, 0.72);
         backdrop-filter: blur(22px);
-        -webkit-backdrop-filter: blur(22px);
         z-index: 49;
         isolation: isolate;
         overflow: hidden;

--- a/web/src/components/layout/Nav.astro
+++ b/web/src/components/layout/Nav.astro
@@ -305,8 +305,12 @@ const isActive = (href: string) =>
         padding-inline: max(24px, 4vw, env(safe-area-inset-left, 0px), env(safe-area-inset-right, 0px));
         border-bottom: var(--border) 1px solid;
         z-index: 50;
+        /* Standard property only, never hand-write -webkit-backdrop-filter:
+           Chrome 151 dropped the alias, and the minifier dedupes the pair to
+           whichever is last, which shipped prefixed-only CSS and killed the
+           blur in every Chromium browser. Lightning CSS re-adds the prefix
+           itself when build targets need it. */
         backdrop-filter: blur(12px);
-        -webkit-backdrop-filter: blur(12px);
         background: rgba(10, 10, 10, 0.7);
     }
 


### PR DESCRIPTION
## Root cause

Chrome 151 removed the `-webkit-backdrop-filter` alias. Every frosted surface declared the standard property followed by a hand-written `-webkit-` one; the minifier dedupes that alias pair keeping whichever declaration is last, so every built bundle shipped the prefixed form only. Chromium now drops it as an unknown property → `backdrop-filter` computed to `none` → no blur anywhere (web nav, mobile menu, console PublicNav/modals/drawers, docs header), while Safari kept honoring `-webkit-` — which made it look Chromium-specific.

Confirmed against the shipped bundle: `.site-nav` / `.mobile-menu` carried only `-webkit-backdrop-filter:blur(...)`, and computed style on the live page resolved to `none`.

## Fix

Removes all 14 hand-written `-webkit-backdrop-filter` declarations across `web/`, `console/` and `docs/`. Lightning CSS adds prefixes from build targets on its own, so the hand-rolled ones were pure liability. A decision-record comment sits on the canonical nav rule so the prefix doesn't get re-added.

## Verification

- Rebuilt `web/`: bundle now ships standard `backdrop-filter:blur(12px/22px)`
- Real-Chrome (Playwright) screenshots of the rebuilt site: desktop nav frosts content under it; mobile menu blurs the hero behind it (previously crisply legible)
- `docs/` and `console/admin` rebuild clean with the standard property in their bundles

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Simplified backdrop blur styling across navigation, menus, modals, drawers, login panels, and documentation components.
  * Maintained the existing visual blur effects using standard browser-supported styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->