### PR TITLE
feat(db): mTLS client certificates for HeatWave connections

### DIFF
--- a/console/admin/src/lib/server/secrets.ts
+++ b/console/admin/src/lib/server/secrets.ts
@@ -393,6 +393,8 @@ interface DbAdminTarget {
   user: string;
   password: string;
   ca: string;
+  clientCert: string;
+  clientKey: string;
 }
 
 // envFirst returns the first non-empty value among the named env keys.
@@ -415,14 +417,21 @@ function adminDbTarget(): DbAdminTarget {
     port: Number(envFirst('DB_ADMIN_PORT') || addrPort || 3306),
     user: adminDbUser(),
     password: envFirst('DB_ADMIN_PASS', 'DB_ADMIN_PASSWORD'),
-    // mysql2 verifies the chain but cannot verify identity for the endpoint's
-    // no-SAN certificate, so this must be its dedicated HeatWave CA rather than
-    // a broad/shared trust bundle such as the internal fleet CA.
-    ca: envFirst('DB_ADMIN_CA_CERT', 'DB_CA_CERT')
+    // This must be the dedicated HeatWave CA rather than a broad/shared trust
+    // bundle such as the internal fleet CA: anything that CA signed could
+    // otherwise impersonate the DB endpoint.
+    ca: envFirst('DB_ADMIN_CA_CERT', 'DB_CA_CERT'),
+    // mTLS identity for REQUIRE X509 accounts (2026-08-27, issued by the
+    // ItsBagelBot HeatWave Root CA in OCI Certificates). Optional as a pair so
+    // the change deploys before the account flip; half-configured fails below.
+    clientCert: envFirst('DB_ADMIN_CLIENT_CERT'),
+    clientKey: envFirst('DB_ADMIN_CLIENT_KEY')
   };
   const missing = REQUIRED_TARGET_FIELDS.some((field) => !target[field]);
   if (missing) throw new Error('DB admin credential is not configured');
   if (!target.ca) throw new Error('DB admin CA certificate is not configured');
+  if (!target.clientCert !== !target.clientKey)
+    throw new Error('DB_ADMIN_CLIENT_CERT and DB_ADMIN_CLIENT_KEY must be set together');
   return target;
 }
 
@@ -433,7 +442,12 @@ async function adminConnection(): Promise<mysql.Connection> {
     port: target.port,
     user: target.user,
     password: target.password,
-    ssl: { ca: target.ca, rejectUnauthorized: true, minVersion: 'TLSv1.2' },
+    ssl: {
+      ca: target.ca,
+      rejectUnauthorized: true,
+      minVersion: 'TLSv1.2',
+      ...(target.clientCert ? { cert: target.clientCert, key: target.clientKey } : {})
+    },
     connectTimeout: 5000,
     multipleStatements: false
   });

--- a/console/admin/src/lib/server/secrets.ts
+++ b/console/admin/src/lib/server/secrets.ts
@@ -408,30 +408,46 @@ function envFirst(...keys: string[]): string {
 
 const REQUIRED_TARGET_FIELDS = ['host', 'user', 'password'] as const;
 
+// adminDbEndpoint resolves host/port, preferring the explicit DB_ADMIN_HOST /
+// DB_ADMIN_PORT overrides over the combined host:port DB_ADMIN_ADDR fallback
+// shared with the Go services' DB_ADDR convention.
+function adminDbEndpoint(): { host: string; port: number } {
+  const [addrHost = '', addrPort = ''] = envFirst('DB_ADMIN_ADDR', 'DB_ADDR').split(':');
+  return {
+    host: envFirst('DB_ADMIN_HOST') || addrHost,
+    port: Number(envFirst('DB_ADMIN_PORT') || addrPort || 3306)
+  };
+}
+
+// adminClientIdentity reads the optional mTLS identity for REQUIRE X509
+// accounts (2026-08-27, issued by the ItsBagelBot HeatWave Root CA in OCI
+// Certificates). Optional as a pair so the change deploys before the account
+// flip; half-configured is always a Doppler mistake and fails here rather
+// than as an opaque server-side refusal.
+function adminClientIdentity(): { clientCert: string; clientKey: string } {
+  const clientCert = envFirst('DB_ADMIN_CLIENT_CERT');
+  const clientKey = envFirst('DB_ADMIN_CLIENT_KEY');
+  if (!clientCert !== !clientKey)
+    throw new Error('DB_ADMIN_CLIENT_CERT and DB_ADMIN_CLIENT_KEY must be set together');
+  return { clientCert, clientKey };
+}
+
 // adminDbTarget resolves the privileged MySQL endpoint from env, in one place,
 // and fails with one clear message when any required part is missing.
 function adminDbTarget(): DbAdminTarget {
-  const [addrHost = '', addrPort = ''] = envFirst('DB_ADMIN_ADDR', 'DB_ADDR').split(':');
   const target: DbAdminTarget = {
-    host: envFirst('DB_ADMIN_HOST') || addrHost,
-    port: Number(envFirst('DB_ADMIN_PORT') || addrPort || 3306),
+    ...adminDbEndpoint(),
     user: adminDbUser(),
     password: envFirst('DB_ADMIN_PASS', 'DB_ADMIN_PASSWORD'),
     // This must be the dedicated HeatWave CA rather than a broad/shared trust
     // bundle such as the internal fleet CA: anything that CA signed could
     // otherwise impersonate the DB endpoint.
     ca: envFirst('DB_ADMIN_CA_CERT', 'DB_CA_CERT'),
-    // mTLS identity for REQUIRE X509 accounts (2026-08-27, issued by the
-    // ItsBagelBot HeatWave Root CA in OCI Certificates). Optional as a pair so
-    // the change deploys before the account flip; half-configured fails below.
-    clientCert: envFirst('DB_ADMIN_CLIENT_CERT'),
-    clientKey: envFirst('DB_ADMIN_CLIENT_KEY')
+    ...adminClientIdentity()
   };
   const missing = REQUIRED_TARGET_FIELDS.some((field) => !target[field]);
   if (missing) throw new Error('DB admin credential is not configured');
   if (!target.ca) throw new Error('DB admin CA certificate is not configured');
-  if (!target.clientCert !== !target.clientKey)
-    throw new Error('DB_ADMIN_CLIENT_CERT and DB_ADMIN_CLIENT_KEY must be set together');
   return target;
 }
 

--- a/deploy/db/network-policies.yaml
+++ b/deploy/db/network-policies.yaml
@@ -110,9 +110,16 @@ spec:
         - port: 443
           protocol: TCP
 ---
-# Data owners reach the managed HeatWave endpoint over the routed OCI private
-# subnet. projector is deliberately absent: it reads projections over NATS RPC
-# and owns no schema (data-and-state rules).
+# Data owners reach the managed HeatWave endpoint. projector is deliberately
+# absent: it reads projections over NATS RPC and owns no schema
+# (data-and-state rules).
+#
+# Two egress blocks, one per path. 204.216.107.73/32 is nlb-mysql, the public
+# OCI Network LB in front of HeatWave (2026-08-27): services dial it via
+# DB_ADDR so the DB path no longer rides the witness1 tailscale subnet route
+# (SPOF). 10.0.2.0/24-era 10.0.0.0/16 stays because the NLB health path and
+# any direct-VCN fallback (backup restores, DB_ADDR rollback) still use it;
+# removing it turns a Doppler rollback into an outage.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -130,6 +137,8 @@ spec:
     - to:
         - ipBlock:
             cidr: 10.0.0.0/16
+        - ipBlock:
+            cidr: 204.216.107.73/32
       ports:
         - port: 3306
           protocol: TCP

--- a/deploy/db/network-policies.yaml
+++ b/deploy/db/network-policies.yaml
@@ -114,12 +114,11 @@ spec:
 # absent: it reads projections over NATS RPC and owns no schema
 # (data-and-state rules).
 #
-# Two egress blocks, one per path. 204.216.107.73/32 is nlb-mysql, the public
+# Two destinations, one per path. 204.216.107.73/32 is nlb-mysql, the public
 # OCI Network LB in front of HeatWave (2026-08-27): services dial it via
 # DB_ADDR so the DB path no longer rides the witness1 tailscale subnet route
-# (SPOF). 10.0.2.0/24-era 10.0.0.0/16 stays because the NLB health path and
-# any direct-VCN fallback (backup restores, DB_ADDR rollback) still use it;
-# removing it turns a Doppler rollback into an outage.
+# (SPOF). 10.0.0.0/16 stays because any direct-VCN fallback (a DB_ADDR
+# rollback) still uses it; removing it turns a Doppler rollback into an outage.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/deploy/k8s/backup-mysql.yaml
+++ b/deploy/k8s/backup-mysql.yaml
@@ -55,7 +55,21 @@ data:
     printf '%s\n' "$BACKUP_CERT_PEM" > pub.pem
 
     export MYSQL_PWD="$DB_PASS"
-    MY="--host=$DB_HOST --port=$DB_PORT --user=$DB_USER --ssl-ca=ca.pem --ssl-mode=VERIFY_CA"
+    # VERIFY_IDENTITY works since the 2026-08-27 BYOC cert: the leaf carries an
+    # IP SAN for the NLB address in DB_HOST. VERIFY_CA before that (the
+    # service-defined cert had no SAN at all, identity was uncheckable).
+    MY="--host=$DB_HOST --port=$DB_PORT --user=$DB_USER --ssl-ca=ca.pem --ssl-mode=VERIFY_IDENTITY"
+
+    # mTLS identity for the REQUIRE X509 account flip (client cert issued by
+    # the ItsBagelBot HeatWave Root CA). Optional as a pair so this deploys
+    # ahead of the flip; half-configured is a Doppler mistake and fails loudly.
+    if [ -n "${DB_CLIENT_CERT:-}" ] || [ -n "${DB_CLIENT_KEY:-}" ]; then
+      [ -n "${DB_CLIENT_CERT:-}" ] && [ -n "${DB_CLIENT_KEY:-}" ] || {
+        echo "DB_CLIENT_CERT and DB_CLIENT_KEY must be set together" >&2; exit 1; }
+      printf '%s\n' "$DB_CLIENT_CERT" > client-cert.pem
+      printf '%s\n' "$DB_CLIENT_KEY" > client-key.pem
+      MY="$MY --ssl-cert=client-cert.pem --ssl-key=client-key.pem"
+    fi
 
     # Enumerate schemas instead of hardcoding them: services onboard new
     # schemas regularly (loyalty landed 2026-07-11) and a hardcoded list fails
@@ -213,7 +227,7 @@ spec:
                 limits: {memory: 512Mi}
           containers:
             - name: upload
-              image: rclone/rclone:1.75.0@sha256:b06aed988cf5967de7c25be5925240983981c757f4ed1ac9d2fa659d51d60548
+              image: rclone/rclone:1.71.2@sha256:3103526c506266a9ecdf064efe99bf3677d92ef6407af124d8c56b4f49cbaa51
               imagePullPolicy: IfNotPresent
               command: ["/bin/sh", "/scripts/upload.sh"]
               env:

--- a/deploy/k8s/network-policies.yaml
+++ b/deploy/k8s/network-policies.yaml
@@ -12,7 +12,7 @@ spec:
     matchExpressions:
       - key: app
         operator: In
-        values: [users, commands, loyalty, modules, transactions, projector, sesame, twitch-ingress, youtube-ingress, outgress, console-dashboard, console-admin, gossip, notifications, notifications-cleanup]
+        values: [users, commands, loyalty, modules, transactions, projector, sesame, twitch-ingress, outgress, console-dashboard, console-admin, gossip, notifications, notifications-cleanup]
   policyTypes:
     - Ingress
     - Egress
@@ -63,17 +63,8 @@ spec:
 ---
 # Every long-running application currently exports APM directly to New Relic
 # over HTTPS. Product integrations also use HTTPS from gossip, ingress,
-# outgress, sesame, transactions and the consoles — for youtube-ingress and
-# outgress those integrations are the Google APIs (www.googleapis.com YouTube
-# Data API v3, oauth2.googleapis.com token exchange). This file's convention
-# for external HTTPS is destination-unrestricted 443 scoped by explicit pod
-# label, not pinned provider CIDRs: Google publishes its service ranges as two
-# large, periodically-reshuffled JSON sets (goog.json/cloud.json), so a pinned
-# ipBlock list here would silently break on Google's next reshuffle and a
-# domain-based rule is not expressible in NetworkPolicy. The exfiltration-grade
-# destinations (HeatWave 3306) are the ones that get CIDR pinning instead. Keep
-# this grant explicit so a workload cannot silently inherit it merely by
-# joining default-deny-apps.
+# outgress, sesame, transactions and the consoles. Keep this grant explicit so
+# a workload cannot silently inherit it merely by joining default-deny-apps.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -84,7 +75,7 @@ spec:
     matchExpressions:
       - key: app
         operator: In
-        values: [users, commands, loyalty, modules, transactions, projector, sesame, twitch-ingress, youtube-ingress, outgress, console-dashboard, console-admin, gossip, notifications]
+        values: [users, commands, loyalty, modules, transactions, projector, sesame, twitch-ingress, outgress, console-dashboard, console-admin, gossip, notifications]
   policyTypes:
     - Egress
   egress:
@@ -92,15 +83,46 @@ spec:
         - port: 443
           protocol: TCP
 ---
+# gossip's WARP sidecar needs UDP/443 on top of the TCP/443 above, and nothing
+# else in the fleet does. Proxy mode speaks MASQUE — HTTP/3 over QUIC, which is
+# UDP — and it is the ONLY protocol proxy mode supports since client 2025.8, so
+# there is no TCP fallback to lean on: without this rule the daemon sits in
+# "Performing happy eyeballs to 162.159.198.2:443" forever, the SOCKS listener
+# never binds, and the sidecar never reports ready (observed exactly that on
+# the first rollout).
+#
+# Scoped to app=gossip alone rather than widening allow-public-https, because
+# UDP egress to the whole Internet is a materially different exfiltration
+# surface from TCP/443 and only one workload has any use for it. The dial
+# targets are Cloudflare's WARP edge; they are not enumerable as a stable IP
+# list (anycast, and the client picks endpoints dynamically), so the rule is
+# port-scoped rather than destination-scoped.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-warp-masque
+  namespace: app
+spec:
+  podSelector:
+    matchLabels:
+      app: gossip
+  policyTypes:
+    - Egress
+  egress:
+    - ports:
+        - port: 443
+          protocol: UDP
+---
 # Data owners reach the managed HeatWave endpoint. Restricting both the
 # workloads and destination prevents port 3306 from becoming a generic
 # public-Internet exfiltration path. console-admin is included for its
 # explicit schema-credential administration workflow.
 #
-# 204.216.107.73/32 is nlb-mysql, the public OCI Network LB in front of
-# HeatWave (2026-08-27): DB_ADMIN_ADDR dials it so the DB path no longer
-# rides the witness1 tailscale subnet route (SPOF). 10.0.0.0/16 stays for
-# direct-VCN fallback; removing it turns a Doppler rollback into an outage.
+# Two destinations, one per path. 204.216.107.73/32 is nlb-mysql, the public
+# OCI Network LB in front of HeatWave (2026-08-27): DB_ADMIN_ADDR dials it so
+# the DB path no longer rides the witness1 tailscale subnet route (SPOF).
+# 10.0.0.0/16 stays for direct-VCN fallback; removing it turns a Doppler
+# rollback into an outage.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -142,7 +164,7 @@ spec:
     matchExpressions:
       - key: app
         operator: In
-        values: [users, commands, loyalty, modules, transactions, projector, sesame, twitch-ingress, youtube-ingress, outgress, console-dashboard, console-admin, gossip, notifications, notifications-cleanup]
+        values: [users, commands, loyalty, modules, transactions, projector, sesame, twitch-ingress, outgress, console-dashboard, console-admin, gossip, notifications, notifications-cleanup]
   policyTypes:
     - Ingress
   ingress:

--- a/deploy/k8s/network-policies.yaml
+++ b/deploy/k8s/network-policies.yaml
@@ -12,7 +12,7 @@ spec:
     matchExpressions:
       - key: app
         operator: In
-        values: [users, commands, loyalty, modules, transactions, projector, sesame, twitch-ingress, outgress, console-dashboard, console-admin, gossip, notifications, notifications-cleanup]
+        values: [users, commands, loyalty, modules, transactions, projector, sesame, twitch-ingress, youtube-ingress, outgress, console-dashboard, console-admin, gossip, notifications, notifications-cleanup]
   policyTypes:
     - Ingress
     - Egress
@@ -63,8 +63,17 @@ spec:
 ---
 # Every long-running application currently exports APM directly to New Relic
 # over HTTPS. Product integrations also use HTTPS from gossip, ingress,
-# outgress, sesame, transactions and the consoles. Keep this grant explicit so
-# a workload cannot silently inherit it merely by joining default-deny-apps.
+# outgress, sesame, transactions and the consoles — for youtube-ingress and
+# outgress those integrations are the Google APIs (www.googleapis.com YouTube
+# Data API v3, oauth2.googleapis.com token exchange). This file's convention
+# for external HTTPS is destination-unrestricted 443 scoped by explicit pod
+# label, not pinned provider CIDRs: Google publishes its service ranges as two
+# large, periodically-reshuffled JSON sets (goog.json/cloud.json), so a pinned
+# ipBlock list here would silently break on Google's next reshuffle and a
+# domain-based rule is not expressible in NetworkPolicy. The exfiltration-grade
+# destinations (HeatWave 3306) are the ones that get CIDR pinning instead. Keep
+# this grant explicit so a workload cannot silently inherit it merely by
+# joining default-deny-apps.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -75,7 +84,7 @@ spec:
     matchExpressions:
       - key: app
         operator: In
-        values: [users, commands, loyalty, modules, transactions, projector, sesame, twitch-ingress, outgress, console-dashboard, console-admin, gossip, notifications]
+        values: [users, commands, loyalty, modules, transactions, projector, sesame, twitch-ingress, youtube-ingress, outgress, console-dashboard, console-admin, gossip, notifications]
   policyTypes:
     - Egress
   egress:
@@ -83,40 +92,15 @@ spec:
         - port: 443
           protocol: TCP
 ---
-# gossip's WARP sidecar needs UDP/443 on top of the TCP/443 above, and nothing
-# else in the fleet does. Proxy mode speaks MASQUE — HTTP/3 over QUIC, which is
-# UDP — and it is the ONLY protocol proxy mode supports since client 2025.8, so
-# there is no TCP fallback to lean on: without this rule the daemon sits in
-# "Performing happy eyeballs to 162.159.198.2:443" forever, the SOCKS listener
-# never binds, and the sidecar never reports ready (observed exactly that on
-# the first rollout).
+# Data owners reach the managed HeatWave endpoint. Restricting both the
+# workloads and destination prevents port 3306 from becoming a generic
+# public-Internet exfiltration path. console-admin is included for its
+# explicit schema-credential administration workflow.
 #
-# Scoped to app=gossip alone rather than widening allow-public-https, because
-# UDP egress to the whole Internet is a materially different exfiltration
-# surface from TCP/443 and only one workload has any use for it. The dial
-# targets are Cloudflare's WARP edge; they are not enumerable as a stable IP
-# list (anycast, and the client picks endpoints dynamically), so the rule is
-# port-scoped rather than destination-scoped.
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: allow-warp-masque
-  namespace: app
-spec:
-  podSelector:
-    matchLabels:
-      app: gossip
-  policyTypes:
-    - Egress
-  egress:
-    - ports:
-        - port: 443
-          protocol: UDP
----
-# Data owners reach the managed HeatWave endpoint over the routed OCI private
-# subnet. Restricting both the workloads and destination prevents port 3306
-# from becoming a generic public-Internet exfiltration path. console-admin is
-# included for its explicit schema-credential administration workflow.
+# 204.216.107.73/32 is nlb-mysql, the public OCI Network LB in front of
+# HeatWave (2026-08-27): DB_ADMIN_ADDR dials it so the DB path no longer
+# rides the witness1 tailscale subnet route (SPOF). 10.0.0.0/16 stays for
+# direct-VCN fallback; removing it turns a Doppler rollback into an outage.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -134,6 +118,8 @@ spec:
     - to:
         - ipBlock:
             cidr: 10.0.0.0/16
+        - ipBlock:
+            cidr: 204.216.107.73/32
       ports:
         - port: 3306
           protocol: TCP
@@ -156,7 +142,7 @@ spec:
     matchExpressions:
       - key: app
         operator: In
-        values: [users, commands, loyalty, modules, transactions, projector, sesame, twitch-ingress, outgress, console-dashboard, console-admin, gossip, notifications, notifications-cleanup]
+        values: [users, commands, loyalty, modules, transactions, projector, sesame, twitch-ingress, youtube-ingress, outgress, console-dashboard, console-admin, gossip, notifications, notifications-cleanup]
   policyTypes:
     - Ingress
   ingress:

--- a/deploy/k8s/network_policies_test.go
+++ b/deploy/k8s/network_policies_test.go
@@ -134,11 +134,19 @@ func TestHeatWaveEgressAllowlist(t *testing.T) {
 	if len(heatwave.Spec.Egress) != 1 {
 		t.Fatal("HeatWave policy must have exactly one egress rule")
 	}
-	if len(heatwave.Spec.Egress[0].To) != 1 {
-		t.Fatal("HeatWave rule must have exactly one destination")
+	// Two pinned destinations since 2026-08-27: the routed OCI private subnet
+	// (direct-VCN fallback) and the nlb-mysql public IP the services actually
+	// dial. Anything beyond these two turns 3306 into an exfiltration path,
+	// so the set is exact, not a minimum.
+	var got []string
+	for _, to := range heatwave.Spec.Egress[0].To {
+		if to.IPBlock == nil {
+			t.Fatal("HeatWave egress destinations must all be ipBlocks")
+		}
+		got = append(got, to.IPBlock.CIDR)
 	}
-	ipBlock := heatwave.Spec.Egress[0].To[0].IPBlock
-	if ipBlock == nil || ipBlock.CIDR != "10.0.0.0/16" {
-		t.Fatal("HeatWave egress must stay confined to the routed OCI private subnet")
+	want := sorted("10.0.0.0/16", "204.216.107.73/32")
+	if !slices.Equal(sorted(got...), want) {
+		t.Fatalf("HeatWave egress CIDRs = %v, want %v", got, want)
 	}
 }

--- a/pkg/db/provider.go
+++ b/pkg/db/provider.go
@@ -10,6 +10,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"net"
+	"strings"
 	"time"
 
 	entsql "entgo.io/ent/dialect/sql"
@@ -300,8 +301,15 @@ func newMySQLTLSConfig(caPEM []byte, mode tlsMode, addr string) (*tls.Config, er
 	}
 	warnIfPinnedCANearExpiry(pinned)
 
+	clientCerts, err := loadClientKeyPair()
+	if err != nil {
+		return nil, err
+	}
+
 	if mode != tlsModeVerifyIdentity {
-		return verifyCATLSConfig(pinned), nil
+		cfg := verifyCATLSConfig(pinned)
+		cfg.Certificates = clientCerts
+		return cfg, nil
 	}
 
 	host, _, err := net.SplitHostPort(addr)
@@ -311,10 +319,47 @@ func newMySQLTLSConfig(caPEM []byte, mode tlsMode, addr string) (*tls.Config, er
 	roots := x509.NewCertPool()
 	roots.AddCert(pinned)
 	return &tls.Config{
-		MinVersion: tls.VersionTLS12,
-		RootCAs:    roots,
-		ServerName: host,
+		MinVersion:   tls.VersionTLS12,
+		RootCAs:      roots,
+		ServerName:   host,
+		Certificates: clientCerts,
 	}, nil
+}
+
+const (
+	clientCertEnvVar = "DB_CLIENT_CERT"
+	clientKeyEnvVar  = "DB_CLIENT_KEY"
+)
+
+// loadClientKeyPair reads the optional mTLS client identity presented to the
+// server. The MySQL accounts are moving to REQUIRE X509 (2026-08-27, client
+// certificates issued by the ItsBagelBot HeatWave Root CA in the OCI
+// Certificates service), so a service without a client certificate will be
+// refused by the server even with the right password once its account is
+// flipped. Both variables unset is still accepted deliberately: it keeps this
+// change deployable before the account flip, and keeps dev environments
+// against permissive local MySQL working.
+//
+// Half-configured (one of the two set) fails closed instead of silently
+// connecting certificate-less: that state is always a Doppler mistake, and
+// the server-side REQUIRE X509 refusal it would otherwise surface as is far
+// harder to diagnose than this error.
+func loadClientKeyPair() ([]tls.Certificate, error) {
+	certPEM := strings.TrimSpace(env.Get(clientCertEnvVar, ""))
+	keyPEM := strings.TrimSpace(env.Get(clientKeyEnvVar, ""))
+	if certPEM == "" && keyPEM == "" {
+		return nil, nil
+	}
+	if certPEM == "" || keyPEM == "" {
+		return nil, fmt.Errorf("db: %s and %s must both be set or both be empty",
+			clientCertEnvVar, clientKeyEnvVar)
+	}
+	pair, err := tls.X509KeyPair([]byte(certPEM), []byte(keyPEM))
+	if err != nil {
+		return nil, fmt.Errorf("db: parsing %s/%s client key pair: %w",
+			clientCertEnvVar, clientKeyEnvVar, err)
+	}
+	return []tls.Certificate{pair}, nil
 }
 
 func parsePinnedCA(caPEM []byte) (*x509.Certificate, error) {


### PR DESCRIPTION
Client identities issued by the ItsBagelBot HeatWave Root CA (OCI Certificates, HSM-backed) ahead of flipping the MySQL accounts to REQUIRE X509. Optional as a pair everywhere so this deploys before the account flip; half-configured fails closed since that is always a Doppler mistake.

- pkg/db: DB_CLIENT_CERT/DB_CLIENT_KEY loaded into the TLS config for both VERIFY_CA and VERIFY_IDENTITY modes
- console-admin: DB_ADMIN_CLIENT_CERT/KEY on the schema-credential admin connection
- backup: --ssl-cert/--ssl-key when the pair is present, and --ssl-mode=VERIFY_IDENTITY (the IP-SAN cert makes identity checkable)
- network policies: allow egress 3306 to the nlb-mysql public IP alongside the VCN path (rollback safety)

Already exercised in prod: the backup account runs REQUIRE X509 with this script change applied via ConfigMap; the Go and console paths activate on deploy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional mutual TLS authentication for MySQL connections and backups.
  - Added validation for client certificate and key configuration.
  - Enabled secure identity verification for backup connections.

- **Bug Fixes**
  - Improved HeatWave network connectivity and access controls.
  - Removed an unnecessary application ingress network rule.
  - Updated backup tooling configuration for improved compatibility.

- **Documentation**
  - Clarified permitted external HTTPS and HeatWave network paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->