### PR TITLE
docs(web): guides cover the wager games, Valorant and emote play

### DIFF
--- a/web/src/components/home/QuietWork.astro
+++ b/web/src/components/home/QuietWork.astro
@@ -73,10 +73,7 @@ const t = useTranslations(lang);
                 <span class="qw-win__label">{t('qw.winLabel')}</span>
                 <span class="qw-win__name" data-qw-winner>night_owl_77</span>
             </div>
-            <h3 class="qw__title">
-                {t('qw.winTitle')}
-                <IncomingBadge label={t('badge.incoming')} />
-            </h3>
+            <h3 class="qw__title">{t('qw.winTitle')}</h3>
             <p class="qw__desc">{t('qw.winDesc')}</p>
         </Card>
 

--- a/web/src/pages/fr/guides/getting-started.astro
+++ b/web/src/pages/fr/guides/getting-started.astro
@@ -179,7 +179,7 @@ const sections = [
                     <div class="df-topbar"><span class="df-brand">ItsBagelBot <small>Console</small></span><span class="df-crumb">ItsBagelBot / <b>Modules</b></span><span class="df-account">streamer · Diffuseur</span></div>
                     <span class="df-eyebrow">Gérer</span>
                     <p class="df-title">Modules de <i>chaîne</i></p>
-                    <p class="df-sub">Fonctions optionnelles pour votre chaîne. 1 sur 13 activée.</p>
+                    <p class="df-sub">Fonctions optionnelles pour votre chaîne. 1 sur 20 activée.</p>
                     <div class="df-search" style="max-width:200px;">Rechercher un module…</div>
                     <div class="df-cols df-cols--rail">
                         <div class="df-rail"><b>Categories</b><span class="is-active">Chat Tools</span><span>Community</span><span>Games</span></div>

--- a/web/src/pages/fr/guides/modules.astro
+++ b/web/src/pages/fr/guides/modules.astro
@@ -11,16 +11,16 @@ import DashFrame from '../../../components/guides/DashFrame.astro';
 const sections = [
     { id: 'how', heading: 'Comment fonctionnent les modules', note: 'Un interrupteur par fonction. Cliquez la tuile pour que ses messages sonnent comme vous.' },
     { id: 'welcome', heading: 'Accueillir le monde', note: "Alertes, shoutouts de raid, mots déclencheurs et l'heure chez vous." },
-    { id: 'economy', heading: 'Points, récompenses et minuteries', note: 'Des points de fidélité pour la présence, des récompenses de points de chaîne qui agissent, et des messages planifiés.' },
-    { id: 'together', heading: 'Jouer ensemble', note: "Une loterie sans contestation possible, une file d'attente équitable et un recueil des meilleures citations du chat." },
-    { id: 'games', heading: 'Stats de jeu dans le chat', note: 'Hypixel Bedwars, MCSR Ranked et Fortnite, à une commande de distance.' },
-    { id: 'safety', heading: 'Modération et commandes intégrées', note: "Les quatre niveaux d'AutoMod, et les trois commandes livrées avec le bot." },
+    { id: 'economy', heading: 'Points, récompenses et minuteries', note: 'Des points de fidélité pour la présence, des récompenses de points de chaîne qui agissent, des messages planifiés et deux jeux de mise pour les courageux.' },
+    { id: 'together', heading: 'Jouer ensemble', note: "Une loterie sans contestation possible, une file d'attente équitable, un recueil des meilleures citations du chat et des applaudissements pour les pyramides d'émotes." },
+    { id: 'games', heading: 'Stats de jeu dans le chat', note: 'Bedwars, MCSR Ranked, Fortnite, Clash Royale et Valorant, à une commande de distance.' },
+    { id: 'safety', heading: 'Modération et commandes intégrées', note: "Les quatre niveaux d'AutoMod, et les quatre commandes livrées avec le bot." },
 ];
 ---
 
 <Layout
     title="Le manuel des modules — Guides ItsBagelBot"
-    description="Chaque module d'ItsBagelBot expliqué: alertes de chat, shoutout automatique, mots déclencheurs, points de fidélité, récompenses de points de chaîne, minuteries, loteries, file d'attente, citations, stats de jeu et AutoMod."
+    description="Chaque module d'ItsBagelBot expliqué: alertes de chat, shoutout automatique, mots déclencheurs, points de fidélité, récompenses de points de chaîne, minuteries, loteries, jeux de mise, file d'attente, citations, stats de jeu, pyramides d'émotes et AutoMod."
     ogType="article"
 >
     <PageHero
@@ -43,9 +43,11 @@ const sections = [
                 réglages. La plupart des modules parlent dans le chat, et chacune de leurs phrases est
                 un modèle que vous pouvez réécrire, avec les mêmes variables à accolades que les
                 <a href="/fr/guides/commands">commandes personnalisées</a> (plus quelques extras par
-                module, listés plus bas). À noter: les noms des modules s'affichent en anglais dans
-                le tableau de bord (Chat Alerts, Timers, Loyalty Points…), comme dans les aperçus
-                ci-dessous.
+                module, listés plus bas). Chaque modèle est accompagné de la même répétition en direct
+                que les commandes, juste sous son éditeur : vous voyez la réponse atterrir dans un chat
+                factice avant n'importe quel spectateur. À noter: les noms des modules s'affichent en
+                anglais dans le tableau de bord (Chat Alerts, Timers, Loyalty Points…), comme dans les
+                aperçus ci-dessous.
             </p>
             <DashFrame
                 path="/modules"
@@ -59,7 +61,7 @@ const sections = [
                     <div class="df-topbar"><span class="df-brand">ItsBagelBot <small>Console</small></span><span class="df-crumb">ItsBagelBot / <b>Modules</b></span><span class="df-account">streamer · Diffuseur</span></div>
                     <span class="df-eyebrow">Gérer</span>
                     <p class="df-title">Modules de <i>chaîne</i></p>
-                    <p class="df-sub">Fonctions optionnelles pour votre chaîne. 1 sur 13 activée.</p>
+                    <p class="df-sub">Fonctions optionnelles pour votre chaîne. 1 sur 20 activée.</p>
                     <div class="df-cols df-cols--rail">
                         <div class="df-rail"><b>Categories</b><span>Chat Tools</span><span class="is-active">Community</span><span>Games</span></div>
                         <div style="display:grid; gap:10px; align-content:start;">
@@ -164,6 +166,32 @@ const sections = [
                 ne fonctionnent pas dans les minuteries. Gardez-les pour les commandes et les réponses
                 de modules.
             </p>
+            <h3>Pari</h3>
+            <p>
+                Transforme vos points en jeu : les spectateurs misent leur propre solde avec
+                <code>!gamble 100</code>, ou <code>!gamble half</code> / <code>!gamble all</code> pour
+                les téméraires, et le bot lance un dé de 1 à 100. Atterrir dans la chance de gain que
+                vous avez fixée rapporte la mise plus son équivalent ; sinon elle est prise. Vous
+                choisissez aussi les limites de mise et un délai par spectateur, et chaque paiement ou
+                débit passe par le même registre que <code>!points</code>. Les lignes de gain et de
+                perte sont des modèles, avec <code>&#123;roll&#125;</code>,
+                <code>&#123;chance&#125;</code>, <code>&#123;amount&#125;</code> et
+                <code>&#123;balance&#125;</code>.
+            </p>
+            <h3>Duels</h3>
+            <p>
+                Des duels de points entre spectateurs, de deux façons. Le pot : quelqu'un ouvre avec
+                <code>!duel 100</code>, chacun ajoute sa mise tant que la fenêtre est ouverte, puis le
+                bot tire un gagnant pondéré par la mise et il rafle tout. Le défi :
+                <code>!duel @maya_live 500</code> désigne un adversaire qui doit taper
+                <code>!duel accept</code> avant la fin du délai — mises égales, pile ou face, le
+                gagnant prend tout. Refus, annulations et absences remboursent toujours chaque point.
+            </p>
+            <p class="gtip">
+                <b>Équitable par conception</b>
+                Les deux jeux passent par le registre des Points de fidélité : personne ne peut miser
+                ce qu'il n'a pas, et la cote est exactement le nombre que vous fixez.
+            </p>
         </Fragment>
 
         <Fragment slot="together">
@@ -220,11 +248,19 @@ const sections = [
                 <code>!quote remove</code>. La collection se consulte et se modifie depuis sa page
                 du tableau de bord.
             </p>
+            <h3>Pyramides et séries d'émotes</h3>
+            <p>
+                Une clique d'encouragements pour les projets artistiques du chat. Le module surveille
+                les pyramides d'émotes (le même émote empilé 1-2-3 puis redescendu) et les séries de
+                messages à émote unique, et publie une ligne de célébration quand l'une atterrit
+                proprement — rien d'autre posté entre deux. Totalement automatique : pas de commande,
+                pas de réglage, juste l'interrupteur.
+            </p>
         </Fragment>
 
         <Fragment slot="games">
             <p>
-                Quatre intégrations mettent les stats de jeu dans le chat pour que personne ne quitte le
+                Cinq intégrations mettent les stats de jeu dans le chat pour que personne ne quitte le
                 stream. Liez votre compte une fois sur la page du module; chaque réponse est un modèle
                 réécrivable avec des variables propres au jeu.
             </p>
@@ -252,6 +288,11 @@ const sections = [
                             <td><code>!cr</code> <code>!cr decks</code> <code>!cr ranked</code> <code>!cr road</code></td>
                             <td>Profil à vie (niveau, victoires/défaites, taux de victoire), le deck actuel avec son élixir moyen, le classement Path of Legends et le record trophée — par tag de joueur.</td>
                         </tr>
+                        <tr>
+                            <td>Stats Valorant</td>
+                            <td><code>!val</code> <code>!val matches</code> <code>!val account</code> <code>!val lb</code> <code>!val shop</code></td>
+                            <td>Classement compétitif (rang, RR, variation du dernier match, record), dernières parties classées en K/D/A d'agent, résolution d'un Riot ID avec son niveau de compte, top 10 régionaux sur PC ou console, et rotation boutique du jour avec prix en VP et compte à rebours. Les formes contractées comme <code>!valrank</code> marchent aussi ; un mot de shard ou de ladder dans la ligne délimite cette recherche.</td>
+                        </tr>
                     </tbody>
                 </table>
             </div>
@@ -275,14 +316,15 @@ const sections = [
                 jamais. Il n'y a pas encore de tuile ni de page de réglages dans le tableau de bord;
                 les contrôles fins arrivent.
             </p>
-            <h3>Les trois commandes intégrées</h3>
+            <h3>Les quatre commandes intégrées</h3>
             <p>
                 Sur la <a href="https://dashboard.itsbagelbot.com/commands" target="_blank" rel="noopener noreferrer">page Commandes</a>,
-                au-dessus de vos propres commandes, vivent trois commandes livrées avec le bot:
+                au-dessus de vos propres commandes, vivent quatre commandes livrées avec le bot:
             </p>
             <ul>
                 <li><code>!followage</code>: depuis combien de temps quelqu'un vous suit.</li>
                 <li><code>!accountage</code>: l'âge d'un compte Twitch.</li>
+                <li><code>!uptime</code>: depuis combien de temps votre stream est en direct.</li>
                 <li><code>!clip</code>: crée un clip des derniers instants et publie le lien (en direct seulement). Sa réponse est un modèle réécrivable, avec <code>&#123;clip&#125;</code>, <code>&#123;user&#125;</code> et <code>&#123;target&#125;</code>.</li>
             </ul>
             <p>

--- a/web/src/pages/guides/getting-started.astro
+++ b/web/src/pages/guides/getting-started.astro
@@ -177,7 +177,7 @@ const sections = [
                     <div class="df-topbar"><span class="df-brand">ItsBagelBot <small>Console</small></span><span class="df-crumb">ItsBagelBot / <b>Modules</b></span><span class="df-account">streamer · Broadcaster</span></div>
                     <span class="df-eyebrow">Manage</span>
                     <p class="df-title">Channel <i>modules</i></p>
-                    <p class="df-sub">Optional features for your channel. 1 of 13 enabled.</p>
+                    <p class="df-sub">Optional features for your channel. 1 of 20 enabled.</p>
                     <div class="df-search" style="max-width:200px;">Search modules…</div>
                     <div class="df-cols df-cols--rail">
                         <div class="df-rail"><b>Categories</b><span class="is-active">Chat Tools</span><span>Community</span><span>Games</span></div>

--- a/web/src/pages/guides/modules.astro
+++ b/web/src/pages/guides/modules.astro
@@ -11,16 +11,16 @@ import DashFrame from '../../components/guides/DashFrame.astro';
 const sections = [
     { id: 'how', heading: 'How modules work', note: 'One switch per feature. Click the tile to make its messages sound like you.' },
     { id: 'welcome', heading: 'Welcoming people', note: 'Alerts, raid shoutouts, trigger words, and the time where you live.' },
-    { id: 'economy', heading: 'Points, rewards & timers', note: 'Loyalty points for watching, channel-point rewards that do things, and scheduled messages.' },
-    { id: 'together', heading: 'Playing together', note: "A raffle chat can't argue with, a fair play queue and a quote book for chat's greatest hits." },
-    { id: 'games', heading: 'Game stats in chat', note: 'Hypixel Bedwars, MCSR Ranked and Fortnite, one command away.' },
-    { id: 'safety', heading: 'Moderation & built-ins', note: "AutoMod's four levels, and the three commands that come with the bot." },
+    { id: 'economy', heading: 'Points, rewards & timers', note: 'Loyalty points for watching, channel-point rewards that do things, scheduled messages, and two wager games for the brave.' },
+    { id: 'together', heading: 'Playing together', note: "A raffle chat can't argue with, a fair play queue, a quote book for chat's greatest hits, and a cheer squad for emote pyramids." },
+    { id: 'games', heading: 'Game stats in chat', note: 'Bedwars, MCSR Ranked, Fortnite, Clash Royale and Valorant, one command away.' },
+    { id: 'safety', heading: 'Moderation & built-ins', note: "AutoMod's four levels, and the four commands that come with the bot." },
 ];
 ---
 
 <Layout
     title="The modules handbook — ItsBagelBot Guides"
-    description="Every ItsBagelBot module explained: chat alerts, auto shoutout, trigger words, loyalty points, channel-point rewards, timers, raffles, play queue, quotes, game stats and AutoMod."
+    description="Every ItsBagelBot module explained: chat alerts, auto shoutout, trigger words, loyalty points, channel-point rewards, timers, raffles, wager games, play queue, quotes, game stats, emote pyramids and AutoMod."
     ogType="article"
 >
     <PageHero
@@ -43,6 +43,8 @@ const sections = [
                 settings. Most modules speak in chat, and every line they say is a template you can
                 rewrite, with the same brace variables as
                 <a href="/guides/commands">custom commands</a> (plus a few extras per module, listed below).
+                Every template comes with the same live chat rehearsal as commands, right under its
+                editor: you watch the reply land in a mock chat before any viewer does.
             </p>
             <DashFrame
                 path="/modules"
@@ -56,7 +58,7 @@ const sections = [
                     <div class="df-topbar"><span class="df-brand">ItsBagelBot <small>Console</small></span><span class="df-crumb">ItsBagelBot / <b>Modules</b></span><span class="df-account">streamer · Broadcaster</span></div>
                     <span class="df-eyebrow">Manage</span>
                     <p class="df-title">Channel <i>modules</i></p>
-                    <p class="df-sub">Optional features for your channel. 1 of 13 enabled.</p>
+                    <p class="df-sub">Optional features for your channel. 1 of 20 enabled.</p>
                     <div class="df-cols df-cols--rail">
                         <div class="df-rail"><b>Categories</b><span>Chat Tools</span><span class="is-active">Community</span><span>Games</span></div>
                         <div style="display:grid; gap:10px; align-content:start;">
@@ -157,6 +159,31 @@ const sections = [
                 Timer messages are posted exactly as written: brace variables do not run inside timers.
                 Keep them for commands and module replies.
             </p>
+            <h3>Gamble</h3>
+            <p>
+                Turns your points into a game: viewers stake their own balance with
+                <code>!gamble 100</code>, or <code>!gamble half</code> / <code>!gamble all</code> for
+                the fearless, and the bot rolls 1-100. Landing inside the win chance you set pays the
+                stake back plus its match; anything else takes it. You also pick the bet limits and a
+                per-viewer cooldown, and every payout and debit moves real loyalty points through the
+                same ledger as <code>!points</code>. The win and lose lines are templates, with
+                <code>&#123;roll&#125;</code>, <code>&#123;chance&#125;</code>,
+                <code>&#123;amount&#125;</code> and <code>&#123;balance&#125;</code>.
+            </p>
+            <h3>Duels</h3>
+            <p>
+                Viewer-vs-viewer point duels, two ways. The pot: someone opens with
+                <code>!duel 100</code>, everyone adds their own stake while the window is open, then
+                the bot draws one winner weighted by stake and they take everything. The challenge:
+                <code>!duel @maya_live 500</code> names an opponent who must type
+                <code>!duel accept</code> before time runs out — equal stakes, a coin flip, winner
+                takes both. Declines, cancellations and no-shows always refund every point.
+            </p>
+            <p class="gtip">
+                <b>Fair by design</b>
+                Both games ride the Loyalty Points ledger: nobody can wager what they don't have, and
+                the odds are exactly the number you set.
+            </p>
         </Fragment>
 
         <Fragment slot="together">
@@ -210,11 +237,18 @@ const sections = [
                 allow. Mods can prune with <code>!quote remove</code>. The collection is browsable and
                 editable from its dashboard page.
             </p>
+            <h3>Emote Pyramids &amp; Streaks</h3>
+            <p>
+                A cheer squad for chat's art projects. The module watches chat stack the same emote
+                into a pyramid (1-2-3 and back down) or hold a streak of single-emote messages, and
+                fires a celebration line when one lands clean — nothing else posted in between.
+                Fully automatic: no commands, no settings, just the switch.
+            </p>
         </Fragment>
 
         <Fragment slot="games">
             <p>
-                Four integrations put game stats in chat so nobody alt-tabs. Link your account once on
+                Five integrations put game stats in chat so nobody alt-tabs. Link your account once on
                 the module's page; every reply is a rewritable template with game-specific variables.
             </p>
             <div class="gtable-wrap">
@@ -241,6 +275,11 @@ const sections = [
                             <td><code>!cr</code> <code>!cr decks</code> <code>!cr ranked</code> <code>!cr road</code></td>
                             <td>Lifetime profile (level, win/loss, win rate), the current battle deck with its average elixir, Path of Legends standing, and trophy-road record — by player tag.</td>
                         </tr>
+                        <tr>
+                            <td>Valorant Stats</td>
+                            <td><code>!val</code> <code>!val matches</code> <code>!val account</code> <code>!val lb</code> <code>!val shop</code></td>
+                            <td>Competitive standing (tier, RR, last game's change, peak tier), recent ranked games as agent K/D/A lines, who a Riot ID resolves to with account level, regional top-10 leaderboards on PC or console, and today's skin rotation with VP prices and the reset countdown. Squashed spellings like <code>!valrank</code> work too; a shard or ladder word anywhere in the line scopes that one lookup.</td>
+                        </tr>
                     </tbody>
                 </table>
             </div>
@@ -263,14 +302,15 @@ const sections = [
                 (slurs, scam links) can never be turned off. There is no tile or settings page for
                 it in the dashboard yet; the finer controls are on their way.
             </p>
-            <h3>The three built-ins</h3>
+            <h3>The four built-ins</h3>
             <p>
                 On the <a href="https://dashboard.itsbagelbot.com/commands" target="_blank" rel="noopener noreferrer">Commands page</a>,
-                above your own commands, live three that ship with the bot:
+                above your own commands, live four that ship with the bot:
             </p>
             <ul>
                 <li><code>!followage</code>: how long someone has followed you.</li>
                 <li><code>!accountage</code>: how old a Twitch account is.</li>
+                <li><code>!uptime</code>: how long your current stream has been live.</li>
                 <li><code>!clip</code>: creates a clip of the last moments and posts the link (live only). Its reply is a template you can rewrite, with <code>&#123;clip&#125;</code>, <code>&#123;user&#125;</code> and <code>&#123;target&#125;</code>.</li>
             </ul>
             <p>


### PR DESCRIPTION
## What

- **Modules handbook (EN + FR)**: new sections for **Gamble**, **Duels** and **Emote Pyramids & Streaks**; a **Valorant Stats** row in the game-stats table; section notes, SEO descriptions and the games intro updated to match.
- **Rehearsal**: the handbook intro now states every module reply template ships with the same live chat rehearsal as commands, under its editor.
- **Tile-count mocks**: '1 of 13 enabled' → '1 of 20' in both getting-started guides and both modules handbooks, matching MODULE_CATALOG minus hidden AutoMod.
- **Homepage**: the giveaway card drops its Incoming badge — chat raffles shipped in #634. Polls keep theirs.

Only the five content files are touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the modules guide with Gamble, Duels, Emote Pyramids & Streaks, and Valorant Stats.
  * Added documentation for the `!uptime` command and expanded existing module descriptions.
  * Updated module dashboards to show 20 available modules instead of 13 in English and French guides.
* **Style**
  * Removed the incoming badge from the giveaway card title.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->