### PR TITLE
feat(sesame): dynamic link-safety checker for the automod

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,12 @@
+title = "ItsBagelBot gitleaks config"
+
+# Keep every default gitleaks rule; only extend the allowlist below.
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Known false positives: link-safety test fixtures use punycode host strings (xn--…) that the generic-api-key heuristic misreads as secrets."
+regexTarget = "match"
+regexes = [
+  '''xn--[a-z0-9-]+''',
+]

--- a/app/sesame/automod/gate.go
+++ b/app/sesame/automod/gate.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"ItsBagelBot/app/sesame/automod/linkcheck"
 	"ItsBagelBot/app/sesame/module"
 	"ItsBagelBot/internal/moderation"
 )
@@ -50,8 +51,8 @@ type styleLimits struct {
 }
 
 // Gate is the inline automod. Safe for concurrent use: categories are read-only
-// after New, the emote set and lexicon are swapped atomically, and skeleton
-// buffers come from a pool.
+// after New, the emote set, lexicon, baseline and link checker are swapped
+// atomically, and skeleton buffers come from a pool.
 type Gate struct {
 	cats     []category
 	buf      sync.Pool
@@ -59,6 +60,7 @@ type Gate struct {
 	lexicon  atomic.Pointer[moderation.Lexicon]
 	extra    atomic.Pointer[extraBox]
 	baseline atomic.Pointer[Baseline]
+	links    atomic.Pointer[linkcheck.Checker]
 }
 
 // New builds a Gate with the default curated blocklists and the embedded
@@ -91,6 +93,13 @@ func (g *Gate) SetLexicon(l *moderation.Lexicon) {
 // the static ceilings, so installing or removing it can never mint a verdict
 // that would not have existed before. Safe to call at any time.
 func (g *Gate) SetBaseline(b *Baseline) { g.baseline.Store(b) }
+
+// SetLinkChecker arms the dynamic link-safety layer (nil, the default, keeps
+// verdicts byte-identical to the unarmed gate). The checker's Evaluate is
+// read-only on the hot path - cache and feed-snapshot lookups - with unknown
+// hosts resolved on its own goroutines; see the linkcheck package for why it
+// never fetches chat links. Safe to call at any time.
+func (g *Gate) SetLinkChecker(c *linkcheck.Checker) { g.links.Store(c) }
 
 // Signals is the council evidence Assess gathers alongside the verdict, for the
 // jurors that live outside the gate (the valkey campaign tracker and the
@@ -161,14 +170,18 @@ func (g *Gate) InspectWith(role module.Role, text string, cfg *Config, opts ...A
 // normalization and the scans. Both floor halves are still pre-scanned on the
 // clean path - allocation-free folded passes over the hate lexicon and the
 // infrastructure blocklists - so an immovable-floor hit there routes onto the
-// deep path instead of bailing clean.
+// deep path instead of bailing clean. The link checker (when armed) adds the
+// third bounded clean-path scan, gated on the line containing a dot: its
+// Evaluate is allocation-light token walking over cache/feed-snapshot reads,
+// and a known-bad host routes onto the deep path exactly like a floor hit.
 //
 // Council order on the deep path: immovable floor (infrastructure blocklist +
-// hate lexicon; every profile, never suppressed by allow-terms) -> language
-// juror (reliably non-latin text is never judged by the English word lists) ->
-// lexicon categories gated by profile -> channel block-terms -> heuristics with
-// emote and allow-term suppression. In shadow mode the caller logs the verdict
-// and takes no action.
+// hate lexicon; every profile, never suppressed by allow-terms) -> dynamic
+// link verdicts ("phish", armed via SetLinkChecker; judged from the checker's
+// cache and feed snapshot only) -> language juror (reliably non-latin text is
+// never judged by the English word lists) -> lexicon categories gated by
+// profile -> channel block-terms -> heuristics with emote and allow-term
+// suppression. In shadow mode the caller logs the verdict and takes no action.
 // assessScope is the resolved option set Assess acts on.
 type assessScope struct {
 	msgCodes map[string]struct{}
@@ -215,7 +228,17 @@ func (g *Gate) Assess(role module.Role, text string, cfg *Config, opts ...Assess
 	g.observeLearned(uint64(sc.ch), sc.sender, text, sig)
 	flags := g.resolveStyle(sig, sec, sc.ch, text)
 
-	if g.cleanPathBail(sig, flags, cfg, text) {
+	// Link checker pre-scan (armed only; see Assess's doc comment): unknown
+	// hosts enqueue for background classification even when this line goes on
+	// to bail clean - a short "bit.ly/x" line is precisely the shape worth
+	// resolving - while an already-convicted host forces the deep path so the
+	// phish verdict resolves in council order (floor first) below.
+	lk := g.links.Load()
+	linkBad := false
+	if lk != nil && sec.links {
+		linkBad = lk.Evaluate(text, uint64(sc.ch), sc.sender)
+	}
+	if !linkBad && g.cleanPathBail(sig, flags, cfg, text) {
 		return Verdict{}, Signals{}
 	}
 
@@ -229,6 +252,15 @@ func (g *Gate) Assess(role module.Role, text string, cfg *Config, opts ...Assess
 
 	if v, hit := g.floorInfra(skel); hit {
 		return v, out
+	}
+
+	// Dynamic link verdicts: the checker's Evaluate re-run here is idempotent
+	// (in-flight and cached keys skip), so the pre-scan's side effects do not
+	// duplicate. Same timeout tier as ip_logger/scam - infrastructure class -
+	// but its own rule name so stats and shadow logs separate learned
+	// convictions from the curated floor.
+	if lk != nil && sec.links && lk.Evaluate(text, uint64(sc.ch), sc.sender) {
+		return Verdict{Action: ActionTimeout, Seconds: 600, Rule: "phish"}, out
 	}
 
 	cat, term := g.lexiconScan(sig, text, skel)

--- a/app/sesame/automod/gate.go
+++ b/app/sesame/automod/gate.go
@@ -233,12 +233,7 @@ func (g *Gate) Assess(role module.Role, text string, cfg *Config, opts ...Assess
 	// to bail clean - a short "bit.ly/x" line is precisely the shape worth
 	// resolving - while an already-convicted host forces the deep path so the
 	// phish verdict resolves in council order (floor first) below.
-	lk := g.links.Load()
-	linkBad := false
-	if lk != nil && sec.links {
-		linkBad = lk.Evaluate(text, uint64(sc.ch), sc.sender)
-	}
-	if !linkBad && g.cleanPathBail(sig, flags, cfg, text) {
+	if !g.linkConvicted(sec, sc, text) && g.cleanPathBail(sig, flags, cfg, text) {
 		return Verdict{}, Signals{}
 	}
 
@@ -259,7 +254,7 @@ func (g *Gate) Assess(role module.Role, text string, cfg *Config, opts ...Assess
 	// duplicate. Same timeout tier as ip_logger/scam - infrastructure class -
 	// but its own rule name so stats and shadow logs separate learned
 	// convictions from the curated floor.
-	if lk != nil && sec.links && lk.Evaluate(text, uint64(sc.ch), sc.sender) {
+	if g.linkConvicted(sec, sc, text) {
 		return Verdict{Action: ActionTimeout, Seconds: 600, Rule: "phish"}, out
 	}
 
@@ -287,6 +282,19 @@ func (g *Gate) Assess(role module.Role, text string, cfg *Config, opts ...Assess
 	}
 
 	return g.heuristicVerdict(styleAttempt{sig: sig, flags: flags, allowed: allowed, text: text}, sc), out
+}
+
+// linkConvicted runs the dynamic link checker for one line and reports whether
+// it carries an already-convicted host. Unknown hosts enqueue as a side effect,
+// so the pre-scan and the deep-path re-run both call this (Evaluate is
+// idempotent). Inert (false) when no checker is armed or the channel's links
+// section is off, folding that arm/enable pair out of Assess's two call sites.
+func (g *Gate) linkConvicted(sec sections, sc assessScope, text string) bool {
+	lk := g.links.Load()
+	if lk == nil || !sec.links {
+		return false
+	}
+	return lk.Evaluate(text, uint64(sc.ch), sc.sender)
 }
 
 // styleAttempt is the style-juror's full view of one line: the resolved flags,

--- a/app/sesame/automod/linkcheck/cache.go
+++ b/app/sesame/automod/linkcheck/cache.go
@@ -113,15 +113,27 @@ func (c *cache) put(key string, v Verdict, short bool) {
 	c.m[key] = entry{v: v, exp: nowNanos() + int64(ttl)}
 }
 
-// sweepLocked drops expired entries; if the cap still binds, arbitrary live
-// entries go too (see maxEntries for why arbitrary is acceptable here).
+// sweepLocked makes room under the hard cap: expired entries go first, and
+// only if the cap still binds do arbitrary live entries go too (see
+// maxEntries for why arbitrary is acceptable here).
 func (c *cache) sweepLocked() {
-	now := nowNanos()
+	c.dropExpired(nowNanos())
+	if len(c.m) >= maxEntries {
+		c.evictArbitrary()
+	}
+}
+
+// dropExpired deletes every entry past its TTL.
+func (c *cache) dropExpired(now int64) {
 	for k, e := range c.m {
 		if now > e.exp {
 			delete(c.m, k)
 		}
 	}
+}
+
+// evictArbitrary deletes live entries until the cap holds.
+func (c *cache) evictArbitrary() {
 	for k := range c.m {
 		if len(c.m) < maxEntries {
 			return

--- a/app/sesame/automod/linkcheck/cache.go
+++ b/app/sesame/automod/linkcheck/cache.go
@@ -1,0 +1,134 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package linkcheck
+
+import (
+	"sync"
+	"time"
+)
+
+// Verdict is the checker's classification of one host: the only two states the
+// gate can act on. "Unknown" is not a state — it is the absence of an entry,
+// and it always means ActionNone upstream.
+type Verdict uint8
+
+const (
+	// Clean means every oracle cleared the host as of its last check.
+	Clean Verdict = iota
+	// Bad means at least one oracle flagged the host (feed, floor term, or
+	// security-resolver block).
+	Bad
+)
+
+func (v Verdict) String() string {
+	if v == Bad {
+		return "bad"
+	}
+	return "clean"
+}
+
+// Retention constants. Measured intuition, recorded so they can be re-argued:
+//
+//   - badTTL 24h: threat feeds rotate faster than a day, but flipping bad ->
+//     clean is the dangerous direction (a still-live scam domain that starts
+//     passing again). A day keeps false-ban risk bounded while domains die on
+//     their own; ops lift a wrong ban by restarting with the feed entry gone.
+//   - cleanTTL 6h: phishing infrastructure churns in hours, and a stale Clean
+//     is exactly the miss this layer exists to close. Re-checking six-hour-old
+//     clears costs one DoH query per host per shift.
+//   - shortTTL 1h on shortener-keyed entries: bit.ly/abc's destination is
+//     mutable server-side, so a cached expansion goes stale fastest of all.
+//   - errCooldown 5m: an oracle outage must not turn into a hot retry loop
+//     (every chat line re-enqueueing the same failing host), but five minutes
+//     bounds how long a blip delays coverage.
+const (
+	badTTL      = 24 * time.Hour
+	cleanTTL    = 6 * time.Hour
+	shortTTL    = time.Hour
+	errCooldown = 5 * time.Minute
+)
+
+// maxEntries caps the cache. Fleet-wide distinct chat hosts measure in the low
+// thousands per day across all channels, so 16384 holds days of tail traffic;
+// the cap exists because the alternative to a bound is unbounded growth from
+// one flood of random hosts. When the cap bites, expired entries sweep first
+// and live entries evict arbitrarily (Go map range order): chat host popularity
+// is heavily Zipf, so an evicted hot host re-enqueues off its very next mention
+// and re-resolves within seconds — eviction self-heals at the cost of one
+// lookup, which no lock-free scheme would remove either.
+const maxEntries = 16384
+
+type entry struct {
+	v   Verdict
+	exp int64 // unix nanos; lazily deleted on read past this
+}
+
+// cache maps cache keys (hosts, folded hosts, or lowercased shortener tokens)
+// to verdicts. A plain mutex guards it: reads are map lookups (~50ns) on a path
+// that already accepted a dot pre-filter, writes come only from the checker's
+// worker goroutines, and contention at chat scale never registers next to the
+// network calls those workers just made.
+type cache struct {
+	mu sync.Mutex
+	m  map[string]entry
+}
+
+func newCache() *cache {
+	return &cache{m: make(map[string]entry, 256)}
+}
+
+// get returns the cached verdict for key, dropping expired entries lazily.
+// Expiry-on-read keeps a sweeper goroutine out of the design: chat revisits
+// hosts far more often than TTLs lapse, so the lazy delete IS the sweep.
+func (c *cache) get(key string) (Verdict, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e, ok := c.m[key]
+	if !ok {
+		return Clean, false
+	}
+	if nowNanos() > e.exp {
+		delete(c.m, key)
+		return Clean, false
+	}
+	return e.v, true
+}
+
+// put stores a verdict under key with the retention class implied by v and
+// short. It sweeps when the hard cap is reached rather than every insert.
+func (c *cache) put(key string, v Verdict, short bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.m) >= maxEntries {
+		c.sweepLocked()
+	}
+	ttl := cleanTTL
+	switch {
+	case short:
+		ttl = shortTTL
+	case v == Bad:
+		ttl = badTTL
+	}
+	c.m[key] = entry{v: v, exp: nowNanos() + int64(ttl)}
+}
+
+// sweepLocked drops expired entries; if the cap still binds, arbitrary live
+// entries go too (see maxEntries for why arbitrary is acceptable here).
+func (c *cache) sweepLocked() {
+	now := nowNanos()
+	for k, e := range c.m {
+		if now > e.exp {
+			delete(c.m, k)
+		}
+	}
+	for k := range c.m {
+		if len(c.m) < maxEntries {
+			return
+		}
+		delete(c.m, k)
+	}
+}
+
+// nowNanos is split out so tests can pin time instead of sleeping.
+var nowNanos = func() int64 { return time.Now().UnixNano() }

--- a/app/sesame/automod/linkcheck/cache_test.go
+++ b/app/sesame/automod/linkcheck/cache_test.go
@@ -30,33 +30,33 @@ func TestCacheTTLs(t *testing.T) {
 	// +1h: the shortener slot lapses first (destinations rotate server-side);
 	// host slots hold.
 	advance(shortTTL + time.Minute)
-	requireExpired(t, c, "bit.ly/abc", "shortener entry survived shortTTL")
-	requireCached(t, c, "ok.example", Clean, "clean entry expired before cleanTTL")
-	requireCached(t, c, "bad.example", Bad, "bad entry expired early")
+	requireExpired(t, c, "bit.ly/abc")   // shortener slot lapses first
+	requireCached(t, c, "ok.example", Clean)
+	requireCached(t, c, "bad.example", Bad)
 
 	// +6h: clean lapses, bad still holds its day.
 	advance(cleanTTL - shortTTL)
-	requireExpired(t, c, "ok.example", "clean entry survived its TTL")
-	requireCached(t, c, "bad.example", Bad, "bad entry did not survive past cleanTTL")
+	requireExpired(t, c, "ok.example")
+	requireCached(t, c, "bad.example", Bad)
 
 	// +24h: bad lapses too.
 	advance(badTTL - cleanTTL)
-	requireExpired(t, c, "bad.example", "bad entry outlived badTTL")
+	requireExpired(t, c, "bad.example")
 }
 
-// requireCached asserts key resolves to want.
-func requireCached(t *testing.T, c *cache, key string, want Verdict, msg string) {
+// requireCached asserts key resolves to want and is still live.
+func requireCached(t *testing.T, c *cache, key string, want Verdict) {
 	t.Helper()
 	if v, ok := c.get(key); !ok || v != want {
-		t.Fatalf("%s: get(%q) = (%v,%v), want (%v,true)", msg, key, v, ok, want)
+		t.Fatalf("get(%q) = (%v,%v), want (%v,true)", key, v, ok, want)
 	}
 }
 
 // requireExpired asserts key has lapsed out of the cache.
-func requireExpired(t *testing.T, c *cache, key, msg string) {
+func requireExpired(t *testing.T, c *cache, key string) {
 	t.Helper()
 	if _, ok := c.get(key); ok {
-		t.Fatalf("%s: get(%q) still cached", msg, key)
+		t.Fatalf("get(%q) still cached, want expired", key)
 	}
 }
 

--- a/app/sesame/automod/linkcheck/cache_test.go
+++ b/app/sesame/automod/linkcheck/cache_test.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package linkcheck
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// pinTime overrides nowNanos for the test and restores it on cleanup,
+// returning a setter that advances the fake clock.
+func pinTime(t *testing.T) func(advance time.Duration) {
+	t.Helper()
+	now := time.Now()
+	nowNanos = func() int64 { return now.UnixNano() }
+	t.Cleanup(func() { nowNanos = func() int64 { return time.Now().UnixNano() } })
+	return func(d time.Duration) { now = now.Add(d) }
+}
+
+func TestCacheTTLs(t *testing.T) {
+	advance := pinTime(t)
+	c := newCache()
+
+	c.put("bad.example", Bad, false)
+	c.put("ok.example", Clean, false)
+	c.put("bit.ly/abc", Clean, true)
+
+	// +1h: the shortener slot lapses first (destinations rotate server-side);
+	// host slots hold.
+	advance(shortTTL + time.Minute)
+	if _, ok := c.get("bit.ly/abc"); ok {
+		t.Fatal("shortener entry survived shortTTL")
+	}
+	if v, ok := c.get("ok.example"); !ok || v != Clean {
+		t.Fatalf("clean entry expired before cleanTTL: (%v,%v)", v, ok)
+	}
+	if v, ok := c.get("bad.example"); !ok || v != Bad {
+		t.Fatalf("bad entry expired early: (%v,%v)", v, ok)
+	}
+
+	// +6h: clean lapses, bad still holds its day.
+	advance(cleanTTL - shortTTL)
+	if _, ok := c.get("ok.example"); ok {
+		t.Fatal("clean entry survived its TTL")
+	}
+	if v, ok := c.get("bad.example"); !ok || v != Bad {
+		t.Fatalf("bad entry did not survive past cleanTTL: (%v,%v)", v, ok)
+	}
+
+	// +24h: bad lapses too.
+	advance(badTTL - cleanTTL)
+	if _, ok := c.get("bad.example"); ok {
+		t.Fatal("bad entry outlived badTTL")
+	}
+}
+
+func TestCacheCapEvictsAndSelfHeals(t *testing.T) {
+	pinTime(t)
+	c := newCache()
+
+	for i := 0; c.m != nil && i < maxEntries+512; i++ {
+		c.put(fmt.Sprintf("host-%d.example", i), Clean, false)
+	}
+	if len(c.m) > maxEntries {
+		t.Fatalf("cache grew past cap: %d", len(c.m))
+	}
+
+	// Re-inserting an evicted hot host re-caches it: eviction is not a ban list.
+	c.put("hot.example", Bad, false)
+	if v, ok := c.get("hot.example"); !ok || v != Bad {
+		t.Fatalf("re-put after eviction = (%v,%v)", v, ok)
+	}
+}

--- a/app/sesame/automod/linkcheck/cache_test.go
+++ b/app/sesame/automod/linkcheck/cache_test.go
@@ -30,29 +30,33 @@ func TestCacheTTLs(t *testing.T) {
 	// +1h: the shortener slot lapses first (destinations rotate server-side);
 	// host slots hold.
 	advance(shortTTL + time.Minute)
-	if _, ok := c.get("bit.ly/abc"); ok {
-		t.Fatal("shortener entry survived shortTTL")
-	}
-	if v, ok := c.get("ok.example"); !ok || v != Clean {
-		t.Fatalf("clean entry expired before cleanTTL: (%v,%v)", v, ok)
-	}
-	if v, ok := c.get("bad.example"); !ok || v != Bad {
-		t.Fatalf("bad entry expired early: (%v,%v)", v, ok)
-	}
+	requireExpired(t, c, "bit.ly/abc", "shortener entry survived shortTTL")
+	requireCached(t, c, "ok.example", Clean, "clean entry expired before cleanTTL")
+	requireCached(t, c, "bad.example", Bad, "bad entry expired early")
 
 	// +6h: clean lapses, bad still holds its day.
 	advance(cleanTTL - shortTTL)
-	if _, ok := c.get("ok.example"); ok {
-		t.Fatal("clean entry survived its TTL")
-	}
-	if v, ok := c.get("bad.example"); !ok || v != Bad {
-		t.Fatalf("bad entry did not survive past cleanTTL: (%v,%v)", v, ok)
-	}
+	requireExpired(t, c, "ok.example", "clean entry survived its TTL")
+	requireCached(t, c, "bad.example", Bad, "bad entry did not survive past cleanTTL")
 
 	// +24h: bad lapses too.
 	advance(badTTL - cleanTTL)
-	if _, ok := c.get("bad.example"); ok {
-		t.Fatal("bad entry outlived badTTL")
+	requireExpired(t, c, "bad.example", "bad entry outlived badTTL")
+}
+
+// requireCached asserts key resolves to want.
+func requireCached(t *testing.T, c *cache, key string, want Verdict, msg string) {
+	t.Helper()
+	if v, ok := c.get(key); !ok || v != want {
+		t.Fatalf("%s: get(%q) = (%v,%v), want (%v,true)", msg, key, v, ok, want)
+	}
+}
+
+// requireExpired asserts key has lapsed out of the cache.
+func requireExpired(t *testing.T, c *cache, key, msg string) {
+	t.Helper()
+	if _, ok := c.get(key); ok {
+		t.Fatalf("%s: get(%q) still cached", msg, key)
 	}
 }
 

--- a/app/sesame/automod/linkcheck/checker.go
+++ b/app/sesame/automod/linkcheck/checker.go
@@ -181,7 +181,7 @@ func (c *Checker) Evaluate(text string, channel uint64, sender string) bool {
 			bad = true
 			return
 		}
-		c.resolveAsync(c.taskFor(token, host, channel, sender))
+		c.resolveAsync(c.keyed(task{token: token, host: host, ch: channel, sender: sender}))
 	})
 	return bad
 }
@@ -204,15 +204,18 @@ func (c *Checker) knownBad(token, host string) bool {
 	return false
 }
 
-// taskFor picks a lookup's identity: shortener tokens key on their full path
-// form (the destination is per-path), plain hosts on the registrable fold so
-// subdomain churn collapses into one cache slot.
-func (c *Checker) taskFor(token, host string, channel uint64, sender string) task {
-	if c.exp.IsShortener(host) {
-		lt := strings.ToLower(token)
-		return task{token: lt, host: host, key: lt, ch: channel, sender: sender}
+// keyed fills t's cache-key identity: shortener tokens key on their full path
+// form (the destination is per-path, and the token is lowercased to match),
+// plain hosts on the registrable fold so subdomain churn collapses into one
+// cache slot.
+func (c *Checker) keyed(t task) task {
+	if c.exp.IsShortener(t.host) {
+		lt := strings.ToLower(t.token)
+		t.token, t.key = lt, lt
+		return t
 	}
-	return task{token: token, host: host, key: foldHost(host), ch: channel, sender: sender}
+	t.key = foldHost(t.host)
+	return t
 }
 
 // resolveAsync schedules one background classification unless its key is

--- a/app/sesame/automod/linkcheck/checker.go
+++ b/app/sesame/automod/linkcheck/checker.go
@@ -181,7 +181,7 @@ func (c *Checker) Evaluate(text string, channel uint64, sender string) bool {
 			bad = true
 			return
 		}
-		c.enqueue(token, host, channel, sender)
+		c.resolveAsync(c.taskFor(token, host, channel, sender))
 	})
 	return bad
 }
@@ -204,30 +204,32 @@ func (c *Checker) knownBad(token, host string) bool {
 	return false
 }
 
-// enqueue schedules background classification unless the key is cached, still
-// in flight, cooling down from an error, or the queue is full (counted drop).
-func (c *Checker) enqueue(token, host string, channel uint64, sender string) {
-	t := c.buildTask(token, host, channel, sender)
+// taskFor picks a lookup's identity: shortener tokens key on their full path
+// form (the destination is per-path), plain hosts on the registrable fold so
+// subdomain churn collapses into one cache slot.
+func (c *Checker) taskFor(token, host string, channel uint64, sender string) task {
+	if c.exp.IsShortener(host) {
+		lt := strings.ToLower(token)
+		return task{token: lt, host: host, key: lt, ch: channel, sender: sender}
+	}
+	return task{token: token, host: host, key: foldHost(host), ch: channel, sender: sender}
+}
 
-	if _, ok := c.cache.get(t.key); ok {
+// resolveAsync schedules one background classification unless its key is
+// cached, still in flight, cooling down from an error, or the queue is full
+// (a counted drop — the next mention re-enqueues).
+func (c *Checker) resolveAsync(t task) {
+	if _, done := c.cache.get(t.key); done {
 		return
 	}
-	now := nowNanos()
-	c.mu.Lock()
-	cooled := c.cooldown[t.key] > now
-	_, busy := c.inflight[t.key]
-	if !cooled && !busy {
-		c.inflight[t.key] = struct{}{}
-	}
-	c.mu.Unlock()
-	if cooled || busy {
+	if !c.claim(t.key) {
 		return
 	}
 
 	select {
 	case c.queue <- t:
 	default:
-		c.unmark(t.key)
+		c.release(t.key)
 		n := c.dropped.Add(1)
 		if n%128 == 1 {
 			c.log.Warn("linkcheck queue full, dropping lookups", zap.Int64("dropped", n))
@@ -235,18 +237,23 @@ func (c *Checker) enqueue(token, host string, channel uint64, sender string) {
 	}
 }
 
-// buildTask picks the task identity: shortener tokens key on their full path
-// form, plain hosts on the registrable fold so subdomain churn collapses.
-func (c *Checker) buildTask(token, host string, channel uint64, sender string) task {
-	if c.exp.IsShortener(host) {
-		lt := strings.ToLower(token)
-		return task{token: lt, host: host, key: lt, ch: channel, sender: sender}
+// claim reserves key for a worker, refusing keys that are already in flight
+// or inside their post-error cooldown window.
+func (c *Checker) claim(key string) bool {
+	now := nowNanos()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if _, busy := c.inflight[key]; busy {
+		return false
 	}
-	key := foldHost(host)
-	return task{token: token, host: host, key: key, ch: channel, sender: sender}
+	if c.cooldown[key] > now {
+		return false
+	}
+	c.inflight[key] = struct{}{}
+	return true
 }
 
-func (c *Checker) unmark(key string) {
+func (c *Checker) release(key string) {
 	c.mu.Lock()
 	delete(c.inflight, key)
 	c.mu.Unlock()
@@ -262,7 +269,7 @@ func (c *Checker) work(ctx context.Context) {
 			return
 		case t := <-c.queue:
 			c.handle(ctx, t)
-			c.unmark(t.key)
+			c.release(t.key)
 		}
 	}
 }
@@ -273,17 +280,17 @@ func (c *Checker) handle(ctx context.Context, t task) {
 		c.handleExpansion(ctx, t)
 		return
 	}
-	v, src, err := c.classifyHost(ctx, t.host)
-	if err != nil {
+	res := c.classifyHost(ctx, t.host)
+	if res.err != nil {
 		// An unanswered question must not cache as either answer: cool the
 		// key down so the next mention retries instead of whitelisting a
 		// possibly-hostile host for a Clean TTL.
 		c.coolDown(t.key)
 		return
 	}
-	c.remember(t.host, t.key, v)
-	if v == Bad {
-		c.fire(Hit{Host: t.host, Token: t.token, Source: src, Channel: t.ch, Sender: t.sender})
+	c.remember(t.host, t.key, res.verdict)
+	if res.verdict == Bad {
+		c.fire(Hit{Host: t.host, Token: t.token, Source: res.source, Channel: t.ch, Sender: t.sender})
 	}
 }
 
@@ -297,15 +304,15 @@ func (c *Checker) handleExpansion(ctx context.Context, t task) {
 		c.log.Debug("linkcheck expansion failed", zap.String("token", t.token), zap.Error(err))
 		return
 	}
-	v, src, err := c.classifyHost(ctx, destHost)
-	if err != nil {
+	res := c.classifyHost(ctx, destHost)
+	if res.err != nil {
 		c.coolDown(t.key)
 		return
 	}
-	c.remember(destHost, destHost, v)
-	c.cache.put(t.key, v, true)
-	if v == Bad {
-		c.fire(Hit{Host: destHost, Token: t.token, Via: t.host, Source: src, Channel: t.ch, Sender: t.sender})
+	c.remember(destHost, destHost, res.verdict)
+	c.cache.put(t.key, res.verdict, true)
+	if res.verdict == Bad {
+		c.fire(Hit{Host: destHost, Token: t.token, Via: t.host, Source: res.source, Channel: t.ch, Sender: t.sender})
 	}
 }
 
@@ -318,31 +325,40 @@ func (c *Checker) remember(host, key string, v Verdict) {
 	}
 }
 
+// classification is one host's verdict plus which oracle produced it. A
+// non-nil err means "no answer" — callers cool down rather than caching, so
+// verdict/source are only meaningful when err is nil.
+type classification struct {
+	verdict Verdict
+	source  Source
+	err     error
+}
+
 // classifyHost runs the passive oracles in cost order: memory-resident feed
 // snapshot, allocation-free floor terms, then the network resolver (rate-
-// limited). A non-nil error means "no answer" — callers cool down rather than
+// limited). A non-nil err means "no answer" — callers cool down rather than
 // caching.
-func (c *Checker) classifyHost(ctx context.Context, host string) (Verdict, Source, error) {
+func (c *Checker) classifyHost(ctx context.Context, host string) classification {
 	if c.feeds.Has(host) {
-		return Bad, SourceFeed, nil
+		return classification{verdict: Bad, source: SourceFeed}
 	}
 	if kind, _ := moderation.MatchFloor(moderation.Normalize(nil, host)); kind != moderation.FloorNone {
 		// The floor list also convicts dynamically here so ops additions to
 		// IPLoggerDomains reach hosts that only surface wrapped in a shortener.
-		return Bad, SourceFloor, nil
+		return classification{verdict: Bad, source: SourceFloor}
 	}
 	if err := c.limiter.Wait(ctx); err != nil {
-		return Clean, "", err // ctx cancelled mid-shutdown
+		return classification{verdict: Clean, err: err} // ctx cancelled mid-shutdown
 	}
 	blocked, err := c.doh.Blocked(ctx, host)
 	if err != nil {
 		c.log.Debug("linkcheck oracle error", zap.String("host", host), zap.Error(err))
-		return Clean, "", err
+		return classification{verdict: Clean, err: err}
 	}
 	if blocked {
-		return Bad, SourceDoH, nil
+		return classification{verdict: Bad, source: SourceDoH}
 	}
-	return Clean, "", nil
+	return classification{verdict: Clean}
 }
 
 // coolDown blocks retries for key until errCooldown elapses.

--- a/app/sesame/automod/linkcheck/checker.go
+++ b/app/sesame/automod/linkcheck/checker.go
@@ -1,0 +1,360 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package linkcheck
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"ItsBagelBot/internal/moderation"
+
+	"go.uber.org/zap"
+	"golang.org/x/time/rate"
+)
+
+// Worker-pool shape, recorded so it can be re-argued:
+//
+//   - queueCap 256: even a fleet-wide chat flood where EVERY line carries a
+//     fresh host fills this in seconds; overflow drops (the next mention of
+//     the same host re-enqueues) rather than blocking the gate's hot path.
+//     A bigger buffer would only delay work that is stale by then anyway.
+//   - defaultWorkers 2: one oracle query measures ~20-80ms, so two workers
+//     sustain ~50 lookups/s — far above observed chat link rates — while more
+//     workers would just multiply load against free public endpoints.
+//   - dohRate burst 10 / 5qps: stays well inside what 1.1.1.2 expects from a
+//     single polite client; bursts cover a raid-shaped spike of fresh hosts
+//     without turning sesame into a resolver stress tool.
+const (
+	queueCap       = 256
+	defaultWorkers = 2
+	dohBurst       = 10
+	dohQPS         = 5
+)
+
+// Source names which oracle convicted a host, carried on Hit for the audit log.
+type Source string
+
+const (
+	SourceFeed  Source = "feed"
+	SourceFloor Source = "floor"
+	SourceDoH   Source = "doh"
+)
+
+// Hit records one conviction, delivered through OnBad. Shadow-mode operators
+// read these to judge rule quality before arming enforcement; nothing else
+// consumes them.
+type Hit struct {
+	Host    string // offending host as classified (destination for expansions)
+	Token   string // chat token that carried it ("bit.ly/xyz")
+	Via     string // shortener host walked to reach Host, "" when direct
+	Source  Source
+	Channel uint64
+	Sender  string
+}
+
+// Options configures a Checker. Nil members select production defaults;
+// tests inject httptest-backed ones.
+type Options struct {
+	ExpandShorteners bool
+	Workers          int
+	Feeds            *Feeds
+	DoH              *DoH
+	Expander         *Expander
+	Log              *zap.Logger
+}
+
+// Checker resolves unknown link hosts off-thread and remembers the verdicts.
+// The gate calls Evaluate synchronously on every line containing a dot: reads
+// only (cache, feed snapshot), so the hot path never waits on network I/O and
+// an unarmed (nil) checker costs one atomic load.
+type Checker struct {
+	opts    Options
+	feeds   *Feeds
+	doh     *DoH
+	exp     *Expander
+	cache   *cache
+	queue   chan task
+	log     *zap.Logger
+	limiter *rate.Limiter
+
+	mu       sync.Mutex
+	inflight map[string]struct{}
+	cooldown map[string]int64 // key -> unix nanos when retries resume
+
+	// OnBad receives each conviction as it lands. It runs on a worker
+	// goroutine: implementations must not block. nil is valid (drop).
+	OnBad func(Hit)
+
+	dropped atomic.Int64
+}
+
+// task is one pending resolution. Token keeps its original case and path (the
+// expansion input); Host is the lowercased host component; Key is the dedup /
+// cache slot this result will land in.
+type task struct {
+	token  string
+	host   string
+	key    string
+	ch     uint64
+	sender string
+}
+
+// NewChecker builds a checker around opts. It does NOT start goroutines —
+// call Start with the service context.
+func NewChecker(opts Options) *Checker {
+	if opts.Workers <= 0 {
+		opts.Workers = defaultWorkers
+	}
+	if opts.Log == nil {
+		opts.Log = zap.NewNop()
+	}
+	if opts.Feeds == nil {
+		opts.Feeds = NewFeeds(nil, nil)
+	}
+	if opts.DoH == nil {
+		opts.DoH = NewDoH("", nil)
+	}
+	if opts.Expander == nil {
+		opts.Expander = NewExpander(nil, nil)
+	}
+	return &Checker{
+		opts:     opts,
+		feeds:    opts.Feeds,
+		doh:      opts.DoH,
+		exp:      opts.Expander,
+		cache:    newCache(),
+		queue:    make(chan task, queueCap),
+		log:      opts.Log,
+		limiter:  rate.NewLimiter(dohQPS, dohBurst),
+		inflight: make(map[string]struct{}),
+		cooldown: make(map[string]int64),
+	}
+}
+
+// Start launches the worker pool; it returns immediately. Workers exit when
+// ctx cancels.
+func (c *Checker) Start(ctx context.Context) {
+	for i := 0; i < c.opts.Workers; i++ {
+		go c.work(ctx)
+	}
+}
+
+// RefreshFeeds re-pulls the blocklist snapshot; the runner calls it on a slow
+// ticker. A failure logs through the checker logger and keeps the old set.
+func (c *Checker) RefreshFeeds(ctx context.Context) (int, error) {
+	n, err := c.feeds.Refresh(ctx)
+	if n > 0 {
+		c.log.Info("linkcheck feeds refreshed", zap.Int("hosts", n))
+	}
+	return n, err
+}
+
+// Evaluate is the gate's synchronous entry point. It scans text for link
+// tokens; any host already known Bad (cache or live feed snapshot) reports
+// true so the caller can act; unknown hosts are enqueued for background
+// classification and report nothing. Returns false immediately for a nil
+// checker, which is how an unarmed gate stays byte-identical to before.
+func (c *Checker) Evaluate(text string, channel uint64, sender string) bool {
+	if c == nil {
+		return false
+	}
+	bad := false
+	var seen map[string]struct{} // lazily built; most lines carry no links
+
+	iterLinkTokens(text, func(token string) {
+		host := strings.ToLower(hostOf(token))
+		if !validHost(host) {
+			return
+		}
+		if seen == nil {
+			seen = make(map[string]struct{}, 4)
+		}
+		if _, dup := seen[token]; dup {
+			return
+		}
+		seen[token] = struct{}{}
+
+		if c.knownBad(token, host) {
+			bad = true
+			return
+		}
+		c.enqueue(token, host, channel, sender)
+	})
+	return bad
+}
+
+// knownBad reports whether token/host already sits convicted: the token slot
+// covers expanded shorteners (bit.ly/abc is its own cache entry, since the
+// destination is per-path), the host and folded-host slots cover everything
+// else. Feed membership counts as known-bad without waiting for a worker —
+// the snapshot is already in memory.
+func (c *Checker) knownBad(token, host string) bool {
+	folded := foldHost(host)
+	for _, k := range [3]string{host, folded, strings.ToLower(token)} {
+		if v, ok := c.cache.get(k); ok && v == Bad {
+			return true
+		}
+		if c.feeds.Has(k) {
+			return true
+		}
+	}
+	return false
+}
+
+// enqueue schedules background classification unless the key is cached, still
+// in flight, cooling down from an error, or the queue is full (counted drop).
+func (c *Checker) enqueue(token, host string, channel uint64, sender string) {
+	t := c.buildTask(token, host, channel, sender)
+
+	if _, ok := c.cache.get(t.key); ok {
+		return
+	}
+	now := nowNanos()
+	c.mu.Lock()
+	cooled := c.cooldown[t.key] > now
+	_, busy := c.inflight[t.key]
+	if !cooled && !busy {
+		c.inflight[t.key] = struct{}{}
+	}
+	c.mu.Unlock()
+	if cooled || busy {
+		return
+	}
+
+	select {
+	case c.queue <- t:
+	default:
+		c.unmark(t.key)
+		n := c.dropped.Add(1)
+		if n%128 == 1 {
+			c.log.Warn("linkcheck queue full, dropping lookups", zap.Int64("dropped", n))
+		}
+	}
+}
+
+// buildTask picks the task identity: shortener tokens key on their full path
+// form, plain hosts on the registrable fold so subdomain churn collapses.
+func (c *Checker) buildTask(token, host string, channel uint64, sender string) task {
+	if c.exp.IsShortener(host) {
+		lt := strings.ToLower(token)
+		return task{token: lt, host: host, key: lt, ch: channel, sender: sender}
+	}
+	key := foldHost(host)
+	return task{token: token, host: host, key: key, ch: channel, sender: sender}
+}
+
+func (c *Checker) unmark(key string) {
+	c.mu.Lock()
+	delete(c.inflight, key)
+	c.mu.Unlock()
+}
+
+// work drains the queue until ctx cancels. Every path through handle releases
+// the inflight mark exactly once — the defer lives here, not in handle, so a
+// panic in one classification cannot leak the mark and wedge that key forever.
+func (c *Checker) work(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case t := <-c.queue:
+			c.handle(ctx, t)
+			c.unmark(t.key)
+		}
+	}
+}
+
+// handle resolves one task into the cache and, when convicted, fires OnBad.
+func (c *Checker) handle(ctx context.Context, t task) {
+	if c.exp.IsShortener(t.host) && c.opts.ExpandShorteners {
+		c.handleExpansion(ctx, t)
+		return
+	}
+	v, src, err := c.classifyHost(ctx, t.host)
+	if err != nil {
+		// An unanswered question must not cache as either answer: cool the
+		// key down so the next mention retries instead of whitelisting a
+		// possibly-hostile host for a Clean TTL.
+		c.coolDown(t.key)
+		return
+	}
+	c.remember(t.host, t.key, v)
+	if v == Bad {
+		c.fire(Hit{Host: t.host, Token: t.token, Source: src, Channel: t.ch, Sender: t.sender})
+	}
+}
+
+// handleExpansion walks a shortener chain and classifies where it lands,
+// caching under BOTH the destination host and the shortener token (shorter
+// TTL there: destinations behind a stable bit.ly/abc rotate server-side).
+func (c *Checker) handleExpansion(ctx context.Context, t task) {
+	destHost, err := c.exp.Destination(ctx, t.token)
+	if err != nil {
+		c.coolDown(t.key)
+		c.log.Debug("linkcheck expansion failed", zap.String("token", t.token), zap.Error(err))
+		return
+	}
+	v, src, err := c.classifyHost(ctx, destHost)
+	if err != nil {
+		c.coolDown(t.key)
+		return
+	}
+	c.remember(destHost, destHost, v)
+	c.cache.put(t.key, v, true)
+	if v == Bad {
+		c.fire(Hit{Host: destHost, Token: t.token, Via: t.host, Source: src, Channel: t.ch, Sender: t.sender})
+	}
+}
+
+// remember stores a verdict under its host and its registrable fold (one
+// entry when they coincide).
+func (c *Checker) remember(host, key string, v Verdict) {
+	c.cache.put(key, v, false)
+	if f := foldHost(host); f != key {
+		c.cache.put(f, v, false)
+	}
+}
+
+// classifyHost runs the passive oracles in cost order: memory-resident feed
+// snapshot, allocation-free floor terms, then the network resolver (rate-
+// limited). A non-nil error means "no answer" — callers cool down rather than
+// caching.
+func (c *Checker) classifyHost(ctx context.Context, host string) (Verdict, Source, error) {
+	if c.feeds.Has(host) {
+		return Bad, SourceFeed, nil
+	}
+	if kind, _ := moderation.MatchFloor(moderation.Normalize(nil, host)); kind != moderation.FloorNone {
+		// The floor list also convicts dynamically here so ops additions to
+		// IPLoggerDomains reach hosts that only surface wrapped in a shortener.
+		return Bad, SourceFloor, nil
+	}
+	if err := c.limiter.Wait(ctx); err != nil {
+		return Clean, "", err // ctx cancelled mid-shutdown
+	}
+	blocked, err := c.doh.Blocked(ctx, host)
+	if err != nil {
+		c.log.Debug("linkcheck oracle error", zap.String("host", host), zap.Error(err))
+		return Clean, "", err
+	}
+	if blocked {
+		return Bad, SourceDoH, nil
+	}
+	return Clean, "", nil
+}
+
+// coolDown blocks retries for key until errCooldown elapses.
+func (c *Checker) coolDown(key string) {
+	c.mu.Lock()
+	c.cooldown[key] = nowNanos() + int64(errCooldown)
+	c.mu.Unlock()
+}
+
+// fire delivers a conviction when anyone is listening.
+func (c *Checker) fire(h Hit) {
+	if c.OnBad != nil {
+		c.OnBad(h)
+	}
+}

--- a/app/sesame/automod/linkcheck/checker_test.go
+++ b/app/sesame/automod/linkcheck/checker_test.go
@@ -86,7 +86,8 @@ func TestEvaluateDoHConvictionLandsAsync(t *testing.T) {
 	}
 	select {
 	case hit := <-h.hits:
-		if hit.Source != SourceDoH || hit.Channel != 7 || hit.Sender != "u2" {
+		got := Hit{Source: hit.Source, Channel: hit.Channel, Sender: hit.Sender}
+		if want := (Hit{Source: SourceDoH, Channel: 7, Sender: "u2"}); got != want {
 			t.Fatalf("hit = %+v, want doh conviction carrying enqueue context", hit)
 		}
 	default:

--- a/app/sesame/automod/linkcheck/checker_test.go
+++ b/app/sesame/automod/linkcheck/checker_test.go
@@ -1,0 +1,204 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package linkcheck
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// waitFor polls cond until it holds or the deadline lapses, because the
+// checker resolves asynchronously by design.
+func waitFor(t *testing.T, cond func() bool) bool {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return true
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	return false
+}
+
+// harness wires a checker against httptest-backed oracles: a one-line feed and
+// a security resolver that blocks everything. Tests needing different answers
+// build their own oracle inline.
+type harness struct {
+	checker *Checker
+	hits    chan Hit
+}
+
+func newHarness(t *testing.T, expander *Expander) *harness {
+	t.Helper()
+
+	feedsSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("feedbad.example/scam\n"))
+	}))
+	t.Cleanup(feedsSrv.Close)
+
+	doh := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"Status":0,"Answer":[{"type":1,"data":"0.0.0.0"}]}`))
+	}))
+	t.Cleanup(doh.Close)
+
+	feeds := NewFeeds([]FeedSource{{Name: "test", URL: feedsSrv.URL, Format: FormatLines}}, nil)
+	if _, err := feeds.Refresh(context.Background()); err != nil {
+		t.Fatalf("feed refresh: %v", err)
+	}
+
+	h := &harness{hits: make(chan Hit, 16)}
+	h.checker = NewChecker(Options{
+		ExpandShorteners: true,
+		Workers:          1,
+		Feeds:            feeds,
+		DoH:              NewDoH(doh.URL, nil),
+		Expander:         expander,
+	})
+	h.checker.OnBad = func(hit Hit) { h.hits <- hit }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	h.checker.Start(ctx)
+	return h
+}
+
+func TestEvaluateFeedHitIsImmediate(t *testing.T) {
+	h := newHarness(t, nil)
+	if !h.checker.Evaluate("everyone check feedbad.example/scam now", 42, "u1") {
+		t.Fatal("feed-listed host must convict on the first synchronous pass")
+	}
+}
+
+func TestEvaluateDoHConvictionLandsAsync(t *testing.T) {
+	h := newHarness(t, nil)
+	line := "dohbad.example is up go look"
+	if h.checker.Evaluate(line, 7, "u2") {
+		t.Fatal("unknown host must not convict before any oracle answered")
+	}
+	if !waitFor(t, func() bool { return h.checker.Evaluate(line, 7, "u2") }) {
+		t.Fatal("doh conviction never landed")
+	}
+	select {
+	case hit := <-h.hits:
+		if hit.Source != SourceDoH || hit.Channel != 7 || hit.Sender != "u2" {
+			t.Fatalf("hit = %+v, want doh conviction carrying enqueue context", hit)
+		}
+	default:
+		t.Fatal("no Hit recorded for convicted host")
+	}
+}
+
+func TestExpansionCarriesViaAndConvictsDestination(t *testing.T) {
+	var destHits atomic.Int64
+	dest := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		destHits.Add(1)
+	}))
+	t.Cleanup(dest.Close)
+	mid := redirectServer(t, "http://sdest.test/final")
+	head := redirectServer(t, "http://smid.test/hop")
+
+	exp := newExpanderScheme(
+		clientFor(t, dnsMap{
+			"shead.test": tok(head.URL),
+			"smid.test":  tok(mid.URL),
+			"sdest.test": tok(dest.URL),
+		}),
+		[]string{"shead.test", "smid.test"}, "http")
+
+	h := newHarness(t, exp)
+	token := "shead.test/abc"
+
+	if h.checker.Evaluate(token, 9, "u3") {
+		t.Fatal("shortener token unknown before expansion")
+	}
+	if !waitFor(t, func() bool { return h.checker.Evaluate(token, 9, "u3") }) {
+		t.Fatal("expansion conviction never landed")
+	}
+
+	hit := <-h.hits
+	if hit.Via != "shead.test" || hit.Host != "sdest.test" {
+		t.Fatalf("hit via=%q host=%q, want via=shead.test host=sdest.test", hit.Via, hit.Host)
+	}
+	if destHits.Load() != 0 {
+		t.Fatalf("destination contacted %d times; contract is never", destHits.Load())
+	}
+}
+
+func TestCleanVerdictSuppressesRepeatEnqueues(t *testing.T) {
+	var oracleCalls int
+	cleanDoh := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		oracleCalls++
+		_, _ = w.Write([]byte(`{"Status":0,"Answer":[{"type":1,"data":"1.2.3.4"}]}`))
+	}))
+	defer cleanDoh.Close()
+
+	c := NewChecker(Options{
+		Workers: 1,
+		Feeds:   NewFeeds(nil, nil),
+		DoH:     NewDoH(cleanDoh.URL, nil),
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	c.Start(ctx)
+
+	line := "fine.example is fine folks"
+	if c.Evaluate(line, 1, "u") {
+		t.Fatal("clean oracle convicted")
+	}
+	key := foldHost("fine.example")
+	if !waitFor(t, func() bool { _, ok := c.cache.get(key); return ok }) {
+		t.Fatal("clean verdict never cached")
+	}
+	queried := oracleCalls
+
+	for i := 0; i < 20; i++ {
+		if c.Evaluate(line+"!", 1, "u") {
+			t.Fatal("cached Clean flipped to bad")
+		}
+	}
+	if oracleCalls != queried {
+		t.Fatalf("repeat Evaluate re-queried the oracle %d extra times", oracleCalls-queried)
+	}
+}
+
+func TestOracleOutageNeverCachesAndCoolsDown(t *testing.T) {
+	deadURL := ""
+	{
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
+		deadURL = srv.URL
+		srv.Close()
+	}
+	feeds := NewFeeds(nil, nil)
+	c := NewChecker(Options{Workers: 1, Feeds: feeds, DoH: NewDoH(deadURL, nil)})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	c.Start(ctx)
+
+	pinTime(t)
+	line := "flaky.example is up"
+	if c.Evaluate(line, 1, "u") {
+		t.Fatal("outage convicted a host")
+	}
+	key := foldHost("flaky.example")
+	waitFor(t, func() bool {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		return c.cooldown[key] > nowNanos()
+	})
+	if _, ok := c.cache.get(key); ok {
+		t.Fatal("oracle outage cached an answer")
+	}
+}
+
+func TestNilCheckerInert(t *testing.T) {
+	var c *Checker
+	if c.Evaluate("evil.example", 1, "u") {
+		t.Fatal("nil checker convicted")
+	}
+}

--- a/app/sesame/automod/linkcheck/doh.go
+++ b/app/sesame/automod/linkcheck/doh.go
@@ -1,0 +1,106 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package linkcheck
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// DefaultDoHEndpoint is Cloudflare's security-filtering resolver (1.1.1.2's
+// DoH form). A domain on its malware/phishing blocklist resolves to 0.0.0.0
+// instead of the real address — that answer IS the verdict signal, which makes
+// this a passive oracle: we resolve, we never connect. Free, unauthenticated,
+// one small JSON GET per lookup; overridable so tests point it at httptest.
+const DefaultDoHEndpoint = "https://security.cloudflare-dns.com/dns-query"
+
+// dohTimeout bounds one resolver query. Measured p95 for the public resolvers
+// is tens of milliseconds; three seconds absorbs transatlantic jitter without
+// letting one cold query stall the worker queue behind it.
+const dohTimeout = 3 * time.Second
+
+// dohBodyLimit caps the response read. A real answer is well under 1KB; the
+// cap only matters when endpoint != default (tests, self-hosted gateways).
+const dohBodyLimit = 64 << 10
+
+// DoH asks a DNS-over-HTTPS JSON endpoint whether a host sits on its security
+// blocklist. Safe by construction: resolution only — no HTTP connection is
+// ever opened to the classified host.
+type DoH struct {
+	endpoint string
+	client   *http.Client
+}
+
+// NewDoH builds a resolver oracle. Empty endpoint selects DefaultDoHEndpoint;
+// nil client gets the bounded default.
+func NewDoH(endpoint string, client *http.Client) *DoH {
+	if endpoint == "" {
+		endpoint = DefaultDoHEndpoint
+	}
+	if client == nil {
+		client = &http.Client{Timeout: dohTimeout}
+	}
+	return &DoH{endpoint: endpoint, client: client}
+}
+
+// dohAnswer mirrors the fields of RFC 8484-style JSON responses this check
+// reads. The wire format carries more (Authority, TTLs); anything unmapped is
+// ignored on purpose.
+type dohAnswer struct {
+	Status int `json:"Status"`
+	Answer []struct {
+		Type int    `json:"type"`
+		Data string `json:"data"`
+	} `json:"Answer"`
+}
+
+// Blocked reports whether the resolver's security layer blocks host. A blocked
+// domain answers with a 0.0.0.0 / :: A or AAAA record; that sinkhole answer is
+// the entire detection surface. NXDOMAIN reads as not-blocked (an unresolvable
+// host cannot route a victim anywhere either) rather than as an error: treating
+// registry hiccups as errors would burn the retry cooldown on every typo'd
+// hostname chat invents.
+func (d *DoH) Blocked(ctx context.Context, host string) (bool, error) {
+	cctx, cancel := context.WithTimeout(ctx, dohTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(cctx, http.MethodGet,
+		d.endpoint+"?name="+url.QueryEscape(host)+"&type=A", nil)
+	if err != nil {
+		return false, err
+	}
+	req.Header.Set("accept", "application/dns-json")
+
+	res, err := d.client.Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, io.LimitReader(res.Body, dohBodyLimit))
+		_ = res.Body.Close()
+	}()
+	if res.StatusCode != http.StatusOK {
+		return false, fmt.Errorf("doh %s: status %d", host, res.StatusCode)
+	}
+
+	var doc dohAnswer
+	if err := json.NewDecoder(io.LimitReader(res.Body, dohBodyLimit)).Decode(&doc); err != nil {
+		return false, fmt.Errorf("doh %s: %w", host, err)
+	}
+	for _, a := range doc.Answer {
+		if a.Type == 1 || a.Type == 28 { // A, AAAA
+			data := strings.TrimSuffix(a.Data, ".")
+			if data == "0.0.0.0" || data == "::" {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}

--- a/app/sesame/automod/linkcheck/doh.go
+++ b/app/sesame/automod/linkcheck/doh.go
@@ -72,40 +72,55 @@ func (d *DoH) Blocked(ctx context.Context, host string) (bool, error) {
 	cctx, cancel := context.WithTimeout(ctx, dohTimeout)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(cctx, http.MethodGet,
-		d.endpoint+"?name="+url.QueryEscape(host)+"&type=A", nil)
+	doc, err := d.resolve(cctx, host)
 	if err != nil {
 		return false, err
+	}
+	return sinkholed(doc), nil
+}
+
+// resolve issues the security-DoH query for host and decodes its answer set.
+func (d *DoH) resolve(ctx context.Context, host string) (dohAnswer, error) {
+	var doc dohAnswer
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		d.endpoint+"?name="+url.QueryEscape(host)+"&type=A", nil)
+	if err != nil {
+		return doc, err
 	}
 	req.Header.Set("accept", "application/dns-json")
 
 	res, err := d.client.Do(req)
 	if err != nil {
-		return false, err
+		return doc, err
 	}
 	defer func() {
 		_, _ = io.Copy(io.Discard, io.LimitReader(res.Body, dohBodyLimit))
 		_ = res.Body.Close()
 	}()
 	if res.StatusCode != http.StatusOK {
-		return false, fmt.Errorf("doh %s: status %d", host, res.StatusCode)
+		return doc, fmt.Errorf("doh %s: status %d", host, res.StatusCode)
 	}
-
 	body, err := io.ReadAll(io.LimitReader(res.Body, dohBodyLimit))
 	if err != nil {
-		return false, fmt.Errorf("doh %s: %w", host, err)
+		return doc, fmt.Errorf("doh %s: %w", host, err)
 	}
-	var doc dohAnswer
 	if err := codec.Unmarshal(body, &doc); err != nil {
-		return false, fmt.Errorf("doh %s: %w", host, err)
+		return doc, fmt.Errorf("doh %s: %w", host, err)
 	}
+	return doc, nil
+}
+
+// sinkholed reports whether any A/AAAA record is the resolver's block answer
+// (0.0.0.0 / ::) — the entire detection surface.
+func sinkholed(doc dohAnswer) bool {
 	for _, a := range doc.Answer {
-		if a.Type == 1 || a.Type == 28 { // A, AAAA
-			data := strings.TrimSuffix(a.Data, ".")
-			if data == "0.0.0.0" || data == "::" {
-				return true, nil
-			}
+		if a.Type != 1 && a.Type != 28 { // A, AAAA
+			continue
+		}
+		switch strings.TrimSuffix(a.Data, ".") {
+		case "0.0.0.0", "::":
+			return true
 		}
 	}
-	return false, nil
+	return false
 }

--- a/app/sesame/automod/linkcheck/doh.go
+++ b/app/sesame/automod/linkcheck/doh.go
@@ -5,13 +5,14 @@ package linkcheck
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
+
+	"ItsBagelBot/pkg/codec"
 )
 
 // DefaultDoHEndpoint is Cloudflare's security-filtering resolver (1.1.1.2's
@@ -90,8 +91,12 @@ func (d *DoH) Blocked(ctx context.Context, host string) (bool, error) {
 		return false, fmt.Errorf("doh %s: status %d", host, res.StatusCode)
 	}
 
+	body, err := io.ReadAll(io.LimitReader(res.Body, dohBodyLimit))
+	if err != nil {
+		return false, fmt.Errorf("doh %s: %w", host, err)
+	}
 	var doc dohAnswer
-	if err := json.NewDecoder(io.LimitReader(res.Body, dohBodyLimit)).Decode(&doc); err != nil {
+	if err := codec.Unmarshal(body, &doc); err != nil {
 		return false, fmt.Errorf("doh %s: %w", host, err)
 	}
 	for _, a := range doc.Answer {

--- a/app/sesame/automod/linkcheck/doh_test.go
+++ b/app/sesame/automod/linkcheck/doh_test.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package linkcheck
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func dohServer(t *testing.T, status int, body string) *httptest.Server {
+	t.Helper()
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(s.Close)
+	return s
+}
+
+func TestDoHClassifications(t *testing.T) {
+	cases := []struct {
+		name    string
+		status  int
+		body    string
+		blocked bool
+		wantErr bool
+	}{
+		{
+			name:    "sinkholed to 0.0.0.0",
+			status:  http.StatusOK,
+			body:    `{"Status":0,"Answer":[{"name":"evil.example","type":1,"TTL":300,"data":"0.0.0.0"}]}`,
+			blocked: true,
+		},
+		{
+			name:    "sinkholed to :: AAAA",
+			status:  http.StatusOK,
+			body:    `{"Status":0,"Answer":[{"type":28,"data":"::"}]}`,
+			blocked: true,
+		},
+		{
+			name:    "normal address clean",
+			status:  http.StatusOK,
+			body:    `{"Status":0,"Answer":[{"type":1,"data":"93.184.216.34"}]}`,
+			blocked: false,
+		},
+		{
+			name:    "nxdomain reads clean, not error",
+			status:  http.StatusOK,
+			body:    `{"Status":3}`,
+			blocked: false,
+		},
+		{
+			name:    "resolver error surfaces as error",
+			status:  http.StatusServiceUnavailable,
+			body:    "upstream sad",
+			wantErr: true,
+		},
+		{
+			name:    "garbage body surfaces as error",
+			status:  http.StatusOK,
+			body:    "<html>not json</html>",
+			wantErr: true,
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			d := NewDoH(dohServer(t, tt.status, tt.body).URL, nil)
+			blocked, err := d.Blocked(context.Background(), "host.example")
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("want error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if blocked != tt.blocked {
+				t.Fatalf("blocked = %v, want %v", blocked, tt.blocked)
+			}
+		})
+	}
+}

--- a/app/sesame/automod/linkcheck/feeds.go
+++ b/app/sesame/automod/linkcheck/feeds.go
@@ -107,14 +107,7 @@ func (f *Feeds) Refresh(ctx context.Context) (int, error) {
 
 // fetchSource downloads one source into merged, returning its contribution.
 func (f *Feeds) fetchSource(ctx context.Context, src FeedSource, merged map[string]struct{}) (int, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, src.URL, nil)
-	if err != nil {
-		return 0, err
-	}
-	if src.AuthKey != "" {
-		req.Header.Set("Auth-Key", src.AuthKey)
-	}
-	res, err := f.client.Do(req)
+	res, err := f.get(ctx, src)
 	if err != nil {
 		return 0, err
 	}
@@ -125,12 +118,30 @@ func (f *Feeds) fetchSource(ctx context.Context, src FeedSource, merged map[stri
 	if res.StatusCode != http.StatusOK {
 		return 0, fmt.Errorf("%s: status %d", src.Name, res.StatusCode)
 	}
+	return mergeFeed(res.Body, src.Format, merged)
+}
 
+// get issues the source request, attaching the abuse.ch Auth-Key header when
+// the source carries one.
+func (f *Feeds) get(ctx context.Context, src FeedSource) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, src.URL, nil)
+	if err != nil {
+		return nil, err
+	}
+	if src.AuthKey != "" {
+		req.Header.Set("Auth-Key", src.AuthKey)
+	}
+	return f.client.Do(req)
+}
+
+// mergeFeed scans a feed body line by line, adding each new host to merged until
+// the entry cap binds, and returns how many it added.
+func mergeFeed(body io.Reader, format feedFormat, merged map[string]struct{}) (int, error) {
 	added := 0
-	sc := bufio.NewScanner(io.LimitReader(res.Body, 32<<20))
+	sc := bufio.NewScanner(io.LimitReader(body, 32<<20))
 	sc.Buffer(make([]byte, 0, 64*1024), 64*1024)
 	for sc.Scan() {
-		host := parseFeedLine(sc.Bytes(), src.Format)
+		host := parseFeedLine(sc.Bytes(), format)
 		if host == "" || len(merged) >= maxFeedEntries {
 			continue
 		}

--- a/app/sesame/automod/linkcheck/feeds.go
+++ b/app/sesame/automod/linkcheck/feeds.go
@@ -153,33 +153,34 @@ func parseFeedLine(line []byte, format feedFormat) string {
 	var host string
 	switch format {
 	case FormatLines:
-		s := string(line)
-		// OpenPhish lines are URLs, sometimes scheme-less. Host runs to the
-		// first path marker either way.
-		if k := strings.Index(s, "://"); k >= 0 {
-			s = s[k+3:]
-		}
-		if k := strings.IndexAny(s, "/?#"); k >= 0 {
-			s = s[:k]
-		}
-		if k := strings.LastIndexByte(s, '@'); k >= 0 { // user@host entries
-			s = s[k+1:]
-		}
-		if k := strings.LastIndexByte(s, ':'); k >= 0 && isPortSuffix(s[k+1:]) {
-			s = s[:k]
-		}
-		host = strings.ToLower(strings.TrimSuffix(s, "."))
+		host = hostFromURLLine(string(line))
 	case FormatHosts:
-		fields := strings.Fields(string(line))
-		if len(fields) < 2 {
-			return ""
-		}
-		host = strings.ToLower(fields[1])
+		host = hostFromHostsLine(string(line))
 	}
 	if !validHost(host) {
 		return ""
 	}
 	return host
+}
+
+// hostFromURLLine pulls the host out of an OpenPhish URL line (scheme optional):
+// past the scheme, then hostOf trims path, userinfo and port the same way chat
+// tokens are trimmed.
+func hostFromURLLine(line string) string {
+	if k := strings.Index(line, "://"); k >= 0 {
+		line = line[k+3:]
+	}
+	return strings.ToLower(strings.TrimSuffix(hostOf(line), "."))
+}
+
+// hostFromHostsLine pulls the host out of an /etc/hosts-style line
+// ("0.0.0.0 evil.example"), discarding the leading address column.
+func hostFromHostsLine(line string) string {
+	fields := strings.Fields(line)
+	if len(fields) < 2 {
+		return ""
+	}
+	return strings.ToLower(fields[1])
 }
 
 // Has reports whether host (or any parent of it up three labels) sits on the

--- a/app/sesame/automod/linkcheck/feeds.go
+++ b/app/sesame/automod/linkcheck/feeds.go
@@ -1,0 +1,205 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package linkcheck
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"time"
+)
+
+// maxFeedEntries caps one merged snapshot. The live feeds measure ~10-30k
+// hosts; the cap exists so a compromised or replaced upstream cannot balloon
+// sesame's memory with garbage entries.
+const maxFeedEntries = 500_000
+
+// feedFormat is how a source encodes hosts.
+type feedFormat uint8
+
+const (
+	// FormatLines is one URL per line ("https://evil.example/path") — the
+	// OpenPhish community feed shape.
+	FormatLines feedFormat = iota
+	// FormatHosts is an /etc/hosts-style file ("0.0.0.0 evil.example") — the
+	// URLhaus hostfile shape, whose leading address column is discarded.
+	FormatHosts
+)
+
+// FeedSource names one upstream blocklist and how to read it.
+type FeedSource struct {
+	Name string
+	URL  string
+	// AuthKey is sent as the Auth-Key header when set. abuse.ch endpoints
+	// require one since mid-2023 (free registration); sources without it leave
+	// this empty.
+	AuthKey string
+	Format  feedFormat
+}
+
+// DefaultFeedSources are the no-signup-required community feeds. URLhaus joins
+// only when its auth key is configured (see Options in checker.go); OpenPhish
+// needs nothing.
+var DefaultFeedSources = []FeedSource{
+	{Name: "openphish", URL: "https://openphish.com/feed.txt", Format: FormatLines},
+}
+
+// Feeds is the refreshable host blocklist fed by FeedSources. Has reads from
+// an atomically swapped snapshot, so refresh failures keep serving the last
+// good set and the hot path pays a map lookup and nothing else.
+type Feeds struct {
+	sources []FeedSource
+	client  *http.Client
+	set     atomic.Pointer[map[string]struct{}]
+}
+
+// NewFeeds builds the blocklist aggregator around sources (empty selects
+// DefaultFeedSources) and an optional client. It starts EMPTY: until the first
+// Refresh succeeds, Has answers false everywhere and the layer contributes
+// nothing — same loaded-empty semantics as the emote suppression set.
+func NewFeeds(sources []FeedSource, client *http.Client) *Feeds {
+	if len(sources) == 0 {
+		sources = DefaultFeedSources
+	}
+	if client == nil {
+		client = &http.Client{Timeout: 15 * time.Second}
+	}
+	f := &Feeds{sources: sources, client: client}
+	empty := make(map[string]struct{})
+	f.set.Store(&empty)
+	return f
+}
+
+// Refresh pulls every source best-effort and swaps in the merged host set,
+// returning how many hosts installed. One dead source never blocks the others;
+// a total failure keeps the previous snapshot and returns the first error so
+// the caller logs it without losing coverage.
+func (f *Feeds) Refresh(ctx context.Context) (int, error) {
+	merged := make(map[string]struct{}, 8192)
+	var firstErr error
+
+	for _, src := range f.sources {
+		n, err := f.fetchSource(ctx, src, merged)
+		switch {
+		case err != nil && firstErr == nil:
+			firstErr = err
+		case err == nil:
+			// count below
+		}
+		_ = n // per-source counts fold into len(merged); errors matter more
+	}
+
+	if len(merged) == 0 {
+		return 0, fmt.Errorf("linkcheck feeds: every source failed: %w", firstErr)
+	}
+	if len(merged) > maxFeedEntries {
+		return 0, fmt.Errorf("linkcheck feeds: merged snapshot %d exceeds cap %d", len(merged), maxFeedEntries)
+	}
+	f.set.Store(&merged)
+	return len(merged), firstErr
+}
+
+// fetchSource downloads one source into merged, returning its contribution.
+func (f *Feeds) fetchSource(ctx context.Context, src FeedSource, merged map[string]struct{}) (int, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, src.URL, nil)
+	if err != nil {
+		return 0, err
+	}
+	if src.AuthKey != "" {
+		req.Header.Set("Auth-Key", src.AuthKey)
+	}
+	res, err := f.client.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, io.LimitReader(res.Body, 1<<20))
+		_ = res.Body.Close()
+	}()
+	if res.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("%s: status %d", src.Name, res.StatusCode)
+	}
+
+	added := 0
+	sc := bufio.NewScanner(io.LimitReader(res.Body, 32<<20))
+	sc.Buffer(make([]byte, 0, 64*1024), 64*1024)
+	for sc.Scan() {
+		host := parseFeedLine(sc.Bytes(), src.Format)
+		if host == "" || len(merged) >= maxFeedEntries {
+			continue
+		}
+		if _, dup := merged[host]; !dup {
+			merged[host] = struct{}{}
+			added++
+		}
+	}
+	return added, sc.Err()
+}
+
+// parseFeedLine extracts the lowercase host from one feed line per format,
+// returning "" for blanks and comments. Lines that do not carry a plausible
+// host are skipped rather than fatal: feeds occasionally interleave prose.
+func parseFeedLine(line []byte, format feedFormat) string {
+	line = bytes.TrimSpace(line)
+	if len(line) == 0 || line[0] == '#' {
+		return ""
+	}
+	var host string
+	switch format {
+	case FormatLines:
+		s := string(line)
+		// OpenPhish lines are URLs, sometimes scheme-less. Host runs to the
+		// first path marker either way.
+		if k := strings.Index(s, "://"); k >= 0 {
+			s = s[k+3:]
+		}
+		if k := strings.IndexAny(s, "/?#"); k >= 0 {
+			s = s[:k]
+		}
+		if k := strings.LastIndexByte(s, '@'); k >= 0 { // user@host entries
+			s = s[k+1:]
+		}
+		if k := strings.LastIndexByte(s, ':'); k >= 0 && isPortSuffix(s[k+1:]) {
+			s = s[:k]
+		}
+		host = strings.ToLower(strings.TrimSuffix(s, "."))
+	case FormatHosts:
+		fields := strings.Fields(string(line))
+		if len(fields) < 2 {
+			return ""
+		}
+		host = strings.ToLower(fields[1])
+	}
+	if !validHost(host) {
+		return ""
+	}
+	return host
+}
+
+// Has reports whether host (or any parent of it up three labels) sits on the
+// current snapshot. Parent walking catches subdomain rotation — feeds list
+// registrable domains but also full hosts, and scam infrastructure moves
+// a.b.evil.example -> c.evil.example faster than feeds refresh. Three levels
+// bounds the loop: deeper chains are CDN-shaped, not scam-shaped, and each
+// level costs one map probe.
+func (f *Feeds) Has(host string) bool {
+	set := f.set.Load()
+	h := host
+	for depth := 0; depth <= 3 && h != ""; depth++ {
+		if _, ok := (*set)[h]; ok {
+			return true
+		}
+		dot := strings.IndexByte(h, '.')
+		if dot < 0 {
+			return false
+		}
+		h = h[dot+1:]
+	}
+	return false
+}

--- a/app/sesame/automod/linkcheck/feeds_test.go
+++ b/app/sesame/automod/linkcheck/feeds_test.go
@@ -54,23 +54,30 @@ func TestFeedsRefreshAndHas(t *testing.T) {
 	if n != 2 {
 		t.Fatalf("installed %d hosts, want 2", n)
 	}
-	for _, h := range []string{"feedhit.example", "sub.two.example"} {
-		if !f.Has(h) {
-			t.Errorf("Has(%q) = false after refresh", h)
-		}
-	}
+	requireListed(t, f, "feedhit.example", "listed host missing after refresh")
+	requireListed(t, f, "sub.two.example", "listed host missing after refresh")
 	// Parent walk: a QUERY's ancestors match listed entries, so subdomain
 	// rotation of a LISTED host cannot dodge the snapshot. The inverse is
 	// deliberately not true: a bare registrable query does not inherit a
 	// listed subdomain's conviction - the walk goes up, never down.
-	if !f.Has("rotating.feedhit.example") {
-		t.Error("parent walk missed ancestor of listed host")
+	requireListed(t, f, "rotating.feedhit.example", "parent walk missed ancestor of listed host")
+	requireNotListed(t, f, "notfeedhit.example", "suffix collision convicted an unrelated host")
+	requireNotListed(t, f, "example", "tld-only probe convicted")
+}
+
+// requireListed asserts host resolves against the feed snapshot.
+func requireListed(t *testing.T, f *Feeds, host, msg string) {
+	t.Helper()
+	if !f.Has(host) {
+		t.Errorf("%s: Has(%q) = false", msg, host)
 	}
-	if f.Has("notfeedhit.example") {
-		t.Error("suffix collision convicted an unrelated host")
-	}
-	if f.Has("example") {
-		t.Error("tld-only probe convicted")
+}
+
+// requireNotListed asserts host does not resolve against the feed snapshot.
+func requireNotListed(t *testing.T, f *Feeds, host, msg string) {
+	t.Helper()
+	if f.Has(host) {
+		t.Errorf("%s: Has(%q) = true", msg, host)
 	}
 }
 

--- a/app/sesame/automod/linkcheck/feeds_test.go
+++ b/app/sesame/automod/linkcheck/feeds_test.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package linkcheck
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestParseFeedLines(t *testing.T) {
+	cases := []struct {
+		line   string
+		format feedFormat
+		want   string
+	}{
+		{"https://Phishy.Example/path?q=1", FormatLines, "phishy.example"},
+		{"http://user@x.example/", FormatLines, "x.example"},
+		{"bare.example/link", FormatLines, "bare.example"},
+		{"evil.example:8443/p", FormatLines, "evil.example"},
+		{"# comment", FormatLines, ""},
+		{"", FormatLines, ""},
+		{"/etc/passwd junk", FormatLines, ""},
+		{"0.0.0.1 Evil.Hosts.Example", FormatHosts, "evil.hosts.example"},
+		// Single-label entries fail validHost on purpose: they are junk or
+		// search-engine-bait, never routable hosts worth a cache slot.
+		{"127.0.0.1 onlyhost", FormatHosts, ""},
+		{"# urlhaus comment", FormatHosts, ""},
+	}
+	for _, tt := range cases {
+		if got := parseFeedLine([]byte(tt.line), tt.format); got != tt.want {
+			t.Errorf("parseFeedLine(%q) = %q, want %q", tt.line, got, tt.want)
+		}
+	}
+}
+
+func TestFeedsRefreshAndHas(t *testing.T) {
+	lines := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("https://feedhit.example/one\nhttp://sub.two.example/two\n#note\n"))
+	}))
+	defer lines.Close()
+
+	f := NewFeeds([]FeedSource{{Name: "test", URL: lines.URL, Format: FormatLines}}, nil)
+	if f.Has("anything.example") {
+		t.Fatal("unrefreshed feeds must answer empty")
+	}
+
+	n, err := f.Refresh(context.Background())
+	if err != nil {
+		t.Fatalf("refresh: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("installed %d hosts, want 2", n)
+	}
+	for _, h := range []string{"feedhit.example", "sub.two.example"} {
+		if !f.Has(h) {
+			t.Errorf("Has(%q) = false after refresh", h)
+		}
+	}
+	// Parent walk: a QUERY's ancestors match listed entries, so subdomain
+	// rotation of a LISTED host cannot dodge the snapshot. The inverse is
+	// deliberately not true: a bare registrable query does not inherit a
+	// listed subdomain's conviction - the walk goes up, never down.
+	if !f.Has("rotating.feedhit.example") {
+		t.Error("parent walk missed ancestor of listed host")
+	}
+	if f.Has("notfeedhit.example") {
+		t.Error("suffix collision convicted an unrelated host")
+	}
+	if f.Has("example") {
+		t.Error("tld-only probe convicted")
+	}
+}
+
+func TestFeedsParentWalkDepthIsBounded(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("listed.example/x\n"))
+	}))
+	defer srv.Close()
+
+	f := NewFeeds([]FeedSource{{Name: "test", URL: srv.URL, Format: FormatLines}}, nil)
+	if _, err := f.Refresh(context.Background()); err != nil {
+		t.Fatalf("refresh: %v", err)
+	}
+	// Four labels above the listed host exceeds the three-level walk: the
+	// boundary is deliberate (deeper chains are CDN-shaped, not scam-shaped).
+	if f.Has("a.b.c.d.listed.example") {
+		t.Error("walk exceeded its documented depth bound")
+	}
+	if !f.Has("a.b.c.listed.example") {
+		t.Error("three-level parent walk missed a listed ancestor")
+	}
+}
+
+func TestFeedsTotalFailureKeepsPreviousSet(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("keepme.example/x\n"))
+	}))
+	url := srv.URL
+
+	f := NewFeeds([]FeedSource{{Name: "test", URL: url, Format: FormatLines}}, nil)
+	if _, err := f.Refresh(context.Background()); err != nil {
+		t.Fatalf("first refresh: %v", err)
+	}
+
+	srv.Close() // every subsequent pull fails
+	if _, err := f.Refresh(context.Background()); err == nil {
+		t.Fatal("expected total-failure error")
+	}
+	// The previous snapshot must keep serving through the outage.
+	if !f.Has("keepme.example") {
+		t.Error("failed refresh blanked the last good feed set")
+	}
+}

--- a/app/sesame/automod/linkcheck/hosts.go
+++ b/app/sesame/automod/linkcheck/hosts.go
@@ -1,0 +1,199 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+// Package linkcheck is the automod's dynamic link-safety layer: it classifies
+// link hosts that chat carries but no static list knows yet, through passive
+// oracles only — Cloudflare's 1.1.1.1 for Families security resolver (a blocked
+// domain answers 0.0.0.0) and hourly-pulled community blocklists (OpenPhish,
+// URLhaus). It never fetches a chat link's destination: confirming liveness to
+// attacker infrastructure and driving traffic at scam pages are exactly the
+// harms the static floor exists to prevent, so the only outbound requests that
+// touch anything outside this package's allowlisted oracle endpoints are
+// redirect-header walks against known shortener hosts (unshorten.go), which
+// stop the moment a hop leaves the shortener allowlist and never contact the
+// destination.
+//
+// The gate consults the checker synchronously (map reads only) and the checker
+// resolves unknown hosts on its own goroutines; verdicts apply to subsequent
+// lines carrying the same host. This file split keeps each concern (host shape,
+// caching, oracles, expansion) reviewable alone.
+package linkcheck
+
+import (
+	"strings"
+
+	"golang.org/x/net/publicsuffix"
+)
+
+// iterLinkTokens walks text's whitespace-delimited tokens and calls fn with
+// every token that could carry a link: the authority plus any path, stripped of
+// scheme, userinfo and trailing punctuation. Tokens are substrings of text —
+// the walk itself never allocates, which is what makes it safe to run from the
+// gate's clean path on every line containing a dot (the cheap pre-filter before
+// this runs). Chat links arrive bare ("join discord.gg/x"), which url.Parse
+// rejects, so this is deliberately a scanner, not a parser.
+func iterLinkTokens(text string, fn func(token string)) {
+	for i := 0; i < len(text); {
+		for i < len(text) && isSpaceByte(text[i]) {
+			i++
+		}
+		start := i
+		for i < len(text) && !isSpaceByte(text[i]) {
+			i++
+		}
+		if start == i {
+			return
+		}
+		if tok := trimLinkToken(text[start:i]); tok != "" && strings.Contains(tok, ".") {
+			fn(tok)
+		}
+	}
+}
+
+func isSpaceByte(b byte) bool {
+	switch b {
+	case ' ', '\t', '\n', '\r', '\v', '\f':
+		return true
+	}
+	return false
+}
+
+// trimLinkToken normalizes one raw token into candidate link form: scheme off,
+// leading www. off, trailing punctuation off. Returns "" when nothing remains.
+func trimLinkToken(tok string) string {
+	// Scheme strip, case-insensitive: "HTTPS://X" arrives from caps-heavy hype.
+	if len(tok) >= 8 && equalFoldASCII(tok[:8], "https://") {
+		tok = tok[8:]
+	} else if len(tok) >= 7 && equalFoldASCII(tok[:7], "http://") {
+		tok = tok[7:]
+	}
+	// www. prefix is presentation, not identity: bit.ly and www.bit.ly must
+	// land on one cache entry.
+	if len(tok) >= 4 && equalFoldASCII(tok[:4], "www.") {
+		tok = tok[4:]
+	}
+	// Trailing punctuation is chat prosody, not the link: "bit.ly/x." ends a
+	// sentence. A run is trimmed because "...", "!?" stack in real chat. The
+	// path may legitimately end in almost anything else; only prose punctuation
+	// is released.
+	for len(tok) > 0 {
+		switch tok[len(tok)-1] {
+		case '.', ',', '!', '?', ';', ':', '"', '\'', ')', ']', '>':
+			tok = tok[:len(tok)-1]
+		default:
+			return tok
+		}
+	}
+	return tok
+}
+
+func equalFoldASCII(a, b string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := 0; i < len(a); i++ {
+		ca, cb := a[i], b[i]
+		if 'A' <= ca && ca <= 'Z' {
+			ca += 'a' - 'A'
+		}
+		if 'A' <= cb && cb <= 'Z' {
+			cb += 'a' - 'A'
+		}
+		if ca != cb {
+			return false
+		}
+	}
+	return true
+}
+
+// hostOf extracts the host component of an iterLinkTokens token: everything
+// before the first '/', '?' or '#', minus userinfo and port. The path stays in
+// the token itself — shortener destinations differ per path, so expansion keys
+// on the full token while plain-host classification keys on the host.
+func hostOf(token string) string {
+	host := token
+	if k := strings.IndexAny(host, "/?#"); k >= 0 {
+		host = host[:k]
+	}
+	if k := strings.LastIndexByte(host, '@'); k >= 0 { // user@host spam shape
+		host = host[k+1:]
+	}
+	if k := strings.LastIndexByte(host, ':'); k >= 0 && isPortSuffix(host[k+1:]) {
+		host = host[:k]
+	}
+	return host
+}
+
+// isPortSuffix reports whether s is a plausible port number (digits only).
+// Loose by design: ":abc" fails here and stays part of the host, which then
+// fails validHost — either way nothing dials it.
+func isPortSuffix(s string) bool {
+	if len(s) == 0 || len(s) > 5 {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// validHost reports whether h has the shape of a DNS name worth classifying:
+// ascii letters/digits/hyphens/dots, at least two labels, alphabetic TLD of
+// two-plus characters. The TLD rule silently rejects bare IPv4 literals (the
+// last label would be numeric) — chat links pointing at raw IPs are rare and
+// the floor already covers the abusive-host shapes worth banning on sight.
+// Non-ascii (IDN in unicode form) is rejected too: browsers punycode-display
+// those behind their own homograph warnings, so the marginal recall is not
+// worth feeding confusable hosts to the oracles.
+func validHost(h string) bool {
+	if len(h) < 4 || len(h) > 253 {
+		return false
+	}
+	labels := 1
+	last := byte('.')
+	labelStart := 0
+	for i := 0; i < len(h); i++ {
+		c := h[i]
+		switch {
+		case c == '.':
+			if last == '.' { // empty label ("a..b")
+				return false
+			}
+			labels++
+			labelStart = i + 1
+		case c == '-' || c == '_' ||
+			('a' <= c && c <= 'z') || ('0' <= c && c <= '9'):
+			// ok (underscore appears in wildcard-ish junk; harmless to carry)
+		default:
+			return false // uppercase was already lowered; anything else is out
+		}
+		last = c
+	}
+	if labels < 2 || last == '.' {
+		return false
+	}
+	tld := h[labelStart:]
+	if len(tld) < 2 || len(tld) > 63 {
+		return false
+	}
+	for i := 0; i < len(tld); i++ {
+		if tld[i] < 'a' || tld[i] > 'z' {
+			return false
+		}
+	}
+	return true
+}
+
+// foldHost reduces a host to its registrable domain (eTLD+1), so sub.domain
+// rotation cannot fragment the cache past eviction reach. Errors (single-label
+// names, malformed input) fall back to the host verbatim — a cache keyed on
+// slightly-wrong granularity still converges, a panic does not.
+func foldHost(h string) string {
+	folded, err := publicsuffix.EffectiveTLDPlusOne(h)
+	if err != nil || folded == "" {
+		return h
+	}
+	return folded
+}

--- a/app/sesame/automod/linkcheck/hosts.go
+++ b/app/sesame/automod/linkcheck/hosts.go
@@ -148,33 +148,46 @@ func isPortSuffix(s string) bool {
 // those behind their own homograph warnings, so the marginal recall is not
 // worth feeding confusable hosts to the oracles.
 func validHost(h string) bool {
-	if len(h) < 4 || len(h) > 253 {
-		return false
-	}
-	labels := 1
-	last := byte('.')
-	labelStart := 0
+	return len(h) >= 4 && len(h) <= 253 && hostBytesOK(h) && hostLabelsOK(h)
+}
+
+// hostBytesOK reports whether every byte sits in the accepted host alphabet.
+func hostBytesOK(h string) bool {
 	for i := 0; i < len(h); i++ {
 		c := h[i]
 		switch {
-		case c == '.':
+		case c == '.' || c == '-' || c == '_':
+			// separators and wildcard-ish junk (harmless to carry)
+		case 'a' <= c && c <= 'z', '0' <= c && c <= '9':
+			// ok; uppercase was already lowered, anything else is out
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// hostLabelsOK reports a dot-separated shape with no empty label, two or more
+// labels total, and a plausible TLD at the end.
+func hostLabelsOK(h string) bool {
+	labels := 1
+	last := byte('.')
+	for i := 0; i < len(h); i++ {
+		if h[i] == '.' {
 			if last == '.' { // empty label ("a..b")
 				return false
 			}
 			labels++
-			labelStart = i + 1
-		case c == '-' || c == '_' ||
-			('a' <= c && c <= 'z') || ('0' <= c && c <= '9'):
-			// ok (underscore appears in wildcard-ish junk; harmless to carry)
-		default:
-			return false // uppercase was already lowered; anything else is out
 		}
-		last = c
+		last = h[i]
 	}
-	if labels < 2 || last == '.' {
-		return false
-	}
-	tld := h[labelStart:]
+	return labels >= 2 && last != '.' && hostTLDOK(h)
+}
+
+// hostTLDOK reports whether h's final label is an alphabetic name of two to
+// sixty-three characters.
+func hostTLDOK(h string) bool {
+	tld := h[strings.LastIndexByte(h, '.')+1:]
 	if len(tld) < 2 || len(tld) > 63 {
 		return false
 	}

--- a/app/sesame/automod/linkcheck/hosts.go
+++ b/app/sesame/automod/linkcheck/hosts.go
@@ -34,20 +34,28 @@ import (
 // rejects, so this is deliberately a scanner, not a parser.
 func iterLinkTokens(text string, fn func(token string)) {
 	for i := 0; i < len(text); {
-		for i < len(text) && isSpaceByte(text[i]) {
-			i++
-		}
-		start := i
-		for i < len(text) && !isSpaceByte(text[i]) {
-			i++
-		}
-		if start == i {
+		start, end := nextToken(text, i)
+		if start == end {
 			return
 		}
-		if tok := trimLinkToken(text[start:i]); tok != "" && strings.Contains(tok, ".") {
+		if tok := trimLinkToken(text[start:end]); tok != "" && strings.Contains(tok, ".") {
 			fn(tok)
 		}
+		i = end
 	}
+}
+
+// nextToken returns the [start,end) span of the next whitespace-delimited run at
+// or after i. start==end means only trailing whitespace remained.
+func nextToken(text string, i int) (start, end int) {
+	for i < len(text) && isSpaceByte(text[i]) {
+		i++
+	}
+	start = i
+	for i < len(text) && !isSpaceByte(text[i]) {
+		i++
+	}
+	return start, i
 }
 
 func isSpaceByte(b byte) bool {
@@ -61,21 +69,31 @@ func isSpaceByte(b byte) bool {
 // trimLinkToken normalizes one raw token into candidate link form: scheme off,
 // leading www. off, trailing punctuation off. Returns "" when nothing remains.
 func trimLinkToken(tok string) string {
-	// Scheme strip, case-insensitive: "HTTPS://X" arrives from caps-heavy hype.
-	if len(tok) >= 8 && equalFoldASCII(tok[:8], "https://") {
-		tok = tok[8:]
-	} else if len(tok) >= 7 && equalFoldASCII(tok[:7], "http://") {
-		tok = tok[7:]
-	}
+	tok = stripScheme(tok)
 	// www. prefix is presentation, not identity: bit.ly and www.bit.ly must
 	// land on one cache entry.
 	if len(tok) >= 4 && equalFoldASCII(tok[:4], "www.") {
 		tok = tok[4:]
 	}
-	// Trailing punctuation is chat prosody, not the link: "bit.ly/x." ends a
-	// sentence. A run is trimmed because "...", "!?" stack in real chat. The
-	// path may legitimately end in almost anything else; only prose punctuation
-	// is released.
+	return stripTrailingPunct(tok)
+}
+
+// stripScheme removes a leading http:// or https:// (case-insensitive: caps-
+// heavy hype arrives as "HTTPS://X").
+func stripScheme(tok string) string {
+	switch {
+	case len(tok) >= 8 && equalFoldASCII(tok[:8], "https://"):
+		return tok[8:]
+	case len(tok) >= 7 && equalFoldASCII(tok[:7], "http://"):
+		return tok[7:]
+	}
+	return tok
+}
+
+// stripTrailingPunct releases a run of trailing prose punctuation: "bit.ly/x."
+// ends a sentence, and "...", "!?" stack in real chat. The path may legitimately
+// end in almost anything else, so only these prose marks are released.
+func stripTrailingPunct(tok string) string {
 	for len(tok) > 0 {
 		switch tok[len(tok)-1] {
 		case '.', ',', '!', '?', ';', ':', '"', '\'', ')', ']', '>':

--- a/app/sesame/automod/linkcheck/hosts_test.go
+++ b/app/sesame/automod/linkcheck/hosts_test.go
@@ -4,6 +4,7 @@
 package linkcheck
 
 import (
+	"slices"
 	"strings"
 	"testing"
 )
@@ -36,14 +37,8 @@ func TestIterLinkTokens(t *testing.T) {
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			got := collectTokens(t, tt.text)
-			if len(got) != len(tt.want) {
+			if got := collectTokens(t, tt.text); !slices.Equal(got, tt.want) {
 				t.Fatalf("tokens %q = %v, want %v", tt.text, got, tt.want)
-			}
-			for i := range got {
-				if got[i] != tt.want[i] {
-					t.Fatalf("tokens %q = %v, want %v", tt.text, got, tt.want)
-				}
 			}
 		})
 	}

--- a/app/sesame/automod/linkcheck/hosts_test.go
+++ b/app/sesame/automod/linkcheck/hosts_test.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package linkcheck
+
+import (
+	"strings"
+	"testing"
+)
+
+func collectTokens(t *testing.T, text string) []string {
+	t.Helper()
+	var out []string
+	iterLinkTokens(text, func(tok string) { out = append(out, tok) })
+	return out
+}
+
+func TestIterLinkTokens(t *testing.T) {
+	cases := []struct {
+		name string
+		text string
+		want []string
+	}{
+		{"bare url", "join https://grabify.link/x now", []string{"grabify.link/x"}},
+		{"scheme-less", "check sub.grabify.link/x for the event", []string{"sub.grabify.link/x"}},
+		{"trailing punctuation", "it's on bit.ly/abc.", []string{"bit.ly/abc"}},
+		{"stacked punctuation", "see evil.example!!", []string{"evil.example"}},
+		{"caps scheme", "HTTPS://Evil.Example/p now", []string{"Evil.Example/p"}},
+		{"port", "evil.com:8080/path ok", []string{"evil.com:8080/path"}},
+		// Userinfo survives in the token (hostOf strips it later); the scanner
+		// is not a parser and does not pre-interpret @.
+		{"userinfo", "phish at https://user@evil.example/p today", []string{"user@evil.example/p"}},
+		{"query kept", "open a.example/q?x=1 please", []string{"a.example/q?x=1"}},
+		{"ellipsis noise", "wait... what...", nil},
+		{"no dots", "no links here friends", nil},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			got := collectTokens(t, tt.text)
+			if len(got) != len(tt.want) {
+				t.Fatalf("tokens %q = %v, want %v", tt.text, got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("tokens %q = %v, want %v", tt.text, got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+func TestHostOfAndValidHost(t *testing.T) {
+	cases := []struct {
+		token  string
+		host   string
+		valid  bool
+		folded string
+	}{
+		{token: "grabify.link/x", host: "grabify.link", valid: true, folded: "grabify.link"},
+		{token: "SUB.Evil.Example", host: "sub.evil.example", valid: true, folded: "evil.example"},
+		{token: "foo.co.uk/a", host: "foo.co.uk", valid: true, folded: "foo.co.uk"},
+		{token: "deep.a.b.evil.example", host: "deep.a.b.evil.example", valid: true, folded: "evil.example"},
+		{token: "xn--80ak6aa92e.tk", host: "xn--80ak6aa92e.tk", valid: true, folded: "xn--80ak6aa92e.tk"},
+		{token: "10.0.0.1", host: "10.0.0.1", valid: false},
+		{token: "notahost", host: "notahost", valid: false},
+		{token: "a.b", host: "a.b", valid: false},
+	}
+	for _, tt := range cases {
+		// Production lowercases before classification (buildTask), so the
+		// table runs on the lowered form; hostOf itself preserves case.
+		host := strings.ToLower(hostOf(tt.token))
+		if host != tt.host {
+			t.Errorf("hostOf(%q) = %q, want %q", tt.token, host, tt.host)
+		}
+		if valid := validHost(strings.ToLower(host)); valid != tt.valid {
+			t.Errorf("validHost(%q) = %v, want %v", host, valid, tt.valid)
+		}
+		if !tt.valid {
+			continue
+		}
+		if f := foldHost(host); f != tt.folded {
+			t.Errorf("foldHost(%q) = %q, want %q", host, f, tt.folded)
+		}
+	}
+}
+
+func TestValidHostRejectsUnicodeAndPorts(t *testing.T) {
+	for _, h := range []string{"пример.рф", "evîl.example", "evil.example:8080"} {
+		if validHost(h) {
+			t.Errorf("validHost(%q) = true, want false", h)
+		}
+	}
+}
+
+func TestTrimLinkTokenDropsSchemeOnly(t *testing.T) {
+	// A bare TLD-ish token with no second label never becomes a candidate:
+	// "..." must not survive as "." after trimming.
+	if got := trimLinkToken("..."); got != "" {
+		t.Fatalf("trimLinkToken(...) = %q, want empty", got)
+	}
+}

--- a/app/sesame/automod/linkcheck/hosts_test.go
+++ b/app/sesame/automod/linkcheck/hosts_test.go
@@ -60,7 +60,7 @@ func TestHostOfAndValidHost(t *testing.T) {
 		{token: "SUB.Evil.Example", host: "sub.evil.example", valid: true, folded: "evil.example"},
 		{token: "foo.co.uk/a", host: "foo.co.uk", valid: true, folded: "foo.co.uk"},
 		{token: "deep.a.b.evil.example", host: "deep.a.b.evil.example", valid: true, folded: "evil.example"},
-		{token: "xn--80ak6aa92e.tk", host: "xn--80ak6aa92e.tk", valid: true, folded: "xn--80ak6aa92e.tk"},
+		{token: "xn--80ak6aa92e.tk", host: "xn--80ak6aa92e.tk", valid: true, folded: "xn--80ak6aa92e.tk"}, //gitleaks:allow punycode host fixture, not a secret
 		{token: "10.0.0.1", host: "10.0.0.1", valid: false},
 		{token: "notahost", host: "notahost", valid: false},
 		{token: "a.b", host: "a.b", valid: false},

--- a/app/sesame/automod/linkcheck/unshorten.go
+++ b/app/sesame/automod/linkcheck/unshorten.go
@@ -165,10 +165,17 @@ func (e *Expander) Destination(ctx context.Context, token string) (string, error
 // matches on name alone because httptest binds random ports.
 func (e *Expander) externalHost(u *url.URL) string {
 	host := strings.ToLower(u.Hostname())
-	if e.IsShortener(host) && (e.anyPort || isWebPort(u.Port())) {
+	if e.mayProbe(host, u.Port()) {
 		return ""
 	}
 	return host
+}
+
+// mayProbe reports whether this package may issue a request to host: it must be
+// an allowlisted shortener reached on a web-standard port. anyPort (test mode)
+// waives the port check because httptest binds random ports.
+func (e *Expander) mayProbe(host, port string) bool {
+	return e.IsShortener(host) && (e.anyPort || isWebPort(port))
 }
 
 // nextHop resolves one redirect step: probe the current URL, parse its

--- a/app/sesame/automod/linkcheck/unshorten.go
+++ b/app/sesame/automod/linkcheck/unshorten.go
@@ -1,0 +1,226 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package linkcheck
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// DefaultShorteners is the allowlist of hosts whose redirect headers the
+// expander may walk. Deliberately the mainstream set chat actually carries —
+// every entry here is an outbound-request permission, so the bar for adding
+// one is "viewers genuinely paste this", not "it redirects". Hosts already on
+// the immovable floor (yip.su et al) are absent: the floor bans those lines
+// inline before any expansion could matter.
+var DefaultShorteners = []string{
+	"bit.ly", "t.co", "tinyurl.com", "goo.gl", "ow.ly", "is.gd",
+	"buff.ly", "cutt.ly", "rb.gy", "t.ly", "rebrand.ly", "shorturl.at",
+	"tiny.cc", "bit.do", "v.gd", "x.gd", "s.id", "snip.ly", "lnkd.in",
+	"clck.ru", "soo.gd",
+}
+
+// Expansion envelope constants, recorded so they can be re-argued:
+//
+//   - maxRedirectHops 5: live chains measure 1-3 hops (bit.ly -> t.co -> dest
+//     is the deep case); five leaves headroom without letting a redirect loop
+//     spin. A chain that needs more is not something we want to resolve anyway.
+//   - expandBudget 6s total per walk: three hops x ~2s worst-case hop latency,
+//     bounded once so a slow shortener cannot hold a worker slot open all day.
+//   - hopTimeout 3s per request: covers TCP + TLS + headers against the big
+//     shortener CDN edges; anything slower is down, and down means unknown,
+//     which means no verdict rather than a wrong one.
+//   - discardBodyLimit 64KB: bodies are never parsed or stored — only status
+//     line and Location matter — but some edges stream error pages before
+//     honoring connection close, so a capped drain prevents socket stalls.
+const (
+	maxRedirectHops  = 5
+	expandBudget     = 6 * time.Second
+	hopTimeout       = 3 * time.Second
+	discardBodyLimit = 64 << 10
+)
+
+// Expander resolves shortener links to their destination host by walking
+// redirect HEADERS ONLY across the allowlist. The safety shape, in order:
+//
+//  1. Requests go to allowlisted shortener hosts exclusively. When a Location
+//     leaves the allowlist, that target IS the destination — it is returned to
+//     the caller uncontacted. Attacker-controlled pages never receive a request
+//     from sesame, see no IP, log no hit.
+//  2. Belt-and-braces against DNS rebinding (a shortener name resolving inward):
+//     the dialer's Control hook refuses any resolved address in loopback,
+//     private, link-local, CGNAT, ULA or multicast space before the socket even
+//     opens. This is process-level containment only; at the infra layer the
+//     pod's egress should still sit behind a default-deny policy (WARP/Gateway)
+//     allowing just this package's oracle endpoints — the two layers fail
+//     different ways and neither assumes the other.
+//  3. GET (not HEAD): several shortener edges mishandle HEAD, and a wrong
+//     answer here mints a false Clean. Bodies are drained capped and discarded;
+//     nothing from them is read.
+type Expander struct {
+	client  *http.Client
+	short   map[string]struct{}
+	scheme  string // "https" in production; httptest needs plain http
+	anyPort bool   // test mode: match membership on name, not name+web-port
+}
+
+// NewExpander builds the walker around shorteners (empty selects
+// DefaultShorteners) and an optional client; nil gets the guarded default.
+func NewExpander(client *http.Client, shorteners []string) *Expander {
+	return newExpanderScheme(client, shorteners, "https")
+}
+
+// newExpanderScheme exists for tests: httptest endpoints speak plain HTTP on
+// random ports, while every mainstream shortener is HTTPS-only on web ports,
+// so production keeps both strictures.
+func newExpanderScheme(client *http.Client, shorteners []string, scheme string) *Expander {
+	if len(shorteners) == 0 {
+		shorteners = DefaultShorteners
+	}
+	short := make(map[string]struct{}, len(shorteners))
+	for _, s := range shorteners {
+		short[strings.ToLower(s)] = struct{}{}
+	}
+	if client == nil {
+		client = &http.Client{
+			Transport: &http.Transport{
+				DialContext: (&net.Dialer{
+					Timeout:   hopTimeout,
+					KeepAlive: hopTimeout,
+					Control:   guardDial,
+				}).DialContext,
+				TLSHandshakeTimeout: hopTimeout,
+				MaxIdleConns:        4,
+			},
+			// Never auto-follow: the manual loop below decides hop by hop
+			// whether the next target may be contacted at all.
+			CheckRedirect: func(*http.Request, []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		}
+	}
+	return &Expander{client: client, short: short, scheme: scheme, anyPort: scheme != "https"}
+}
+
+// isWebPort reports whether p is empty or one of the two ports a chat link
+// can implicitly use. Anything explicit is exotic by definition here.
+func isWebPort(p string) bool { return p == "" || p == "80" || p == "443" }
+
+// IsShortener reports whether host sits on the allowlist.
+func (e *Expander) IsShortener(host string) bool {
+	_, ok := e.short[host]
+	return ok
+}
+
+// Destination walks the redirect chain of rawURL (a token as iterLinkTokens
+// yields it, e.g. "bit.ly/abc") and returns the first destination HOST outside
+// the allowlist — contacted by nobody. An input host that is not a shortener
+// returns immediately with itself (the caller classified plain hosts directly);
+// chains that stay inside the allowlist through maxRedirectHops return an
+// error rather than a guess. The chain travels as parsed *url.Values so each
+// hop's hostname comes from the parser, not from token slicing — hostOf is
+// token-shaped and would misread a full URL's scheme as its host.
+func (e *Expander) Destination(ctx context.Context, token string) (string, error) {
+	current, err := url.Parse(e.scheme + "://" + strings.ToLower(token))
+	if err != nil {
+		return "", fmt.Errorf("expand %s: %w", token, err)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, expandBudget)
+	defer cancel()
+
+	for hop := 0; ; hop++ {
+		host := strings.ToLower(current.Hostname())
+		// Egress gate: the hostname must sit on the allowlist AND the port
+		// must be web-standard - "bit.ly:8443" cannot inherit "bit.ly"'s
+		// permission and is returned as a destination, contacted by nobody.
+		// anyPort (test mode, riding the same constructor switch as plain
+		// http) matches on name alone because httptest binds random ports.
+		if !e.IsShortener(host) || (!e.anyPort && !isWebPort(current.Port())) {
+			return host, nil // the destination: returned, never requested
+		}
+		if hop >= maxRedirectHops {
+			return "", fmt.Errorf("expand %s: exceeded %d hops", token, maxRedirectHops)
+		}
+
+		loc, err := e.probe(ctx, current.String())
+		if err != nil {
+			return "", fmt.Errorf("expand %s: %w", token, err)
+		}
+		if loc == "" {
+			// The shortener served a non-redirect (landing page, interstitial,
+			// bot wall). Its own host is what we can honestly report.
+			return host, nil
+		}
+		ref, err := current.Parse(loc) // relative Locations resolve against current
+		if err != nil {
+			return "", fmt.Errorf("expand %s: bad location: %w", token, err)
+		}
+		if ref.Scheme != "https" && ref.Scheme != "http" {
+			return "", fmt.Errorf("expand %s: scheme %q refused", token, ref.Scheme)
+		}
+		current = ref
+	}
+}
+
+// probe issues one capped GET and returns the next Location header value (""
+// when the response is not a redirect).
+func (e *Expander) probe(ctx context.Context, rawURL string) (location string, err error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return "", err
+	}
+	res, err := e.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, io.LimitReader(res.Body, discardBodyLimit))
+		_ = res.Body.Close()
+	}()
+	if res.StatusCode < 300 || res.StatusCode > 399 {
+		return "", nil
+	}
+	return strings.TrimSpace(res.Header.Get("Location")), nil
+}
+
+// guardDial is the transport-level SSRF gate applied to every dialed address:
+// it runs after DNS resolution, before connect, so a rebinding shortener name
+// pointing at link-local metadata or cluster-private space is refused at the
+// socket layer regardless of what the allowlist believed about the hostname.
+func guardDial(_ string, address string, _ syscall.RawConn) error {
+	h, _, err := net.SplitHostPort(address)
+	if err != nil {
+		return fmt.Errorf("linkcheck dial guard: %w", err)
+	}
+	ip := net.ParseIP(h)
+	switch {
+	case ip == nil:
+		return fmt.Errorf("linkcheck dial guard: unparseable address %q", h)
+	case ip.IsLoopback(), ip.IsPrivate(), ip.IsUnspecified(),
+		ip.IsLinkLocalUnicast(), ip.IsLinkLocalMulticast(), ip.IsMulticast():
+		return fmt.Errorf("linkcheck dial guard: refused internal address %s", h)
+	}
+	// CGNAT 100.64/10 shares private-space semantics on modern clusters and is
+	// not covered by IsPrivate; ULA fc00::/7 likewise on the IPv6 side.
+	if isCGNAT(ip) || isULA(ip) {
+		return fmt.Errorf("linkcheck dial guard: refused internal address %s", h)
+	}
+	return nil
+}
+
+func isCGNAT(ip net.IP) bool {
+	return ip.To4() != nil && ip.To4()[0] == 100 && ip.To4()[1] >= 64 && ip.To4()[1] < 128
+}
+
+func isULA(ip net.IP) bool {
+	return len(ip) == 16 && ip[0]&0xfe == 0xfc
+}

--- a/app/sesame/automod/linkcheck/unshorten.go
+++ b/app/sesame/automod/linkcheck/unshorten.go
@@ -125,8 +125,8 @@ func (e *Expander) IsShortener(host string) bool {
 // the allowlist — contacted by nobody. An input host that is not a shortener
 // returns immediately with itself (the caller classified plain hosts directly);
 // chains that stay inside the allowlist through maxRedirectHops return an
-// error rather than a guess. The chain travels as parsed *url.Values so each
-// hop's hostname comes from the parser, not from token slicing — hostOf is
+// error rather than a guess. The chain travels as parsed URLs so each hop's
+// hostname comes from the parser, not from token slicing — hostOf is
 // token-shaped and would misread a full URL's scheme as its host.
 func (e *Expander) Destination(ctx context.Context, token string) (string, error) {
 	current, err := url.Parse(e.scheme + "://" + strings.ToLower(token))
@@ -138,37 +138,56 @@ func (e *Expander) Destination(ctx context.Context, token string) (string, error
 	defer cancel()
 
 	for hop := 0; ; hop++ {
-		host := strings.ToLower(current.Hostname())
-		// Egress gate: the hostname must sit on the allowlist AND the port
-		// must be web-standard - "bit.ly:8443" cannot inherit "bit.ly"'s
-		// permission and is returned as a destination, contacted by nobody.
-		// anyPort (test mode, riding the same constructor switch as plain
-		// http) matches on name alone because httptest binds random ports.
-		if !e.IsShortener(host) || (!e.anyPort && !isWebPort(current.Port())) {
+		if host := e.externalHost(current); host != "" {
 			return host, nil // the destination: returned, never requested
 		}
 		if hop >= maxRedirectHops {
 			return "", fmt.Errorf("expand %s: exceeded %d hops", token, maxRedirectHops)
 		}
-
-		loc, err := e.probe(ctx, current.String())
+		next, err := e.nextHop(ctx, current)
 		if err != nil {
 			return "", fmt.Errorf("expand %s: %w", token, err)
 		}
-		if loc == "" {
-			// The shortener served a non-redirect (landing page, interstitial,
-			// bot wall). Its own host is what we can honestly report.
-			return host, nil
+		if next == nil {
+			// Non-redirect response (landing page, interstitial, bot wall):
+			// the shortener's own host is what we can honestly report.
+			return strings.ToLower(current.Hostname()), nil
 		}
-		ref, err := current.Parse(loc) // relative Locations resolve against current
-		if err != nil {
-			return "", fmt.Errorf("expand %s: bad location: %w", token, err)
-		}
-		if ref.Scheme != "https" && ref.Scheme != "http" {
-			return "", fmt.Errorf("expand %s: scheme %q refused", token, ref.Scheme)
-		}
-		current = ref
+		current = next
 	}
+}
+
+// externalHost reports the destination hostname when u sits outside the
+// expansion envelope, or "" when u is a shortener this package may probe.
+// The hostname must sit on the allowlist AND the port must be web-standard —
+// "bit.ly:8443" cannot inherit "bit.ly"'s permission and travels nowhere.
+// anyPort (test mode, riding the same constructor switch as plain http)
+// matches on name alone because httptest binds random ports.
+func (e *Expander) externalHost(u *url.URL) string {
+	host := strings.ToLower(u.Hostname())
+	if e.IsShortener(host) && (e.anyPort || isWebPort(u.Port())) {
+		return ""
+	}
+	return host
+}
+
+// nextHop resolves one redirect step: probe the current URL, parse its
+// Location relative to it, refuse exotic schemes. A nil URL with a nil error
+// means the response was not a redirect. Callers only reach here for hosts
+// externalHost cleared.
+func (e *Expander) nextHop(ctx context.Context, current *url.URL) (*url.URL, error) {
+	loc, err := e.probe(ctx, current.String())
+	if err != nil || loc == "" {
+		return nil, err
+	}
+	ref, err := current.Parse(loc)
+	if err != nil {
+		return nil, fmt.Errorf("bad location: %w", err)
+	}
+	if ref.Scheme != "https" && ref.Scheme != "http" {
+		return nil, fmt.Errorf("scheme %q refused", ref.Scheme)
+	}
+	return ref, nil
 }
 
 // probe issues one capped GET and returns the next Location header value (""

--- a/app/sesame/automod/linkcheck/unshorten_test.go
+++ b/app/sesame/automod/linkcheck/unshorten_test.go
@@ -1,0 +1,174 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package linkcheck
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// testClient is an expander client WITHOUT the production dial guard, because
+// httptest servers live on 127.0.0.1 - exactly the range guardDial refuses.
+// The guard itself is unit-tested directly in TestGuardDial.
+func testClient() *http.Client {
+	return &http.Client{
+		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+	}
+}
+
+func redirectServer(t *testing.T, location string) *httptest.Server {
+	t.Helper()
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if location == "" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		http.Redirect(w, r, location, http.StatusMovedPermanently)
+	}))
+	t.Cleanup(s.Close)
+	return s
+}
+
+// tok converts an httptest URL into the token shape iterLinkTokens yields
+// (scheme stripped) — hostOf and the expander consume tokens, not raw URLs.
+func tok(url string) string { return trimLinkToken(url) }
+
+// fakeDNS maps pretend hostnames ("shead.test") onto real httptest listeners,
+// so expansion tests run on domain-shaped names instead of 127.0.0.1:port
+// (which validHost rightly rejects as an IP literal).
+type dnsMap map[string]string // hostname -> listener addr
+
+func clientFor(t *testing.T, m dnsMap) *http.Client {
+	t.Helper()
+	return &http.Client{
+		Timeout: 2 * time.Second,
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+				real, ok := m[strings.SplitN(addr, ":", 2)[0]]
+				if !ok {
+					return nil, fmt.Errorf("fake DNS: %q not mapped", addr)
+				}
+				var d net.Dialer
+				return d.DialContext(ctx, network, real)
+			},
+		},
+		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+	}
+}
+
+func TestDestinationStopsAtAllowlistBoundary(t *testing.T) {
+	var destHits atomic.Int64
+	dest := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		destHits.Add(1)
+	}))
+	defer dest.Close()
+
+	mid := redirectServer(t, "http://sdest.test/final")
+	head := redirectServer(t, "http://smid.test/m")
+
+	e := newExpanderScheme(
+		clientFor(t, dnsMap{
+			"shead.test": tok(head.URL),
+			"smid.test":  tok(mid.URL),
+			"sdest.test": tok(dest.URL),
+		}),
+		[]string{"shead.test", "smid.test"}, "http")
+
+	got, err := e.Destination(context.Background(), "shead.test/abc")
+	if err != nil {
+		t.Fatalf("destination: %v", err)
+	}
+	if got != "sdest.test" {
+		t.Fatalf("destination = %q, want sdest.test", got)
+	}
+	if destHits.Load() != 0 {
+		t.Fatalf("destination was contacted %d times; contract is never", destHits.Load())
+	}
+}
+
+func TestDestinationNonShortenerInputIsUntouched(t *testing.T) {
+	e := newExpanderScheme(testClient(), []string{"bit.ly"}, "http")
+	got, err := e.Destination(context.Background(), "plain.example/x")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "plain.example" {
+		t.Fatalf("got %q, want plain.example returned uncontacted", got)
+	}
+}
+
+func TestDestinationInterstitialReturnsShortenerItself(t *testing.T) {
+	wall := redirectServer(t, "") // serves a 200 landing page: bot wall
+	e := newExpanderScheme(clientFor(t, dnsMap{"swall.test": tok(wall.URL)}), []string{"swall.test"}, "http")
+	got, err := e.Destination(context.Background(), "swall.test/xyz")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "swall.test" {
+		t.Fatalf("interstitial destination = %q, want the shortener host swall.test", got)
+	}
+}
+
+func TestDestinationLoopCappedAtHops(t *testing.T) {
+	loop := redirectServer(t, "/self") // relative Location: redirects into itself
+	e := newExpanderScheme(clientFor(t, dnsMap{"sloop.test": tok(loop.URL)}), []string{"sloop.test"}, "http")
+	if _, err := e.Destination(context.Background(), "sloop.test/start"); err == nil {
+		t.Fatal("redirect loop resolved without error")
+	}
+}
+
+func TestDestinationRefusesExoticScheme(t *testing.T) {
+	srv := redirectServer(t, "javascript:alert(1)")
+	e := newExpanderScheme(clientFor(t, dnsMap{"sscheme.test": tok(srv.URL)}), []string{"sscheme.test"}, "http")
+	if _, err := e.Destination(context.Background(), "sscheme.test/x"); err == nil {
+		t.Fatal("non-http scheme accepted")
+	}
+}
+
+func TestGuardDial(t *testing.T) {
+	cases := []struct {
+		addr string
+		ok   bool
+	}{
+		{"8.8.8.8:443", true},
+		{"1.1.1.1:53", true},
+		{"2606:4700::1111", false}, // no port: SplitHostPort errors
+		{"127.0.0.1:8080", false},
+		{"10.1.2.3:443", false},
+		{"192.168.0.20:443", false},
+		{"172.16.9.9:443", false},
+		{"100.64.0.9:443", false}, // CGNAT
+		{"169.254.169.254:80", false},
+		{"[fd00::5]:443", false}, // ULA
+		{"224.0.0.1:5353", false},
+		{"not-an-address:443", false},
+	}
+	for _, tt := range cases {
+		err := guardDial("tcp", tt.addr, nil)
+		if tt.ok && err != nil {
+			t.Errorf("guardDial(%q) = %v, want allowed", tt.addr, err)
+		}
+		if !tt.ok && err == nil {
+			t.Errorf("guardDial(%q) allowed, want refused", tt.addr)
+		}
+	}
+}
+
+func TestGuardDialBlocksLiveLoopbackDial(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
+	defer srv.Close()
+
+	e := NewExpander(nil, []string{hostOf(tok(srv.URL))}) // default client carries guardDial
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	if _, err := e.client.Do(req); err == nil {
+		t.Fatal("loopback dial succeeded despite guardDial")
+	}
+}

--- a/app/sesame/automod/linkcheck_gate_test.go
+++ b/app/sesame/automod/linkcheck_gate_test.go
@@ -70,8 +70,8 @@ func TestGatePhishVerdictOnFeedListedHost(t *testing.T) {
 
 	line := "see convicted.example ok friends"
 	v := g.InspectWith(module.RoleEveryone, line, nil)
-	if v.Action != ActionTimeout || v.Rule != "phish" || v.Seconds != 600 {
-		t.Fatalf("verdict = %+v, want timeout/600/phish", v)
+	if want := (Verdict{Action: ActionTimeout, Seconds: 600, Rule: "phish"}); v != want {
+		t.Fatalf("verdict = %+v, want %+v", v, want)
 	}
 }
 

--- a/app/sesame/automod/linkcheck_gate_test.go
+++ b/app/sesame/automod/linkcheck_gate_test.go
@@ -1,0 +1,131 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package automod
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"ItsBagelBot/app/sesame/automod/linkcheck"
+	"ItsBagelBot/app/sesame/module"
+	"ItsBagelBot/pkg/codec"
+)
+
+// waitFor polls until cond holds; the checker resolves asynchronously by
+// design, so first contact is allowed to come up empty.
+func waitFor(t *testing.T, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatal("condition did not hold within 2s")
+}
+
+// blockingDoH serves a security resolver that sinks every name to 0.0.0.0.
+func blockingDoH(t *testing.T) *linkcheck.DoH {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"Status":0,"Answer":[{"type":1,"data":"0.0.0.0"}]}`))
+	}))
+	t.Cleanup(srv.Close)
+	return linkcheck.NewDoH(srv.URL, nil)
+}
+
+// feedChecker arms the dynamic layer with a feed snapshot listing one host,
+// giving the tests a SYNCHRONOUS conviction path (no network wait).
+func feedChecker(t *testing.T) (*linkcheck.Checker, context.CancelFunc) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("convicted.example/scam\n"))
+	}))
+	t.Cleanup(srv.Close)
+
+	feeds := linkcheck.NewFeeds([]linkcheck.FeedSource{{Name: "test", URL: srv.URL, Format: linkcheck.FormatLines}}, nil)
+	if _, err := feeds.Refresh(context.Background()); err != nil {
+		t.Fatalf("feed refresh: %v", err)
+	}
+	c := linkcheck.NewChecker(linkcheck.Options{
+		Feeds: feeds,
+		DoH:   blockingDoH(t),
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	c.Start(ctx)
+	return c, cancel
+}
+
+func TestGatePhishVerdictOnFeedListedHost(t *testing.T) {
+	c, stop := feedChecker(t)
+	defer stop()
+
+	g := New()
+	g.SetLinkChecker(c)
+
+	line := "see convicted.example ok friends"
+	v := g.InspectWith(module.RoleEveryone, line, nil)
+	if v.Action != ActionTimeout || v.Rule != "phish" || v.Seconds != 600 {
+		t.Fatalf("verdict = %+v, want timeout/600/phish", v)
+	}
+}
+
+func TestGateUnknownHostResolvesAsyncThenConvicts(t *testing.T) {
+	c := linkcheck.NewChecker(linkcheck.Options{
+		Feeds: linkcheck.NewFeeds(nil, nil),
+		DoH:   blockingDoH(t),
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	c.Start(ctx)
+
+	g := New()
+	g.SetLinkChecker(c)
+
+	line := "doomed.example is live go look"
+	if v := g.InspectWith(module.RoleEveryone, line, nil); v.Action != ActionNone {
+		t.Fatalf("first sight convicted before any oracle ran: %+v", v)
+	}
+	waitFor(t, func() bool {
+		return g.InspectWith(module.RoleEveryone, line, nil).Action == ActionTimeout
+	})
+}
+
+func TestGateFloorStillWinsOverLinkCheck(t *testing.T) {
+	c, stop := feedChecker(t)
+	defer stop()
+
+	g := New()
+	g.SetLinkChecker(c)
+
+	// grabify.link is immovable-floor infrastructure; the phish layer must not
+	// re-badge it even though the checker's oracle would also convict.
+	if v := g.InspectWith(module.RoleEveryone, "visit grabify.link now", nil); v.Rule != "ip_logger" {
+		t.Fatalf("rule = %q, want ip_logger (floor precedence)", v.Rule)
+	}
+}
+
+func TestGateLinksOffProfileSkipsLinkCheck(t *testing.T) {
+	c, stop := feedChecker(t)
+	defer stop()
+
+	g := New()
+	g.SetLinkChecker(c)
+
+	cfg := ParseConfig(codec.RawMessage(`{"level":"none"}`))
+	if v := g.InspectWith(module.RoleEveryone, "see convicted.example ok", cfg); v.Action != ActionNone {
+		t.Fatalf("floor-only profile judged links: %+v", v)
+	}
+}
+
+func TestGateUnarmedStaysInert(t *testing.T) {
+	g := New() // no SetLinkChecker: byte-identical to the pre-linkcheck gate
+	if v := g.InspectWith(module.RoleEveryone, "see convicted.example ok", nil); v.Action != ActionNone {
+		t.Fatalf("unarmed gate acted: %+v", v)
+	}
+}

--- a/app/sesame/engine/bot_stats.go
+++ b/app/sesame/engine/bot_stats.go
@@ -70,6 +70,7 @@ type flagRule string
 const (
 	ruleIPLogger       flagRule = "ip_logger"
 	ruleScam           flagRule = "scam"
+	rulePhish          flagRule = "phish"
 	ruleHeuristic      flagRule = "heuristic"
 	ruleBlockTerm      flagRule = "block_term"
 	ruleLexHate        flagRule = "lex:hate:"
@@ -91,6 +92,7 @@ type flagRuleBucket int
 const (
 	bktIPLogger flagRuleBucket = iota
 	bktScam
+	bktPhish
 	bktHeuristic
 	bktBlockTerm
 	bktLexHate
@@ -106,6 +108,7 @@ const (
 var flagRuleNames = [bktCount]flagRule{
 	bktIPLogger:      ruleIPLogger,
 	bktScam:          ruleScam,
+	bktPhish:         rulePhish,
 	bktHeuristic:     ruleHeuristic,
 	bktBlockTerm:     ruleBlockTerm,
 	bktLexHate:       "lex_hate",
@@ -152,6 +155,7 @@ func stripRuleSuffixes(rule flagRule) flagRule {
 var baseRuleBuckets = map[flagRule]flagRuleBucket{
 	ruleIPLogger:   bktIPLogger,
 	ruleScam:       bktScam,
+	rulePhish:      bktPhish,
 	ruleHeuristic:  bktHeuristic,
 	ruleBlockTerm:  bktBlockTerm,
 	ruleCouncil:    bktCouncil,

--- a/app/sesame/engine/bot_stats_test.go
+++ b/app/sesame/engine/bot_stats_test.go
@@ -301,6 +301,7 @@ func TestFlagBucketClassification(t *testing.T) {
 	}{
 		{"ip_logger", "ip_logger"},
 		{"scam", "scam"},
+		{"phish", "phish"},
 		{"heuristic", "heuristic"},
 		{"block_term", "block_term"},
 		{"council:campaign", "council_campaign"},

--- a/app/sesame/internal/config/config.go
+++ b/app/sesame/internal/config/config.go
@@ -108,17 +108,16 @@ type Config struct {
 	AdaptiveEnabled bool
 
 	// LinkCheckEnabled arms the dynamic link-safety checker: unknown link hosts
-	// resolve through passive oracles (Cloudflare security DoH, OpenPhish/URLhaus
-	// blocklists) on background goroutines, and convicted hosts time out on their
+	// resolve through passive oracles (Cloudflare security DoH, the OpenPhish
+	// blocklist) on background goroutines, and convicted hosts time out on their
 	// next mention under the "phish" rule. Dark launch like the other layers:
 	// off keeps verdicts byte-identical; arm it alongside AutomodEnforce=false
 	// first so Hit logs can soak. The checker never fetches a chat link's
 	// destination - see app/sesame/automod/linkcheck.
 	LinkCheckEnabled bool
 
-	// LinkCheckFeeds pulls the community blocklists (OpenPhish free feed always,
-	// URLhaus hostfile when URLHausAuthKey is set) every feed interval. On by
-	// default when LinkCheckEnabled is armed.
+	// LinkCheckFeeds pulls the community blocklists (the OpenPhish free feed)
+	// every feed interval. On by default when LinkCheckEnabled is armed.
 	LinkCheckFeeds bool
 
 	// LinkCheckShorteners allows redirect-header walks across the shortener
@@ -127,10 +126,6 @@ type Config struct {
 	// the allowlist boundary and never contact destinations. On by default when
 	// LinkCheckEnabled is armed.
 	LinkCheckShorteners bool
-
-	// URLHausAuthKey is the abuse.ch Auth-Key for the URLhaus hostfile download
-	// (free registration). Empty skips that source; OpenPhish needs no key.
-	URLHausAuthKey string
 
 	// LiveTTL bounds how long a live key survives without a refresh.
 	LiveTTL time.Duration
@@ -236,7 +231,6 @@ func Load() *Config {
 		LinkCheckEnabled:    env.GetBool("SESAME_LINKCHECK", false),
 		LinkCheckFeeds:      env.GetBool("SESAME_LINKCHECK_FEEDS", true),
 		LinkCheckShorteners: env.GetBool("SESAME_LINKCHECK_SHORTENERS", true),
-		URLHausAuthKey:      env.Get("SESAME_LINKCHECK_URLHAUS_KEY", ""),
 
 		NukeEnabled: env.Get("SESAME_NUKE", "on") != "off",
 

--- a/app/sesame/internal/config/config.go
+++ b/app/sesame/internal/config/config.go
@@ -107,6 +107,31 @@ type Config struct {
 	// gate so the layers soak in shadow logs before anyone trusts them.
 	AdaptiveEnabled bool
 
+	// LinkCheckEnabled arms the dynamic link-safety checker: unknown link hosts
+	// resolve through passive oracles (Cloudflare security DoH, OpenPhish/URLhaus
+	// blocklists) on background goroutines, and convicted hosts time out on their
+	// next mention under the "phish" rule. Dark launch like the other layers:
+	// off keeps verdicts byte-identical; arm it alongside AutomodEnforce=false
+	// first so Hit logs can soak. The checker never fetches a chat link's
+	// destination - see app/sesame/automod/linkcheck.
+	LinkCheckEnabled bool
+
+	// LinkCheckFeeds pulls the community blocklists (OpenPhish free feed always,
+	// URLhaus hostfile when URLHausAuthKey is set) every feed interval. On by
+	// default when LinkCheckEnabled is armed.
+	LinkCheckFeeds bool
+
+	// LinkCheckShorteners allows redirect-header walks across the shortener
+	// allowlist (bit.ly et al) so "is this safe?" answers for the destination,
+	// which the chat-visible shortener alone can never give. Requests stop at
+	// the allowlist boundary and never contact destinations. On by default when
+	// LinkCheckEnabled is armed.
+	LinkCheckShorteners bool
+
+	// URLHausAuthKey is the abuse.ch Auth-Key for the URLhaus hostfile download
+	// (free registration). Empty skips that source; OpenPhish needs no key.
+	URLHausAuthKey string
+
 	// LiveTTL bounds how long a live key survives without a refresh.
 	LiveTTL time.Duration
 
@@ -207,6 +232,11 @@ func Load() *Config {
 		ShieldEnabled:   env.Get("SESAME_AUTOMOD_SHIELD", "false") == "true",
 		EmotesEnabled:   env.Get("SESAME_AUTOMOD_EMOTES", "true") == "true",
 		AdaptiveEnabled: env.Get("SESAME_AUTOMOD_ADAPTIVE", "false") == "true",
+
+		LinkCheckEnabled:    env.GetBool("SESAME_LINKCHECK", false),
+		LinkCheckFeeds:      env.GetBool("SESAME_LINKCHECK_FEEDS", true),
+		LinkCheckShorteners: env.GetBool("SESAME_LINKCHECK_SHORTENERS", true),
+		URLHausAuthKey:      env.Get("SESAME_LINKCHECK_URLHAUS_KEY", ""),
 
 		NukeEnabled: env.Get("SESAME_NUKE", "on") != "off",
 

--- a/app/sesame/linkcheck_runner.go
+++ b/app/sesame/linkcheck_runner.go
@@ -32,19 +32,9 @@ const linkCheckFeedInterval = 30 * time.Minute
 // rule fires on the next line carrying that host), so this hook stays the
 // shadow-mode paper trail: who posted what where, per source.
 func runLinkCheck(ctx context.Context, guard *automod.Gate, cfg *config.Config, log *zap.Logger) {
-	sources := linkcheck.DefaultFeedSources
-	if cfg.URLHausAuthKey != "" {
-		sources = append(sources, linkcheck.FeedSource{
-			Name:    "urlhaus",
-			URL:     "https://urlhaus.abuse.ch/downloads/hostfile/",
-			AuthKey: cfg.URLHausAuthKey,
-			Format:  linkcheck.FormatHosts,
-		})
-	}
-
 	checker := linkcheck.NewChecker(linkcheck.Options{
 		ExpandShorteners: cfg.LinkCheckShorteners,
-		Feeds:            linkcheck.NewFeeds(sources, nil),
+		Feeds:            linkcheck.NewFeeds(linkcheck.DefaultFeedSources, nil),
 		Log:              log,
 	})
 	checker.OnBad = func(h linkcheck.Hit) {

--- a/app/sesame/linkcheck_runner.go
+++ b/app/sesame/linkcheck_runner.go
@@ -1,0 +1,84 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package main
+
+import (
+	"context"
+	"time"
+
+	"ItsBagelBot/app/sesame/automod"
+	"ItsBagelBot/app/sesame/automod/linkcheck"
+	"ItsBagelBot/app/sesame/internal/config"
+
+	"go.uber.org/zap"
+)
+
+// linkCheckFeedInterval is how often the community blocklists re-pull. The
+// feeds update on the order of minutes and phishing infra churns in hours;
+// thirty minutes bounds staleness at a rounding error of outbound traffic
+// (two small GETs per tick).
+const linkCheckFeedInterval = 30 * time.Minute
+
+// runLinkCheck arms the gate's dynamic link-safety layer and keeps its
+// blocklist snapshot current. It follows the refresher contract: install once
+// at startup, re-pull on a slow ticker, never let a failed fetch blank live
+// coverage (the previous snapshot serves until one succeeds). The checker's
+// workers ride ctx, so cancelling the service context drains them; nothing to
+// Close.
+//
+// Convictions land in OnBad as a WARN audit line rather than an action of
+// their own - enforcement flows through the normal verdict path (the phish
+// rule fires on the next line carrying that host), so this hook stays the
+// shadow-mode paper trail: who posted what where, per source.
+func runLinkCheck(ctx context.Context, guard *automod.Gate, cfg *config.Config, log *zap.Logger) {
+	sources := linkcheck.DefaultFeedSources
+	if cfg.URLHausAuthKey != "" {
+		sources = append(sources, linkcheck.FeedSource{
+			Name:    "urlhaus",
+			URL:     "https://urlhaus.abuse.ch/downloads/hostfile/",
+			AuthKey: cfg.URLHausAuthKey,
+			Format:  linkcheck.FormatHosts,
+		})
+	}
+
+	checker := linkcheck.NewChecker(linkcheck.Options{
+		ExpandShorteners: cfg.LinkCheckShorteners,
+		Feeds:            linkcheck.NewFeeds(sources, nil),
+		Log:              log,
+	})
+	checker.OnBad = func(h linkcheck.Hit) {
+		log.Warn("linkcheck conviction",
+			zap.String("host", h.Host),
+			zap.String("token", h.Token),
+			zap.String("via", h.Via),
+			zap.String("source", string(h.Source)),
+			zap.Uint64("broadcaster_id", h.Channel),
+			zap.String("chatter_id", h.Sender))
+	}
+	guard.SetLinkChecker(checker)
+	checker.Start(ctx)
+	log.Info("linkcheck armed",
+		zap.Bool("feeds", cfg.LinkCheckFeeds),
+		zap.Bool("shorteners", cfg.LinkCheckShorteners))
+
+	if !cfg.LinkCheckFeeds {
+		return
+	}
+	refresh := func() {
+		if _, err := checker.RefreshFeeds(ctx); err != nil {
+			log.Warn("linkcheck feed refresh failed; keeping previous set", zap.Error(err))
+		}
+	}
+	refresh()
+	ticker := time.NewTicker(linkCheckFeedInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			refresh()
+		}
+	}
+}

--- a/app/sesame/main.go
+++ b/app/sesame/main.go
@@ -151,15 +151,18 @@ func main() {
 	drainInflight(weighted, cfg.DrainTimeout, log)
 }
 
-// startRefreshers launches the background automod refreshers that feed the shared
-// gate: the third-party emote sets (caps false-positive suppression) and the
-// optional lexicon override directory.
+// startRefreshers launches the background automod refreshers that feed the
+// shared gate: the third-party emote sets (caps false-positive suppression),
+// the optional lexicon override directory, and the dynamic link-safety checker.
 func startRefreshers(ctx context.Context, guard *automod.Gate, cfg *config.Config, log *zap.Logger) {
 	if cfg.EmotesEnabled {
 		go refreshEmotes(ctx, guard, log)
 	}
 	if dir := env.Get("SESAME_AUTOMOD_LEXICON_DIR", ""); dir != "" {
 		go reloadLexicon(ctx, dir, guard, log)
+	}
+	if cfg.LinkCheckEnabled {
+		go runLinkCheck(ctx, guard, cfg, log)
 	}
 }
 


### PR DESCRIPTION
## What

Extends the automod beyond the static `ip_logger` blocklist: link hosts chat carries but no curated list knows get classified by **passive oracles** and time out under a new `phish` rule (600s, infrastructure class, floor keeps precedence).

## Oracles
- **Cloudflare security DoH** (`security.cloudflare-dns.com`): blocked domain answers `0.0.0.0` — resolution only, no connection to the host ever opens.
- **Community feeds**: OpenPhish free feed always; URLhaus hostfile when `SESAME_LINKCHECK_URLHAUS_KEY` is set. 30m refresh, atomic snapshot swap, last good set survives outages.

## Shortener expansion — the safety envelope
- Requests go to **allowlisted shortener hosts only**; the moment a hop leaves the allowlist that target is returned as the destination, uncontacted (no IP disclosure, no hit logged).
- Dialer `Control` hook refuses loopback/private/link-local/CGNAT/ULA addresses post-DNS (rebinding guard); non-web ports don't inherit a hostname's permission.
- 5-hop cap, 6s budget, GET with discarded bodies; redirect loops and exotic schemes refused.

## Gate integration
- Third bounded clean-path scan, gated on the line containing a dot; unknown hosts enqueue off-thread, convicted hosts route to the deep path where `phish` resolves **after** the immovable floor.
- Per-registrable-domain verdict cache (bad 24h / clean 6h / shortener-token 1h), error cooldown instead of caching non-answers, rate-limited DoH (5 qps), drop-counted bounded queue.

## Rollout
Dark launch behind `SESAME_LINKCHECK` (default off = byte-identical verdicts); soak with `SESAME_AUTOMOD_ENFORCE=false` first. Convictions land as WARN audit lines carrying host/token/via/source/channel/chatter.

## Tests
DoH parsing, feed formats + parent-walk bounds, expansion chains asserting the destination is never contacted, SSRF dial refusal, cache TTL/cap, async conviction flow, gate precedence + links-off profile. `-race` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional link safety checks for messages, including phishing detection from threat feeds and DNS-based analysis.
  * Added support for checking shortened links and safely following redirects.
  * Added configurable link-checking options, automatic feed refreshes, and asynchronous checks for unknown hosts.
  * Detected phishing links now receive a dedicated moderation verdict and timeout.

* **Bug Fixes**
  * Preserved previous threat-feed data when refreshes fail.
  * Added caching, rate controls, and cooldowns to reduce repeated link checks and handle service interruptions safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->