### PR TITLE
feat(web): match cards to header orbs

### DIFF
--- a/web/src/components/guides/GuideCard.astro
+++ b/web/src/components/guides/GuideCard.astro
@@ -6,8 +6,11 @@
  * GuideCard — one entry on the guides hub. A numbered chapter card in the
  * site's warm-card language: mono index, display title, body teaser, and a
  * meta strip (reading time · section count) so readers can budget attention
- * before committing — the hub is a menu, not a maze.
+ * before committing — the hub is a menu, not a maze. Atmosphere matches the
+ * shared Card (header orbs, no pointer tracking).
  */
+import CardAtmosphere from '../ui/CardAtmosphere.astro';
+
 interface Props {
     index: string;
     href: string;
@@ -23,6 +26,7 @@ const { index, href, title, description, meta, chips = [], revealIndex = 0 } = A
 ---
 
 <a class="gcard" href={href} data-reveal style={`--reveal-i: ${revealIndex}`}>
+    <CardAtmosphere />
     <span class="gcard__index" aria-hidden="true">{index}</span>
     <span class="gcard__body">
         <b class="gcard__title">{title}</b>
@@ -54,22 +58,17 @@ const { index, href, title, description, meta, chips = [], revealIndex = 0 } = A
         transition: border-color 220ms ease, background 220ms ease, transform 260ms var(--ease-out-expo);
     }
 
-    .gcard::before {
-        content: "";
-        position: absolute;
-        inset: 0;
-        background: radial-gradient(420px 180px at 12% 0%, rgba(201, 168, 124, 0.07), transparent 70%);
-        opacity: 0;
-        transition: opacity 260ms ease;
-        pointer-events: none;
-    }
-
     .gcard:hover {
         border-color: rgba(201, 168, 124, 0.4);
         transform: translateY(-3px);
     }
 
-    .gcard:hover::before { opacity: 1; }
+    .gcard__index,
+    .gcard__body,
+    .gcard__meta {
+        position: relative;
+        z-index: 1;
+    }
 
     .gcard__index {
         display: grid;

--- a/web/src/components/home/QuietWork.astro
+++ b/web/src/components/home/QuietWork.astro
@@ -4,8 +4,8 @@
 
 /**
  * QuietWork — a bento of the bot's chores, each card running its own tiny
- * live demo instead of a feature blurb. Built on the shared Card (spotlight +
- * lift); the demos are CSS loops, with one small script for the giveaway
+ * live demo instead of a feature blurb. Built on the shared Card (header
+ * atmosphere + lift); the demos are CSS loops, with one small script for the giveaway
  * name-shuffle and the poll bars (which want a reveal trigger).
  */
 import Card from '../ui/Card.astro';

--- a/web/src/components/ui/Card.astro
+++ b/web/src/components/ui/Card.astro
@@ -3,11 +3,14 @@
 // Proprietary. No license granted. See LICENSE.md.
 
 /**
- * Shared surface card. One hover language across the whole site: a cursor-
- * tracked tan spotlight, a brightening border, and a small lift. Render as a
- * <div> (default) or an <a> via `as="a"` + `href`. Extra attributes
- * (data-reveal, style, target, rel, aria-*) pass straight through.
+ * Shared surface card. Atmosphere is the header's orb/ring language at card
+ * scale (see CardAtmosphere) — not a pointer-tracked spotlight. Hover still
+ * brightens the border and lifts a few pixels. Render as a <div> (default)
+ * or an <a> via `as="a"` + `href`. Extra attributes (data-reveal, style,
+ * target, rel, aria-*) pass straight through.
  */
+import CardAtmosphere from "./CardAtmosphere.astro";
+
 interface Props {
     as?: "div" | "a";
     href?: string;
@@ -20,7 +23,7 @@ const Tag = as;
 ---
 
 <Tag class:list={["card", className]} href={href} data-card {...attrs}>
-    <span class="card__spotlight" aria-hidden="true"></span>
+    <CardAtmosphere />
     <span class="card__body"><slot /></span>
 </Tag>
 
@@ -39,21 +42,9 @@ const Tag = as;
             transform 360ms var(--ease-out-expo, cubic-bezier(0.16, 1, 0.3, 1));
     }
 
-    .card__spotlight {
-        position: absolute;
-        inset: 0;
-        pointer-events: none;
-        opacity: 0;
-        background: radial-gradient(
-            420px circle at var(--mx, 50%) var(--my, 50%),
-            var(--glow-tan, rgba(201, 168, 124, 0.18)),
-            transparent 60%
-        );
-        transition: opacity 360ms var(--ease-out-expo, cubic-bezier(0.16, 1, 0.3, 1));
-    }
-
     .card__body {
         position: relative;
+        z-index: 1;
         display: block;
     }
 
@@ -61,10 +52,6 @@ const Tag = as;
         .card:hover {
             border-color: rgba(201, 168, 124, 0.38);
             transform: translateY(-3px);
-        }
-
-        .card:hover .card__spotlight {
-            opacity: 1;
         }
     }
 
@@ -74,25 +61,3 @@ const Tag = as;
         }
     }
 </style>
-
-<script>
-    function setupCard(card: HTMLElement) {
-        if (card.dataset.cardReady === "true") return;
-        card.dataset.cardReady = "true";
-
-        card.addEventListener("pointermove", (event) => {
-            const rect = card.getBoundingClientRect();
-            const x = ((event.clientX - rect.left) / rect.width) * 100;
-            const y = ((event.clientY - rect.top) / rect.height) * 100;
-            card.style.setProperty("--mx", `${x.toFixed(2)}%`);
-            card.style.setProperty("--my", `${y.toFixed(2)}%`);
-        });
-    }
-
-    function setupCards() {
-        document.querySelectorAll<HTMLElement>("[data-card]").forEach(setupCard);
-    }
-
-    setupCards();
-    document.addEventListener("astro:page-load", setupCards);
-</script>

--- a/web/src/components/ui/CardAtmosphere.astro
+++ b/web/src/components/ui/CardAtmosphere.astro
@@ -1,0 +1,102 @@
+---
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+/**
+ * Card atmosphere — a pocket of the header's light, not a cursor tracker.
+ *
+ * Same discs as the hero (green top-right, tan bottom-left, a tan→green arc)
+ * at card scale. They stay static: a `filter: blur` on a still layer is one
+ * paint and a cached bitmap. The hitch was animating them — a ::before that
+ * pulsed `scale(1.1)` on every orb, plus a masked ring spinning on every
+ * tile, which re-rasters the blur at 60fps. Hover only changes opacity
+ * (compositor), never transform or filter. Adjacent tiles flip via
+ * :nth-child(even) so a grid is not a stamp.
+ *
+ * The card itself still owns the border and lift.
+ */
+---
+
+<div class="card-atmo" aria-hidden="true">
+    <span class="card-atmo__ring"></span>
+    <span class="card-atmo__orb card-atmo__orb--green"></span>
+    <span class="card-atmo__orb card-atmo__orb--tan"></span>
+</div>
+
+<style>
+    .card-atmo {
+        position: absolute;
+        inset: 0;
+        overflow: hidden;
+        pointer-events: none;
+        z-index: 0;
+        /* Header orbs rest at ~0.16 on a full viewport; cards are smaller so
+           the same number reads as nothing. 0.28 at rest / 0.42 on hover was
+           measured against --card-bg #111110 after the pulse ::before came
+           off: 0.22 (the pulsed rest) went flat without that extra layer. */
+        --card-atmo-orb: 0.28;
+    }
+
+    /* Even siblings flip so neighbouring cards don't share one corner glow.
+       scaleX on this layer only — body copy is a sibling, not a child. */
+    :global(.card:nth-child(even)) .card-atmo,
+    :global(.gcard:nth-child(even)) .card-atmo {
+        transform: scaleX(-1);
+    }
+
+    :global(.card:hover) .card-atmo,
+    :global(.gcard:hover) .card-atmo,
+    :global(.card:focus-visible) .card-atmo,
+    :global(.gcard:focus-visible) .card-atmo {
+        --card-atmo-orb: 0.42;
+    }
+
+    /* Mini of Header's .bg-ring: a 1.5px tan→green arc, not a filled disc.
+       Masked conic so we never mint per-card SVG ids (g1/g2 would collide).
+       Parked half off the right edge the way the hero ring sits off-canvas.
+       No spin — rotating a masked layer on every tile was the other hitch. */
+    .card-atmo__ring {
+        position: absolute;
+        top: 42%;
+        right: -22%;
+        width: 92%;
+        aspect-ratio: 1;
+        translate: 0 -50%;
+        border-radius: 50%;
+        opacity: 0.16;
+        background: conic-gradient(
+            from 210deg,
+            rgba(201, 168, 124, 0.9),
+            rgba(45, 106, 79, 0.14) 30%,
+            rgba(64, 145, 108, 0.75) 55%,
+            rgba(201, 168, 124, 0.2) 80%,
+            rgba(201, 168, 124, 0.9)
+        );
+        -webkit-mask: radial-gradient(farthest-side, transparent calc(100% - 1.6px), #000 calc(100% - 0.4px));
+        mask: radial-gradient(farthest-side, transparent calc(100% - 1.6px), #000 calc(100% - 0.4px));
+    }
+
+    .card-atmo__orb {
+        position: absolute;
+        border-radius: 50%;
+        filter: blur(42px);
+        opacity: var(--card-atmo-orb);
+        transition: opacity 360ms var(--ease-out-expo, cubic-bezier(0.16, 1, 0.3, 1));
+    }
+
+    .card-atmo__orb--green {
+        width: 240px;
+        height: 240px;
+        background-color: var(--green, #2d6a4f);
+        top: -48px;
+        right: -36px;
+    }
+
+    .card-atmo__orb--tan {
+        width: 200px;
+        height: 200px;
+        background-color: var(--tan, #c9a87c);
+        bottom: -40px;
+        left: -32px;
+    }
+</style>


### PR DESCRIPTION
## Summary
- Replace the pointer-tracked tan spotlight on shared cards with a static header-matching atmosphere (green/tan orbs + still ring).
- Drop the `pointermove` listener so tiles are no longer tracking surfaces.
- Keep hover lift/border; only orb opacity changes, so blur is not re-rastered every frame.

## Test plan
- [ ] Home: Quiet Work / Safety / Games cards show green and tan corner wash, not a cursor spotlight
- [ ] Hover a card: wash brightens, border lifts; neighbouring cards stay still
- [ ] Guides hub cards match the same atmosphere
- [ ] Scroll the home page: no hitch from card layers (orbs are static)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added atmospheric background effects to cards, including soft colored orbs and decorative rings.
  * Added alternating visual treatments across cards for more varied presentation.
  * Atmosphere effects respond to hover and keyboard focus.

* **Style**
  * Updated cards with layered content, brighter hover borders, and subtle lift effects.
  * Removed cursor-tracked spotlight behavior in favor of static atmospheric styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->