### PR TITLE
chore(release): v1.0.3-beta changelog and fleet pin

### DIFF
--- a/deploy/k8s/commands.yaml
+++ b/deploy/k8s/commands.yaml
@@ -118,7 +118,7 @@ spec:
       priorityClassName: bagel-service
       containers:
         - name: commands
-          image: ghcr.io/adamousmer/itsbagelbot/commands:main-1787640708-039651a0e98f@sha256:eeaa53766e6832d4e0d650c560bce8542ae46ab17d847471ef475e6bab2abca6
+          image: ghcr.io/adamousmer/itsbagelbot/commands:main-1787653528-bdc9f828db20@sha256:68f5ea69111bd6bdec288cd818155d0284e5ee9e169d9e9be2a42949525e610f
           imagePullPolicy: IfNotPresent
           env:
             - name: NATS_HOST

--- a/deploy/k8s/console-admin.yaml
+++ b/deploy/k8s/console-admin.yaml
@@ -139,7 +139,7 @@ spec:
       priorityClassName: bagel-edge
       containers:
         - name: console-admin
-          image: ghcr.io/adamousmer/itsbagelbot/console-admin:main-1787640708-039651a0e98f@sha256:cc2ce136ad894e15d8732fcc79b10545a826b088f2e07060f2dd31fab2ca12f6
+          image: ghcr.io/adamousmer/itsbagelbot/console-admin:main-1787653528-bdc9f828db20@sha256:cdb299a1aa49180955f1c3ce9066354cb763c4694f770349ec310728a8d3ddfe
           imagePullPolicy: IfNotPresent
           env:
             # mTLS client identity for both NATS planes (nats-client-tls,

--- a/deploy/k8s/console-dashboard.yaml
+++ b/deploy/k8s/console-dashboard.yaml
@@ -139,7 +139,7 @@ spec:
       priorityClassName: bagel-edge
       containers:
         - name: console-dashboard
-          image: ghcr.io/adamousmer/itsbagelbot/console-dashboard:main-1787645105-429f38434052@sha256:5ca4c6e4b79bcb80f0048acd06ebd4a19592e9e7997227b63f745fe5c71dbb16
+          image: ghcr.io/adamousmer/itsbagelbot/console-dashboard:main-1787653528-bdc9f828db20@sha256:74024d879739fb6dd6dc6dde6985344b4aaaa4c259839e409c909181c819be3a
           imagePullPolicy: IfNotPresent
           env:
             - name: PORT

--- a/deploy/k8s/gossip.yaml
+++ b/deploy/k8s/gossip.yaml
@@ -285,7 +285,7 @@ spec:
               memory: 256Mi
       containers:
         - name: gossip
-          image: ghcr.io/adamousmer/itsbagelbot/gossip:main-1787640708-039651a0e98f@sha256:de8ccfe4cb8a66e42202280c30fa664f09190cb604aa5fe87e38622375c9ba53
+          image: ghcr.io/adamousmer/itsbagelbot/gossip:main-1787653528-bdc9f828db20@sha256:f67e2b2d30d542608fb0ddd320ab991b7bf67664770b697119f6d99ee33b2f94
           imagePullPolicy: IfNotPresent
           env:
             # gossip is RPC-only: it answers sesame's requests over

--- a/deploy/k8s/loyalty.yaml
+++ b/deploy/k8s/loyalty.yaml
@@ -118,7 +118,7 @@ spec:
       priorityClassName: bagel-service
       containers:
         - name: loyalty
-          image: ghcr.io/adamousmer/itsbagelbot/loyalty:main-1787640708-039651a0e98f@sha256:a890c4e96257358f7d1fd635f8c2f62ea545cb5b7c78f3fd4e3b955348d9ac71
+          image: ghcr.io/adamousmer/itsbagelbot/loyalty:main-1787653528-bdc9f828db20@sha256:d3f2f44d78dd4839a0fb7b53d5e4bba79af767993b486b222244dba9a9cebc9a
           imagePullPolicy: IfNotPresent
           env:
             - name: NATS_HOST

--- a/deploy/k8s/modules.yaml
+++ b/deploy/k8s/modules.yaml
@@ -118,7 +118,7 @@ spec:
       priorityClassName: bagel-service
       containers:
         - name: modules
-          image: ghcr.io/adamousmer/itsbagelbot/modules:main-1787640708-039651a0e98f@sha256:1dfaa9f51c194fbdfef1ab7908fc63e5651a31509032f4c3cb5565d957ffcc6c
+          image: ghcr.io/adamousmer/itsbagelbot/modules:main-1787653528-bdc9f828db20@sha256:0d1ba573fd854c52ec67b1ba4898b2811767b8ed72dc95e8f5b9701cde930907
           imagePullPolicy: IfNotPresent
           env:
             - name: NATS_HOST

--- a/deploy/k8s/notifications.yaml
+++ b/deploy/k8s/notifications.yaml
@@ -121,7 +121,7 @@ spec:
       priorityClassName: bagel-service
       containers:
         - name: notifications
-          image: ghcr.io/adamousmer/itsbagelbot/notifications:main-1787640708-039651a0e98f@sha256:02780ead7a54f816d1c39c97a11c1615bda34547b2885b0b6fe20ce3258a95f0
+          image: ghcr.io/adamousmer/itsbagelbot/notifications:main-1787653528-bdc9f828db20@sha256:44ce8f6a606a2e67a2f6b611509ff4b5c7531a626f063852c9431cd7109d621d
           imagePullPolicy: IfNotPresent
           env:
             - name: NATS_HOST
@@ -257,7 +257,7 @@ spec:
             seccompProfile: {type: RuntimeDefault}
           containers:
             - name: cleanup
-              image: ghcr.io/adamousmer/itsbagelbot/notifications:main-1787640708-039651a0e98f@sha256:02780ead7a54f816d1c39c97a11c1615bda34547b2885b0b6fe20ce3258a95f0
+              image: ghcr.io/adamousmer/itsbagelbot/notifications:main-1787653528-bdc9f828db20@sha256:44ce8f6a606a2e67a2f6b611509ff4b5c7531a626f063852c9431cd7109d621d
               imagePullPolicy: IfNotPresent
               args: ["cleanup"]
               env:

--- a/deploy/k8s/outgress.yaml
+++ b/deploy/k8s/outgress.yaml
@@ -126,7 +126,7 @@ spec:
       priorityClassName: bagel-service
       containers:
         - name: outgress
-          image: ghcr.io/adamousmer/itsbagelbot/outgress:main-1787640708-039651a0e98f@sha256:49954261d6f9c0cc841aed45552c30e799abd02a70c09b9629989d260e8a9e8d
+          image: ghcr.io/adamousmer/itsbagelbot/outgress:main-1787653528-bdc9f828db20@sha256:f05748bb89181333a07e9cd2423a2e6daa38889feb50ba67fe97579653f88b23
           imagePullPolicy: IfNotPresent
           env:
             - name: NATS_HOST

--- a/deploy/k8s/projector.yaml
+++ b/deploy/k8s/projector.yaml
@@ -118,7 +118,7 @@ spec:
       priorityClassName: bagel-service
       containers:
         - name: projector
-          image: ghcr.io/adamousmer/itsbagelbot/projector:main-1787640708-039651a0e98f@sha256:be565a3f419f8689174aaccb568dc4e8954bb11def0eb9b4e7bcd9f6c5708633
+          image: ghcr.io/adamousmer/itsbagelbot/projector:main-1787653528-bdc9f828db20@sha256:75d5ce9cce4732cee12000b32309c49d2824408db788fc594694c281a4b6724a
           imagePullPolicy: IfNotPresent
           env:
             # The lane catalog is partition-gated; the projector reconciles the

--- a/deploy/k8s/sesame.yaml
+++ b/deploy/k8s/sesame.yaml
@@ -130,7 +130,7 @@ spec:
       priorityClassName: bagel-service
       containers:
         - name: sesame
-          image: ghcr.io/adamousmer/itsbagelbot/sesame:main-1787640708-039651a0e98f@sha256:622e20c45dd04a01f7a98d05d52852687508ec65633c0e8f323690f6abfb66f0
+          image: ghcr.io/adamousmer/itsbagelbot/sesame:main-1787653528-bdc9f828db20@sha256:917d3fdf8051740ad3e2a9a271d72582bcf7a05b2d4575326a1ccd115a5b2826
           imagePullPolicy: IfNotPresent
           env:
             - name: NATS_HOST

--- a/deploy/k8s/transactions.yaml
+++ b/deploy/k8s/transactions.yaml
@@ -118,7 +118,7 @@ spec:
       priorityClassName: bagel-service
       containers:
         - name: transactions
-          image: ghcr.io/adamousmer/itsbagelbot/transactions:main-1787640708-039651a0e98f@sha256:25f7215433be6cbd5c7a5d19c53a3ec3b8ecce74b74faf90272e1d5535392218
+          image: ghcr.io/adamousmer/itsbagelbot/transactions:main-1787653528-bdc9f828db20@sha256:16e840a57ca3a3a84540fbbcf6f68195c383fb4831683a5cdf0a3ec3af8b9e2c
           imagePullPolicy: IfNotPresent
           env:
             - name: NATS_HOST

--- a/deploy/k8s/users.yaml
+++ b/deploy/k8s/users.yaml
@@ -124,7 +124,7 @@ spec:
       priorityClassName: bagel-service
       containers:
         - name: users
-          image: ghcr.io/adamousmer/itsbagelbot/users:main-1787640708-039651a0e98f@sha256:108b855b06d251e9abf562b07f7b95fc0186268c7bf6fd9c42f8c277aa87a290
+          image: ghcr.io/adamousmer/itsbagelbot/users:main-1787653528-bdc9f828db20@sha256:7197c76b02b22be4acafd22186a15ea39d2b200654463b9243bfc906bb26d5e0
           imagePullPolicy: IfNotPresent
           env:
             - name: NATS_HOST

--- a/web/src/content/changelog/v1.0.3-beta.json
+++ b/web/src/content/changelog/v1.0.3-beta.json
@@ -1,0 +1,14 @@
+{
+  "tag": "beta",
+  "version": "v1.0.3-beta",
+  "date": "2026-08-25",
+  "title": {
+    "en": "BYO Spotify Apps & Modules Directory",
+    "fr": "Apps Spotify personnelles et annuaire des modules"
+  },
+  "description": {
+    "en": "Each broadcaster registers their own Spotify app and connects against it, and !current reads the live player instead of the queue. The modules page is a searchable directory, Add to Twitch jumps straight into dashboard OAuth, and marketing cards match the header orbs.",
+    "fr": "Chaque diffuseur enregistre sa propre application Spotify et s'y connecte, et !current lit le lecteur en direct plutôt que la file. La page modules devient un annuaire avec recherche, Ajouter à Twitch ouvre directement l'OAuth du dashboard, et les cartes du site reprennent les orbes de l'en-tête."
+  },
+  "github": "https://github.com/AdamOusmer/ItsBagelBot/releases/tag/v1.0.3-beta"
+}


### PR DESCRIPTION
## Summary
- Adds the web changelog entry for `v1.0.3-beta` (BYO Spotify, modules directory, Add to Twitch OAuth hop, card atmosphere).
- Pins rebuilt services to the #710 unified build `main-1787653528-bdc9f828db20`.
- Leaves warp and twitch-ingress on the prior pin (no newer image published).

## Test plan
- [ ] Merge, then `kubectl apply -k deploy/messaging` so Spotify exchange ACL is live
- [ ] Apply db → workers → consoles; watch each `rollout status`
- [ ] Public 200 on marketing, console, admin, docs
- [ ] Cut GitHub release `v1.0.3-beta`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added release notes for version 1.0.3-beta, including broadcaster-owned Spotify apps, live-player support for `!current`, a searchable modules directory, and direct dashboard access from “Add to Twitch.”
  - Updated marketing content and provided English and French changelog descriptions.

- **Chores**
  - Updated service deployments to newer pinned builds for improved consistency and reliability.
  - Refreshed notification processing and cleanup components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->