### PR TITLE
feat(sesame): auto-refund special-user channel point redemptions on the home channel

### DIFF
--- a/app/sesame/engine/autorefund.go
+++ b/app/sesame/engine/autorefund.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package engine
+
+import (
+	"strings"
+
+	"ItsBagelBot/app/sesame/module"
+	"ItsBagelBot/internal/domain/outgress"
+	"ItsBagelBot/pkg/codec"
+)
+
+// redemptionAddType is the EventSub type a channel-points redemption arrives
+// on (the channelpoints module keeps its own copy; the engine cannot import
+// modules without a cycle).
+const redemptionAddType = "channel.channel_points_custom_reward_redemption.add"
+
+// refundRedemption is the slice of the redemption.add payload the auto-refund
+// gate needs: who redeemed, on whose channel, and the ids Helix wants back to
+// cancel it.
+type refundRedemption struct {
+	ID                   string `json:"id"`
+	BroadcasterUserID    string `json:"broadcaster_user_id"`
+	BroadcasterUserLogin string `json:"broadcaster_user_login"`
+	UserID               string `json:"user_id"`
+	Reward               struct {
+		ID string `json:"id"`
+	} `json:"reward"`
+}
+
+// refundSpecialRedemption is the special-user auto-refund gate: on the one
+// configured channel (Config.AutoRefundChannel, a Doppler secret), every
+// channel-points redemption by a special user is cancelled — Twitch returns
+// the points on CANCELED — before any module sees the event. It is a pipeline
+// stage, not a registered module, for the same reason automod is: a module
+// runs in registration order behind the enable/ModuleView machinery, and this
+// must fire even when the channelpoints module is disabled or has no binding
+// for the reward. true means the event is consumed: runStages skips the
+// handlers so no module acts on (or double-resolves) a refunded redemption.
+func (p *Pipeline) refundSpecialRedemption(mctx *module.Context, emit module.Emit) bool {
+	if p.autoRefundChannel == "" || mctx.Env.Type != redemptionAddType {
+		return false
+	}
+	var ev refundRedemption
+	if codec.Unmarshal(mctx.Env.Event, &ev) != nil {
+		return false
+	}
+	if ev.ID == "" || ev.Reward.ID == "" {
+		return false
+	}
+	if !p.refundChannelMatches(ev) || !p.special.Has(ev.UserID) {
+		return false
+	}
+	emit(&module.Output{
+		Type:          outgress.TypeRedemptionUpdate,
+		BroadcasterID: ev.BroadcasterUserID,
+		RewardID:      ev.Reward.ID,
+		RedemptionID:  ev.ID,
+		Status:        outgress.RedemptionCanceled,
+	})
+	return true
+}
+
+// refundChannelMatches accepts the secret as either the broadcaster's numeric
+// user id or their login (case-insensitive, Twitch logins are lowercase): the
+// two forms are disjoint (ids are numeric, logins cannot be), so matching both
+// costs nothing and keeps the Doppler value human-checkable.
+func (p *Pipeline) refundChannelMatches(ev refundRedemption) bool {
+	return ev.BroadcasterUserID == p.autoRefundChannel ||
+		strings.EqualFold(ev.BroadcasterUserLogin, p.autoRefundChannel)
+}

--- a/app/sesame/engine/autorefund_test.go
+++ b/app/sesame/engine/autorefund_test.go
@@ -1,0 +1,112 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"ItsBagelBot/app/sesame/module"
+	"ItsBagelBot/internal/domain/outgress"
+	"ItsBagelBot/pkg/bus"
+	"ItsBagelBot/pkg/codec"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+const (
+	refundTestChannelID = "123"
+	refundTestSpecialID = "777"
+)
+
+// redemptionTestModule stands in for the channelpoints module: any handler
+// output proves the gate did NOT consume the event. KindCore so it runs
+// without ModuleView plumbing.
+func redemptionTestModule() module.Module {
+	m := module.NewModule("", module.KindCore)
+	m.On(redemptionAddType, func(_ context.Context, c *module.Context, emit module.Emit) error {
+		emit(&module.Output{Type: outgress.TypeChat, BroadcasterID: c.Env.BroadcasterUserID, Text: "handled"})
+		return nil
+	})
+	return m.Build()
+}
+
+func newRefundPipeline(pub bus.Publisher, channel string) *Pipeline {
+	d := Deps{
+		Proj: fakeReader{}, Live: liveAlways{}, Cooldown: NoopCooldown{},
+		Pub: pub, Log: zap.NewNop(),
+		Special: NewSpecialSet(refundTestSpecialID),
+	}
+	cfg := Config{OutgressPremium: premiumSubj, OutgressStandard: standardSubj, AutoRefundChannel: channel}
+	return NewPipeline(d, NewRegistry(zap.NewNop(), redemptionTestModule()), cfg)
+}
+
+func redemptionMessage(t *testing.T, broadcasterID, broadcasterLogin, userID string) *bus.Message {
+	t.Helper()
+	body, err := codec.Marshal(map[string]any{
+		"type":                redemptionAddType,
+		"lane":                "standard",
+		"broadcaster_user_id": broadcasterID,
+		"event": map[string]any{
+			"id":                     "redeem-1",
+			"broadcaster_user_id":    broadcasterID,
+			"broadcaster_user_login": broadcasterLogin,
+			"user_id":                userID,
+			"reward":                 map[string]any{"id": "reward-1"},
+		},
+	})
+	require.NoError(t, err)
+	return bus.NewMessage("u", body)
+}
+
+func TestAutoRefundCancelsSpecialRedemption(t *testing.T) {
+	pub := &fakePublisher{}
+	p := newRefundPipeline(pub, refundTestChannelID)
+
+	require.NoError(t, p.Process(redemptionMessage(t, refundTestChannelID, "itsmavey", refundTestSpecialID)))
+	require.Len(t, pub.got, 1, "one cancel, no handler output: the gate precedes the modules")
+	assert.Equal(t, outgress.TypeRedemptionUpdate, pub.got[0].msg.Type)
+	assert.Equal(t, outgress.RedemptionCanceled, pub.got[0].msg.Status)
+	assert.Equal(t, refundTestChannelID, pub.got[0].msg.BroadcasterID)
+	assert.Equal(t, "reward-1", pub.got[0].msg.RewardID)
+	assert.Equal(t, "redeem-1", pub.got[0].msg.RedemptionID)
+}
+
+func TestAutoRefundMatchesChannelLogin(t *testing.T) {
+	pub := &fakePublisher{}
+	p := newRefundPipeline(pub, "ItsMavey")
+
+	require.NoError(t, p.Process(redemptionMessage(t, refundTestChannelID, "itsmavey", refundTestSpecialID)))
+	require.Len(t, pub.got, 1)
+	assert.Equal(t, outgress.TypeRedemptionUpdate, pub.got[0].msg.Type)
+}
+
+func TestAutoRefundIgnoresOtherChannels(t *testing.T) {
+	pub := &fakePublisher{}
+	p := newRefundPipeline(pub, refundTestChannelID)
+
+	require.NoError(t, p.Process(redemptionMessage(t, "456", "otherchan", refundTestSpecialID)))
+	require.Len(t, pub.got, 1, "handlers must still run on unmatched channels")
+	assert.Equal(t, outgress.TypeChat, pub.got[0].msg.Type)
+}
+
+func TestAutoRefundIgnoresNonSpecialUsers(t *testing.T) {
+	pub := &fakePublisher{}
+	p := newRefundPipeline(pub, refundTestChannelID)
+
+	require.NoError(t, p.Process(redemptionMessage(t, refundTestChannelID, "itsmavey", "999")))
+	require.Len(t, pub.got, 1, "handlers must still run for regular redeemers")
+	assert.Equal(t, outgress.TypeChat, pub.got[0].msg.Type)
+}
+
+func TestAutoRefundOffWhenUnconfigured(t *testing.T) {
+	pub := &fakePublisher{}
+	p := newRefundPipeline(pub, "")
+
+	require.NoError(t, p.Process(redemptionMessage(t, refundTestChannelID, "itsmavey", refundTestSpecialID)))
+	require.Len(t, pub.got, 1)
+	assert.Equal(t, outgress.TypeChat, pub.got[0].msg.Type)
+}

--- a/app/sesame/engine/pipeline.go
+++ b/app/sesame/engine/pipeline.go
@@ -48,6 +48,12 @@ type Config struct {
 	// community vocabulary, ingress emote spans). Off keeps gate verdicts
 	// byte-identical to the pre-learned gate; see internal/config.
 	AdaptiveEnabled bool
+
+	// AutoRefundChannel names the one channel (Twitch user id or login, from
+	// the TWITCH_AUTOREFUND_CHANNEL Doppler secret) where special-user
+	// channel-points redemptions are auto-cancelled — refunded — ahead of every
+	// module. Empty (the default) disables the gate everywhere else.
+	AutoRefundChannel string
 }
 
 // Pipeline is the per-message stage the consumer hands each decoded message to.
@@ -108,6 +114,12 @@ type Pipeline struct {
 	// memory behind !nuke) and answers its overflow escalations through this
 	// pipeline's Shield Mode policy. nil records nothing.
 	nuke *Nuke
+
+	// special + autoRefundChannel feed the special-redemption auto-refund gate
+	// (autorefund.go): on that one channel, a special user's redemption is
+	// cancelled before any module runs.
+	special           *SpecialSet
+	autoRefundChannel string
 }
 
 // NewPipeline wires a Pipeline from the shared Deps, a pre-built registry, and
@@ -115,27 +127,29 @@ type Pipeline struct {
 // store, publisher and logger from d, so main constructs those once.
 func NewPipeline(d Deps, registry *Registry, cfg Config) *Pipeline {
 	p := &Pipeline{
-		log:              d.Log,
-		pub:              d.Pub,
-		proj:             d.Proj,
-		registry:         registry,
-		live:             d.Live,
-		cooldown:         d.Cooldown,
-		loyalty:          d.Loyalty,
-		dedup:            d.Dedup,
-		customFetch:      d.CustomFetch,
-		botID:            cfg.BotID,
-		outgressPremium:  cfg.OutgressPremium,
-		outgressStandard: cfg.OutgressStandard,
-		automod:          d.Automod,
-		automodEnforce:   cfg.AutomodEnforce,
-		reputation:       d.Reputation,
-		campaign:         d.Campaign,
-		shieldEnabled:    cfg.ShieldEnabled,
-		adaptiveEnabled:  cfg.AdaptiveEnabled,
-		raidGate:         newRaidCooldown(raidCooldownTTL),
-		roster:           newChatterRoster(),
-		nuke:             d.Nuke,
+		log:               d.Log,
+		pub:               d.Pub,
+		proj:              d.Proj,
+		registry:          registry,
+		live:              d.Live,
+		cooldown:          d.Cooldown,
+		loyalty:           d.Loyalty,
+		dedup:             d.Dedup,
+		customFetch:       d.CustomFetch,
+		botID:             cfg.BotID,
+		outgressPremium:   cfg.OutgressPremium,
+		outgressStandard:  cfg.OutgressStandard,
+		automod:           d.Automod,
+		automodEnforce:    cfg.AutomodEnforce,
+		reputation:        d.Reputation,
+		campaign:          d.Campaign,
+		shieldEnabled:     cfg.ShieldEnabled,
+		adaptiveEnabled:   cfg.AdaptiveEnabled,
+		raidGate:          newRaidCooldown(raidCooldownTTL),
+		roster:            newChatterRoster(),
+		nuke:              d.Nuke,
+		special:           d.Special,
+		autoRefundChannel: cfg.AutoRefundChannel,
 	}
 	if cfg.CountUses && d.Pub != nil {
 		p.uses = newUseReporter(d.Pub, d.Log)
@@ -412,17 +426,19 @@ func (p *Pipeline) newEmit(ctx context.Context, partition string, state *emitSta
 
 // runStages executes the moderation gate, command dispatch and the event
 // handlers under the shared skip rules: an actioned line (the chatter is being
-// moderated) skips dispatch and handlers, and a folded duplicate cohort
-// (Senders present) never dispatches a command.
+// moderated) skips dispatch and handlers, a refunded special redemption skips
+// the handlers (the event is consumed by the auto-refund gate), and a folded
+// duplicate cohort (Senders present) never dispatches a command.
 func (p *Pipeline) runStages(ctx context.Context, mctx *module.Context, views map[string]projection.ModuleView, emit module.Emit) {
 	env := &mctx.Env
 	soloChat := env.Type == chatType && len(env.Senders) == 0
 
 	actioned := p.moderateChat(ctx, mctx, views, emit)
+	refunded := p.refundSpecialRedemption(mctx, emit)
 	if soloChat && !actioned {
 		p.dispatch(ctx, mctx, views, emit)
 	}
-	if len(p.registry.For(env.Type)) > 0 && !actioned {
+	if len(p.registry.For(env.Type)) > 0 && !actioned && !refunded {
 		// Event handlers can emit localized system text too (for example the
 		// stream-online bagel announcement). Command dispatch resolves locale for
 		// baked commands, but non-command events never pass through that path.

--- a/app/sesame/engine/pipeline.go
+++ b/app/sesame/engine/pipeline.go
@@ -433,12 +433,15 @@ func (p *Pipeline) runStages(ctx context.Context, mctx *module.Context, views ma
 	env := &mctx.Env
 	soloChat := env.Type == chatType && len(env.Senders) == 0
 
-	actioned := p.moderateChat(ctx, mctx, views, emit)
-	refunded := p.refundSpecialRedemption(mctx, emit)
-	if soloChat && !actioned {
+	// The two gates are event-type-disjoint (moderateChat acts on chat lines,
+	// the refund gate on redemptions), so one consumed flag covers both without
+	// changing either type's behavior.
+	consumed := p.moderateChat(ctx, mctx, views, emit)
+	consumed = p.refundSpecialRedemption(mctx, emit) || consumed
+	if soloChat && !consumed {
 		p.dispatch(ctx, mctx, views, emit)
 	}
-	if len(p.registry.For(env.Type)) > 0 && !actioned && !refunded {
+	if len(p.registry.For(env.Type)) > 0 && !consumed {
 		// Event handlers can emit localized system text too (for example the
 		// stream-online bagel announcement). Command dispatch resolves locale for
 		// baked commands, but non-command events never pass through that path.

--- a/app/sesame/internal/config/config.go
+++ b/app/sesame/internal/config/config.go
@@ -74,6 +74,11 @@ type Config struct {
 	// user ids, the same Doppler secret ingress uses to lane them premium.
 	SpecialUserIDs string
 
+	// AutoRefundChannel is the one channel (Twitch user id or login) where a
+	// special user's channel-points redemptions are auto-cancelled — refunded —
+	// before any module runs. Doppler secret; empty (default) disables the gate.
+	AutoRefundChannel string
+
 	// BotUserID is the bot's own Twitch user id; the engine skips the bot's own
 	// chat messages so it never reacts to itself.
 	BotUserID string
@@ -220,6 +225,8 @@ func Load() *Config {
 		ProjectionLiveSubject: env.Get("NATS_BROADCASTER_LIVE_SUBJECT", "bagel.rpc.broadcaster.live.get"),
 
 		SpecialUserIDs: env.Get("TWITCH_SPECIAL_USER_IDS", ""),
+
+		AutoRefundChannel: env.Get("TWITCH_AUTOREFUND_CHANNEL", ""),
 
 		BotUserID: env.Get("TWITCH_BOT_USER_ID", ""),
 

--- a/app/sesame/wiring.go
+++ b/app/sesame/wiring.go
@@ -276,12 +276,13 @@ func newLoyaltyClock(w wireCtx, proj *projection.Client, live *engine.ValkeyLive
 
 func newPipeline(deps engine.Deps, registry *engine.Registry, cfg *config.Config) *engine.Pipeline {
 	return engine.NewPipeline(deps, registry, engine.Config{
-		BotID:            cfg.BotUserID,
-		OutgressPremium:  cfg.OutgressPremiumSubject,
-		OutgressStandard: cfg.OutgressStandardSubject,
-		CountUses:        true,
-		AutomodEnforce:   cfg.AutomodEnforce,
-		ShieldEnabled:    cfg.ShieldEnabled,
+		BotID:             cfg.BotUserID,
+		OutgressPremium:   cfg.OutgressPremiumSubject,
+		OutgressStandard:  cfg.OutgressStandardSubject,
+		CountUses:         true,
+		AutomodEnforce:    cfg.AutomodEnforce,
+		ShieldEnabled:     cfg.ShieldEnabled,
+		AutoRefundChannel: cfg.AutoRefundChannel,
 	})
 }
 


### PR DESCRIPTION
## What

A pre-module pipeline gate that auto-refunds channel-points redemptions made by special users (`TWITCH_SPECIAL_USER_IDS`) on one configured channel.

- New Doppler secret `TWITCH_AUTOREFUND_CHANNEL`: the Twitch user id **or** login of the channel the gate applies to. Empty (default) disables the gate everywhere.
- On a matching redemption the engine emits an outgress `redemption_update` with status `CANCELED`; Twitch returns the points to the redeemer.
- The gate is a structural pipeline stage (like automod), not a registered module: it precedes every module, fires even when the channelpoints module is disabled or the reward has no binding, and a refunded event skips the handlers so nothing double-resolves or reacts to it.

## Limits

Helix only allows the app that created the reward to update a redemption, and only while it is `UNFULFILLED` - so the gate covers dashboard-created rewards; Twitch-native or third-party rewards cannot be cancelled by any API client.

## Tests

Five engine tests: cancel emitted and handlers skipped (precedence), login match, other channels pass through, non-special redeemers pass through, unconfigured gate off. Full `./app/sesame/...` build and test suite green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic refunds for eligible channel-point redemptions from designated special users.
  * Auto-refunds can be enabled for a specific channel using `TWITCH_AUTOREFUND_CHANNEL`.
  * Channel matching supports broadcaster IDs and case-insensitive channel names.
  * Automatically refunded redemptions are consumed without triggering additional handlers or commands.

* **Bug Fixes**
  * Redemptions from other channels or non-eligible users continue through normal processing.
  * Auto-refunds remain disabled when no channel is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->