### PR TITLE
feat(gossip): Spotify music provider — link/text search over broadcaster OAuth

### DIFF
--- a/app/gossip/internal/config/config.go
+++ b/app/gossip/internal/config/config.go
@@ -98,6 +98,21 @@ type Config struct {
 	GoveeRateLimit        float64
 	GoveeKeySubjectPrefix string
 
+	// Spotify music provider (search / track / artist / now-playing). Like
+	// govee it holds no per-broadcaster secret itself: each broadcaster
+	// connects their own account and SpotifyKeys — the modules service's
+	// internal RPC named by SpotifyKeySubjectPrefix, empty = provider
+	// disabled — hands over the stored OAuth refresh token. Gossip exchanges
+	// that token for short-lived access tokens using the fleet's ONE Spotify
+	// app (SPOTIFY_CLIENT_ID/SECRET): the app every broadcaster consents to.
+	// Both halves must be present or the whole provider skips at boot.
+	SpotifyBaseURL          string
+	SpotifyAccountsURL      string
+	SpotifyClientID         string
+	SpotifyClientSecret     string
+	SpotifyRateLimit        float64
+	SpotifyKeySubjectPrefix string
+
 	// Clash Royale provider (!cr / !crstats / !crdecks / !crranked /
 	// !crtrophy): the official Supercell player API through RoyaleAPI's
 	// supported proxy. APIKey is a standard Supercell key created on
@@ -188,6 +203,13 @@ func Load() *Config {
 		GoveeBaseURL:          env.Get("GOVEE_BASE_URL", "https://openapi.api.govee.com"),
 		GoveeRateLimit:        env.GetFloat("GOVEE_RATE_LIMIT", 8.0),
 		GoveeKeySubjectPrefix: env.Get("NATS_INTERNAL_GOVEE_KEY_SUBJECT_PREFIX", "bagel.rpc.internal.govee.key"),
+
+		SpotifyBaseURL:          env.Get("SPOTIFY_BASE_URL", "https://api.spotify.com"),
+		SpotifyAccountsURL:      env.Get("SPOTIFY_ACCOUNTS_URL", "https://accounts.spotify.com"),
+		SpotifyClientID:         env.Get("SPOTIFY_CLIENT_ID", ""),
+		SpotifyClientSecret:     env.Get("SPOTIFY_CLIENT_SECRET", ""),
+		SpotifyRateLimit:        env.GetFloat("SPOTIFY_RATE_LIMIT", 30.0),
+		SpotifyKeySubjectPrefix: env.Get("NATS_INTERNAL_SPOTIFY_KEY_SUBJECT_PREFIX", "bagel.rpc.internal.spotify.key"),
 
 		ClashRoyaleBaseURL:   env.Get("CLASHROYALE_BASE_URL", "https://proxy.royaleapi.dev/v1"),
 		ClashRoyaleAPIKey:    env.Get("CLASHROYALE_API_KEY", ""),

--- a/app/gossip/internal/core/http.go
+++ b/app/gossip/internal/core/http.go
@@ -248,6 +248,14 @@ func (c *HTTPClient) newRequest(ctx context.Context, r Request) (*http.Request, 
 // (carrying the upstream's own error text when present), and otherwise decodes
 // the body into out.
 func decodeJSON(resp *http.Response, out any) error {
+	// A 204 carries no body by definition, so there is nothing to unmarshal:
+	// leave out zero-valued and report success. Falling through used to
+	// surface as a confusing decode error indistinguishable from an upstream
+	// fault; Spotify's currently-playing endpoint answers 204 for "nothing
+	// playing", which is an answer, not a failure.
+	if resp.StatusCode == http.StatusNoContent {
+		return nil
+	}
 	body, err := io.ReadAll(io.LimitReader(resp.Body, maxBody))
 	if err != nil {
 		return err

--- a/app/gossip/internal/core/spotifykeys.go
+++ b/app/gossip/internal/core/spotifykeys.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package core
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	spotifyrpc "ItsBagelBot/internal/domain/rpc/spotify"
+	"ItsBagelBot/pkg/bus"
+
+	"github.com/nats-io/nats.go"
+)
+
+// spotifyKeyTimeout bounds the internal refresh-token lookup. Same reasoning
+// as goveeKeyTimeout: the modules service answers from its own database with
+// no upstream hop, and the caller's handler budget carries the rest.
+const spotifyKeyTimeout = 2 * time.Second
+
+// SpotifyKeyClient resolves a broadcaster's decrypted Spotify OAuth refresh
+// token over the modules service's internal RPC, gossip's twin of outgress's
+// tokenstore and the spotify sibling of GoveeKeyClient. The plaintext token
+// is used to mint one short-lived access token (cached separately, see the
+// spotify provider's tokenCacheTTL) and is itself never cached.
+type SpotifyKeyClient struct {
+	nc     *nats.Conn
+	prefix string // e.g. "bagel.rpc.internal.spotify.key"
+}
+
+// NewSpotifyKeyClient builds the resolver against the modules internal
+// refresh-token RPC.
+func NewSpotifyKeyClient(nc *nats.Conn, prefix string) *SpotifyKeyClient {
+	return &SpotifyKeyClient{nc: nc, prefix: prefix}
+}
+
+// Key returns the broadcaster's decrypted Spotify refresh token, or "" (nil
+// error) when none is on file. A transport or service failure is returned as
+// an error.
+func (c *SpotifyKeyClient) Key(ctx context.Context, broadcasterID string) (string, error) {
+	reply, err := bus.RequestJSONTimeout[spotifyrpc.RefreshTokenGetReply](
+		ctx, c.nc, c.prefix+".get", spotifyrpc.RefreshTokenGetRequest{UserID: broadcasterID}, spotifyKeyTimeout)
+	if err != nil {
+		return "", fmt.Errorf("spotify key get rpc: %w", err)
+	}
+	if reply.Error != "" {
+		return "", fmt.Errorf("spotify key get: %s", reply.Error)
+	}
+	return reply.RefreshToken, nil
+}

--- a/app/gossip/internal/provider/provider.go
+++ b/app/gossip/internal/provider/provider.go
@@ -53,13 +53,15 @@ type Provider interface {
 	Endpoints() []Endpoint
 }
 
-// GoveeKeyResolver hands the govee provider the decrypted Govee API key for one
-// broadcaster, resolved from the modules service over an internal RPC. It is
-// the gossip service's twin of outgress's tokenstore: the service that dials the
-// upstream fetches the sealed credential just-in-time instead of holding a
-// copy. An empty key with a nil error means the broadcaster has none on file
-// (govee not set up), which the provider reports as a friendly reply error.
-type GoveeKeyResolver interface {
+// BroadcasterKeyResolver hands a provider the decrypted per-broadcaster
+// credential for one external system — govee's API key, spotify's OAuth
+// refresh token — resolved from the modules service over an internal RPC. It
+// is the gossip service's twin of outgress's tokenstore: the service that
+// dials the upstream fetches the sealed credential just-in-time instead of
+// holding a copy. An empty key with a nil error means the broadcaster has
+// none on file (not set up), which the providers report as a friendly reply
+// error.
+type BroadcasterKeyResolver interface {
 	Key(ctx context.Context, broadcasterID string) (string, error)
 }
 
@@ -73,7 +75,10 @@ type Deps struct {
 	// GoveeKeys resolves per-broadcaster Govee API keys for the govee provider.
 	// nil disables that provider (providers.All skips it), the same degrade as a
 	// missing service API key.
-	GoveeKeys GoveeKeyResolver
+	GoveeKeys BroadcasterKeyResolver
+	// SpotifyKeys resolves per-broadcaster Spotify OAuth refresh tokens for
+	// the spotify provider, under the same custody split as GoveeKeys.
+	SpotifyKeys BroadcasterKeyResolver
 }
 
 // Logger returns Log, or a nop logger when it is unset, so providers and the

--- a/app/gossip/internal/providers/all.go
+++ b/app/gossip/internal/providers/all.go
@@ -15,6 +15,7 @@ import (
 	"ItsBagelBot/app/gossip/internal/providers/hypixel"
 	"ItsBagelBot/app/gossip/internal/providers/mcsr"
 	"ItsBagelBot/app/gossip/internal/providers/paceman"
+	"ItsBagelBot/app/gossip/internal/providers/spotify"
 	"ItsBagelBot/app/gossip/internal/providers/urchin"
 	"ItsBagelBot/app/gossip/internal/providers/valorant"
 
@@ -40,6 +41,7 @@ func All(cfg *config.Config, d provider.Deps) []provider.Provider {
 	out = appendGovee(out, cfg, d, log)
 	out = appendClashRoyale(out, cfg, d, log)
 	out = appendValorant(out, cfg, d, log)
+	out = appendSpotify(out, cfg, d, log)
 	return out
 }
 
@@ -157,5 +159,28 @@ func appendValorant(out []provider.Provider, cfg *config.Config, d provider.Deps
 		APIKey:           cfg.ValorantAPIKey,
 		RateLimit:        cfg.ValorantRateLimit,
 		ContentRateLimit: cfg.ValorantContentRateLimit,
+	}, d)
+}
+
+// appendSpotify adds the Spotify music provider. Like govee it needs no
+// service key of its own — each broadcaster connects their own account — but
+// it needs BOTH halves of the credential chain before any endpoint can
+// authenticate: the modules-side resolver that hands over a broadcaster's
+// stored OAuth refresh token, and the fleet's one Spotify app that token is
+// exchanged against. Whichever half is missing skips the whole provider.
+func appendSpotify(out []provider.Provider, cfg *config.Config, d provider.Deps, log *zap.Logger) []provider.Provider {
+	disabled, reason := false, ""
+	switch {
+	case d.SpotifyKeys == nil:
+		disabled, reason = true, "spotify provider disabled: no refresh-token resolver (modules spotify RPC unwired)"
+	case cfg.SpotifyClientID == "" || cfg.SpotifyClientSecret == "":
+		disabled, reason = true, "spotify provider disabled: SPOTIFY_CLIENT_ID/SPOTIFY_CLIENT_SECRET not set"
+	}
+	return gated(out, log, disabled, reason, spotify.New, spotify.Config{
+		BaseURL:      cfg.SpotifyBaseURL,
+		AccountsURL:  cfg.SpotifyAccountsURL,
+		ClientID:     cfg.SpotifyClientID,
+		ClientSecret: cfg.SpotifyClientSecret,
+		RateLimit:    cfg.SpotifyRateLimit,
 	}, d)
 }

--- a/app/gossip/internal/providers/govee/govee.go
+++ b/app/gossip/internal/providers/govee/govee.go
@@ -87,7 +87,7 @@ const providerName = "govee"
 type api struct {
 	http    *core.HTTPClient
 	cache   *core.Cache
-	keys    provider.GoveeKeyResolver
+	keys    provider.BroadcasterKeyResolver
 	log     *zap.Logger
 	limiter *ratelimit.Limiter
 

--- a/app/gossip/internal/providers/govee/govee_test.go
+++ b/app/gossip/internal/providers/govee/govee_test.go
@@ -67,7 +67,7 @@ type fakeKeys struct {
 
 func (f fakeKeys) Key(context.Context, string) (string, error) { return f.key, f.err }
 
-func newTestProvider(t *testing.T, keys provider.GoveeKeyResolver, handler http.Handler) provider.Provider {
+func newTestProvider(t *testing.T, keys provider.BroadcasterKeyResolver, handler http.Handler) provider.Provider {
 	t.Helper()
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)

--- a/app/gossip/internal/providers/spotify/parse.go
+++ b/app/gossip/internal/providers/spotify/parse.go
@@ -1,0 +1,272 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package spotify
+
+import (
+	"net/url"
+	"strings"
+)
+
+// resolveKind classifies what one search input turned out to be. The kinds
+// decide both the cheapest upstream route (a pasted link resolves by id in
+// one immutable-object fetch; text searches) and how long the answer may be
+// cached (ids are forever; text answers drift with the catalog).
+type resolveKind uint8
+
+const (
+	// resolveText is anything that is not recognizably a Spotify reference.
+	resolveText resolveKind = iota
+	resolveTrackID
+	resolveArtistID
+	resolveAlbumID
+	// resolveUnsupportedLink marks a well-formed Spotify link to a type this
+	// provider deliberately does not serve (playlists, podcasts, audiobooks).
+	// It is reported as such rather than searched as text: sharing a podcast
+	// episode should not return songs that merely share its words.
+	resolveUnsupportedLink
+)
+
+// resolvedInput is the outcome of classifying one search input.
+type resolvedInput struct {
+	kind resolveKind
+	// id carries the bare catalog id (validated base62) for the *_ID kinds.
+	id string
+	// text carries the normalized free text for resolveText.
+	text string
+}
+
+// cacheKey is the canonical identity of the input for cache purposes: every
+// spelling that resolves to the same thing shares one entry (the same track
+// linked by URL, URI or regional deep link collapses onto one key), while
+// text keys on the whitespace-normalized phrase.
+func (r resolvedInput) cacheKey() string {
+	switch r.kind {
+	case resolveTrackID:
+		return "track:" + r.id
+	case resolveArtistID:
+		return "artist:" + r.id
+	case resolveAlbumID:
+		return "album:" + r.id
+	default:
+		return "text:" + r.text
+	}
+}
+
+// linkHosts are the hosts whose URL paths carry catalog ids. spotify.link /
+// spoti.fi shorteners are deliberately absent: they interstitial through JS,
+// so following them lands on HTML no JSON decoder can read.
+var linkHosts = map[string]bool{
+	"open.spotify.com": true,
+	"play.spotify.com": true,
+}
+
+// linkKinds maps the link/URI type segment onto a resolve kind. Types present
+// but mapped to resolveUnsupportedLink are recognized so they can be reported
+// precisely instead of silently degraded to a text search.
+var linkKinds = map[string]resolveKind{
+	"track":     resolveTrackID,
+	"artist":    resolveArtistID,
+	"album":     resolveAlbumID,
+	"playlist":  resolveUnsupportedLink,
+	"episode":   resolveUnsupportedLink,
+	"show":      resolveUnsupportedLink,
+	"user":      resolveUnsupportedLink,
+	"audiobook": resolveUnsupportedLink,
+}
+
+// classify inspects one raw search input and decides how the provider will
+// resolve it. Classification never errors: anything it cannot pin down
+// degrades to resolveText, which is always servable.
+func classify(raw string) resolvedInput {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return resolvedInput{kind: resolveText}
+	}
+	lower := strings.ToLower(s)
+	switch {
+	case strings.HasPrefix(lower, "spotify:"):
+		return classifyURI(s)
+	case strings.HasPrefix(lower, "https://"), strings.HasPrefix(lower, "http://"):
+		return classifyURL(s)
+	case strings.Contains(lower, "open.spotify.com/"), strings.Contains(lower, "play.spotify.com/"):
+		// Schemeless paste ("open.spotify.com/track/x"): parse tolerantly.
+		return classifyURL("https://" + s)
+	default:
+		return resolvedInput{kind: resolveText, text: normalizeText(s)}
+	}
+}
+
+// classifyURI parses the spotify:<type>:<id> URI form. The id segment must be
+// taken verbatim — base62 ids are case-sensitive, so nothing here may fold
+// case after the type token.
+func classifyURI(s string) resolvedInput {
+	parts := strings.Split(s, ":")
+	if len(parts) != 3 {
+		return resolvedInput{kind: resolveText}
+	}
+	return resolveCatalogLink(linkRef{typeSeg: parts[1], id: parts[2]})
+}
+
+// classifyURL parses an open/play.spotify.com page URL, including the
+// regional deep-link form (.../intl-<region>/track/<id>) and any tracking
+// query (which url.Parse discards).
+func classifyURL(raw string) resolvedInput {
+	u, err := url.Parse(raw)
+	if err != nil || !linkHosts[strings.ToLower(u.Hostname())] {
+		return resolvedInput{kind: resolveText}
+	}
+	segs := strings.Split(strings.Trim(u.Path, "/"), "/")
+	for len(segs) > 0 && strings.HasPrefix(strings.ToLower(segs[0]), "intl-") {
+		segs = segs[1:]
+	}
+	if len(segs) != 2 {
+		return resolvedInput{kind: resolveText}
+	}
+	return resolveCatalogLink(linkRef{typeSeg: segs[0], id: segs[1]})
+}
+
+// catalogTarget validates one parsed link target against its resolve kind.
+// Recognized-but-unsupported types are reported precisely; ids must be REAL
+// catalog ids — Spotify's are always 22 base62 characters, so anything else
+// is a typo-shaped phrase better served by a text search than by a
+// guaranteed 404. An unrecognized segment reads as the zero kind and degrades
+// to text like any other unclassifiable input.
+// linkRef is a recognized Spotify reference pulled out of an input: the type
+// segment exactly as written (its case decides nothing here) plus the id
+// verbatim — base62 ids are case-sensitive, so nothing may fold them.
+type linkRef struct {
+	typeSeg string
+	id      string
+}
+
+// resolveCatalogLink maps one recognized reference onto a resolvedInput.
+// Recognized-but-unsupported types are reported precisely; ids must be REAL
+// catalog ids — Spotify's are always 22 base62 characters, so anything else
+// is a typo-shaped phrase better served by a text search than by a
+// guaranteed 404. An unrecognized segment reads as the zero kind and degrades
+// to text like any other unclassifiable input.
+func resolveCatalogLink(ref linkRef) resolvedInput {
+	kind, ok := linkKinds[strings.ToLower(ref.typeSeg)]
+	switch {
+	case !ok:
+		return resolvedInput{kind: resolveText}
+	case kind == resolveUnsupportedLink:
+		return resolvedInput{kind: kind}
+	case len(ref.id) != 22 || !validCatalogID(ref.id):
+		return resolvedInput{kind: resolveText}
+	default:
+		return resolvedInput{kind: kind, id: ref.id}
+	}
+}
+
+// Tokens reported in SpotifySearchReply.ResolvedAs, telling the caller how an
+// input was interpreted: which upstream shape answered and whether the match
+// was exact (a link id) or best-effort (text).
+const (
+	viaTrackLink = "track_link"
+	viaArtistTop = "artist_top"
+	viaAlbum     = "album"
+	viaFiltered  = "filtered"
+	viaText      = "text"
+)
+
+// searchCandidate is one upstream query attempt in a text plan.
+type searchCandidate struct {
+	// q is the literal search string sent upstream.
+	q string
+	// name is the ResolvedAs token this candidate reports on success.
+	name string
+}
+
+// planTextSearch turns chat text into ordered search candidates. The FIRST
+// candidate that returns tracks wins; later ones are degradations. Today's
+// plans are at most two deep (field-filtered, then plain), so a mis-split
+// costs one cheap empty search, never a wrong answer served confidently.
+func planTextSearch(raw string) []searchCandidate {
+	s := normalizeText(raw)
+	if s == "" {
+		return nil
+	}
+	if first, ok := heuristicCandidate(s); ok {
+		return []searchCandidate{first, {q: s, name: viaText}}
+	}
+	return []searchCandidate{{q: s, name: viaText}}
+}
+
+// heuristicCandidate builds the field-scoped first candidate from whichever
+// naming convention the input follows — "song by artist" first, then the
+// dash form copied from video titles. ok is false when neither convention
+// matches or a split leaves a usable side empty; the caller then plans the
+// plain search alone. A false positive ("Stand by Me") survives as the
+// fallback candidate, which is why the two-step plan exists.
+func heuristicCandidate(s string) (searchCandidate, bool) {
+	split := splitBy(s)
+	if !split.ok {
+		split = splitDash(s)
+		split.swap() // the dash convention orders artist first
+	}
+	if !split.ok {
+		return searchCandidate{}, false
+	}
+	return split.candidate()
+}
+
+// textSplit is the two halves of one convention split (song left / artist
+// right for the by-form; the dash form swaps before building its candidate);
+// ok reports whether the separator was found with content on both sides.
+type textSplit struct {
+	left, right string
+	ok          bool
+}
+
+// swap flips which half leads, for conventions that order the artist first.
+func (t *textSplit) swap() { t.left, t.right = t.right, t.left }
+
+// candidate shapes the split into Spotify's field-scoped query. Inner quotes
+// are stripped (they would terminate the qualifier's phrase early); a side
+// left empty after stripping means the heuristic misfired and the candidate
+// is dropped entirely rather than sent malformed.
+func (t textSplit) candidate() (searchCandidate, bool) {
+	song := strings.TrimSpace(strings.ReplaceAll(t.left, `"`, ""))
+	artist := strings.TrimSpace(strings.ReplaceAll(t.right, `"`, ""))
+	if song == "" || artist == "" {
+		return searchCandidate{}, false
+	}
+	return searchCandidate{
+		q:    `track:"` + song + `" artist:"` + artist + `"`,
+		name: viaFiltered,
+	}, true
+}
+
+// splitBy splits s around its first standalone "by", requiring at least one
+// field on each side. A false positive ("Stand by Me") survives as the
+// fallback candidate, which is why the two-step plan exists.
+func splitBy(s string) textSplit {
+	fields := strings.Fields(s)
+	for i := 1; i <= len(fields)-2; i++ {
+		if !strings.EqualFold(fields[i], "by") {
+			continue
+		}
+		return textSplit{left: strings.Join(fields[:i], " "), right: strings.Join(fields[i+1:], " "), ok: true}
+	}
+	return textSplit{}
+}
+
+// splitDash splits on the spaced-hyphen convention copied from video titles;
+// the LEFT side is treated as the artist. Only the first separator splits, so
+// "A - B - Remix" reads artist "A", song "B - Remix".
+func splitDash(s string) textSplit {
+	i := strings.Index(s, " - ")
+	if i <= 0 || i+3 >= len(s) {
+		return textSplit{}
+	}
+	return textSplit{left: strings.TrimSpace(s[:i]), right: strings.TrimSpace(s[i+3:]), ok: true}
+}
+
+// normalizeText folds case and collapses runs of whitespace, so "Mr.
+// Brightside", "mr   brightside" and "MR BRIGHTSIDE" share one cache entry
+// and one upstream query (catalog search itself is case-insensitive).
+func normalizeText(s string) string {
+	return strings.ToLower(strings.Join(strings.Fields(s), " "))
+}

--- a/app/gossip/internal/providers/spotify/parse_test.go
+++ b/app/gossip/internal/providers/spotify/parse_test.go
@@ -1,0 +1,119 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package spotify
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClassify(t *testing.T) {
+	const id = "3n3Ppam7vgaVa1iaRUc9Lp"
+	tests := []struct {
+		name string
+		in   string
+		want resolveKind
+		id   string
+	}{
+		{"plain text", "mr brightside", resolveText, ""},
+		{"empty", "   ", resolveText, ""},
+		{"track url with tracking params", "https://open.spotify.com/track/" + id + "?si=abc123&utm=x", resolveTrackID, id},
+		{"regional deep link keeps id case", "https://open.spotify.com/intl-de/track/AbC0123456789012345678", resolveTrackID, "AbC0123456789012345678"},
+		{"schemeless paste", "open.spotify.com/album/1DFixLWuPkv3KT3TnV35m3", resolveAlbumID, "1DFixLWuPkv3KT3TnV35m3"},
+		{"play host", "http://play.spotify.com/artist/4pt28jZ9p8nMW6RdcM8GMg", resolveArtistID, "4pt28jZ9p8nMW6RdcM8GMg"},
+		{"uri form preserves base62 case", "spotify:track:" + id, resolveTrackID, id},
+		{"foreign host is text", "https://youtube.com/watch?v=abc", resolveText, ""},
+		{"unknown type segment is text", "https://open.spotify.com/genre/something", resolveText, ""},
+		{"truncated path is text", "https://open.spotify.com/track", resolveText, ""},
+		{"invalid id chars degrade to text", "https://open.spotify.com/track/not_a_real_id!!", resolveText, ""},
+		{"uri with short id degrades to text", "spotify:track:short", resolveText, ""},
+		{"uri wrong arity is text", "spotify:track", resolveText, ""},
+		{"playlist link is recognized-unsupported", "https://open.spotify.com/playlist/37i9dQZF1DXcBWIGoYBM5M?si=x", resolveUnsupportedLink, ""},
+		{"podcast uri is recognized-unsupported", "spotify:show:4rOoJ6Egrf8K2IrywzwOMk", resolveUnsupportedLink, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := classify(tt.in)
+			assert.Equal(t, tt.want, got.kind)
+			if tt.id != "" || got.kind != resolveText {
+				assert.Equal(t, tt.id, got.id)
+			}
+		})
+	}
+}
+
+// The same track through every spelling must collapse onto ONE cache key.
+func TestCacheKeyCollapsesSpellings(t *testing.T) {
+	const id = "3n3Ppam7vgaVa1iaRUc9Lp"
+	url := classify("https://open.spotify.com/track/" + id + "?si=x")
+	uri := classify("spotify:track:" + id)
+	regional := classify("https://open.spotify.com/intl-fr/track/" + id)
+	assert.Equal(t, url.cacheKey(), uri.cacheKey())
+	assert.Equal(t, url.cacheKey(), regional.cacheKey())
+
+	text := classify("Mr.   Brightside ")
+	assert.Contains(t, text.cacheKey(), "mr. brightside", "whitespace normalizes")
+}
+
+func TestPlanTextSearch(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []searchCandidate
+	}{
+		{
+			name: "song by artist",
+			in:   "mr brightside BY the killers",
+			want: []searchCandidate{
+				{q: `track:"mr brightside" artist:"the killers"`, name: viaFiltered},
+				{q: "mr brightside by the killers", name: viaText},
+			},
+		},
+		{
+			name: "artist - song dash convention",
+			in:   "the killers - mr brightside",
+			want: []searchCandidate{
+				{q: `track:"mr brightside" artist:"the killers"`, name: viaFiltered},
+				{q: "the killers - mr brightside", name: viaText},
+			},
+		},
+		{
+			name: "false by split still plans a fallback",
+			in:   "stand by me",
+			want: []searchCandidate{
+				{q: `track:"stand" artist:"me"`, name: viaFiltered},
+				{q: "stand by me", name: viaText},
+			},
+		},
+		{
+			name: "plain text stays single-shot",
+			in:   "daft punk one more time",
+			want: []searchCandidate{{q: "daft punk one more time", name: viaText}},
+		},
+		{
+			name: "inner quotes stripped from qualifiers",
+			in:   `say "hi" by x`,
+			want: []searchCandidate{
+				{q: `track:"say hi" artist:"x"`, name: viaFiltered},
+				{q: `say "hi" by x`, name: viaText},
+			},
+		},
+		{
+			name: "empty input plans nothing",
+			in:   "   ",
+			want: nil,
+		},
+		{
+			name: "dash needs content on both sides",
+			in:   "ac/dc - ",
+			want: []searchCandidate{{q: "ac/dc -", name: viaText}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, planTextSearch(tt.in))
+		})
+	}
+}

--- a/app/gossip/internal/providers/spotify/search_links_test.go
+++ b/app/gossip/internal/providers/spotify/search_links_test.go
@@ -1,0 +1,149 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package spotify
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"testing"
+
+	gossiprpc "ItsBagelBot/internal/domain/rpc/gossip"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// denyAll fails the test on ANY api.spotify.com call — used when a route must
+// never reach the data API.
+func denyAll(t *testing.T) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("unexpected upstream call: %s %s", r.Method, r.URL.Path)
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+}
+
+func TestSearchTrackLinkLooksUpDirectly(t *testing.T) {
+	mint, _ := newMintServer(t, "tok-1")
+	api := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/v1/tracks/3n3Ppam7vgaVa1iaRUc9Lp", r.URL.Path)
+		assert.Equal(t, "Bearer tok-1", r.Header.Get("Authorization"))
+		_, _ = io.WriteString(w, brightsideBody)
+	})
+	p := newTestProvider(t, fakeKeys{key: "rt-1"}, api, mint)
+
+	reply := asReply[gossiprpc.SpotifySearchReply](t,
+		endpoint(t, p, "search")(context.Background(), gossiprpc.Request{
+			ChannelID: "2",
+			Query:     "https://open.spotify.com/track/3n3Ppam7vgaVa1iaRUc9Lp?si=abc",
+		}))
+	assert.Equal(t, viaTrackLink, reply.ResolvedAs, "a pasted link must report an exact match")
+	require.Len(t, reply.Tracks, 1)
+	assert.Equal(t, "3n3Ppam7vgaVa1iaRUc9Lp", reply.Tracks[0].ID)
+}
+
+func TestSearchUnsupportedLinkRejectedWithoutCredentials(t *testing.T) {
+	mint, mints := newMintServer(t, "unused")
+	p := newTestProvider(t, fakeKeys{key: "should-not-be-read"}, denyAll(t), mint)
+
+	reply := asReply[gossiprpc.SpotifySearchReply](t,
+		endpoint(t, p, "search")(context.Background(), gossiprpc.Request{
+			ChannelID: "2",
+			Query:     "https://open.spotify.com/playlist/37i9dQZF1DXcBWIGoYBM5M",
+		}))
+	assert.Contains(t, reply.Error, "isn't supported")
+	assert.Zero(t, mints.Load(), "an unsupported share must not spend a token mint")
+}
+
+func TestSearchArtistLinkServesTopTracks(t *testing.T) {
+	mint, _ := newMintServer(t, "tok-1")
+	api := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/v1/artists/4pt28jZ9p8nMW6RdcM8GMg/top-tracks", r.URL.Path)
+		_, _ = io.WriteString(w, `{"tracks":[`+
+			`{"id":"a1","name":"Human","artists":[{"name":"The Killers"}],"duration_ms":1},`+
+			`{"id":"a2","name":"Read My Mind","artists":[{"name":"The Killers"}],"duration_ms":2}]}`)
+	})
+	p := newTestProvider(t, fakeKeys{key: "rt-1"}, api, mint)
+
+	reply := asReply[gossiprpc.SpotifySearchReply](t,
+		endpoint(t, p, "search")(context.Background(), gossiprpc.Request{
+			ChannelID: "2",
+			Query:     "https://open.spotify.com/artist/4pt28jZ9p8nMW6RdcM8GMg",
+			Limit:     1,
+		}))
+	assert.Equal(t, viaArtistTop, reply.ResolvedAs)
+	require.Len(t, reply.Tracks, 1, "the caller's limit truncates the fixed top-tracks window")
+	assert.Equal(t, "a1", reply.Tracks[0].ID)
+}
+
+func TestSearchAlbumLinkFillsAlbumFieldsOntoSlimTracks(t *testing.T) {
+	mint, _ := newMintServer(t, "tok-1")
+	api := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/v1/albums/1DFixLWuPkv3KT3TnV35m3", r.URL.Path)
+		_, _ = io.WriteString(w, `{"name":"Hot Fuss","images":[{"url":"https://i.scdn.co/image/big"}],`+
+			`"tracks":{"items":[{"id":"s1","name":"Jenny Was a Friend of Mine",`+
+			`"artists":[{"name":"The Killers"}],"duration_ms":239000,`+
+			`"external_urls":{"spotify":"https://open.spotify.com/track/s1"}}]}}`)
+	})
+	p := newTestProvider(t, fakeKeys{key: "rt-1"}, api, mint)
+
+	reply := asReply[gossiprpc.SpotifySearchReply](t,
+		endpoint(t, p, "search")(context.Background(), gossiprpc.Request{
+			ChannelID: "2",
+			Query:     "open.spotify.com/album/1DFixLWuPkv3KT3TnV35m3",
+		}))
+	assert.Equal(t, viaAlbum, reply.ResolvedAs)
+	require.Len(t, reply.Tracks, 1)
+	track := reply.Tracks[0]
+	assert.Equal(t, "Hot Fuss", track.Album, "slim album-track objects get the album stamped on")
+	assert.Equal(t, "https://i.scdn.co/image/big", track.ImageURL, "album art covers the artwork-less items")
+	assert.Equal(t, "The Killers", track.Artists[0])
+}
+
+func TestSearchFilteredFallsBackToPlainWhenEmpty(t *testing.T) {
+	mint, _ := newMintServer(t, "tok-1")
+	var searches []string
+	api := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/v1/search", r.URL.Path)
+		searches = append(searches, r.URL.Query().Get("q"))
+		if len(searches) == 1 {
+			// The field-scoped candidate found nothing ("Stand by Me" split).
+			_, _ = io.WriteString(w, `{"tracks":{"items":[]}}`)
+			return
+		}
+		_, _ = io.WriteString(w, `{"tracks":{"items":[`+brightsideBody+`]}}`)
+	})
+	p := newTestProvider(t, fakeKeys{key: "rt-1"}, api, mint)
+
+	reply := asReply[gossiprpc.SpotifySearchReply](t,
+		endpoint(t, p, "search")(context.Background(), gossiprpc.Request{
+			ChannelID: "2",
+			Query:     "stand by me",
+		}))
+	require.Len(t, searches, 2, "a missed filtered search must fall back to plain text")
+	assert.Contains(t, searches[0], `track:"stand"`)
+	assert.Equal(t, "stand by me", searches[1])
+	assert.Equal(t, viaText, reply.ResolvedAs, "the fallback win reports itself as best-effort")
+	require.Len(t, reply.Tracks, 1)
+}
+
+func TestSearchPlainTextStaysSingleShot(t *testing.T) {
+	mint, mints := newMintServer(t, "tok-1")
+	calls := 0
+	api := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		_, _ = io.WriteString(w, `{"tracks":{"items":[`+brightsideBody+`]}}`)
+	})
+	p := newTestProvider(t, fakeKeys{key: "rt-1"}, api, mint)
+
+	reply := asReply[gossiprpc.SpotifySearchReply](t,
+		endpoint(t, p, "search")(context.Background(), gossiprpc.Request{
+			ChannelID: "2",
+			Query:     "mr   brightside",
+		}))
+	assert.Equal(t, 1, calls)
+	assert.EqualValues(t, 1, mints.Load())
+	assert.Equal(t, viaText, reply.ResolvedAs)
+	require.Len(t, reply.Tracks, 1)
+}

--- a/app/gossip/internal/providers/spotify/spotify.go
+++ b/app/gossip/internal/providers/spotify/spotify.go
@@ -1,0 +1,830 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+// Package spotify is the gossip provider for the Spotify Web API
+// (api.spotify.com). Like govee it holds no per-broadcaster secret of its
+// own: every call authenticates as a broadcaster, whose OAuth refresh token
+// is resolved just-in-time from the modules service
+// (provider.Deps.SpotifyKeys) by the broadcaster id the caller passes as
+// Request.ChannelID. Gossip holds only the fleet's own Spotify app
+// credentials (Config.ClientID/ClientSecret) and exchanges each
+// broadcaster's refresh token for a short-lived access token, cached per
+// broadcaster until shortly before Spotify expires it. The plaintext refresh
+// token lives only inside one token mint and is never cached or logged.
+//
+// Four endpoints back the music module: "search" resolves free text to
+// tracks, "track" and "artist" look up bare catalog ids, and "nowplaying"
+// reads the broadcaster's currently-playing track. Search and the lookups
+// ride any valid user token; nowplaying additionally requires
+// user-read-currently-playing (or user-read-playback-state) on the
+// broadcaster's grant.
+package spotify
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"ItsBagelBot/app/gossip/internal/core"
+	"ItsBagelBot/app/gossip/internal/provider"
+	gossiprpc "ItsBagelBot/internal/domain/rpc/gossip"
+	"ItsBagelBot/pkg/codec"
+	"ItsBagelBot/pkg/monitor"
+	"ItsBagelBot/pkg/ratelimit"
+
+	"go.uber.org/zap"
+)
+
+const (
+	// Catalog TTLs: track/artist metadata changes on album-drop timescales,
+	// but nowplaying is asked about "what is playing right now", so it stays
+	// short enough that a !song command never feels stale while still
+	// collapsing a chatty audience onto one upstream call per window.
+	searchTTL     = 10 * time.Minute
+	trackTTL      = time.Hour
+	nowplayingTTL = 15 * time.Second
+	negativeTTL   = 15 * time.Second
+
+	// httpTimeout bounds one Spotify call. Both hosts answer a healthy
+	// request well inside a second; the budget matters most for the token
+	// mint, which sits on the critical path of a cold call.
+	httpTimeout = 6 * time.Second
+	// lookupTimeout bounds one search/track/artist handler run (key resolve +
+	// possible token mint + one data call). Kept under the dashboard's 9s RPC
+	// budget, the same ceiling govee.devices answers within.
+	lookupTimeout = 8 * time.Second
+	// nowplayingTimeout bounds the nowplaying handler, which has the same
+	// worst case as a lookup (cold token plus one data call).
+	nowplayingTimeout = 8 * time.Second
+
+	// Spotify publishes no fixed per-token request number: it throttles a
+	// token that hammers the API with 429 + Retry-After. 30/min per
+	// broadcaster is far above what chat-triggered lookups need and far below
+	// where Spotify starts complaining; the bucket is per caller, so this is
+	// each broadcaster's own ceiling, never a shared one.
+	rateWindowSeconds = 60.0
+	defaultRateLimit  = 30.0
+
+	tokenPath      = "/api/token"
+	searchPath     = "/v1/search"
+	trackPath      = "/v1/tracks/"
+	artistPath     = "/v1/artists/"
+	albumPath      = "/v1/albums/"
+	nowPlayingPath = "/v1/me/player/currently-playing"
+
+	bearerTokenType = "Bearer"
+
+	defaultSearchLimit = 5
+	maxSearchLimit     = 10
+
+	// tokenExpirySkew is the clock-skew margin kept between a cached access
+	// token's last certain-valid moment and Spotify's own expiry. See
+	// tokenCacheTTL for why it is subtracted before halving rather than after.
+	tokenExpirySkew = 60 * time.Second
+	// minTokenTTL floors the cached-token window so a degenerate expires_in
+	// cannot turn the cache into a churn loop (Spotify answers 3600).
+	minTokenTTL = 30 * time.Second
+)
+
+// Config carries the provider's environment: the two Spotify hosts, the
+// fleet's one Spotify app credentials, and the per-broadcaster request
+// ceiling. There is no broadcaster credential here — those are per caller,
+// resolved just-in-time.
+type Config struct {
+	BaseURL      string
+	AccountsURL  string
+	ClientID     string
+	ClientSecret string
+	RateLimit    float64
+}
+
+// providerName is the subject token this provider answers under.
+const providerName = "spotify"
+
+// api holds the provider's runtime pieces; the declared endpoints capture it.
+// Every endpoint stays a bespoke handler: they must resolve the broadcaster's
+// credential (and possibly mint a token) before any cache or upstream work,
+// which the shared byte-flow skeleton deliberately does not model — a cached
+// reply must never bypass the credential checks.
+type api struct {
+	// http dials api.spotify.com. No baked auth header: the access token is
+	// per broadcaster (see bearerHeader).
+	http *core.HTTPClient
+	// auth dials accounts.spotify.com for the token mint; the app credentials
+	// ride the form body, not a baked header.
+	auth    *core.HTTPClient
+	cache   *core.Cache
+	keys    provider.BroadcasterKeyResolver
+	log     *zap.Logger
+	limiter *ratelimit.Limiter
+
+	// buckets is the per-broadcaster budget template: the derived specs are
+	// computed once here and re-keyed per caller (see rateAdmit).
+	buckets core.Buckets
+
+	clientID     string
+	clientSecret string
+}
+
+// New builds the spotify provider. d.SpotifyKeys and the app credentials must
+// all be present (providers.All skips the provider otherwise, since with no
+// resolver or no app to exchange against it can authenticate nothing).
+func New(cfg Config, d provider.Deps) provider.Provider {
+	p := newAPI(cfg, d)
+	b := provider.NewProvider(providerName, d)
+	b.Endpoint("search").Timeout(lookupTimeout).Handle(p.search)
+	b.Endpoint("track").Timeout(lookupTimeout).Handle(p.track)
+	b.Endpoint("artist").Timeout(lookupTimeout).Handle(p.artist)
+	b.Endpoint("nowplaying").Timeout(nowplayingTimeout).Handle(p.nowPlaying)
+	return b.Build()
+}
+
+func newAPI(cfg Config, d provider.Deps) *api {
+	base := strings.TrimSuffix(cfg.BaseURL, "/")
+	if base == "" {
+		base = "https://api.spotify.com"
+	}
+	accounts := strings.TrimSuffix(cfg.AccountsURL, "/")
+	if accounts == "" {
+		accounts = "https://accounts.spotify.com"
+	}
+	if cfg.RateLimit <= 0 {
+		cfg.RateLimit = defaultRateLimit
+	}
+	return &api{
+		http:         core.NewHTTPClient(base, nil, httpTimeout),
+		auth:         core.NewHTTPClient(accounts, nil, httpTimeout),
+		cache:        d.Cache,
+		keys:         d.SpotifyKeys,
+		log:          d.Logger(),
+		limiter:      d.Limiter,
+		buckets:      core.NewBuckets("ratelimit:gossip:spotify", cfg.RateLimit, rateWindowSeconds),
+		clientID:     cfg.ClientID,
+		clientSecret: cfg.ClientSecret,
+	}
+}
+
+// --- credentials -------------------------------------------------------------
+
+// accessToken is a live Spotify bearer credential for ONE broadcaster,
+// minted from their stored refresh token. It is its own type so the value
+// riding between the mint, its cache and every data call cannot be
+// silently confused with any other string on the way through.
+
+// tokenResponse is the subset of POST /api/token we read.
+type tokenResponse struct {
+	AccessToken string `json:"access_token"`
+	ExpiresIn   int    `json:"expires_in"`
+	// RefreshToken appears only when Spotify ROTATES the refresh token. See
+	// mintToken for why rotation is logged rather than persisted.
+	RefreshToken string `json:"refresh_token"`
+}
+
+// accessToken is a live Spotify bearer credential for ONE broadcaster,
+// minted from their stored refresh token. It is its own type so the value
+// riding between the mint, its cache and every data call cannot be silently
+// confused with any other string on the way through.
+type accessToken string
+
+// accessToken returns a live access token for the broadcaster: minted from
+// their refresh token, or served from the short-lived per-broadcaster cache.
+func (p *api) accessToken(ctx context.Context, broadcaster, refreshToken string) (accessToken, error) {
+	cacheKey := core.Key(providerName, "token", broadcaster)
+	b, err := core.CachedBytes(ctx, p.cache, cacheKey, nil, func(ctx context.Context) ([]byte, time.Duration, error) {
+		tok, err := p.mintToken(ctx, broadcaster, refreshToken)
+		if err != nil {
+			return nil, 0, err
+		}
+		return []byte(tok.AccessToken), tokenCacheTTL(tok.ExpiresIn), nil
+	})
+	if err != nil {
+		return "", err
+	}
+	return accessToken(b), nil
+}
+
+// tokenCacheTTL shrinks Spotify's expires_in into a safe cache window. The
+// byte-flow cache retains an entry for TWICE its fresh window (stale-while-
+// revalidate), and serving an access token past Spotify's own expiry would
+// 401 every call until the background refill lands — so the skew margin is
+// subtracted BEFORE halving, which keeps fresh + retained at most at
+// expiresIn - skew, strictly inside the token's real life.
+func tokenCacheTTL(expiresIn int) time.Duration {
+	ttl := (time.Duration(expiresIn)*time.Second - tokenExpirySkew) / 2
+	if ttl < minTokenTTL {
+		ttl = minTokenTTL
+	}
+	return ttl
+}
+
+// mintToken exchanges the broadcaster's refresh token for an access token
+// using the fleet's own app credentials (confidential-client form flow).
+//
+// Spotify MAY rotate the refresh token on this exchange. Gossip cannot
+// persist the replacement — custody of the stored token belongs to the
+// modules service — so a rotation is surfaced loudly here instead of dropped
+// silently: the operator needs to know the store still holds the previous
+// token, which Spotify keeps valid unless it explicitly invalidates it.
+func (p *api) mintToken(ctx context.Context, broadcaster, refreshToken string) (tokenResponse, error) {
+	form := url.Values{
+		"grant_type":    {"refresh_token"},
+		"refresh_token": {refreshToken},
+		"client_id":     {p.clientID},
+		"client_secret": {p.clientSecret},
+	}
+	var tok tokenResponse
+	req := core.Request{
+		Method: http.MethodPost,
+		Path:   tokenPath,
+		Headers: map[string]string{
+			// The token endpoint takes a form body; core would otherwise set JSON.
+			"Content-Type": "application/x-www-form-urlencoded",
+		},
+		Body: []byte(form.Encode()),
+	}
+	if err := p.auth.Do(ctx, req, &tok); err != nil {
+		return tok, err
+	}
+	if tok.AccessToken == "" {
+		return tok, fmt.Errorf("spotify token mint: empty access_token")
+	}
+	if tok.RefreshToken != "" && tok.RefreshToken != refreshToken {
+		monitor.TxnLogger(ctx, p.log).Warn(
+			"spotify rotated a broadcaster's refresh token; the modules store still holds the previous one",
+			zap.String("broadcaster", broadcaster))
+	}
+	return tok, nil
+}
+
+// accessTokenFor resolves the broadcaster's refresh token and returns a live
+// access token, or ("", msg) with a reply-safe reason when it cannot.
+func (p *api) accessTokenFor(ctx context.Context, broadcaster string) (tok accessToken, msg string) {
+	refresh, err := p.keys.Key(ctx, broadcaster)
+	if err != nil {
+		p.log.Warn("spotify refresh-token resolve failed", zap.String("broadcaster", broadcaster), zap.Error(err))
+		return "", "could not read your Spotify connection"
+	}
+	if refresh == "" {
+		return "", "no Spotify connection on file"
+	}
+	tok, err = p.accessToken(ctx, broadcaster, refresh)
+	if err != nil {
+		p.log.Warn("spotify token mint failed", zap.String("broadcaster", broadcaster), zap.Error(err))
+		return "", friendlyAuthError(err)
+	}
+	return tok, ""
+}
+
+// deadCredential reports the token-endpoint statuses that mean the stored
+// grant itself is gone — revoked, expired, disconnected — rather than
+// Spotify being unreachable. Recovery is a console reconnect, not a retry.
+func deadCredential(status int) bool {
+	switch status {
+	case http.StatusBadRequest, http.StatusUnauthorized, http.StatusForbidden:
+		return true
+	}
+	return false
+}
+
+// friendlyAuthError maps a token-mint failure onto a chat-safe message. A
+// dead credential says so plainly; anything else stays generic so an
+// accounts.spotify.com outage never leaks detail.
+func friendlyAuthError(err error) string {
+	var ue *core.UpstreamError
+	if errors.As(err, &ue) && deadCredential(ue.Status) {
+		return "your Spotify connection needs to be set up again"
+	}
+	return "could not reach Spotify"
+}
+
+// bearerHeader is the per-request authorization for data calls.
+func bearerHeader(token accessToken) map[string]string {
+	return map[string]string{"Authorization": bearerTokenType + " " + string(token)}
+}
+
+// rateAdmit spends one cache miss from the broadcaster's own budget. The
+// bucket specs come pre-derived from the template; only the key is per caller.
+func (p *api) rateAdmit(broadcaster string) func(context.Context) error {
+	return func(ctx context.Context) error {
+		return p.buckets.WithKey("ratelimit:gossip:spotify:"+broadcaster).Enforce(ctx, p.limiter, true)
+	}
+}
+
+// fetchFailed maps a CachedBytes failure onto a typed error message. A
+// budget denial or a friendly upstream failure has a message of its own
+// (core.FriendlyUpstream); anything else is infrastructure and reports the
+// endpoint's fallback after logging, mirroring what the FlowBuilder does for
+// flow-declared endpoints.
+func (p *api) fetchFailed(what, fallback string, err error) string {
+	if msg, _ := core.FriendlyUpstream(err); msg != "" {
+		return msg
+	}
+	p.log.Warn(what, zap.Error(err))
+	return fallback
+}
+
+// --- shared upstream shapes --------------------------------------------------
+
+// trackItem is Spotify's track object trimmed to what the module renders; it
+// is the wire shape of both search results and the /tracks/{id} lookup, and
+// nests as "item" in the currently-playing body.
+type trackItem struct {
+	ID      string `json:"id"`
+	Name    string `json:"name"`
+	Artists []struct {
+		Name string `json:"name"`
+	} `json:"artists"`
+	Album struct {
+		Name   string `json:"name"`
+		Images []struct {
+			URL string `json:"url"`
+		} `json:"images"`
+	} `json:"album"`
+	DurationMS   int64 `json:"duration_ms"`
+	ExternalURLs struct {
+		Spotify string `json:"spotify"`
+	} `json:"external_urls"`
+}
+
+// shapeTrack projects one upstream track onto the wire reply. Album art takes
+// the FIRST image (Spotify orders widest first): consumers can downscale,
+// never upscale.
+func shapeTrack(it trackItem) *gossiprpc.SpotifyTrack {
+	out := &gossiprpc.SpotifyTrack{
+		ID:         it.ID,
+		Name:       it.Name,
+		Artists:    make([]string, 0, len(it.Artists)),
+		Album:      it.Album.Name,
+		DurationMS: it.DurationMS,
+		URL:        it.ExternalURLs.Spotify,
+	}
+	for _, a := range it.Artists {
+		out.Artists = append(out.Artists, a.Name)
+	}
+	if len(it.Album.Images) > 0 {
+		out.ImageURL = it.Album.Images[0].URL
+	}
+	return out
+}
+
+// artistItem is Spotify's artist object trimmed the same way.
+type artistItem struct {
+	Name      string   `json:"name"`
+	Genres    []string `json:"genres"`
+	Followers struct {
+		Total int64 `json:"total"`
+	} `json:"followers"`
+	Images []struct {
+		URL string `json:"url"`
+	} `json:"images"`
+	ExternalURLs struct {
+		Spotify string `json:"spotify"`
+	} `json:"external_urls"`
+}
+
+func shapeArtist(id string, it artistItem) *gossiprpc.SpotifyArtist {
+	out := &gossiprpc.SpotifyArtist{
+		ID:        id,
+		Name:      it.Name,
+		Genres:    it.Genres,
+		Followers: it.Followers.Total,
+		URL:       it.ExternalURLs.Spotify,
+	}
+	if len(it.Images) > 0 {
+		out.ImageURL = it.Images[0].URL
+	}
+	return out
+}
+
+// validCatalogID reports whether id is a bare Spotify base62 catalog id. The
+// id is concatenated into the request path, so anything outside [A-Za-z0-9]
+// (full URIs, open.spotify.com links, traversal) is rejected rather than
+// escaped — callers resolve URIs down to ids themselves.
+func validCatalogID(id string) bool {
+	if id == "" || len(id) > 22 {
+		return false
+	}
+	for _, r := range id {
+		switch {
+		case r >= '0' && r <= '9', r >= 'A' && r <= 'Z', r >= 'a' && r <= 'z':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// --- search ------------------------------------------------------------------
+//
+// One endpoint answers every input shape a chat can produce: pasted Spotify
+// links (page URLs, regional deep links, spotify:type:id URIs) resolve by
+// catalog id in one direct immutable-object fetch, "song by artist" /
+// "artist - song" text becomes a field-scoped search with a plain-text
+// fallback, and anything else searches plainly. The route also picks the
+// cache TTL: ids are forever, text answers drift with the catalog.
+
+// searchResponse is the subset of GET /v1/search?type=track we read.
+type searchResponse struct {
+	Tracks struct {
+		Items []trackItem `json:"items"`
+	} `json:"tracks"`
+}
+
+// topTracksResponse is the subset of GET /v1/artists/{id}/top-tracks we read.
+type topTracksResponse struct {
+	Tracks []trackItem `json:"tracks"`
+}
+
+// albumResponse is the subset of GET /v1/albums/{id} we read. Its track items
+// are the slim variant — names, artists, durations, links, but no album
+// object and no artwork — so both are filled in from the album itself.
+type albumResponse struct {
+	Name   string `json:"name"`
+	Images []struct {
+		URL string `json:"url"`
+	} `json:"images"`
+	Tracks struct {
+		Items []struct {
+			ID      string `json:"id"`
+			Name    string `json:"name"`
+			Artists []struct {
+				Name string `json:"name"`
+			} `json:"artists"`
+			DurationMS   int64 `json:"duration_ms"`
+			ExternalURLs struct {
+				Spotify string `json:"spotify"`
+			} `json:"external_urls"`
+		} `json:"items"`
+	} `json:"tracks"`
+}
+
+func (p *api) search(ctx context.Context, req gossiprpc.Request) any {
+	if msg := missingSearchInput(req); msg != "" {
+		return gossiprpc.SpotifySearchReply{Error: msg}
+	}
+	broadcaster := strings.TrimSpace(req.ChannelID)
+
+	target := classify(strings.TrimSpace(req.Query))
+
+	// Said plainly BEFORE any credential work: an unsupported share should
+	// not spend a token mint to end in results that merely echo its words.
+	if target.kind == resolveUnsupportedLink {
+		return gossiprpc.SpotifySearchReply{Error: "that Spotify link type isn't supported; share a track, artist or album"}
+	}
+
+	tok, msg := p.accessTokenFor(ctx, broadcaster)
+	if msg != "" {
+		return gossiprpc.SpotifySearchReply{Error: msg}
+	}
+
+	scope := searchScope{
+		broadcaster: broadcaster,
+		limit:       clampSearchLimit(req.Limit),
+		canonical:   target.cacheKey(),
+		ttl:         searchTTL,
+	}
+	switch target.kind {
+	case resolveTrackID:
+		scope.ttl = trackTTL
+		return p.searchCached(ctx, scope, p.trackByIDFetch(tok, target.id))
+	case resolveArtistID:
+		return p.searchCached(ctx, scope, p.artistTopFetch(tok, target.id, scope.limit))
+	case resolveAlbumID:
+		scope.ttl = trackTTL
+		return p.searchCached(ctx, scope, p.albumTracksFetch(tok, target.id, scope.limit))
+	default:
+		return p.searchCached(ctx, scope, p.textFetch(tok, rawQuery(req), scope.limit))
+	}
+}
+
+// missingSearchInput reports the reply error for a request missing either
+// identifier every route needs, or "" when it is well-formed.
+func missingSearchInput(req gossiprpc.Request) string {
+	if strings.TrimSpace(req.Query) == "" {
+		return "missing search query"
+	}
+	if strings.TrimSpace(req.ChannelID) == "" {
+		return "missing channel"
+	}
+	return ""
+}
+
+// rawQuery re-reads the trimmed query for the text route; classify already
+// normalized its own copy for cache-keying.
+func rawQuery(req gossiprpc.Request) string {
+	return strings.TrimSpace(req.Query)
+}
+
+func clampSearchLimit(limit int) int {
+	if limit <= 0 {
+		return defaultSearchLimit
+	}
+	if limit > maxSearchLimit {
+		return maxSearchLimit
+	}
+	return limit
+}
+
+// searchScope bundles everything one classified branch needs to key and
+// window its cache entry — broadcaster scoping, result cap, canonical input
+// identity, freshness — so the cache wrapper takes two arguments instead of
+// six loose primitives.
+type searchScope struct {
+	broadcaster string
+	limit       int
+	canonical   string
+	ttl         time.Duration
+}
+
+// searchFetch produces one branch's typed reply on a cache miss. Each route
+// is its own constructor capturing only what it needs (the access token, the
+// catalog id), which keeps the dispatcher in search to if/switch statements
+// alone.
+type searchFetch func(context.Context) (gossiprpc.SpotifySearchReply, error)
+
+// searchCached wraps one classified branch in the byte-flow cache. Results do
+// not depend on who asked, but the quota spent does: keys stay
+// broadcaster-scoped so one channel's cache entry can never be filled at
+// another channel's expense (matching govee's rule), and admission stays nil
+// because every branch spends the broadcaster's OWN token allowance against
+// heavily cached reads.
+func (p *api) searchCached(ctx context.Context, scope searchScope, fetch searchFetch) any {
+	cacheKey := core.Key(providerName, "search",
+		fmt.Sprintf("%s|%d|%s", scope.broadcaster, scope.limit, scope.canonical))
+	b, err := core.CachedBytes(ctx, p.cache, cacheKey, nil, func(ctx context.Context) ([]byte, time.Duration, error) {
+		b, ttl, _, err := core.BuildReply(ctx, scope.ttl, negativeTTL,
+			func(ctx context.Context) (any, error) { return fetch(ctx) },
+			func(msg string) any { return gossiprpc.SpotifySearchReply{Error: msg} },
+		)
+		return b, ttl, err
+	})
+	if err != nil {
+		return gossiprpc.SpotifySearchReply{Error: p.fetchFailed("spotify search fetch failed", "track search failed", err)}
+	}
+	return codec.RawMessage(b)
+}
+
+// trackByIDFetch resolves a pasted link straight to its immutable object.
+func (p *api) trackByIDFetch(tok accessToken, id string) searchFetch {
+	return func(ctx context.Context) (gossiprpc.SpotifySearchReply, error) {
+		var it trackItem
+		r := core.Request{Method: http.MethodGet, Path: trackPath + id, Headers: bearerHeader(tok)}
+		if err := p.http.Do(ctx, r, &it); err != nil {
+			return gossiprpc.SpotifySearchReply{}, err
+		}
+		return gossiprpc.SpotifySearchReply{
+			ResolvedAs: viaTrackLink,
+			Tracks:     []gossiprpc.SpotifyTrack{*shapeTrack(it)},
+		}, nil
+	}
+}
+
+// artistTopFetch serves an artist link as their current top tracks, capped at
+// the caller's limit (the upstream window is fixed at ten).
+func (p *api) artistTopFetch(tok accessToken, id string, limit int) searchFetch {
+	return func(ctx context.Context) (gossiprpc.SpotifySearchReply, error) {
+		var resp topTracksResponse
+		r := core.Request{Method: http.MethodGet, Path: artistPath + id + "/top-tracks", Headers: bearerHeader(tok)}
+		if err := p.http.Do(ctx, r, &resp); err != nil {
+			return gossiprpc.SpotifySearchReply{}, err
+		}
+		reply := gossiprpc.SpotifySearchReply{
+			ResolvedAs: viaArtistTop,
+			Tracks:     make([]gossiprpc.SpotifyTrack, 0, len(resp.Tracks)),
+		}
+		for _, it := range resp.Tracks {
+			reply.Tracks = append(reply.Tracks, *shapeTrack(it))
+		}
+		return truncateTracks(reply, limit), nil
+	}
+}
+
+// albumTracksFetch lists an album capped at the caller's limit.
+func (p *api) albumTracksFetch(tok accessToken, id string, limit int) searchFetch {
+	return func(ctx context.Context) (gossiprpc.SpotifySearchReply, error) {
+		return p.albumTracks(ctx, tok, id, limit)
+	}
+}
+
+// textFetch runs the ordered candidate plan for free-text inputs.
+func (p *api) textFetch(tok accessToken, raw string, limit int) searchFetch {
+	return func(ctx context.Context) (gossiprpc.SpotifySearchReply, error) {
+		return p.searchText(ctx, tok, planTextSearch(raw), limit)
+	}
+}
+
+// searchText walks the plan in order: the first candidate returning tracks
+// wins, an upstream failure aborts outright (infrastructure is not answered
+// by quietly degrading further down the plan), and a plan exhausted without a
+// hit returns the final empty reply — no result is an answer, not an error.
+func (p *api) searchText(ctx context.Context, tok accessToken, plan []searchCandidate, limit int) (gossiprpc.SpotifySearchReply, error) {
+	var last gossiprpc.SpotifySearchReply
+	for _, c := range plan {
+		reply, err := p.runSearch(ctx, tok, c, limit)
+		if err != nil {
+			return gossiprpc.SpotifySearchReply{}, err
+		}
+		last = reply
+		if len(reply.Tracks) > 0 {
+			return reply, nil
+		}
+	}
+	return last, nil
+}
+
+func (p *api) runSearch(ctx context.Context, tok accessToken, c searchCandidate, limit int) (gossiprpc.SpotifySearchReply, error) {
+	q := url.Values{"q": {c.q}, "type": {"track"}, "limit": {strconv.Itoa(limit)}}
+	var resp searchResponse
+	r := core.Request{Method: http.MethodGet, Path: searchPath, Query: q, Headers: bearerHeader(tok)}
+	if err := p.http.Do(ctx, r, &resp); err != nil {
+		return gossiprpc.SpotifySearchReply{}, err
+	}
+	reply := gossiprpc.SpotifySearchReply{
+		ResolvedAs: c.name,
+		Tracks:     make([]gossiprpc.SpotifyTrack, 0, len(resp.Tracks.Items)),
+	}
+	for _, it := range resp.Tracks.Items {
+		reply.Tracks = append(reply.Tracks, *shapeTrack(it))
+	}
+	return reply, nil
+}
+
+// albumTracks lists an album's tracks capped at limit, stamping the album
+// name and artwork onto every entry since the slim track objects lack them.
+func (p *api) albumTracks(ctx context.Context, tok accessToken, id string, limit int) (gossiprpc.SpotifySearchReply, error) {
+	var resp albumResponse
+	r := core.Request{Method: http.MethodGet, Path: albumPath + id, Headers: bearerHeader(tok)}
+	if err := p.http.Do(ctx, r, &resp); err != nil {
+		return gossiprpc.SpotifySearchReply{}, err
+	}
+	reply := gossiprpc.SpotifySearchReply{
+		ResolvedAs: viaAlbum,
+		Tracks:     make([]gossiprpc.SpotifyTrack, 0, len(resp.Tracks.Items)),
+	}
+	image := ""
+	if len(resp.Images) > 0 {
+		image = resp.Images[0].URL
+	}
+	for _, it := range resp.Tracks.Items {
+		track := gossiprpc.SpotifyTrack{
+			ID:         it.ID,
+			Name:       it.Name,
+			Artists:    make([]string, 0, len(it.Artists)),
+			Album:      resp.Name,
+			DurationMS: it.DurationMS,
+			URL:        it.ExternalURLs.Spotify,
+			ImageURL:   image,
+		}
+		for _, a := range it.Artists {
+			track.Artists = append(track.Artists, a.Name)
+		}
+		reply.Tracks = append(reply.Tracks, track)
+	}
+	return truncateTracks(reply, limit), nil
+}
+
+// truncateTracks caps a reply at limit: top-tracks and album listings come
+// back in fixed-size upstream windows regardless of the requested count.
+func truncateTracks(reply gossiprpc.SpotifySearchReply, limit int) gossiprpc.SpotifySearchReply {
+	if len(reply.Tracks) > limit {
+		reply.Tracks = reply.Tracks[:limit]
+	}
+	return reply
+}
+
+// --- track / artist ----------------------------------------------------------
+
+func (p *api) track(ctx context.Context, req gossiprpc.Request) any {
+	id := strings.TrimSpace(req.TrackID)
+	if !validCatalogID(id) {
+		return gossiprpc.SpotifyTrackReply{Error: "invalid track id"}
+	}
+	broadcaster := strings.TrimSpace(req.ChannelID)
+	if broadcaster == "" {
+		return gossiprpc.SpotifyTrackReply{Error: "missing channel"}
+	}
+
+	tok, msg := p.accessTokenFor(ctx, broadcaster)
+	if msg != "" {
+		return gossiprpc.SpotifyTrackReply{Error: msg}
+	}
+
+	cacheKey := core.Key(providerName, "track", broadcaster+"|"+id)
+	b, err := core.CachedBytes(ctx, p.cache, cacheKey, nil, func(ctx context.Context) ([]byte, time.Duration, error) {
+		b, ttl, _, err := core.BuildReply(ctx, trackTTL, negativeTTL,
+			func(ctx context.Context) (any, error) {
+				var it trackItem
+				req := core.Request{Method: http.MethodGet, Path: trackPath + id, Headers: bearerHeader(tok)}
+				if err := p.http.Do(ctx, req, &it); err != nil {
+					return nil, err
+				}
+				return gossiprpc.SpotifyTrackReply{Track: shapeTrack(it)}, nil
+			},
+			func(msg string) any { return gossiprpc.SpotifyTrackReply{Error: msg} },
+		)
+		return b, ttl, err
+	})
+	if err != nil {
+		return gossiprpc.SpotifyTrackReply{Error: p.fetchFailed("spotify track fetch failed", "track lookup failed", err)}
+	}
+	return codec.RawMessage(b)
+}
+
+// artistResponse wraps the bare artist object GET /v1/artists/{id} answers.
+type artistResponse struct {
+	artistItem
+	ID string `json:"id"`
+}
+
+func (p *api) artist(ctx context.Context, req gossiprpc.Request) any {
+	id := strings.TrimSpace(req.ArtistID)
+	if !validCatalogID(id) {
+		return gossiprpc.SpotifyArtistReply{Error: "invalid artist id"}
+	}
+	broadcaster := strings.TrimSpace(req.ChannelID)
+	if broadcaster == "" {
+		return gossiprpc.SpotifyArtistReply{Error: "missing channel"}
+	}
+
+	tok, msg := p.accessTokenFor(ctx, broadcaster)
+	if msg != "" {
+		return gossiprpc.SpotifyArtistReply{Error: msg}
+	}
+
+	cacheKey := core.Key(providerName, "artist", broadcaster+"|"+id)
+	b, err := core.CachedBytes(ctx, p.cache, cacheKey, nil, func(ctx context.Context) ([]byte, time.Duration, error) {
+		b, ttl, _, err := core.BuildReply(ctx, trackTTL, negativeTTL,
+			func(ctx context.Context) (any, error) {
+				var resp artistResponse
+				req := core.Request{Method: http.MethodGet, Path: artistPath + id, Headers: bearerHeader(tok)}
+				if err := p.http.Do(ctx, req, &resp); err != nil {
+					return nil, err
+				}
+				return gossiprpc.SpotifyArtistReply{Artist: shapeArtist(resp.ID, resp.artistItem)}, nil
+			},
+			func(msg string) any { return gossiprpc.SpotifyArtistReply{Error: msg} },
+		)
+		return b, ttl, err
+	})
+	if err != nil {
+		return gossiprpc.SpotifyArtistReply{Error: p.fetchFailed("spotify artist fetch failed", "artist lookup failed", err)}
+	}
+	return codec.RawMessage(b)
+}
+
+// --- nowplaying --------------------------------------------------------------
+
+// nowPlayingResponse is the subset of GET /v1/me/player/currently-playing we
+// read. Spotify answers 204 with no body when playback is idle or private;
+// core decodes that as a zero value, which reads back here as IsPlaying false
+// with no item — exactly the right shape for "nothing playing".
+type nowPlayingResponse struct {
+	IsPlaying  bool      `json:"is_playing"`
+	ProgressMS int64     `json:"progress_ms"`
+	Item       trackItem `json:"item"`
+}
+
+func (p *api) nowPlaying(ctx context.Context, req gossiprpc.Request) any {
+	broadcaster := strings.TrimSpace(req.ChannelID)
+	if broadcaster == "" {
+		return gossiprpc.SpotifyNowPlayingReply{Error: "missing channel"}
+	}
+
+	tok, msg := p.accessTokenFor(ctx, broadcaster)
+	if msg != "" {
+		return gossiprpc.SpotifyNowPlayingReply{Error: msg}
+	}
+
+	// Unlike the catalog reads this endpoint is polled — chat asks many times
+	// a minute against ONE broadcaster's token allowance — so its miss path
+	// admits through their bucket: a flood degrades to the friendly busy
+	// message instead of burning the token Spotify throttles.
+	b, err := core.CachedBytes(ctx, p.cache, core.Key(providerName, "nowplaying", broadcaster), p.rateAdmit(broadcaster),
+		func(ctx context.Context) ([]byte, time.Duration, error) {
+			b, ttl, _, err := core.BuildReply(ctx, nowplayingTTL, negativeTTL,
+				func(ctx context.Context) (any, error) {
+					var resp nowPlayingResponse
+					req := core.Request{Method: http.MethodGet, Path: nowPlayingPath, Headers: bearerHeader(tok)}
+					if err := p.http.Do(ctx, req, &resp); err != nil {
+						return nil, err
+					}
+					reply := gossiprpc.SpotifyNowPlayingReply{IsPlaying: resp.IsPlaying, ProgressMS: resp.ProgressMS}
+					if resp.IsPlaying && resp.Item.ID != "" {
+						reply.Track = shapeTrack(resp.Item)
+					}
+					return reply, nil
+				},
+				func(msg string) any { return gossiprpc.SpotifyNowPlayingReply{Error: msg} },
+			)
+			return b, ttl, err
+		})
+	if err != nil {
+		return gossiprpc.SpotifyNowPlayingReply{Error: p.fetchFailed("spotify now-playing fetch failed", "could not reach Spotify", err)}
+	}
+	return codec.RawMessage(b)
+}

--- a/app/gossip/internal/providers/spotify/spotify_test.go
+++ b/app/gossip/internal/providers/spotify/spotify_test.go
@@ -1,0 +1,261 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package spotify
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"ItsBagelBot/app/gossip/internal/core"
+	"ItsBagelBot/app/gossip/internal/provider"
+	gossiprpc "ItsBagelBot/internal/domain/rpc/gossip"
+	"ItsBagelBot/pkg/codec"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// memStore is an in-memory core.Store for tests.
+type memStore struct {
+	mu sync.Mutex
+	m  map[string][]byte
+}
+
+func newMemStore() *memStore { return &memStore{m: map[string][]byte{}} }
+
+func (s *memStore) Get(_ context.Context, key string) ([]byte, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	b, ok := s.m[key]
+	return b, ok, nil
+}
+func (s *memStore) Set(_ context.Context, key string, val []byte, _ time.Duration) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.m[key] = append([]byte(nil), val...)
+	return nil
+}
+func (s *memStore) Del(_ context.Context, key string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.m, key)
+	return nil
+}
+
+func (s *memStore) SetNX(_ context.Context, key string, val []byte, _ time.Duration) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.m[key]; ok {
+		return false, nil
+	}
+	s.m[key] = append([]byte(nil), val...)
+	return true, nil
+}
+
+// fakeKeys is a canned credential resolver: key by broadcaster id, err
+// short-circuits.
+type fakeKeys struct {
+	key string
+	err error
+}
+
+func (f fakeKeys) Key(context.Context, string) (string, error) { return f.key, f.err }
+
+// newMintServer stands in for accounts.spotify.com: it answers the refresh
+// grant, asserts the app credentials rode the form, counts mints and echoes
+// tok as the access token.
+func newMintServer(t *testing.T, tok string) (http.Handler, *atomic.Int32) {
+	t.Helper()
+	var mints atomic.Int32
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/token", r.URL.Path)
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "application/x-www-form-urlencoded", r.Header.Get("Content-Type"))
+		require.NoError(t, r.ParseForm())
+		assert.Equal(t, "refresh_token", r.FormValue("grant_type"))
+		assert.Equal(t, "cid", r.FormValue("client_id"))
+		assert.Equal(t, "csecret", r.FormValue("client_secret"))
+		mints.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"access_token":%q,"token_type":"Bearer","expires_in":3600}`, tok)
+	}), &mints
+}
+
+func newTestProvider(t *testing.T, keys provider.BroadcasterKeyResolver, api, accounts http.Handler) provider.Provider {
+	t.Helper()
+	apiSrv := httptest.NewServer(api)
+	t.Cleanup(apiSrv.Close)
+	authSrv := httptest.NewServer(accounts)
+	t.Cleanup(authSrv.Close)
+	return New(Config{
+		BaseURL:      apiSrv.URL,
+		AccountsURL:  authSrv.URL,
+		ClientID:     "cid",
+		ClientSecret: "csecret",
+	}, provider.Deps{Cache: core.NewCache(newMemStore()), Log: zap.NewNop(), SpotifyKeys: keys})
+}
+
+func endpoint(t *testing.T, p provider.Provider, name string) func(context.Context, gossiprpc.Request) any {
+	t.Helper()
+	for _, ep := range p.Endpoints() {
+		if ep.Name == name {
+			return ep.Handle
+		}
+	}
+	t.Fatalf("endpoint %q not declared", name)
+	return nil
+}
+
+func asReply[T any](t *testing.T, res any) T {
+	t.Helper()
+	if v, ok := res.(T); ok {
+		return v
+	}
+	raw, ok := res.(codec.RawMessage)
+	require.True(t, ok, "unexpected handler result type %T", res)
+	var v T
+	require.NoError(t, codec.Unmarshal(raw, &v))
+	return v
+}
+
+const brightsideBody = `{
+	"id": "3n3Ppam7vgaVa1iaRUc9Lp",
+	"name": "Mr. Brightside",
+	"artists": [{"name": "The Killers"}],
+	"album": {
+		"name": "Hot Fuss",
+		"images": [
+			{"url": "https://i.scdn.co/image/large"},
+			{"url": "https://i.scdn.co/image/small"}
+		]
+	},
+	"duration_ms": 222000,
+	"external_urls": {"spotify": "https://open.spotify.com/track/3n3Ppam7vgaVa1iaRUc9Lp"}
+}`
+
+func TestSearchMintsTokenAndParses(t *testing.T) {
+	mint, _ := newMintServer(t, "tok-1")
+	var gotAuth string
+	api := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v1/search", r.URL.Path)
+		assert.Equal(t, "track", r.URL.Query().Get("type"))
+		gotAuth = r.Header.Get("Authorization")
+		_, _ = io.WriteString(w, `{"tracks":{"items":[`+brightsideBody+`]}}`)
+	})
+	p := newTestProvider(t, fakeKeys{key: "rt-1"}, api, mint)
+
+	reply := asReply[gossiprpc.SpotifySearchReply](t,
+		endpoint(t, p, "search")(context.Background(), gossiprpc.Request{ChannelID: "2", Query: "mr brightside"}))
+
+	assert.Equal(t, "Bearer tok-1", gotAuth, "the minted access token must ride the data call")
+	require.Len(t, reply.Tracks, 1)
+	track := reply.Tracks[0]
+	assert.Equal(t, "3n3Ppam7vgaVa1iaRUc9Lp", track.ID)
+	assert.Equal(t, "Mr. Brightside", track.Name)
+	require.Len(t, track.Artists, 1)
+	assert.Equal(t, "The Killers", track.Artists[0])
+	assert.Equal(t, "Hot Fuss", track.Album)
+	assert.EqualValues(t, 222000, track.DurationMS)
+	assert.Equal(t, "https://i.scdn.co/image/large", track.ImageURL, "largest art wins")
+	assert.Equal(t, "https://open.spotify.com/track/3n3Ppam7vgaVa1iaRUc9Lp", track.URL)
+}
+
+func TestTokenReusedAcrossCalls(t *testing.T) {
+	mint, mints := newMintServer(t, "tok-1")
+	api := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"tracks":{"items":[`+brightsideBody+`]}}`)
+	})
+	p := newTestProvider(t, fakeKeys{key: "rt-1"}, api, mint)
+
+	req := gossiprpc.Request{ChannelID: "2", Query: "mr brightside"}
+	for i := 0; i < 2; i++ {
+		reply := asReply[gossiprpc.SpotifySearchReply](t, endpoint(t, p, "search")(context.Background(), req))
+		require.Empty(t, reply.Error)
+	}
+	assert.EqualValues(t, 1, mints.Load(), "the cached access token must serve the second call without a re-mint")
+}
+
+func TestNoConnectionOnFile(t *testing.T) {
+	mint, _ := newMintServer(t, "unused")
+	api := http.HandlerFunc(func(http.ResponseWriter, *http.Request) { t.Fatal("must not dial Spotify with no connection on file") })
+	p := newTestProvider(t, fakeKeys{key: ""}, api, mint)
+
+	reply := asReply[gossiprpc.SpotifyTrackReply](t,
+		endpoint(t, p, "track")(context.Background(), gossiprpc.Request{ChannelID: "2", TrackID: "3n3Ppam7vgaVa1iaRUc9Lp"}))
+	assert.Contains(t, reply.Error, "no Spotify connection on file")
+}
+
+func TestDeadRefreshTokenMapsFriendly(t *testing.T) {
+	mint := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = io.WriteString(w, `{"error":"invalid_grant","error_description":"Refresh token revoked"}`)
+	})
+	api := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Fatal("a dead refresh token must never reach the data API")
+	})
+	p := newTestProvider(t, fakeKeys{key: "rt-dead"}, api, mint)
+
+	reply := asReply[gossiprpc.SpotifySearchReply](t,
+		endpoint(t, p, "search")(context.Background(), gossiprpc.Request{ChannelID: "2", Query: "x"}))
+	assert.Contains(t, reply.Error, "set up again")
+}
+
+func TestTrackRejectsNonCatalogID(t *testing.T) {
+	mint, _ := newMintServer(t, "tok-1")
+	api := http.HandlerFunc(func(http.ResponseWriter, *http.Request) { t.Fatal("must not dial Spotify with a non-catalog id") })
+	p := newTestProvider(t, fakeKeys{key: "rt-1"}, api, mint)
+
+	reply := asReply[gossiprpc.SpotifyTrackReply](t,
+		endpoint(t, p, "track")(context.Background(), gossiprpc.Request{ChannelID: "2", TrackID: "../../accounts"}))
+	assert.Contains(t, reply.Error, "invalid track id")
+}
+
+func TestNowPlayingIdleAnswers204(t *testing.T) {
+	mint, _ := newMintServer(t, "tok-1")
+	api := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v1/me/player/currently-playing", r.URL.Path)
+		assert.Equal(t, "Bearer tok-1", r.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusNoContent)
+	})
+	p := newTestProvider(t, fakeKeys{key: "rt-1"}, api, mint)
+
+	reply := asReply[gossiprpc.SpotifyNowPlayingReply](t,
+		endpoint(t, p, "nowplaying")(context.Background(), gossiprpc.Request{ChannelID: "2"}))
+	assert.Empty(t, reply.Error, "nothing playing is an answer, not a failure")
+	assert.False(t, reply.IsPlaying)
+	assert.Nil(t, reply.Track)
+}
+
+func TestNowPlayingParsesItem(t *testing.T) {
+	mint, _ := newMintServer(t, "tok-1")
+	api := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"is_playing":true,"progress_ms":42000,"item":`+brightsideBody+`}`)
+	})
+	p := newTestProvider(t, fakeKeys{key: "rt-1"}, api, mint)
+
+	reply := asReply[gossiprpc.SpotifyNowPlayingReply](t,
+		endpoint(t, p, "nowplaying")(context.Background(), gossiprpc.Request{ChannelID: "2"}))
+	assert.True(t, reply.IsPlaying)
+	assert.EqualValues(t, 42000, reply.ProgressMS)
+	require.NotNil(t, reply.Track)
+	assert.Equal(t, "Mr. Brightside", reply.Track.Name)
+}
+
+func TestSearchMissingQuery(t *testing.T) {
+	mint, _ := newMintServer(t, "unused")
+	api := http.HandlerFunc(func(http.ResponseWriter, *http.Request) { t.Fatal("must not dial Spotify with no query") })
+	p := newTestProvider(t, fakeKeys{key: "rt-1"}, api, mint)
+
+	reply := asReply[gossiprpc.SpotifySearchReply](t,
+		endpoint(t, p, "search")(context.Background(), gossiprpc.Request{ChannelID: "2", Query: "   "}))
+	assert.Contains(t, reply.Error, "missing search query")
+}

--- a/app/gossip/main.go
+++ b/app/gossip/main.go
@@ -73,19 +73,12 @@ func main() {
 	// providers.All returns the configured providers, which the engine
 	// subscribes. Adding an external system is a new package under
 	// internal/providers plus one line in all.go — no wiring here.
-	//
-	// GoveeKeys is the one provider dependency that needs the RPC connection:
-	// the govee provider authenticates with each broadcaster's own key, fetched
-	// just-in-time from the modules service. An empty subject prefix leaves it
-	// nil, which disables the govee provider.
 	deps := provider.Deps{
 		Cache:   core.NewCache(core.NewValkeyStore(valkeyClient)),
 		Limiter: ratelimit.New(valkeyClient),
 		Log:     log,
 	}
-	if cfg.GoveeKeySubjectPrefix != "" {
-		deps.GoveeKeys = core.NewGoveeKeyClient(nc, cfg.GoveeKeySubjectPrefix)
-	}
+	wireKeyResolvers(cfg, nc, &deps)
 
 	active := providers.All(cfg, deps)
 	if len(active) == 0 {
@@ -137,5 +130,20 @@ func drainRPCHandlers(log *zap.Logger) {
 func subscribeRPCHealth(nc *nats.Conn, queueGroup string, log *zap.Logger) {
 	if err := bus.SubscribeRPCHealth(nc, serviceName, queueGroup); err != nil {
 		log.Fatal("failed to subscribe rpc health", zap.Error(err))
+	}
+}
+
+// wireKeyResolvers attaches the just-in-time credential resolvers to deps —
+// the provider dependencies that need the RPC connection. Govee
+// authenticates with each broadcaster's own API key and spotify with their
+// connected account's OAuth refresh token, both fetched from the modules
+// service at call time. An empty subject prefix leaves a resolver nil, which
+// disables its provider (providers.All skips it).
+func wireKeyResolvers(cfg *config.Config, nc *nats.Conn, deps *provider.Deps) {
+	if cfg.GoveeKeySubjectPrefix != "" {
+		deps.GoveeKeys = core.NewGoveeKeyClient(nc, cfg.GoveeKeySubjectPrefix)
+	}
+	if cfg.SpotifyKeySubjectPrefix != "" {
+		deps.SpotifyKeys = core.NewSpotifyKeyClient(nc, cfg.SpotifyKeySubjectPrefix)
 	}
 }

--- a/internal/domain/rpc/gossip/gossip.go
+++ b/internal/domain/rpc/gossip/gossip.go
@@ -50,6 +50,21 @@ type Request struct {
 	// opt-in "a viewer types off to turn the lights off" reward behaviour.
 	PowerOff bool `json:"power_off,omitempty"`
 
+	// --- spotify (per-broadcaster music lookups) -----------------------------
+	// The spotify provider authenticates with the broadcaster's connected
+	// account (OAuth refresh token resolved from ChannelID), so these carry
+	// only what to look up. Zero on every non-spotify request.
+
+	// Query is the free-text search string spotify.search resolves to tracks.
+	Query string `json:"query,omitempty"`
+	// TrackID is the bare Spotify track id (base62) spotify.track looks up.
+	TrackID string `json:"track_id,omitempty"`
+	// ArtistID is the bare Spotify artist id (base62) spotify.artist looks up.
+	ArtistID string `json:"artist_id,omitempty"`
+	// Limit caps spotify.search's result count (1..10); zero lets the provider
+	// apply its own default rather than every caller repeating it.
+	Limit int `json:"limit,omitempty"`
+
 	// --- fortnite (fortnite-api.com stats lookups) ---------------------------
 
 	// AccountType is the platform namespace Account lives in for fortnite.stats:
@@ -320,6 +335,70 @@ type GoveeDevicesReply struct {
 type GoveeControlReply struct {
 	OK    bool   `json:"ok"`
 	Error string `json:"error,omitempty"`
+}
+
+// --- spotify (music over each broadcaster's connected account) ---------------
+
+// SpotifyTrack is one resolved track, shaped for chat and overlay rendering.
+type SpotifyTrack struct {
+	// ID is the bare catalog id; callers pair it with spotify.track to re-read
+	// the full object without another search.
+	ID         string   `json:"id"`
+	Name       string   `json:"name"`
+	Artists    []string `json:"artists"`
+	Album      string   `json:"album"`
+	DurationMS int64    `json:"duration_ms"`
+	// ImageURL is the album art at its largest size, so consumers downscale
+	// rather than upscale; empty when the album carries no artwork.
+	ImageURL string `json:"image_url,omitempty"`
+	// URL is the open.spotify.com track link.
+	URL string `json:"url,omitempty"`
+}
+
+// SpotifySearchReply is the answer to spotify.search: up to Limit tracks,
+// best match first. ResolvedAs reports HOW the input was interpreted —
+// "track_link", "artist_top" or "album" (direct catalog lookups off a pasted
+// link), "filtered" (field-scoped text search) or "text" (plain search, also
+// the token when a filtered search fell back) — so callers can present
+// "exact match" vs "best guess" without re-parsing the input themselves.
+// Display metadata, never a discriminator to switch on.
+type SpotifySearchReply struct {
+	Tracks     []SpotifyTrack `json:"tracks"`
+	ResolvedAs string         `json:"resolved_as,omitempty"`
+	Error      string         `json:"error,omitempty"`
+}
+
+// SpotifyTrackReply is the answer to spotify.track. A missing or malformed id
+// surfaces as Error.
+type SpotifyTrackReply struct {
+	Track *SpotifyTrack `json:"track,omitempty"`
+	Error string        `json:"error,omitempty"`
+}
+
+// SpotifyArtist is one resolved artist.
+type SpotifyArtist struct {
+	ID        string   `json:"id"`
+	Name      string   `json:"name"`
+	Genres    []string `json:"genres,omitempty"`
+	Followers int64    `json:"followers"`
+	ImageURL  string   `json:"image_url,omitempty"`
+	URL       string   `json:"url,omitempty"`
+}
+
+// SpotifyArtistReply is the answer to spotify.artist.
+type SpotifyArtistReply struct {
+	Artist *SpotifyArtist `json:"artist,omitempty"`
+	Error  string         `json:"error,omitempty"`
+}
+
+// SpotifyNowPlayingReply is the answer to spotify.nowplaying: the
+// broadcaster's currently-playing track with playback progress, or IsPlaying
+// false when playback is idle or private — an answer, not an error.
+type SpotifyNowPlayingReply struct {
+	IsPlaying  bool          `json:"is_playing"`
+	ProgressMS int64         `json:"progress_ms,omitempty"`
+	Track      *SpotifyTrack `json:"track,omitempty"`
+	Error      string        `json:"error,omitempty"`
 }
 
 // McsrSessionReply is the answer to mcsr.session: the change in a player's

--- a/internal/domain/rpc/spotify/spotify.go
+++ b/internal/domain/rpc/spotify/spotify.go
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+// Package spotifyrpc holds the shared wire types for the Spotify refresh-token
+// custody RPC the modules service owns. A broadcaster's refresh token is an
+// account secret: like the Govee API key it is stored encrypted at rest (Tink
+// AEAD, the modules service's own keyset) and never leaves the fleet except
+// decrypted to the gateway, the one service that exchanges it for access
+// tokens against accounts.spotify.com.
+//
+// Two subject families, split by trust (the goveerpc pattern):
+//
+//   - Dashboard verbs under a public-ish prefix (default
+//     "bagel.rpc.modules.spotify"): "set" stores a token, "clear" removes it,
+//     "status" reports only whether one is on file. None ever echoes the
+//     token back — the console shows "connected", never the value.
+//   - One internal verb, "bagel.rpc.internal.spotify.key.get",
+//     export/import-scoped at the NATS account level to the gateway alone,
+//     mirroring the users service's token/email RPCs. It returns the
+//     decrypted refresh token so the gateway can mint a short-lived access
+//     token.
+package spotifyrpc
+
+// RefreshTokenSetRequest stores (or replaces) a broadcaster's connected
+// Spotify account credential: the OAuth refresh token minted by the console's
+// connect flow.
+type RefreshTokenSetRequest struct {
+	UserID       string `json:"user_id"`
+	RefreshToken string `json:"refresh_token"`
+}
+
+// RefreshTokenClearRequest removes a broadcaster's stored refresh token
+// ("disconnect Spotify").
+type RefreshTokenClearRequest struct {
+	UserID string `json:"user_id"`
+}
+
+// RefreshTokenStatusRequest asks whether a broadcaster has a token on file.
+type RefreshTokenStatusRequest struct {
+	UserID string `json:"user_id"`
+}
+
+// RefreshTokenStatusReply reports only presence, never the token itself.
+type RefreshTokenStatusReply struct {
+	Present bool   `json:"present"`
+	Error   string `json:"error,omitempty"`
+}
+
+// RefreshTokenMutateReply is the ack for set/clear: a bare error envelope.
+type RefreshTokenMutateReply struct {
+	Error string `json:"error,omitempty"`
+}
+
+// RefreshTokenGetRequest is the internal decrypt request the gateway makes.
+type RefreshTokenGetRequest struct {
+	UserID string `json:"user_id"`
+}
+
+// RefreshTokenGetReply carries the decrypted refresh token or a terminal
+// error. An empty RefreshToken with empty Error means the broadcaster has not
+// connected Spotify yet (the caller treats that as "not set up", not a
+// failure).
+type RefreshTokenGetReply struct {
+	RefreshToken string `json:"refresh_token,omitempty"`
+	Error        string `json:"error,omitempty"`
+}

--- a/pkg/bus/rpc_pool.go
+++ b/pkg/bus/rpc_pool.go
@@ -163,15 +163,15 @@ const (
 	//	than a slow one, so the ceiling stops where the budget stops.
 	//
 	// Pools are per subscription, so the process-wide worst case is this ceiling
-	// times the number of subjects. gossip registers nineteen: urchin 5,
-	// fortnite 4, clashroyale 4, mcsr 3, govee 2, hypixel 1. All nineteen
-	// saturated with
+	// times the number of subjects. gossip registers thirty-seven: mcsr 8,
+	// valorant 5, urchin 5, fortnite 4, clashroyale 4, paceman 4, spotify 4,
+	// govee 2, hypixel 1. All thirty-seven saturated with
 	// pathological 4MiB bodies is past the limit and is NOT defended by this
 	// ceiling; it is defended by the shape of the workload (chat commands, one or
 	// two hot endpoints at a time), by the per-upstream buckets, and by the fact
 	// that 4MiB is the guard against a misbehaving upstream while the largest
 	// real payload — a full Hypixel profile — is a few hundred KiB, which puts
-	// even all fifteen saturated well inside the budget. If that ever stops being
+	// even all thirty-seven saturated well inside the budget. If that ever stops being
 	// true the answer is a process-wide admission gate or a lower ceiling, not a
 	// bigger container.
 	//


### PR DESCRIPTION
> [!NOTE]
> Stack **1/3** — bottom of the stack. Followed by #<custody> (token custody) and #654 (!sr song queue).

## Summary

The gossip-side Spotify provider, govee-shaped: no service secret of its own. Each broadcaster's OAuth refresh token is fetched just-in-time from the modules service and exchanged against `accounts.spotify.com` using the fleet's one app; access tokens cache per broadcaster with a halved TTL so the stale-while-revalidate tail can never serve an expired token.

- Endpoints under `bagel.rpc.gossip.spotify.*`: `search`, `track`, `artist`, `nowplaying`
- Smart input routing: page URLs / regional deep links / URIs / 22-char ids resolve by direct catalog fetch; `song by artist` and `artist - song` become field-scoped searches with plain-text fallback; playlists/podcasts rejected before spending a token mint
- `GoveeKeyResolver` → `BroadcasterKeyResolver` (shared per-broadcaster credential seam)
- HTTP 204 decodes as empty success (Spotify answers 204 for "nothing playing"); rpc_pool subject arithmetic corrected

## Ops

Doppler `gossip-env`: `SPOTIFY_CLIENT_ID` / `SPOTIFY_CLIENT_SECRET`. Provider stays dark without them or without the key-resolver RPC.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Spotify support for track, artist, album, and text searches.
  - Added support for Spotify links and URIs, including regional URLs.
  - Added currently-playing track lookups, artist top tracks, and enriched album details.
  - Added secure Spotify account connection and credential management.
  - Added result limits, caching, and rate-aware request handling.

- **Bug Fixes**
  - Improved handling of empty responses, including idle currently-playing results.
  - Added clearer handling for invalid links, missing connections, and expired credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->