### PR TITLE
chore(deploy): bump fleet to tonight's images

### DIFF
--- a/deploy/k8s/commands.yaml
+++ b/deploy/k8s/commands.yaml
@@ -118,7 +118,7 @@ spec:
       priorityClassName: bagel-service
       containers:
         - name: commands
-          image: ghcr.io/adamousmer/itsbagelbot/commands:main-1787603663-a1c27f889ca7@sha256:f164758dc3b5f1006e21f323cf5a9ab9aaa7cf10f377e0cdccdbcc3c4a3b312d # {"$imagepolicy": "flux-system:commands"}
+          image: ghcr.io/adamousmer/itsbagelbot/commands:main-1787628494-8c32b708fb7f@sha256:78ba639b964e9360b585034e84b64828134edc758d02b8edcca0832b9746ce23
           imagePullPolicy: IfNotPresent
           env:
             - name: NATS_HOST

--- a/deploy/k8s/console-admin.yaml
+++ b/deploy/k8s/console-admin.yaml
@@ -139,7 +139,7 @@ spec:
       priorityClassName: bagel-edge
       containers:
         - name: console-admin
-          image: ghcr.io/adamousmer/itsbagelbot/console-admin:main-1787603663-a1c27f889ca7@sha256:8f8a7639bffc85673d1fa5c5c090223d2e6b4bd82d7b345838c606076be69e14
+          image: ghcr.io/adamousmer/itsbagelbot/console-admin:main-1787632371-54cfd0c27add@sha256:61fe2793fdfb8e8ec34cfb64e9346d51a7c2748a5ec3e1f25957af75d67e9b14
           imagePullPolicy: IfNotPresent
           env:
             # mTLS client identity for both NATS planes (nats-client-tls,

--- a/deploy/k8s/console-dashboard.yaml
+++ b/deploy/k8s/console-dashboard.yaml
@@ -139,7 +139,7 @@ spec:
       priorityClassName: bagel-edge
       containers:
         - name: console-dashboard
-          image: ghcr.io/adamousmer/itsbagelbot/console-dashboard:main-1787603663-a1c27f889ca7@sha256:f1f4f58b1fb45a341905972a42ea38b9a064f8548ddbfd8532c5c03186985b1c
+          image: ghcr.io/adamousmer/itsbagelbot/console-dashboard:main-1787632371-54cfd0c27add@sha256:f015ef741acf93bba9e04194b36c0781b876fd1a6a48702cc7b28a30b48a160b
           imagePullPolicy: IfNotPresent
           env:
             - name: PORT

--- a/deploy/k8s/gossip.yaml
+++ b/deploy/k8s/gossip.yaml
@@ -285,7 +285,7 @@ spec:
               memory: 256Mi
       containers:
         - name: gossip
-          image: ghcr.io/adamousmer/itsbagelbot/gossip:main-1787603663-a1c27f889ca7@sha256:88401dd6400106d5a597227664b168a4ef19dc6a18e5106fb3b6e270a63e798c
+          image: ghcr.io/adamousmer/itsbagelbot/gossip:main-1787628494-8c32b708fb7f@sha256:5180685a104b3ca7cb94d2862f5155a19f7f5532a084ccee9bb5be8b37d69fdc
           imagePullPolicy: IfNotPresent
           env:
             # gossip is RPC-only: it answers sesame's requests over

--- a/deploy/k8s/loyalty.yaml
+++ b/deploy/k8s/loyalty.yaml
@@ -118,7 +118,7 @@ spec:
       priorityClassName: bagel-service
       containers:
         - name: loyalty
-          image: ghcr.io/adamousmer/itsbagelbot/loyalty:main-1787603663-a1c27f889ca7@sha256:4293e98cfca80e77b284c646d9185c1deec733ef213f031b612c21bb452e63ea
+          image: ghcr.io/adamousmer/itsbagelbot/loyalty:main-1787628494-8c32b708fb7f@sha256:f27092dba8edeee9cd0328136e18e725e2c02bf70243e03424a15d66c9f6a9ba
           imagePullPolicy: IfNotPresent
           env:
             - name: NATS_HOST

--- a/deploy/k8s/modules.yaml
+++ b/deploy/k8s/modules.yaml
@@ -118,7 +118,7 @@ spec:
       priorityClassName: bagel-service
       containers:
         - name: modules
-          image: ghcr.io/adamousmer/itsbagelbot/modules:main-1787603663-a1c27f889ca7@sha256:f500963c20f571889c6b1ff37349cc8e395e4b72cf34176fd7dc2a59a062d2dd
+          image: ghcr.io/adamousmer/itsbagelbot/modules:main-1787628494-8c32b708fb7f@sha256:5e4d6addeef88bb4faf8e63b5547d5032a4a1f3dcd03425735f5bf9ff9ae2b03
           imagePullPolicy: IfNotPresent
           env:
             - name: NATS_HOST

--- a/deploy/k8s/notifications.yaml
+++ b/deploy/k8s/notifications.yaml
@@ -121,7 +121,7 @@ spec:
       priorityClassName: bagel-service
       containers:
         - name: notifications
-          image: ghcr.io/adamousmer/itsbagelbot/notifications:main-1787603663-a1c27f889ca7@sha256:b865c4cb6e1e51e17c53f38c44e2be346b0b2dcff76af306856cb96b748df751 # {"$imagepolicy": "flux-system:notifications"}
+          image: ghcr.io/adamousmer/itsbagelbot/notifications:main-1787628494-8c32b708fb7f@sha256:6904644374854dee347eaeb54efcc322bf09a8e10c4d3c27f35728ebeb798c66
           imagePullPolicy: IfNotPresent
           env:
             - name: NATS_HOST
@@ -257,7 +257,7 @@ spec:
             seccompProfile: {type: RuntimeDefault}
           containers:
             - name: cleanup
-              image: ghcr.io/adamousmer/itsbagelbot/notifications:main-1787603663-a1c27f889ca7@sha256:b865c4cb6e1e51e17c53f38c44e2be346b0b2dcff76af306856cb96b748df751 # {"$imagepolicy": "flux-system:notifications"}
+              image: ghcr.io/adamousmer/itsbagelbot/notifications:main-1787628494-8c32b708fb7f@sha256:6904644374854dee347eaeb54efcc322bf09a8e10c4d3c27f35728ebeb798c66
               imagePullPolicy: IfNotPresent
               args: ["cleanup"]
               env:

--- a/deploy/k8s/outgress.yaml
+++ b/deploy/k8s/outgress.yaml
@@ -126,7 +126,7 @@ spec:
       priorityClassName: bagel-service
       containers:
         - name: outgress
-          image: ghcr.io/adamousmer/itsbagelbot/outgress:main-1787603663-a1c27f889ca7@sha256:df0c1dbfa7744cb7a99fd821dae4c54194690b0fd80af9628c0abf149d551fa1 # {"$imagepolicy": "flux-system:outgress"}
+          image: ghcr.io/adamousmer/itsbagelbot/outgress:main-1787628494-8c32b708fb7f@sha256:9c696bfa40c7e4b8cc561f50fc3a025db8d3ca9394d51f2f164ab18fa1af6d65
           imagePullPolicy: IfNotPresent
           env:
             - name: NATS_HOST

--- a/deploy/k8s/projector.yaml
+++ b/deploy/k8s/projector.yaml
@@ -118,7 +118,7 @@ spec:
       priorityClassName: bagel-service
       containers:
         - name: projector
-          image: ghcr.io/adamousmer/itsbagelbot/projector:main-1787603663-a1c27f889ca7@sha256:9fe036f8a6530a3c544b1038c726430f71a815dc8f32f9985ecc580eb49f6b3b # {"$imagepolicy": "flux-system:projector"}
+          image: ghcr.io/adamousmer/itsbagelbot/projector:main-1787628494-8c32b708fb7f@sha256:1319da299a30295c03cc050bb239787a4b8acb2480df35e44c3c3d754a704e0b
           imagePullPolicy: IfNotPresent
           env:
             # The lane catalog is partition-gated; the projector reconciles the

--- a/deploy/k8s/sesame.yaml
+++ b/deploy/k8s/sesame.yaml
@@ -130,7 +130,7 @@ spec:
       priorityClassName: bagel-service
       containers:
         - name: sesame
-          image: ghcr.io/adamousmer/itsbagelbot/sesame:main-1787603663-a1c27f889ca7@sha256:40e15fb07062348c3fc82bce9ce010a6d7e6477caefe8cd3f75c214ecf3cd133
+          image: ghcr.io/adamousmer/itsbagelbot/sesame:main-1787630592-9c1554eedb1d@sha256:c12bdda5a7367b00474017734568ef42d23c7acfd3dff2e40a406311aa9eac7f
           imagePullPolicy: IfNotPresent
           env:
             - name: NATS_HOST

--- a/deploy/k8s/transactions.yaml
+++ b/deploy/k8s/transactions.yaml
@@ -118,7 +118,7 @@ spec:
       priorityClassName: bagel-service
       containers:
         - name: transactions
-          image: ghcr.io/adamousmer/itsbagelbot/transactions:main-1787603663-a1c27f889ca7@sha256:dd8a123ac4ab006e1f4756ce9229a9f5e7ed1c78520b2b2d28ee2c6bfbeebb6a # {"$imagepolicy": "flux-system:transactions"}
+          image: ghcr.io/adamousmer/itsbagelbot/transactions:main-1787628494-8c32b708fb7f@sha256:4f6c1955fe248705cbcaa982f21bb74f251fe61521df9da7bc31c555ddc602cc
           imagePullPolicy: IfNotPresent
           env:
             - name: NATS_HOST

--- a/deploy/k8s/users.yaml
+++ b/deploy/k8s/users.yaml
@@ -124,7 +124,7 @@ spec:
       priorityClassName: bagel-service
       containers:
         - name: users
-          image: ghcr.io/adamousmer/itsbagelbot/users:main-1787603663-a1c27f889ca7@sha256:256576d66edf6cdccb0b691c67254680c317bd022a3d844032d21802de900dbd
+          image: ghcr.io/adamousmer/itsbagelbot/users:main-1787628494-8c32b708fb7f@sha256:331f0629d55e617f2a520520dab021382ac04d33c7a94fe3f4f4eb0e82a92ec3
           imagePullPolicy: IfNotPresent
           env:
             - name: NATS_HOST


### PR DESCRIPTION
## Summary
- Pin consoles to `54cfd0c2` (#700 songqueue layout), sesame to `9c1554ee` (clips-only), remaining Go services to `8c32b708` (post-#697 revert).
- Twitch-ingress and warp stay on last night's pin — no later image was published.
- Drop leftover Flux `$imagepolicy` comments on the lines this touches.

NATS hub was already applied and rolled serially (`nats-2` → `nats-1` → `nats-0`) so the Spotify/uptime/fetch ACL grants are live before these clients.

## Test plan
- [ ] `kubectl apply -k deploy/messaging` already done; hub 3/3, cluster_size 3, leaves healthz ok
- [ ] Apply db-tier then app-tier then consoles; watch each `rollout status`
- [ ] Public 200 on console, admin, marketing site


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container images across core services to newer immutable builds.
  * Refreshed deployment images for commands, administration, dashboard, gossip, loyalty, modules, notifications, outgress, projector, Sesame, transactions, and users.
  * Updated the notifications cleanup task to use the latest image.
  * Removed outdated image-policy comments from notification deployment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->