### PR TITLE
perf(commands): batch the uses flush by increment

### DIFF
--- a/app/commands/repository/commands.go
+++ b/app/commands/repository/commands.go
@@ -457,29 +457,44 @@ func (r *Commands) drainPendingUses() map[commandKey]uint64 {
 }
 
 // persistUses applies uses = uses + n per key and returns the keys that
-// landed. A single missing/deleted row must not drop the whole window, so
-// per-row failures are logged and skipped.
+// landed. Keys are grouped by their increment so one UPDATE with OR-ed key
+// predicates lands every key sharing a count: a 30s window is mostly n=1, so
+// this turns up to usesFlushMaxKeys per-row statements — each a ~1ms NLB
+// round trip since the 2026-08-27 cutover — into one or two statements
+// total. Groups stay bounded by usesFlushMaxKeys (512), well under MySQL's
+// placeholder limit. A failed group is logged and skipped rather than
+// failing the window (loss-tolerant counters, the same rule as the loyalty
+// flush); a missing/deleted row simply matches nothing and is later dropped
+// by rowStates' reload.
 func (r *Commands) persistUses(ctx context.Context, txn *newrelic.Transaction, pend map[commandKey]uint64) ([]commandKey, error) {
+	byCount := map[uint64][]commandKey{}
+	for key, n := range pend {
+		byCount[n] = append(byCount[n], key)
+	}
 	keys := make([]commandKey, 0, len(pend))
 	err := db.WithExec(ctx, func(ctx context.Context) error {
-		for key, n := range pend {
-			_, err := r.client.Commands.Update().
-				Where(
+		for n, group := range byCount {
+			preds := make([]predicate.Commands, 0, len(group))
+			for _, key := range group {
+				preds = append(preds, commands.And(
 					commands.UserIDEQ(key.userID),
 					commands.NameEQ(key.name),
-				).
+				))
+			}
+			_, err := r.client.Commands.Update().
+				Where(commands.Or(preds...)).
 				AddUses(int64(n)). //nolint:gosec // n is a small per-window count
 				Save(ctx)
 			if err != nil {
 				txn.NoticeError(err)
 				r.log.Warn("failed to persist command uses",
-					zap.Uint64("user_id", key.userID),
-					zap.String("command", key.name),
+					zap.Int("commands", len(group)),
+					zap.Uint64("delta", n),
 					zap.Error(err),
 				)
 				continue
 			}
-			keys = append(keys, key)
+			keys = append(keys, group...)
 		}
 		return nil
 	})

--- a/app/commands/repository/flush_internal_test.go
+++ b/app/commands/repository/flush_internal_test.go
@@ -68,3 +68,41 @@ func TestBulkUpsertPreservesUses(t *testing.T) {
 	assert.Equal(t, "new wording", row.Response)
 	assert.Equal(t, uint64(42), row.Uses)
 }
+
+// The uses flush groups keys by increment so one statement lands every key
+// sharing a count. Distinct counts must each land their own delta, and a key
+// whose row vanished before the flush must not fail its group — it matches
+// nothing and is dropped later by the reload in publishUseEvents.
+func TestPersistUsesGroupsByIncrement(t *testing.T) {
+	client := enttest.Open(t, "sqlite3", "file:commandsusesgroup?mode=memory&cache=shared&_fk=1")
+	t.Cleanup(func() { _ = client.Close() })
+
+	r := NewCommands(client, bustest.NewPublisher(), nil, zap.NewNop())
+
+	ctx := context.Background()
+	for _, name := range []string{"a", "b", "c"} {
+		client.Commands.Create().
+			SetUserID(1001).
+			SetName(name).
+			SetResponse("r").
+			SetUses(10).
+			SaveX(ctx)
+	}
+
+	pend := map[commandKey]uint64{
+		{userID: 1001, name: "a"}:       1,
+		{userID: 1001, name: "b"}:       1,
+		{userID: 1001, name: "c"}:       3,
+		{userID: 1001, name: "deleted"}: 1,
+	}
+	landed, err := r.persistUses(ctx, nil, pend)
+	require.NoError(t, err)
+	assert.Len(t, landed, 4)
+
+	rows := client.Commands.Query().AllX(ctx)
+	got := map[string]uint64{}
+	for _, row := range rows {
+		got[row.Name] = row.Uses
+	}
+	assert.Equal(t, map[string]uint64{"a": 11, "b": 11, "c": 13}, got)
+}


### PR DESCRIPTION
persistUses ran one UPDATE per (user, command) key per 30s window — up to usesFlushMaxKeys sequential statements, each a ~1ms NLB round trip since the DB moved behind nlb-mysql. Keys are now grouped by their increment and each group lands as a single UPDATE with OR-ed key predicates; a window is mostly n=1, so the whole flush is one or two statements.

Failure isolation moves from per-row to per-group (the same loss-tolerant rule the loyalty flush uses); a deleted row matches nothing and is dropped by the rowStates reload as before. TestPersistUsesGroupsByIncrement pins the semantics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when saving command usage counters in batches.
  * Missing or deleted command records no longer interrupt the remaining updates.
  * Updated command usage state continues to reload correctly after saving.

* **Tests**
  * Added coverage for grouped usage updates, independent counter changes, and missing records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->