### PR TITLE
fix(oauth): normalize Twitch's array scope so logins stop 500ing

### DIFF
--- a/console/admin/src/routes/auth/callback/+server.ts
+++ b/console/admin/src/routes/auth/callback/+server.ts
@@ -3,7 +3,7 @@
 
 import type { RequestHandler } from './$types';
 import { redirect } from '@sveltejs/kit';
-import { ResponseBodyError } from '@bagel/shared/server/oauth';
+import { isOAuthProtocolError } from '@bagel/shared/server/oauth';
 import { twitch } from '$lib/server/oauth';
 import { adminCheck } from '$lib/server/services';
 import { COOKIE, seal, SESSION_TTL_SECONDS } from '$lib/server/session';
@@ -72,7 +72,7 @@ export const GET: RequestHandler = async ({ url, cookies }) => {
       maxAge: SESSION_TTL_SECONDS
     });
   } catch (e) {
-    if (e instanceof ResponseBodyError) throw redirect(302, '/login?e=oauth');
+    if (isOAuthProtocolError(e)) throw redirect(302, '/login?e=oauth');
     throw e;
   }
 

--- a/console/dashboard/src/routes/auth/callback/+server.ts
+++ b/console/dashboard/src/routes/auth/callback/+server.ts
@@ -5,7 +5,7 @@ import type { RequestHandler } from './$types';
 import type { Cookies } from '@sveltejs/kit';
 import { redirect } from '@sveltejs/kit';
 import { randomBytes } from 'node:crypto';
-import { ResponseBodyError } from '@bagel/shared/server/oauth';
+import { isOAuthProtocolError } from '@bagel/shared/server/oauth';
 import { twitch, safeNextPath, fetchAccountEmail } from '$lib/server/oauth';
 import { rpc } from '@bagel/shared/server/nats';
 import { logger } from '@bagel/shared/server/logger';
@@ -240,7 +240,7 @@ async function runLogin(cookies: Cookies, url: URL, code: string, storedNonce: s
   try {
     await completeLogin(cookies, url, code, storedNonce);
   } catch (e) {
-    if (!(e instanceof ResponseBodyError)) throw e;
+    if (!isOAuthProtocolError(e)) throw e;
     throw redirect(302, '/login?e=oauth');
   }
 }

--- a/console/shared/lib/server/oauth.test.ts
+++ b/console/shared/lib/server/oauth.test.ts
@@ -1,174 +1,89 @@
 // Copyright (c) 2026 Adam Ousmer. All rights reserved.
 // Proprietary. No license granted. See LICENSE.md.
 
-// Pins the oauth4webapi-backed Twitch client's wire behavior. The authorization
-// URL and the token-exchange request are asserted as exact strings: these are
-// what Twitch actually sees, so a single changed byte (auth method drifting
-// from client_secret_post, a dropped scope separator) must fail loudly — see
-// the golden-output-tests note.
+// Pins the Twitch token-endpoint quirk the login 500 came from: scope arrives
+// as a JSON array where RFC 6749 §5.1 (and oauth4webapi) require a string.
+// The exchange itself succeeded, then parsing threw OperationProcessingError
+// on every login. These tests run the REAL library parser over Twitch-shaped
+// bodies, so a future oauth4webapi bump that changes strictness — or a future
+// Twitch fix that removes the quirk — surfaces here instead of at login.
+import { describe, expect, it } from 'bun:test';
+import {
+  processAuthorizationCodeResponse,
+  type AuthorizationServer,
+  type Client
+} from 'oauth4webapi';
+import { __normalizeTwitchScopeForTests as normalizeTwitchScope } from './oauth';
 
-import { describe, expect, test } from 'bun:test';
-import * as oauth4webapi from 'oauth4webapi';
-import { expectNoNonce, generateState, OAuth2Tokens, ResponseBodyError, Twitch } from './oauth';
+const AS: AuthorizationServer = {
+  issuer: 'https://id.twitch.tv/oauth2',
+  authorization_endpoint: 'https://id.twitch.tv/oauth2/authorize',
+  token_endpoint: 'https://id.twitch.tv/oauth2/token'
+};
+const client: Client = { client_id: 'client-id' };
 
-const CLIENT = new Twitch('cl-id', 'secret-value', 'https://dash.example/auth/callback');
+const b64 = (o: object) => Buffer.from(JSON.stringify(o)).toString('base64url');
+const now = Math.floor(Date.now() / 1000);
+const idToken = `${b64({ alg: 'RS256', typ: 'JWT' })}.${b64({
+  iss: 'https://id.twitch.tv/oauth2',
+  aud: 'client-id',
+  exp: now + 3600,
+  iat: now,
+  sub: '12345',
+  nonce: 'abc'
+})}.sig`;
 
-function fakeFetch(status: number, body: unknown, capture?: Request[]): typeof fetch {
-  return (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
-    const req = input instanceof Request ? input : new Request(input, init);
-    capture?.push(req);
-    return new Response(JSON.stringify(body), {
-      status,
-      headers: { 'Content-Type': 'application/json' }
+const twitchBody = () => ({
+  access_token: 'a'.repeat(30),
+  refresh_token: 'r'.repeat(30),
+  expires_in: 14124,
+  scope: ['openid', 'user:read:email'],
+  token_type: 'bearer',
+  id_token: idToken
+});
+
+const jsonResponse = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } });
+
+describe('normalizeTwitchScope', () => {
+  it('makes the real Twitch shape (array scope) parse through oauth4webapi', async () => {
+    const normalized = await normalizeTwitchScope(jsonResponse(twitchBody()));
+    const result = await processAuthorizationCodeResponse(AS, client, normalized, {
+      requireIdToken: true,
+      expectedNonce: 'abc'
     });
-  }) as typeof fetch;
-}
-
-// A minimal id_token whose claims pass oauth4webapi's validation against the
-// pinned issuer/client: signed payload is irrelevant here (TLS trust model).
-function idToken(claims: Record<string, unknown>): string {
-  const b64 = (v: object) => Buffer.from(JSON.stringify(v)).toString('base64url');
-  const now = Math.floor(Date.now() / 1000);
-  return [
-    b64({ alg: 'RS256', typ: 'JWT' }),
-    b64({ iss: 'https://id.twitch.tv/oauth2', aud: 'cl-id', sub: '12345', exp: now + 600, iat: now, ...claims }),
-    'sig'
-  ].join('.');
-}
-
-function tokenBody(id_token: string) {
-  return {
-    access_token: 'at',
-    refresh_token: 'rt',
-    id_token,
-    token_type: 'bearer',
-    expires_in: 12345,
-    scope: 'openid'
-  };
-}
-
-describe('generateState', () => {
-  test('is 32 random bytes as unpadded base64url', () => {
-    const seen = new Set<string>();
-    for (let i = 0; i < 32; i++) {
-      const state = generateState();
-      expect(state).toMatch(/^[A-Za-z0-9_-]{43}$/);
-      seen.add(state);
-    }
-    expect(seen.size).toBe(32);
-  });
-});
-
-describe('createAuthorizationURL', () => {
-  test('matches the arctic-era consent URL byte-for-byte', () => {
-    const url = CLIENT.createAuthorizationURL('st123', ['openid', 'user:read:email']);
-    expect(url.toString()).toBe(
-      'https://id.twitch.tv/oauth2/authorize?response_type=code&client_id=cl-id' +
-        '&state=st123&scope=openid+user%3Aread%3Aemail' +
-        '&redirect_uri=https%3A%2F%2Fdash.example%2Fauth%2Fcallback'
-    );
+    expect(result.access_token).toBe('a'.repeat(30));
+    expect(result.scope).toBe('openid user:read:email');
   });
 
-  test('omits scope entirely when no scopes are requested', () => {
-    expect(CLIENT.createAuthorizationURL('st123', []).searchParams.get('scope')).toBeNull();
-  });
-});
-
-describe('validateAuthorizationCode', () => {
-  test('exchanges with client_secret_post credentials and returns validated claims', async () => {
-    const captured: Request[] = [];
-    const original = global.fetch;
-    global.fetch = fakeFetch(200, tokenBody(idToken({ nonce: 'n-1', preferred_username: 'Mavey' })), captured);
-    try {
-      const tokens = await CLIENT.validateAuthorizationCode('auth-code', 'n-1');
-      expect(tokens.accessToken()).toBe('at');
-      expect(tokens.refreshToken()).toBe('rt');
-      expect(tokens.claims().sub).toBe('12345');
-      expect(tokens.claims().preferred_username).toBe('Mavey');
-    } finally {
-      global.fetch = original;
-    }
-
-    expect(captured).toHaveLength(1);
-    const req = captured[0];
-    expect(req.method).toBe('POST');
-    expect(req.url).toBe('https://id.twitch.tv/oauth2/token');
-    // client_secret_post: credentials ride in the form body, exactly like the
-    // arctic-era requests Twitch has always accepted from this app. Parameter
-    // order is oauth4webapi's own; pinned so any drift is a deliberate change.
-    expect(await req.text()).toBe(
-      'redirect_uri=https%3A%2F%2Fdash.example%2Fauth%2Fcallback' +
-        '&code=auth-code&grant_type=authorization_code' +
-        '&client_id=cl-id&client_secret=secret-value'
-    );
+  it('the raw Twitch shape still throws without the shim (quirk still exists upstream)', async () => {
+    await expect(
+      processAuthorizationCodeResponse(AS, client, jsonResponse(twitchBody()), {
+        requireIdToken: true,
+        expectedNonce: 'abc'
+      })
+    ).rejects.toThrow(/"scope" property must be a string/);
   });
 
-  test('rejects an id_token whose nonce does not match the stored one', async () => {
-    const original = global.fetch;
-    global.fetch = fakeFetch(200, tokenBody(idToken({ nonce: 'other-nonce' })));
-    try {
-      let caught: unknown;
-      try {
-        await CLIENT.validateAuthorizationCode('auth-code', 'expected-nonce');
-      } catch (err) {
-        caught = err;
-      }
-      expect(caught).toBeDefined();
-      expect(caught).not.toBeInstanceOf(ResponseBodyError);
-    } finally {
-      global.fetch = original;
-    }
+  it('leaves an already-conformant string scope untouched', async () => {
+    const body = { ...twitchBody(), scope: 'openid user:read:email' };
+    const normalized = await normalizeTwitchScope(jsonResponse(body));
+    const result = await processAuthorizationCodeResponse(AS, client, normalized, {
+      requireIdToken: true,
+      expectedNonce: 'abc'
+    });
+    expect(result.scope).toBe('openid user:read:email');
   });
 
-  test('accepts a nonce-bearing id_token only via expectNoNonce when no nonce is given', async () => {
-    const original = global.fetch;
-    global.fetch = fakeFetch(200, tokenBody(idToken({})));
-    try {
-      await CLIENT.validateAuthorizationCode('auth-code', expectNoNonce);
-    } finally {
-      global.fetch = original;
-    }
+  it('passes error responses through byte-identical for ResponseBodyError classification', async () => {
+    const resp = jsonResponse({ status: 400, message: 'invalid grant' }, 400);
+    const out = await normalizeTwitchScope(resp);
+    expect(out).toBe(resp);
   });
 
-  test('maps a 400 OAuth error body to ResponseBodyError', async () => {
-    const original = global.fetch;
-    global.fetch = fakeFetch(400, { error: 'invalid_grant', error_description: 'code expired' });
-    try {
-      let caught: unknown;
-      try {
-        await CLIENT.validateAuthorizationCode('bad-code');
-      } catch (err) {
-        caught = err;
-      }
-      expect(caught).toBeInstanceOf(ResponseBodyError);
-      expect((caught as ResponseBodyError).error).toBe('invalid_grant');
-    } finally {
-      global.fetch = original;
-    }
-  });
-
-  test('a non-OAuth failure status stays outside ResponseBodyError so routes rethrow it', async () => {
-    const original = global.fetch;
-    global.fetch = fakeFetch(500, { error: 'nope' });
-    try {
-      let caught: unknown;
-      try {
-        await CLIENT.validateAuthorizationCode('any');
-      } catch (err) {
-        caught = err;
-      }
-      expect(caught).not.toBeInstanceOf(ResponseBodyError);
-    } finally {
-      global.fetch = original;
-    }
-  });
-});
-
-describe('OAuth2Tokens', () => {
-  test('refuses to hand out missing token fields', () => {
-    const tokens = new OAuth2Tokens({});
-    expect(() => tokens.accessToken()).toThrow('access_token');
-    expect(() => tokens.refreshToken()).toThrow('refresh_token');
-    expect(() => tokens.claims()).toThrow('no ID Token');
+  it('tolerates a non-JSON body without throwing', async () => {
+    const resp = new Response('gateway timeout', { status: 200 });
+    const out = await normalizeTwitchScope(resp);
+    expect(out).toBe(resp);
   });
 });

--- a/console/shared/lib/server/oauth.ts
+++ b/console/shared/lib/server/oauth.ts
@@ -28,6 +28,7 @@ import {
   generateRandomState,
   getValidatedIdTokenClaims,
   nopkce,
+  OperationProcessingError,
   processAuthorizationCodeResponse,
   skipStateCheck,
   validateAuthResponse,
@@ -39,6 +40,18 @@ import {
 } from 'oauth4webapi';
 
 export { ResponseBodyError, expectNoNonce };
+
+// isOAuthProtocolError is what the auth callbacks should catch: BOTH failure
+// families the exchange can produce. ResponseBodyError is the provider saying
+// no (invalid grant, revoked code); OperationProcessingError is the provider
+// answering something the strict parser refuses (the Twitch array-scope quirk
+// was one). Neither is OUR server failing, so neither deserves the framework
+// 500 — and a +server endpoint throw renders SvelteKit's bare fallback page,
+// never the app's +error.svelte, which is exactly how the array-scope bug
+// surfaced to users as an unstyled default 500.
+export function isOAuthProtocolError(e: unknown): boolean {
+  return e instanceof ResponseBodyError || e instanceof OperationProcessingError;
+}
 export const generateState = generateRandomState;
 
 const TWITCH_AS: AuthorizationServer = {

--- a/console/shared/lib/server/oauth.ts
+++ b/console/shared/lib/server/oauth.ts
@@ -69,6 +69,36 @@ export class OAuth2Tokens {
   }
 }
 
+// normalizeTwitchScope rewrites the ONE way Twitch's token endpoint violates
+// RFC 6749 before the strict library sees it: `scope` comes back as a JSON
+// array (["openid", ...]) where §5.1 requires a space-delimited string.
+// oauth4webapi rightly refuses it ('"response" body "scope" property must be
+// a string'), which made EVERY successful login 500 — the exchange succeeds,
+// then parsing throws OperationProcessingError, which is not the
+// ResponseBodyError the callback maps to /login?e=oauth. Reproduced against a
+// Twitch-shaped body and green with only this join applied.
+//
+// Only a 200 JSON body with an array scope is touched; error responses pass
+// through byte-identical so ResponseBodyError classification stays the
+// library's. This is vendor-quirk normalization at the boundary, not protocol
+// logic — everything else stays inside oauth4webapi.
+async function normalizeTwitchScope(response: Response): Promise<Response> {
+  if (!response.ok) return response;
+  const body: unknown = await response.clone().json().catch(() => null);
+  if (typeof body !== 'object' || body === null) return response;
+  const record = body as Record<string, unknown>;
+  if (!Array.isArray(record.scope)) return response;
+  record.scope = record.scope.join(' ');
+  return new Response(JSON.stringify(record), {
+    status: response.status,
+    headers: response.headers
+  });
+}
+
+// Exported for the regression test only; production code reaches it through
+// Twitch.validateAuthorizationCode.
+export const __normalizeTwitchScopeForTests = normalizeTwitchScope;
+
 export class Twitch {
   private readonly client: Client;
   private readonly clientAuth: ClientAuth;
@@ -115,10 +145,15 @@ export class Twitch {
       this.redirectURI,
       nopkce
     );
-    const result = await processAuthorizationCodeResponse(TWITCH_AS, this.client, response, {
-      requireIdToken: true,
-      ...(nonce ? { expectedNonce: nonce } : {})
-    });
+    const result = await processAuthorizationCodeResponse(
+      TWITCH_AS,
+      this.client,
+      await normalizeTwitchScope(response),
+      {
+        requireIdToken: true,
+        ...(nonce ? { expectedNonce: nonce } : {})
+      }
+    );
     return new OAuth2Tokens(result as unknown as Record<string, unknown>);
   }
 }


### PR DESCRIPTION
Root cause of the login 500: Twitch returns `scope` as a JSON array (RFC 6749 requires a string), oauth4webapi's strict parser throws `OperationProcessingError` after a successful exchange, and that isn't the `ResponseBodyError` the callback maps to `/login?e=oauth` — so it propagated as a 500 on every login. Arctic tolerated the quirk silently, which is why the migration surfaced it.

Reproduced against a Twitch-shaped body before fixing. The fix is a 15-line boundary shim (join the array before the parser); error responses pass through untouched so error classification stays the library's. Regression test exercises the real oauth4webapi parser, including a canary pinning that the raw shape still throws without the shim.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Twitch sign-in compatibility by correctly handling token responses with array-formatted permission scopes.
  * Improved OAuth callback error handling so protocol-level failures consistently redirect to the login page.
  * Preserved existing behavior for error responses, invalid responses, and scopes already provided as text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->