### PR TITLE
fix(nats): let the dashboard reach gossip's fetch rehearsal verb

### DIFF
--- a/deploy/messaging/nats-auth.conf
+++ b/deploy/messaging/nats-auth.conf
@@ -775,6 +775,15 @@ accounts: {
       # the gossip service (which holds the decrypted key), scoped to just that verb.
       { service: { account: "GOSSIP_RPC",   subject: "bagel.rpc.gossip.govee.devices" } }
       { service: { account: "GOSSIP_RPC",   subject: "bagel.rpc.gossip.govee.devices.node.*" } }
+      # The fetch-definition rehearsal ("Test run" on the fetches page) runs
+      # the REAL chat path: same subject, same SSRF gate, same buckets, with
+      # DryRun set. Scoped to this one verb rather than bagel.rpc.gossip.>,
+      # matching the govee precedent above — the web tier has no business
+      # reaching the provider endpoints sesame calls. Without it the request
+      # is dropped by the ACL with no error on either side and the button just
+      # times out, which is how this class of gap has bitten twice before.
+      { service: { account: "GOSSIP_RPC",   subject: "bagel.rpc.gossip.custom.fetch" } }
+      { service: { account: "GOSSIP_RPC",   subject: "bagel.rpc.gossip.custom.fetch.node.*" } }
       { service: { account: "NOTIFICATIONS_RPC", subject: "bagel.rpc.notifications.>" } }
       { service: { account: "TRANSACTIONS_RPC",  subject: "bagel.rpc.transactions.>" } }
       { stream: { account: "USERS_RPC",     subject: "bagel.cache.invalidate.grant" } }


### PR DESCRIPTION
DASHBOARD_RPC imported only the govee verbs from GOSSIP_RPC, but the fetches page's Test run calls bagel.rpc.gossip.custom.fetch — the classic silent ACL drop (request vanishes, button times out). Scoped to the single verb per the govee precedent. Needs the nats conf apply + SIGHUP to take effect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled dashboard-initiated custom fetch test runs through improved service authorization.
  - Added support for accessing node-specific custom fetch services during gossip operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->