### PR TITLE
chore(deploy): re-pin warp to the image that actually contains the client

### DIFF
--- a/deploy/k8s/gossip.yaml
+++ b/deploy/k8s/gossip.yaml
@@ -168,7 +168,7 @@ spec:
       # "warp" package private right after its first publish.
       initContainers:
         - name: warp
-          image: ghcr.io/adamousmer/itsbagelbot/warp:main-1787595359-141d372665a9@sha256:379732f5759c50b95b7e827c878e8df3cf97619a66adb6d52293a70b37577bd4
+          image: ghcr.io/adamousmer/itsbagelbot/warp:main-1787597825-d5324cbf57a0@sha256:8b4e50ca01a8137164e8f3f309417c88393c5800d4afae7ea0b0455dd6859ab4
           imagePullPolicy: IfNotPresent
           restartPolicy: Always # native sidecar: runs for the pod's lifetime
           # Bootstrap (consumer WARP, deliberately NO Zero Trust org). Two


### PR DESCRIPTION
The prior warp pin predated the autoremove fix and shipped an empty image (no warp-cli, no warp-svc). Re-pins to the rebuilt image, verified by pulling the exact digest from ghcr and running warp-cli --version inside it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the WARP initialization component to a newer, verified build for improved deployment reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->