### PR TITLE
feat(sesame): !nuke phrase sweep over a centralized recent-chat window

### DIFF
--- a/app/sesame/engine/chatcap.go
+++ b/app/sesame/engine/chatcap.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package engine
+
+import (
+	"strings"
+
+	"ItsBagelBot/app/sesame/module"
+	"ItsBagelBot/internal/domain/outgress"
+	"ItsBagelBot/internal/domain/validate"
+)
+
+// capChatText is the runtime backstop for the response shape CommandResponse
+// enforces at save time (at most MaxResponseLines lines, each at most
+// MaxResponseLineLength): old stored configs written before the validator, and
+// any module path that renders unvalidated third-party values, must still
+// publish a bounded message instead of a guaranteed Twitch 400. Untouched
+// output comes back byte-identical — the common case pays one split-scan and
+// no rebuild — and the cut backs up to a rune start so outgress never marshals
+// invalid UTF-8. Only plain chat is capped: announce/pin carry their own,
+// smaller Twitch limits handled downstream.
+func capChatText(text string) (string, bool) {
+	lines := strings.Split(text, "\n")
+	changed := false
+	if len(lines) > validate.MaxResponseLines {
+		lines = lines[:validate.MaxResponseLines]
+		changed = true
+	}
+	for i, line := range lines {
+		if len(line) > validate.MaxResponseLineLength {
+			lines[i] = truncateLine(line, validate.MaxResponseLineLength)
+			changed = true
+		}
+	}
+	if !changed {
+		return text, false
+	}
+	return strings.Join(lines, "\n"), true
+}
+
+// capEmitText applies the chat cap to one output on the emit sink. A no-op
+// for every non-chat carrier.
+func capEmitText(o *module.Output) {
+	if o.Type != outgress.TypeChat {
+		return
+	}
+	if capped, changed := capChatText(o.Text); changed {
+		o.Text = capped
+	}
+}

--- a/app/sesame/engine/deps.go
+++ b/app/sesame/engine/deps.go
@@ -128,6 +128,13 @@ type Deps struct {
 	// intra-replica half of the fix — the versioned LiveStore writes are the
 	// cross-replica half. nil leaves every handler plain fire-and-forget.
 	Seq *Sequencer
+	// Nuke is the phrase-targeted mass-moderation service behind !nuke. When
+	// set, the pipeline feeds each chat line into its recentStore (the sweep
+	// memory — ValkeyRecent in production, centralized because the replica
+	// pool shares one durable consumer) and binds its Shield Mode escalation
+	// decision; the moderation module reads the same handle to run sweeps.
+	// nil disables both: nothing is recorded and !nuke is inert.
+	Nuke *Nuke
 }
 
 // FeedCounts is one feeding's fleet-wide readout: how often the bagel has been

--- a/app/sesame/engine/dispatch.go
+++ b/app/sesame/engine/dispatch.go
@@ -267,24 +267,62 @@ func (p *Pipeline) bumpCounterTokens(ctx context.Context, c *module.Context, com
 		if strings.HasPrefix(base, botCounterTokenPrefix) {
 			continue // bot counters are admin-only; the token stays visible
 		}
-		value, err := p.loyalty.CounterBump(ctx, CounterBump{
+		value := p.claimedCounterValue(ctx, c, base, viewer, command)
+		if value == "" {
+			continue // bump failed / counter unknown: the token stays visible
+		}
+		counters[name] = value
+	}
+	return counters
+}
+
+// claimedCounterValue applies one event's counter bump exactly once: a fresh
+// dedup claim bumps and renders the new value; a replay (redelivered command
+// line) skips the increment and renders the counter's CURRENT value via a
+// peek, so the re-run line shows the same number instead of double-counting;
+// a failed bump releases its claim so redelivery retries. The kill switch
+// (nil dedup) degrades to the plain unguarded bump. An empty result means
+// "render without a value" — a bump error or an unknown-counter peek.
+func (p *Pipeline) claimedCounterValue(ctx context.Context, c *module.Context, name string, viewer Viewer, command string) string {
+	bump := func() (int64, error) {
+		return p.loyalty.CounterBump(ctx, CounterBump{
 			BroadcasterID: c.BroadcasterID,
-			Name:          base,
+			Name:          name,
 			Viewer:        viewer,
 			Command:       command,
 			Delta:         1,
 		})
-		if err != nil {
-			p.log.Warn("counter token bump failed",
-				zap.Uint64("broadcaster_id", c.BroadcasterID),
-				zap.String("counter", base),
-				zap.Error(err),
-			)
-			continue
-		}
-		counters[name] = strconv.FormatInt(value, 10)
 	}
-	return counters
+	fail := func(err error) string {
+		p.log.Warn("counter token bump failed",
+			zap.Uint64("broadcaster_id", c.BroadcasterID),
+			zap.String("counter", name),
+			zap.Error(err),
+		)
+		return ""
+	}
+	if p.dedup == nil {
+		value, err := bump()
+		if err != nil {
+			return fail(err)
+		}
+		return strconv.FormatInt(value, 10)
+	}
+	dup, release := p.dedup.Claim(ctx, EffectRef{Identity: EventIdentity(&c.Env), Effect: CounterEffect(name)})
+	if dup {
+		return CounterPeekValue(ctx, p.loyalty, CounterTarget{
+			BroadcasterID: c.BroadcasterID,
+			Name:          name,
+			ViewerID:      viewer.ID,
+			Command:       command,
+		})
+	}
+	value, err := bump()
+	if err != nil {
+		release()
+		return fail(err)
+	}
+	return strconv.FormatInt(value, 10)
 }
 
 // firstArg returns the first whitespace-delimited word of a command's

--- a/app/sesame/engine/external_var.go
+++ b/app/sesame/engine/external_var.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package engine
+
+import "unicode/utf8"
+
+// MaxExternalVarBytes caps one third-party value a module expands into a chat
+// template ({player}, {tags}, an upstream error message). The bound exists at
+// the variable-provider level, before ANY template consumes the value: gossip
+// replies are external systems whose fields we do not control, so a hostile or
+// broken upstream must not be able to size (or control-char-poison) a bot chat
+// line through whatever template references it. 100 bytes covers every real
+// player name and tag list head with room to spare.
+const MaxExternalVarBytes = 100
+
+// ExternalVar sanitizes and caps one third-party value for template
+// expansion: sanitizeVar strips control characters (so no embedded newline can
+// mint extra lines and no leading slash run can mint a verb) and truncateLine
+// caps the length without splitting a UTF-8 rune. Numeric/enum tokens do not
+// need this - only values that originate outside the bot.
+func ExternalVar(v string) string {
+	return truncateLine(sanitizeVar(v), MaxExternalVarBytes)
+}
+
+// truncateLine caps s at max bytes without splitting a UTF-8 rune: when the
+// cut would land mid-rune it backs up to the previous rune boundary. A
+// multibyte tail loses at most three bytes against the cap.
+func truncateLine(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	cut := max
+	for cut > 0 && !utf8.RuneStart(s[cut]) {
+		cut--
+	}
+	return s[:cut]
+}

--- a/app/sesame/engine/loyalty_tick.go
+++ b/app/sesame/engine/loyalty_tick.go
@@ -53,7 +53,6 @@ const (
 	// instant (a mass stream.online after an ingress restart) don't line their
 	// chatters fetches up.
 	watchTickJitter = time.Minute
-
 	// loyaltyTickClaimTTL covers one tick's work: a paginated chatters fetch
 	// (10s handler budget) plus the reporter hand-off.
 	loyaltyTickClaimTTL = 30 * time.Second
@@ -523,6 +522,23 @@ func rearmAfterFailure(failures int) time.Duration {
 		return watchTickQuickRetry
 	}
 	return watchTickInterval
+}
+
+// watchTickIdentity is the stable dedup identity for the accrual bucket that
+// contains at on one channel: the channel id plus the interval index of the
+// event's OWN timestamp. Both replicas firing the same key expiry derive the
+// same string (the bucket comes from the payload's clock, never the local
+// one), yet the next legitimate window indexes differently — so the dedup
+// guard collapses a refired expiry without suppressing the following accrual.
+func watchTickIdentity(broadcasterID uint64, at time.Time) string {
+	buf := GetBuf()
+	buf = append(buf, "wtick:"...)
+	buf = strconv.AppendUint(buf, broadcasterID, 10)
+	buf = append(buf, ':')
+	buf = strconv.AppendInt(buf, at.Unix()/int64(watchTickInterval/time.Second), 10)
+	key := string(buf)
+	PutBuf(buf)
+	return key
 }
 
 // requestLiveRecheck asks outgress to resolve the broadcaster's live state

--- a/app/sesame/engine/moderate.go
+++ b/app/sesame/engine/moderate.go
@@ -86,7 +86,7 @@ func (p *Pipeline) gateChat(ctx context.Context, mctx *module.Context, amCfg *au
 		automod.WithChannel(mctx.BroadcasterID),
 		automod.WithChatter(env.ChatterUserID),
 		automod.WithMessageEmotes(p.adaptiveEmoteCodes(mctx)))
-	v = p.campaignVote(ctx, voteInput{
+	v, councilMint := p.campaignVote(ctx, voteInput{
 		verdict:     v,
 		simhash:     sigs.SimHash,
 		linkish:     sigs.Linkish,
@@ -104,8 +104,9 @@ func (p *Pipeline) gateChat(ctx context.Context, mctx *module.Context, amCfg *au
 		// enforcement switch: strikes used to be recorded before this check,
 		// so shadow-mode verdicts accrued them, and arming enforcement later
 		// inherited escalated punishments from history that was never
-		// actioned. Shadow keeps logging verdicts; it no longer scores them.
-		if p.reputation != nil {
+		// actioned. A council-minted verdict skips scoring entirely — see
+		// campaignVote for the attribution rule.
+		if p.reputation != nil && !councilMint {
 			v = escalateByReputation(v, p.reputation.Score(ctx, env.ChatterUserID))
 			p.reputation.Bump(ctx, env.ChatterUserID)
 		}
@@ -150,31 +151,40 @@ type voteInput struct {
 // the valkey distinct-sender count for this line's template, when the line is
 // either already content-flagged at delete level or an unflagged link carrier.
 // The broadcaster scopes the count to this one channel — a quorum is senders
-// within a tenant, never across the fleet. Corroboration escalates a delete to
-// a timeout; on its own it only adds the mildest action (delete), never a
-// punishment - abstain in favor of the user. Observe is HLL-idempotent per sender.
-func (p *Pipeline) campaignVote(ctx context.Context, in voteInput) automod.Verdict {
+// within a tenant, never across the fleet. It returns the verdict plus whether
+// the juror AUTHORED the action alone (the ActionNone mint): a band quorum can
+// be manufactured by colluding accounts, so a council-only verdict enforces
+// its immediate delete but records NO reputation strike — letting it score
+// would let eight accounts pump an innocent user up the ladder while the
+// reason launders it as automod. Content-backed escalations keep their
+// strike. Every quorum activation lands one Warn audit line naming the
+// channel and the consulted chatter. Observe is HLL-idempotent per sender.
+func (p *Pipeline) campaignVote(ctx context.Context, in voteInput) (automod.Verdict, bool) {
 	if p.campaign == nil || in.simhash == 0 {
-		return in.verdict
+		return in.verdict, false
 	}
 	if !in.linkish && in.verdict.Action != automod.ActionDelete {
-		return in.verdict
+		return in.verdict, false
 	}
 	if p.campaign.Observe(ctx, in.broadcaster, in.simhash, in.sender) < campaignThreshold {
-		return in.verdict
+		return in.verdict, false
 	}
+
+	p.log.Warn("campaign band quorum",
+		zap.Uint64("broadcaster_id", in.broadcaster),
+		zap.String("chatter_id", in.sender))
 
 	switch in.verdict.Action {
 	case automod.ActionNone:
-		return automod.Verdict{Action: automod.ActionDelete, Rule: "council:campaign"}
+		return automod.Verdict{Action: automod.ActionDelete, Rule: "council:campaign"}, true
 	case automod.ActionDelete:
 		v := in.verdict
 		v.Action = automod.ActionTimeout
 		v.Seconds = 600
 		v.Rule += "+campaign"
-		return v
+		return v, false
 	}
-	return in.verdict
+	return in.verdict, false
 }
 
 // gateCohort handles a folded duplicate cohort: plain chat the ingress squash

--- a/app/sesame/engine/nuke.go
+++ b/app/sesame/engine/nuke.go
@@ -158,12 +158,19 @@ func emitChat(emit module.Emit, broadcasterID, text string) {
 func filterNukeTargets(hits []RecentHit, broadcasterID uint64, botID uint64) []RecentHit {
 	targets := make([]RecentHit, 0, len(hits))
 	for _, h := range hits {
-		if h.Role >= module.RoleVIP || h.UserID == broadcasterID || h.UserID == botID {
+		if protectedFromSweep(h, broadcasterID, botID) {
 			continue
 		}
 		targets = append(targets, h)
 	}
 	return targets
+}
+
+// protectedFromSweep reports whether a phrase collision must never punish the
+// matched sender: VIP and above are staff in the line of fire of their own
+// raid cleanup, and the broadcaster and bot anchor the channel.
+func protectedFromSweep(h RecentHit, broadcasterID uint64, botID uint64) bool {
+	return h.Role >= module.RoleVIP || h.UserID == broadcasterID || h.UserID == botID
 }
 
 // emitTimeouts translates the capped target list into Helix timeout jobs.

--- a/app/sesame/engine/nuke.go
+++ b/app/sesame/engine/nuke.go
@@ -81,6 +81,8 @@ func (n *Nuke) recordChat(broadcasterID uint64, env *lane.Envelope) {
 	n.Recent.Record(broadcasterID, env, n.now())
 }
 
+const nukeUsage = "usage: !nuke <phrase> [seconds] — sweeps the last 10m of chat for messages containing phrase"
+
 // parseNukeArgs splits "!nuke" arguments into the phrase and the timeout
 // seconds. A trailing token of bare digits (or digits+"s") is the duration;
 // anything else leaves the default. A phrase-less invocation parses but
@@ -121,57 +123,18 @@ func (n *Nuke) Execute(ctx context.Context, c *module.Context, args string, emit
 	defer PutBuf(norm)
 	runes := utf8.RuneCount(norm)
 	if runes < nukeMinPhraseRunes || runes > nukeMaxPhraseRunes {
-		emitChat(emit, c.Env.BroadcasterUserID, "usage: !nuke <phrase> [seconds] — sweeps the last 10m of chat for messages containing phrase")
+		emitChat(emit, c.Env.BroadcasterUserID, nukeUsage)
 		return nil
 	}
 
 	hits := n.Recent.Sweep(ctx, c.BroadcasterID, phrase, n.now())
-	targets := make([]RecentHit, 0, len(hits))
-	for _, h := range hits {
-		if h.Role >= module.RoleVIP || h.UserID == c.BroadcasterID || h.UserID == n.BotID {
-			continue // never sweep staff, the broadcaster, or the bot
-		}
-		targets = append(targets, h)
-	}
+	targets := filterNukeTargets(hits, c.BroadcasterID, n.BotID)
 	overflow := max(len(targets)-nukeMaxTargets, 0)
 	targets = targets[:min(len(targets), nukeMaxTargets)]
 
-	broadcasterID := c.Env.BroadcasterUserID
-	id := GetBuf()
-	defer PutBuf(id)
-	for i := range targets {
-		emit(&module.Output{
-			Type:          outgress.TypeTimeout,
-			BroadcasterID: broadcasterID,
-			TargetUserID:  string(strconv.AppendUint(id[:0], targets[i].UserID, 10)),
-			Duration:      float64(secs),
-			Reason:        "nuke",
-		})
-	}
-
-	shielded := overflow > 0 && n.shield != nil && n.shield(c.BroadcasterID)
-	if shielded {
-		o := GetOutput()
-		o.Type = outgress.TypeShieldMode
-		o.BroadcasterID = broadcasterID
-		o.Reason = "nuke:overflow"
-		emit(o)
-		PutOutput(o)
-	}
-
-	switch {
-	case len(targets) == 0:
-		emitChat(emit, broadcasterID, "no recent messages matched — nothing nuked")
-	case shielded:
-		emitChat(emit, broadcasterID, "🚯 nuked "+strconv.Itoa(len(targets))+
-			" user(s) with "+strconv.FormatInt(secs, 10)+"s timeouts — over budget, Shield Mode activated")
-	case overflow > 0:
-		emitChat(emit, broadcasterID, "🚯 nuked "+strconv.Itoa(len(targets))+
-			" user(s) with "+strconv.FormatInt(secs, 10)+"s timeouts — cap reached, "+strconv.Itoa(overflow)+" more left for Shield Mode")
-	default:
-		emitChat(emit, broadcasterID, "🚯 nuked "+strconv.Itoa(len(targets))+
-			" user(s) with "+strconv.FormatInt(secs, 10)+"s timeouts")
-	}
+	emitTimeouts(c.Env.BroadcasterUserID, targets, secs, emit)
+	shielded := escalateOnOverflow(n.shield, overflow, c.BroadcasterID, emit)
+	emitChat(emit, c.Env.BroadcasterUserID, nukeSummary(len(targets), overflow, shielded, secs))
 
 	n.log.Info("nuke executed",
 		zap.Uint64("broadcaster_id", c.BroadcasterID),
@@ -187,6 +150,71 @@ func (n *Nuke) Execute(ctx context.Context, c *module.Context, args string, emit
 
 func emitChat(emit module.Emit, broadcasterID, text string) {
 	emit(&module.Output{Type: outgress.TypeChat, BroadcasterID: broadcasterID, Text: text})
+}
+
+// filterNukeTargets drops everyone a phrase collision must never punish:
+// VIPs and above (staff in the line of fire of their own raid cleanup),
+// the broadcaster, and the bot.
+func filterNukeTargets(hits []RecentHit, broadcasterID uint64, botID uint64) []RecentHit {
+	targets := make([]RecentHit, 0, len(hits))
+	for _, h := range hits {
+		if h.Role >= module.RoleVIP || h.UserID == broadcasterID || h.UserID == botID {
+			continue
+		}
+		targets = append(targets, h)
+	}
+	return targets
+}
+
+// emitTimeouts translates the capped target list into Helix timeout jobs.
+// The outgress lane buckets pace them within Twitch's action budget; this
+// side only enforces its own per-sweep cap.
+func emitTimeouts(broadcasterID string, targets []RecentHit, secs int64, emit module.Emit) {
+	id := GetBuf()
+	defer PutBuf(id)
+	for i := range targets {
+		emit(&module.Output{
+			Type:          outgress.TypeTimeout,
+			BroadcasterID: broadcasterID,
+			TargetUserID:  string(strconv.AppendUint(id[:0], targets[i].UserID, 10)),
+			Duration:      float64(secs),
+			Reason:        "nuke",
+		})
+	}
+}
+
+// escalateOnOverflow activates Shield Mode when matches overrun the budget,
+// reporting whether it did. Only an armed policy escalates, and the
+// pipeline's raid gate dedups the activation so a raid already escalated by
+// the automod is not double-tripped.
+func escalateOnOverflow(shield func(uint64) bool, overflow int, broadcasterID uint64, emit module.Emit) bool {
+	if overflow == 0 || shield == nil || !shield(broadcasterID) {
+		return false
+	}
+	o := GetOutput()
+	o.Type = outgress.TypeShieldMode
+	o.BroadcasterID = strconv.FormatUint(broadcasterID, 10)
+	o.Reason = "nuke:overflow"
+	emit(o)
+	PutOutput(o)
+	return true
+}
+
+// nukeSummary renders the chat-facing outcome: what happened, and — when the
+// budget capped the sweep — what covered the rest. The matched phrase stays
+// out of the reply so a mod cannot make the bot echo spam back into chat.
+func nukeSummary(actioned, overflow int, shielded bool, secs int64) string {
+	if actioned == 0 {
+		return "no recent messages matched — nothing nuked"
+	}
+	s := "🚯 nuked " + strconv.Itoa(actioned) + " user(s) with " + strconv.FormatInt(secs, 10) + "s timeouts"
+	switch {
+	case shielded:
+		s += " — over budget, Shield Mode activated"
+	case overflow > 0:
+		s += " — cap reached, " + strconv.Itoa(overflow) + " more left for Shield Mode"
+	}
+	return s
 }
 
 // shieldDecision is the pipeline's escalation policy, shared with the cohort

--- a/app/sesame/engine/nuke.go
+++ b/app/sesame/engine/nuke.go
@@ -195,8 +195,14 @@ func emitTimeouts(broadcasterID string, targets []RecentHit, secs int64, emit mo
 // pipeline's raid gate dedups the activation so a raid already escalated by
 // the automod is not double-tripped.
 func escalateOnOverflow(shield func(uint64) bool, overflow int, broadcasterID uint64, emit module.Emit) bool {
-	if overflow == 0 || shield == nil || !shield(broadcasterID) {
-		return false
+	if overflow == 0 {
+		return false // within budget: nothing to cover for
+	}
+	if shield == nil {
+		return false // no armed policy: report the cap instead
+	}
+	if !shield(broadcasterID) {
+		return false // disarmed for this channel or raid-gated by the automod
 	}
 	o := GetOutput()
 	o.Type = outgress.TypeShieldMode

--- a/app/sesame/engine/nuke.go
+++ b/app/sesame/engine/nuke.go
@@ -52,7 +52,7 @@ type Nuke struct {
 	BotID uint64
 
 	log    *zap.Logger
-	shield func(broadcasterID uint64) bool
+	shield func(channelID) bool
 	now    func() time.Time
 }
 
@@ -66,7 +66,9 @@ func NewNuke(recent recentStore, botID uint64, log *zap.Logger) *Nuke {
 
 // setShield wires the pipeline's escalation decision (armed + raid-gate dedup)
 // after construction; modules hold the Nuke before the Pipeline exists.
-func (n *Nuke) setShield(fn func(broadcasterID uint64) bool) { n.shield = fn }
+func (n *Nuke) setShield(fn func(broadcasterID uint64) bool) {
+	n.shield = func(id channelID) bool { return fn(uint64(id)) }
+}
 
 // setClock overrides the time source (tests).
 func (n *Nuke) setClock(fn func() time.Time) { n.now = fn }
@@ -128,17 +130,23 @@ func (n *Nuke) Execute(ctx context.Context, c *module.Context, args string, emit
 	}
 
 	hits := n.Recent.Sweep(ctx, channelID(c.BroadcasterID), phrase, n.now())
-	targets := filterNukeTargets(hits, c.BroadcasterID, n.BotID)
-	overflow := max(len(targets)-nukeMaxTargets, 0)
-	targets = targets[:min(len(targets), nukeMaxTargets)]
+	matched := filterNukeTargets(hits, c.BroadcasterID, n.BotID)
 
-	emitTimeouts(c.Env.BroadcasterUserID, targets, secs, emit)
-	shielded := escalateOnOverflow(n.shield, overflow, c.BroadcasterID, emit)
-	emitChat(emit, c.Env.BroadcasterUserID, nukeSummary(len(targets), overflow, shielded, secs))
+	res := sweepResult{
+		broadcaster: c.Env.BroadcasterUserID,
+		tenant:      channelID(c.BroadcasterID),
+		seconds:     secs,
+		actioned:    min(len(matched), nukeMaxTargets),
+	}
+	res.overflow = max(len(matched)-nukeMaxTargets, 0)
+
+	emitTimeouts(matched[:res.actioned], res, emit)
+	shielded := n.escalateOnOverflow(res, emit)
+	emitChat(emit, res.broadcaster, res.summary(shielded))
 
 	n.log.Info("nuke executed",
 		zap.Uint64("broadcaster_id", c.BroadcasterID),
-		zap.Int("targets", len(targets)),
+		zap.Int("targets", res.actioned),
 		zap.Int("matched", len(hits)),
 		zap.Int("phrase_runes", runes),
 		zap.Int64("seconds", secs),
@@ -186,15 +194,18 @@ func (h RecentHit) sweepable(p protectedIDs) bool {
 // emitTimeouts translates the capped target list into Helix timeout jobs.
 // The outgress lane buckets pace them within Twitch's action budget; this
 // side only enforces its own per-sweep cap.
-func emitTimeouts(broadcasterID string, targets []RecentHit, secs int64, emit module.Emit) {
+// emitTimeouts translates the capped target list into Helix timeout jobs.
+// The outgress lane buckets pace them within Twitch's action budget; this
+// side only enforces its own per-sweep cap.
+func emitTimeouts(targets []RecentHit, res sweepResult, emit module.Emit) {
 	id := GetBuf()
 	defer PutBuf(id)
 	for i := range targets {
 		emit(&module.Output{
 			Type:          outgress.TypeTimeout,
-			BroadcasterID: broadcasterID,
+			BroadcasterID: res.broadcaster,
 			TargetUserID:  string(strconv.AppendUint(id[:0], uint64(targets[i].UserID), 10)),
-			Duration:      float64(secs),
+			Duration:      float64(res.seconds),
 			Reason:        "nuke",
 		})
 	}
@@ -204,38 +215,51 @@ func emitTimeouts(broadcasterID string, targets []RecentHit, secs int64, emit mo
 // reporting whether it did. Only an armed policy escalates, and the
 // pipeline's raid gate dedups the activation so a raid already escalated by
 // the automod is not double-tripped.
-func escalateOnOverflow(shield func(uint64) bool, overflow int, broadcasterID uint64, emit module.Emit) bool {
-	if overflow == 0 {
+func (n *Nuke) escalateOnOverflow(res sweepResult, emit module.Emit) bool {
+	if res.overflow == 0 {
 		return false // within budget: nothing to cover for
 	}
-	if shield == nil {
+	if n.shield == nil {
 		return false // no armed policy: report the cap instead
 	}
-	if !shield(broadcasterID) {
+	if !n.shield(res.tenant) {
 		return false // disarmed for this channel or raid-gated by the automod
 	}
 	o := GetOutput()
 	o.Type = outgress.TypeShieldMode
-	o.BroadcasterID = strconv.FormatUint(broadcasterID, 10)
+	o.BroadcasterID = res.broadcaster
 	o.Reason = "nuke:overflow"
 	emit(o)
 	PutOutput(o)
 	return true
 }
 
-// nukeSummary renders the chat-facing outcome: what happened, and — when the
+// sweepResult is what one !nuke invocation found and did. The reporting,
+// capping and escalation helpers consume this one value instead of parallel
+// primitives that drift apart when a new field joins the story. broadcaster
+// is the raw channel id outgress outputs address; chan is the same tenant in
+// its domain type for policy calls.
+type sweepResult struct {
+	broadcaster string
+	tenant      channelID
+	seconds     int64 // timeout length every target receives
+	actioned    int   // senders actually timed out (within budget)
+	overflow    int   // matched senders left over the budget cap
+}
+
+// summary renders the chat-facing outcome: what happened, and — when the
 // budget capped the sweep — what covered the rest. The matched phrase stays
 // out of the reply so a mod cannot make the bot echo spam back into chat.
-func nukeSummary(actioned, overflow int, shielded bool, secs int64) string {
-	if actioned == 0 {
+func (res sweepResult) summary(shielded bool) string {
+	if res.actioned == 0 {
 		return "no recent messages matched — nothing nuked"
 	}
-	s := "🚯 nuked " + strconv.Itoa(actioned) + " user(s) with " + strconv.FormatInt(secs, 10) + "s timeouts"
+	s := "🚯 nuked " + strconv.Itoa(res.actioned) + " user(s) with " + strconv.FormatInt(res.seconds, 10) + "s timeouts"
 	switch {
 	case shielded:
 		s += " — over budget, Shield Mode activated"
-	case overflow > 0:
-		s += " — cap reached, " + strconv.Itoa(overflow) + " more left for Shield Mode"
+	case res.overflow > 0:
+		s += " — cap reached, " + strconv.Itoa(res.overflow) + " more left for Shield Mode"
 	}
 	return s
 }

--- a/app/sesame/engine/nuke.go
+++ b/app/sesame/engine/nuke.go
@@ -1,0 +1,201 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package engine
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"ItsBagelBot/app/sesame/module"
+	"ItsBagelBot/internal/domain/event/lane"
+	"ItsBagelBot/internal/domain/outgress"
+	"ItsBagelBot/internal/moderation"
+
+	"go.uber.org/zap"
+)
+
+// The nuke budget. massRaidBanCap bounds one folded cohort's bans at 40; a
+// sweep covers minutes of chat, so its budget is wider — but 100 timeout
+// calls still ride inside Twitch's 800-action/min Helix budget alongside
+// whatever else the lane is doing, and outgress's lane buckets pace them.
+const (
+	nukeMaxTargets     = 100
+	nukeDefaultSeconds = 600
+	// nukeMinSeconds floors the duration so a fat-fingered "!nuke spam 1"
+	// cannot become a meaningless 1s ban wave; the ceiling is Twitch's own
+	// maximum timeout (two weeks).
+	nukeMinSeconds = 30
+	nukeMaxSeconds = 14 * 24 * 60 * 60
+	// The phrase floor keeps "!nuke a" from sweeping half the chat; it is
+	// measured on the NORMALIZED phrase so leet ("h8") is judged as what it
+	// says ("hate"), not as what was typed.
+	nukeMinPhraseRunes = 3
+	nukeMaxPhraseRunes = 120
+)
+
+// Nuke is the phrase-targeted mass-moderation service behind !nuke: it reads
+// the sweep memory, times out every matched chatter within budget, and
+// escalates to channel-level Shield Mode when the matches overrun the budget
+// and Shield Mode is armed. nil in Deps leaves the command inert and records
+// nothing.
+type Nuke struct {
+	// Recent is the sweep memory. Production wires ValkeyRecent (centralized:
+	// the replica pool shares one durable consumer, so no pod sees a channel's
+	// whole chat); RecentLog is the single-replica/test double.
+	Recent recentStore
+	// BotID is the bot's own parsed user id; the pipeline never records bot
+	// chat anyway, this only guards against a stale record timing the bot out.
+	BotID uint64
+
+	log    *zap.Logger
+	shield func(broadcasterID uint64) bool
+	now    func() time.Time
+}
+
+// NewNuke builds the service over an empty recent log.
+func NewNuke(recent recentStore, botID uint64, log *zap.Logger) *Nuke {
+	if log == nil {
+		log = zap.NewNop()
+	}
+	return &Nuke{Recent: recent, BotID: botID, log: log, now: time.Now}
+}
+
+// setShield wires the pipeline's escalation decision (armed + raid-gate dedup)
+// after construction; modules hold the Nuke before the Pipeline exists.
+func (n *Nuke) setShield(fn func(broadcasterID uint64) bool) { n.shield = fn }
+
+// setClock overrides the time source (tests).
+func (n *Nuke) setClock(fn func() time.Time) { n.now = fn }
+
+// recordChat retains one chat envelope into the sweep log. Called for every
+// chat line that reaches the pipeline stages; the log itself filters command
+// shapes and empty text.
+func (n *Nuke) recordChat(broadcasterID uint64, env *lane.Envelope) {
+	if n.Recent == nil || env.Type != chatType {
+		return
+	}
+	n.Recent.Record(broadcasterID, env, n.now())
+}
+
+// parseNukeArgs splits "!nuke" arguments into the phrase and the timeout
+// seconds. A trailing token of bare digits (or digits+"s") is the duration;
+// anything else leaves the default. A phrase-less invocation parses but
+// yields the empty phrase, which Execute rejects as usage.
+func parseNukeArgs(args string) (phrase string, seconds int64) {
+	seconds = nukeDefaultSeconds
+	fields := strings.Fields(args)
+	if len(fields) == 0 {
+		return "", seconds
+	}
+	last := fields[len(fields)-1]
+	if secs, ok := parseDurationToken(last); ok {
+		seconds = secs
+		fields = fields[:len(fields)-1]
+	}
+	return strings.Join(fields, " "), seconds
+}
+
+// parseDurationToken accepts "600" or "600s", clamped to [min,max]. Anything
+// else is not a duration token (it stays part of the phrase).
+func parseDurationToken(tok string) (int64, bool) {
+	tok = strings.TrimSuffix(tok, "s")
+	secs, err := strconv.ParseInt(tok, 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return min(max(secs, nukeMinSeconds), nukeMaxSeconds), true
+}
+
+// Execute runs one nuke: sweep the recent log for the phrase, drop trusted
+// roles and protected ids, emit timeouts within budget, escalate to Shield
+// Mode on overflow when armed, and answer with a summary line. It returns
+// nil even on zero hits or bad usage — those are chat replies, not errors,
+// and must never nack the invoking message.
+func (n *Nuke) Execute(ctx context.Context, c *module.Context, args string, emit module.Emit) error {
+	phrase, secs := parseNukeArgs(args)
+	norm := moderation.Normalize(GetBuf(), phrase)
+	defer PutBuf(norm)
+	runes := utf8.RuneCount(norm)
+	if runes < nukeMinPhraseRunes || runes > nukeMaxPhraseRunes {
+		emitChat(emit, c.Env.BroadcasterUserID, "usage: !nuke <phrase> [seconds] — sweeps the last 10m of chat for messages containing phrase")
+		return nil
+	}
+
+	hits := n.Recent.Sweep(ctx, c.BroadcasterID, phrase, n.now())
+	targets := make([]RecentHit, 0, len(hits))
+	for _, h := range hits {
+		if h.Role >= module.RoleVIP || h.UserID == c.BroadcasterID || h.UserID == n.BotID {
+			continue // never sweep staff, the broadcaster, or the bot
+		}
+		targets = append(targets, h)
+	}
+	overflow := max(len(targets)-nukeMaxTargets, 0)
+	targets = targets[:min(len(targets), nukeMaxTargets)]
+
+	broadcasterID := c.Env.BroadcasterUserID
+	id := GetBuf()
+	defer PutBuf(id)
+	for i := range targets {
+		emit(&module.Output{
+			Type:          outgress.TypeTimeout,
+			BroadcasterID: broadcasterID,
+			TargetUserID:  string(strconv.AppendUint(id[:0], targets[i].UserID, 10)),
+			Duration:      float64(secs),
+			Reason:        "nuke",
+		})
+	}
+
+	shielded := overflow > 0 && n.shield != nil && n.shield(c.BroadcasterID)
+	if shielded {
+		o := GetOutput()
+		o.Type = outgress.TypeShieldMode
+		o.BroadcasterID = broadcasterID
+		o.Reason = "nuke:overflow"
+		emit(o)
+		PutOutput(o)
+	}
+
+	switch {
+	case len(targets) == 0:
+		emitChat(emit, broadcasterID, "no recent messages matched — nothing nuked")
+	case shielded:
+		emitChat(emit, broadcasterID, "🚯 nuked "+strconv.Itoa(len(targets))+
+			" user(s) with "+strconv.FormatInt(secs, 10)+"s timeouts — over budget, Shield Mode activated")
+	case overflow > 0:
+		emitChat(emit, broadcasterID, "🚯 nuked "+strconv.Itoa(len(targets))+
+			" user(s) with "+strconv.FormatInt(secs, 10)+"s timeouts — cap reached, "+strconv.Itoa(overflow)+" more left for Shield Mode")
+	default:
+		emitChat(emit, broadcasterID, "🚯 nuked "+strconv.Itoa(len(targets))+
+			" user(s) with "+strconv.FormatInt(secs, 10)+"s timeouts")
+	}
+
+	n.log.Info("nuke executed",
+		zap.Uint64("broadcaster_id", c.BroadcasterID),
+		zap.Int("targets", len(targets)),
+		zap.Int("matched", len(hits)),
+		zap.Int("phrase_runes", runes),
+		zap.Int64("seconds", secs),
+		zap.Bool("shield", shielded),
+		zap.String("by", c.Env.ChatterUserID),
+	)
+	return nil
+}
+
+func emitChat(emit module.Emit, broadcasterID, text string) {
+	emit(&module.Output{Type: outgress.TypeChat, BroadcasterID: broadcasterID, Text: text})
+}
+
+// shieldDecision is the pipeline's escalation policy, shared with the cohort
+// path: only when Shield Mode is armed, and deduped per channel through the
+// same raid gate, so a raid already escalated by the automod within the TTL
+// window does not double-activate on nuke overflow.
+func (p *Pipeline) shieldDecision(broadcasterID uint64) bool {
+	if !p.shieldEnabled {
+		return false
+	}
+	return p.raidGate.trip(broadcasterID, time.Now())
+}

--- a/app/sesame/engine/nuke.go
+++ b/app/sesame/engine/nuke.go
@@ -78,7 +78,7 @@ func (n *Nuke) recordChat(broadcasterID uint64, env *lane.Envelope) {
 	if n.Recent == nil || env.Type != chatType {
 		return
 	}
-	n.Recent.Record(broadcasterID, env, n.now())
+	n.Recent.Record(channelID(broadcasterID), env, n.now())
 }
 
 const nukeUsage = "usage: !nuke <phrase> [seconds] — sweeps the last 10m of chat for messages containing phrase"
@@ -127,7 +127,7 @@ func (n *Nuke) Execute(ctx context.Context, c *module.Context, args string, emit
 		return nil
 	}
 
-	hits := n.Recent.Sweep(ctx, c.BroadcasterID, phrase, n.now())
+	hits := n.Recent.Sweep(ctx, channelID(c.BroadcasterID), phrase, n.now())
 	targets := filterNukeTargets(hits, c.BroadcasterID, n.BotID)
 	overflow := max(len(targets)-nukeMaxTargets, 0)
 	targets = targets[:min(len(targets), nukeMaxTargets)]
@@ -156,9 +156,10 @@ func emitChat(emit module.Emit, broadcasterID, text string) {
 // VIPs and above (staff in the line of fire of their own raid cleanup),
 // the broadcaster, and the bot.
 func filterNukeTargets(hits []RecentHit, broadcasterID uint64, botID uint64) []RecentHit {
+	protected := protectedIDs{broadcaster: channelID(broadcasterID), bot: channelID(botID)}
 	targets := make([]RecentHit, 0, len(hits))
 	for _, h := range hits {
-		if protectedFromSweep(h, broadcasterID, botID) {
+		if !h.sweepable(protected) {
 			continue
 		}
 		targets = append(targets, h)
@@ -166,11 +167,20 @@ func filterNukeTargets(hits []RecentHit, broadcasterID uint64, botID uint64) []R
 	return targets
 }
 
-// protectedFromSweep reports whether a phrase collision must never punish the
-// matched sender: VIP and above are staff in the line of fire of their own
-// raid cleanup, and the broadcaster and bot anchor the channel.
-func protectedFromSweep(h RecentHit, broadcasterID uint64, botID uint64) bool {
-	return h.Role >= module.RoleVIP || h.UserID == broadcasterID || h.UserID == botID
+// protectedIDs names the two identities a sweep must never punish no matter
+// what they typed: the channel's owner and the bot itself.
+type protectedIDs struct {
+	broadcaster channelID
+	bot         channelID
+}
+
+// sweepable reports whether a matched sender may take the punishment: staff
+// (VIP and up), the broadcaster and the bot are never swept on a phrase hit.
+func (h RecentHit) sweepable(p protectedIDs) bool {
+	if h.Role >= module.RoleVIP {
+		return false
+	}
+	return h.UserID != p.broadcaster && h.UserID != p.bot
 }
 
 // emitTimeouts translates the capped target list into Helix timeout jobs.
@@ -183,7 +193,7 @@ func emitTimeouts(broadcasterID string, targets []RecentHit, secs int64, emit mo
 		emit(&module.Output{
 			Type:          outgress.TypeTimeout,
 			BroadcasterID: broadcasterID,
-			TargetUserID:  string(strconv.AppendUint(id[:0], targets[i].UserID, 10)),
+			TargetUserID:  string(strconv.AppendUint(id[:0], uint64(targets[i].UserID), 10)),
 			Duration:      float64(secs),
 			Reason:        "nuke",
 		})

--- a/app/sesame/engine/pipeline.go
+++ b/app/sesame/engine/pipeline.go
@@ -100,6 +100,11 @@ type Pipeline struct {
 	// codes at the door so gate options match the pre-learned call shape.
 	adaptiveEnabled bool
 	raidGate        *raidCooldown
+
+	// nuke, when set, receives every chat line into its recent log (the sweep
+	// memory behind !nuke) and answers its overflow escalations through this
+	// pipeline's Shield Mode policy. nil records nothing.
+	nuke *Nuke
 }
 
 // NewPipeline wires a Pipeline from the shared Deps, a pre-built registry, and
@@ -126,9 +131,16 @@ func NewPipeline(d Deps, registry *Registry, cfg Config) *Pipeline {
 		adaptiveEnabled:  cfg.AdaptiveEnabled,
 		raidGate:         newRaidCooldown(raidCooldownTTL),
 		roster:           newChatterRoster(),
+		nuke:             d.Nuke,
 	}
 	if cfg.CountUses && d.Pub != nil {
 		p.uses = newUseReporter(d.Pub, d.Log)
+	}
+	// The nuke service is built before the pipeline (the modules capture it),
+	// so its Shield Mode policy binds back here once this pipeline's raid gate
+	// exists.
+	if d.Nuke != nil {
+		d.Nuke.setShield(p.shieldDecision)
 	}
 	if d.Stats != nil {
 		// d.Log rides along so the automod detection-flag windows actually
@@ -185,6 +197,13 @@ func (p *Pipeline) Process(msg *bus.Message) error {
 	traceEvent(ctx, env.Type, env.Lane, broadcasterID)
 
 	p.roster.ObserveEnvelope(broadcasterID, env)
+
+	// Feed the nuke sweep memory before any stage can action the line: a
+	// message the automod times out is exactly the one a following !nuke must
+	// still be able to target (its siblings who landed a second earlier).
+	if p.nuke != nil {
+		p.nuke.recordChat(broadcasterID, env)
+	}
 
 	views, err := p.tracedModuleViews(ctx, env.Type, broadcasterID)
 	if err != nil {
@@ -371,6 +390,7 @@ func (p *Pipeline) newEmit(ctx context.Context, partition string, state *emitSta
 		if isEmptyAction(o) {
 			return
 		}
+		capEmitText(o)
 		if p.floorSuppressed(o) {
 			return
 		}

--- a/app/sesame/engine/pipeline_bench_test.go
+++ b/app/sesame/engine/pipeline_bench_test.go
@@ -11,6 +11,8 @@ import (
 	"ItsBagelBot/internal/projection"
 	"ItsBagelBot/pkg/bus"
 	"ItsBagelBot/pkg/codec"
+
+	"go.uber.org/zap"
 )
 
 // benchChatBody builds a representative channel.chat.message envelope once, so the
@@ -136,4 +138,20 @@ func TestProcessWithViewsAllocCeiling(t *testing.T) {
 	if avg > allocViewsCeiling {
 		t.Fatalf("views-path no-output hot path allocates %.1f allocs/op, ceiling %.0f: view-map pooling likely regressed", avg, allocViewsCeiling)
 	}
+}
+
+// BenchmarkProcessNoOutputWithRecording is the hot path with the nuke sweep
+// memory armed (Deps.Nuke set): every plain chat line additionally parses and
+// buffers into the sweep memory. Production's ValkeyRecent flushes that
+// buffer off-path every 50ms; this measures only the on-path stage against
+// the in-memory double. Measured on M1 Pro (2026-08-24): 767 -> 813 ns/op
+// (+6%), 687 -> 703 B/op (+2.3%), allocs 12 -> 12.
+func BenchmarkProcessNoOutputWithRecording(b *testing.B) {
+	n := NewNuke(NewRecentLog(), 0, zap.NewNop())
+	d := Deps{Proj: fakeReader{}, Live: liveAlways{}, Cooldown: NoopCooldown{},
+		Pub: &fakePublisher{}, Log: zap.NewNop(), Nuke: n}
+	p := NewPipeline(d, NewRegistry(zap.NewNop(), silentCore()), Config{
+		OutgressPremium: premiumSubj, OutgressStandard: standardSubj,
+	})
+	benchProcess(b, p, benchMsg())
 }

--- a/app/sesame/engine/recent.go
+++ b/app/sesame/engine/recent.go
@@ -50,6 +50,11 @@ const (
 	recentChanCap = 4096
 )
 
+// channelID is a Twitch broadcaster id: the tenant every piece of sweep
+// state is scoped by. Keys, quorums and windows never fuse across tenants,
+// so the boundary gets a name the compiler enforces.
+type channelID uint64
+
 // stamp is a unix-nano instant in the recent window's clock domain. A named
 // integer keeps the ring's expiry arithmetic (record cutoffs, idle prunes,
 // TTL comparisons) from blending with unrelated int64s — the type system now
@@ -111,8 +116,8 @@ type recentShard struct {
 // centralized store production runs — see recent_valkey.go for why a replica
 // pool cannot share an in-memory window).
 type recentStore interface {
-	Record(chanID uint64, env *lane.Envelope, now time.Time)
-	Sweep(ctx context.Context, chanID uint64, phrase string, now time.Time) []RecentHit
+	Record(chanID channelID, env *lane.Envelope, now time.Time)
+	Sweep(ctx context.Context, chanID channelID, phrase string, now time.Time) []RecentHit
 }
 
 // RecentLog is the IN-MEMORY recentStore: correct only when a single sesame
@@ -169,7 +174,7 @@ func chatEntriesFromEnvelope(env *lane.Envelope, now time.Time) []recentEntry {
 
 // Record retains one chat envelope: the solo sender, or every sender of a
 // folded cohort (which share one text copy).
-func (l *RecentLog) Record(chanID uint64, env *lane.Envelope, now time.Time) {
+func (l *RecentLog) Record(chanID channelID, env *lane.Envelope, now time.Time) {
 	entries := chatEntriesFromEnvelope(env, now)
 	if entries == nil {
 		return
@@ -177,17 +182,17 @@ func (l *RecentLog) Record(chanID uint64, env *lane.Envelope, now time.Time) {
 	at := entries[0].at
 	cutoff := at - stamp(recentTTL)
 
-	sh := &l.shards[chanID%recentShards]
+	sh := &l.shards[uint64(chanID)%recentShards]
 	sh.mu.Lock()
 	defer sh.mu.Unlock()
 
-	c := sh.chans[chanID]
+	c := sh.chans[uint64(chanID)]
 	if c == nil {
 		if len(sh.chans) >= recentChanCap {
 			pruneChannels(sh, cutoff)
 		}
 		c = &chanRecent{}
-		sh.chans[chanID] = c
+		sh.chans[uint64(chanID)] = c
 	}
 	for _, e := range entries {
 		c.push(e, cutoff)
@@ -201,7 +206,7 @@ func (l *RecentLog) Record(chanID uint64, env *lane.Envelope, now time.Time) {
 
 // RecentHit is one distinct sender whose recent line matched a nuke phrase.
 type RecentHit struct {
-	UserID uint64
+	UserID channelID
 	Role   module.Role
 }
 
@@ -212,18 +217,18 @@ type RecentHit struct {
 // The accepted residual mirrors the floor's documented one: fused tokens
 // ("freenitro") miss — splitting fused words needs edit-distance machinery
 // whose false-positive rate no nuke should carry.
-func (l *RecentLog) Sweep(_ context.Context, chanID uint64, phrase string, now time.Time) []RecentHit {
+func (l *RecentLog) Sweep(_ context.Context, chanID channelID, phrase string, now time.Time) []RecentHit {
 	q := moderation.Normalize(GetBuf(), phrase)
 	defer PutBuf(q)
 	if utf8.RuneCount(q) == 0 {
 		return nil
 	}
 
-	sh := &l.shards[chanID%recentShards]
+	sh := &l.shards[uint64(chanID)%recentShards]
 	sh.mu.Lock()
 	defer sh.mu.Unlock()
 
-	c := sh.chans[chanID]
+	c := sh.chans[uint64(chanID)]
 	if c == nil {
 		return nil
 	}
@@ -239,10 +244,10 @@ func (l *RecentLog) Sweep(_ context.Context, chanID uint64, phrase string, now t
 			break // walking newest→oldest: everything further back is expired
 		}
 		t = moderation.Normalize(t, e.text)
-		if !containsPhrase(t, q) || seenUID(hits, e.uid) {
+		if !containsPhrase(t, q) || seenUID(hits, channelID(e.uid)) {
 			continue
 		}
-		hits = append(hits, RecentHit{UserID: e.uid, Role: e.role})
+		hits = append(hits, RecentHit{UserID: channelID(e.uid), Role: e.role})
 	}
 	PutBuf(t)
 	return hits
@@ -290,7 +295,7 @@ func isWordByte(b byte) bool {
 	}
 }
 
-func seenUID(hits []RecentHit, uid uint64) bool {
+func seenUID(hits []RecentHit, uid channelID) bool {
 	for i := range hits {
 		if hits[i].UserID == uid {
 			return true

--- a/app/sesame/engine/recent.go
+++ b/app/sesame/engine/recent.go
@@ -50,13 +50,19 @@ const (
 	recentChanCap = 4096
 )
 
+// stamp is a unix-nano instant in the recent window's clock domain. A named
+// integer keeps the ring's expiry arithmetic (record cutoffs, idle prunes,
+// TTL comparisons) from blending with unrelated int64s — the type system now
+// carries the distinction the comments used to.
+type stamp int64
+
 // recentEntry is one retained chat line: who said it, when, with what trust
 // level, and the truncated text. The user id is stored parsed because Helix
 // takes numeric ids anyway and a uint64 never dangles — envelope strings are
 // zero-copy views into a recycled lane payload, so anything retained past the
 // handler must be copied or parsed.
 type recentEntry struct {
-	at   int64 // unix nanos
+	at   stamp // unix nanos
 	uid  uint64
 	text string
 	role module.Role
@@ -69,10 +75,10 @@ type chanRecent struct {
 	buf  []recentEntry
 	head int
 	len  int
-	last int64 // newest entry's unix nanos; the channel-prune key
+	last stamp // newest entry's timestamp; the channel-prune key
 }
 
-func (c *chanRecent) push(e recentEntry, cutoff int64) {
+func (c *chanRecent) push(e recentEntry, cutoff stamp) {
 	for c.len > 0 && c.buf[c.oldestIdx()].at < cutoff {
 		c.len--
 	}
@@ -143,7 +149,7 @@ func chatEntriesFromEnvelope(env *lane.Envelope, now time.Time) []recentEntry {
 		return nil
 	}
 	text := truncateRunes(env.Text, recentMaxTextRunes)
-	at := now.UnixNano()
+	at := stamp(now.UnixNano())
 	var out []recentEntry
 	add := func(id string, role module.Role) {
 		if uid, ok := parseTwitchID(id); ok {
@@ -169,7 +175,7 @@ func (l *RecentLog) Record(chanID uint64, env *lane.Envelope, now time.Time) {
 		return
 	}
 	at := entries[0].at
-	cutoff := at - int64(recentTTL)
+	cutoff := at - stamp(recentTTL)
 
 	sh := &l.shards[chanID%recentShards]
 	sh.mu.Lock()
@@ -221,7 +227,7 @@ func (l *RecentLog) Sweep(_ context.Context, chanID uint64, phrase string, now t
 	if c == nil {
 		return nil
 	}
-	cutoff := now.Add(-recentTTL).UnixNano()
+	cutoff := stamp(now.Add(-recentTTL).UnixNano())
 	hits := make([]RecentHit, 0, 16)
 	t := GetBuf()
 	// The ring bounds the walk (≤ recentRingCap entries), so no separate
@@ -330,7 +336,7 @@ func parseTwitchID(s string) (uint64, bool) {
 // pruneChannels drops channels idle past the TTL and, if still over the cap,
 // the stalest remainder. Called under the shard lock, amortized once per
 // recentPruneEvery records.
-func pruneChannels(sh *recentShard, cutoff int64) {
+func pruneChannels(sh *recentShard, cutoff stamp) {
 	for id, c := range sh.chans {
 		if c.last < cutoff {
 			delete(sh.chans, id)
@@ -346,7 +352,7 @@ func pruneChannels(sh *recentShard, cutoff int64) {
 // while over the cap).
 func stalestChannel(chans map[uint64]*chanRecent) uint64 {
 	var staleID uint64
-	var staleAt int64
+	var staleAt stamp
 	first := true
 	for id, c := range chans {
 		if first || c.last < staleAt {

--- a/app/sesame/engine/recent.go
+++ b/app/sesame/engine/recent.go
@@ -254,11 +254,20 @@ func containsPhrase(text, phrase []byte) bool {
 		}
 		s := off + i
 		e := s + len(phrase)
-		if (s == 0 || !isWordByte(text[s-1])) && (e >= len(text) || !isWordByte(text[e])) {
+		if atWordBoundary(text, s, e) {
 			return true
 		}
 		off = s + 1
 	}
+}
+
+// atWordBoundary reports whether text[s:e] stands as its own token: neither
+// edge may continue a word character.
+func atWordBoundary(text []byte, s, e int) bool {
+	if s > 0 && isWordByte(text[s-1]) {
+		return false
+	}
+	return e >= len(text) || !isWordByte(text[e])
 }
 
 // isWordByte treats any non-ASCII byte as part of a word (conservative: a
@@ -328,14 +337,21 @@ func pruneChannels(sh *recentShard, cutoff int64) {
 		}
 	}
 	for len(sh.chans) > recentChanCap {
-		var staleID uint64
-		var staleAt int64
-		first := true
-		for id, c := range sh.chans {
-			if first || c.last < staleAt {
-				staleID, staleAt, first = id, c.last, false
-			}
-		}
-		delete(sh.chans, staleID)
+		delete(sh.chans, stalestChannel(sh.chans))
 	}
+}
+
+// stalestChannel finds the channel whose newest line is oldest. Callers hold
+// the shard lock; the map is never empty when this runs (the caller only asks
+// while over the cap).
+func stalestChannel(chans map[uint64]*chanRecent) uint64 {
+	var staleID uint64
+	var staleAt int64
+	first := true
+	for id, c := range chans {
+		if first || c.last < staleAt {
+			staleID, staleAt, first = id, c.last, false
+		}
+	}
+	return staleID
 }

--- a/app/sesame/engine/recent.go
+++ b/app/sesame/engine/recent.go
@@ -1,0 +1,341 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package engine
+
+import (
+	"bytes"
+	"context"
+	"strconv"
+	"sync"
+	"time"
+	"unicode/utf8"
+
+	"ItsBagelBot/app/sesame/module"
+	"ItsBagelBot/internal/domain/event/lane"
+	"ItsBagelBot/internal/moderation"
+)
+
+// The recent-chat log is the memory behind the !nuke sweep: a bounded,
+// in-process per-channel ring of the last few seconds of plain chat, written
+// on the pipeline hot path and read only when a moderator nukes. Everything
+// about its geometry follows the learned layers' memory discipline
+// (vocab.go / baseline.go): shard, cap, TTL, prune lazily, allocate nothing
+// steady-state.
+const (
+	// recentTTL is how long a recorded line stays eligible for a nuke. A raid
+	// wave is acted on within seconds-to-minutes; ten minutes matches the
+	// campaign HLL's sliding TTL so every "recent" window in the automod stack
+	// tells the same story.
+	recentTTL = 10 * time.Minute
+	// recentRingCap caps the lines kept per channel. During a raid a channel
+	// blows through 128 lines in seconds — which is exactly the point: the
+	// ring holds the raid's tail (the last ~seconds before the mod types
+	// !nuke), not the stream's whole history. 128 entries × ≤200 runes keeps
+	// a channel at roughly a dozen KB.
+	recentRingCap = 128
+	// recentShards spreads the per-channel mutexes; chat partitions by
+	// broadcaster across consumer goroutines, so contention per shard is low.
+	recentShards = 16
+	// recentMaxTextRunes truncates stored text. Matching runs on the head of
+	// the message; spam waves repeat their payload early, and capping bounds
+	// both the copy cost per record and the normalize cost per swept line.
+	recentMaxTextRunes = 200
+	// recentPruneEvery records-per-shard between whole-channel prunes. Idle
+	// channels then die within one TTL without any timer goroutine.
+	recentPruneEvery = 1024
+	// recentChanCap bounds channels per shard, same geometry as
+	// vocabChanCap: it only bites if 4096 channels are genuinely chatting
+	// within one TTL window on one replica, and the prune pass sheds them.
+	recentChanCap = 4096
+)
+
+// recentEntry is one retained chat line: who said it, when, with what trust
+// level, and the truncated text. The user id is stored parsed because Helix
+// takes numeric ids anyway and a uint64 never dangles — envelope strings are
+// zero-copy views into a recycled lane payload, so anything retained past the
+// handler must be copied or parsed.
+type recentEntry struct {
+	at   int64 // unix nanos
+	uid  uint64
+	text string
+	role module.Role
+}
+
+// chanRecent is one channel's FIFO ring. buf grows lazily up to
+// recentRingCap and then wraps: head always marks the next write slot, so
+// during growth head == len and after full the write overwrites the oldest.
+type chanRecent struct {
+	buf  []recentEntry
+	head int
+	len  int
+	last int64 // newest entry's unix nanos; the channel-prune key
+}
+
+func (c *chanRecent) push(e recentEntry, cutoff int64) {
+	for c.len > 0 && c.buf[c.oldestIdx()].at < cutoff {
+		c.len--
+	}
+	if c.buf == nil {
+		c.buf = make([]recentEntry, 0, recentRingCap)
+	}
+	if c.len < recentRingCap {
+		c.buf = append(c.buf, e)
+		c.len++
+	} else {
+		c.buf[c.head] = e
+	}
+	c.head = (c.head + 1) % recentRingCap
+	if e.at > c.last {
+		c.last = e.at
+	}
+}
+
+func (c *chanRecent) oldestIdx() int { return (c.head - c.len + recentRingCap) % recentRingCap }
+
+// recentShard owns one slice of the channel keyspace.
+type recentShard struct {
+	mu      sync.Mutex
+	chans   map[uint64]*chanRecent
+	records int
+}
+
+// recentStore is the sweep memory behind the Nuke service. Implementations:
+// RecentLog (in-process, single-replica / tests) and ValkeyRecent (the
+// centralized store production runs — see recent_valkey.go for why a replica
+// pool cannot share an in-memory window).
+type recentStore interface {
+	Record(chanID uint64, env *lane.Envelope, now time.Time)
+	Sweep(ctx context.Context, chanID uint64, phrase string, now time.Time) []RecentHit
+}
+
+// RecentLog is the IN-MEMORY recentStore: correct only when a single sesame
+// replica consumes a channel's chat, which makes it the test double. Production
+// runs a replica pool sharing one durable JetStream consumer (pkg/bus), so any
+// pod sees an arbitrary fraction of a channel's lines — the centralized
+// ValkeyRecent is what ships (recent_valkey.go).
+type RecentLog struct {
+	shards [recentShards]recentShard
+}
+
+// NewRecentLog builds an empty log.
+func NewRecentLog() *RecentLog {
+	l := &RecentLog{}
+	for i := range l.shards {
+		l.shards[i].chans = make(map[uint64]*chanRecent)
+	}
+	return l
+}
+
+// chatEntriesFromEnvelope parses one chat envelope into retainable entries —
+// the solo sender, or every sender of a folded cohort (sharing one text view).
+// Command-shaped lines are skipped: a mod must never be nuked by the very
+// command line they typed to invoke it, and squashed cohorts are plain chat
+// anyway. nil when nothing is retainable.
+//
+// The retained text aliases the lane payload's bytes, which is deliberate: the
+// transport never reuses a delivered payload buffer (pkg/bus pullEnvelopePool
+// recycles only the nats.Msg struct and leaves Data uncleared precisely so
+// delivered Messages may keep aliasing it), so Go's collector owns the
+// lifetime and no copy is needed on the hot path.
+func chatEntriesFromEnvelope(env *lane.Envelope, now time.Time) []recentEntry {
+	if env.Text == "" || isCommandShape(env.Text) {
+		return nil
+	}
+	text := truncateRunes(env.Text, recentMaxTextRunes)
+	at := now.UnixNano()
+	var out []recentEntry
+	add := func(id string, role module.Role) {
+		if uid, ok := parseTwitchID(id); ok {
+			out = append(out, recentEntry{at: at, uid: uid, text: text, role: role})
+		}
+	}
+	if len(env.Senders) == 0 {
+		add(env.ChatterUserID, module.ParseRole(*env))
+	} else {
+		for i := range env.Senders {
+			s := &env.Senders[i]
+			add(s.ChatterUserID, senderRole(env, s))
+		}
+	}
+	return out
+}
+
+// Record retains one chat envelope: the solo sender, or every sender of a
+// folded cohort (which share one text copy).
+func (l *RecentLog) Record(chanID uint64, env *lane.Envelope, now time.Time) {
+	entries := chatEntriesFromEnvelope(env, now)
+	if entries == nil {
+		return
+	}
+	at := entries[0].at
+	cutoff := at - int64(recentTTL)
+
+	sh := &l.shards[chanID%recentShards]
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+
+	c := sh.chans[chanID]
+	if c == nil {
+		if len(sh.chans) >= recentChanCap {
+			pruneChannels(sh, cutoff)
+		}
+		c = &chanRecent{}
+		sh.chans[chanID] = c
+	}
+	for _, e := range entries {
+		c.push(e, cutoff)
+	}
+
+	sh.records++
+	if sh.records%recentPruneEvery == 0 {
+		pruneChannels(sh, cutoff)
+	}
+}
+
+// RecentHit is one distinct sender whose recent line matched a nuke phrase.
+type RecentHit struct {
+	UserID uint64
+	Role   module.Role
+}
+
+// Sweep returns the distinct senders within the TTL whose retained line
+// contains phrase, newest first. Matching is normalized on both sides
+// (moderation.Normalize: case, leet, confusables, zero-width) at token
+// boundaries, so "FR33 N1TRO" matches "free nitro" while "ass" misses "bass".
+// The accepted residual mirrors the floor's documented one: fused tokens
+// ("freenitro") miss — splitting fused words needs edit-distance machinery
+// whose false-positive rate no nuke should carry.
+func (l *RecentLog) Sweep(_ context.Context, chanID uint64, phrase string, now time.Time) []RecentHit {
+	q := moderation.Normalize(GetBuf(), phrase)
+	defer PutBuf(q)
+	if utf8.RuneCount(q) == 0 {
+		return nil
+	}
+
+	sh := &l.shards[chanID%recentShards]
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+
+	c := sh.chans[chanID]
+	if c == nil {
+		return nil
+	}
+	cutoff := now.Add(-recentTTL).UnixNano()
+	hits := make([]RecentHit, 0, 16)
+	t := GetBuf()
+	// The ring bounds the walk (≤ recentRingCap entries), so no separate
+	// result cap exists: a channel can never surface more senders than it
+	// retained lines.
+	for i := 0; i < c.len; i++ {
+		e := &c.buf[(c.head-1-i+recentRingCap)%recentRingCap]
+		if e.at < cutoff {
+			break // walking newest→oldest: everything further back is expired
+		}
+		t = moderation.Normalize(t, e.text)
+		if !containsPhrase(t, q) || seenUID(hits, e.uid) {
+			continue
+		}
+		hits = append(hits, RecentHit{UserID: e.uid, Role: e.role})
+	}
+	PutBuf(t)
+	return hits
+}
+
+// containsPhrase reports whether phrase occurs in text at word boundaries.
+func containsPhrase(text, phrase []byte) bool {
+	if len(phrase) == 0 {
+		return false
+	}
+	for off := 0; ; {
+		i := bytes.Index(text[off:], phrase)
+		if i < 0 {
+			return false
+		}
+		s := off + i
+		e := s + len(phrase)
+		if (s == 0 || !isWordByte(text[s-1])) && (e >= len(text) || !isWordByte(text[e])) {
+			return true
+		}
+		off = s + 1
+	}
+}
+
+// isWordByte treats any non-ASCII byte as part of a word (conservative: a
+// CJK/Arabic neighbor must not mint a boundary) alongside ASCII letters,
+// digits and underscore — the alphabet normalization leaves behind.
+func isWordByte(b byte) bool {
+	switch {
+	case b >= utf8.RuneSelf:
+		return true
+	case b >= 'a' && b <= 'z', b >= '0' && b <= '9', b == '_':
+		return true
+	default:
+		return false
+	}
+}
+
+func seenUID(hits []RecentHit, uid uint64) bool {
+	for i := range hits {
+		if hits[i].UserID == uid {
+			return true
+		}
+	}
+	return false
+}
+
+// isCommandShape mirrors parseCommand's trigger rule without parsing: any
+// '!'-leading line is a command candidate and stays out of the buffer.
+func isCommandShape(text string) bool {
+	i := 0
+	for i < len(text) && text[i] == ' ' {
+		i++
+	}
+	return i < len(text) && text[i] == '!'
+}
+
+// senderRole resolves a folded cohort sender's trust tier. ParseRole reads an
+// Envelope, so the sender's fields ride a value-shaped probe — no heap.
+func senderRole(env *lane.Envelope, s *lane.Sender) module.Role {
+	probe := lane.Envelope{ChatterUserID: s.ChatterUserID, BroadcasterUserID: env.BroadcasterUserID, Badges: s.Badges}
+	return module.ParseRole(probe)
+}
+
+// truncateRunes returns the first max runes of s (zero-copy; the caller copies).
+func truncateRunes(s string, max int) string {
+	n := 0
+	for i := range s {
+		if n == max {
+			return s[:i]
+		}
+		n++
+	}
+	return s
+}
+
+func parseTwitchID(s string) (uint64, bool) {
+	uid, err := strconv.ParseUint(s, 10, 64)
+	return uid, err == nil && uid != 0
+}
+
+// pruneChannels drops channels idle past the TTL and, if still over the cap,
+// the stalest remainder. Called under the shard lock, amortized once per
+// recentPruneEvery records.
+func pruneChannels(sh *recentShard, cutoff int64) {
+	for id, c := range sh.chans {
+		if c.last < cutoff {
+			delete(sh.chans, id)
+		}
+	}
+	for len(sh.chans) > recentChanCap {
+		var staleID uint64
+		var staleAt int64
+		first := true
+		for id, c := range sh.chans {
+			if first || c.last < staleAt {
+				staleID, staleAt, first = id, c.last, false
+			}
+		}
+		delete(sh.chans, staleID)
+	}
+}

--- a/app/sesame/engine/recent_test.go
+++ b/app/sesame/engine/recent_test.go
@@ -136,7 +136,7 @@ func TestRecentSweepMatchesNormalizedPhrase(t *testing.T) {
 
 	hits := l.Sweep(context.Background(), 123, "free nitro", nukeClockBase)
 	require.Len(t, hits, 1)
-	assert.Equal(t, uint64(999), hits[0].UserID)
+	assert.Equal(t, channelID(999), hits[0].UserID)
 	assert.Equal(t, module.RoleEveryone, hits[0].Role)
 }
 

--- a/app/sesame/engine/recent_test.go
+++ b/app/sesame/engine/recent_test.go
@@ -1,0 +1,325 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package engine
+
+import (
+	"context"
+	"strconv"
+	"testing"
+	"time"
+
+	"ItsBagelBot/app/sesame/module"
+	"ItsBagelBot/internal/domain/event/lane"
+	"ItsBagelBot/internal/domain/outgress"
+	"ItsBagelBot/pkg/bus"
+	"ItsBagelBot/pkg/codec"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+var nukeClockBase = time.Unix(1_800_000_000, 0)
+
+func nukeTestPipeline(pub *fakePublisher, n *Nuke, mods ...module.Module) *Pipeline {
+	reg := NewRegistry(zap.NewNop(), mods...)
+	d := Deps{Proj: fakeReader{}, Live: liveAlways{}, Cooldown: NoopCooldown{},
+		Pub: pub, Log: zap.NewNop(), Nuke: n}
+	return NewPipeline(d, reg, Config{OutgressPremium: premiumSubj, OutgressStandard: standardSubj})
+}
+
+func newNukeUnderTest() *Nuke {
+	n := NewNuke(NewRecentLog(), 42, zap.NewNop())
+	n.setClock(func() time.Time { return nukeClockBase })
+	return n
+}
+
+// chatFrom processes one plain chat line through a recording pipeline.
+func chatFrom(t *testing.T, p *Pipeline, uuid, chatter, text string) {
+	t.Helper()
+	body, err := codec.Marshal(map[string]any{
+		"type":                chatType,
+		"lane":                "standard",
+		"broadcaster_user_id": "123",
+		"chatter_user_id":     chatter,
+		"text":                text,
+	})
+	require.NoError(t, err)
+	require.NoError(t, p.Process(bus.NewMessage(uuid, body)))
+}
+
+func chatWithBadges(t *testing.T, p *Pipeline, uuid, chatter, text string, badges []map[string]string) {
+	t.Helper()
+	body, err := codec.Marshal(map[string]any{
+		"type":                chatType,
+		"lane":                "standard",
+		"broadcaster_user_id": "123",
+		"chatter_user_id":     chatter,
+		"text":                text,
+		"badges":              badges,
+	})
+	require.NoError(t, err)
+	require.NoError(t, p.Process(bus.NewMessage(uuid, body)))
+}
+
+// nukeModule mirrors the production moderation module's registration so the
+// dispatch path (gate, cooldown, emit middleware) is exercised for real; the
+// engine test package cannot import app/sesame/modules without a cycle.
+func nukeModule(n *Nuke) module.Module {
+	b := module.NewModule("moderation", module.KindDefault)
+	b.Command("nuke").Mod().Cooldown(5 * time.Second).Run(func(ctx context.Context, c *module.Context, args string, emit module.Emit) error {
+		if n == nil {
+			return nil
+		}
+		return n.Execute(ctx, c, args, emit)
+	})
+	return b.Build()
+}
+
+// moderatorNuke processes "!nuke <args>" from a moderator in channel 123.
+func moderatorNuke(t *testing.T, p *Pipeline, args string) {
+	t.Helper()
+	chatWithBadges(t, p, "uuid-nuke:"+args, "777", "!nuke "+args,
+		[]map[string]string{{"set_id": "moderator"}})
+}
+
+func soloChatEnv(chatter, text string) *lane.Envelope {
+	return &lane.Envelope{Type: chatType, BroadcasterUserID: "123", ChatterUserID: chatter, Text: text}
+}
+
+func cohortChatEnv(chatters []string, text string) *lane.Envelope {
+	env := &lane.Envelope{Type: chatType, BroadcasterUserID: "123", Text: text}
+	for _, c := range chatters {
+		env.Senders = append(env.Senders, lane.Sender{ChatterUserID: c})
+	}
+	return env
+}
+
+func timeoutTargets(t *testing.T, pub *fakePublisher) []string {
+	t.Helper()
+	var ids []string
+	for _, c := range pub.got {
+		if c.msg.Type != outgress.TypeTimeout {
+			continue
+		}
+		var body struct {
+			Data struct {
+				UserID   string `json:"user_id"`
+				Duration int    `json:"duration"`
+				Reason   string `json:"reason"`
+			} `json:"data"`
+		}
+		require.NoError(t, codec.Unmarshal(c.msg.Payload, &body))
+		assert.Equal(t, 600, body.Data.Duration)
+		assert.Equal(t, "nuke", body.Data.Reason)
+		ids = append(ids, body.Data.UserID)
+	}
+	return ids
+}
+
+// --- RecentLog ---
+
+func TestRecentSweepMatchesNormalizedPhrase(t *testing.T) {
+	l := NewRecentLog()
+	l.Record(123, soloChatEnv("999", "FREE N1TRO!!! claim it"), nukeClockBase)
+	l.Record(123, soloChatEnv("998", "totally clean chat"), nukeClockBase)
+
+	hits := l.Sweep(context.Background(), 123, "free nitro", nukeClockBase)
+	require.Len(t, hits, 1)
+	assert.Equal(t, uint64(999), hits[0].UserID)
+	assert.Equal(t, module.RoleEveryone, hits[0].Role)
+}
+
+func TestRecentSweepBoundaryMissesPartialToken(t *testing.T) {
+	l := NewRecentLog()
+	l.Record(123, soloChatEnv("999", "grabbing bass vibes"), nukeClockBase)
+	assert.Empty(t, l.Sweep(context.Background(), 123, "ass", nukeClockBase))
+	assert.Len(t, l.Sweep(context.Background(), 123, "bass", nukeClockBase), 1)
+}
+
+func TestRecentSweepDedupesAndExpires(t *testing.T) {
+	l := NewRecentLog()
+	env := soloChatEnv("999", "raid plan meet here")
+	l.Record(123, env, nukeClockBase)
+	l.Record(123, env, nukeClockBase.Add(time.Second))
+	assert.Len(t, l.Sweep(context.Background(), 123, "raid plan", nukeClockBase.Add(time.Second)), 1, "one user, two lines")
+
+	assert.Empty(t, l.Sweep(context.Background(), 123, "raid plan", nukeClockBase.Add(recentTTL+time.Minute)), "past the TTL nothing sweeps")
+}
+
+func TestRecentRecordsCohortSendersIndividually(t *testing.T) {
+	l := NewRecentLog()
+	l.Record(123, cohortChatEnv([]string{"1", "2", "3"}, "same copypasta everywhere"), nukeClockBase)
+	assert.Len(t, l.Sweep(context.Background(), 123, "copypasta", nukeClockBase), 3)
+}
+
+func TestRecentSkipsCommandShapes(t *testing.T) {
+	l := NewRecentLog()
+	l.Record(123, soloChatEnv("999", "!nuke spam"), nukeClockBase)
+	l.Record(123, soloChatEnv("998", "  !ping"), nukeClockBase)
+	assert.Empty(t, l.Sweep(context.Background(), 123, "spam", nukeClockBase), "a command line must never be sweepable")
+	assert.Empty(t, l.Sweep(context.Background(), 123, "!ping", nukeClockBase))
+}
+
+func TestRecentChannelsAreIsolated(t *testing.T) {
+	l := NewRecentLog()
+	l.Record(123, soloChatEnv("999", "secret phrase x"), nukeClockBase)
+	assert.Empty(t, l.Sweep(context.Background(), 456, "secret phrase", nukeClockBase))
+}
+
+func TestRecentRingEvictsOldestBeyondCap(t *testing.T) {
+	l := NewRecentLog()
+	for i := 0; i < recentRingCap+10; i++ {
+		l.Record(123, soloChatEnv(strconv.Itoa(i), "filler "+strconv.Itoa(i)),
+			nukeClockBase.Add(time.Duration(i)*time.Millisecond))
+	}
+	sweepAt := nukeClockBase.Add(time.Duration(recentRingCap+20) * time.Millisecond)
+	assert.Empty(t, l.Sweep(context.Background(), 123, "filler 3", sweepAt), "the oldest lines fell off the ring")
+	assert.NotEmpty(t, l.Sweep(context.Background(), 123, "filler 130", sweepAt), "the newest survived")
+}
+
+func TestRecentSweepCapsResults(t *testing.T) {
+	l := NewRecentLog()
+	for i := 0; i < recentRingCap+50; i++ {
+		l.Record(123, soloChatEnv(strconv.Itoa(i), "nuke bait"), nukeClockBase)
+	}
+	assert.Len(t, l.Sweep(context.Background(), 123, "nuke bait", nukeClockBase), recentRingCap,
+		"the ring, not the match count, bounds a sweep")
+}
+
+// --- !nuke end to end ---
+
+func TestNukeTimesOutMatchedChattersAndReports(t *testing.T) {
+	n := newNukeUnderTest()
+	pub := &fakePublisher{}
+	p := nukeTestPipeline(pub, n, nukeModule(n))
+
+	chatFrom(t, p, "u1", "111", "join my free nitro giveaway now")
+	chatFrom(t, p, "u2", "222", "totally innocent message")
+	chatFrom(t, p, "u3", "333", "FREE NITRO over here!!")
+	moderatorNuke(t, p, "free nitro")
+
+	ids := timeoutTargets(t, pub)
+	assert.ElementsMatch(t, []string{"111", "333"}, ids)
+
+	reports := 0
+	for _, c := range pub.got {
+		if c.msg.Type != outgress.TypeChat {
+			continue
+		}
+		reports++
+		var body struct {
+			Message string `json:"message"`
+		}
+		require.NoError(t, codec.Unmarshal(c.msg.Payload, &body))
+		assert.Contains(t, body.Message, "2 user(s)")
+	}
+	assert.Equal(t, 1, reports, "exactly one summary line")
+}
+
+func TestNukeNeverTouchesStaffBroadcasterOrBot(t *testing.T) {
+	n := newNukeUnderTest()
+	pub := &fakePublisher{}
+	p := nukeTestPipeline(pub, n, nukeModule(n))
+
+	chatWithBadges(t, p, "u1", "555", "free nitro friends", []map[string]string{{"set_id": "vip"}})
+	chatWithBadges(t, p, "u2", "666", "free nitro friends", []map[string]string{{"set_id": "moderator"}})
+	chatFrom(t, p, "u3", "123", "free nitro friends") // the broadcaster themself
+	chatFrom(t, p, "u4", "888", "free nitro friends")
+	moderatorNuke(t, p, "free nitro")
+
+	assert.Equal(t, []string{"888"}, timeoutTargets(t, pub))
+}
+
+func TestNukeOverflowEscalatesShieldOncePerWindow(t *testing.T) {
+	n := newNukeUnderTest()
+	pub := &fakePublisher{}
+	p := nukeTestPipeline(pub, n, nukeModule(n))
+
+	shieldCalls := 0
+	n.setShield(func(uint64) bool { shieldCalls++; return true })
+
+	for i := 0; i < nukeMaxTargets+5; i++ {
+		chatFrom(t, p, "u"+strconv.Itoa(i), strconv.Itoa(1000+i), "the raid has arrived brothers")
+	}
+	moderatorNuke(t, p, "raid has arrived")
+
+	assert.Len(t, timeoutTargets(t, pub), nukeMaxTargets, "the budget cap holds")
+
+	shields := 0
+	for _, c := range pub.got {
+		if c.msg.Type == outgress.TypeShieldMode {
+			shields++
+		}
+	}
+	assert.Equal(t, 1, shields, "overflow activates Shield Mode once")
+	assert.Equal(t, 1, shieldCalls)
+}
+
+func TestNukeWithoutShieldArmedStillReportsTheCap(t *testing.T) {
+	n := newNukeUnderTest()
+	n.shield = nil
+	pub := &fakePublisher{}
+	p := nukeTestPipeline(pub, n, nukeModule(n))
+
+	for i := 0; i < nukeMaxTargets+1; i++ {
+		chatFrom(t, p, "u"+strconv.Itoa(i), strconv.Itoa(1000+i), "spam wave incoming now")
+	}
+	moderatorNuke(t, p, "spam wave incoming")
+
+	for _, c := range pub.got {
+		assert.NotEqual(t, outgress.TypeShieldMode, c.msg.Type, "no armed policy, no activation")
+	}
+	assert.Len(t, timeoutTargets(t, pub), nukeMaxTargets)
+}
+
+func TestNukeZeroHitsAndUsageReplies(t *testing.T) {
+	n := newNukeUnderTest()
+	pub := &fakePublisher{}
+	p := nukeTestPipeline(pub, n, nukeModule(n))
+
+	moderatorNuke(t, p, "nothing matches this")
+	moderatorNuke(t, p, "ab")
+
+	timeouts := timeoutTargets(t, pub)
+	assert.Empty(t, timeouts)
+	chats := 0
+	for _, c := range pub.got {
+		if c.msg.Type == outgress.TypeChat {
+			chats++
+		}
+	}
+	assert.Equal(t, 2, chats, "a reply per invocation, no actions")
+}
+
+func TestNukeDurationParsing(t *testing.T) {
+	tests := []struct {
+		args string
+		want int64
+	}{
+		{"spam wave", nukeDefaultSeconds},
+		{"spam wave 300", 300},
+		{"spam wave 300s", 300},
+		{"spam wave 1", nukeMinSeconds},
+		{"spam wave 99999999", nukeMaxSeconds},
+	}
+	for _, tt := range tests {
+		phrase, secs := parseNukeArgs(tt.args)
+		assert.Equal(t, tt.want, secs, tt.args)
+		assert.Equal(t, "spam wave", phrase, tt.args)
+	}
+}
+
+func TestNukeInertWithoutService(t *testing.T) {
+	pub := &fakePublisher{}
+	p := nukeTestPipeline(pub, nil, nukeModule(nil))
+
+	chatFrom(t, p, "u1", "111", "free nitro everyone come")
+	moderatorNuke(t, p, "free nitro")
+
+	assert.Empty(t, timeoutTargets(t, pub), "no service wired, no actions")
+	for _, c := range pub.got {
+		assert.NotEqual(t, outgress.TypeChat, c.msg.Type, "inert means silent, not chatty")
+	}
+}

--- a/app/sesame/engine/recent_test.go
+++ b/app/sesame/engine/recent_test.go
@@ -35,32 +35,38 @@ func newNukeUnderTest() *Nuke {
 	return n
 }
 
-// chatFrom processes one plain chat line through a recording pipeline.
-func chatFrom(t *testing.T, p *Pipeline, uuid, chatter, text string) {
-	t.Helper()
-	body, err := codec.Marshal(map[string]any{
-		"type":                chatType,
-		"lane":                "standard",
-		"broadcaster_user_id": "123",
-		"chatter_user_id":     chatter,
-		"text":                text,
-	})
-	require.NoError(t, err)
-	require.NoError(t, p.Process(bus.NewMessage(uuid, body)))
+// chatLineInput is one synthetic chat line: who said what (and wearing what).
+// The bus uuid derives from the pair, so callers stay two-argument simple and
+// distinct lines still get distinct identities for free.
+type chatLineInput struct {
+	chatter string
+	text    string
+	badges  []map[string]string
 }
 
-func chatWithBadges(t *testing.T, p *Pipeline, uuid, chatter, text string, badges []map[string]string) {
+// processChat marshals one input into a channel-123 chat envelope and runs it
+// through the pipeline.
+func processChat(t *testing.T, p *Pipeline, in chatLineInput) {
 	t.Helper()
-	body, err := codec.Marshal(map[string]any{
+	body := map[string]any{
 		"type":                chatType,
 		"lane":                "standard",
 		"broadcaster_user_id": "123",
-		"chatter_user_id":     chatter,
-		"text":                text,
-		"badges":              badges,
-	})
+		"chatter_user_id":     in.chatter,
+		"text":                in.text,
+	}
+	if in.badges != nil {
+		body["badges"] = in.badges
+	}
+	payload, err := codec.Marshal(body)
 	require.NoError(t, err)
-	require.NoError(t, p.Process(bus.NewMessage(uuid, body)))
+	require.NoError(t, p.Process(bus.NewMessage("u-"+in.chatter+":"+in.text, payload)))
+}
+
+// chatFrom processes one plain chat line through a recording pipeline.
+func chatFrom(t *testing.T, p *Pipeline, chatter, text string) {
+	t.Helper()
+	processChat(t, p, chatLineInput{chatter: chatter, text: text})
 }
 
 // nukeModule mirrors the production moderation module's registration so the
@@ -80,8 +86,11 @@ func nukeModule(n *Nuke) module.Module {
 // moderatorNuke processes "!nuke <args>" from a moderator in channel 123.
 func moderatorNuke(t *testing.T, p *Pipeline, args string) {
 	t.Helper()
-	chatWithBadges(t, p, "uuid-nuke:"+args, "777", "!nuke "+args,
-		[]map[string]string{{"set_id": "moderator"}})
+	processChat(t, p, chatLineInput{
+		chatter: "777",
+		text:    "!nuke " + args,
+		badges:  []map[string]string{{"set_id": "moderator"}},
+	})
 }
 
 func soloChatEnv(chatter, text string) *lane.Envelope {
@@ -195,9 +204,9 @@ func TestNukeTimesOutMatchedChattersAndReports(t *testing.T) {
 	pub := &fakePublisher{}
 	p := nukeTestPipeline(pub, n, nukeModule(n))
 
-	chatFrom(t, p, "u1", "111", "join my free nitro giveaway now")
-	chatFrom(t, p, "u2", "222", "totally innocent message")
-	chatFrom(t, p, "u3", "333", "FREE NITRO over here!!")
+	chatFrom(t, p, "111", "join my free nitro giveaway now")
+	chatFrom(t, p, "222", "totally innocent message")
+	chatFrom(t, p, "333", "FREE NITRO over here!!")
 	moderatorNuke(t, p, "free nitro")
 
 	ids := timeoutTargets(t, pub)
@@ -223,10 +232,10 @@ func TestNukeNeverTouchesStaffBroadcasterOrBot(t *testing.T) {
 	pub := &fakePublisher{}
 	p := nukeTestPipeline(pub, n, nukeModule(n))
 
-	chatWithBadges(t, p, "u1", "555", "free nitro friends", []map[string]string{{"set_id": "vip"}})
-	chatWithBadges(t, p, "u2", "666", "free nitro friends", []map[string]string{{"set_id": "moderator"}})
-	chatFrom(t, p, "u3", "123", "free nitro friends") // the broadcaster themself
-	chatFrom(t, p, "u4", "888", "free nitro friends")
+	processChat(t, p, chatLineInput{chatter: "555", text: "free nitro friends", badges: []map[string]string{{"set_id": "vip"}}})
+	processChat(t, p, chatLineInput{chatter: "666", text: "free nitro friends", badges: []map[string]string{{"set_id": "moderator"}}})
+	chatFrom(t, p, "123", "free nitro friends") // the broadcaster themself
+	chatFrom(t, p, "888", "free nitro friends")
 	moderatorNuke(t, p, "free nitro")
 
 	assert.Equal(t, []string{"888"}, timeoutTargets(t, pub))
@@ -241,7 +250,7 @@ func TestNukeOverflowEscalatesShieldOncePerWindow(t *testing.T) {
 	n.setShield(func(uint64) bool { shieldCalls++; return true })
 
 	for i := 0; i < nukeMaxTargets+5; i++ {
-		chatFrom(t, p, "u"+strconv.Itoa(i), strconv.Itoa(1000+i), "the raid has arrived brothers")
+		chatFrom(t, p, strconv.Itoa(1000+i), "the raid has arrived brothers")
 	}
 	moderatorNuke(t, p, "raid has arrived")
 
@@ -264,7 +273,7 @@ func TestNukeWithoutShieldArmedStillReportsTheCap(t *testing.T) {
 	p := nukeTestPipeline(pub, n, nukeModule(n))
 
 	for i := 0; i < nukeMaxTargets+1; i++ {
-		chatFrom(t, p, "u"+strconv.Itoa(i), strconv.Itoa(1000+i), "spam wave incoming now")
+		chatFrom(t, p, strconv.Itoa(1000+i), "spam wave incoming now")
 	}
 	moderatorNuke(t, p, "spam wave incoming")
 
@@ -315,7 +324,7 @@ func TestNukeInertWithoutService(t *testing.T) {
 	pub := &fakePublisher{}
 	p := nukeTestPipeline(pub, nil, nukeModule(nil))
 
-	chatFrom(t, p, "u1", "111", "free nitro everyone come")
+	chatFrom(t, p, "111", "free nitro everyone come")
 	moderatorNuke(t, p, "free nitro")
 
 	assert.Empty(t, timeoutTargets(t, pub), "no service wired, no actions")

--- a/app/sesame/engine/recent_valkey.go
+++ b/app/sesame/engine/recent_valkey.go
@@ -138,11 +138,10 @@ func (v *ValkeyRecent) flush(ctx context.Context) {
 	v.mu.Unlock()
 
 	flushAt := newestBufferedAt(batch)
-	cutoff := strconv.FormatInt((flushAt-int64(recentTTL))/int64(time.Millisecond), 10)
-	ttlSec := int64(recentTTL / time.Second)
+	cutoff := strconv.FormatInt(int64((flushAt-stamp(recentTTL))/stamp(time.Millisecond)), 10)
 
 	for chanID, entries := range batch {
-		v.flushChannel(ctx, chanID, entries, cutoff, ttlSec)
+		v.flushChannel(ctx, chanID, entries, cutoff)
 	}
 }
 
@@ -150,8 +149,8 @@ func (v *ValkeyRecent) flush(ctx context.Context) {
 // derives from it rather than wall-clock time, so tests stay deterministic and
 // a quiet channel's stale members still die on its next activity (the sliding
 // EXPIRE covers the idle case).
-func newestBufferedAt(batch map[uint64][]recentEntry) int64 {
-	newest := int64(0)
+func newestBufferedAt(batch map[uint64][]recentEntry) stamp {
+	newest := stamp(0)
 	for _, entries := range batch {
 		for i := range entries {
 			if entries[i].at > newest {
@@ -165,17 +164,17 @@ func newestBufferedAt(batch map[uint64][]recentEntry) int64 {
 // flushChannel writes one channel's buffered lines as a single pipelined
 // DoMulti: add the new members, evict expired ones, enforce the cardinality
 // cap, and slide the key's TTL.
-func (v *ValkeyRecent) flushChannel(ctx context.Context, chanID uint64, entries []recentEntry, cutoff string, ttlSec int64) {
+func (v *ValkeyRecent) flushChannel(ctx context.Context, chanID uint64, entries []recentEntry, cutoff string) {
 	key := recentChannelKey(chanID)
 	zadd := v.client.B().Zadd().Key(key).ScoreMember()
 	for i := range entries {
-		zadd = zadd.ScoreMember(float64(entries[i].at/int64(time.Millisecond)), encodeRecentMember(entries[i]))
+		zadd = zadd.ScoreMember(float64(entries[i].at/stamp(time.Millisecond)), encodeRecentMember(entries[i]))
 	}
 	resps := v.client.DoMulti(ctx,
 		zadd.Build(),
 		v.client.B().Zremrangebyscore().Key(key).Min("-inf").Max(cutoff).Build(),
 		v.client.B().Zremrangebyrank().Key(key).Start(0).Stop(-(recentRingCap + 1)).Build(),
-		v.client.B().Expire().Key(key).Seconds(ttlSec).Build(),
+		v.client.B().Expire().Key(key).Seconds(int64(recentTTL/time.Second)).Build(),
 	)
 	v.noteErrors(resps)
 }

--- a/app/sesame/engine/recent_valkey.go
+++ b/app/sesame/engine/recent_valkey.go
@@ -1,0 +1,266 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package engine
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+	"unicode/utf8"
+
+	"ItsBagelBot/app/sesame/module"
+	"ItsBagelBot/internal/domain/event/lane"
+	"ItsBagelBot/internal/moderation"
+
+	"github.com/valkey-io/valkey-go"
+	"go.uber.org/zap"
+)
+
+// ValkeyRecent is the centralized sweep memory behind !nuke. Sesame's replica
+// pool shares one durable JetStream consumer (pkg/bus), so no pod sees more
+// than an arbitrary fraction of a channel's chat — an in-process window would
+// make every sweep silently incomplete, exactly during the raids it exists
+// for. The ZSET at am:recent:<chan> gives every pod the same complete view;
+// it joins the automod state family (am:*) whose members are all TTL-bound,
+// tenant-scoped and never leave the cache tier.
+//
+// The hot path pays no I/O: Record appends into a per-process buffer that a
+// ticker flushes as one pipelined DoMulti per touched channel (ZADD the new
+// members, ZREMRANGEBYSCORE the expired ones, ZREMRANGEBYRANK enforce the
+// cardinality cap, EXPIRE slide the window). Batching keeps the firehose at
+// one round trip per ~50ms instead of per line — the campaign juror's six
+// commands per line is documented in docs/automod as a cost to dig out of,
+// not one to add back. A flush loses at most one interval of lines on a hard
+// crash; for raid-cleanup memory that trade is free.
+//
+// Scores are unix MILLIS: exact in float64 (nanos are not), so expiry cutoffs
+// never jitter. Members encode "uid:role:text" — both prefixes are numeric,
+// so parsing cuts twice and the text may contain anything Twitch delivers.
+const (
+	recentKeyPrefix      = "am:recent:"
+	recentFlushInterval  = 50 * time.Millisecond
+	recentFlushMaxBuffer = 512 // pending entries before an early flush fires
+	recentFetchLimit     = 256 // sweep read cap; server-side cardinality ≤ recentRingCap
+)
+
+// ValkeyRecent implements recentStore over valkey.
+type ValkeyRecent struct {
+	client valkey.Client
+	log    *zap.Logger
+
+	mu       sync.Mutex
+	pending  map[uint64][]recentEntry
+	buffered int
+
+	// Write/read-error visibility, the campaign juror's lesson: a dead backend
+	// must show up once per interval carrying how many operations were
+	// swallowed, not vanish into per-line debug spam or silence.
+	errPending     atomic.Int64
+	lastWriteLogNs atomic.Int64
+}
+
+// NewValkeyRecent builds the store over the shared client. A nil client is
+// the kill switch: records are dropped and sweeps come back empty, matching
+// every other store's nil-degrades behavior.
+func NewValkeyRecent(client valkey.Client, log *zap.Logger) *ValkeyRecent {
+	if log == nil {
+		log = zap.NewNop()
+	}
+	return &ValkeyRecent{
+		client:  client,
+		log:     log,
+		pending: make(map[uint64][]recentEntry),
+	}
+}
+
+func recentChannelKey(chanID uint64) string {
+	return recentKeyPrefix + strconv.FormatUint(chanID, 10)
+}
+
+// Start runs the flush loop until ctx is canceled, then best-effort flushes
+// what remains. Wiring starts it on the process lifecycle context.
+func (v *ValkeyRecent) Start(ctx context.Context) {
+	ticker := time.NewTicker(recentFlushInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			v.flush(context.WithoutCancel(ctx))
+			return
+		case <-ticker.C:
+			v.flush(ctx)
+		}
+	}
+}
+
+// Record buffers one chat envelope for the next flush. It parses and bounds
+// here (the envelope is pooled by the caller) but copies nothing: retained
+// strings alias the payload buffer, which the transport never reuses.
+func (v *ValkeyRecent) Record(chanID uint64, env *lane.Envelope, now time.Time) {
+	if v.client == nil {
+		return
+	}
+	entries := chatEntriesFromEnvelope(env, now)
+	if entries == nil {
+		return
+	}
+	var early bool
+	v.mu.Lock()
+	v.pending[chanID] = append(v.pending[chanID], entries...)
+	v.buffered += len(entries)
+	if v.buffered >= recentFlushMaxBuffer {
+		early = true
+	}
+	v.mu.Unlock()
+	if early {
+		go v.flush(context.Background())
+	}
+}
+
+// flush drains the pending buffer as one pipelined DoMulti per touched
+// channel. The eviction cutoff derives from the batch's newest entry rather
+// than wall-clock time, so tests stay deterministic and a quiet channel's
+// stale members still die on its next activity (the sliding EXPIRE covers
+// the idle case).
+func (v *ValkeyRecent) flush(ctx context.Context) {
+	v.mu.Lock()
+	if len(v.pending) == 0 {
+		v.mu.Unlock()
+		return
+	}
+	batch := v.pending
+	v.pending = make(map[uint64][]recentEntry)
+	v.buffered = 0
+	v.mu.Unlock()
+
+	newest := int64(0)
+	for _, entries := range batch {
+		for i := range entries {
+			if entries[i].at > newest {
+				newest = entries[i].at
+			}
+		}
+	}
+	cutoff := strconv.FormatInt((newest-int64(recentTTL))/int64(time.Millisecond), 10)
+	ttlSec := int64(recentTTL / time.Second)
+
+	for chanID, entries := range batch {
+		key := recentChannelKey(chanID)
+		zadd := v.client.B().Zadd().Key(key).ScoreMember()
+		for i := range entries {
+			zadd = zadd.ScoreMember(float64(entries[i].at/int64(time.Millisecond)), encodeRecentMember(entries[i]))
+		}
+		resps := v.client.DoMulti(ctx,
+			zadd.Build(),
+			v.client.B().Zremrangebyscore().Key(key).Min("-inf").Max(cutoff).Build(),
+			v.client.B().Zremrangebyrank().Key(key).Start(0).Stop(-(recentRingCap + 1)).Build(),
+			v.client.B().Expire().Key(key).Seconds(ttlSec).Build(),
+		)
+		v.noteErrors(resps)
+	}
+}
+
+// Sweep reads the channel's fresh members in one round trip and matches them
+// in-process with the same normalization and word-boundary rules as the
+// in-memory store. Fail-open: any read error yields no hits, never a block.
+func (v *ValkeyRecent) Sweep(ctx context.Context, chanID uint64, phrase string, now time.Time) []RecentHit {
+	q := moderation.Normalize(GetBuf(), phrase)
+	defer PutBuf(q)
+	if v.client == nil || utf8.RuneCount(q) == 0 {
+		return nil
+	}
+	cutoff := strconv.FormatInt(now.Add(-recentTTL).UnixMilli(), 10)
+
+	resp := v.client.Do(ctx, v.client.B().Zrangebyscore().
+		Key(recentChannelKey(chanID)).
+		Min(cutoff).Max("+inf").
+		Limit(0, recentFetchLimit).
+		Build())
+	members, err := resp.AsStrSlice()
+	if err != nil {
+		v.noteReadError(err)
+		return nil
+	}
+
+	hits := make([]RecentHit, 0, len(members))
+	t := GetBuf()
+	defer PutBuf(t)
+	for _, m := range members {
+		e, ok := parseRecentMember(m)
+		if !ok {
+			continue // the score carried the age; the member carries only identity
+		}
+		t = moderation.Normalize(t, e.text)
+		if !containsPhrase(t, q) || seenUID(hits, e.uid) {
+			continue
+		}
+		hits = append(hits, RecentHit{UserID: e.uid, Role: e.role})
+	}
+	return hits
+}
+
+func encodeRecentMember(e recentEntry) string {
+	return strconv.FormatUint(e.uid, 10) + ":" + strconv.Itoa(int(e.role)) + ":" + e.text
+}
+
+// parseRecentMember decodes "uid:role:text". Both prefixes are numeric, so
+// the two cuts are unambiguous no matter what the text carries.
+func parseRecentMember(m string) (recentEntry, bool) {
+	uidStr, rest, ok := strings.Cut(m, ":")
+	if !ok {
+		return recentEntry{}, false
+	}
+	roleStr, text, ok := strings.Cut(rest, ":")
+	if !ok {
+		return recentEntry{}, false
+	}
+	uid, err := strconv.ParseUint(uidStr, 10, 64)
+	if err != nil || uid == 0 {
+		return recentEntry{}, false
+	}
+	role, err := strconv.Atoi(roleStr)
+	if err != nil || role < 0 {
+		return recentEntry{}, false
+	}
+	return recentEntry{uid: uid, role: module.Role(role), text: text}, true
+}
+
+// noteErrors sweeps write replies so a failing backend surfaces once per
+// interval with the swallowed count (see ValkeyCampaign for the origin).
+func (v *ValkeyRecent) noteErrors(resps []valkey.ValkeyResult) {
+	var failed int64
+	var first error
+	for _, r := range resps {
+		if err := r.Error(); err != nil {
+			failed++
+			if first == nil {
+				first = err
+			}
+		}
+	}
+	v.noteFailure(failed, first)
+}
+
+func (v *ValkeyRecent) noteReadError(err error) { v.noteFailure(1, err) }
+
+func (v *ValkeyRecent) noteFailure(failed int64, first error) {
+	if failed == 0 {
+		return
+	}
+	now := time.Now().UnixNano()
+	last := v.lastWriteLogNs.Load()
+	if last == 0 || now-last > int64(campaignErrLogInterval) {
+		if v.lastWriteLogNs.CompareAndSwap(last, now) {
+			v.log.Warn("nuke recent-chat store errors",
+				zap.Int64("suppressed", v.errPending.Load()+failed),
+				zap.Error(first))
+			v.errPending.Store(0)
+			return
+		}
+	}
+	v.errPending.Add(failed)
+}

--- a/app/sesame/engine/recent_valkey.go
+++ b/app/sesame/engine/recent_valkey.go
@@ -137,6 +137,20 @@ func (v *ValkeyRecent) flush(ctx context.Context) {
 	v.buffered = 0
 	v.mu.Unlock()
 
+	flushAt := newestBufferedAt(batch)
+	cutoff := strconv.FormatInt((flushAt-int64(recentTTL))/int64(time.Millisecond), 10)
+	ttlSec := int64(recentTTL / time.Second)
+
+	for chanID, entries := range batch {
+		v.flushChannel(ctx, chanID, entries, cutoff, ttlSec)
+	}
+}
+
+// newestBufferedAt finds the freshest entry in the batch; the eviction cutoff
+// derives from it rather than wall-clock time, so tests stay deterministic and
+// a quiet channel's stale members still die on its next activity (the sliding
+// EXPIRE covers the idle case).
+func newestBufferedAt(batch map[uint64][]recentEntry) int64 {
 	newest := int64(0)
 	for _, entries := range batch {
 		for i := range entries {
@@ -145,23 +159,25 @@ func (v *ValkeyRecent) flush(ctx context.Context) {
 			}
 		}
 	}
-	cutoff := strconv.FormatInt((newest-int64(recentTTL))/int64(time.Millisecond), 10)
-	ttlSec := int64(recentTTL / time.Second)
+	return newest
+}
 
-	for chanID, entries := range batch {
-		key := recentChannelKey(chanID)
-		zadd := v.client.B().Zadd().Key(key).ScoreMember()
-		for i := range entries {
-			zadd = zadd.ScoreMember(float64(entries[i].at/int64(time.Millisecond)), encodeRecentMember(entries[i]))
-		}
-		resps := v.client.DoMulti(ctx,
-			zadd.Build(),
-			v.client.B().Zremrangebyscore().Key(key).Min("-inf").Max(cutoff).Build(),
-			v.client.B().Zremrangebyrank().Key(key).Start(0).Stop(-(recentRingCap + 1)).Build(),
-			v.client.B().Expire().Key(key).Seconds(ttlSec).Build(),
-		)
-		v.noteErrors(resps)
+// flushChannel writes one channel's buffered lines as a single pipelined
+// DoMulti: add the new members, evict expired ones, enforce the cardinality
+// cap, and slide the key's TTL.
+func (v *ValkeyRecent) flushChannel(ctx context.Context, chanID uint64, entries []recentEntry, cutoff string, ttlSec int64) {
+	key := recentChannelKey(chanID)
+	zadd := v.client.B().Zadd().Key(key).ScoreMember()
+	for i := range entries {
+		zadd = zadd.ScoreMember(float64(entries[i].at/int64(time.Millisecond)), encodeRecentMember(entries[i]))
 	}
+	resps := v.client.DoMulti(ctx,
+		zadd.Build(),
+		v.client.B().Zremrangebyscore().Key(key).Min("-inf").Max(cutoff).Build(),
+		v.client.B().Zremrangebyrank().Key(key).Start(0).Stop(-(recentRingCap + 1)).Build(),
+		v.client.B().Expire().Key(key).Seconds(ttlSec).Build(),
+	)
+	v.noteErrors(resps)
 }
 
 // Sweep reads the channel's fresh members in one round trip and matches them

--- a/app/sesame/engine/recent_valkey.go
+++ b/app/sesame/engine/recent_valkey.go
@@ -137,12 +137,22 @@ func (v *ValkeyRecent) flush(ctx context.Context) {
 	v.buffered = 0
 	v.mu.Unlock()
 
-	flushAt := newestBufferedAt(batch)
-	cutoff := strconv.FormatInt(int64((flushAt-stamp(recentTTL))/stamp(time.Millisecond)), 10)
+	plan := flushPlan{
+		cutoff: strconv.FormatInt(int64((newestBufferedAt(batch)-stamp(recentTTL))/stamp(time.Millisecond)), 10),
+		ttlSec: int64(recentTTL / time.Second),
+	}
 
 	for chanID, entries := range batch {
-		v.flushChannel(ctx, chanID, entries, cutoff)
+		v.flushChannel(ctx, chanID, entries, plan)
 	}
+}
+
+// flushPlan carries the batch-wide eviction bounds every per-channel pipeline
+// shares: the TTL cutoff in millis (derived from the freshest buffered line,
+// keeping tests deterministic) and the sliding key expiry.
+type flushPlan struct {
+	cutoff string
+	ttlSec int64
 }
 
 // newestBufferedAt finds the freshest entry in the batch; the eviction cutoff
@@ -164,7 +174,7 @@ func newestBufferedAt(batch map[uint64][]recentEntry) stamp {
 // flushChannel writes one channel's buffered lines as a single pipelined
 // DoMulti: add the new members, evict expired ones, enforce the cardinality
 // cap, and slide the key's TTL.
-func (v *ValkeyRecent) flushChannel(ctx context.Context, chanID uint64, entries []recentEntry, cutoff string) {
+func (v *ValkeyRecent) flushChannel(ctx context.Context, chanID uint64, entries []recentEntry, plan flushPlan) {
 	key := recentChannelKey(chanID)
 	zadd := v.client.B().Zadd().Key(key).ScoreMember()
 	for i := range entries {
@@ -172,9 +182,9 @@ func (v *ValkeyRecent) flushChannel(ctx context.Context, chanID uint64, entries 
 	}
 	resps := v.client.DoMulti(ctx,
 		zadd.Build(),
-		v.client.B().Zremrangebyscore().Key(key).Min("-inf").Max(cutoff).Build(),
+		v.client.B().Zremrangebyscore().Key(key).Min("-inf").Max(plan.cutoff).Build(),
 		v.client.B().Zremrangebyrank().Key(key).Start(0).Stop(-(recentRingCap + 1)).Build(),
-		v.client.B().Expire().Key(key).Seconds(int64(recentTTL/time.Second)).Build(),
+		v.client.B().Expire().Key(key).Seconds(plan.ttlSec).Build(),
 	)
 	v.noteErrors(resps)
 }

--- a/app/sesame/engine/recent_valkey.go
+++ b/app/sesame/engine/recent_valkey.go
@@ -77,8 +77,8 @@ func NewValkeyRecent(client valkey.Client, log *zap.Logger) *ValkeyRecent {
 	}
 }
 
-func recentChannelKey(chanID uint64) string {
-	return recentKeyPrefix + strconv.FormatUint(chanID, 10)
+func recentChannelKey(chanID channelID) string {
+	return recentKeyPrefix + strconv.FormatUint(uint64(chanID), 10)
 }
 
 // Start runs the flush loop until ctx is canceled, then best-effort flushes
@@ -100,7 +100,7 @@ func (v *ValkeyRecent) Start(ctx context.Context) {
 // Record buffers one chat envelope for the next flush. It parses and bounds
 // here (the envelope is pooled by the caller) but copies nothing: retained
 // strings alias the payload buffer, which the transport never reuses.
-func (v *ValkeyRecent) Record(chanID uint64, env *lane.Envelope, now time.Time) {
+func (v *ValkeyRecent) Record(chanID channelID, env *lane.Envelope, now time.Time) {
 	if v.client == nil {
 		return
 	}
@@ -110,7 +110,7 @@ func (v *ValkeyRecent) Record(chanID uint64, env *lane.Envelope, now time.Time) 
 	}
 	var early bool
 	v.mu.Lock()
-	v.pending[chanID] = append(v.pending[chanID], entries...)
+	v.pending[uint64(chanID)] = append(v.pending[uint64(chanID)], entries...)
 	v.buffered += len(entries)
 	if v.buffered >= recentFlushMaxBuffer {
 		early = true
@@ -142,8 +142,8 @@ func (v *ValkeyRecent) flush(ctx context.Context) {
 		ttlSec: int64(recentTTL / time.Second),
 	}
 
-	for chanID, entries := range batch {
-		v.flushChannel(ctx, chanID, entries, plan)
+	for id, entries := range batch {
+		v.flushChannel(ctx, channelID(id), entries, plan)
 	}
 }
 
@@ -174,7 +174,7 @@ func newestBufferedAt(batch map[uint64][]recentEntry) stamp {
 // flushChannel writes one channel's buffered lines as a single pipelined
 // DoMulti: add the new members, evict expired ones, enforce the cardinality
 // cap, and slide the key's TTL.
-func (v *ValkeyRecent) flushChannel(ctx context.Context, chanID uint64, entries []recentEntry, plan flushPlan) {
+func (v *ValkeyRecent) flushChannel(ctx context.Context, chanID channelID, entries []recentEntry, plan flushPlan) {
 	key := recentChannelKey(chanID)
 	zadd := v.client.B().Zadd().Key(key).ScoreMember()
 	for i := range entries {
@@ -192,7 +192,7 @@ func (v *ValkeyRecent) flushChannel(ctx context.Context, chanID uint64, entries 
 // Sweep reads the channel's fresh members in one round trip and matches them
 // in-process with the same normalization and word-boundary rules as the
 // in-memory store. Fail-open: any read error yields no hits, never a block.
-func (v *ValkeyRecent) Sweep(ctx context.Context, chanID uint64, phrase string, now time.Time) []RecentHit {
+func (v *ValkeyRecent) Sweep(ctx context.Context, chanID channelID, phrase string, now time.Time) []RecentHit {
 	q := moderation.Normalize(GetBuf(), phrase)
 	defer PutBuf(q)
 	if v.client == nil || utf8.RuneCount(q) == 0 {
@@ -220,10 +220,10 @@ func (v *ValkeyRecent) Sweep(ctx context.Context, chanID uint64, phrase string, 
 			continue // the score carried the age; the member carries only identity
 		}
 		t = moderation.Normalize(t, e.text)
-		if !containsPhrase(t, q) || seenUID(hits, e.uid) {
+		if !containsPhrase(t, q) || seenUID(hits, channelID(e.uid)) {
 			continue
 		}
-		hits = append(hits, RecentHit{UserID: e.uid, Role: e.role})
+		hits = append(hits, RecentHit{UserID: channelID(e.uid), Role: e.role})
 	}
 	return hits
 }

--- a/app/sesame/engine/recent_valkey_test.go
+++ b/app/sesame/engine/recent_valkey_test.go
@@ -78,28 +78,36 @@ func (s *recentScriptedServer) handle(c net.Conn) {
 		}
 		switch strings.ToUpper(cmd.args[0]) {
 		case "HELLO":
-			if _, err := io.WriteString(c, "-ERR unknown command 'HELLO'\r\n"); err != nil {
-				return
-			}
+			writeLine(c, "-ERR unknown command 'HELLO'\r\n")
 		case "ZRANGEBYSCORE":
-			s.mu.Lock()
-			members := append([]string(nil), s.members...)
-			s.lastRange = append([]string(nil), cmd.args...)
-			s.mu.Unlock()
-			var b strings.Builder
-			fmt.Fprintf(&b, "*%d\r\n", len(members))
-			for _, m := range members {
-				fmt.Fprintf(&b, "$%d\r\n%s\r\n", len(m), m)
-			}
-			if _, err := io.WriteString(c, b.String()); err != nil {
-				return
-			}
+			s.writeMemberArray(c, cmd.args)
 		default:
-			if _, err := io.WriteString(c, ":1\r\n"); err != nil {
-				return
-			}
+			writeLine(c, ":1\r\n")
 		}
 	}
+}
+
+// writeLine emits one raw RESP line; a write failure ends the connection.
+func writeLine(c net.Conn, line string) {
+	if _, err := io.WriteString(c, line); err != nil {
+		c.Close()
+	}
+}
+
+// writeMemberArray answers a ZRANGEBYSCORE with the currently scripted
+// members, recording the command that asked so tests can pin the read shape.
+func (s *recentScriptedServer) writeMemberArray(c net.Conn, args []string) {
+	s.mu.Lock()
+	members := append([]string(nil), s.members...)
+	s.lastRange = append([]string(nil), args...)
+	s.mu.Unlock()
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "*%d\r\n", len(members))
+	for _, m := range members {
+		fmt.Fprintf(&b, "$%d\r\n%s\r\n", len(m), m)
+	}
+	writeLine(c, b.String())
 }
 
 func dialRecentClient(tb testing.TB, addr string) valkey.Client {

--- a/app/sesame/engine/recent_valkey_test.go
+++ b/app/sesame/engine/recent_valkey_test.go
@@ -1,0 +1,301 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package engine
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"ItsBagelBot/app/sesame/module"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/valkey-io/valkey-go"
+	"go.uber.org/zap"
+)
+
+// --- test double: a real client against a scripted TCP server ---
+
+// recentScriptedServer answers the client handshake with the one error the
+// RESP2 fallback tolerates, replies to ZRANGEBYSCORE with the currently
+// scripted member array, and acks everything else. It exists because sweep
+// results must come off the WIRE (ValkeyMessage arrays cannot be synthesized
+// from outside the library).
+type recentScriptedServer struct {
+	ln net.Listener
+
+	mu        sync.Mutex
+	members   []string
+	lastRange []string
+}
+
+func newRecentScriptedServer(tb testing.TB) *recentScriptedServer {
+	tb.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(tb, err)
+	tb.Cleanup(func() { ln.Close() })
+	s := &recentScriptedServer{ln: ln}
+	go s.serve()
+	return s
+}
+
+func (s *recentScriptedServer) scriptMembers(members []string) {
+	s.mu.Lock()
+	s.members = members
+	s.mu.Unlock()
+}
+
+func (s *recentScriptedServer) serve() {
+	for {
+		conn, err := s.ln.Accept()
+		if err != nil {
+			return
+		}
+		go s.handle(conn)
+	}
+}
+
+func (s *recentScriptedServer) handle(c net.Conn) {
+	defer c.Close()
+	r := bufio.NewReader(c)
+	for {
+		cmd, err := parseRespCommand(r)
+		if err != nil {
+			return
+		}
+		if len(cmd.args) == 0 {
+			continue
+		}
+		switch strings.ToUpper(cmd.args[0]) {
+		case "HELLO":
+			if _, err := io.WriteString(c, "-ERR unknown command 'HELLO'\r\n"); err != nil {
+				return
+			}
+		case "ZRANGEBYSCORE":
+			s.mu.Lock()
+			members := append([]string(nil), s.members...)
+			s.lastRange = append([]string(nil), cmd.args...)
+			s.mu.Unlock()
+			var b strings.Builder
+			fmt.Fprintf(&b, "*%d\r\n", len(members))
+			for _, m := range members {
+				fmt.Fprintf(&b, "$%d\r\n%s\r\n", len(m), m)
+			}
+			if _, err := io.WriteString(c, b.String()); err != nil {
+				return
+			}
+		default:
+			if _, err := io.WriteString(c, ":1\r\n"); err != nil {
+				return
+			}
+		}
+	}
+}
+
+func dialRecentClient(tb testing.TB, addr string) valkey.Client {
+	tb.Helper()
+	real, err := valkey.NewClient(valkey.ClientOption{
+		InitAddress:       []string{addr},
+		AlwaysRESP2:       true,
+		DisableCache:      true,
+		ForceSingleClient: true,
+	})
+	require.NoError(tb, err)
+	tb.Cleanup(real.Close)
+	return real
+}
+
+// recentRecordingClient captures every pipelined command while delegating to
+// the real client, so writes both land on the scripted server and are
+// assertable as raw argument vectors.
+type recentRecordingClient struct {
+	valkey.Client
+
+	mu   sync.Mutex
+	cmds [][]string
+}
+
+func (r *recentRecordingClient) DoMulti(ctx context.Context, cmds ...valkey.Completed) []valkey.ValkeyResult {
+	r.mu.Lock()
+	for _, cmd := range cmds {
+		// Deep-copy before delegating: execution returns the builder state to
+		// valkey-go's pool, which zeroes whatever Commands() aliased.
+		r.cmds = append(r.cmds, append([]string(nil), cmd.Commands()...))
+	}
+	r.mu.Unlock()
+	return r.Client.DoMulti(ctx, cmds...)
+}
+
+func (r *recentRecordingClient) captured() [][]string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([][]string(nil), r.cmds...)
+}
+
+func newRecentStoreUnderTest(tb testing.TB) (*ValkeyRecent, *recentRecordingClient, *recentScriptedServer) {
+	tb.Helper()
+	server := newRecentScriptedServer(tb)
+	rec := &recentRecordingClient{Client: dialRecentClient(tb, server.ln.Addr().String())}
+	v := NewValkeyRecent(rec, zap.NewNop())
+	return v, rec, server
+}
+
+// --- flush shape ---
+
+func TestValkeyRecentFlushPipelinesPerChannelShape(t *testing.T) {
+	v, rec, _ := newRecentStoreUnderTest(t)
+
+	v.Record(123, soloChatEnv("999", "hello there"), nukeClockBase)
+	v.Record(123, cohortChatEnv([]string{"555", "556"}, "same copypasta everywhere"), nukeClockBase.Add(time.Second))
+	v.Record(456, soloChatEnv("777", "other channel line"), nukeClockBase)
+	v.flush(context.Background())
+
+	cmds := rec.captured()
+
+	byKey := map[string][][]string{}
+	for _, cmd := range cmds {
+		require.GreaterOrEqual(t, len(cmd), 2)
+		byKey[cmd[1]] = append(byKey[cmd[1]], cmd)
+	}
+	require.Len(t, byKey, 2, "one pipelined group per touched channel")
+
+	k123 := byKey["am:recent:123"]
+	require.Len(t, k123, 4)
+	assert.Equal(t, []string{"ZADD", "am:recent:123",
+		strconv.FormatInt(nukeClockBase.UnixMilli(), 10), "999:0:hello there",
+		strconv.FormatInt(nukeClockBase.Add(time.Second).UnixMilli(), 10), "555:0:same copypasta everywhere",
+		strconv.FormatInt(nukeClockBase.Add(time.Second).UnixMilli(), 10), "556:0:same copypasta everywhere"}, k123[0])
+	cutoff := strconv.FormatInt((nukeClockBase.Add(time.Second).UnixNano()-int64(recentTTL))/int64(time.Millisecond), 10)
+	assert.Equal(t, []string{"ZREMRANGEBYSCORE", "am:recent:123", "-inf", cutoff}, k123[1])
+	assert.Equal(t, []string{"ZREMRANGEBYRANK", "am:recent:123", "0", strconv.Itoa(-(recentRingCap + 1))}, k123[2])
+	assert.Equal(t, []string{"EXPIRE", "am:recent:123", strconv.FormatInt(int64(recentTTL/time.Second), 10)}, k123[3])
+
+	assert.Equal(t, "am:recent:456", byKey["am:recent:456"][0][1], "the second channel is tenant-scoped")
+}
+
+func TestValkeyRecentSkipsCommandShapesAndEmptyText(t *testing.T) {
+	v, rec, _ := newRecentStoreUnderTest(t)
+
+	v.Record(123, soloChatEnv("999", "!nuke spam"), nukeClockBase)
+	v.Record(123, soloChatEnv("999", ""), nukeClockBase)
+	v.flush(context.Background())
+	assert.Empty(t, rec.captured(), "nothing retainable means no round trip")
+}
+
+func TestValkeyRecentFlushAfterEmptyFlushIsNoop(t *testing.T) {
+	v, rec, _ := newRecentStoreUnderTest(t)
+	v.flush(context.Background())
+	assert.Empty(t, rec.captured())
+}
+
+// --- sweep over the wire ---
+
+func TestValkeyRecentSweepParsesMatchesAndDedupes(t *testing.T) {
+	v, rec, server := newRecentStoreUnderTest(t)
+	server.scriptMembers([]string{
+		"111:0:join my FREE N1TRO giveaway",
+		encodeRecentMember(recentEntry{uid: 111, text: "free nitro again!!"}), // same user, second line
+		"222:4:free nitro is my whole personality",                            // lead mod: parsed, not filtered here
+		"garbage-without-colons",
+		"zero:0:no uid",
+	})
+
+	hits := v.Sweep(context.Background(), 123, "free nitro", nukeClockBase)
+	require.Len(t, hits, 2)
+	assert.Equal(t, uint64(111), hits[0].UserID)
+	assert.Equal(t, module.RoleEveryone, hits[0].Role)
+	assert.Equal(t, uint64(222), hits[1].UserID)
+	assert.Equal(t, module.RoleLeadModerator, hits[1].Role)
+
+	cmds := rec.captured() // sweep rides Do (single), so nothing pipelined was captured
+	assert.Empty(t, cmds)
+}
+
+func TestValkeyRecentSweepCutoffRidesTheCommand(t *testing.T) {
+	v, _, server := newRecentStoreUnderTest(t)
+
+	v.Sweep(context.Background(), 123, "phrase", nukeClockBase)
+
+	server.mu.Lock()
+	last := append([]string(nil), server.lastRange...)
+	server.mu.Unlock()
+	wantMin := strconv.FormatInt(nukeClockBase.Add(-recentTTL).UnixMilli(), 10)
+	require.Len(t, last, 7)
+	assert.Equal(t, []string{"ZRANGEBYSCORE", "am:recent:123", wantMin, "+inf", "LIMIT", "0", strconv.Itoa(recentFetchLimit)}, last)
+}
+
+// --- guards ---
+
+func TestValkeyRecentNilClientDegradesSilently(t *testing.T) {
+	v := NewValkeyRecent(nil, zap.NewNop())
+	v.Record(123, soloChatEnv("999", "free nitro everyone"), nukeClockBase)
+	assert.Empty(t, v.Sweep(context.Background(), 123, "free nitro", nukeClockBase))
+}
+
+func TestParseRecentMember(t *testing.T) {
+	e, ok := parseRecentMember("44322889:2:KEKW KEKW :D")
+	assert.True(t, ok)
+	assert.Equal(t, uint64(44322889), e.uid)
+	assert.Equal(t, module.RoleVIP, e.role)
+	assert.Equal(t, "KEKW KEKW :D", e.text)
+
+	for _, bad := range []string{
+		"", "nocolons", "abc:0:text", "44322889:x:text", "0:0:text", "44322889:", "44322889",
+	} {
+		_, ok := parseRecentMember(bad)
+		assert.False(t, ok, bad)
+	}
+}
+
+// --- error visibility ---
+
+func TestValkeyRecentErrorsSurfaceOncePerInterval(t *testing.T) {
+	v, rec, _ := newRecentStoreUnderTest(t)
+
+	failFirst := true
+	rec.Client = failClient{Client: rec.Client, shouldFail: &failFirst}
+	v.client = rec
+
+	v.Record(123, soloChatEnv("999", "hello world again"), nukeClockBase)
+	v.flush(context.Background())
+
+	// The failed batch left nothing behind that a later healthy flush would
+	// double-write: pending was drained either way.
+	v.Record(123, soloChatEnv("998", "second line here"), nukeClockBase)
+	failFirst = false
+	v.flush(context.Background())
+
+	found := false
+	for _, cmd := range rec.captured() {
+		if cmd[0] == "ZADD" && len(cmd) > 3 && strings.Contains(cmd[len(cmd)-1], "second line") {
+			found = true
+		}
+	}
+	assert.True(t, found, "entries recorded after a failed flush still land")
+}
+
+type failClient struct {
+	valkey.Client
+	shouldFail *bool
+}
+
+func (c failClient) DoMulti(ctx context.Context, cmds ...valkey.Completed) []valkey.ValkeyResult {
+	if *c.shouldFail {
+		out := make([]valkey.ValkeyResult, len(cmds))
+		for i := range cmds {
+			out[i] = valkey.NewErrorResult(errors.New("valkey down"))
+		}
+		return out
+	}
+	return c.Client.DoMulti(ctx, cmds...)
+}

--- a/app/sesame/engine/recent_valkey_test.go
+++ b/app/sesame/engine/recent_valkey_test.go
@@ -220,9 +220,9 @@ func TestValkeyRecentSweepParsesMatchesAndDedupes(t *testing.T) {
 
 	hits := v.Sweep(context.Background(), 123, "free nitro", nukeClockBase)
 	require.Len(t, hits, 2)
-	assert.Equal(t, uint64(111), hits[0].UserID)
+	assert.Equal(t, channelID(111), hits[0].UserID)
 	assert.Equal(t, module.RoleEveryone, hits[0].Role)
-	assert.Equal(t, uint64(222), hits[1].UserID)
+	assert.Equal(t, channelID(222), hits[1].UserID)
 	assert.Equal(t, module.RoleLeadModerator, hits[1].Role)
 
 	cmds := rec.captured() // sweep rides Do (single), so nothing pipelined was captured
@@ -320,6 +320,7 @@ func zaddCarriesMember(cmd []string, substr string) bool {
 			return true
 		}
 	}
+	return false
 }
 
 type failClient struct {

--- a/app/sesame/engine/recent_valkey_test.go
+++ b/app/sesame/engine/recent_valkey_test.go
@@ -302,16 +302,24 @@ func zaddCarrying(cmd []string, text string) bool {
 // member whose text contains substr.
 func wroteMemberContaining(rec *recentRecordingClient, substr string) bool {
 	for _, cmd := range rec.captured() {
-		if cmd[0] != "ZADD" {
-			continue
-		}
-		for i, arg := range cmd {
-			if i >= 2 && i%2 == 0 && strings.Contains(arg, substr) {
-				return true
-			}
+		if zaddCarriesMember(cmd, substr) {
+			return true
 		}
 	}
 	return false
+}
+
+// zaddCarriesMember scans a captured ZADD's score/member pairs (everything
+// after the key) for a member whose text contains substr.
+func zaddCarriesMember(cmd []string, substr string) bool {
+	if len(cmd) < 4 || cmd[0] != "ZADD" {
+		return false
+	}
+	for i := 3; i < len(cmd); i += 2 {
+		if strings.Contains(cmd[i], substr) {
+			return true
+		}
+	}
 }
 
 type failClient struct {

--- a/app/sesame/engine/recent_valkey_test.go
+++ b/app/sesame/engine/recent_valkey_test.go
@@ -298,6 +298,22 @@ func zaddCarrying(cmd []string, text string) bool {
 	return cmd[0] == "ZADD" && len(cmd) > 3 && strings.Contains(cmd[len(cmd)-1], text)
 }
 
+// wroteMemberContaining reports whether any captured pipelined ZADD carried a
+// member whose text contains substr.
+func wroteMemberContaining(rec *recentRecordingClient, substr string) bool {
+	for _, cmd := range rec.captured() {
+		if cmd[0] != "ZADD" {
+			continue
+		}
+		for i, arg := range cmd {
+			if i >= 2 && i%2 == 0 && strings.Contains(arg, substr) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 type failClient struct {
 	valkey.Client
 	shouldFail *bool

--- a/app/sesame/engine/recent_valkey_test.go
+++ b/app/sesame/engine/recent_valkey_test.go
@@ -285,11 +285,17 @@ func TestValkeyRecentErrorsSurfaceOncePerInterval(t *testing.T) {
 
 	found := false
 	for _, cmd := range rec.captured() {
-		if cmd[0] == "ZADD" && len(cmd) > 3 && strings.Contains(cmd[len(cmd)-1], "second line") {
+		if zaddCarrying(cmd, "second line") {
 			found = true
 		}
 	}
 	assert.True(t, found, "entries recorded after a failed flush still land")
+}
+
+// zaddCarrying reports whether a captured command vector is the pipelined
+// ZADD whose final score-member pair embeds text.
+func zaddCarrying(cmd []string, text string) bool {
+	return cmd[0] == "ZADD" && len(cmd) > 3 && strings.Contains(cmd[len(cmd)-1], text)
 }
 
 type failClient struct {

--- a/app/sesame/engine/secfix2_campaign_emit_test.go
+++ b/app/sesame/engine/secfix2_campaign_emit_test.go
@@ -1,0 +1,181 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package engine
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"ItsBagelBot/app/sesame/automod"
+	"ItsBagelBot/app/sesame/module"
+	"ItsBagelBot/internal/domain/outgress"
+	"ItsBagelBot/pkg/bus"
+	"ItsBagelBot/pkg/codec"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+// --- emit-side chat cap (the runtime backstop for pre-walk stored configs) ---
+
+// Untouched output is returned byte-identical: the common case must not pay a
+// rebuild (or drift by a join/split round trip).
+func TestCapChatTextPassthrough(t *testing.T) {
+	for _, text := range []string{
+		"",
+		"hello",
+		"a\nb\nc\nd\ne",
+		strings.Repeat("x", 500),
+	} {
+		got, changed := capChatText(text)
+		assert.False(t, changed)
+		assert.Equal(t, text, got)
+	}
+}
+
+func TestCapChatTextTruncates(t *testing.T) {
+	// Six lines -> first five.
+	got, changed := capChatText("1\n2\n3\n4\n5\n6")
+	assert.True(t, changed)
+	assert.Equal(t, "1\n2\n3\n4\n5", got)
+
+	// Oversized line cut to the byte limit.
+	got, changed = capChatText(strings.Repeat("a", 501))
+	assert.True(t, changed)
+	assert.Len(t, got, 500)
+}
+
+// A byte-exact cut could split a multibyte rune and hand outgress an invalid
+// UTF-8 sequence; the cut backs up to a rune start instead.
+func TestCapChatTextRuneSafe(t *testing.T) {
+	confetti := "\U0001F389" // 4 bytes
+	line := strings.Repeat("a", 498) + confetti + confetti
+	got, changed := capChatText(line)
+	assert.True(t, changed)
+	assert.LessOrEqual(t, len(got), 500)
+	require.NotPanics(t, func() { _, _ = codec.Marshal(got) })
+}
+
+// The full emit path: a module (or old stored config) that renders an oversized
+// line publishes a bounded message instead of a guaranteed Twitch 400.
+func TestEmitCapsOversizedChatOutput(t *testing.T) {
+	pub := &fakePublisher{}
+	p := newPipelineWith(pub, fakeReader{},
+		emitModule("", module.KindCore, strings.Repeat("a", 600)+"\n"+strings.Repeat("b", 600)+"\nthird"))
+	require.NoError(t, p.Process(chatMsg(t, "standard", "hello")))
+	require.Len(t, pub.got, 1)
+
+	var body struct {
+		Message string `json:"message"`
+	}
+	require.NoError(t, codec.Unmarshal(pub.got[0].msg.Payload, &body))
+	assert.Equal(t,
+		strings.Repeat("a", 500)+"\n"+strings.Repeat("b", 500)+"\nthird",
+		body.Message,
+		"each oversized line is capped in place; nothing over five lines goes out")
+}
+
+// --- external variable capping ---
+
+func TestExternalVarCapsAndSanitizes(t *testing.T) {
+	assert.Equal(t, "sniper", ExternalVar("sniper"))
+	// Control characters stripped, so no embedded newline can mint extra
+	// lines (the leftover "/" is inert mid-line; only a LEADING slash run is
+	// a verb vector and sanitizeVar trims that too).
+	assert.Equal(t, "evil/ban everyone bot", ExternalVar("evil\n/ban everyone bot"))
+	assert.Equal(t, "ban everyone", ExternalVar("/ban everyone"))
+	// ...and length capped at MaxExternalVarBytes without splitting runes.
+	long := strings.Repeat("x", 300) + "\U0001F389"
+	got := ExternalVar(long)
+	assert.LessOrEqual(t, len(got), MaxExternalVarBytes)
+	assert.Equal(t, strings.Repeat("x", MaxExternalVarBytes), got)
+}
+
+// --- campaign-band poisoning mitigations ---
+
+// recordingReputation records strikes so the attribution rule can be observed:
+// council-only verdicts must not score, content-backed ones must.
+type recordingReputation struct {
+	scores map[string]int
+	bumps  []string
+}
+
+func newRecordingReputation() *recordingReputation {
+	return &recordingReputation{scores: map[string]int{}}
+}
+
+func (r *recordingReputation) Score(_ context.Context, id string) int { return r.scores[id] }
+
+func (r *recordingReputation) Bump(_ context.Context, id string) { r.bumps = append(r.bumps, id) }
+
+// campaignPipeline is councilPipeline with a reputation store and an injectable
+// zap core (pass nil for a nop logger).
+func campaignPipeline(pub *fakePublisher, camp Campaign, rep Reputation, zc zapcore.Core) *Pipeline {
+	gate := automod.New()
+	gate.SetEmotes(automod.NewEmoteSet(nil))
+	log := zap.NewNop()
+	if zc != nil {
+		log = zap.New(zc)
+	}
+	d := Deps{
+		Proj: fakeReader{}, Live: liveAlways{}, Cooldown: NoopCooldown{},
+		Pub: pub, Log: log, Automod: gate, Campaign: camp, Reputation: rep,
+	}
+	return NewPipeline(d, NewRegistry(zap.NewNop()), Config{
+		OutgressPremium: premiumSubj, OutgressStandard: standardSubj, AutomodEnforce: true,
+	})
+}
+
+// A band quorum with NO content signal behind it (clean link carrier, delete
+// minted purely by "council:campaign") enforces the immediate delete — a real
+// flood needs it — but records NO reputation strike: 8 colluding accounts can
+// manufacture the quorum, so letting it score would let them pump an innocent
+// user up the warn->timeout->ban ladder while the reason launders it as
+// automod. The activation itself lands one Warn audit line naming the channel
+// and the actioned chatter.
+func TestCampaignOnlyVerdictSkipsReputationStrikeButAudits(t *testing.T) {
+	pub := &fakePublisher{}
+	rep := newRecordingReputation()
+	core, logs := observer.New(zapcore.DebugLevel)
+	p := campaignPipeline(pub, &fakeCampaign{count: campaignThreshold}, rep, core)
+
+	require.NoError(t, p.Process(linkChat(t, "777")))
+	require.Len(t, pub.got, 1, "the delete still fires")
+	assert.Equal(t, outgress.TypeDelete, pub.got[0].msg.Type)
+	assert.Empty(t, rep.bumps, "an attacker-minted quorum must not score a strike")
+
+	matched := logs.FilterMessage("campaign band quorum")
+	require.Equal(t, 1, matched.Len(), "one audit line per quorum activation")
+	assert.Equal(t, "777", matched.All()[0].ContextMap()["chatter_id"])
+}
+
+// A content-backed verdict escalated BY the campaign juror keeps its strike:
+// the content signal alone justifies it regardless of what the band said.
+// (The link makes the base evidence content-backed — under the jury rule a
+// style-only delete at quorum stays delete and is covered over in
+// council_test.go.)
+func TestContentBackedCampaignEscalationStillScores(t *testing.T) {
+	pub := &fakePublisher{}
+	rep := newRecordingReputation()
+	p := campaignPipeline(pub, &fakeCampaign{count: campaignThreshold}, rep, nil)
+
+	body, err := codec.Marshal(map[string]any{
+		"type":                chatType,
+		"lane":                "standard",
+		"broadcaster_user_id": "123",
+		"chatter_user_id":     "888",
+		"msg_id":              "m-888",
+		"text":                "FREE VBUCKS CLICK MY PROFILE RIGHT NOW EVERYONE HURRY bit.ly/free-vbucks",
+	})
+	require.NoError(t, err)
+	require.NoError(t, p.Process(bus.NewMessage("u-888", body)))
+
+	require.Len(t, pub.got, 1)
+	assert.Equal(t, outgress.TypeTimeout, pub.got[0].msg.Type, "delete + campaign quorum = timeout")
+	assert.Equal(t, []string{"888"}, rep.bumps, "content-backed verdict scores normally")
+}

--- a/app/sesame/engine/secfix_dedup_test.go
+++ b/app/sesame/engine/secfix_dedup_test.go
@@ -1,0 +1,131 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package engine
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	loyaltyrpc "ItsBagelBot/internal/domain/rpc/loyalty"
+	"ItsBagelBot/internal/projection"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// --- sanitizeVar: the newline-smuggling fix ---
+
+// A viewer-supplied {args}/{touser} must never be able to mint per-line
+// slash-verbs: emitResponse splits the expanded response on "\n" and routes
+// each line through Translate independently, so an embedded newline plus a
+// leading slash was a remote moderation verb executed as the bot.
+func TestSanitizeVarStripsControlChars(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain arg untouched", "hello world", "hello world"},
+		{"leading slashes trimmed", "//ban everyone", "ban everyone"},
+		{"newline verb dropped", "hi\n/ban everyone", "hi/ban everyone"},
+		{"newline then slash-run", "\n\n/ban everyone", "ban everyone"},
+		{"crlf smuggling", "hi\r\n/timeout @user", "hi/timeout @user"},
+		{"tab-padded verb", "\t/announce raid", "announce raid"},
+		{"carriage return alone", "a\rb", "ab"},
+		{"nul byte dropped", "a\x00b", "ab"},
+		{"all C0 controls", "\x01\x02\x1f x", "x"}, // controls stripped, then the leading space run trims
+		{"del byte dropped", "a\x7fb", "ab"},
+		{"mid-text url keeps slashes", "see https://example.com/x", "see https://example.com/x"},
+		{"emoji survive", "café ☕ 🥯", "café ☕ 🥯"},
+		{"empty stays empty", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, sanitizeVar(tt.in))
+		})
+	}
+}
+
+// --- watch tick: stable per-bucket identity ---
+
+// The identity must be byte-stable across replicas firing the same expiry,
+// yet differ for the NEXT legitimate tick one interval later — otherwise the
+// guard either misses replays or suppresses every second accrual.
+func TestWatchTickIdentityStableWithinBucketDistinctAcross(t *testing.T) {
+	base := time.Unix(1_800_000_000, 0)
+	sameMoment := base.Add(37 * time.Second) // another replica's clock, same bucket
+	nextTick := base.Add(watchTickInterval)
+
+	a := watchTickIdentity(42, base)
+	assert.Equal(t, a, watchTickIdentity(42, sameMoment), "same bucket must collide")
+	assert.NotEqual(t, a, watchTickIdentity(42, nextTick), "the next tick must earn again")
+	assert.NotEqual(t, a, watchTickIdentity(43, base), "channels are independent")
+}
+
+// End-to-end shape of the guard: claiming the same tick identity twice
+// reports a duplicate, so a re-fired tick's chatter is paid exactly once.
+func TestWatchTickGuardCollapsesRefire(t *testing.T) {
+	store := newRecordingStore()
+	d := NewEventDedup(store, "sesame:seen:", time.Hour, zap.NewNop())
+	ctx := context.Background()
+
+	ref := EffectRef{Identity: watchTickIdentity(42, time.Unix(1_800_000_000, 0)) + ":7", Effect: EffectEarn}
+	assert.False(t, d.Duplicate(ctx, ref), "first fire applies")
+	assert.True(t, d.Duplicate(ctx, ref), "re-fired tick is recognized")
+}
+
+// --- custom-command counter tokens: claim + peek on the dispatch path ---
+
+// countingLoyalty counts bumps and serves the current value to peeks. The
+// embedded nil interface covers the methods these tests never touch.
+type countingLoyalty struct {
+	LoyaltyStore
+	bumps     int
+	peekCalls int
+	value     int64
+}
+
+func (l *countingLoyalty) CounterBump(_ context.Context, _ CounterBump) (int64, error) {
+	l.bumps++
+	l.value++
+	return l.value, nil
+}
+
+func (l *countingLoyalty) CounterPeek(context.Context, uint64, string, uint64, string) (loyaltyrpc.Counter, bool, error) {
+	l.peekCalls++
+	return loyaltyrpc.Counter{Name: "deaths", Value: l.value}, true, nil
+}
+
+// A redelivered command line must bump its {counter} token ONCE and render the
+// peeked value on the replay, while a DISTINCT event bumps again.
+func TestCounterTokenBumpReplayRendersPeekNotDoubleBump(t *testing.T) {
+	store := newRecordingStore()
+	pub := &rawPublisher{}
+	loyal := &countingLoyalty{}
+	reader := fakeReader{cmd: projection.Command{
+		Name: "foo", Response: "died {counter:deaths}", IsActive: true,
+	}, cmdFound: true}
+
+	d := Deps{
+		Proj: reader, Live: liveAlways{}, Cooldown: NoopCooldown{},
+		Loyalty: loyal, Pub: pub, Log: zap.NewNop(),
+		Dedup: NewEventDedup(store, "sesame:seen:", time.Minute, zap.NewNop()),
+	}
+	p := NewPipeline(d, NewRegistry(zap.NewNop()), Config{
+		OutgressPremium: premiumSubj, OutgressStandard: standardSubj, CountUses: true,
+	})
+	defer p.Close()
+
+	require.NoError(t, p.Process(commandMsg(t, "m1", "!foo")))
+	require.NoError(t, p.Process(commandMsg(t, "m1", "!foo"))) // replay: same msg_id
+	require.NoError(t, p.Process(commandMsg(t, "m2", "!foo"))) // distinct event
+
+	// The claim lives under the CounterEffect namespace, the exact key
+	// CounterClaim hands a folded claim+increment bump.
+	require.Contains(t, store.keys(), "m1:cbump:deaths")
+	assert.Equal(t, 2, loyal.bumps, "replay must not re-bump; distinct event must")
+	assert.Equal(t, 1, loyal.peekCalls, "exactly one replay rendered the peeked value")
+}

--- a/app/sesame/engine/vars.go
+++ b/app/sesame/engine/vars.go
@@ -6,6 +6,7 @@ package engine
 import (
 	"slices"
 	"strings"
+	"unicode/utf8"
 
 	"ItsBagelBot/app/sesame/module"
 )
@@ -96,12 +97,32 @@ func counterTokenNames(tmpl string) []string {
 	}
 }
 
-// sanitizeVar neutralizes a user-supplied command variable so it cannot inject a
-// leading slash-verb into the expanded response. Leading spaces and slashes are
-// trimmed; the rest is untouched (a URL's "http://" keeps its slashes because
-// they are not leading).
+// sanitizeVar neutralizes a user-supplied command variable so it cannot inject
+// a leading slash-verb into the expanded response. Control characters (C0 plus
+// DEL) are stripped first — an embedded newline would otherwise survive into
+// the expansion and emitResponse's per-line split would mint it a fresh line,
+// which a leading slash then turns into a remote moderation verb — and
+// leading spaces/slashes are trimmed after. The rest is untouched: a URL's
+// "http://" keeps its slashes because they are not leading.
 func sanitizeVar(s string) string {
-	return trimLeftSlashSpace(s)
+	return trimLeftSlashSpace(stripControls(s))
+}
+
+// stripControls removes every ASCII control rune, returning s unchanged when
+// it carries none (the overwhelmingly common case pays only the scan).
+func stripControls(s string) string {
+	i := strings.IndexFunc(s, func(r rune) bool { return r < ' ' || r == '\x7f' })
+	if i < 0 {
+		return s
+	}
+	out := make([]byte, 0, len(s))
+	out = append(out, s[:i]...)
+	for _, r := range s[i:] {
+		if r >= ' ' && r != '\x7f' {
+			out = utf8.AppendRune(out, r)
+		}
+	}
+	return string(out)
 }
 
 func trimLeftSlashSpace(s string) string {

--- a/app/sesame/internal/config/config.go
+++ b/app/sesame/internal/config/config.go
@@ -93,6 +93,12 @@ type Config struct {
 	// suppression. On by default; the endpoints are small, public and unauthenticated.
 	EmotesEnabled bool
 
+	// NukeEnabled arms the !nuke mass-moderation feature: the per-channel
+	// recent-chat sweep memory on the pipeline hot path and the moderation
+	// module's command. On by default; off (SESAME_NUKE=off) is the kill
+	// switch — nothing is recorded and the command goes inert.
+	NukeEnabled bool
+
 	// AdaptiveEnabled arms the learned false-positive layers: the per-channel
 	// style baselines (caps/symbol thresholds adapt to a channel's house style)
 	// and the learned community vocabulary (high-consensus tokens shed style
@@ -201,6 +207,8 @@ func Load() *Config {
 		ShieldEnabled:   env.Get("SESAME_AUTOMOD_SHIELD", "false") == "true",
 		EmotesEnabled:   env.Get("SESAME_AUTOMOD_EMOTES", "true") == "true",
 		AdaptiveEnabled: env.Get("SESAME_AUTOMOD_ADAPTIVE", "false") == "true",
+
+		NukeEnabled: env.Get("SESAME_NUKE", "on") != "off",
 
 		LiveTTL: env.GetDuration("SESAME_LIVE_TTL", 12*time.Hour),
 

--- a/app/sesame/modules/all.go
+++ b/app/sesame/modules/all.go
@@ -35,6 +35,7 @@ func All(d engine.Deps) []module.Module {
 		Queue(d),
 		Quotes(d),
 		Automod(d),
+		Moderation(d),
 		ChannelPoints(d),
 		Loyalty(d),
 		// The wager games ride the loyalty economy; they register right after

--- a/app/sesame/modules/moderation.go
+++ b/app/sesame/modules/moderation.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package modules
+
+import (
+	"context"
+	"time"
+
+	"ItsBagelBot/app/sesame/engine"
+	"ItsBagelBot/app/sesame/module"
+)
+
+// Moderation surfaces phrase-targeted mass moderation as a named KindDefault
+// module (ships enabled; a broadcaster can disable it from the dashboard like
+// any other module). It owns !nuke: a moderator sweeps the recent chat window
+// for a phrase and everyone whose message matched is timed out within budget,
+// with Shield Mode escalation on overflow when armed.
+//
+// The sweep memory and the escalation policy live engine-side (the pipeline
+// records every chat line into Deps.Nuke's RecentLog); this module only
+// registers the trigger. A nil Deps.Nuke leaves the command inert — the same
+// graceful degradation every store-backed module here follows.
+func Moderation(d engine.Deps) module.Module {
+	m := module.NewModule("moderation", module.KindDefault)
+	m.Command("nuke").Mod().Cooldown(nukeCooldown).Run(func(ctx context.Context, c *module.Context, args string, emit module.Emit) error {
+		if d.Nuke == nil {
+			return nil
+		}
+		return d.Nuke.Execute(ctx, c, args, emit)
+	})
+	return m.Build()
+}
+
+// nukeCooldown keeps a double-typed !nuke from firing two overlapping sweeps;
+// a mod re-nuking mid-raid waits five seconds, which no real response needs
+// to beat.
+const nukeCooldown = 5 * time.Second

--- a/app/sesame/modules/moderation_test.go
+++ b/app/sesame/modules/moderation_test.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package modules
+
+import (
+	"context"
+	"testing"
+
+	"ItsBagelBot/app/sesame/engine"
+	"ItsBagelBot/app/sesame/module"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The moderation module registers !nuke at moderator tier with a shared
+// cooldown window, so a stray viewer invocation never reaches the sweep.
+func TestModerationRegistersNukeAtModTier(t *testing.T) {
+	m := Moderation(engine.Deps{})
+	assert.Equal(t, "moderation", m.Name)
+	require.Len(t, m.Commands, 1)
+
+	cmd := m.Commands[0]
+	assert.Equal(t, "nuke", cmd.Name)
+	assert.Equal(t, module.RoleModerator, cmd.Perm)
+	assert.Positive(t, cmd.Cooldown)
+}
+
+// A nil Deps.Nuke leaves the command inert: it runs, emits nothing, errors
+// nothing — the graceful degradation every store-backed module follows.
+func TestModerationInertWithoutService(t *testing.T) {
+	m := Moderation(engine.Deps{})
+	run := m.Commands[0].Run
+
+	emitted := 0
+	err := run(context.Background(), &module.Context{}, "free nitro now everyone",
+		func(o *module.Output) { emitted++ })
+	assert.NoError(t, err, "inert must be silent, not an error")
+	assert.Zero(t, emitted)
+}

--- a/internal/domain/validate/validate.go
+++ b/internal/domain/validate/validate.go
@@ -18,16 +18,20 @@ import (
 )
 
 const (
-	maxUsernameLength     = 25  // Twitch login limit
-	maxEmailLength        = 254 // RFC 5321
-	maxCommandNameLength  = 64
-	maxCommandAliases     = 25
-	maxResponseLineLength = 500   // Twitch chat message limit, per line
-	maxCooldownSeconds    = 86400 // one day; guards against absurd values
-	maxModuleNameLength   = 64
-	maxConfigsBytes       = 16 << 10
-	maxTokenBytes         = 8 << 10
+	maxUsernameLength    = 25  // Twitch login limit
+	maxEmailLength       = 254 // RFC 5321
+	maxCommandNameLength = 64
+	maxCommandAliases    = 25
+	maxCooldownSeconds   = 86400 // one day; guards against absurd values
+	maxModuleNameLength  = 64
+	maxConfigsBytes      = 16 << 10
+	maxTokenBytes        = 8 << 10
 )
+
+// MaxResponseLineLength is the per-line chat message limit. Exported alongside
+// MaxResponseLines so the engine's emit-side cap mirrors the save-time shape
+// from one constant instead of a duplicated literal.
+const MaxResponseLineLength = 500
 
 // MaxResponseLines caps how many chat messages one command response may fan
 // out into: the response is newline-delimited and the bot sends one message
@@ -177,7 +181,7 @@ func CommandResponse(response string) error {
 // validResponseLine reports whether one chat line is within the single-message
 // limit and carries no control characters (including CR).
 func validResponseLine(line string) bool {
-	if len(line) == 0 || len(line) > maxResponseLineLength {
+	if len(line) == 0 || len(line) > MaxResponseLineLength {
 		return false
 	}
 	for _, r := range line {


### PR DESCRIPTION
## What

Fossabot-parity mass moderation for mods:

- `!nuke <phrase> [seconds|600s]` — sweeps the last **10 minutes** of plain chat and times out everyone whose message matched (normalized: case/leet/confusables, token-bounded so `ass` never hits `bass`)
- Budget-capped at 100 timeouts/sweep; overflow escalates to **Shield Mode** through the existing armed + raid-gate-deduped policy
- Staff-safe: VIP+, the broadcaster and the bot are never swept; command-shaped lines are never recorded (a mod cannot be nuked by their own invocation)
- New `moderation` module (KindDefault), `Mod()` tier, 5s cooldown; inert when `Deps.Nuke` is nil or `SESAME_NUKE=off`

## Why centralized

Sesame's replica pool shares one durable JetStream consumer — no pod sees a channel's whole chat, so an in-process window would silently under-sweep during exactly the raids it exists for. The window lives in Valkey at `am:recent:<chan>` (ZSET): writes batch every 50ms into one pipelined DoMulti per touched channel (ZADD + TTL evict + rank cap 128 + sliding EXPIRE), sweeps are one read. Hot-path cost measured at +6% ns/op, 0 added allocs (`BenchmarkProcessNoOutputWithRecording`). RAM ceiling ≈13 KB/channel (~26 MB @ 2k live channels).

## Also completes pinned contracts from prior sessions

- emit-side `capChatText` backstop (≤5 lines × ≤500B, rune-safe) — validate exports `MaxResponseLineLength` as the single constant
- `sanitizeVar` control-char stripping (newline → slash-verb smuggling fix) + `external_var.go`
- watch-tick dedup identity; counter-token claim+peek replays (no double-bump on redelivery)
- campaign juror strike-attribution: council-minted verdicts enforce but never score; one Warn audit line per quorum

## Tests

Engine suite green incl. `-race`; scripted RESP server verifies sweep reads off the wire, DoMulti recorder pins pipelined shapes; alloc ceilings unchanged. Privacy note for follow-up: legal copy should disclose the minutes-scale in-memory cache window.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the moderator-only `!nuke` command for phrase-based moderation of recent chat.
  - Added optional Shield Mode escalation for large moderation events.
  - Added configurable moderation enablement with in-memory or persistent recent-chat tracking.

- **Bug Fixes**
  - Chat responses now enforce safe line and length limits.
  - Sanitized command and external values while preserving valid UTF-8.
  - Prevented duplicate deliveries from repeating counters or actions.
  - Improved campaign moderation attribution and watch-event deduplication.
  - Excluded protected accounts and safely bounded moderation targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->