### PR TITLE
docs(web): add v1.0.2-beta changelog

### DIFF
--- a/web/src/content/changelog/v1.0.2-beta.json
+++ b/web/src/content/changelog/v1.0.2-beta.json
@@ -1,0 +1,14 @@
+{
+  "tag": "beta",
+  "version": "v1.0.2-beta",
+  "date": "2026-08-25",
+  "title": {
+    "en": "Loyalty Leaderboards & Song Requests",
+    "fr": "Classements de fidélité et demandes de chansons"
+  },
+  "description": {
+    "en": "Loyalty gains a per-channel leaderboard page, granular moderator grants, and viewer-to-viewer point transfers. Song requests get their own console page alongside standalone !song and !skip. AutoMod adds a dynamic link-safety checker and an opt-in clips-only filter, and the console boots faster behind a rebuilt login.",
+    "fr": "La fidélité gagne une page de classement par chaîne, des permissions de modération granulaires et des transferts de points entre spectateurs. Les demandes de chansons ont leur propre page de console, avec les commandes !song et !skip. L'AutoMod ajoute un vérificateur de liens dynamique et un filtre « clips uniquement » optionnel, et la console démarre plus vite derrière une connexion repensée."
+  },
+  "github": "https://github.com/AdamOusmer/ItsBagelBot/releases/tag/v1.0.2-beta"
+}


### PR DESCRIPTION
Publishes the v1.0.2-beta entry on the web changelog.

Covers everything merged since v1.0.1-beta: loyalty leaderboards / mod grants / viewer transfers (#696), song request console page (#700) and standalone `!song` / `!skip` (#702), automod link-safety checker (#690) and clips-only filter (#699), data sources in the command editor (#694), console boot perf (#692) and the rebuilt hero + login (#691, #698).

This commit is the build point for the unified all-service image publish that follows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added loyalty leaderboards and point-transfer tools.
  - Added moderation grants for managing community rewards.
  - Expanded song-request console features and commands.
  - Added AutoMod link-safety protections and clips-only filtering.
  - Improved console startup speed.
  - Redesigned login experience with English and French language support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->