### PR TITLE
fix(security): publish security.txt and record status-path invariant

### DIFF
--- a/console/dashboard/static/.well-known/security.txt
+++ b/console/dashboard/static/.well-known/security.txt
@@ -1,0 +1,4 @@
+Contact: mailto:support@itsbagelbot.com
+Expires: 2027-08-25T00:00:00Z
+Preferred-Languages: en
+Canonical: https://itsbagelbot.com/.well-known/security.txt

--- a/deploy/db/status-routes.yaml
+++ b/deploy/db/status-routes.yaml
@@ -7,6 +7,11 @@
 # Services, transports, middleware and routes live here beside the pods after
 # the app/db split. The webhook route rides along: it terminates on the same
 # transactions Service.
+#
+# Path-shape note (measured 2026-08-25): edge normalization folds //svc,
+# /./svc onto the clean path before matching, but replacePath pins the
+# backend to /status for every match, so the reachable set is still exactly
+# {<svc> -> /status}. See deploy/k8s/status-routes.yaml for the probe list.
 apiVersion: v1
 kind: Service
 metadata:

--- a/deploy/k8s/status-routes.yaml
+++ b/deploy/k8s/status-routes.yaml
@@ -8,6 +8,15 @@
 # from outside; /healthz, /readyz and /drain stay cluster-internal (a public
 # /drain would let anyone hold handler goroutines for 10s a request).
 #
+# Path-shape note (measured 2026-08-25, live-probed): edge URL normalization
+# folds //gossip and /./gossip onto the clean path before matching, so those
+# shapes DO reach this router — but replacePath pins every match to /status,
+# and /gossip%2fstatus, /gossip/../drain, //gossip/drain all miss into the
+# unrouted fallback (302). The reachable-endpoint invariant survives every
+# observed shape: exactly {<svc> -> /status}. Accepted as-is rather than
+# adding a canonicalization middleware: it would buy zero reachable-set
+# reduction on a surface whose only endpoint is already public.
+#
 # DNS needs no record work: the cloudflared tunnel wildcard admits any
 # *.itsbagelbot.com hostname, and this router claiming Host(health...) is what
 # lifts it out of the unrouted-host fallback (web-error-pages.yaml, priority 1).

--- a/web/public/.well-known/security.txt
+++ b/web/public/.well-known/security.txt
@@ -1,0 +1,4 @@
+Contact: mailto:support@itsbagelbot.com
+Expires: 2027-08-25T00:00:00Z
+Preferred-Languages: en
+Canonical: https://itsbagelbot.com/.well-known/security.txt


### PR DESCRIPTION
Fixes findings #4/#5 from the Aug 2026 external security test.

- **security.txt** served per RFC 9116 from the apex (`web/public/.well-known/`) and console static dir (dashboard, stats, commands, leaderboard hosts). Contact: support@, expires 2027-08-25.
- **status-route path-shape record**: both `status-routes.yaml` manifests now document the live-measured normalization behaviour — `//svc`/`/./svc` fold onto the clean path but `replacePath` pins every match to `/status`; `%2f`, dot-segment and multi-slash variants of blocked paths all fall through to the unrouted fallback. Reachable set stays exactly `{<svc> -> /status}`, so no canonicalization middleware is added.

CAA, SPF/DKIM/DMARC and HSTS are applied out-of-band in the Cloudflare dashboard.

Verification: `.github/scripts/check_route_schemes.py` passes; comment-only YAML changes plus two new static files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added security contact information, expiration details, preferred language, and canonical URL for vulnerability reporting.
  * Documented status-route normalization and rewriting behavior across deployment configurations.
  * Clarified how normalized, encoded, and traversal-style paths are handled by routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->