### PR TITLE
fix(warp): sidecar fixes found by rolling it to production

### DIFF
--- a/deploy/k8s/gossip.yaml
+++ b/deploy/k8s/gossip.yaml
@@ -228,9 +228,18 @@ spec:
             # (MASQUE) SOCKS proxy, so it needs neither — and withholding them
             # is the hard guarantee that WARP CANNOT create a tunnel interface
             # or rewrite routes in the shared pod netns, which is what would
-            # otherwise blackhole gossip's pod-to-pod traffic. runAsNonRoot
-            # stays false only because warp-svc writes its registration state
-            # as root; it binds loopback:40000 (>1024), needing no privilege.
+            # otherwise blackhole gossip's pod-to-pod traffic.
+            #
+            # runAsUser/runAsGroup 0 must be stated EXPLICITLY: the pod-level
+            # securityContext pins 65532, and runAsNonRoot:false alone does not
+            # replace it — the daemon then dies immediately with
+            # "PermissionDenied" (reproduced: `podman run --user 65532 …
+            # warp-svc` fails exactly this way, `--user 0` comes up in ~2s)
+            # because it cannot create its IPC socket or write its registration
+            # state. Root here buys no network privilege: it still holds no
+            # capabilities and binds only loopback:40000.
+            runAsUser: 0
+            runAsGroup: 0
             runAsNonRoot: false
             capabilities:
               drop: ["ALL"]
@@ -241,13 +250,22 @@ spec:
             - name: warp-socks
               containerPort: 40000
           readinessProbe:
-            # 45 x 2s = 90s. The listener binds only after daemon boot (~2s)
-            # AND consumer registration, which is a live call to Cloudflare —
-            # the old 30s budget left no room for a slow enrollment, and this
-            # is a native sidecar, so a sidecar that never reports ready keeps
-            # the whole gossip pod out of service and stalls the rollout.
-            tcpSocket:
-              port: warp-socks
+            # EXEC, not tcpSocket: warp-svc binds the proxy on 127.0.0.1:40000
+            # only — which is exactly what we want, since nothing outside this
+            # pod should reach the untrusted egress lane — but a tcpSocket
+            # probe dials the POD IP, where nothing is listening, so it can
+            # never pass. Observed as a pod stuck at 1/2 with the tunnel
+            # already Connected and the listener bound. The probe therefore
+            # has to run INSIDE the container's netns and check loopback.
+            #
+            # 45 x 2s = 90s: the listener appears only after daemon boot (~2s)
+            # plus consumer registration, a live call to Cloudflare, and this
+            # is a native sidecar whose readiness gates the whole gossip pod.
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - "ss -ltn | grep -q '127.0.0.1:40000'"
             periodSeconds: 2
             failureThreshold: 45
           livenessProbe:

--- a/deploy/k8s/gossip.yaml
+++ b/deploy/k8s/gossip.yaml
@@ -202,13 +202,24 @@ spec:
             - -ec
             - |
               warp-svc &
-              # Proxy mode is MASQUE-only since 2025.8; set it explicitly and
-              # tolerate a no-op on builds where proxy mode already implies it.
-              warp-cli --accept-tos tunnel protocol set MASQUE || true
+              # WAIT for the daemon's IPC socket before any warp-cli call.
+              # Without this the container crashloops on
+              # "Unable to connect to the CloudflareWARP daemon: No such file
+              # or directory" — warp-svc backgrounds instantly but takes ~2s to
+              # bind its socket, so every command raced it and failed. Polling
+              # `status` is the readiness signal (it answers "Registration
+              # Missing" once the daemon is up, which is a live response).
+              for i in $(seq 1 60); do
+                warp-cli --accept-tos status >/dev/null 2>&1 && break
+                sleep 1
+              done
+              # Consumer registration: no organization, no service token, no
+              # seat, no charge. Tolerated on failure because an in-place
+              # container restart reuses the emptyDir state and is already
+              # registered; a genuinely broken registration surfaces at connect.
+              warp-cli --accept-tos registration new || true
               warp-cli --accept-tos mode proxy
               warp-cli --accept-tos proxy port 40000
-              # Consumer registration: no organization, no service token, no seat.
-              warp-cli --accept-tos registration new || true
               warp-cli --accept-tos connect || true
               # Keep PID 1 alive for the sidecar lifetime; warp-svc serves the proxy.
               wait
@@ -230,15 +241,22 @@ spec:
             - name: warp-socks
               containerPort: 40000
           readinessProbe:
-            # 15 x 2s: generous enough to cover daemon boot, tight enough that
-            # a pod whose tunnel never comes up stops receiving traffic.
+            # 45 x 2s = 90s. The listener binds only after daemon boot (~2s)
+            # AND consumer registration, which is a live call to Cloudflare —
+            # the old 30s budget left no room for a slow enrollment, and this
+            # is a native sidecar, so a sidecar that never reports ready keeps
+            # the whole gossip pod out of service and stalls the rollout.
             tcpSocket:
               port: warp-socks
             periodSeconds: 2
-            failureThreshold: 15
+            failureThreshold: 45
           livenessProbe:
+            # initialDelaySeconds covers the same boot+registration window:
+            # without it the probe runs `status` against a daemon that is not
+            # listening yet and restarts the container mid-enrollment.
             exec:
               command: ["warp-cli", "--accept-tos", "status"]
+            initialDelaySeconds: 60
             periodSeconds: 30
           resources:
             requests:

--- a/deploy/k8s/network-policies.yaml
+++ b/deploy/k8s/network-policies.yaml
@@ -83,6 +83,36 @@ spec:
         - port: 443
           protocol: TCP
 ---
+# gossip's WARP sidecar needs UDP/443 on top of the TCP/443 above, and nothing
+# else in the fleet does. Proxy mode speaks MASQUE — HTTP/3 over QUIC, which is
+# UDP — and it is the ONLY protocol proxy mode supports since client 2025.8, so
+# there is no TCP fallback to lean on: without this rule the daemon sits in
+# "Performing happy eyeballs to 162.159.198.2:443" forever, the SOCKS listener
+# never binds, and the sidecar never reports ready (observed exactly that on
+# the first rollout).
+#
+# Scoped to app=gossip alone rather than widening allow-public-https, because
+# UDP egress to the whole Internet is a materially different exfiltration
+# surface from TCP/443 and only one workload has any use for it. The dial
+# targets are Cloudflare's WARP edge; they are not enumerable as a stable IP
+# list (anycast, and the client picks endpoints dynamically), so the rule is
+# port-scoped rather than destination-scoped.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-warp-masque
+  namespace: app
+spec:
+  podSelector:
+    matchLabels:
+      app: gossip
+  policyTypes:
+    - Egress
+  egress:
+    - ports:
+        - port: 443
+          protocol: UDP
+---
 # Data owners reach the managed HeatWave endpoint over the routed OCI private
 # subnet. Restricting both the workloads and destination prevents port 3306
 # from becoming a generic public-Internet exfiltration path. console-admin is


### PR DESCRIPTION
Three defects a dry-run cannot catch, each found and fixed during the live gossip rollout, now running on all 3 pods:

- **runAsUser 0**: pod-level securityContext pins 65532 and `runAsNonRoot:false` does not replace it, so warp-svc died instantly with PermissionDenied. Reproduced with podman (`--user 65532` fails, `--user 0` boots in ~2s). No capabilities added; still loopback-only.
- **allow-warp-masque netpol**: only TCP/443 egress existed, but proxy mode speaks MASQUE (HTTP/3 over QUIC = UDP/443) with no TCP fallback since client 2025.8 — the daemon hung in happy-eyeballs forever. Scoped to `app=gossip` alone.
- **readiness by exec**: warp binds 127.0.0.1:40000 only (correct), but a tcpSocket probe dials the pod IP and could never pass, holding the pod at 1/2 with a Connected tunnel.
- Plus the daemon-socket wait loop (warp-svc backgrounds instantly, takes ~2s to bind its IPC socket).

Verified in-cluster on all 3 pods: WARP Connected, and from the sidecar a direct curl reports `warp=off` while the same curl through the SOCKS proxy reports `warp=on` — proxy mode captures only what is handed to it, so pod-to-pod stays on the normal cluster path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved WARP proxy startup and readiness handling for more reliable connections.
  * Updated health checks to better reflect service availability and allow additional startup time.
  * Enabled the required secure network access for WARP MASQUE proxy connections.
  * Strengthened container security settings while preserving a restricted capability set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->