### PR TITLE
Hop Add to Twitch through dashboard OAuth

### DIFF
--- a/console/dashboard/src/lib/components/public/PublicNav.svelte
+++ b/console/dashboard/src/lib/components/public/PublicNav.svelte
@@ -9,7 +9,7 @@
   import { getI18n } from '@bagel/shared';
   import LangSwitch from '$lib/components/LangSwitch.svelte';
   import NavLink from './NavLink.svelte';
-  import { dashHref, webHome, webHref, type PublicNavLink } from './links';
+  import { dashLoginHref, webHome, webHref, type PublicNavLink } from './links';
 
   let {
     links,
@@ -48,7 +48,7 @@
 
     <div class="nav-cta">
       {#if showLang}<LangSwitch />{/if}
-      <a class="cta-btn" href={dashHref(locale)} target="_blank" rel="noopener noreferrer"
+      <a class="cta-btn" href={dashLoginHref(locale)} target="_blank" rel="noopener noreferrer"
         >{t('public.nav.cta')}</a
       >
     </div>

--- a/console/dashboard/src/lib/components/public/links.ts
+++ b/console/dashboard/src/lib/components/public/links.ts
@@ -9,8 +9,10 @@ import { DEFAULT_LOCALE, type Locale } from '@bagel/shared/i18n';
 
 /** The live marketing site. */
 export const WEB = 'https://itsbagelbot.com';
-/** This app's own public origin, used by the nav CTA and the footer. */
+/** This app's own public origin, used by the footer Dashboard link. */
 export const DASH = 'https://dashboard.itsbagelbot.com';
+/** OAuth start. Add to Twitch hits this so Twitch redirects into the console. */
+export const DASH_LOGIN = `${DASH}/auth/login`;
 
 /** One entry in the public nav's link row. */
 export interface PublicNavLink {
@@ -35,10 +37,14 @@ export function webHome(locale: Locale): string {
 }
 
 /**
- * The dashboard entry point. The dashboard has no /<locale> routes — it reads
- * ?lang= — so a non-default locale rides over as a query, exactly as the
- * marketing nav's CTA builds it.
+ * The dashboard origin. The dashboard has no /<locale> routes — it reads
+ * ?lang= — so a non-default locale rides over as a query. Footer "Dashboard"
+ * uses this; Add to Twitch uses dashLoginHref so the click starts OAuth.
  */
 export function dashHref(locale: Locale): string {
   return locale === DEFAULT_LOCALE ? DASH : `${DASH}?lang=${locale}`;
+}
+
+export function dashLoginHref(locale: Locale): string {
+  return locale === DEFAULT_LOCALE ? DASH_LOGIN : `${DASH_LOGIN}?lang=${locale}`;
 }

--- a/console/dashboard/src/lib/server/oauth-start.test.ts
+++ b/console/dashboard/src/lib/server/oauth-start.test.ts
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+import { describe, expect, test } from 'bun:test';
+import { skipAuthorizeIfSignedIn } from './oauth-start';
+
+describe('skipAuthorizeIfSignedIn', () => {
+  test('starts OAuth for a signed-out visitor', () => {
+    expect(
+      skipAuthorizeIfSignedIn({ hasSession: false, pendingDelegation: undefined, reauth: null })
+    ).toBe(false);
+  });
+
+  test('skips OAuth when the marketing CTA hits a live session', () => {
+    expect(
+      skipAuthorizeIfSignedIn({ hasSession: true, pendingDelegation: undefined, reauth: null })
+    ).toBe(true);
+  });
+
+  test('still authorizes settings reconnect', () => {
+    expect(
+      skipAuthorizeIfSignedIn({ hasSession: true, pendingDelegation: undefined, reauth: '1' })
+    ).toBe(false);
+  });
+
+  test('still authorizes delegate-accept', () => {
+    expect(
+      skipAuthorizeIfSignedIn({
+        hasSession: true,
+        pendingDelegation: 'share-token',
+        reauth: null
+      })
+    ).toBe(false);
+  });
+});

--- a/console/dashboard/src/lib/server/oauth-start.ts
+++ b/console/dashboard/src/lib/server/oauth-start.ts
@@ -1,0 +1,19 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+// Marketing "Add to Twitch" now hits GET /auth/login instead of the dashboard
+// origin. A signed-in visitor must not be sent through Twitch: persistGrant
+// would rotate the bot refresh token. Skipping whenever a session exists was
+// tried first and is wrong — settings reconnect and /delegate/accept both
+// arrive here with a live session and must re-run authorize. Those paths opt
+// in: reconnect passes ?reauth=1; accept sets pending_delegation before the hop.
+export function skipAuthorizeIfSignedIn(opts: {
+  hasSession: boolean;
+  pendingDelegation: string | undefined;
+  reauth: string | null;
+}): boolean {
+  if (!opts.hasSession) return false;
+  if (opts.pendingDelegation) return false;
+  if (opts.reauth === '1') return false;
+  return true;
+}

--- a/console/dashboard/src/routes/(app)/settings/+page.svelte
+++ b/console/dashboard/src/routes/(app)/settings/+page.svelte
@@ -205,7 +205,7 @@
         <b>{t('settings.reconnectTwitch')}</b>
         <p class="hint">{t('settings.reconnectTwitchHint')}</p>
       </div>
-      <ButtonLink href="/auth/login" variant="ghost" icon="power">{t('common.reconnect')}</ButtonLink>
+      <ButtonLink href="/auth/login?reauth=1" variant="ghost" icon="power">{t('common.reconnect')}</ButtonLink>
     </div>
   </section>
 

--- a/console/dashboard/src/routes/auth/login/+page.server.ts
+++ b/console/dashboard/src/routes/auth/login/+page.server.ts
@@ -8,6 +8,7 @@ import { env } from '$env/dynamic/private';
 import { generateState } from '@bagel/shared/server/oauth';
 import { randomBytes } from 'node:crypto';
 import { twitch, scopes, safeNextPath } from '$lib/server/oauth';
+import { skipAuthorizeIfSignedIn } from '$lib/server/oauth-start';
 
 // Gated on the build-time `dev` constant first, so Rollup erases the demo
 // branch from production builds.
@@ -22,11 +23,23 @@ const DEMO = dev && env.DEMO === '1';
 // callback (CSRF protection for OAuth). Nonce is also generated and stored:
 // the shared Twitch client does not accept a nonce arg, so we append it
 // directly to the URL and verify claims.nonce in the callback.
-export const load: PageServerLoad = ({ cookies, url }) => {
+export const load: PageServerLoad = ({ cookies, url, locals }) => {
   // DEMO has no Twitch app credentials and already synthesizes a session in
   // (app)/+layout.server.ts. Sending the visitor to Twitch would 500; send
   // them into the demo console instead, honouring ?next= when it is safe.
   if (DEMO) {
+    throw redirect(302, safeNextPath(url.searchParams.get('next')) ?? '/');
+  }
+
+  // Signed-in marketing CTA: land in the console. Reconnect and delegate-accept
+  // opt out of this skip (see skipAuthorizeIfSignedIn).
+  if (
+    skipAuthorizeIfSignedIn({
+      hasSession: !!locals.session,
+      pendingDelegation: cookies.get('pending_delegation'),
+      reauth: url.searchParams.get('reauth')
+    })
+  ) {
     throw redirect(302, safeNextPath(url.searchParams.get('next')) ?? '/');
   }
 

--- a/console/package.json
+++ b/console/package.json
@@ -9,7 +9,7 @@
     "dev:dashboard": "bun run --filter dashboard dev",
     "dev:admin": "bun run --filter admin dev",
     "check": "bun run --filter '*' check",
-    "test": "bun test shared && bun shared/scripts/size.ts"
+    "test": "bun test shared dashboard/src/lib/server/oauth-start.test.ts && bun shared/scripts/size.ts"
   },
   "devDependencies": {
     "@types/node": "^26.0.0",

--- a/web/src/components/home/Finale.astro
+++ b/web/src/components/home/Finale.astro
@@ -8,7 +8,7 @@
  */
 import MainButton from '../ui/Buttons/MainButton.astro';
 import SecondaryButton from '../ui/Buttons/SecondaryButton.astro';
-import { getLangFromUrl, useTranslations, localizePath, defaultLang } from '../../i18n/ui';
+import { getLangFromUrl, useTranslations, localizePath, dashLoginHref } from '../../i18n/ui';
 
 const lang = getLangFromUrl(Astro.url);
 const t = useTranslations(lang);
@@ -28,7 +28,7 @@ const titleWords = t('finale.title').split(' ');
             {t('finale.sub')}
         </p>
         <div class="finale__actions" data-reveal style="--reveal-i: 9">
-            <MainButton href={`https://dashboard.itsbagelbot.com${lang === defaultLang ? '' : `?lang=${lang}`}`} label={t('nav.cta')} />
+            <MainButton href={dashLoginHref(lang)} label={t('nav.cta')} />
             <SecondaryButton href={localizePath('/pricing', lang)} label={t('finale.seePricing')} />
         </div>
         <span class="finale__honesty" data-reveal style="--reveal-i: 10">

--- a/web/src/components/layout/Nav.astro
+++ b/web/src/components/layout/Nav.astro
@@ -8,7 +8,7 @@ import {Image} from "astro:assets";
 import Hamburger  from '../ui/Hamburger.astro';
 import MobileMenu from './MobileMenu.astro';
 import LanguageSwitcher from './LanguageSwitcher.astro';
-import { getLangFromUrl, useTranslations, localizePath, defaultLang } from '../../i18n/ui';
+import { getLangFromUrl, useTranslations, localizePath, dashLoginHref } from '../../i18n/ui';
 
 const lang = getLangFromUrl(Astro.url);
 const t = useTranslations(lang);
@@ -21,7 +21,7 @@ const links = [
     { href: "https://status.itsbagelbot.com",label: t('nav.status')   },
 ];
 
-const cta = { href: `https://dashboard.itsbagelbot.com${lang === defaultLang ? '' : `?lang=${lang}`}`, label: t('nav.cta') };
+const cta = { href: dashLoginHref(lang), label: t('nav.cta') };
 const homeHref = localizePath("/", lang);
 
 const currentPath = Astro.url.pathname.replace(/\/+$/, "") || "/";

--- a/web/src/components/pricing/Tiers.astro
+++ b/web/src/components/pricing/Tiers.astro
@@ -8,7 +8,7 @@
  * Enterprise sits quietly beside it. Count-up price, stroke-drawn checks.
  */
 import Card from '../ui/Card.astro';
-import { getLangFromUrl, useTranslations, defaultLang } from '../../i18n/ui';
+import { getLangFromUrl, useTranslations, defaultLang, dashLoginHref } from '../../i18n/ui';
 
 const lang = getLangFromUrl(Astro.url);
 const t = useTranslations(lang);
@@ -41,7 +41,7 @@ const enterpriseFeatures = [
                 </p>
                 <a
                     class="tier__btn tier__btn--main"
-                    href={`https://dashboard.itsbagelbot.com${lang === defaultLang ? '' : `?lang=${lang}`}`}
+                    href={dashLoginHref(lang)}
                     target="_blank"
                     rel="noopener noreferrer"
                 >{t('tier.getStarted')}</a>

--- a/web/src/i18n/ui.ts
+++ b/web/src/i18n/ui.ts
@@ -101,6 +101,18 @@ export function languageName(lang: Lang): string {
   return catalog[lang]?.['lang.name'] ?? lang;
 }
 
+// Add to Twitch must hit the dashboard OAuth *start*, not the console origin.
+// /auth/login sets the host-only state/nonce cookies, 302s to Twitch, and the
+// callback lands the visitor in the console. Linking the origin instead showed
+// /login first (an extra click) and never bound CSRF to the dashboard host if
+// we ever built the authorize URL on this site. Footer "Dashboard" still uses
+// the origin; only the CTA uses this.
+const DASHBOARD_LOGIN = 'https://dashboard.itsbagelbot.com/auth/login';
+
+export function dashLoginHref(lang: Lang): string {
+  return lang === defaultLang ? DASHBOARD_LOGIN : `${DASHBOARD_LOGIN}?lang=${lang}`;
+}
+
 // Build-time parity warning: for every non-English locale, list the keys it is
 // missing (rendered in English) or carries in excess (typos / stale keys). Runs
 // once at module init during `astro build`; never fails the build.

--- a/web/src/pages/fr/guides/getting-started.astro
+++ b/web/src/pages/fr/guides/getting-started.astro
@@ -35,7 +35,7 @@ const sections = [
     >
         <Fragment slot="connect">
             <p>
-                Rendez-vous sur <a href="https://dashboard.itsbagelbot.com?lang=fr" target="_blank" rel="noopener noreferrer">dashboard.itsbagelbot.com</a>
+                Rendez-vous sur <a href="https://dashboard.itsbagelbot.com/auth/login?lang=fr" target="_blank" rel="noopener noreferrer">dashboard.itsbagelbot.com</a>
                 et connectez-vous avec votre compte Twitch. Twitch affiche exactement ce que le bot a le
                 droit de faire avant que vous n'approuviez quoi que ce soit, et c'est toute
                 l'installation. Dès que vous êtes connecté, ItsBagelBot rejoint votre chat et reste

--- a/web/src/pages/guides/getting-started.astro
+++ b/web/src/pages/guides/getting-started.astro
@@ -35,7 +35,7 @@ const sections = [
     >
         <Fragment slot="connect">
             <p>
-                Head to <a href="https://dashboard.itsbagelbot.com" target="_blank" rel="noopener noreferrer">dashboard.itsbagelbot.com</a>
+                Head to <a href="https://dashboard.itsbagelbot.com/auth/login" target="_blank" rel="noopener noreferrer">dashboard.itsbagelbot.com</a>
                 and sign in with your Twitch account. Twitch shows you exactly what the bot is allowed
                 to do before you approve anything, and that's the whole setup. The moment you're in,
                 ItsBagelBot joins your chat and sits quietly until it's spoken to.

--- a/web/tests/site.spec.js
+++ b/web/tests/site.spec.js
@@ -98,6 +98,24 @@ test.describe('ItsBagelBot site', () => {
         await expect(ignLinks).toHaveCount(2);
     });
 
+    test('Add to Twitch starts dashboard OAuth, not the console origin', async ({ page }) => {
+        await page.goto('/');
+        await expect(page.locator('.site-nav a.cta')).toHaveAttribute(
+            'href',
+            'https://dashboard.itsbagelbot.com/auth/login'
+        );
+        await expect(page.locator('.finale__actions a').first()).toHaveAttribute(
+            'href',
+            'https://dashboard.itsbagelbot.com/auth/login'
+        );
+
+        await page.goto('/fr/');
+        await expect(page.locator('.site-nav a.cta')).toHaveAttribute(
+            'href',
+            'https://dashboard.itsbagelbot.com/auth/login?lang=fr'
+        );
+    });
+
     test('pricing renders free-first tiers, oath, and faq', async ({ page }) => {
         await page.goto('/pricing');
 


### PR DESCRIPTION
## Summary
- Marketing Add to Twitch (nav, finale, free-tier Get started) now hits `dashboard.itsbagelbot.com/auth/login`, so Twitch’s redirect lands in the console without the extra `/login` click.
- CSRF stays on the dashboard host: `/auth/login` still sets the host-only state/nonce cookies before the Twitch 302.
- Signed-in visitors skip a token-rotating re-consent. Settings reconnect passes `?reauth=1`; share-link accept still runs authorize because of `pending_delegation`. Footer “Dashboard” is unchanged.

## Test plan
- [ ] Click Add to Twitch on itsbagelbot.com while signed out: Twitch consent, then dashboard home. No `/login` interstitial.
- [ ] Same click while already signed into the dashboard: land in the console, no new Twitch grant.
- [ ] Settings → Reconnect Twitch still opens Twitch authorize.
- [ ] Opening a fresh share link still binds after Twitch login.
- [ ] Footer Dashboard still goes to the console origin, not `/auth/login`.
- [ ] French CTA carries `?lang=fr`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added localized dashboard login links across navigation, pricing, guides, and promotional calls to action.
  - French and other non-English locales now preserve language settings when opening dashboard login.
  - Signed-in visitors are redirected appropriately, while reconnect and pending delegation flows continue through authorization when needed.

- **Bug Fixes**
  - Updated reconnect links to explicitly request reauthentication.
  - Improved dashboard login routing for existing sessions and OAuth flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->