### PR TITLE
chore(deploy): bump fleet to main-1787603663-a1c27f889ca7

### DIFF
--- a/deploy/k8s/commands.yaml
+++ b/deploy/k8s/commands.yaml
@@ -118,7 +118,7 @@ spec:
       priorityClassName: bagel-service
       containers:
         - name: commands
-          image: ghcr.io/adamousmer/itsbagelbot/commands:main-1787595359-141d372665a9@sha256:655cbee27d71566983be1b74c016676d59dcfcd9f984c5119d99fa9dd0a50533 # {"$imagepolicy": "flux-system:commands"}
+          image: ghcr.io/adamousmer/itsbagelbot/commands:main-1787603663-a1c27f889ca7@sha256:f164758dc3b5f1006e21f323cf5a9ab9aaa7cf10f377e0cdccdbcc3c4a3b312d # {"$imagepolicy": "flux-system:commands"}
           imagePullPolicy: IfNotPresent
           env:
             - name: NATS_HOST

--- a/deploy/k8s/console-admin.yaml
+++ b/deploy/k8s/console-admin.yaml
@@ -139,7 +139,7 @@ spec:
       priorityClassName: bagel-edge
       containers:
         - name: console-admin
-          image: ghcr.io/adamousmer/itsbagelbot/console-admin:main-1787602824-6d5407f480ab@sha256:66d9b099276205a547ab934eb73a4d863c4670fc2df998b23f7f3bc3b325f313
+          image: ghcr.io/adamousmer/itsbagelbot/console-admin:main-1787603663-a1c27f889ca7@sha256:8f8a7639bffc85673d1fa5c5c090223d2e6b4bd82d7b345838c606076be69e14
           imagePullPolicy: IfNotPresent
           env:
             # mTLS client identity for both NATS planes (nats-client-tls,

--- a/deploy/k8s/console-dashboard.yaml
+++ b/deploy/k8s/console-dashboard.yaml
@@ -139,7 +139,7 @@ spec:
       priorityClassName: bagel-edge
       containers:
         - name: console-dashboard
-          image: ghcr.io/adamousmer/itsbagelbot/console-dashboard:main-1787602824-6d5407f480ab@sha256:8707a5acd2613c5c80d7a5a85feadd05747b46f927bec51f659fd3a301fb45fa
+          image: ghcr.io/adamousmer/itsbagelbot/console-dashboard:main-1787603663-a1c27f889ca7@sha256:f1f4f58b1fb45a341905972a42ea38b9a064f8548ddbfd8532c5c03186985b1c
           imagePullPolicy: IfNotPresent
           env:
             - name: PORT

--- a/deploy/k8s/gossip.yaml
+++ b/deploy/k8s/gossip.yaml
@@ -168,7 +168,7 @@ spec:
       # "warp" package private right after its first publish.
       initContainers:
         - name: warp
-          image: ghcr.io/adamousmer/itsbagelbot/warp:main-1787597825-d5324cbf57a0@sha256:8b4e50ca01a8137164e8f3f309417c88393c5800d4afae7ea0b0455dd6859ab4
+          image: ghcr.io/adamousmer/itsbagelbot/warp:main-1787603663-a1c27f889ca7@sha256:68baa5313abcb1ea376f99a0aa06faeaa37df3dcb4ab6c1dddc0cc6f13a2d66e
           imagePullPolicy: IfNotPresent
           restartPolicy: Always # native sidecar: runs for the pod's lifetime
           # Bootstrap (consumer WARP, deliberately NO Zero Trust org). Two
@@ -285,7 +285,7 @@ spec:
               memory: 256Mi
       containers:
         - name: gossip
-          image: ghcr.io/adamousmer/itsbagelbot/gossip:main-1787595359-141d372665a9@sha256:d3df8ccc667e269fde4b5a8210fba1517ccfdab61db88a19dcf8e96d0db4a5a5
+          image: ghcr.io/adamousmer/itsbagelbot/gossip:main-1787603663-a1c27f889ca7@sha256:88401dd6400106d5a597227664b168a4ef19dc6a18e5106fb3b6e270a63e798c
           imagePullPolicy: IfNotPresent
           env:
             # gossip is RPC-only: it answers sesame's requests over

--- a/deploy/k8s/loyalty.yaml
+++ b/deploy/k8s/loyalty.yaml
@@ -118,7 +118,7 @@ spec:
       priorityClassName: bagel-service
       containers:
         - name: loyalty
-          image: ghcr.io/adamousmer/itsbagelbot/loyalty:main-1787595359-141d372665a9@sha256:cc8b2fb2033c1c4c2fd86ee4be413f454350b8d5d0dedc0edca0be9f8d937506
+          image: ghcr.io/adamousmer/itsbagelbot/loyalty:main-1787603663-a1c27f889ca7@sha256:4293e98cfca80e77b284c646d9185c1deec733ef213f031b612c21bb452e63ea
           imagePullPolicy: IfNotPresent
           env:
             - name: NATS_HOST

--- a/deploy/k8s/modules.yaml
+++ b/deploy/k8s/modules.yaml
@@ -118,7 +118,7 @@ spec:
       priorityClassName: bagel-service
       containers:
         - name: modules
-          image: ghcr.io/adamousmer/itsbagelbot/modules:main-1787595359-141d372665a9@sha256:0e7d047f8f8882116d685f82562e821642d972087856a8cbe2048178030794cb
+          image: ghcr.io/adamousmer/itsbagelbot/modules:main-1787603663-a1c27f889ca7@sha256:f500963c20f571889c6b1ff37349cc8e395e4b72cf34176fd7dc2a59a062d2dd
           imagePullPolicy: IfNotPresent
           env:
             - name: NATS_HOST

--- a/deploy/k8s/notifications.yaml
+++ b/deploy/k8s/notifications.yaml
@@ -121,7 +121,7 @@ spec:
       priorityClassName: bagel-service
       containers:
         - name: notifications
-          image: ghcr.io/adamousmer/itsbagelbot/notifications:main-1787595359-141d372665a9@sha256:a9cdc98fb1d9dc0ee26205351f9748184110bed85077155a8248d21b61e66176 # {"$imagepolicy": "flux-system:notifications"}
+          image: ghcr.io/adamousmer/itsbagelbot/notifications:main-1787603663-a1c27f889ca7@sha256:b865c4cb6e1e51e17c53f38c44e2be346b0b2dcff76af306856cb96b748df751 # {"$imagepolicy": "flux-system:notifications"}
           imagePullPolicy: IfNotPresent
           env:
             - name: NATS_HOST
@@ -257,7 +257,7 @@ spec:
             seccompProfile: {type: RuntimeDefault}
           containers:
             - name: cleanup
-              image: ghcr.io/adamousmer/itsbagelbot/notifications:main-1787595359-141d372665a9@sha256:a9cdc98fb1d9dc0ee26205351f9748184110bed85077155a8248d21b61e66176 # {"$imagepolicy": "flux-system:notifications"}
+              image: ghcr.io/adamousmer/itsbagelbot/notifications:main-1787603663-a1c27f889ca7@sha256:b865c4cb6e1e51e17c53f38c44e2be346b0b2dcff76af306856cb96b748df751 # {"$imagepolicy": "flux-system:notifications"}
               imagePullPolicy: IfNotPresent
               args: ["cleanup"]
               env:

--- a/deploy/k8s/outgress.yaml
+++ b/deploy/k8s/outgress.yaml
@@ -126,7 +126,7 @@ spec:
       priorityClassName: bagel-service
       containers:
         - name: outgress
-          image: ghcr.io/adamousmer/itsbagelbot/outgress:main-1787595359-141d372665a9@sha256:6f4f9546cb4832cdee616c54a99f73d8aa080436a95b8b5e89910b754f601a24 # {"$imagepolicy": "flux-system:outgress"}
+          image: ghcr.io/adamousmer/itsbagelbot/outgress:main-1787603663-a1c27f889ca7@sha256:df0c1dbfa7744cb7a99fd821dae4c54194690b0fd80af9628c0abf149d551fa1 # {"$imagepolicy": "flux-system:outgress"}
           imagePullPolicy: IfNotPresent
           env:
             - name: NATS_HOST

--- a/deploy/k8s/projector.yaml
+++ b/deploy/k8s/projector.yaml
@@ -118,7 +118,7 @@ spec:
       priorityClassName: bagel-service
       containers:
         - name: projector
-          image: ghcr.io/adamousmer/itsbagelbot/projector:main-1787595359-141d372665a9@sha256:2a7f88e7be85e75f5a1071343ea755f4b0e2c156446b7852b7989e6978c423e9 # {"$imagepolicy": "flux-system:projector"}
+          image: ghcr.io/adamousmer/itsbagelbot/projector:main-1787603663-a1c27f889ca7@sha256:9fe036f8a6530a3c544b1038c726430f71a815dc8f32f9985ecc580eb49f6b3b # {"$imagepolicy": "flux-system:projector"}
           imagePullPolicy: IfNotPresent
           env:
             # The lane catalog is partition-gated; the projector reconciles the

--- a/deploy/k8s/sesame.yaml
+++ b/deploy/k8s/sesame.yaml
@@ -130,7 +130,7 @@ spec:
       priorityClassName: bagel-service
       containers:
         - name: sesame
-          image: ghcr.io/adamousmer/itsbagelbot/sesame:main-1787595359-141d372665a9@sha256:745c330c5720c1a92f74229648d9d8e0ffd31f1723dbbc3cfc562c47b7f71188
+          image: ghcr.io/adamousmer/itsbagelbot/sesame:main-1787603663-a1c27f889ca7@sha256:40e15fb07062348c3fc82bce9ce010a6d7e6477caefe8cd3f75c214ecf3cd133
           imagePullPolicy: IfNotPresent
           env:
             - name: NATS_HOST

--- a/deploy/k8s/transactions.yaml
+++ b/deploy/k8s/transactions.yaml
@@ -118,7 +118,7 @@ spec:
       priorityClassName: bagel-service
       containers:
         - name: transactions
-          image: ghcr.io/adamousmer/itsbagelbot/transactions:main-1787595359-141d372665a9@sha256:a3800029fedc38a5637706befd1335da244e91043d76aecec905df0c36e4aaa7 # {"$imagepolicy": "flux-system:transactions"}
+          image: ghcr.io/adamousmer/itsbagelbot/transactions:main-1787603663-a1c27f889ca7@sha256:dd8a123ac4ab006e1f4756ce9229a9f5e7ed1c78520b2b2d28ee2c6bfbeebb6a # {"$imagepolicy": "flux-system:transactions"}
           imagePullPolicy: IfNotPresent
           env:
             - name: NATS_HOST

--- a/deploy/k8s/twitch-ingress.yaml
+++ b/deploy/k8s/twitch-ingress.yaml
@@ -152,7 +152,7 @@ spec:
       priorityClassName: bagel-service
       containers:
         - name: ingress
-          image: ghcr.io/adamousmer/itsbagelbot/twitch-ingress:main-1787595359-141d372665a9@sha256:1b37a27d5f6334afd1691a3ec2686248d304a7b5603b140011bcb37b22adb0cc
+          image: ghcr.io/adamousmer/itsbagelbot/twitch-ingress:main-1787603663-a1c27f889ca7@sha256:a0669decd767a7f85831580dac417e4595fc6563d90d1bdb68b6dda75b3dd7c1
           imagePullPolicy: IfNotPresent
           envFrom:
             - secretRef:

--- a/deploy/k8s/users.yaml
+++ b/deploy/k8s/users.yaml
@@ -124,7 +124,7 @@ spec:
       priorityClassName: bagel-service
       containers:
         - name: users
-          image: ghcr.io/adamousmer/itsbagelbot/users:main-1787595359-141d372665a9@sha256:40c60d183ce5e1353eb1dcf92f232961ab29dc63c61b8b46e6fbb26badd15164
+          image: ghcr.io/adamousmer/itsbagelbot/users:main-1787603663-a1c27f889ca7@sha256:256576d66edf6cdccb0b691c67254680c317bd022a3d844032d21802de900dbd
           imagePullPolicy: IfNotPresent
           env:
             - name: NATS_HOST


### PR DESCRIPTION
Pins every service to the current main tip from the clean full rebuild (tag@digest): go-dependency bumps in the Go binaries, oauth login fix + motion bump in consoles, WARP sidecar config carried forward. Applied to the cluster as the deploy; this records the pins.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment images across platform services to newer immutable, digest-pinned builds.
  * Refreshed the gossip sidecar and service images.
  * Updated the notifications deployment and cleanup job to the latest release build.
  * Improved consistency and traceability of deployed container versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->