### PR TITLE
perf(console): cut the dashboard boot long task into per-route chunks

### DIFF
--- a/console/dashboard/src/app.d.ts
+++ b/console/dashboard/src/app.d.ts
@@ -3,6 +3,7 @@
 
 import type { Session } from '$lib/server/session';
 import type { Locale } from '@bagel/shared/i18n';
+import type { AccountState } from '$lib/server/services';
 
 declare global {
   namespace App {
@@ -10,6 +11,14 @@ declare global {
       session: Session | null;
       locale: Locale;
       cursorEnabled: boolean;
+      /**
+       * The account-state read guardSession already made for the request's
+       * gates, so the (app) layout reuses it instead of paying a second RPC.
+       * Settled result, never a live rejected promise: `{ ghost: true }` means
+       * the users service authoritatively reported no such user; an unset
+       * field means the read blipped and the caller may retry.
+       */
+      accountState?: { value: AccountState } | { ghost: true };
     }
     interface PageData {
       role?: 'streamer' | 'mod';

--- a/console/dashboard/src/lib/components/InstallAppPrompt.svelte
+++ b/console/dashboard/src/lib/components/InstallAppPrompt.svelte
@@ -12,7 +12,8 @@
   import { onMount } from 'svelte';
   import { browser } from '$app/environment';
   import { page } from '$app/state';
-  import { Icon, getI18n } from '@bagel/shared';
+  import Icon from '@bagel/shared/components/Icon.svelte';
+  import { getI18n } from '@bagel/shared/i18n/context';
 
   const { t } = getI18n();
 

--- a/console/dashboard/src/lib/components/LangSwitch.svelte
+++ b/console/dashboard/src/lib/components/LangSwitch.svelte
@@ -3,15 +3,26 @@
 	// Proprietary. No license granted. See LICENSE.md.
   // Compact EN/FR toggle. Posts to /lang (plain form, no fetch) with the current
   // path as `next` so the switch keeps you on the same page in the new language.
+  import { onMount } from 'svelte';
   import { page } from '$app/state';
   import { getI18n, LOCALES, type Locale } from '@bagel/shared';
-  import { localeName } from '@bagel/shared/i18n';
+  import { ensureCatalog, localeName } from '@bagel/shared/i18n';
 
   let { selected }: { selected?: Locale } = $props();
   const i18n = getI18n();
   const active = $derived(selected ?? i18n.locale);
   const next = $derived(page.url.pathname + page.url.search);
   const short = (l: Locale) => l.toUpperCase();
+
+  // Tooltips show each locale's self-name, which lives in its catalog. Catalogs
+  // load lazily now (boot no longer evaluates all of them), so pull them in here
+  // where the names are actually displayed; until one lands the title falls
+  // back to the bare code.
+  let named = $state(false);
+  onMount(async () => {
+    await Promise.all(LOCALES.map((l) => ensureCatalog(l)));
+    named = true;
+  });
 </script>
 
 <form method="POST" action="/lang" class="lang" aria-label={i18n.t('lang.switchAria')}>
@@ -24,7 +35,7 @@
       class="lang-opt"
       class:active={l === active}
       aria-pressed={l === active}
-      title={localeName(l)}
+      title={named ? localeName(l) : l}
     >{short(l)}</button>
   {/each}
 </form>

--- a/console/dashboard/src/lib/components/OnboardingGuide.svelte
+++ b/console/dashboard/src/lib/components/OnboardingGuide.svelte
@@ -9,7 +9,10 @@
   // dialog stepper, but the blob walks the screen instead of sitting still in
   // a card. Dismissal is remembered in localStorage; `?welcome=1` re-opens it
   // for a refresher (both handled by the caller).
-  import { Icon, Bolota, Toggle, getI18n } from '@bagel/shared';
+  import Icon from '@bagel/shared/components/Icon.svelte';
+  import Bolota from '@bagel/shared/components/Bolota.svelte';
+  import Toggle from '@bagel/shared/components/Toggle.svelte';
+  import { getI18n } from '@bagel/shared/i18n/context';
   import LangSwitch from './LangSwitch.svelte';
   import CursorSwitch from './CursorSwitch.svelte';
 

--- a/console/dashboard/src/lib/components/overview/BotStatusPanel.svelte
+++ b/console/dashboard/src/lib/components/overview/BotStatusPanel.svelte
@@ -14,7 +14,12 @@
   // for a delegate session server-side.
   import { enhance } from '$app/forms';
   import type { SubmitFunction } from '@sveltejs/kit';
-  import { Button, ButtonLink, Icon, Skeleton, getI18n, type ConnUi } from '@bagel/shared';
+  import Button from '@bagel/shared/components/Button.svelte';
+  import ButtonLink from '@bagel/shared/components/ButtonLink.svelte';
+  import Icon from '@bagel/shared/components/Icon.svelte';
+  import Skeleton from '@bagel/shared/components/Skeleton.svelte';
+  import { getI18n } from '@bagel/shared/i18n/context';
+  import type { ConnUi } from '@bagel/shared/connection-state';
   import { statusTone } from './status';
 
   const { t } = getI18n();

--- a/console/dashboard/src/lib/components/overview/LinkedSummary.svelte
+++ b/console/dashboard/src/lib/components/overview/LinkedSummary.svelte
@@ -10,7 +10,10 @@
   // indistinguishable from an empty account. Rather than claim "Add your first
   // command" during an outage, a failed read falls back to a neutral "manage"
   // label that makes no count claim; the linked page shows the real state.
-  import { ButtonLink, Icon, getI18n, type IconName } from '@bagel/shared';
+  import ButtonLink from '@bagel/shared/components/ButtonLink.svelte';
+  import Icon from '@bagel/shared/components/Icon.svelte';
+  import { getI18n } from '@bagel/shared/i18n/context';
+  import type { IconName } from '@bagel/shared/icons';
 
   const { t } = getI18n();
 

--- a/console/dashboard/src/lib/components/overview/NeedsAttention.svelte
+++ b/console/dashboard/src/lib/components/overview/NeedsAttention.svelte
@@ -10,7 +10,10 @@
   // active/total/pending as 0, which is indistinguishable from an empty account,
   // so a down read must never manufacture an "all disabled" / "invites pending"
   // row. Guard every issue on its read having actually landed.
-  import { ButtonLink, Icon, getI18n, type IconName } from '@bagel/shared';
+  import ButtonLink from '@bagel/shared/components/ButtonLink.svelte';
+  import Icon from '@bagel/shared/components/Icon.svelte';
+  import { getI18n } from '@bagel/shared/i18n/context';
+  import type { IconName } from '@bagel/shared/icons';
 
   const { t } = getI18n();
 

--- a/console/dashboard/src/lib/components/overview/QuickActions.svelte
+++ b/console/dashboard/src/lib/components/overview/QuickActions.svelte
@@ -6,7 +6,8 @@
   // competes. A Settings shortcut appears as a third action ONLY while the bot
   // needs attention (anything but a healthy, online connection); a healthy board
   // leaves it out.
-  import { ButtonLink, getI18n } from '@bagel/shared';
+  import ButtonLink from '@bagel/shared/components/ButtonLink.svelte';
+  import { getI18n } from '@bagel/shared/i18n/context';
 
   const { t } = getI18n();
 

--- a/console/dashboard/src/lib/components/overview/SetupProgress.svelte
+++ b/console/dashboard/src/lib/components/overview/SetupProgress.svelte
@@ -6,7 +6,11 @@
   // not just a tick), and links to where it gets done. `receiving` is main's honest
   // "online" (grant + active + enroll ok), so a pending/failing connection does not
   // read as connected here.
-  import { Card, ButtonLink, Icon, getI18n, type IconName } from '@bagel/shared';
+  import Card from '@bagel/shared/components/Card.svelte';
+  import ButtonLink from '@bagel/shared/components/ButtonLink.svelte';
+  import Icon from '@bagel/shared/components/Icon.svelte';
+  import { getI18n } from '@bagel/shared/i18n/context';
+  import type { IconName } from '@bagel/shared/icons';
 
   const { t } = getI18n();
 

--- a/console/dashboard/src/lib/components/overview/TopCommands.svelte
+++ b/console/dashboard/src/lib/components/overview/TopCommands.svelte
@@ -4,7 +4,10 @@
   // Established accounts: the most-used commands, each a compact ledger line. The
   // section owns its <h2>; the card title role is folded into it so the heading
   // order stays h1 -> h2 with no decorative h3 in between.
-  import { Card, Icon, getI18n, type CommandView } from '@bagel/shared';
+  import Card from '@bagel/shared/components/Card.svelte';
+  import Icon from '@bagel/shared/components/Icon.svelte';
+  import { getI18n } from '@bagel/shared/i18n/context';
+  import type { CommandView } from '@bagel/shared/types';
 
   const { t } = getI18n();
 

--- a/console/dashboard/src/lib/components/overview/status.ts
+++ b/console/dashboard/src/lib/components/overview/status.ts
@@ -7,7 +7,7 @@
 // only layers the page's VISUAL tone on top of that kind, so the status panel and
 // its dot/colour never disagree with the word they sit beside. Colour is always
 // decoration on top of the textual state, never the only signal.
-import type { ConnKind } from '@bagel/shared';
+import type { ConnKind } from '@bagel/shared/connection-state';
 
 export type StatusTone = 'success' | 'warning' | 'error' | 'neutral';
 

--- a/console/dashboard/src/lib/server/demo-data.ts
+++ b/console/dashboard/src/lib/server/demo-data.ts
@@ -28,7 +28,7 @@ import {
 } from '@bagel/shared';
 import { DEFAULT_LOCALE } from '@bagel/shared/i18n';
 import type { Session } from './session';
-import type { BillingState, NotificationWire } from './services';
+import type { AccountState, BillingState, NotificationWire } from './services';
 import type { QuoteView } from './quotes-store';
 import type { GoveeDevice, GoveeView } from './govee-store';
 import type { FetchDefView, FetchKeyView } from './fetches-store';
@@ -90,7 +90,13 @@ export const demoAuthorizedDashboards = [
   { href: '/delegate/enter?owner=77', name: 'bagel_queen' }
 ];
 
-export const demoAccountState = { active: true, status: 'vip', onboarded: true, creatorCode: null };
+export const demoAccountState: AccountState = {
+  active: true,
+  status: 'vip',
+  onboarded: true,
+  creatorCode: null,
+  username: 'demo'
+};
 
 // Sample grants covering the full lifecycle (pending + consumed) so the
 // settings page renders and is exercisable without OAuth + NATS.

--- a/console/dashboard/src/lib/server/guard.ts
+++ b/console/dashboard/src/lib/server/guard.ts
@@ -23,7 +23,7 @@ import { dev } from '$app/environment';
 import { redirect, type RequestEvent } from '@sveltejs/kit';
 import { MODULE_CATALOG, moduleDelegateSections } from '@bagel/shared';
 import { COOKIE, type Session } from '$lib/server/session';
-import { accountState, delegationAccess, isBanned } from '$lib/server/services';
+import { accountState, delegationAccess, isBanned, type AccountState } from '$lib/server/services';
 import { RpcError } from '@bagel/shared/server/nats';
 import { isSessionRevoked } from '@bagel/shared/server/session-revocation';
 
@@ -100,37 +100,48 @@ function moduleSubpathAllowed(id: string, sections: readonly string[]): boolean 
 //     session issued before that moment. isSessionRevoked never throws.
 //   * ghost session — only an RpcError ("no such user") wipes; anything else
 //     keeps the session and lets pages degrade.
+// publishAccountState hands the gate's own account read to the (app) layout via
+// locals, so the shell does not spend a second RPC on it.
+//
+// Settled result, never a live rejected promise (a request that never reads
+// locals must not raise an unhandled rejection): a fulfilled read is reused by
+// the layout, an RpcError means the user is gone (no retry), and any other
+// failure leaves the field unset so the layout retries like it used to.
+function publishAccountState(event: RequestEvent, state: PromiseSettledResult<AccountState>): void {
+  if (state.status === 'fulfilled') event.locals.accountState = { value: state.value };
+  else if (state.reason instanceof RpcError) event.locals.accountState = { ghost: true };
+}
+
+// refusalSlug reduces three gates that each answer in a different shape — a
+// boolean, a boolean, a rejection kind — to the single question the caller
+// actually has: which `?e=` slug, if any, refuses this session.
+//
+// Kept separate from the wipe/redirect so that pair is written once instead of
+// three times; the order is the precedence, most conclusive first.
+function refusalSlug(
+  ban: PromiseSettledResult<boolean>,
+  revoked: PromiseSettledResult<boolean>,
+  state: PromiseSettledResult<AccountState>
+): string | null {
+  if (ban.status === 'fulfilled' && ban.value) return 'banned';
+  if (revoked.status === 'fulfilled' && revoked.value) return 'revoked';
+  if (state.status === 'rejected' && state.reason instanceof RpcError) return 'signedout';
+  return null;
+}
+
 async function assertAccountUsable(event: RequestEvent, s: Session): Promise<void> {
   const [ban, revoked, state] = await Promise.allSettled([
     isBanned(s.user_id),
     isSessionRevoked({ sid: s.sid, userId: s.user_id, iat: s.iat }),
-    // Exposed on locals so the same read feeds the (app) layout's premium/
-    // onboarded data without a second RPC on cache-miss requests.
     accountState(s.user_id)
   ]);
-  // Settled result, never a live rejected promise (a request that never reads
-  // locals must not raise an unhandled rejection): a fulfilled read is reused
-  // by the layout, an RpcError means the user is gone (no retry), and any other
-  // failure leaves the field unset so the layout retries like it used to.
-  if (state.status === 'fulfilled') event.locals.accountState = { value: state.value };
-  else if (state.reason instanceof RpcError) event.locals.accountState = { ghost: true };
 
-  if (ban.status === 'fulfilled' && ban.value) {
-    wipe(event);
-    throw redirect(303, '/login?e=banned');
-  }
+  publishAccountState(event, state);
 
-  if (revoked.status === 'fulfilled' && revoked.value) {
-    wipe(event);
-    throw redirect(303, '/login?e=revoked');
-  }
-
-  if (state.status === 'rejected') {
-    if (state.reason instanceof RpcError) {
-      wipe(event);
-      throw redirect(303, '/login?e=signedout');
-    }
-  }
+  const slug = refusalSlug(ban, revoked, state);
+  if (!slug) return;
+  wipe(event);
+  throw redirect(303, `/login?e=${slug}`);
 }
 
 // guardSession validates an already-opened session against authoritative

--- a/console/dashboard/src/lib/server/guard.ts
+++ b/console/dashboard/src/lib/server/guard.ts
@@ -88,32 +88,45 @@ function moduleSubpathAllowed(id: string, sections: readonly string[]): boolean 
   return moduleDelegateSections(def).some((sec) => sections.includes(sec));
 }
 
-// assertAccountUsable runs the three gates that judge the session itself,
-// each with the same outage posture: fail open on a transport blip, wipe the
-// cookie only on an authoritative answer.
+// assertAccountUsable runs the three gates that judge the session itself.
+// They fire CONCURRENTLY: each is an independent read (ban via cache fabric,
+// revocation via Valkey, account state via users RPC), and sequential awaits
+// stacked three round trips on every authed request — visible as a stalled
+// first paint on the dashboard. Outcomes keep their priority: ban outranks
+// revocation, which outranks ghost-session; only an authoritative answer wipes
+// the cookie, transport blips fail open exactly as before.
 //   * ban — isBanned serves last-known state through a users-service outage.
 //   * revocation — logout kills this sid; "sign out everywhere" kills every
 //     session issued before that moment. isSessionRevoked never throws.
 //   * ghost session — only an RpcError ("no such user") wipes; anything else
 //     keeps the session and lets pages degrade.
 async function assertAccountUsable(event: RequestEvent, s: Session): Promise<void> {
-  if (await isBanned(s.user_id)) {
+  const [ban, revoked, state] = await Promise.allSettled([
+    isBanned(s.user_id),
+    isSessionRevoked({ sid: s.sid, userId: s.user_id, iat: s.iat }),
+    // Exposed on locals so the same read feeds the (app) layout's premium/
+    // onboarded data without a second RPC on cache-miss requests.
+    accountState(s.user_id)
+  ]);
+  // Settled result, never a live rejected promise (a request that never reads
+  // locals must not raise an unhandled rejection): a fulfilled read is reused
+  // by the layout, an RpcError means the user is gone (no retry), and any other
+  // failure leaves the field unset so the layout retries like it used to.
+  if (state.status === 'fulfilled') event.locals.accountState = { value: state.value };
+  else if (state.reason instanceof RpcError) event.locals.accountState = { ghost: true };
+
+  if (ban.status === 'fulfilled' && ban.value) {
     wipe(event);
     throw redirect(303, '/login?e=banned');
   }
 
-  if (await isSessionRevoked({ sid: s.sid, userId: s.user_id, iat: s.iat })) {
+  if (revoked.status === 'fulfilled' && revoked.value) {
     wipe(event);
-    // Not ?e=signedout: that notice tells the visitor their account no longer
-    // exists, which is the ghost-session case below. A revoked session is a
-    // live account the user deliberately signed out.
     throw redirect(303, '/login?e=revoked');
   }
 
-  try {
-    await accountState(s.user_id);
-  } catch (err) {
-    if (err instanceof RpcError) {
+  if (state.status === 'rejected') {
+    if (state.reason instanceof RpcError) {
       wipe(event);
       throw redirect(303, '/login?e=signedout');
     }

--- a/console/dashboard/src/routes/(app)/+layout.server.ts
+++ b/console/dashboard/src/routes/(app)/+layout.server.ts
@@ -18,10 +18,13 @@ const BELL_PEEK = 5;
 // must never block the shell, so a failed fetch just shows an empty peek.
 // Delegates have no bell.
 async function loadBellPeek(s: Session): Promise<{ unreadCount: number; notifications: NotificationWire[] }> {
+  // The peek is hard-capped here, at the source, so the streamed payload stays
+  // bounded no matter how deep the mailbox is.
+  const cap = (list: NotificationWire[]): NotificationWire[] => list.slice(0, BELL_PEEK);
   if (DEMO) {
     const { demoNotifications } = await import('$lib/server/demo-data');
     return {
-      notifications: demoNotifications,
+      notifications: cap(demoNotifications),
       unreadCount: demoNotifications.filter((n) => !n.read).length
     };
   }
@@ -35,7 +38,7 @@ async function loadBellPeek(s: Session): Promise<{ unreadCount: number; notifica
       unreadCount = r.unreadCount;
     })
     .catch(() => {});
-  return { unreadCount, notifications };
+  return { unreadCount, notifications: cap(notifications) };
 }
 
 // loadAuthorizedDashboards lists the boards shared with this user, for the
@@ -68,13 +71,18 @@ export const load: LayoutServerLoad = async ({ locals, url }) => {
     throw redirect(302, next === '/' ? '/login' : `/login?next=${encodeURIComponent(next)}`);
   }
 
-  const [{ unreadCount, notifications }, authorizedDashboards, acc] = await Promise.all([
-    loadBellPeek(s),
-    loadAuthorizedDashboards(s),
-    DEMO
-      ? import('$lib/server/demo-data').then((m) => m.demoAccountState)
-      : accountState(s.user_id).catch(() => null)
-  ]);
+  // The gates already read account state once per request (hooks.server.ts ->
+  // guardSession), and the result rides locals. Reuse it; only a blipped gate
+  // read (field unset) retries here, and an authoritative ghost answer renders
+  // the shell with no account data instead of re-asking a service that already
+  // said no.
+  const acc: Awaited<ReturnType<typeof accountState>> | null = DEMO
+    ? await import('$lib/server/demo-data').then((m) => m.demoAccountState)
+    : locals.accountState
+      ? 'value' in locals.accountState
+        ? locals.accountState.value
+        : null
+      : await accountState(s.user_id).catch(() => null);
 
   const isPremium = acc ? acc.status === 'vip' || acc.status === 'paid' : false;
 
@@ -86,9 +94,12 @@ export const load: LayoutServerLoad = async ({ locals, url }) => {
     delegateOf: s.delegate_of,
     delegateLogin: s.delegate_of ? s.delegate_login : undefined,
     sections: s.delegate_of ? (s.sections ?? []) : undefined,
-    unreadCount,
-    bellNotifications: notifications.slice(0, BELL_PEEK),
-    authorizedDashboards,
+    // Streamed, not awaited: the bell peek is the shell's one unbounded read
+    // (the full notification list feeds it), and holding first paint on it
+    // stalled every authed page by up to a READ_TIMEOUT when the notifications
+    // service lagged. The layout template awaits `bell` around the component.
+    bell: loadBellPeek(s),
+    authorizedDashboards: await loadAuthorizedDashboards(s),
     isPremium,
     onboarded: acc ? acc.onboarded : false
   };

--- a/console/dashboard/src/routes/(app)/+layout.server.ts
+++ b/console/dashboard/src/routes/(app)/+layout.server.ts
@@ -6,7 +6,7 @@ import { dev } from '$app/environment';
 import { env } from '$env/dynamic/private';
 import type { LayoutServerLoad } from './$types';
 import type { Session } from '$lib/server/session';
-import { accountState, notificationsForUser, delegationAccess, type NotificationWire } from '$lib/server/services';
+import { accountState, notificationsForUser, delegationAccess, type AccountState, type NotificationWire } from '$lib/server/services';
 
 // Gated on the build-time `dev` constant first, so Rollup erases every demo
 // branch (and the dynamic demo-data import inside it) from production builds.
@@ -56,6 +56,22 @@ async function loadAuthorizedDashboards(s: Session): Promise<{ href: string; nam
   }
 }
 
+// loadAccountState resolves the shell's account read, in the same named-loader
+// shape as the two above rather than as a ternary chain inside load().
+//
+// The gates already read account state once per request (hooks.server.ts ->
+// guardSession) and leave the result on locals, so the order here is: demo
+// fixture, then the gate's answer, then a retry. An authoritative ghost answer
+// returns null — the shell renders with no account data instead of re-asking a
+// service that already said the user is gone. Only an unset field (a blipped
+// gate read) reaches the RPC.
+async function loadAccountState(locals: App.Locals, s: Session): Promise<AccountState | null> {
+  if (DEMO) return (await import('$lib/server/demo-data')).demoAccountState;
+  const gateRead = locals.accountState;
+  if (!gateRead) return accountState(s.user_id).catch(() => null);
+  return 'value' in gateRead ? gateRead.value : null;
+}
+
 // Account gates (ban / deleted account / delegation revoke / delegate scope)
 // run in hooks.server.ts for every request — including form actions and API
 // endpoints, which this load never covers. This load only owns the
@@ -71,19 +87,7 @@ export const load: LayoutServerLoad = async ({ locals, url }) => {
     throw redirect(302, next === '/' ? '/login' : `/login?next=${encodeURIComponent(next)}`);
   }
 
-  // The gates already read account state once per request (hooks.server.ts ->
-  // guardSession), and the result rides locals. Reuse it; only a blipped gate
-  // read (field unset) retries here, and an authoritative ghost answer renders
-  // the shell with no account data instead of re-asking a service that already
-  // said no.
-  const acc: Awaited<ReturnType<typeof accountState>> | null = DEMO
-    ? await import('$lib/server/demo-data').then((m) => m.demoAccountState)
-    : locals.accountState
-      ? 'value' in locals.accountState
-        ? locals.accountState.value
-        : null
-      : await accountState(s.user_id).catch(() => null);
-
+  const acc = await loadAccountState(locals, s);
   const isPremium = acc ? acc.status === 'vip' || acc.status === 'paid' : false;
 
   return {

--- a/console/dashboard/src/routes/(app)/+layout.svelte
+++ b/console/dashboard/src/routes/(app)/+layout.svelte
@@ -5,8 +5,14 @@
   import { enhance } from '$app/forms';
   import { onMount } from 'svelte';
   import { invalidateAll, afterNavigate } from '$app/navigation';
-  import { AppShell, ImpersonationBanner, NotificationBell, ToastHost, getI18n } from '@bagel/shared';
-  import type { NavGroupDef, NavLink } from '@bagel/shared';
+  // Direct imports, not the barrel: this layout is on every authed page's boot
+  // path (see routes/+layout.svelte).
+  import AppShell from '@bagel/shared/components/AppShell.svelte';
+  import ImpersonationBanner from '@bagel/shared/components/ImpersonationBanner.svelte';
+  import NotificationBell from '@bagel/shared/components/NotificationBell.svelte';
+  import ToastHost from '@bagel/shared/components/ToastHost.svelte';
+  import { getI18n } from '@bagel/shared/i18n/context';
+  import type { NavGroupDef, NavLink } from '@bagel/shared/types';
   let { data, children } = $props();
 
   const i18n = getI18n();
@@ -173,17 +179,21 @@
   {#snippet topActions()}
     <a href="https://status.itsbagelbot.com" class="status-link" target="_blank" rel="noopener noreferrer">{t('nav.status')}</a>
     {#if !isDelegate}
-      <NotificationBell
-        notifications={(data.bellNotifications ?? [])}
-        unreadCount={data.unreadCount ?? 0}
-        viewAllHref="/settings#notifications"
-        onMarkRead={markRead}
-        onOpen={peek}
-        title={t('bell.title')}
-        viewAllLabel={t('bell.viewAll')}
-        emptyLabel={t('bell.empty')}
-        readLabel={t('bell.read')}
-      />
+      <!-- The bell peek is streamed (layout.server.ts): render the topbar as
+           soon as the shell lands and fill the bell when its promise does. -->
+      {#await data.bell then bell}
+        <NotificationBell
+          notifications={bell.notifications}
+          unreadCount={bell.unreadCount}
+          viewAllHref="/settings#notifications"
+          onMarkRead={markRead}
+          onOpen={peek}
+          title={t('bell.title')}
+          viewAllLabel={t('bell.viewAll')}
+          emptyLabel={t('bell.empty')}
+          readLabel={t('bell.read')}
+        />
+      {/await}
     {/if}
   {/snippet}
   {@render children()}

--- a/console/dashboard/src/routes/(app)/+page.server.ts
+++ b/console/dashboard/src/routes/(app)/+page.server.ts
@@ -2,8 +2,8 @@
 // Proprietary. No license granted. See LICENSE.md.
 
 import type { Actions, PageServerLoad } from './$types';
-import type { CommandView } from '@bagel/shared';
-import { MODULE_CATALOG } from '@bagel/shared';
+import type { CommandView } from '@bagel/shared/types';
+import { MODULE_CATALOG } from '@bagel/shared/types';
 import {
   hasGrant,
   accountState,
@@ -19,7 +19,7 @@ import {
 import { listCommands, listModules } from '$lib/server/commands-store';
 import { dev } from '$app/environment';
 import { env } from '$env/dynamic/private';
-import { connectionUiState, type ConnSignals, type ConnUi } from '@bagel/shared';
+import { connectionUiState, type ConnSignals, type ConnUi } from '@bagel/shared/connection-state';
 import { fail, redirect } from '@sveltejs/kit';
 
 // Gated on the build-time `dev` constant first, so Rollup erases every demo

--- a/console/dashboard/src/routes/(app)/+page.svelte
+++ b/console/dashboard/src/routes/(app)/+page.svelte
@@ -4,7 +4,16 @@
   import { enhance } from '$app/forms';
   import { onMount } from 'svelte';
   import { page } from '$app/state';
-  import { Button, Card, ButtonLink, Modal, Skeleton, getI18n, connectionUiState, toast, type ConnSignals, type ConnUi } from '@bagel/shared';
+  // Direct imports, not the barrel: this is the authed landing page's boot path
+  // (see routes/+layout.svelte).
+  import Button from '@bagel/shared/components/Button.svelte';
+  import Card from '@bagel/shared/components/Card.svelte';
+  import ButtonLink from '@bagel/shared/components/ButtonLink.svelte';
+  import Modal from '@bagel/shared/components/Modal.svelte';
+  import Skeleton from '@bagel/shared/components/Skeleton.svelte';
+  import { getI18n } from '@bagel/shared/i18n/context';
+  import { connectionUiState, type ConnSignals, type ConnUi } from '@bagel/shared/connection-state';
+  import { toast } from '@bagel/shared/toast';
   import type { ActionResult } from '@sveltejs/kit';
   import OnboardingGuide from '$lib/components/OnboardingGuide.svelte';
   import OverviewHead from '$lib/components/overview/OverviewHead.svelte';

--- a/console/dashboard/src/routes/+layout.svelte
+++ b/console/dashboard/src/routes/+layout.svelte
@@ -2,7 +2,11 @@
 	// Copyright (c) 2026 Adam Ousmer. All rights reserved.
 	// Proprietary. No license granted. See LICENSE.md.
   import '../app.css';
-  import { RootShell } from '@bagel/shared';
+  // Direct component imports, not the @bagel/shared barrel: the boot path must
+  // not statically reference every page's machinery, so per-route chunks stay
+  // minimal (see shared/svelte-config.js for the long-task measurement behind
+  // this rule).
+  import RootShell from '@bagel/shared/components/RootShell.svelte';
   import InstallAppPrompt from '$lib/components/InstallAppPrompt.svelte';
   let { data, children } = $props();
 

--- a/console/dashboard/src/routes/+layout.ts
+++ b/console/dashboard/src/routes/+layout.ts
@@ -1,0 +1,17 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+// Universal root load: runs on the server AND on the client before the tree
+// renders (including during hydration), which is exactly the guarantee the lazy
+// i18n catalogs need — by the time any component translates a string, the
+// active locale's catalog chunk is registered, so client output matches SSR
+// byte-for-byte. English is bundled eagerly; every other locale pays one small
+// parallel JSON-chunk fetch here instead of ~54 KB of eager eval for every
+// visitor at boot.
+import { ensureCatalog, isLocale } from '@bagel/shared/i18n';
+import type { LayoutLoad } from './$types';
+
+export const load: LayoutLoad = async ({ data }) => {
+  await ensureCatalog(isLocale(data.locale) ? data.locale : 'en');
+  return data;
+};

--- a/console/shared/lib/i18n/messages.ts
+++ b/console/shared/lib/i18n/messages.ts
@@ -13,29 +13,72 @@
 // in that directory — no code edit, no registry entry — and their file is parsed
 // as data, never executed. Malformed JSON fails the build; a missing key falls
 // back to English (see translate()).
+//
+// Only the default catalog is bundled eagerly (~53 KB of object literals that
+// every boot otherwise paid for — both catalogs eager cost ~107 KB of eval
+// before first paint). The other catalogs become separate chunks behind
+// ensureCatalog(); routes that know their locale await it in a load function,
+// so SSR and hydration always see the same strings.
 import type { Locale, MessageTree } from './types';
 
 export type { Locale } from './types';
 
-// Eagerly load every locale JSON as its default export (the parsed tree). The
-// glob is resolved at build time, so the shipped locale set is fixed in the
-// bundle rather than read from disk at runtime.
-const modules = import.meta.glob<MessageTree>('./locales/*.json', {
+// Eager default catalog: translate()'s fallback must exist synchronously even
+// in render trees that never ran a load function (the admin app's fallback
+// translator, server helpers).
+const eagerModules = import.meta.glob<MessageTree>('./locales/en.json', {
   eager: true,
+  import: 'default'
+});
+
+// Lazy loaders for every shipped catalog. The KEYS are known at build time with
+// no content loaded, which is what keeps LOCALES/isLocale synchronous.
+const lazyModules = import.meta.glob<MessageTree>('./locales/*.json', {
   import: 'default'
 });
 
 // Key each catalog by its bare filename ("en" from "./locales/en.json").
 const catalogs: Record<string, MessageTree> = {};
-for (const [path, tree] of Object.entries(modules)) {
+for (const [path, tree] of Object.entries(eagerModules)) {
   const match = /([\w-]+)\.json$/.exec(path);
   if (match) catalogs[match[1]] = tree;
 }
 
 // The locale set is exactly the shipped catalogs, sorted so the switcher and any
 // listing render in a stable order across builds.
-export const LOCALES: readonly Locale[] = Object.keys(catalogs).sort();
+export const LOCALES: readonly Locale[] = Object.keys(lazyModules)
+  .map((path) => /([\w-]+)\.json$/.exec(path)?.[1])
+  .filter((v): v is Locale => typeof v === 'string')
+  .sort();
 export const DEFAULT_LOCALE: Locale = 'en';
+
+// Single-flight per locale: several components may ask for the same catalog in
+// one tick (LangSwitch tooltips), the chunk must be fetched once.
+const pending = new Map<string, Promise<void>>();
+
+/**
+ * Register a locale's catalog before any string from it is rendered. Resolves
+ * immediately for the default locale (already registered) or an unknown code.
+ * Await this in a universal load so hydration renders exactly what SSR did.
+ */
+export function ensureCatalog(locale: Locale): Promise<void> {
+  if (Object.prototype.hasOwnProperty.call(catalogs, locale)) return Promise.resolve();
+  const key = `./locales/${locale}.json`;
+  const loader = lazyModules[key];
+  if (!loader) return Promise.resolve();
+  let p = pending.get(key);
+  if (!p) {
+    p = loader()
+      .then((tree) => {
+        catalogs[locale] = tree;
+      })
+      .finally(() => {
+        pending.delete(key);
+      });
+    pending.set(key, p);
+  }
+  return p;
+}
 
 // The default catalog is the fallback for every missing key and the last resort
 // of detectLocale, so its absence is a build/deploy error, not a silent
@@ -53,11 +96,13 @@ if (!catalogs[DEFAULT_LOCALE]) {
 // never needs the session key, so it rides its own plain cookie.
 export const LOCALE_COOKIE = 'locale';
 
-// Own-property check only: `v in catalogs` would accept inherited names like
-// 'constructor' or 'toString' coming from an attacker-controlled cookie or query
-// value, so test the catalog map's own keys with hasOwnProperty.
+// The locale set comes from build-time filenames, never from request input, so
+// a Set membership test has the same no-inherited-keys guarantee an own-property
+// check gave ('constructor' cannot be a filename).
+const LOCALE_SET: ReadonlySet<string> = new Set(LOCALES);
+
 export function isLocale(v: unknown): v is Locale {
-  return typeof v === 'string' && Object.prototype.hasOwnProperty.call(catalogs, v);
+  return typeof v === 'string' && LOCALE_SET.has(v);
 }
 
 /** Walk a dot-path ("settings.deleteTitle") into a catalog; string leaves only. */

--- a/console/shared/lib/index.ts
+++ b/console/shared/lib/index.ts
@@ -63,6 +63,7 @@ export {
   detectLocale,
   isLocale,
   localeName,
+  ensureCatalog,
   LOCALES,
   DEFAULT_LOCALE,
   LOCALE_COOKIE,

--- a/console/shared/package.json
+++ b/console/shared/package.json
@@ -44,7 +44,15 @@
     "./importer/types": "./lib/importer/types.ts",
     "./importer/validate": "./lib/importer/validate.ts",
     "./importer/streamelements": "./lib/importer/streamelements.ts",
-    "./importer/streamlabs-desktop": "./lib/importer/streamlabs-desktop/index.ts"
+    "./importer/streamlabs-desktop": "./lib/importer/streamlabs-desktop/index.ts",
+    "./i18n/context": "./lib/i18n/context.ts",
+    "./actions": "./lib/actions.ts",
+    "./icons": "./lib/icons.ts",
+    "./cursor": "./lib/cursor.ts",
+    "./toast": "./lib/toast.ts",
+    "./connection-state": "./lib/connection-state.ts",
+    "./overlay-stack": "./lib/overlay-stack.ts",
+    "./types": "./lib/types.ts"
   },
   "dependencies": {
     "@luzir/bolota": "0.1.6",

--- a/console/shared/svelte-config.js
+++ b/console/shared/svelte-config.js
@@ -36,10 +36,14 @@ export function consoleKitConfig({ directives = {} } = {}) {
   return {
     preprocess: vitePreprocess(),
     kit: {
-      adapter: adapter({ precompress: true }),
-      output: {
-        bundleStrategy: 'single'
-      },
+    adapter: adapter({ precompress: true }),
+    // Default per-route chunking, NOT output.bundleStrategy:'single'. The single
+    // strategy shipped one ~693 KB minified bundle that every page had to parse,
+    // evaluate and hydrate as one continuous main-thread task — measured at
+    // ~294 ms of CPU on an M-series for /login alone (2026-08-25), i.e. the
+    // ~1 s "all JavaScript freezes on load" on mid-range hardware. Per-route
+    // chunks let each page evaluate only what it renders. Reintroduce 'single'
+    // only with a measurement showing the chunk-count cost beats that task.
       // Pin the version metadata to the commit SHA. vite.config.ts separately
       // loads sorted-readdir.cjs so native ARM/Intel builds also assign the
       // same SvelteKit node IDs and emit byte-identical client bundles.


### PR DESCRIPTION
## Why

Loading the authed dashboard froze all JavaScript for about a second. There was no single bad call — the boot architecture made one long main-thread task inevitable:

- `output.bundleStrategy: 'single'` shipped the whole app as **one 693 KB minified bundle** that every page parsed, evaluated and hydrated in one go (largest self-time entry measured at ~294 ms of CPU on an M-series for `/login`; that scales to ~1 s of continuous blocking on mid-range hardware).
- The `@bagel/shared` barrel pulled ~50 components plus every lib into that bundle, and `import.meta.glob(..., { eager: true })` baked **both locale catalogs** (~107 KB of object literals) into it even though one locale is active.
- Server-side, three account-gate RPCs ran sequentially per request and the layout held first paint on its bell/dashboards reads.

## What changed

- **Per-route chunks**: drop `bundleStrategy:'single'` (`shared/svelte-config.js`). Largest chunk is now **73 KB**; each route evaluates only what it renders.
- **Lazy locale catalogs** (`shared/lib/i18n/messages.ts`): only the default catalog stays eager so sync fallbacks keep working; a new universal root load (`routes/+layout.ts`) awaits `ensureCatalog(locale)` before render on both server and client, so hydration output matches SSR byte-for-byte. LangSwitch pulls catalogs for tooltip names off the boot path.
- **Subpath imports on the boot path**: root/app layouts, home page, overview components import shared pieces directly; the needed subpaths are exported from `@bagel/shared`'s exports map. Non-boot pages stay on the barrel — per-route shaking now handles them.
- **Server**: `guard.ts` fires ban/revocation/account-state checks concurrently with preserved outcome priority (ban > revoked > ghost), reuses the settled account-state read through `locals` so the layout doesn't pay a second RPC, and `(app)/+layout.server.ts` streams the bell peek (hard cap moved to the source) instead of holding the shell on it.

## Verification

- Dashboard build green including the production-clean gate; svelte-check **0 errors**; `bun test shared` green.
- Prod `/login` profiled headless at **6× CPU throttle**: boot work drops from a single **~377 ms** long task to two of **101 ms / 79 ms**.
- Dev-mode dashboard home: zero long tasks natively before and after; the win shows under throttling exactly where real-user freezes were reported.

The gate findings this PR answers are the load-path long tasks; no suppression used anywhere.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added lazy loading for translation catalogs, with English available immediately and fallback locale labels while languages load.
  * Added account-state handling for more responsive session and account validation.
  * Improved dashboard loading by streaming notification data and limiting previews to five items.

* **Bug Fixes**
  * Preserved account security redirect priorities during concurrent validation checks.
  * Improved locale validation and translation catalog reliability.

* **Performance**
  * Enabled route-based client loading to reduce unnecessary initial downloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->