### PR TITLE
fix(urlfetch): consumer WARP in proxy mode, no team and no netns capture

### DIFF
--- a/app/warp/Containerfile
+++ b/app/warp/Containerfile
@@ -13,9 +13,11 @@
 #   podman build -t itsbagelbot/warp -f app/warp/Containerfile .
 #
 # The image is deliberately inert: no ENTRYPOINT/CMD. The manifest owns the
-# bootstrap (warp-svc, mode proxy, registration, connect) so proxy port and
-# enrollment stay deployment concerns; runtime needs NET_ADMIN and
-# /dev/net/tun, granted by the pod spec, never baked in here.
+# bootstrap (warp-svc, mode proxy, consumer registration, connect) so the
+# proxy port stays a deployment concern. Runtime needs NO NET_ADMIN and NO tun
+# device: proxy mode is a userspace L4 (MASQUE) SOCKS proxy — see the sidecar
+# securityContext note in deploy/k8s/gossip.yaml for why withholding them is
+# the pod-to-pod safety guarantee.
 
 FROM docker.io/library/debian:bookworm-slim@sha256:abd67ffcfa541b485a3dff59865ab629aa048a6c613e639d36e7456b0b229241
 

--- a/deploy/cache/dopplersecrets.yaml
+++ b/deploy/cache/dopplersecrets.yaml
@@ -53,34 +53,3 @@ spec:
       type: plain
   resyncSeconds: 60
   verifyTLS: true
----
-# gossip-warp-env backs the Cloudflare WARP sidecar in deploy/k8s/gossip.yaml.
-# It lives beside the gossip workload (namespace app) and reuses gossip's
-# existing operator token — the same pattern as the gossip-env DopplerSecret
-# declared in gossip.yaml itself, kept here because this file is where the
-# processors/asName rename convention lives.
-#
-# DEPENDENCY: WARP_ENROLL_TOKEN must exist in Doppler under the gossip
-# project/config (Zero Trust service token for one seat per replica, free
-# tier). Until it is provisioned this DopplerSecret stays unresolved and the
-# sidecar sits in CreateContainerConfigError; gossip itself still boots and
-# serves every trusted provider — only user-defined fetches fail closed.
-apiVersion: secrets.doppler.com/v1alpha1
-kind: DopplerSecret
-metadata:
-  name: doppler-gossip-warp
-  namespace: app
-spec:
-  host: https://api.doppler.com
-  tokenSecret:
-    name: gossip-doppler-token
-  managedSecret:
-    name: gossip-warp-env
-    namespace: app
-    type: Opaque
-  processors:
-    WARP_ENROLL_TOKEN:
-      asName: WARP_ENROLL_TOKEN
-      type: plain
-  resyncSeconds: 60
-  verifyTLS: true

--- a/deploy/k8s/gossip.yaml
+++ b/deploy/k8s/gossip.yaml
@@ -171,39 +171,61 @@ spec:
           image: ghcr.io/adamousmer/itsbagelbot/warp:main-0000000000-placeholder
           imagePullPolicy: IfNotPresent
           restartPolicy: Always # native sidecar: runs for the pod's lifetime
-          # Bootstrap: start the daemon, switch the client to proxy mode (this
-          # binds the loopback listener immediately, so readiness goes green
-          # before Zero Trust enrollment finishes), enroll with the service
-          # token from Doppler, then connect the tunnel. Enrollment failures
-          # keep the container running (the daemon retries); liveness catches
-          # a wedged daemon via warp-cli status.
+          # Bootstrap (consumer WARP, deliberately NO Zero Trust org). Two
+          # reasons this uses the free consumer account rather than a team:
+          #   1. No seats, no team, no charge — a Zero Trust org bills per
+          #      enrolled device, and this sidecar only needs egress-IP
+          #      masking, not any Gateway/Access feature.
+          #   2. The SSRF gate is entirely LOCAL. gossip resolves and
+          #      classifies every user-defined target itself (core.resolveAllowed
+          #      / classifyAddr, global-unicast-or-nothing) and dials the PINNED
+          #      IP through the SOCKS proxy; WARP is only the packet path, so a
+          #      target sees a Cloudflare egress IP and cannot null-route the
+          #      hot-path nodes. An edge Gateway policy would be pure
+          #      defense-in-depth, which is why we do not pay for one.
+          #
+          # Proxy mode (MASQUE, L4) is why this cannot break pod-to-pod: it
+          # binds a userspace SOCKS5 listener on loopback and captures NOTHING
+          # else — every dial that is not sent to 127.0.0.1:40000 (all of
+          # gossip's NATS-leaf, Valkey and CoreDNS traffic) leaves the pod
+          # netns untouched, over the normal cluster path. There is no tun
+          # device and no route table change; see the securityContext note.
+          #
+          # `registration new` with no token registers a consumer device. The
+          # SOCKS listener binds as soon as `mode proxy` lands, so readiness
+          # goes green before the tunnel finishes connecting; requests during
+          # that window fail closed (core.ErrWARPDown → "limited"), never
+          # unproxied. Registration/connect failures keep the container
+          # running (the daemon retries); liveness catches a wedged daemon.
           command:
             - /bin/sh
             - -ec
             - |
               warp-svc &
+              # Proxy mode is MASQUE-only since 2025.8; set it explicitly and
+              # tolerate a no-op on builds where proxy mode already implies it.
+              warp-cli --accept-tos tunnel protocol set MASQUE || true
               warp-cli --accept-tos mode proxy
-              warp-cli --accept-tos registration token "$WARP_ENROLL_TOKEN"
-              warp-cli --accept-tos connect
-              # Keep PID 1 alive for the sidecar lifetime; warp-svc serves the tunnel.
+              warp-cli --accept-tos proxy port 40000
+              # Consumer registration: no organization, no service token, no seat.
+              warp-cli --accept-tos registration new || true
+              warp-cli --accept-tos connect || true
+              # Keep PID 1 alive for the sidecar lifetime; warp-svc serves the proxy.
               wait
           securityContext:
-            runAsNonRoot: false # warp-svc needs root to own the tun device
+            # NO NET_ADMIN and NO tun device: proxy mode is a userspace L4
+            # (MASQUE) SOCKS proxy, so it needs neither — and withholding them
+            # is the hard guarantee that WARP CANNOT create a tunnel interface
+            # or rewrite routes in the shared pod netns, which is what would
+            # otherwise blackhole gossip's pod-to-pod traffic. runAsNonRoot
+            # stays false only because warp-svc writes its registration state
+            # as root; it binds loopback:40000 (>1024), needing no privilege.
+            runAsNonRoot: false
             capabilities:
-              add: ["NET_ADMIN"]
               drop: ["ALL"]
-          # /dev/net/tun rides a hostPath mount: securityContext has no
-          # device field in any shipped k8s (1.33 included), so NET_ADMIN +
-          # the char device mounted in is the standard non-privileged shape.
           volumeMounts:
-            - name: dev-net-tun
-              mountPath: /dev/net/tun
             - name: warp-state
               mountPath: /var/lib/cloudflare-warp
-          envFrom:
-            - secretRef:
-                name: gossip-warp-env # DopplerSecret wired like gossip-env,
-                # renamed via processors in deploy/cache/dopplersecrets.yaml
           ports:
             - name: warp-socks
               containerPort: 40000
@@ -338,13 +360,9 @@ spec:
         - name: valkey-client-tls
           secret:
             secretName: valkey-client-tls
-        # WARP sidecar: the tun char device (type guards against a directory
-        # silently appearing if the node module were missing) and a scratch
-        # home for warp-svc registration state, gone with the pod.
-        - name: dev-net-tun
-          hostPath:
-            path: /dev/net/tun
-            type: CharDevice
+        # WARP sidecar scratch home for warp-svc registration state, gone with
+        # the pod. No tun device: proxy mode is userspace, see the sidecar's
+        # securityContext note.
         - name: warp-state
           emptyDir: {}
       terminationGracePeriodSeconds: 45


### PR DESCRIPTION
Reworks the gossip egress sidecar onto free consumer WARP (registration new, no org, no seat, no charge) — the SSRF gate is fully local, WARP only masks the egress IP. Proxy mode (MASQUE, L4) captures only 127.0.0.1:40000 traffic, so NATS-leaf/Valkey/CoreDNS dials leave the shared pod netns untouched; drops NET_ADMIN and /dev/net/tun as the hard guarantee. Removes the now-unused gossip-warp-env DopplerSecret and WARP_ENROLL_TOKEN. Passes kubectl --dry-run=server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Updated WARP connectivity to use userspace proxy mode for improved compatibility.
  * Simplified proxy setup by removing the need for host networking permissions and tunnel devices.
  * Added more resilient startup behavior, allowing connectivity registration and retries to recover automatically.
  * Retained explicit SOCKS proxy configuration for consistent application traffic routing.
* **Deployment**
  * Removed obsolete WARP enrollment secret configuration from the deployment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->