### PR TITLE
fix(svcboot): default APP_ENV to production with a visible boot warning

### DIFF
--- a/pkg/svcboot/svcboot.go
+++ b/pkg/svcboot/svcboot.go
@@ -16,9 +16,9 @@ import (
 	"os/signal"
 	"syscall"
 
+	entsql "entgo.io/ent/dialect/sql"
 	"github.com/nats-io/nats.go"
 	"github.com/newrelic/go-agent/v3/newrelic"
-	entsql "entgo.io/ent/dialect/sql"
 
 	"ItsBagelBot/pkg/bus"
 	"ItsBagelBot/pkg/db"
@@ -28,6 +28,26 @@ import (
 
 	"go.uber.org/zap"
 )
+
+// APP_ENV values logger.New understands.
+const (
+	appEnvProduction  = "production"
+	appEnvDevelopment = "development"
+	appEnvDebug       = "debug"
+)
+
+// resolveAppEnv resolves APP_ENV through get and reports whether it was
+// defaulted. Defaults to production, not development (flipped 2026-08): a
+// production boot that forgot APP_ENV used to silently get verbose, unsampled
+// development logs — the expensive configuration — with nothing saying so. A
+// missing value must fall to the restrictive end, and defaulted=true is what
+// NewCore turns into the one-time boot warning that says it happened.
+func resolveAppEnv(get func(string) string) (string, bool) {
+	if value := get("APP_ENV"); value != "" {
+		return value, false
+	}
+	return appEnvProduction, true
+}
 
 // Core bundles the observability and lifecycle plumbing every service starts
 // with: the named, New-Relic-wrapped logger, the APM app and the SIGINT/SIGTERM
@@ -42,7 +62,12 @@ type Core struct {
 // returned cleanup stops signal delivery, flushes the APM agent and syncs the
 // logger, in that order; defer it first so it runs last.
 func NewCore(serviceName string) (Core, func()) {
-	log := logger.New(env.Get("APP_ENV", "development")).Named(serviceName)
+	appEnv, defaulted := resolveAppEnv(os.Getenv)
+	log := logger.New(appEnv).Named(serviceName)
+	if defaulted {
+		// Once, before any wiring: after this point nothing else will say it.
+		log.Warn("APP_ENV not set; defaulted to production logging")
+	}
 
 	nrApp, err := monitor.New(serviceName, log)
 	if err != nil {

--- a/pkg/svcboot/svcboot_test.go
+++ b/pkg/svcboot/svcboot_test.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package svcboot
+
+import "testing"
+
+// A production boot that forgot APP_ENV used to get development logging
+// (verbose, unsampled) with nothing saying so. The fallback must be
+// production, and it must be visible: defaulted=true is what NewCore turns
+// into the one-time boot warning.
+func TestResolveAppEnvDefaultsToProductionWhenUnset(t *testing.T) {
+	scenarios := []struct {
+		name       string
+		value      string
+		wantEnv    string
+		wantNotice bool
+	}{
+		{"unset", "", appEnvProduction, true},
+		{"empty counts as unset", "", appEnvProduction, true},
+		{"explicit production", "production", "production", false},
+		{"explicit development", "development", "development", false},
+		{"explicit debug", "debug", "debug", false},
+	}
+	for _, tc := range scenarios {
+		t.Run(tc.name, func(t *testing.T) {
+			values := map[string]string{"APP_ENV": tc.value}
+			get := func(key string) string { return values[key] }
+
+			env, defaulted := resolveAppEnv(get)
+			if env != tc.wantEnv {
+				t.Fatalf("env = %q, want %q", env, tc.wantEnv)
+			}
+			if defaulted != tc.wantNotice {
+				t.Fatalf("defaulted = %v, want %v", defaulted, tc.wantNotice)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- `NewCore` resolved `APP_ENV` with a `development` fallback, so a production boot that forgot the variable silently got verbose, unsampled development logging with nothing saying so.
- New `resolveAppEnv(get)` defaults unset/empty to **production** and reports whether it defaulted; `NewCore` emits a one-time warn when it did. The getter is injected, so the resolver is unit-testable without touching process env.
- Table-driven test pins the five resolution cases (unset/empty/explicit).

## Test plan
- [x] `go test ./pkg/svcboot/`
- [x] `go vet ./pkg/svcboot/`
- [x] `go build ./app/commands/ ./app/modules/` (the two svcboot consumers)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application startup behavior when `APP_ENV` is missing or empty by defaulting to production logging.
  * Added a warning when the production default is applied.
  * Preserved explicit production, development, and debug environment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->