### PR TITLE
chore(deploy): bump fleet to main-1787595359-141d372665a9

### DIFF
--- a/app/warp/Containerfile
+++ b/app/warp/Containerfile
@@ -21,11 +21,17 @@
 
 FROM docker.io/library/debian:bookworm-slim@sha256:abd67ffcfa541b485a3dff59865ab629aa048a6c613e639d36e7456b0b229241
 
-# Exact version pin per repo dependency policy: bump deliberately, in its own
-# commit, after checking the Cloudflare release notes. 2026.6.880.0 is current
-# in the bookworm channel as of 2026-08-24.
-ARG WARP_VERSION=2026.6.880.0
-
+# No hand-written version: install whatever Cloudflare currently ships as
+# stable in the bookworm channel. Transcribing a version here would be a
+# number nobody re-checks — it goes stale silently, and pinning one we cannot
+# verify is worse than tracking the vendor's own stable line, since WARP
+# client releases carry the protocol fixes (proxy mode is MASQUE-only since
+# 2025.8) that keep egress working at all.
+#
+# What actually freezes a rollout is the IMAGE digest, not this apt version:
+# deploy/k8s/gossip.yaml pins warp by tag@sha256, so the cluster runs exactly
+# the bytes that were built and tested. A rebuild picks up the newer client;
+# the fleet only moves when someone re-pins that digest deliberately.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl gnupg ca-certificates \
     && curl -fsSL https://pkg.cloudflareclient.com/pubkey.gpg \
@@ -33,7 +39,13 @@ RUN apt-get update \
     && echo "deb [signed-by=/usr/share/keyrings/cloudflare-warp-archive-keyring.gpg] https://pkg.cloudflareclient.com/ bookworm main" \
         > /etc/apt/sources.list.d/cloudflare-client.list \
     && apt-get update \
-    && apt-get install -y --no-install-recommends "cloudflare-warp=${WARP_VERSION}" \
-    && apt-get purge -y curl gnupg \
-    && apt-get autoremove -y \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get install -y --no-install-recommends cloudflare-warp \
+    # NO purge/autoremove of curl+gnupg here, deliberately. cloudflare-warp
+    # DEPENDS on gnupg, so `apt-get autoremove` uninstalls the WARP client
+    # itself and leaves an image whose only job is running warp-svc with no
+    # warp-svc in it — a silent empty sidecar, not a build error. Verified by
+    # `podman run <img> warp-cli --version` returning "not found" after the
+    # purge and succeeding without it, which is why that check is the last
+    # line of this layer and must stay.
+    && rm -rf /var/lib/apt/lists/* \
+    && warp-cli --version

--- a/deploy/k8s/commands.yaml
+++ b/deploy/k8s/commands.yaml
@@ -118,7 +118,7 @@ spec:
       priorityClassName: bagel-service
       containers:
         - name: commands
-          image: ghcr.io/adamousmer/itsbagelbot/commands:main-1787252044-f4347119cdf9@sha256:1686b24cca763f31be9107a6fef4f6fa1db93af5cd31e0c61773460a239be25c # {"$imagepolicy": "flux-system:commands"}
+          image: ghcr.io/adamousmer/itsbagelbot/commands:main-1787595359-141d372665a9@sha256:655cbee27d71566983be1b74c016676d59dcfcd9f984c5119d99fa9dd0a50533 # {"$imagepolicy": "flux-system:commands"}
           imagePullPolicy: IfNotPresent
           env:
             - name: NATS_HOST

--- a/deploy/k8s/console-admin.yaml
+++ b/deploy/k8s/console-admin.yaml
@@ -139,7 +139,7 @@ spec:
       priorityClassName: bagel-edge
       containers:
         - name: console-admin
-          image: ghcr.io/adamousmer/itsbagelbot/console-admin:main-1787254007-c739a93c3aff
+          image: ghcr.io/adamousmer/itsbagelbot/console-admin:main-1787595359-141d372665a9@sha256:ce8f5e067ad49be671b2f5dafb1f89b28cc0ae8f424b6d1b62302aad8599fa5c
           imagePullPolicy: IfNotPresent
           env:
             # mTLS client identity for both NATS planes (nats-client-tls,

--- a/deploy/k8s/console-dashboard.yaml
+++ b/deploy/k8s/console-dashboard.yaml
@@ -139,7 +139,7 @@ spec:
       priorityClassName: bagel-edge
       containers:
         - name: console-dashboard
-          image: ghcr.io/adamousmer/itsbagelbot/console-dashboard:main-1787272591-28ef907478c4@sha256:44b6be690a4ef1af2a0de84c202da5495ad91683455468f7f13e6f61c8df250c
+          image: ghcr.io/adamousmer/itsbagelbot/console-dashboard:main-1787595359-141d372665a9@sha256:f454315d21533c22aa71043da2b2b9dd00a5541f9ab185dddd054d2fcb774827
           imagePullPolicy: IfNotPresent
           env:
             - name: PORT

--- a/deploy/k8s/gossip.yaml
+++ b/deploy/k8s/gossip.yaml
@@ -168,7 +168,7 @@ spec:
       # "warp" package private right after its first publish.
       initContainers:
         - name: warp
-          image: ghcr.io/adamousmer/itsbagelbot/warp:main-0000000000-placeholder
+          image: ghcr.io/adamousmer/itsbagelbot/warp:main-1787595359-141d372665a9@sha256:379732f5759c50b95b7e827c878e8df3cf97619a66adb6d52293a70b37577bd4
           imagePullPolicy: IfNotPresent
           restartPolicy: Always # native sidecar: runs for the pod's lifetime
           # Bootstrap (consumer WARP, deliberately NO Zero Trust org). Two
@@ -249,7 +249,7 @@ spec:
               memory: 256Mi
       containers:
         - name: gossip
-          image: ghcr.io/adamousmer/itsbagelbot/gossip:main-1787194469-cb0d16209c6d@sha256:aa3094009ee618ca3bdb9bedd1136f6710f68cb9a901050361eaff6785bf6d38
+          image: ghcr.io/adamousmer/itsbagelbot/gossip:main-1787595359-141d372665a9@sha256:d3df8ccc667e269fde4b5a8210fba1517ccfdab61db88a19dcf8e96d0db4a5a5
           imagePullPolicy: IfNotPresent
           env:
             # gossip is RPC-only: it answers sesame's requests over

--- a/deploy/k8s/loyalty.yaml
+++ b/deploy/k8s/loyalty.yaml
@@ -118,7 +118,7 @@ spec:
       priorityClassName: bagel-service
       containers:
         - name: loyalty
-          image: ghcr.io/adamousmer/itsbagelbot/loyalty:main-1787270234-93d15b31822f@sha256:a1d7216beace84203dc5da52639ec982641a50efa51c8a568fa697cac2fa06d3
+          image: ghcr.io/adamousmer/itsbagelbot/loyalty:main-1787595359-141d372665a9@sha256:cc8b2fb2033c1c4c2fd86ee4be413f454350b8d5d0dedc0edca0be9f8d937506
           imagePullPolicy: IfNotPresent
           env:
             - name: NATS_HOST

--- a/deploy/k8s/modules.yaml
+++ b/deploy/k8s/modules.yaml
@@ -118,7 +118,7 @@ spec:
       priorityClassName: bagel-service
       containers:
         - name: modules
-          image: ghcr.io/adamousmer/itsbagelbot/modules:main-1787270234-93d15b31822f@sha256:0abc0f5c823539bb3391eac17597298714b5c2915e19dcf1ec9dcba466a2c838
+          image: ghcr.io/adamousmer/itsbagelbot/modules:main-1787595359-141d372665a9@sha256:0e7d047f8f8882116d685f82562e821642d972087856a8cbe2048178030794cb
           imagePullPolicy: IfNotPresent
           env:
             - name: NATS_HOST

--- a/deploy/k8s/notifications.yaml
+++ b/deploy/k8s/notifications.yaml
@@ -121,7 +121,7 @@ spec:
       priorityClassName: bagel-service
       containers:
         - name: notifications
-          image: ghcr.io/adamousmer/itsbagelbot/notifications:main-1787252044-f4347119cdf9@sha256:544b29cd22ef5b196bfb85a9e7d056622b3b464fafc98316bb069cfae093cd6a # {"$imagepolicy": "flux-system:notifications"}
+          image: ghcr.io/adamousmer/itsbagelbot/notifications:main-1787595359-141d372665a9@sha256:a9cdc98fb1d9dc0ee26205351f9748184110bed85077155a8248d21b61e66176 # {"$imagepolicy": "flux-system:notifications"}
           imagePullPolicy: IfNotPresent
           env:
             - name: NATS_HOST
@@ -257,7 +257,7 @@ spec:
             seccompProfile: {type: RuntimeDefault}
           containers:
             - name: cleanup
-              image: ghcr.io/adamousmer/itsbagelbot/notifications:main-1787252044-f4347119cdf9@sha256:544b29cd22ef5b196bfb85a9e7d056622b3b464fafc98316bb069cfae093cd6a # {"$imagepolicy": "flux-system:notifications"}
+              image: ghcr.io/adamousmer/itsbagelbot/notifications:main-1787595359-141d372665a9@sha256:a9cdc98fb1d9dc0ee26205351f9748184110bed85077155a8248d21b61e66176 # {"$imagepolicy": "flux-system:notifications"}
               imagePullPolicy: IfNotPresent
               args: ["cleanup"]
               env:

--- a/deploy/k8s/outgress.yaml
+++ b/deploy/k8s/outgress.yaml
@@ -126,7 +126,7 @@ spec:
       priorityClassName: bagel-service
       containers:
         - name: outgress
-          image: ghcr.io/adamousmer/itsbagelbot/outgress:main-1787252044-f4347119cdf9@sha256:11c377dce91778e91ae6dd7f1a7d2a5d3aa8694808a5e05e8049b86d54537310 # {"$imagepolicy": "flux-system:outgress"}
+          image: ghcr.io/adamousmer/itsbagelbot/outgress:main-1787595359-141d372665a9@sha256:6f4f9546cb4832cdee616c54a99f73d8aa080436a95b8b5e89910b754f601a24 # {"$imagepolicy": "flux-system:outgress"}
           imagePullPolicy: IfNotPresent
           env:
             - name: NATS_HOST

--- a/deploy/k8s/projector.yaml
+++ b/deploy/k8s/projector.yaml
@@ -118,7 +118,7 @@ spec:
       priorityClassName: bagel-service
       containers:
         - name: projector
-          image: ghcr.io/adamousmer/itsbagelbot/projector:main-1787252044-f4347119cdf9@sha256:6710f204b08274f1a19d18b3cfcbeca918f1e5eae516d68f2a686f46dbe3ccf3 # {"$imagepolicy": "flux-system:projector"}
+          image: ghcr.io/adamousmer/itsbagelbot/projector:main-1787595359-141d372665a9@sha256:2a7f88e7be85e75f5a1071343ea755f4b0e2c156446b7852b7989e6978c423e9 # {"$imagepolicy": "flux-system:projector"}
           imagePullPolicy: IfNotPresent
           env:
             # The lane catalog is partition-gated; the projector reconciles the

--- a/deploy/k8s/sesame.yaml
+++ b/deploy/k8s/sesame.yaml
@@ -130,7 +130,7 @@ spec:
       priorityClassName: bagel-service
       containers:
         - name: sesame
-          image: ghcr.io/adamousmer/itsbagelbot/sesame:main-1787270234-93d15b31822f@sha256:beda82e5c7cc3199260c694bbd5fa5d9bc332be0ef0b52baec94047411f1e1ec
+          image: ghcr.io/adamousmer/itsbagelbot/sesame:main-1787595359-141d372665a9@sha256:745c330c5720c1a92f74229648d9d8e0ffd31f1723dbbc3cfc562c47b7f71188
           imagePullPolicy: IfNotPresent
           env:
             - name: NATS_HOST

--- a/deploy/k8s/transactions.yaml
+++ b/deploy/k8s/transactions.yaml
@@ -118,7 +118,7 @@ spec:
       priorityClassName: bagel-service
       containers:
         - name: transactions
-          image: ghcr.io/adamousmer/itsbagelbot/transactions:main-1787252044-f4347119cdf9@sha256:1f1225f1014e8c9450d6320032bec9d7e7d9a89a4d45586a469a1461893f5f3c # {"$imagepolicy": "flux-system:transactions"}
+          image: ghcr.io/adamousmer/itsbagelbot/transactions:main-1787595359-141d372665a9@sha256:a3800029fedc38a5637706befd1335da244e91043d76aecec905df0c36e4aaa7 # {"$imagepolicy": "flux-system:transactions"}
           imagePullPolicy: IfNotPresent
           env:
             - name: NATS_HOST

--- a/deploy/k8s/twitch-ingress.yaml
+++ b/deploy/k8s/twitch-ingress.yaml
@@ -152,7 +152,7 @@ spec:
       priorityClassName: bagel-service
       containers:
         - name: ingress
-          image: ghcr.io/adamousmer/itsbagelbot/twitch-ingress:main-1787254007-c739a93c3aff
+          image: ghcr.io/adamousmer/itsbagelbot/twitch-ingress:main-1787595359-141d372665a9@sha256:1b37a27d5f6334afd1691a3ec2686248d304a7b5603b140011bcb37b22adb0cc
           imagePullPolicy: IfNotPresent
           envFrom:
             - secretRef:

--- a/deploy/k8s/users.yaml
+++ b/deploy/k8s/users.yaml
@@ -124,7 +124,7 @@ spec:
       priorityClassName: bagel-service
       containers:
         - name: users
-          image: ghcr.io/adamousmer/itsbagelbot/users:main-1787270234-93d15b31822f@sha256:d3f5de9fe8619fd4c14efeea2198ced21ee9e5a14211275d9debe6ca6095a106
+          image: ghcr.io/adamousmer/itsbagelbot/users:main-1787595359-141d372665a9@sha256:40c60d183ce5e1353eb1dcf92f232961ab29dc63c61b8b46e6fbb26badd15164
           imagePullPolicy: IfNotPresent
           env:
             - name: NATS_HOST


### PR DESCRIPTION
Pins every service to the current main tip from the clean full rebuild (all multi-arch manifests complete), tag@digest. Ships the whole undeployed wave: urlfetch, spotify stack, nuke, uptime, valorant, config import, #637 atomic-publish activation, plus today's i18n/size/go-mod CI fixes. Wires the real warp sidecar image (consumer WARP, proxy mode). Passes kubectl --dry-run=server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated container images across core application services to newer immutable builds.
  - Refreshed images for commands, administration, dashboard, gossip, loyalty, modules, notifications, outgress, projector, Sesame, transactions, Twitch ingress, and users.
  - Updated the notifications cleanup job and gossip support image.
  - Added digest pinning for the Twitch ingress image to ensure deployments use a specific, verifiable build.
  - Updated the WARP image to install the current Bookworm package and verify the installed client version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->