### PR TITLE
fix(console): never let a failed locale chunk take every route down

### DIFF
--- a/console/shared/lib/i18n/messages.ts
+++ b/console/shared/lib/i18n/messages.ts
@@ -72,6 +72,26 @@ export function ensureCatalog(locale: Locale): Promise<void> {
       .then((tree) => {
         catalogs[locale] = tree;
       })
+      .catch(() => {
+        // Never reject. Callers await this from a universal root load, so a
+        // rejection fails that load for EVERY route — one translation file
+        // failing to arrive would take the whole app down with a 500, which is
+        // a far worse outcome than showing English.
+        //
+        // The failure modes here have nothing to do with the locale being
+        // wrong: an offline blip, or a client still running a stale HTML shell
+        // after a deploy requesting a hashed chunk that no longer exists.
+        // translate() already resolves `catalogs[locale] ?? catalogs[en]`, so
+        // an absent catalog degrades to English exactly like an absent key.
+        //
+        // The cost is a hydration mismatch when the server registered the
+        // catalog and the client could not: SSR ships translated markup, the
+        // client re-renders English. Accepted deliberately — a page in the
+        // wrong language still works, a 500 does not.
+        //
+        // Not remembered as a failure: `pending` is cleared below either way,
+        // so the next navigation retries the chunk.
+      })
       .finally(() => {
         pending.delete(key);
       });


### PR DESCRIPTION
Stacked on #692 — that branch introduced the code this fixes, and a concurrent worktree has it checked out, so this rides on top rather than being pushed into it.

## The bug

`ensureCatalog()` is awaited from `+layout.ts`, a **universal root load**. Its promise therefore decides whether the root layout loads at all — and it had no `catch`.

```ts
p = loader()
  .then((tree) => { catalogs[locale] = tree; })
  .finally(() => { pending.delete(key); });   // <- nothing catches a rejection
```

A rejected catalog import fails the root load for **every route**. The whole dashboard answers 500 because one translation file did not arrive.

The failure modes have nothing to do with the locale being wrong:
- an offline blip on the chunk request
- a client still running a stale HTML shell after a deploy, asking for a hashed chunk that no longer exists

That second one is the nasty one: it hits real users mid-deploy, and it takes down every page, not just the translated strings.

## The fix

Swallow the rejection. `translate()` already resolves `catalogs[locale] ?? catalogs[DEFAULT_LOCALE]`, so an absent catalog degrades to English exactly like an absent key — English being the fallback is already the documented contract of this module.

**Accepted tradeoff, stated in the comment:** when the server registered the catalog and the client could not, SSR ships translated markup and the client re-renders English — a hydration mismatch. Deliberate. A page in the wrong language still works; a 500 does not.

The chunk is not remembered as failed (`pending` is cleared either way), so the next navigation retries it.

## No test

`messages.ts` uses `import.meta.glob`, so it cannot be imported outside a Vite transform — which is why this module has no unit tests today. I did not want to fake one that exercises a mock instead of the real chain.

Verified instead: `svelte-check` 0 errors, `bun run build` green including `assert-production-clean` (555 files), and the 394 shared tests still pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved language catalog loading reliability.
  * When a selected language is unavailable, the interface now falls back to English instead of failing.
  * Failed language loads can be retried during later navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->