### PR TITLE
chore(deploy): pin fleet to unified v1.0.2-beta build

### DIFF
--- a/deploy/k8s/commands.yaml
+++ b/deploy/k8s/commands.yaml
@@ -118,7 +118,7 @@ spec:
       priorityClassName: bagel-service
       containers:
         - name: commands
-          image: ghcr.io/adamousmer/itsbagelbot/commands:main-1787628494-8c32b708fb7f@sha256:78ba639b964e9360b585034e84b64828134edc758d02b8edcca0832b9746ce23
+          image: ghcr.io/adamousmer/itsbagelbot/commands:main-1787640708-039651a0e98f@sha256:eeaa53766e6832d4e0d650c560bce8542ae46ab17d847471ef475e6bab2abca6
           imagePullPolicy: IfNotPresent
           env:
             - name: NATS_HOST

--- a/deploy/k8s/console-admin.yaml
+++ b/deploy/k8s/console-admin.yaml
@@ -139,7 +139,7 @@ spec:
       priorityClassName: bagel-edge
       containers:
         - name: console-admin
-          image: ghcr.io/adamousmer/itsbagelbot/console-admin:main-1787637317-6ff19650b709@sha256:59204e6163b5854528774c038cc1bcce842340f3d6da7a83394fc5bd1e50ef91
+          image: ghcr.io/adamousmer/itsbagelbot/console-admin:main-1787640708-039651a0e98f@sha256:cc2ce136ad894e15d8732fcc79b10545a826b088f2e07060f2dd31fab2ca12f6
           imagePullPolicy: IfNotPresent
           env:
             # mTLS client identity for both NATS planes (nats-client-tls,

--- a/deploy/k8s/console-dashboard.yaml
+++ b/deploy/k8s/console-dashboard.yaml
@@ -139,7 +139,7 @@ spec:
       priorityClassName: bagel-edge
       containers:
         - name: console-dashboard
-          image: ghcr.io/adamousmer/itsbagelbot/console-dashboard:main-1787637317-6ff19650b709@sha256:89eb4ac0101648de31f325bb51da6cfa60b02f263014beebab3ac2d1fb45cfac
+          image: ghcr.io/adamousmer/itsbagelbot/console-dashboard:main-1787640708-039651a0e98f@sha256:b688670a625b5fe477ecd0580edc9ffab5da41409e2b64a38a503c3fb3be7377
           imagePullPolicy: IfNotPresent
           env:
             - name: PORT

--- a/deploy/k8s/gossip.yaml
+++ b/deploy/k8s/gossip.yaml
@@ -168,7 +168,7 @@ spec:
       # "warp" package private right after its first publish.
       initContainers:
         - name: warp
-          image: ghcr.io/adamousmer/itsbagelbot/warp:main-1787603663-a1c27f889ca7@sha256:68baa5313abcb1ea376f99a0aa06faeaa37df3dcb4ab6c1dddc0cc6f13a2d66e
+          image: ghcr.io/adamousmer/itsbagelbot/warp:main-1787640708-039651a0e98f@sha256:420fe3179a92b0c77e0e7e98a4df375bd1715fe9dde8017cc07005e73da7437b
           imagePullPolicy: IfNotPresent
           restartPolicy: Always # native sidecar: runs for the pod's lifetime
           # Bootstrap (consumer WARP, deliberately NO Zero Trust org). Two
@@ -285,7 +285,7 @@ spec:
               memory: 256Mi
       containers:
         - name: gossip
-          image: ghcr.io/adamousmer/itsbagelbot/gossip:main-1787628494-8c32b708fb7f@sha256:5180685a104b3ca7cb94d2862f5155a19f7f5532a084ccee9bb5be8b37d69fdc
+          image: ghcr.io/adamousmer/itsbagelbot/gossip:main-1787640708-039651a0e98f@sha256:de8ccfe4cb8a66e42202280c30fa664f09190cb604aa5fe87e38622375c9ba53
           imagePullPolicy: IfNotPresent
           env:
             # gossip is RPC-only: it answers sesame's requests over

--- a/deploy/k8s/loyalty.yaml
+++ b/deploy/k8s/loyalty.yaml
@@ -118,7 +118,7 @@ spec:
       priorityClassName: bagel-service
       containers:
         - name: loyalty
-          image: ghcr.io/adamousmer/itsbagelbot/loyalty:main-1787628494-8c32b708fb7f@sha256:f27092dba8edeee9cd0328136e18e725e2c02bf70243e03424a15d66c9f6a9ba
+          image: ghcr.io/adamousmer/itsbagelbot/loyalty:main-1787640708-039651a0e98f@sha256:a890c4e96257358f7d1fd635f8c2f62ea545cb5b7c78f3fd4e3b955348d9ac71
           imagePullPolicy: IfNotPresent
           env:
             - name: NATS_HOST

--- a/deploy/k8s/modules.yaml
+++ b/deploy/k8s/modules.yaml
@@ -118,7 +118,7 @@ spec:
       priorityClassName: bagel-service
       containers:
         - name: modules
-          image: ghcr.io/adamousmer/itsbagelbot/modules:main-1787628494-8c32b708fb7f@sha256:5e4d6addeef88bb4faf8e63b5547d5032a4a1f3dcd03425735f5bf9ff9ae2b03
+          image: ghcr.io/adamousmer/itsbagelbot/modules:main-1787640708-039651a0e98f@sha256:1dfaa9f51c194fbdfef1ab7908fc63e5651a31509032f4c3cb5565d957ffcc6c
           imagePullPolicy: IfNotPresent
           env:
             - name: NATS_HOST

--- a/deploy/k8s/notifications.yaml
+++ b/deploy/k8s/notifications.yaml
@@ -121,7 +121,7 @@ spec:
       priorityClassName: bagel-service
       containers:
         - name: notifications
-          image: ghcr.io/adamousmer/itsbagelbot/notifications:main-1787628494-8c32b708fb7f@sha256:6904644374854dee347eaeb54efcc322bf09a8e10c4d3c27f35728ebeb798c66
+          image: ghcr.io/adamousmer/itsbagelbot/notifications:main-1787640708-039651a0e98f@sha256:02780ead7a54f816d1c39c97a11c1615bda34547b2885b0b6fe20ce3258a95f0
           imagePullPolicy: IfNotPresent
           env:
             - name: NATS_HOST
@@ -257,7 +257,7 @@ spec:
             seccompProfile: {type: RuntimeDefault}
           containers:
             - name: cleanup
-              image: ghcr.io/adamousmer/itsbagelbot/notifications:main-1787628494-8c32b708fb7f@sha256:6904644374854dee347eaeb54efcc322bf09a8e10c4d3c27f35728ebeb798c66
+              image: ghcr.io/adamousmer/itsbagelbot/notifications:main-1787640708-039651a0e98f@sha256:02780ead7a54f816d1c39c97a11c1615bda34547b2885b0b6fe20ce3258a95f0
               imagePullPolicy: IfNotPresent
               args: ["cleanup"]
               env:

--- a/deploy/k8s/outgress.yaml
+++ b/deploy/k8s/outgress.yaml
@@ -126,7 +126,7 @@ spec:
       priorityClassName: bagel-service
       containers:
         - name: outgress
-          image: ghcr.io/adamousmer/itsbagelbot/outgress:main-1787628494-8c32b708fb7f@sha256:9c696bfa40c7e4b8cc561f50fc3a025db8d3ca9394d51f2f164ab18fa1af6d65
+          image: ghcr.io/adamousmer/itsbagelbot/outgress:main-1787640708-039651a0e98f@sha256:49954261d6f9c0cc841aed45552c30e799abd02a70c09b9629989d260e8a9e8d
           imagePullPolicy: IfNotPresent
           env:
             - name: NATS_HOST

--- a/deploy/k8s/projector.yaml
+++ b/deploy/k8s/projector.yaml
@@ -118,7 +118,7 @@ spec:
       priorityClassName: bagel-service
       containers:
         - name: projector
-          image: ghcr.io/adamousmer/itsbagelbot/projector:main-1787628494-8c32b708fb7f@sha256:1319da299a30295c03cc050bb239787a4b8acb2480df35e44c3c3d754a704e0b
+          image: ghcr.io/adamousmer/itsbagelbot/projector:main-1787640708-039651a0e98f@sha256:be565a3f419f8689174aaccb568dc4e8954bb11def0eb9b4e7bcd9f6c5708633
           imagePullPolicy: IfNotPresent
           env:
             # The lane catalog is partition-gated; the projector reconciles the

--- a/deploy/k8s/sesame.yaml
+++ b/deploy/k8s/sesame.yaml
@@ -130,7 +130,7 @@ spec:
       priorityClassName: bagel-service
       containers:
         - name: sesame
-          image: ghcr.io/adamousmer/itsbagelbot/sesame:main-1787637317-6ff19650b709@sha256:d738b789c3dffb5ae41f112c75510add07fe43c89e844b29f5ac4f32b7360189
+          image: ghcr.io/adamousmer/itsbagelbot/sesame:main-1787640708-039651a0e98f@sha256:622e20c45dd04a01f7a98d05d52852687508ec65633c0e8f323690f6abfb66f0
           imagePullPolicy: IfNotPresent
           env:
             - name: NATS_HOST

--- a/deploy/k8s/transactions.yaml
+++ b/deploy/k8s/transactions.yaml
@@ -118,7 +118,7 @@ spec:
       priorityClassName: bagel-service
       containers:
         - name: transactions
-          image: ghcr.io/adamousmer/itsbagelbot/transactions:main-1787628494-8c32b708fb7f@sha256:4f6c1955fe248705cbcaa982f21bb74f251fe61521df9da7bc31c555ddc602cc
+          image: ghcr.io/adamousmer/itsbagelbot/transactions:main-1787640708-039651a0e98f@sha256:25f7215433be6cbd5c7a5d19c53a3ec3b8ecce74b74faf90272e1d5535392218
           imagePullPolicy: IfNotPresent
           env:
             - name: NATS_HOST

--- a/deploy/k8s/twitch-ingress.yaml
+++ b/deploy/k8s/twitch-ingress.yaml
@@ -152,7 +152,7 @@ spec:
       priorityClassName: bagel-service
       containers:
         - name: ingress
-          image: ghcr.io/adamousmer/itsbagelbot/twitch-ingress:main-1787603663-a1c27f889ca7@sha256:a0669decd767a7f85831580dac417e4595fc6563d90d1bdb68b6dda75b3dd7c1
+          image: ghcr.io/adamousmer/itsbagelbot/twitch-ingress:main-1787640708-039651a0e98f@sha256:72a485918d8580f6cc30ea3f19e19c9558bf6c78f25e8f11aadd60b1a4c4fdd7
           imagePullPolicy: IfNotPresent
           envFrom:
             - secretRef:

--- a/deploy/k8s/users.yaml
+++ b/deploy/k8s/users.yaml
@@ -124,7 +124,7 @@ spec:
       priorityClassName: bagel-service
       containers:
         - name: users
-          image: ghcr.io/adamousmer/itsbagelbot/users:main-1787628494-8c32b708fb7f@sha256:331f0629d55e617f2a520520dab021382ac04d33c7a94fe3f4f4eb0e82a92ec3
+          image: ghcr.io/adamousmer/itsbagelbot/users:main-1787640708-039651a0e98f@sha256:108b855b06d251e9abf562b07f7b95fc0186268c7bf6fd9c42f8c277aa87a290
           imagePullPolicy: IfNotPresent
           env:
             - name: NATS_HOST


### PR DESCRIPTION
Pins all 14 images to `main-1787640708-039651a0e98f`, the single all-service build from run [32818883534](https://github.com/AdamOusmer/ItsBagelBot/actions/runs/32818883534) at commit 039651a0.

Why one tag: the previous pins were assembled from several path-filtered builds, and two of those source commits (`6ff19650`, `ee7c8b05`) were orphaned by history rewrites. Nothing in prod could be traced back to a commit on main. This replaces that with a single build point.

Services: commands, loyalty, modules, notifications, outgress, projector, transactions, users, sesame, gossip, warp, twitch-ingress, console-dashboard, console-admin. Digests resolved from the registry, not copied from logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container images across core services to newer, immutable builds.
  * Refreshed images for notifications, gossip, and related cleanup tasks.
  * Improved deployment consistency by pinning services to verified image digests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->