### PR TITLE
chore(deploy): bump the spotify path to #717

### DIFF
--- a/deploy/k8s/console-dashboard.yaml
+++ b/deploy/k8s/console-dashboard.yaml
@@ -141,7 +141,7 @@ spec:
       priorityClassName: bagel-edge
       containers:
         - name: console-dashboard
-          image: ghcr.io/adamousmer/itsbagelbot/console-dashboard:main-1787687110-3eb4a2e4d281@sha256:acae617587b178a0ef91ddab45489880c8f50f81eaf6a08684ecf7c4bbfedc21
+          image: ghcr.io/adamousmer/itsbagelbot/console-dashboard:main-1787729904-0b0f5081af8e@sha256:1a1621c30c5afcf791d28d73e29d5fb90cbe9e85095cddd1c08fe491a33e2308
           imagePullPolicy: IfNotPresent
           env:
             - name: PORT

--- a/deploy/k8s/gossip.yaml
+++ b/deploy/k8s/gossip.yaml
@@ -285,7 +285,7 @@ spec:
               memory: 256Mi
       containers:
         - name: gossip
-          image: ghcr.io/adamousmer/itsbagelbot/gossip:main-1787653528-bdc9f828db20@sha256:f67e2b2d30d542608fb0ddd320ab991b7bf67664770b697119f6d99ee33b2f94
+          image: ghcr.io/adamousmer/itsbagelbot/gossip:main-1787729904-0b0f5081af8e@sha256:33a0841ec1b176333d22e8c974f317092acad32825461d89750a2a52f332a9d5
           imagePullPolicy: IfNotPresent
           env:
             # gossip is RPC-only: it answers sesame's requests over

--- a/deploy/k8s/modules.yaml
+++ b/deploy/k8s/modules.yaml
@@ -118,7 +118,7 @@ spec:
       priorityClassName: bagel-service
       containers:
         - name: modules
-          image: ghcr.io/adamousmer/itsbagelbot/modules:main-1787653528-bdc9f828db20@sha256:0d1ba573fd854c52ec67b1ba4898b2811767b8ed72dc95e8f5b9701cde930907
+          image: ghcr.io/adamousmer/itsbagelbot/modules:main-1787729904-0b0f5081af8e@sha256:e256c18353e88bce169ea884883a8c4ff4a20d2e7b3bb9ee5c6600345db445eb
           imagePullPolicy: IfNotPresent
           env:
             - name: NATS_HOST

--- a/deploy/k8s/sesame.yaml
+++ b/deploy/k8s/sesame.yaml
@@ -130,7 +130,7 @@ spec:
       priorityClassName: bagel-service
       containers:
         - name: sesame
-          image: ghcr.io/adamousmer/itsbagelbot/sesame:main-1787687110-3eb4a2e4d281@sha256:e42902100a13f198704b2c9d4131055f8211ec5145109ff5fa6b6d00d9876f99
+          image: ghcr.io/adamousmer/itsbagelbot/sesame:main-1787729904-0b0f5081af8e@sha256:789e3329d2f782dde21a08ca89e8a482b1f08cccf02dbd3d9396c551d2cf86b4
           imagePullPolicy: IfNotPresent
           env:
             - name: NATS_HOST


### PR DESCRIPTION
Pins gossip, modules, sesame and console-dashboard to `main-1787729904-0b0f5081af8e` (the merge of #717).

Ordering matters on this one: modules carries the new `scopes` column and applies it on boot, so it rolls first, then gossip (writes the scopes), then sesame and console-dashboard (read them). Every service tolerates the column being absent or empty, so a half-rolled fleet stays correct, it just reports grants as unknown until modules is up.

All four are `maxSurge: 0` / `maxUnavailable: 1`, one pod at a time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the container versions used by the console dashboard, gossip, modules, and Sesame services.
  * Pinned deployments to newer container image builds for improved consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->