### PR TITLE
chore(deploy): bump sesame and console-dashboard to #715

### DIFF
--- a/deploy/k8s/console-dashboard.yaml
+++ b/deploy/k8s/console-dashboard.yaml
@@ -141,7 +141,7 @@ spec:
       priorityClassName: bagel-edge
       containers:
         - name: console-dashboard
-          image: ghcr.io/adamousmer/itsbagelbot/console-dashboard:main-1787653528-bdc9f828db20@sha256:74024d879739fb6dd6dc6dde6985344b4aaaa4c259839e409c909181c819be3a
+          image: ghcr.io/adamousmer/itsbagelbot/console-dashboard:main-1787687110-3eb4a2e4d281@sha256:acae617587b178a0ef91ddab45489880c8f50f81eaf6a08684ecf7c4bbfedc21
           imagePullPolicy: IfNotPresent
           env:
             - name: PORT

--- a/deploy/k8s/sesame.yaml
+++ b/deploy/k8s/sesame.yaml
@@ -130,7 +130,7 @@ spec:
       priorityClassName: bagel-service
       containers:
         - name: sesame
-          image: ghcr.io/adamousmer/itsbagelbot/sesame:main-1787653528-bdc9f828db20@sha256:917d3fdf8051740ad3e2a9a271d72582bcf7a05b2d4575326a1ccd115a5b2826
+          image: ghcr.io/adamousmer/itsbagelbot/sesame:main-1787687110-3eb4a2e4d281@sha256:e42902100a13f198704b2c9d4131055f8211ec5145109ff5fa6b6d00d9876f99
           imagePullPolicy: IfNotPresent
           env:
             - name: NATS_HOST


### PR DESCRIPTION
Pins both services to `main-1787687110-3eb4a2e4d281` (the merge of #715).

Range pulled in since the current pin (`main-1787653528-bdc9f828db20`, the #710 merge): #711 web cards, #712 docs, #713 release changelog, #715 song-request wiring.

Rollout shape for both is `maxSurge: 0` / `maxUnavailable: 1` — one pod at a time, two of three keep serving.

Note for after the rollout: broadcasters already connected to Spotify hold a token without `user-modify-playback-state`, so queue control stays 403 for them until they reconnect on /songqueue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Console Dashboard container to a newer pinned release.
  * Updated the Sesame container to a newer pinned release.
  * No other deployment behavior was changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->