### PR TITLE
chore(deploy): bump the songqueue player path to #719

### DIFF
--- a/deploy/k8s/console-dashboard.yaml
+++ b/deploy/k8s/console-dashboard.yaml
@@ -141,7 +141,7 @@ spec:
       priorityClassName: bagel-edge
       containers:
         - name: console-dashboard
-          image: ghcr.io/adamousmer/itsbagelbot/console-dashboard:main-1787729904-0b0f5081af8e@sha256:1a1621c30c5afcf791d28d73e29d5fb90cbe9e85095cddd1c08fe491a33e2308
+          image: ghcr.io/adamousmer/itsbagelbot/console-dashboard:main-1787816014-ed17ec910137@sha256:6bc33409428b4ecc14239e58e3f28ebc7370683b6ed4a50da6c2e18b1233500a
           imagePullPolicy: IfNotPresent
           env:
             - name: PORT

--- a/deploy/k8s/gossip.yaml
+++ b/deploy/k8s/gossip.yaml
@@ -285,7 +285,7 @@ spec:
               memory: 256Mi
       containers:
         - name: gossip
-          image: ghcr.io/adamousmer/itsbagelbot/gossip:main-1787729904-0b0f5081af8e@sha256:33a0841ec1b176333d22e8c974f317092acad32825461d89750a2a52f332a9d5
+          image: ghcr.io/adamousmer/itsbagelbot/gossip:main-1787816014-ed17ec910137@sha256:3565605e5a7f334dd7d05a3836f7748aab9874b1d40c56b7e044976bcbc9b948
           imagePullPolicy: IfNotPresent
           env:
             # gossip is RPC-only: it answers sesame's requests over

--- a/deploy/k8s/sesame.yaml
+++ b/deploy/k8s/sesame.yaml
@@ -130,7 +130,7 @@ spec:
       priorityClassName: bagel-service
       containers:
         - name: sesame
-          image: ghcr.io/adamousmer/itsbagelbot/sesame:main-1787729904-0b0f5081af8e@sha256:789e3329d2f782dde21a08ca89e8a482b1f08cccf02dbd3d9396c551d2cf86b4
+          image: ghcr.io/adamousmer/itsbagelbot/sesame:main-1787816014-ed17ec910137@sha256:f2aaf724ecfd35065b47c445c7f71fad8ad02643484392819f5ba6e80b5833fc
           imagePullPolicy: IfNotPresent
           env:
             - name: NATS_HOST


### PR DESCRIPTION
Pins gossip, sesame and console-dashboard to `main-1787816014-ed17ec910137` (the merge of #719).

No ordering constraint this time: the wire additions (SpotifyPlayerReply, i18n keys) are additive and every service tolerates the old shape, so a half-rolled fleet stays correct. All three are `maxSurge: 0` / `maxUnavailable: 1`, one pod at a time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment images for the console dashboard, gossip service, and Sesame service.
  * Improved image version pinning for more consistent and reliable deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->