### PR TITLE
chore(deploy): bump console-dashboard to #707

### DIFF
--- a/deploy/k8s/console-dashboard.yaml
+++ b/deploy/k8s/console-dashboard.yaml
@@ -139,7 +139,7 @@ spec:
       priorityClassName: bagel-edge
       containers:
         - name: console-dashboard
-          image: ghcr.io/adamousmer/itsbagelbot/console-dashboard:main-1787640708-039651a0e98f@sha256:b688670a625b5fe477ecd0580edc9ffab5da41409e2b64a38a503c3fb3be7377
+          image: ghcr.io/adamousmer/itsbagelbot/console-dashboard:main-1787645105-429f38434052@sha256:5ca4c6e4b79bcb80f0048acd06ebd4a19592e9e7997227b63f745fe5c71dbb16
           imagePullPolicy: IfNotPresent
           env:
             - name: PORT


### PR DESCRIPTION
## Summary
- Update the existing `console-dashboard` Deployment image pin to `main-1787645105-429f38434052` (#707 modules directory).
- Does not create or delete a Deployment — only the image line changes.

## Test plan
- [ ] `kubectl -n app rollout status deploy/console-dashboard`
- [ ] https://dashboard.itsbagelbot.com/modules loads the directory UI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Console Dashboard deployment to use a newer, verified container image version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->