### PR TITLE
chore(deploy): bump consoles and sesame to #702

### DIFF
--- a/deploy/k8s/console-admin.yaml
+++ b/deploy/k8s/console-admin.yaml
@@ -139,7 +139,7 @@ spec:
       priorityClassName: bagel-edge
       containers:
         - name: console-admin
-          image: ghcr.io/adamousmer/itsbagelbot/console-admin:main-1787632371-54cfd0c27add@sha256:61fe2793fdfb8e8ec34cfb64e9346d51a7c2748a5ec3e1f25957af75d67e9b14
+          image: ghcr.io/adamousmer/itsbagelbot/console-admin:main-1787637317-6ff19650b709@sha256:59204e6163b5854528774c038cc1bcce842340f3d6da7a83394fc5bd1e50ef91
           imagePullPolicy: IfNotPresent
           env:
             # mTLS client identity for both NATS planes (nats-client-tls,

--- a/deploy/k8s/console-dashboard.yaml
+++ b/deploy/k8s/console-dashboard.yaml
@@ -139,7 +139,7 @@ spec:
       priorityClassName: bagel-edge
       containers:
         - name: console-dashboard
-          image: ghcr.io/adamousmer/itsbagelbot/console-dashboard:main-1787632371-54cfd0c27add@sha256:f015ef741acf93bba9e04194b36c0781b876fd1a6a48702cc7b28a30b48a160b
+          image: ghcr.io/adamousmer/itsbagelbot/console-dashboard:main-1787637317-6ff19650b709@sha256:89eb4ac0101648de31f325bb51da6cfa60b02f263014beebab3ac2d1fb45cfac
           imagePullPolicy: IfNotPresent
           env:
             - name: PORT

--- a/deploy/k8s/sesame.yaml
+++ b/deploy/k8s/sesame.yaml
@@ -130,7 +130,7 @@ spec:
       priorityClassName: bagel-service
       containers:
         - name: sesame
-          image: ghcr.io/adamousmer/itsbagelbot/sesame:main-1787630592-9c1554eedb1d@sha256:c12bdda5a7367b00474017734568ef42d23c7acfd3dff2e40a406311aa9eac7f
+          image: ghcr.io/adamousmer/itsbagelbot/sesame:main-1787637317-6ff19650b709@sha256:d738b789c3dffb5ae41f112c75510add07fe43c89e844b29f5ac4f32b7360189
           imagePullPolicy: IfNotPresent
           env:
             - name: NATS_HOST


### PR DESCRIPTION
## Summary
- Pin console-dashboard, console-admin, and sesame to `main-1787637317-6ff19650b709` (#702: standalone `!song`/`!skip`, settings key rows, gamble nested under loyalty).
- Remaining Go services stay on the #701 pin; they were never applied to the cluster and roll out with this.

## Test plan
- [ ] Apply db-tier (users → transactions), then sesame/gossip/outgress, then consoles
- [ ] Hub NATS already rolled this morning; leave it
- [ ] Public 200 on console and admin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Console Admin, Console Dashboard, and Sesame services to newer immutable builds.
  * Includes the latest deployment image versions for improved reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->