### PR TITLE
docs(web): add v1.0.1-beta changelog

### DIFF
--- a/web/src/content/changelog/v1.0.1-beta.json
+++ b/web/src/content/changelog/v1.0.1-beta.json
@@ -1,0 +1,14 @@
+{
+  "tag": "beta",
+  "version": "v1.0.1-beta",
+  "date": "2026-08-25",
+  "title": {
+    "en": "Game Integrations & AutoMod Beta",
+    "fr": "Intégrations de jeux et Bêta AutoMod"
+  },
+  "description": {
+    "en": "Added Valorant, Spotify, and Clash Royale integrations. Launched the new AutoMod (Beta) with reputation-based cohorts and learned protections. Included various security fixes.",
+    "fr": "Ajout des intégrations Valorant, Spotify et Clash Royale. Lancement du nouvel AutoMod (Bêta) avec des cohortes basées sur la réputation et des protections apprises. Inclusion de divers correctifs de sécurité."
+  },
+  "github": "https://github.com/AdamOusmer/ItsBagelBot/releases/tag/v1.0.1-beta"
+}


### PR DESCRIPTION
Added changelog json for v1.0.1-beta

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added the v1.0.1-beta changelog entry dated August 25, 2026.
  - Documented new Valorant, Spotify, and Clash Royale integrations.
  - Highlighted the AutoMod beta, reputation-based cohorts, learned protections, and security fixes.
  - Provided English and French translations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->