### PR TITLE
feat(automod): opt-in Twitch clips-only link filter

### DIFF
--- a/app/sesame/automod/clips.go
+++ b/app/sesame/automod/clips.go
@@ -1,0 +1,247 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package automod
+
+import "strings"
+
+// hasNonClipLink reports whether text carries a link-shaped token that is not
+// a Twitch clip URL. Used only when the clips_only section is on: clip links
+// stay, every other host shape is deleted. Chat links arrive bare
+// ("discord.gg/x"), which url.Parse rejects, so this is a whitespace-token
+// scanner rather than a parser - same shape as the campaign linkish signal,
+// but host-validated so prose ellipses ("wait...") never mint a delete.
+//
+// Allowed clip forms (scheme and leading www. optional):
+//
+//	clips.twitch.tv/<slug>
+//	twitch.tv/<login>/clip/<slug>
+//
+// Bare twitch.tv/<login>, clips.twitch.tv with no slug, and every other host
+// count as non-clip. Shorteners are never treated as clips: the destination is
+// not fetched (same account-safety rule as the IP-logger floor).
+func hasNonClipLink(text string) bool {
+	for i := 0; i < len(text); {
+		start, end := nextSpaceToken(text, i)
+		if start == end {
+			return false
+		}
+		if tok := trimLinkToken(text[start:end]); tok != "" && looksLikeLinkHost(tok) && !isTwitchClipToken(tok) {
+			return true
+		}
+		i = end
+	}
+	return false
+}
+
+// maybeLinkText is the cheap pre-filter before forcing the deep path for
+// clips_only: a line with no '.' and no http scheme cannot carry a host-shaped
+// token, so the clean path may still bail.
+func maybeLinkText(text string) bool {
+	if strings.Contains(text, ".") {
+		return true
+	}
+	// Caps-heavy hype arrives as HTTPS://…; ContainsFold keeps the pre-filter
+	// aligned with stripScheme without allocating a lowered copy.
+	return containsFoldASCII(text, "http://") || containsFoldASCII(text, "https://")
+}
+
+func nextSpaceToken(text string, i int) (start, end int) {
+	for i < len(text) && isSpaceByte(text[i]) {
+		i++
+	}
+	start = i
+	for i < len(text) && !isSpaceByte(text[i]) {
+		i++
+	}
+	return start, i
+}
+
+func isSpaceByte(b byte) bool {
+	switch b {
+	case ' ', '\t', '\n', '\r', '\v', '\f':
+		return true
+	}
+	return false
+}
+
+// trimLinkToken strips a leading http(s) scheme, a leading www., and trailing
+// prose punctuation so "HTTPS://www.clips.twitch.tv/Slug!" compares as a clip.
+func trimLinkToken(tok string) string {
+	tok = stripScheme(tok)
+	if len(tok) >= 4 && equalFoldASCII(tok[:4], "www.") {
+		tok = tok[4:]
+	}
+	return stripTrailingPunct(tok)
+}
+
+func stripScheme(tok string) string {
+	switch {
+	case len(tok) >= 8 && equalFoldASCII(tok[:8], "https://"):
+		return tok[8:]
+	case len(tok) >= 7 && equalFoldASCII(tok[:7], "http://"):
+		return tok[7:]
+	}
+	return tok
+}
+
+func stripTrailingPunct(tok string) string {
+	for len(tok) > 0 {
+		switch tok[len(tok)-1] {
+		case '.', ',', '!', '?', ';', ':', '"', '\'', ')', ']', '>':
+			tok = tok[:len(tok)-1]
+		default:
+			return tok
+		}
+	}
+	return tok
+}
+
+// looksLikeLinkHost reports whether tok (already trimmed) has a DNS-shaped
+// host worth judging as a link. Rejects ellipsis debris and single-label
+// tokens so the clips_only delete cannot fire on ordinary prose.
+func looksLikeLinkHost(tok string) bool {
+	host := hostOf(tok)
+	if len(host) < 4 || len(host) > 253 {
+		return false
+	}
+	labels := 0
+	lastDot := true
+	alphaTLD := false
+	for i := 0; i < len(host); i++ {
+		c := host[i]
+		if c == '.' {
+			if lastDot {
+				return false
+			}
+			labels++
+			lastDot = true
+			alphaTLD = false
+			continue
+		}
+		lastDot = false
+		if c >= 'A' && c <= 'Z' {
+			c += 'a' - 'A'
+		}
+		switch {
+		case c == '-' || c == '_':
+		case c >= 'a' && c <= 'z':
+			alphaTLD = true
+		case c >= '0' && c <= '9':
+			alphaTLD = false
+		default:
+			return false
+		}
+	}
+	if lastDot {
+		return false
+	}
+	labels++
+	return labels >= 2 && alphaTLD
+}
+
+func hostOf(token string) string {
+	host := token
+	if k := strings.IndexAny(host, "/?#"); k >= 0 {
+		host = host[:k]
+	}
+	if k := strings.LastIndexByte(host, '@'); k >= 0 {
+		host = host[k+1:]
+	}
+	if k := strings.LastIndexByte(host, ':'); k >= 0 && isPortSuffix(host[k+1:]) {
+		host = host[:k]
+	}
+	return host
+}
+
+func isPortSuffix(s string) bool {
+	if len(s) == 0 || len(s) > 5 {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// isTwitchClipToken reports whether a trimmed token is a Twitch clip URL.
+// Matching is ASCII-fold only: clip slugs and logins are ASCII in practice,
+// and folding the whole token avoids a lowered allocation on every candidate.
+func isTwitchClipToken(tok string) bool {
+	const clipsHost = "clips.twitch.tv/"
+	const twitchHost = "twitch.tv/"
+	const clipPath = "/clip/"
+	if hasFoldPrefix(tok, clipsHost) {
+		return clipSlugOK(tok[len(clipsHost):])
+	}
+	if !hasFoldPrefix(tok, twitchHost) {
+		return false
+	}
+	rest := tok[len(twitchHost):]
+	// login/clip/slug - login must be non-empty (Index of /clip/ > 0).
+	i := indexFold(rest, clipPath)
+	if i <= 0 {
+		return false
+	}
+	return clipSlugOK(rest[i+len(clipPath):])
+}
+
+func clipSlugOK(rest string) bool {
+	if k := strings.IndexAny(rest, "/?#"); k >= 0 {
+		rest = rest[:k]
+	}
+	if len(rest) == 0 {
+		return false
+	}
+	for i := 0; i < len(rest); i++ {
+		c := rest[i]
+		switch {
+		case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z', c >= '0' && c <= '9', c == '-' || c == '_':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func equalFoldASCII(a, b string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := 0; i < len(a); i++ {
+		ca, cb := a[i], b[i]
+		if 'A' <= ca && ca <= 'Z' {
+			ca += 'a' - 'A'
+		}
+		if 'A' <= cb && cb <= 'Z' {
+			cb += 'a' - 'A'
+		}
+		if ca != cb {
+			return false
+		}
+	}
+	return true
+}
+
+func hasFoldPrefix(s, prefix string) bool {
+	return len(s) >= len(prefix) && equalFoldASCII(s[:len(prefix)], prefix)
+}
+
+func indexFold(s, sub string) int {
+	n := len(sub)
+	if n == 0 {
+		return 0
+	}
+	for i := 0; i+n <= len(s); i++ {
+		if equalFoldASCII(s[i:i+n], sub) {
+			return i
+		}
+	}
+	return -1
+}
+
+func containsFoldASCII(s, sub string) bool {
+	return indexFold(s, sub) >= 0
+}

--- a/app/sesame/automod/clips_test.go
+++ b/app/sesame/automod/clips_test.go
@@ -1,0 +1,100 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package automod
+
+import (
+	"testing"
+
+	"ItsBagelBot/app/sesame/module"
+	"ItsBagelBot/pkg/codec"
+)
+
+func TestHasNonClipLink(t *testing.T) {
+	cases := []struct {
+		name string
+		text string
+		want bool
+	}{
+		{"clean prose", "hello friends tonight", false},
+		{"ellipsis", "wait... what...", false},
+		{"clips host slug", "check https://clips.twitch.tv/CoolClip-Name_1 now", false},
+		{"clips bare www", "see www.clips.twitch.tv/AnotherClip!", false},
+		{"channel clip path", "https://www.twitch.tv/itsmavey/clip/CoolClip", false},
+		{"scheme-less channel clip", "twitch.tv/someone/clip/Slug_here", false},
+		{"discord", "join discord.gg/abcd please", true},
+		{"example com", "open https://example.com/watch", true},
+		{"bare channel page", "follow twitch.tv/itsmavey thanks", true},
+		{"clips host no slug", "visit clips.twitch.tv later", true},
+		{"clip plus discord", "clip https://clips.twitch.tv/CoolClip and discord.gg/x", true},
+		{"shortener", "https://bit.ly/abc", true},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasNonClipLink(tt.text); got != tt.want {
+				t.Fatalf("hasNonClipLink(%q) = %v, want %v", tt.text, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClipsOnlyDeletesNonClipLinks(t *testing.T) {
+	g := New()
+	cfg := ParseConfig(codec.RawMessage(`{"level":"none","clips_only":"on"}`))
+	if cfg == nil || !cfg.clipsOnlyOn() {
+		t.Fatal("clips_only must parse on under level none")
+	}
+
+	if v := g.InspectWith(module.RoleEveryone, "join discord.gg/abcd please friends", cfg); v.Action != ActionDelete || v.Rule != "clips_only" {
+		t.Fatalf("non-clip link must delete: got action=%s rule=%s", v.Action, v.Rule)
+	}
+	if v := g.InspectWith(module.RoleEveryone, "nice clip https://clips.twitch.tv/CoolClip-Name", cfg); v.Action != ActionNone {
+		t.Fatalf("clip link must pass: got action=%s rule=%s", v.Action, v.Rule)
+	}
+	if v := g.InspectWith(module.RoleEveryone, "twitch.tv/itsmavey/clip/CoolClip", cfg); v.Action != ActionNone {
+		t.Fatalf("channel clip path must pass: got %s", v.Action)
+	}
+	if v := g.InspectWith(module.RoleEveryone, "no links here friends", cfg); v.Action != ActionNone {
+		t.Fatalf("linkless line must pass: got %s", v.Action)
+	}
+}
+
+func TestClipsOnlyOffByDefault(t *testing.T) {
+	g := New()
+	// Moderate defaults enable link-spam radar but never clips_only.
+	if v := g.Inspect(module.RoleEveryone, "check https://example.com/watch tonight friends"); v.Action != ActionNone {
+		t.Fatalf("default must not delete a single ordinary link, got %s/%s", v.Action, v.Rule)
+	}
+	off := ParseConfig(codec.RawMessage(`{"clips_only":"off"}`))
+	if off.clipsOnlyOn() {
+		t.Fatal("explicit off must stay off")
+	}
+}
+
+func TestClipsOnlyAllowTermSuppresses(t *testing.T) {
+	g := New()
+	cfg := ParseConfig(codec.RawMessage(`{"clips_only":"on","allow_terms":"discord"}`))
+	if v := g.InspectWith(module.RoleEveryone, "join discord.gg/abcd please friends", cfg); v.Action != ActionNone {
+		t.Fatalf("allow term must suppress clips_only, got %s/%s", v.Action, v.Rule)
+	}
+}
+
+func TestClipsOnlyVIPExempt(t *testing.T) {
+	g := New()
+	cfg := ParseConfig(codec.RawMessage(`{"clips_only":"on"}`))
+	if v := g.InspectWith(module.RoleVIP, "join discord.gg/abcd please", cfg); v.Action != ActionNone {
+		t.Fatalf("VIP must be exempt, got %s", v.Action)
+	}
+}
+
+func TestClipsOnlyDisabledModuleIgnores(t *testing.T) {
+	g := New()
+	cfg := ParseConfig(codec.RawMessage(`{"clips_only":"on"}`))
+	cfg.Disabled = true
+	if cfg.clipsOnlyOn() {
+		t.Fatal("disabled row must not enable clips_only")
+	}
+	if v := g.InspectWith(module.RoleEveryone, "join discord.gg/abcd please friends", cfg); v.Action != ActionNone {
+		t.Fatalf("disabled row must ignore clips_only, got %s/%s", v.Action, v.Rule)
+	}
+}

--- a/app/sesame/automod/config.go
+++ b/app/sesame/automod/config.go
@@ -66,6 +66,7 @@ type sections struct {
 	profanity  bool // plain profanity (delete)
 	style      bool // caps / symbol / repeat heuristics (delete)
 	links      bool // count link templates across senders (campaign juror)
+	clipsOnly  bool // delete any link that is not a Twitch clip URL (opt-in)
 	capsThresh float64
 }
 
@@ -126,7 +127,7 @@ type Config struct {
 	Disabled bool
 	Level    Level
 
-	harassment, sexual, profanity, style, links triState
+	harassment, sexual, profanity, style, links, clipsOnly triState
 
 	blockTerms [][]byte // channel-added blocked substrings (skeleton space)
 	allowTerms [][]byte // channel-permitted substrings; suppress non-floor flags
@@ -147,6 +148,7 @@ type wireConfig struct {
 	Profanity  string `json:"profanity"`
 	Style      string `json:"style"`
 	Links      string `json:"links"`
+	ClipsOnly  string `json:"clips_only"`
 	BlockTerms string `json:"block_terms"`
 	AllowTerms string `json:"allow_terms"`
 }
@@ -173,6 +175,7 @@ func ParseConfig(raw codec.RawMessage) *Config {
 		profanity:  parseTri(w.Profanity),
 		style:      parseTri(w.Style),
 		links:      parseTri(w.Links),
+		clipsOnly:  parseTri(w.ClipsOnly),
 		blockTerms: normalizeTerms(splitTerms(w.BlockTerms)),
 		allowTerms: normalizeTerms(splitTerms(w.AllowTerms)),
 	}
@@ -194,6 +197,7 @@ func (c *Config) resolved() sections {
 	s.profanity = c.profanity.apply(s.profanity)
 	s.style = c.style.apply(s.style)
 	s.links = c.links.apply(s.links)
+	s.clipsOnly = c.clipsOnly.apply(s.clipsOnly)
 	return s
 }
 
@@ -237,6 +241,14 @@ func (c *Config) disabled() bool { return c != nil && c.Disabled }
 // row's terms are not).
 func (c *Config) hasBlockTerms() bool {
 	return c != nil && !c.Disabled && len(c.blockTerms) > 0
+}
+
+// clipsOnlyOn reports whether the clips-only link filter is active for this
+// channel. Opt-in only: every level defaults it off, so an unset toggle never
+// starts deleting ordinary links. A disabled module row resolves floor-only
+// and therefore returns false here too.
+func (c *Config) clipsOnlyOn() bool {
+	return c.resolved().clipsOnly
 }
 
 // allows reports whether the skeleton contains a channel allow-term, which

--- a/app/sesame/automod/gate.go
+++ b/app/sesame/automod/gate.go
@@ -180,8 +180,9 @@ func (g *Gate) InspectWith(role module.Role, text string, cfg *Config, opts ...A
 // link verdicts ("phish", armed via SetLinkChecker; judged from the checker's
 // cache and feed snapshot only) -> language juror (reliably non-latin text is
 // never judged by the English word lists) -> lexicon categories gated by
-// profile -> channel block-terms -> heuristics with emote and allow-term
-// suppression. In shadow mode the caller logs the verdict and takes no action.
+// profile -> channel block-terms -> clips-only link filter -> heuristics with
+// emote and allow-term suppression. In shadow mode the caller logs the verdict
+// and takes no action.
 // assessScope is the resolved option set Assess acts on.
 type assessScope struct {
 	msgCodes map[string]struct{}
@@ -278,6 +279,11 @@ func (g *Gate) Assess(role module.Role, text string, cfg *Config, opts ...Assess
 		if v, ok := cfg.blockTermVerdict(skel); ok {
 			g.purgeLearned(uint64(sc.ch), text)
 			return v, out
+		}
+		// clips_only is a channel preference (not the immovable floor): allow
+		// terms suppress it the same way they suppress heuristics / block terms.
+		if sec.clipsOnly && hasNonClipLink(text) {
+			return Verdict{Action: ActionDelete, Rule: "clips_only"}, out
 		}
 	}
 
@@ -404,6 +410,11 @@ func (f *styleFlags) restripe(adj signals, sec sections, lim styleLimits) {
 // bait). The pre-scans only ever route; they never produce verdicts.
 func (g *Gate) cleanPathBail(sig signals, flags styleFlags, cfg *Config, text string) bool {
 	if flags.any() || cfg.hasBlockTerms() {
+		return false
+	}
+	// clips_only needs the deep path only when the line might carry a host:
+	// otherwise the clean zero-alloc bail still holds for ordinary short chat.
+	if cfg.clipsOnlyOn() && maybeLinkText(text) {
 		return false
 	}
 	if sig.hasNonASCII || sig.runes > shortLen {

--- a/console/shared/lib/types.ts
+++ b/console/shared/lib/types.ts
@@ -681,6 +681,12 @@ export const MODULE_CATALOG: readonly ModuleDef[] = [
         help: 'Watches for the same link template posted by many different accounts and removes the wave. Single links are never touched.'
       },
       {
+        key: 'clips_only',
+        label: 'Twitch clips only',
+        type: 'toggle',
+        help: 'Removes messages that contain any link other than a Twitch clip (clips.twitch.tv/… or twitch.tv/…/clip/…). Off by default: turn on when chat should only share clips.'
+      },
+      {
         key: 'block_terms',
         label: 'Blocked terms',
         type: 'textarea',


### PR DESCRIPTION
## Summary
- Adds a dashboard **Twitch clips only** automod toggle (`clips_only`, off by default)
- When enabled, deletes chat messages that contain any link other than a Twitch clip (`clips.twitch.tv/…` or `twitch.tv/…/clip/…`)
- Leaves the existing link-spam radar untouched; allow-terms and VIP/mod exemption still apply

## Test plan
- [x] `go test ./app/sesame/automod/ -run 'ClipsOnly|HasNonClip'`
- [ ] Toggle **Twitch clips only** on in Automod settings and save
- [ ] Post `discord.gg/…` → message deleted
- [ ] Post `https://clips.twitch.tv/…` → kept
- [ ] Post `twitch.tv/<login>/clip/…` → kept
- [ ] Confirm link-spam radar still works independently


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in AutoMod setting to allow only Twitch clip links.
  * Non-clip links are automatically removed when enabled.
  * Valid Twitch clip URLs remain permitted, including common URL formats.
  * Added a console toggle for configuring the setting.

* **Bug Fixes**
  * Honors channel allow terms and VIP exemptions.
  * Remains inactive when AutoMod is disabled or the setting is off.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->