### PR TITLE
chore(deploy): roll consoles onto the oauth login fix

### DIFF
--- a/deploy/k8s/console-admin.yaml
+++ b/deploy/k8s/console-admin.yaml
@@ -139,7 +139,7 @@ spec:
       priorityClassName: bagel-edge
       containers:
         - name: console-admin
-          image: ghcr.io/adamousmer/itsbagelbot/console-admin:main-1787595359-141d372665a9@sha256:ce8f5e067ad49be671b2f5dafb1f89b28cc0ae8f424b6d1b62302aad8599fa5c
+          image: ghcr.io/adamousmer/itsbagelbot/console-admin:main-1787602824-6d5407f480ab@sha256:66d9b099276205a547ab934eb73a4d863c4670fc2df998b23f7f3bc3b325f313
           imagePullPolicy: IfNotPresent
           env:
             # mTLS client identity for both NATS planes (nats-client-tls,

--- a/deploy/k8s/console-dashboard.yaml
+++ b/deploy/k8s/console-dashboard.yaml
@@ -139,7 +139,7 @@ spec:
       priorityClassName: bagel-edge
       containers:
         - name: console-dashboard
-          image: ghcr.io/adamousmer/itsbagelbot/console-dashboard:main-1787595359-141d372665a9@sha256:f454315d21533c22aa71043da2b2b9dd00a5541f9ab185dddd054d2fcb774827
+          image: ghcr.io/adamousmer/itsbagelbot/console-dashboard:main-1787602824-6d5407f480ab@sha256:8707a5acd2613c5c80d7a5a85feadd05747b46f927bec51f659fd3a301fb45fa
           imagePullPolicy: IfNotPresent
           env:
             - name: PORT


### PR DESCRIPTION
Pins both console images to main-1787602824-6d5407f480ab (Twitch array-scope normalization + protocol-error redirect hardening). Already applied to the cluster as the login hotfix; this records the pins.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Console Admin and Console Dashboard deployments to use newer pinned container images.
  * Improved deployment consistency and reproducibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->