### PR TITLE
fix(console): bind per-app AAD into session cookies

### DIFF
--- a/console/admin/src/lib/server/session.ts
+++ b/console/admin/src/lib/server/session.ts
@@ -23,7 +23,7 @@ export interface Session {
   expires_at: number;
 }
 
-const codec = createSessionCodec<Session>(() => decodeKey(process.env.SESSION_KEY));
+const codec = createSessionCodec<Session>(() => decodeKey(process.env.SESSION_KEY), 'admin-session');
 
 export const seal = (s: Session): string => codec.seal(s);
 // Total lifetime is capped from iat, so a re-sealed payload with a pushed-out

--- a/console/dashboard/src/lib/server/session.ts
+++ b/console/dashboard/src/lib/server/session.ts
@@ -46,7 +46,7 @@ export interface Session {
   sections?: string[];
 }
 
-const codec = createSessionCodec<Session>(() => decodeKey(process.env.SESSION_KEY));
+const codec = createSessionCodec<Session>(() => decodeKey(process.env.SESSION_KEY), 'dashboard-session');
 
 export const seal = (s: Session): string => codec.seal(s);
 

--- a/console/shared/lib/server/session.test.ts
+++ b/console/shared/lib/server/session.test.ts
@@ -10,7 +10,7 @@ interface TestSession extends SessionBase {
 }
 
 const key = randomBytes(32);
-const codec = createSessionCodec<TestSession>(() => key);
+const codec = createSessionCodec<TestSession>(() => key, 'test-session');
 const now = () => Math.floor(Date.now() / 1000);
 
 function make(overrides: Partial<TestSession> = {}): TestSession {
@@ -22,7 +22,7 @@ function make(overrides: Partial<TestSession> = {}): TestSession {
 function sealRaw(payload: unknown): string {
   const iv = randomBytes(12);
   const c = createCipheriv('aes-256-gcm', key, iv);
-  c.setAAD(Buffer.from('session'));
+  c.setAAD(Buffer.from('test-session'));
   const ct = Buffer.concat([c.update(JSON.stringify(payload), 'utf8'), c.final()]);
   return Buffer.concat([iv, ct, c.getAuthTag()]).toString('base64url');
 }
@@ -36,8 +36,13 @@ describe('session codec', () => {
   test('rejects tampered ciphertext and the wrong key', () => {
     const sealed = codec.seal(make());
     expect(codec.open(sealed.slice(0, -2))).toBeNull();
-    const other = createSessionCodec<TestSession>(() => randomBytes(32));
+    const other = createSessionCodec<TestSession>(() => randomBytes(32), 'test-session');
     expect(other.open(sealed)).toBeNull();
+  });
+
+  test('rejects a cookie sealed under a different AAD even with the same key', () => {
+    const sameKeyOtherApp = createSessionCodec<TestSession>(() => key, 'other-session');
+    expect(sameKeyOtherApp.open(codec.seal(make()))).toBeNull();
   });
 
   test('rejects an expired session', () => {

--- a/console/shared/lib/server/session.ts
+++ b/console/shared/lib/server/session.ts
@@ -2,14 +2,16 @@
 // Proprietary. No license granted. See LICENSE.md.
 
 // Encrypted session cookie codec: AES-256-GCM, layout base64url(nonce[12] ||
-// ct||tag), AAD "session". The crypto is identical across the console apps, but
-// each app keeps its OWN Session shape and its OWN isolated SESSION_KEY (separate
-// Doppler configs); secrets are never shared, so an app's session can only be
-// minted by that app's own OAuth callback. This module factors out the shared
+// ct||tag), AAD is a per-app label passed at construction (e.g.
+// "dashboard-session" / "admin-session"). The crypto is identical across the
+// console apps, but each app keeps its OWN Session shape and its OWN isolated
+// SESSION_KEY (separate Doppler configs); secrets are never shared, so an app's
+// session can only be minted by that app's own OAuth callback. The distinct AAD
+// makes that isolation cryptographic, not just operational: even if the two
+// apps' SESSION_KEYs were ever mixed up, a cookie sealed under one app's label
+// fails GCM authentication in the other. This module factors out the shared
 // crypto as a generic codec; each app instantiates it over its own type.
 import { createCipheriv, createDecipheriv, randomBytes } from 'node:crypto';
-
-const AAD = Buffer.from('session');
 
 /**
  * Minimum contract: every session carries unix-seconds issue + expiry stamps.
@@ -55,9 +57,15 @@ export function decodeKey(b64: string | undefined): Buffer {
 /**
  * Build a codec over session type `T`. `getKey` is called per seal/open so the
  * key can come from `$env/dynamic/private` (read at request time, never cached
- * at module-eval).
+ * at module-eval). `aad` is the app's session label ("dashboard-session",
+ * "admin-session"): it is bound into the GCM tag, so cookies never validate
+ * across apps even under a shared or swapped key.
  */
-export function createSessionCodec<T extends SessionBase>(getKey: () => Buffer): SessionCodec<T> {
+export function createSessionCodec<T extends SessionBase>(
+  getKey: () => Buffer,
+  aad: string
+): SessionCodec<T> {
+  const AAD = Buffer.from(aad);
   return {
     seal(s: T): string {
       const iv = randomBytes(12);


### PR DESCRIPTION
Both console apps sealed session cookies with AAD `"session"`; cross-app isolation rested entirely on the two `SESSION_KEY`s staying separate (operational, not cryptographic).

This binds the app label into the GCM tag instead: `createSessionCodec(getKey, aad)` now takes a required AAD, with the dashboard passing `dashboard-session` and the admin console `admin-session`. A mixed-up or shared `SESSION_KEY` now produces cookies that fail authentication in the other app instead of validating.

- New test: same key, different AAD → `open()` returns `null`.
- Deploy note: AAD change invalidates every live cookie in both apps — one forced re-login, same precedent as the `iat` retirement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security Enhancements**
  - Session cookies now use application-specific authentication identifiers.
  - Added isolation between admin, dashboard, and other session cookies.
  - Cookies created for a different application context are rejected, even when encryption keys match.
- **Tests**
  - Expanded session validation coverage for application-specific authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->