### PR TITLE
style: one card surface everywhere, atmosphere on public pages only

### DIFF
--- a/console/dashboard/src/lib/components/overview/BotStatusPanel.svelte
+++ b/console/dashboard/src/lib/components/overview/BotStatusPanel.svelte
@@ -16,6 +16,7 @@
   import type { SubmitFunction } from '@sveltejs/kit';
   import Button from '@bagel/shared/components/Button.svelte';
   import ButtonLink from '@bagel/shared/components/ButtonLink.svelte';
+  import Card from '@bagel/shared/components/Card.svelte';
   import Icon from '@bagel/shared/components/Icon.svelte';
   import Skeleton from '@bagel/shared/components/Skeleton.svelte';
   import { getI18n } from '@bagel/shared/i18n/context';
@@ -100,7 +101,7 @@
   });
 </script>
 
-<section class="ov-status card sheen" class:ov-status--premium={isPremium} aria-labelledby="ov-status-h">
+<Card as="section" sheen class="ov-status {isPremium ? 'ov-status--premium' : ''}" aria-labelledby="ov-status-h">
   <div class="ov-status__mark"><img src={logoSrc} alt="" /></div>
 
   <div class="ov-status__body">
@@ -161,17 +162,19 @@
       {/if}
     </div>
   {/if}
-</section>
+</Card>
 
 <style>
-  .ov-status {
+  /* :global on every .ov-status / --premium rule: the class now rides <Card>'s
+     root element, which this component's scoping hash never reaches. */
+  :global(.ov-status) {
     display: grid;
     grid-template-columns: auto 1fr auto;
     gap: 22px;
     align-items: center;
     margin-bottom: var(--row-gap);
   }
-  .ov-status--premium {
+  :global(.ov-status--premium) {
     border-color: rgba(201, 168, 124, 0.4);
   }
 
@@ -186,7 +189,7 @@
     justify-content: center;
     flex: none;
   }
-  .ov-status--premium .ov-status__mark {
+  :global(.ov-status--premium) .ov-status__mark {
     border-color: rgba(201, 168, 124, 0.4);
     background: rgba(201, 168, 124, 0.05);
   }
@@ -321,7 +324,7 @@
   /* Stack the panel on narrow screens; actions become full-width, comfortably
      tappable, and never force horizontal scroll at 320px. */
   @media (max-width: 760px) {
-    .ov-status {
+    :global(.ov-status) {
       grid-template-columns: auto 1fr;
       gap: 16px;
     }

--- a/console/dashboard/src/routes/(app)/loyalty/+page.svelte
+++ b/console/dashboard/src/routes/(app)/loyalty/+page.svelte
@@ -9,6 +9,7 @@
     MasterToggle,
     Switch,
     AlertBanner,
+    Card,
     ButtonLink,
     Button,
     Field,
@@ -131,7 +132,7 @@
   <!-- 1) Module status: the master enable, in its own labelled section. -->
   <section class="block" aria-labelledby="loy-status-h">
     <h2 id="loy-status-h" class="block-title">{t('loyalty.statusTitle')}</h2>
-    <div class="card status-row">
+    <Card class="status-row">
       <MasterToggle
         action="?/toggle"
         bind:enabled
@@ -141,7 +142,7 @@
         failMessage={t('loyalty.toastToggleFailed')}
       />
       <ButtonLink href="/counters" variant="ghost" icon="modules">{t('loyalty.countersLink')}</ButtonLink>
-    </div>
+    </Card>
   </section>
 
   <!-- Nested wager games: two rows, not a third settings form. Odds and chat
@@ -149,19 +150,19 @@
   {#if games.length}
     <section class="block" aria-labelledby="loy-games-h">
       <h2 id="loy-games-h" class="block-title">{t('loyalty.gamesTitle')}</h2>
-      <div class="card">
+      <Card>
         <p class="hint">{enabled ? t('loyalty.gamesHint') : t('loyalty.gamesNeedsOn')}</p>
         {#each games as g (g.def.id)}
           <LoyaltyGameRow def={g.def} bind:enabled={g.enabled} loyaltyOn={enabled} />
         {/each}
-      </div>
+      </Card>
     </section>
   {/if}
 
   <!-- 2) Configuration: earning rates, an explicit Save form with Field labels. -->
   <section class="block" aria-labelledby="loy-rates-h">
     <h2 id="loy-rates-h" class="block-title">{t('loyalty.ratesTitle')}</h2>
-    <div class="card">
+    <Card>
       <p class="hint">{t('loyalty.ratesHint')}</p>
 
       <form method="POST" action="?/save" use:enhance={saveSubmit} class="rates" novalidate>
@@ -204,14 +205,14 @@
           <Button variant="primary" type="submit" icon="check" loading={busy}>{t('loyalty.save')}</Button>
         </div>
       </form>
-    </div>
+    </Card>
   </section>
 
   <!-- 3) Leaderboard: a data table with a caption, column headers and a per-row
        header. Rank is textual (never conveyed by position or colour alone). -->
   <section class="block" aria-labelledby="loy-top-h">
     <h2 id="loy-top-h" class="block-title">{t('loyalty.topTitle')}</h2>
-    <div class="card">
+    <Card>
       {#if top.length === 0}
         <EmptyState icon="coin" title={t('loyalty.topEmpty')} />
       {:else}
@@ -239,7 +240,7 @@
           </table>
         </div>
       {/if}
-    </div>
+    </Card>
   </section>
 
   {#if loyaltyCommands.length}
@@ -262,15 +263,9 @@
     margin: 0 0 12px;
   }
 
-  /* Local card shell (shared Card is a component; a plain block keeps this page's
-     four sections visually consistent without nesting extra wrappers). */
-  .card {
-    padding: 18px;
-    border: 1px solid var(--bb-border);
-    border-radius: 10px;
-    background: rgba(240, 236, 228, 0.02);
-  }
-  .status-row {
+  /* Passed to <Card>, so it needs :global — the parent's scoping hash never
+     reaches a child component's root element. */
+  :global(.status-row) {
     display: flex;
     align-items: center;
     justify-content: space-between;

--- a/console/dashboard/src/routes/(app)/modules/+page.svelte
+++ b/console/dashboard/src/routes/(app)/modules/+page.svelte
@@ -15,6 +15,7 @@
     Icon,
     PageHead,
     AlertBanner,
+    Card,
     EmptyState,
     toast,
     getI18n,
@@ -214,11 +215,11 @@
                 <p>{catHint(group.name)}</p>
               {/if}
             </header>
-            <div class="family-list">
+            <Card style="padding:0">
               {#each group.modules as m (m.def.id)}
                 <ModuleIndexRow module={m} status={modStatus[m.def.id] ?? 'idle'} toggleSubmit={toggleSubmit(m)} />
               {/each}
-            </div>
+            </Card>
           </section>
         {/each}
       </div>
@@ -296,13 +297,6 @@
     color: var(--bb-muted);
     max-width: 52ch;
   }
-  .family-list {
-    border: 1px solid var(--rule);
-    border-radius: 8px;
-    background: rgba(240, 236, 228, 0.018);
-    overflow: hidden;
-  }
-
   @media (max-width: 760px) {
     .deck {
       top: calc(52px + env(safe-area-inset-top, 0px));

--- a/console/dashboard/src/routes/(app)/quotes/+page.svelte
+++ b/console/dashboard/src/routes/(app)/quotes/+page.svelte
@@ -16,6 +16,7 @@
     MasterToggle,
     PageToolbar,
     AlertBanner,
+    Card,
     DeckList,
     EmptyState,
     moduleDef
@@ -328,7 +329,7 @@
        change; each form names the gate it writes via its hidden kind field. -->
   <section class="block" aria-labelledby="quotes-perms-h">
     <h2 id="quotes-perms-h" class="block-title">{t('quotes.permsTitle')}</h2>
-    <div class="card">
+    <Card>
       <p class="hint">{t('quotes.permsHint')}</p>
       <div class="perm-grid">
         <form method="POST" action="?/perm" use:enhance={addPermSubmit} bind:this={addPermForm}>
@@ -353,7 +354,7 @@
           </Field>
         </form>
       </div>
-    </div>
+    </Card>
   </section>
 
   <!-- Polite live region: announces the match count as the search narrows. -->
@@ -499,12 +500,6 @@
     letter-spacing: -0.01em;
     color: var(--bb-white);
     margin: 0 0 12px;
-  }
-  .card {
-    padding: 18px;
-    border: 1px solid var(--bb-border);
-    border-radius: 10px;
-    background: rgba(240, 236, 228, 0.02);
   }
   .hint { margin: 0 0 14px; font-family: var(--bb-font-body); font-size: 12px; color: var(--bb-muted); }
   .perm-grid {

--- a/console/dashboard/src/routes/(app)/settings/+page.svelte
+++ b/console/dashboard/src/routes/(app)/settings/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	// Copyright (c) 2026 Adam Ousmer. All rights reserved.
 	// Proprietary. No license granted. See LICENSE.md.
-  import { Icon, Button, ButtonLink, PageHead, ConfirmDialog, EmptyState, toast, getI18n, type Locale } from '@bagel/shared';
+  import { Icon, Button, ButtonLink, Card, PageHead, ConfirmDialog, EmptyState, toast, getI18n, type Locale } from '@bagel/shared';
   import { page } from '$app/state';
   import { enhance, deserialize } from '$app/forms';
   import FetchKeyManager from '$lib/components/commands/fetches/FetchKeyManager.svelte';
@@ -198,7 +198,7 @@
   <SettingsNav label={t('settings.navSections')} items={navItems} />
 
   <!-- ACCOUNT -->
-  <section id="account" class="settings-section" tabindex="-1" aria-labelledby="h-account">
+  <Card as="section" id="account" class="settings-section" tabindex="-1" aria-labelledby="h-account">
     <h2 id="h-account">{t('settings.account')}</h2>
     <div class="row">
       <div>
@@ -207,19 +207,19 @@
       </div>
       <ButtonLink href="/auth/login?reauth=1" variant="ghost" icon="power">{t('common.reconnect')}</ButtonLink>
     </div>
-  </section>
+  </Card>
 
   <!-- IMPORT: prominent entry to the config-import flow (/settings/import).
        Kept as its own section so the section nav and the onboarding CTA have
        a stable anchor, same as every other entry point here. -->
-  <section id="import" class="settings-section" tabindex="-1" aria-labelledby="h-import">
+  <Card as="section" id="import" class="settings-section" tabindex="-1" aria-labelledby="h-import">
     <h2 id="h-import">{t('settings.importSetup')}</h2>
     <p class="hint">{t('settings.importSetupHint')}</p>
     <ButtonLink href="/settings/import" variant="secondary" icon="send">{t('settings.importSetupCta')}</ButtonLink>
-  </section>
+  </Card>
 
   <!-- SHARED ACCESS: links you granted + dashboards shared with you. -->
-  <section id="access" class="settings-section" tabindex="-1" aria-labelledby="h-access">
+  <Card as="section" id="access" class="settings-section" tabindex="-1" aria-labelledby="h-access">
     <h2 id="h-access">{t('settings.sharedAccess')}</h2>
 
     <h3>{t('settings.accessGranted')}</h3>
@@ -353,10 +353,10 @@
         {/each}
       </ul>
     {/if}
-  </section>
+  </Card>
 
   <!-- NOTIFICATIONS: the bell dropdown's "view all" target (/settings#notifications). -->
-  <section id="notifications" class="settings-section" tabindex="-1" aria-labelledby="h-notifications">
+  <Card as="section" id="notifications" class="settings-section" tabindex="-1" aria-labelledby="h-notifications">
     <h2 id="h-notifications">{t('settings.notifications')}</h2>
     {#if notifications.length === 0}
       <p class="hint">{t('settings.notificationsEmpty')}</p>
@@ -380,10 +380,10 @@
         {/each}
       </ul>
     {/if}
-  </section>
+  </Card>
 
   <!-- PREFERENCES -->
-  <section id="preferences" class="settings-section" tabindex="-1" aria-labelledby="h-preferences">
+  <Card as="section" id="preferences" class="settings-section" tabindex="-1" aria-labelledby="h-preferences">
     <h2 id="h-preferences">{t('settings.preferences')}</h2>
     <div class="row">
       <div>
@@ -399,12 +399,12 @@
       </div>
       <CursorSwitch describedby="cursor-hint" />
     </div>
-  </section>
+  </Card>
 
   <!-- API KEYS: account-level secrets for data sources. Owner-only, like the
        rest of this page. Data sources themselves are created inside the command
        editor; only the keys they spend are managed here. -->
-  <section id="api-keys" class="settings-section" tabindex="-1" aria-labelledby="h-api-keys">
+  <Card as="section" id="api-keys" class="settings-section" tabindex="-1" aria-labelledby="h-api-keys">
     <h2 id="h-api-keys">{t('fetches.keysTitle')}</h2>
     <FetchKeyManager
       keys={fetchKeys}
@@ -413,10 +413,10 @@
       onSetKey={handleSetKey}
       onDeleteKey={handleDeleteKey}
     />
-  </section>
+  </Card>
 
   <!-- DANGER ZONE: visually separated, last. -->
-  <section id="danger-zone" class="settings-section danger-section" tabindex="-1" aria-labelledby="h-danger">
+  <Card as="section" id="danger-zone" class="settings-section danger-section" tabindex="-1" aria-labelledby="h-danger">
     <h2 id="h-danger">{t('settings.dangerZone')}</h2>
     <p class="hint">{t('settings.dangerZoneHint')}</p>
     <div class="row">
@@ -433,7 +433,7 @@
       </div>
       <Button variant="destructive" onclick={() => (deleteOpen = true)}>{t('settings.deleteAccount')}</Button>
     </div>
-  </section>
+  </Card>
 </section>
 
 <!-- Revoke confirm -->
@@ -517,16 +517,15 @@
 {/if}
 
 <style>
-  .settings-section {
+  /* Surface (bg/border/radius/padding) comes from <Card>; only the layout and
+     scroll-anchoring live here. :global because the class rides a component
+     root, which the parent's scoping hash never reaches. */
+  :global(.settings-section) {
     margin-top: 18px;
-    padding: var(--card-pad, 22px);
-    background: var(--bb-card-bg);
-    border: 1px solid var(--bb-border);
-    border-radius: 8px;
     /* Anchor + programmatic focus land below the sticky topbar. */
     scroll-margin-top: calc(80px + env(safe-area-inset-top, 0px));
   }
-  .settings-section:focus { outline: none; }
+  :global(.settings-section:focus) { outline: none; }
 
   h2 { margin: 0 0 6px; font-size: 16px; }
   h3 { margin: 18px 0 6px; font-size: 14px; }
@@ -641,7 +640,7 @@
   .level.critical { background: rgba(176,90,70,0.15); color: #cf8a78; border-color: rgba(176,90,70,0.4); }
 
   /* --- danger zone --- */
-  .danger-section {
+  :global(.danger-section) {
     margin-top: 28px;
     border-color: var(--bb-status-error-border, rgba(176, 90, 70, 0.4));
     background: var(--bb-status-error-bg, rgba(176, 90, 70, 0.06));

--- a/console/dashboard/src/routes/(app)/settings/import/+page.svelte
+++ b/console/dashboard/src/routes/(app)/settings/import/+page.svelte
@@ -28,6 +28,7 @@
     AlertBanner,
     Badge,
     Button,
+    Card,
     Icon,
     PageHead,
     toast,
@@ -431,7 +432,7 @@
   </PageHead>
 
   <!-- Horizontal stepper: completed / current / future stages. -->
-  <ol class="stepper" aria-label={t('import.stagesLabel')}>
+  <Card as="ol" class="stepper" aria-label={t('import.stagesLabel')}>
     {#each STAGES as key, i (key)}
       {#if i > 0}<li class="bar" aria-hidden="true"></li>{/if}
       <li
@@ -446,10 +447,10 @@
         {t(key)}
       </li>
     {/each}
-  </ol>
+  </Card>
 
   {#if step === 'pick'}
-    <div class="panel">
+    <Card>
       <h2>{t('import.stepPick')}</h2>
       <p class="hint">{t('import.pickHint')}</p>
 
@@ -519,9 +520,9 @@
           <span class="tile-desc">{t('import.slDesc')}</span>
         </label>
       </div>
-    </div>
+    </Card>
   {:else if step === 'instructions' && source}
-    <div class="panel">
+    <Card>
       <h2>{t('import.stepInstructions', { source: SOURCE_LABEL[source] })}</h2>
       <p class="hint">{t('import.instrHint', { source: SOURCE_LABEL[source] })}</p>
 
@@ -599,9 +600,9 @@
           </Button>
         </div>
       </form>
-    </div>
+    </Card>
   {:else if step === 'review' && previewResult?.manifest}
-    <div class="panel">
+    <Card>
       <h2>{t('import.reviewTitle')}</h2>
       <p class="hint">{reviewHint}</p>
 
@@ -774,9 +775,9 @@
           </Button>
         </div>
       </form>
-    </div>
+    </Card>
   {:else if step === 'done'}
-    <div class="panel done-panel">
+    <Card class="done-panel">
       <h2>{t('import.doneTitle')}</h2>
       {#if commitResult}
         <p class="hint">
@@ -806,17 +807,11 @@
       <div class="actions">
         <Button variant="primary" icon="check" onclick={reset}>{t('import.backToSources')}</Button>
       </div>
-    </div>
+    </Card>
   {/if}
 </section>
 
 <style>
-  .panel {
-    padding: var(--card-pad, 22px);
-    background: var(--bb-card-bg);
-    border: 1px solid var(--bb-border);
-    border-radius: 8px;
-  }
   h2 {
     margin: 0 0 6px;
     font-size: 16px;
@@ -832,16 +827,15 @@
   }
 
   /* --- stepper header --- */
-  .stepper {
+  /* Surface comes from <Card>; :global because the class rides a component
+     root, which this page's scoping hash never reaches. */
+  :global(.stepper) {
     display: flex;
     align-items: center;
     gap: 10px;
     list-style: none;
     margin: 0 0 16px;
     padding: 14px 18px;
-    background: var(--bb-card-bg);
-    border: 1px solid var(--bb-border);
-    border-radius: 8px;
   }
   .stage {
     display: inline-flex;
@@ -887,7 +881,7 @@
     background: var(--glass-border);
   }
   @media (max-width: 560px) {
-    .stepper {
+    :global(.stepper) {
       gap: 7px;
       padding: 12px 14px;
     }

--- a/console/dashboard/src/routes/(public)/[user]/+page.svelte
+++ b/console/dashboard/src/routes/(public)/[user]/+page.svelte
@@ -71,7 +71,7 @@
     </div>
   {:else if data.top.length === 0}
     <div class="podium-wrap reveal" style="--i:3">
-      <Card class="empty-card">
+      <Card atmosphere class="empty-card">
         <span class="ico gem" aria-hidden="true"><Icon name="gem" size={18} /></span>
         <h2>{t('leaderboard.emptyTitle')}</h2>
         <p>{t('leaderboard.emptyBody', { channel: data.channelName })}</p>
@@ -83,7 +83,7 @@
     <section class="podium" aria-label={t('leaderboard.podiumLabel')}>
       {#each podium as viewer, i (viewer.viewerId)}
         <div class="spot-wrap reveal place-{i + 1}" style="--i:{3 + i * 0.5}">
-          <Card hover class="spot">
+          <Card atmosphere hover class="spot">
             <span class="medal medal-{i + 1}" aria-hidden="true">{i + 1}</span>
             <span class="avatar" aria-hidden="true">{rowName(viewer).slice(0, 2)}</span>
             <span class="name" title={viewer.viewerLogin || viewer.viewerName}>{rowName(viewer)}</span>
@@ -101,7 +101,7 @@
     </section>
 
     <section class="board-wrap reveal" style="--i:5" aria-label={t('leaderboard.boardLabel')}>
-      <Card class="board">
+      <Card atmosphere class="board">
         <header class="board-head">
           <span class="ico" aria-hidden="true"><Icon name="users" size={16} /></span>
           <div class="board-titles">
@@ -148,7 +148,7 @@
 
   {#if data.commands.length > 0 || commandTriggers.length > 0}
     <section class="cmds-wrap reveal" style="--i:6" aria-label={t('leaderboard.commandsLabel')}>
-      <Card class="cmds-card">
+      <Card atmosphere class="cmds-card">
         <header class="cmds-head">
           <span class="ico" aria-hidden="true"><Icon name="commands" size={16} /></span>
           <h2>{t('leaderboard.commandsTitle')}</h2>

--- a/console/dashboard/src/routes/(public)/stats/+page.svelte
+++ b/console/dashboard/src/routes/(public)/stats/+page.svelte
@@ -352,7 +352,7 @@
          card's own hover lift. -->
     {#each tiles as tile, i (tile.label)}
       <div class="tile-wrap reveal" style="--i:{5 + i * 0.5}">
-        <Card hover class="tile">
+        <Card atmosphere hover class="tile">
           <div class="tile-head">
             <span class="ico" class:tan={tile.tan} aria-hidden="true"><Icon name={tile.icon} size={16} /></span>
             <span class="label">{tile.label}</span>
@@ -375,7 +375,7 @@
 
   <section class="boards" aria-label={t('stats.boardsEyebrow')}>
     <div class="board-wrap reveal" style="--i:6">
-      <Card class="board">
+      <Card atmosphere class="board">
         <header class="board-head">
           <span class="ico" aria-hidden="true"><Icon name="activity" size={16} /></span>
           <div class="board-titles">
@@ -421,7 +421,7 @@
     </div>
 
     <div class="board-wrap reveal" style="--i:6.5">
-      <Card class="board">
+      <Card atmosphere class="board">
         <header class="board-head">
           <span class="ico tan" aria-hidden="true"><Icon name="heart" size={16} /></span>
           <div class="board-titles">

--- a/console/dashboard/src/routes/user/[channel]/+page.svelte
+++ b/console/dashboard/src/routes/user/[channel]/+page.svelte
@@ -185,7 +185,7 @@
     {#if data.commands.length}
       <div class="grid">
         {#each data.commands as command}
-          <Card hover class="tile">
+          <Card atmosphere hover class="tile">
             <div class="tile-top">
               <h3 class="trigger">{command.trigger}</h3>
               {#if command.uses}
@@ -209,7 +209,7 @@
         {/each}
       </div>
     {:else}
-      <Card class="empty">No active custom commands.</Card>
+      <Card atmosphere class="empty">No active custom commands.</Card>
     {/if}
   </section>
 
@@ -223,7 +223,7 @@
     {#if data.modules.length}
       <div class="grid">
         {#each data.modules as mod}
-          <Card hover class="tile">
+          <Card atmosphere hover class="tile">
             <div class="tile-top">
               <div class="tile-title">
                 <span class="cat">{mod.category}</span>
@@ -252,7 +252,7 @@
         {/each}
       </div>
     {:else}
-      <Card class="empty">No active modules.</Card>
+      <Card atmosphere class="empty">No active modules.</Card>
     {/if}
   </section>
 </main>

--- a/console/shared/components/Card.svelte
+++ b/console/shared/components/Card.svelte
@@ -2,37 +2,48 @@
 	// Copyright (c) 2026 Adam Ousmer. All rights reserved.
 	// Proprietary. No license granted. See LICENSE.md.
   // Shared surface card, ported from the marketing site's Card.astro: solid
-  // warm ink, tan hairline, 16px radius, and — when `hover` is on — the
-  // cursor-tracked tan spotlight with a border brighten + small lift.
+  // warm ink, tan hairline. Radius is 8px here, not the marketing site's 16px:
+  // f453b3a2 standardized console radii on 8px.
+  //
+  // `atmosphere` opts a card into the header's orb/ring light at card scale
+  // (see CardAtmosphere) and is OFF by default. It belongs to the PUBLIC
+  // surfaces only — the stats page, channel leaderboards, /user/[channel].
+  // Signed-in dashboard pages stack many cards per screen and the orbs read as
+  // noise there, so they stay flat ink. Do not enable it inside (app).
+  //
+  // `hover` keeps the interactive language — border brighten, small lift, and
+  // the atmosphere's opacity bump. It is opt-in because the console stacks
+  // dense non-interactive panels that must not react to a passing cursor.
+  //
+  // The pointer-tracked tan spotlight this used to carry is gone; the marketing
+  // Card dropped it for the atmosphere, and keeping it here would have left the
+  // two sites with different hover languages.
+  //
+  // `as` picks the tag so a card can stay a landmark. Pages that need a
+  // <section> with aria-labelledby must pass as="section" — rendering it as a
+  // bare <div> silently drops the labelled region from the a11y tree.
   import type { Snippet } from 'svelte';
+  import CardAtmosphere from './CardAtmosphere.svelte';
   let {
+    as = 'div',
+    atmosphere = false,
     sheen = false,
     stat = false,
     hover = false,
     class: cls = '',
     children,
     ...rest
-  }: { sheen?: boolean; stat?: boolean; hover?: boolean; class?: string; children: Snippet; [key: string]: unknown } = $props();
-
-  let el = $state<HTMLDivElement | null>(null);
-
-  function track(e: PointerEvent) {
-    if (!hover || !el) return;
-    const r = el.getBoundingClientRect();
-    el.style.setProperty('--mx', `${(((e.clientX - r.left) / r.width) * 100).toFixed(2)}%`);
-    el.style.setProperty('--my', `${(((e.clientY - r.top) / r.height) * 100).toFixed(2)}%`);
-  }
+  }: { as?: string; atmosphere?: boolean; sheen?: boolean; stat?: boolean; hover?: boolean; class?: string; children: Snippet; [key: string]: unknown } = $props();
 </script>
 
-<div
-  class="card {sheen ? 'sheen' : ''} {stat ? 'stat' : ''} {hover ? 'hoverable' : ''} {cls}"
-  bind:this={el}
-  onpointermove={hover ? track : undefined}
+<svelte:element
+  this={as}
+  class="card {atmosphere ? 'atmo' : ''} {sheen ? 'sheen' : ''} {stat ? 'stat' : ''} {hover ? 'hoverable' : ''} {cls}"
   {...rest}
 >
-  {#if hover}<span class="spotlight" aria-hidden="true"></span>{/if}
+  {#if atmosphere}<CardAtmosphere />{/if}
   {@render children()}
-</div>
+</svelte:element>
 
 <style>
   .card {
@@ -46,28 +57,19 @@
       border-color 360ms var(--bb-ease-out-expo),
       transform 360ms var(--bb-ease-out-expo);
   }
+  /* Stacking context only where it is needed: it keeps the atmosphere's
+     z-index:-1 between this card's background and its content instead of
+     letting it escape to the page. Flat cards must not create one — an
+     inspector's sticky panel and the overlay stack sit above them. */
+  .card.atmo { isolation: isolate; }
   .card.sheen::before { content: ""; position: absolute; inset: 0; pointer-events: none; border-radius: inherit;
     background: radial-gradient(circle at 88% 0%, var(--glow-green, rgba(82,183,136,0.16)), transparent 50%); }
   .card.stat { padding: calc(20px * var(--d)); }
-
-  .spotlight {
-    position: absolute;
-    inset: 0;
-    pointer-events: none;
-    opacity: 0;
-    background: radial-gradient(
-      420px circle at var(--mx, 50%) var(--my, 50%),
-      var(--glow-tan, rgba(201, 168, 124, 0.18)),
-      transparent 60%
-    );
-    transition: opacity 360ms var(--bb-ease-out-expo);
-  }
 
   @media (hover: hover) and (pointer: fine) {
     .card.hoverable:hover {
       border-color: rgba(201, 168, 124, 0.38);
       transform: translateY(-3px);
     }
-    .card.hoverable:hover .spotlight { opacity: 1; }
   }
 </style>

--- a/console/shared/components/CardAtmosphere.svelte
+++ b/console/shared/components/CardAtmosphere.svelte
@@ -1,0 +1,103 @@
+<script lang="ts">
+	// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+	// Proprietary. No license granted. See LICENSE.md.
+  // Card atmosphere — a pocket of the header's light, not a cursor tracker.
+  // Ported from the marketing site's CardAtmosphere.astro so console surfaces
+  // read as the same material as itsbagelbot.dev.
+  //
+  // Same discs as the hero (green top-right, tan bottom-left, a tan->green arc)
+  // at card scale. They stay static: a `filter: blur` on a still layer is one
+  // paint and a cached bitmap. The hitch upstream was animating them — a
+  // ::before that pulsed scale(1.1) on every orb plus a masked ring spinning on
+  // every tile, which re-rasters the blur at 60fps. Hover only changes opacity
+  // (compositor), never transform or filter.
+  //
+  // Divergence from the .astro original: it stacks content above the orbs with
+  // a `.card__body` wrapper at z-index 1. Console cards put layout on the card
+  // ROOT (loyalty's .status-row and the importer's .stepper are display:flex
+  // cards), and a wrapper element would swallow their children out of the flex
+  // container. So the orbs go to z-index:-1 under Card's `isolation: isolate`
+  // instead: a negative-z child paints after the card's own background but
+  // before in-flow content, which is the same result with no extra box.
+</script>
+
+<div class="card-atmo" aria-hidden="true">
+  <span class="card-atmo__ring"></span>
+  <span class="card-atmo__orb card-atmo__orb--green"></span>
+  <span class="card-atmo__orb card-atmo__orb--tan"></span>
+</div>
+
+<style>
+  .card-atmo {
+    position: absolute;
+    inset: 0;
+    z-index: -1;
+    overflow: hidden;
+    pointer-events: none;
+    border-radius: inherit;
+    /* Header orbs rest at ~0.16 on a full viewport; cards are smaller so the
+       same number reads as nothing. 0.28 at rest / 0.42 on hover was measured
+       upstream against --bb-card-bg #111110 (same ink here) after the pulsed
+       ::before came off: 0.22 (the pulsed rest) went flat without that layer. */
+    --card-atmo-orb: 0.28;
+  }
+
+  /* Even siblings flip so neighbouring cards don't share one corner glow. */
+  :global(.card:nth-child(even)) .card-atmo { transform: scaleX(-1); }
+
+  /* Only interactive cards brighten. Console stacks dense non-interactive
+     panels, so an unconditional :hover would make the whole page twitch. */
+  :global(.card.hoverable:hover) .card-atmo,
+  :global(.card.hoverable:focus-visible) .card-atmo {
+    --card-atmo-orb: 0.42;
+  }
+
+  /* Mini of the header's ring: a 1.5px tan->green arc, not a filled disc.
+     Masked conic so we never mint per-card SVG ids (g1/g2 would collide).
+     Parked half off the right edge the way the hero ring sits off-canvas.
+     No spin — rotating a masked layer on every tile was the other hitch. */
+  .card-atmo__ring {
+    position: absolute;
+    top: 42%;
+    right: -22%;
+    width: 92%;
+    aspect-ratio: 1;
+    translate: 0 -50%;
+    border-radius: 50%;
+    opacity: 0.16;
+    background: conic-gradient(
+      from 210deg,
+      rgba(201, 168, 124, 0.9),
+      rgba(45, 106, 79, 0.14) 30%,
+      rgba(64, 145, 108, 0.75) 55%,
+      rgba(201, 168, 124, 0.2) 80%,
+      rgba(201, 168, 124, 0.9)
+    );
+    -webkit-mask: radial-gradient(farthest-side, transparent calc(100% - 1.6px), #000 calc(100% - 0.4px));
+    mask: radial-gradient(farthest-side, transparent calc(100% - 1.6px), #000 calc(100% - 0.4px));
+  }
+
+  .card-atmo__orb {
+    position: absolute;
+    border-radius: 50%;
+    filter: blur(42px);
+    opacity: var(--card-atmo-orb);
+    transition: opacity 360ms var(--bb-ease-out-expo, cubic-bezier(0.16, 1, 0.3, 1));
+  }
+
+  .card-atmo__orb--green {
+    width: 240px;
+    height: 240px;
+    background-color: var(--bb-green, #2d6a4f);
+    top: -48px;
+    right: -36px;
+  }
+
+  .card-atmo__orb--tan {
+    width: 200px;
+    height: 200px;
+    background-color: var(--bb-tan, #c9a87c);
+    bottom: -40px;
+    left: -32px;
+  }
+</style>

--- a/console/shared/components/InspectorSurface.svelte
+++ b/console/shared/components/InspectorSurface.svelte
@@ -7,6 +7,7 @@
   // scrim/Escape — reusing the shared overlay foundation. One component so every
   // route's inspector behaves identically instead of each re-styling an <aside>.
   import type { Snippet } from 'svelte';
+  import Card from './Card.svelte';
   import Icon from './Icon.svelte';
   import { pushOverlay, removeOverlay, isTopmost, overlayIndex, hasOpenOverlay, portal, trapFocus } from '../lib/overlay-stack';
 
@@ -102,24 +103,24 @@
       </div>
     </div>
   {:else}
-    <aside class="surface docked" aria-label={title}>
+    <!-- Docked: in-flow beside the deck's Card, so it IS a Card — same ink,
+         hairline and atmosphere. padding:0 because the head/body own theirs. -->
+    <Card as="aside" class="surface docked" style="padding:0" aria-label={title}>
       {@render body()}
-    </aside>
+    </Card>
   {/if}
 {/if}
 
 <style>
-  .surface {
+  /* Layout only, shared by both variants. :global because the docked variant's
+     class rides <Card>'s root, which this component's scoping hash never
+     reaches; the sheet is an in-template element and matches either way. */
+  :global(.surface) {
     display: flex;
     flex-direction: column;
     min-height: 0;
-    border: 1px solid var(--rule);
-    border-top-color: var(--rule-strong);
-    border-radius: 8px;
-    background: linear-gradient(180deg, rgba(240, 236, 228, 0.03), rgba(240, 236, 228, 0.012));
-    overflow: hidden;
   }
-  .surface.docked {
+  :global(.surface.docked) {
     position: sticky;
     top: 62px;
     max-height: calc(100dvh - 62px - 108px);
@@ -168,11 +169,17 @@
     border: 0; padding: 0;
     background: rgba(0, 0, 0, 0.55);
   }
+  /* The sheet keeps its own material rather than becoming a Card: it floats
+     over a scrim on --bb-bg-1, where the card's warm ink and corner orbs read
+     as a second panel showing through the first. */
   .surface.sheet {
     position: absolute;
     left: 0; right: 0; bottom: 0;
     max-height: 88dvh;
+    border: 1px solid var(--rule);
+    border-top-color: var(--rule-strong);
     border-radius: 8px 8px 0 0;
+    overflow: hidden;
     background: var(--bb-bg-1, #111);
     padding-bottom: env(safe-area-inset-bottom, 0);
     animation: sheet-in var(--bb-dur-base, 320ms) var(--bb-ease-out-expo, cubic-bezier(.16, 1, .3, 1)) both;

--- a/web/src/components/changelog/ChangelogList.astro
+++ b/web/src/components/changelog/ChangelogList.astro
@@ -8,6 +8,7 @@
  * description, and a link to the GitHub release.
  */
 import type { CollectionEntry } from 'astro:content';
+import CardAtmosphere from '../ui/CardAtmosphere.astro';
 import ReleaseTag from './ReleaseTag.astro';
 import TextLink from '../ui/TextLink.astro';
 import { getLangFromUrl, useTranslations } from '../../i18n/ui';
@@ -54,6 +55,7 @@ const tagLabel: Record<CollectionEntry<'changelog'>['data']['tag'], string> = {
                             <time datetime={date.toISOString()}>{dateFmt.format(date)}</time>
                         </div>
                         <article class="clog__card">
+                            <CardAtmosphere />
                             <header class="clog__meta">
                                 <ReleaseTag tag={tag} label={tagLabel[tag]} />
                                 <span class="clog__ver">{version}</span>
@@ -160,18 +162,10 @@ const tagLabel: Record<CollectionEntry<'changelog'>['data']['tag'], string> = {
             transform 260ms var(--ease-out-expo, cubic-bezier(0.16, 1, 0.3, 1));
     }
 
-    .clog__card::before {
-        content: "";
-        position: absolute;
-        inset: 0;
-        background: radial-gradient(
-            420px 180px at 8% 0%,
-            rgba(201, 168, 124, 0.08),
-            transparent 70%
-        );
-        opacity: 0;
-        transition: opacity 260ms ease;
-        pointer-events: none;
+    /* Content rides above the atmosphere layer (which paints at z-index 0). */
+    .clog__card > :global(*:not(.card-atmo)) {
+        position: relative;
+        z-index: 1;
     }
 
     @media (hover: hover) and (pointer: fine) {
@@ -180,7 +174,6 @@ const tagLabel: Record<CollectionEntry<'changelog'>['data']['tag'], string> = {
             transform: translateY(-3px);
         }
 
-        .clog__item:hover .clog__card::before { opacity: 1; }
 
         .clog__item:hover::before {
             background: var(--tan, #c9a87c);

--- a/web/src/components/ui/CardAtmosphere.astro
+++ b/web/src/components/ui/CardAtmosphere.astro
@@ -40,12 +40,14 @@
     /* Even siblings flip so neighbouring cards don't share one corner glow.
        scaleX on this layer only — body copy is a sibling, not a child. */
     :global(.card:nth-child(even)) .card-atmo,
-    :global(.gcard:nth-child(even)) .card-atmo {
+    :global(.gcard:nth-child(even)) .card-atmo,
+    :global(.clog__item:nth-child(even) .clog__card) .card-atmo {
         transform: scaleX(-1);
     }
 
     :global(.card:hover) .card-atmo,
     :global(.gcard:hover) .card-atmo,
+    :global(.clog__item:hover) .card-atmo,
     :global(.card:focus-visible) .card-atmo,
     :global(.gcard:focus-visible) .card-atmo {
         --card-atmo-orb: 0.42;


### PR DESCRIPTION
Every card-shaped surface in the console and on the marketing site now renders the shared `Card`, and the header's orb/ring atmosphere is confined to pages a signed-out visitor can see.

## Card

- `as` prop picks the tag, so a card can stay a landmark. Settings' sections keep their `aria-labelledby` region instead of collapsing into a bare `<div>`.
- `atmosphere` prop, **off by default**, carries the marketing site's static orb/ring light (new `CardAtmosphere.svelte`). Signed-in pages stack many cards per screen and the orbs read as noise there, so only `/stats` and the public channel boards switch it on.
- The pointer-tracked tan spotlight is gone. The marketing `Card.astro` dropped it for the atmosphere; keeping it here would leave the two sites with different hover languages.

`isolation: isolate` sits on `.card.atmo`, not every card — a flat card must not create a stacking context or it paints above the inspector's sticky panel and the overlay stack.

## Surfaces converted

Each of these restated the card's ink, hairline and radius by hand:

| surface | was |
|---|---|
| loyalty, quotes | local `.card`, radius 10, `rgba(240,236,228,.02)` |
| settings | `.settings-section` |
| settings/import | `.panel` + `.stepper` |
| modules | `.family-list` on `--rule` |
| docked inspector | own `--rule` border + translucent gradient |
| overview status hero | the global `.card` class, which cannot render a child |
| changelog release cards (web) | bespoke `::before` corner tint |

Classes that now ride a component root moved to `:global()` — the parent's scoping hash never reaches a child component's element.

## Deliberately left alone

The mobile bottom sheet keeps its own material: it floats over a scrim on `--bb-bg-1`, where the card's warm ink and corner orbs read as a second panel showing through the first (and it carries `bind:this` + `use:trapFocus`, neither of which works on a component). On web, the playground chat window is a mock app frame, the guide pager cards and table wraps are too small for 240px orbs, and the command-builder promo has its own green identity glow.

## Verification

Runtime sweep across all 13 `(app)` routes plus the public ones, counting `.card-atmo` nodes:

```
(app)  /  /commands  /modules  /loyalty  /quotes  /settings
       /settings/import  /billing        →  0 atmosphere, 26 cards
public /stats                            →  4 atmosphere
       /user/[channel]                   →  3 atmosphere
```

A second probe looked for anything ≥24000px² with a 1px border and ≥6px radius that is not a `Card`; the only hits left are rows and tiles nested *inside* cards, plus billing's dashed `.oath` pill.

`svelte-check`: 1 error, 2 warnings — all pre-existing on `main` (`bun:test` types in `oauth-start.test.ts`, a `line-clamp` prefix note, a `state_referenced_locally` hint). Admin app: 0/0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added atmospheric visual effects to cards across dashboards, public pages, user pages, and changelogs.
  * Added configurable card elements and improved support for interactive hover and focus states.
  * Standardized major dashboard sections on the shared card design.

* **Style**
  * Improved card consistency, layering, responsive layouts, and mobile presentation.
  * Updated inspector surfaces and changelog cards with refreshed visual treatments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->