### PR TITLE
feat(web): add About colophon naming the Hypixel account owner

### DIFF
--- a/web/src/components/home/About.astro
+++ b/web/src/components/home/About.astro
@@ -1,0 +1,85 @@
+---
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+/**
+ * About — the ownership colophon, the last thing on the page before the
+ * footer's sign-off. Quiet by design: small mono type like the footer note,
+ * no links row, no display type.
+ *
+ * Why this exists: Hypixel verifies that a product belongs to an account by
+ * scanning the site for the username as visible text. Until now the only
+ * mention of ItsMavey sat mid-sentence in 10px legal fine print under Game
+ * Integrations — technically present, practically unfindable for a reviewer,
+ * which is exactly why the verification kept bouncing.
+ *
+ * This section is deliberately NOT gated behind data-reveal: every other
+ * section starts at opacity 0 (style.css [data-reveal]) and only appears
+ * once reveal.js runs and you scroll past it. A reviewer or headless checker
+ * with JS disabled would see blank space where the proof should be, so this
+ * one stays statically visible. The only links are the two inline NameMC
+ * anchors — the public registry page is the ownership evidence itself.
+ */
+import { OWNER_IGN, OWNER_PROFILE_URL } from '../../owner';
+import { getLangFromUrl, useTranslations } from '../../i18n/ui';
+
+const lang = getLangFromUrl(Astro.url);
+const t = useTranslations(lang);
+
+// The ign placeholder marks where the linked handle sits so each locale keeps
+// its own prose order (same convention as games.legal).
+const [line1Before, line1After = ''] = t('about.line1').split('{ign}');
+const [mcBefore, mcAfter = ''] = t('about.mcLine').split('{ign}');
+---
+
+<section class="about" id="about">
+    <p class="about__line">{line1Before}<a
+        class="about__ign"
+        href={OWNER_PROFILE_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+    >{OWNER_IGN}</a>{line1After}</p>
+    <p class="about__line">{mcBefore}<a
+        class="about__ign"
+        href={OWNER_PROFILE_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+    >{OWNER_IGN}</a>{mcAfter}</p>
+</section>
+
+<style>
+    .about {
+        position: relative;
+        padding: 56px 24px 64px;
+        max-width: var(--content-max, 1200px);
+        margin: 0 auto;
+        z-index: 3;
+        text-align: center;
+        border-top: 1px solid rgba(255, 255, 255, 0.05);
+    }
+
+    .about__line {
+        max-width: 560px;
+        margin: 0 auto 10px;
+        font-family: var(--font-mono, "DM Mono", monospace);
+        font-size: 0.72rem;
+        letter-spacing: 0.05em;
+        line-height: 1.8;
+        color: var(--muted, #888077);
+    }
+
+    .about__ign {
+        color: var(--tan-light, #e0c49a);
+        text-decoration: underline;
+        text-decoration-color: rgba(224, 196, 154, 0.4);
+        text-underline-offset: 3px;
+        transition: color 180ms ease, text-decoration-color 180ms ease;
+    }
+
+    .about__ign:is(:hover, :focus-visible) {
+        color: var(--white, #f0ece4);
+        text-decoration-color: rgba(240, 236, 228, 0.7);
+    }
+
+    .about__line:last-child { margin-bottom: 0; }
+</style>

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -116,6 +116,8 @@
   "games.reqTitle": "Want another game?",
   "games.reqDesc": "We are adding more. Open an issue on GitHub and tell us what you play.",
   "games.legal": "ItsBagelBot is not an official Minecraft service and is not approved by or associated with Mojang or Microsoft. Not affiliated with or endorsed by Hypixel Inc. or MCSR Ranked. Hypixel data is retrieved through the official Hypixel API, using a developer key linked to the Minecraft account {ign}, the developer and owner of ItsBagelBot. Portions of the materials used are trademarks and/or copyrighted works of Epic Games, Inc. Not endorsed by Epic Games. Not affiliated with or endorsed by Riot Games. This content is not affiliated with, endorsed, sponsored, or specifically approved by Supercell and Supercell is not responsible for it; see Supercell's Fan Content Policy: supercell.com/en/fan-content-policy.",
+  "about.line1": "ItsBagelBot is built and operated by {ign}.",
+  "about.mcLine": "Game stats come through the official Hypixel API, with the developer key registered to the Minecraft account {ign}.",
   "qw.eyebrow": "The quiet work",
   "qw.title": "While you play, it sweeps the floor.",
   "qw.goveeReward": "moth_lamp redeemed · sunset",

--- a/web/src/i18n/locales/fr.json
+++ b/web/src/i18n/locales/fr.json
@@ -116,6 +116,8 @@
   "games.reqTitle": "Vous voulez un autre jeu ?",
   "games.reqDesc": "Nous en ajoutons d'autres. Ouvrez une issue sur GitHub et dites-nous à quoi vous jouez.",
   "games.legal": "ItsBagelBot n'est pas un service Minecraft officiel et n'est ni approuvé par ni associé à Mojang ou Microsoft. Non affilié à ni approuvé par Hypixel Inc. ou MCSR Ranked. Les données Hypixel sont récupérées via l'API officielle Hypixel, avec une clé développeur liée au compte Minecraft {ign}, développeur et propriétaire d'ItsBagelBot. Certains éléments utilisés sont des marques et/ou des œuvres protégées d'Epic Games, Inc. Non approuvé par Epic Games. Non affilié à ni approuvé par Riot Games. Ce contenu n'est pas affilié à, ni approuvé, sponsorisé ou spécifiquement validé par Supercell, et Supercell n'en est pas responsable ; voir la Politique de contenu fan de Supercell : supercell.com/en/fan-content-policy.",
+  "about.line1": "ItsBagelBot est développé et opéré par {ign}.",
+  "about.mcLine": "Les stats de jeux passent par l'API officielle Hypixel, avec la clé développeur enregistrée au compte Minecraft {ign}.",
   "qw.eyebrow": "Le travail discret",
   "qw.title": "Pendant que vous jouez, il balaie le sol.",
   "qw.goveeReward": "moth_lamp a échangé · coucher de soleil",

--- a/web/src/owner.ts
+++ b/web/src/owner.ts
@@ -1,0 +1,18 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+/**
+ * The one Minecraft identity this product answers for.
+ *
+ * Hypixel verifies that a product belongs to an account by looking for the
+ * username as plain, visible text on the site (their reviewers and automated
+ * checks read served HTML, not repo source). Every surface that names the
+ * owner — the Games legal line, the About colophon, the JSON-LD founder in
+ * Layout — must spell it identically, so it lives here and nowhere else.
+ * Changing the IGN here changes it everywhere at once; changing it anywhere
+ * else desynchronizes the ownership proof.
+ */
+export const OWNER_IGN = 'ItsMavey';
+
+/** Public registry page proving the account exists; linked wherever OWNER_IGN appears. */
+export const OWNER_PROFILE_URL = `https://namemc.com/profile/${OWNER_IGN}`;

--- a/web/src/pages/[...lang]/index.astro
+++ b/web/src/pages/[...lang]/index.astro
@@ -13,6 +13,7 @@ import SafetyLayers from '../../components/home/SafetyLayers.astro'
 import Steps from '../../components/home/Steps.astro'
 import Letter from '../../components/home/Letter.astro'
 import Finale from '../../components/home/Finale.astro'
+import About from '../../components/home/About.astro'
 import { getLangFromUrl, useTranslations, locales, defaultLang } from '../../i18n/ui';
 
 // One route per locale: the default locale emits the bare path (params.lang
@@ -36,4 +37,5 @@ const t = useTranslations(getLangFromUrl(Astro.url));
     <Steps />
     <Letter />
     <Finale />
+    <About />
 </Layout>

--- a/web/tests/site.spec.js
+++ b/web/tests/site.spec.js
@@ -90,6 +90,12 @@ test.describe('ItsBagelBot site', () => {
         await expect(page.locator('#letter')).toContainText('no trackers, no data sold');
         await expect(page.locator('[data-letter-stamp]')).toHaveCount(1);
         await expect(page.locator('.finale')).toContainText('Stream');
+
+        // Ownership colophon names the account Hypixel verification looks for
+        const about = page.locator('#about');
+        await expect(about).toContainText('ItsMavey');
+        const ignLinks = about.locator('a[href="https://namemc.com/profile/ItsMavey"]');
+        await expect(ignLinks).toHaveCount(2);
     });
 
     test('pricing renders free-first tiers, oath, and faq', async ({ page }) => {


### PR DESCRIPTION
## Why

Hypixel product verification keeps bouncing: the only mention of the owning Minecraft account sat mid-sentence in the 10px games legal fine print, and every homepage section is gated behind the scroll-reveal system (opacity 0 until JS runs), so reviewers and headless checkers see no ownership proof at all.

## What

- New `About.astro` colophon at the bottom of the homepage: two quiet mono lines stating that ItsBagelBot is built and operated by **ItsMavey** and that the Hypixel API developer key is registered to that Minecraft account, with inline NameMC profile links as the public evidence.
- New `src/owner.ts` — single source of truth for the IGN + profile URL so every ownership surface spells it identically.
- Mounted after `<Finale />` on the homepage; bilingual copy (en/fr).
- Deliberately **not** gated behind `data-reveal`: it renders with JavaScript disabled, which is exactly the checker scenario that made the old reference unfindable.
- Playwright home test asserts the colophon text and both NameMC links.

## Verification

- `bun run build` green (28 pages)
- Home spec green on this branch
- Served HTML contains the account name as plain text at `/#about` in both locales

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an About section to the home page with operator attribution and Hypixel API/developer-key information.
  - Added localized English and French text.
  - Included links to the operator’s NameMC profile.

- **Tests**
  - Added end-to-end checks confirming the attribution text and profile links appear correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->