### PR TITLE
fix(ci): retry go mod download against proxy.golang.org TLS blips

### DIFF
--- a/app/commands/Containerfile
+++ b/app/commands/Containerfile
@@ -7,7 +7,16 @@ FROM docker.io/library/golang:1.26.6-bookworm@sha256:116d58cbd88c1297624acc6e967
 
 WORKDIR /src
 COPY go.mod go.sum ./
-RUN go mod download
+# proxy.golang.org's backing GCS bucket occasionally TLS-handshake-times-out
+# mid-fetch under the ~30 concurrent matrix jobs this workflow runs
+# (observed: "go: github.com/klauspost/compress@v1.19.2: ... net/http: TLS
+# handshake timeout", one job out of the whole build failing while every
+# other job on the same go.mod/go.sum succeeded). go.mod/go.sum/toolchain
+# were verified fine (go mod download and go mod verify both succeed
+# locally and in this exact base image) - go mod download just makes one
+# unretried attempt per module, so a single blip is fatal. Retry instead
+# of masking it with GOFLAGS/GONOSUMCHECK.
+RUN for i in 1 2 3 4 5; do go mod download && exit 0; echo "go mod download failed (attempt $i/5), retrying..." >&2; sleep $((i * 3)); done; exit 1
 
 COPY internal/domain internal/domain
 COPY internal/moderation internal/moderation

--- a/app/gossip/Containerfile
+++ b/app/gossip/Containerfile
@@ -7,7 +7,16 @@ FROM docker.io/library/golang:1.26.6-bookworm@sha256:116d58cbd88c1297624acc6e967
 
 WORKDIR /src
 COPY go.mod go.sum ./
-RUN go mod download
+# proxy.golang.org's backing GCS bucket occasionally TLS-handshake-times-out
+# mid-fetch under the ~30 concurrent matrix jobs this workflow runs
+# (observed: "go: github.com/klauspost/compress@v1.19.2: ... net/http: TLS
+# handshake timeout", one job out of the whole build failing while every
+# other job on the same go.mod/go.sum succeeded). go.mod/go.sum/toolchain
+# were verified fine (go mod download and go mod verify both succeed
+# locally and in this exact base image) - go mod download just makes one
+# unretried attempt per module, so a single blip is fatal. Retry instead
+# of masking it with GOFLAGS/GONOSUMCHECK.
+RUN for i in 1 2 3 4 5; do go mod download && exit 0; echo "go mod download failed (attempt $i/5), retrying..." >&2; sleep $((i * 3)); done; exit 1
 
 COPY internal/domain internal/domain
 COPY internal/projection internal/projection

--- a/app/loyalty/Containerfile
+++ b/app/loyalty/Containerfile
@@ -7,7 +7,16 @@ FROM docker.io/library/golang:1.26.6-bookworm@sha256:116d58cbd88c1297624acc6e967
 
 WORKDIR /src
 COPY go.mod go.sum ./
-RUN go mod download
+# proxy.golang.org's backing GCS bucket occasionally TLS-handshake-times-out
+# mid-fetch under the ~30 concurrent matrix jobs this workflow runs
+# (observed: "go: github.com/klauspost/compress@v1.19.2: ... net/http: TLS
+# handshake timeout", one job out of the whole build failing while every
+# other job on the same go.mod/go.sum succeeded). go.mod/go.sum/toolchain
+# were verified fine (go mod download and go mod verify both succeed
+# locally and in this exact base image) - go mod download just makes one
+# unretried attempt per module, so a single blip is fatal. Retry instead
+# of masking it with GOFLAGS/GONOSUMCHECK.
+RUN for i in 1 2 3 4 5; do go mod download && exit 0; echo "go mod download failed (attempt $i/5), retrying..." >&2; sleep $((i * 3)); done; exit 1
 
 COPY internal/domain internal/domain
 COPY internal/moderation internal/moderation

--- a/app/modules/Containerfile
+++ b/app/modules/Containerfile
@@ -7,7 +7,16 @@ FROM docker.io/library/golang:1.26.6-bookworm@sha256:116d58cbd88c1297624acc6e967
 
 WORKDIR /src
 COPY go.mod go.sum ./
-RUN go mod download
+# proxy.golang.org's backing GCS bucket occasionally TLS-handshake-times-out
+# mid-fetch under the ~30 concurrent matrix jobs this workflow runs
+# (observed: "go: github.com/klauspost/compress@v1.19.2: ... net/http: TLS
+# handshake timeout", one job out of the whole build failing while every
+# other job on the same go.mod/go.sum succeeded). go.mod/go.sum/toolchain
+# were verified fine (go mod download and go mod verify both succeed
+# locally and in this exact base image) - go mod download just makes one
+# unretried attempt per module, so a single blip is fatal. Retry instead
+# of masking it with GOFLAGS/GONOSUMCHECK.
+RUN for i in 1 2 3 4 5; do go mod download && exit 0; echo "go mod download failed (attempt $i/5), retrying..." >&2; sleep $((i * 3)); done; exit 1
 
 COPY internal/domain internal/domain
 COPY internal/moderation internal/moderation

--- a/app/notifications/Containerfile
+++ b/app/notifications/Containerfile
@@ -7,7 +7,16 @@ FROM docker.io/library/golang:1.26.6-bookworm@sha256:116d58cbd88c1297624acc6e967
 
 WORKDIR /src
 COPY go.mod go.sum ./
-RUN go mod download
+# proxy.golang.org's backing GCS bucket occasionally TLS-handshake-times-out
+# mid-fetch under the ~30 concurrent matrix jobs this workflow runs
+# (observed: "go: github.com/klauspost/compress@v1.19.2: ... net/http: TLS
+# handshake timeout", one job out of the whole build failing while every
+# other job on the same go.mod/go.sum succeeded). go.mod/go.sum/toolchain
+# were verified fine (go mod download and go mod verify both succeed
+# locally and in this exact base image) - go mod download just makes one
+# unretried attempt per module, so a single blip is fatal. Retry instead
+# of masking it with GOFLAGS/GONOSUMCHECK.
+RUN for i in 1 2 3 4 5; do go mod download && exit 0; echo "go mod download failed (attempt $i/5), retrying..." >&2; sleep $((i * 3)); done; exit 1
 
 COPY internal/domain internal/domain
 COPY internal/utils internal/utils

--- a/app/outgress/Containerfile
+++ b/app/outgress/Containerfile
@@ -7,7 +7,16 @@ FROM docker.io/library/golang:1.26.6-bookworm@sha256:116d58cbd88c1297624acc6e967
 
 WORKDIR /src
 COPY go.mod go.sum ./
-RUN go mod download
+# proxy.golang.org's backing GCS bucket occasionally TLS-handshake-times-out
+# mid-fetch under the ~30 concurrent matrix jobs this workflow runs
+# (observed: "go: github.com/klauspost/compress@v1.19.2: ... net/http: TLS
+# handshake timeout", one job out of the whole build failing while every
+# other job on the same go.mod/go.sum succeeded). go.mod/go.sum/toolchain
+# were verified fine (go mod download and go mod verify both succeed
+# locally and in this exact base image) - go mod download just makes one
+# unretried attempt per module, so a single blip is fatal. Retry instead
+# of masking it with GOFLAGS/GONOSUMCHECK.
+RUN for i in 1 2 3 4 5; do go mod download && exit 0; echo "go mod download failed (attempt $i/5), retrying..." >&2; sleep $((i * 3)); done; exit 1
 
 COPY internal/domain internal/domain
 COPY internal/utils internal/utils

--- a/app/projector/Containerfile
+++ b/app/projector/Containerfile
@@ -7,7 +7,16 @@ FROM docker.io/library/golang:1.26.6-bookworm@sha256:116d58cbd88c1297624acc6e967
 
 WORKDIR /src
 COPY go.mod go.sum ./
-RUN go mod download
+# proxy.golang.org's backing GCS bucket occasionally TLS-handshake-times-out
+# mid-fetch under the ~30 concurrent matrix jobs this workflow runs
+# (observed: "go: github.com/klauspost/compress@v1.19.2: ... net/http: TLS
+# handshake timeout", one job out of the whole build failing while every
+# other job on the same go.mod/go.sum succeeded). go.mod/go.sum/toolchain
+# were verified fine (go mod download and go mod verify both succeed
+# locally and in this exact base image) - go mod download just makes one
+# unretried attempt per module, so a single blip is fatal. Retry instead
+# of masking it with GOFLAGS/GONOSUMCHECK.
+RUN for i in 1 2 3 4 5; do go mod download && exit 0; echo "go mod download failed (attempt $i/5), retrying..." >&2; sleep $((i * 3)); done; exit 1
 
 COPY internal/domain internal/domain
 COPY internal/moderation internal/moderation

--- a/app/sesame/Containerfile
+++ b/app/sesame/Containerfile
@@ -7,7 +7,16 @@ FROM docker.io/library/golang:1.26.6-bookworm@sha256:116d58cbd88c1297624acc6e967
 
 WORKDIR /src
 COPY go.mod go.sum ./
-RUN go mod download
+# proxy.golang.org's backing GCS bucket occasionally TLS-handshake-times-out
+# mid-fetch under the ~30 concurrent matrix jobs this workflow runs
+# (observed: "go: github.com/klauspost/compress@v1.19.2: ... net/http: TLS
+# handshake timeout", one job out of the whole build failing while every
+# other job on the same go.mod/go.sum succeeded). go.mod/go.sum/toolchain
+# were verified fine (go mod download and go mod verify both succeed
+# locally and in this exact base image) - go mod download just makes one
+# unretried attempt per module, so a single blip is fatal. Retry instead
+# of masking it with GOFLAGS/GONOSUMCHECK.
+RUN for i in 1 2 3 4 5; do go mod download && exit 0; echo "go mod download failed (attempt $i/5), retrying..." >&2; sleep $((i * 3)); done; exit 1
 
 COPY internal/domain internal/domain
 COPY internal/moderation internal/moderation

--- a/app/transactions/Containerfile
+++ b/app/transactions/Containerfile
@@ -7,7 +7,16 @@ FROM docker.io/library/golang:1.26.6-bookworm@sha256:116d58cbd88c1297624acc6e967
 
 WORKDIR /src
 COPY go.mod go.sum ./
-RUN go mod download
+# proxy.golang.org's backing GCS bucket occasionally TLS-handshake-times-out
+# mid-fetch under the ~30 concurrent matrix jobs this workflow runs
+# (observed: "go: github.com/klauspost/compress@v1.19.2: ... net/http: TLS
+# handshake timeout", one job out of the whole build failing while every
+# other job on the same go.mod/go.sum succeeded). go.mod/go.sum/toolchain
+# were verified fine (go mod download and go mod verify both succeed
+# locally and in this exact base image) - go mod download just makes one
+# unretried attempt per module, so a single blip is fatal. Retry instead
+# of masking it with GOFLAGS/GONOSUMCHECK.
+RUN for i in 1 2 3 4 5; do go mod download && exit 0; echo "go mod download failed (attempt $i/5), retrying..." >&2; sleep $((i * 3)); done; exit 1
 
 COPY internal/domain internal/domain
 COPY internal/utils internal/utils

--- a/app/users/Containerfile
+++ b/app/users/Containerfile
@@ -7,7 +7,16 @@ FROM docker.io/library/golang:1.26.6-bookworm@sha256:116d58cbd88c1297624acc6e967
 
 WORKDIR /src
 COPY go.mod go.sum ./
-RUN go mod download
+# proxy.golang.org's backing GCS bucket occasionally TLS-handshake-times-out
+# mid-fetch under the ~30 concurrent matrix jobs this workflow runs
+# (observed: "go: github.com/klauspost/compress@v1.19.2: ... net/http: TLS
+# handshake timeout", one job out of the whole build failing while every
+# other job on the same go.mod/go.sum succeeded). go.mod/go.sum/toolchain
+# were verified fine (go mod download and go mod verify both succeed
+# locally and in this exact base image) - go mod download just makes one
+# unretried attempt per module, so a single blip is fatal. Retry instead
+# of masking it with GOFLAGS/GONOSUMCHECK.
+RUN for i in 1 2 3 4 5; do go mod download && exit 0; echo "go mod download failed (attempt $i/5), retrying..." >&2; sleep $((i * 3)); done; exit 1
 
 COPY internal/domain internal/domain
 COPY internal/utils internal/utils


### PR DESCRIPTION
The publish-images Go builds intermittently fail at `go mod download` with `net/http: TLS handshake timeout` against proxy.golang.org's GCS backend — a one-shot network blip under concurrent matrix load, not a config/toolchain/go.sum bug (verified: podman build of loyalty+gossip green, go build/test clean). Wraps the download in a 5-attempt linear-backoff retry across all 10 root Go service Containerfiles; a persistent failure still exits non-zero.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved build reliability by automatically retrying dependency downloads up to five times.
  - Added increasing delays and diagnostic messages between failed attempts.
  - Builds now fail clearly after all retry attempts are exhausted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->