### PR TITLE
fix(dashboard): keep command Active off content save

### DIFF
--- a/console/dashboard/src/lib/components/commands/CommandEditor.svelte
+++ b/console/dashboard/src/lib/components/commands/CommandEditor.svelte
@@ -11,9 +11,11 @@
     FieldError,
     Scroller,
     EditorFooter,
+    Switch,
     PERMS,
     PERM_LABELS,
     validateCommand,
+    commandContentSnapshot,
     normName,
     COOLDOWN_MAX,
     RESPONSE_MAX_LINES,
@@ -37,7 +39,9 @@
     fetchKeys = [],
     onFetchDefsChanged,
     onCancel,
-    onSubmit
+    onSubmit,
+    liveActive = false,
+    onToggleActive
   }: {
     draft: CommandDraft;
     serverErrors?: CommandErrors | null;
@@ -50,6 +54,11 @@
     onFetchDefsChanged?: (defs: SourceDef[]) => void;
     onCancel: () => void;
     onSubmit: SubmitFunction;
+    // Edit: live row enabled state. The inspector Switch posts the same toggle
+    // as the row so Active is not a draft field (#221). Create still uses the
+    // checkbox below — there is no row yet.
+    liveActive?: boolean;
+    onToggleActive?: (next: boolean) => void;
   } = $props();
 
   const busy = $derived(status === 'saving');
@@ -62,11 +71,13 @@
   const errors = $derived<CommandErrors>({ ...(serverErrors ?? {}), ...clientErrors });
 
   // Mirror the working draft to sessionStorage (skip the initial unmodified
-  // state so merely opening an editor doesn't flag the row as unsaved).
+  // state so merely opening an editor doesn't flag the row as unsaved). Active
+  // is compared out: a live toggle must not persist a draft that only differs
+  // in is_active, or the row would show an unsaved chip after a pause/resume.
   const key = draftKey(draft.originalName, draft.edit);
-  const initial = JSON.stringify(draft);
+  const initial = commandContentSnapshot(draft);
   $effect(() => {
-    const current = JSON.stringify(draft);
+    const current = commandContentSnapshot(draft);
     if (current === initial) return;
     try {
       sessionStorage.setItem(key, current);
@@ -166,7 +177,23 @@
   </label>
 
   <div class="check">
-    <CheckButton name="is_active" bind:checked={draft.is_active} label={t('commandEditor.active')} />
+    {#if draft.edit && onToggleActive}
+      <!-- type=button: this form is ?/save; a nested toggle form is invalid
+           HTML. The Switch posts via onToggleActive (same optimistic toggle
+           as the row) so Save cannot write a stale Active snapshot (#221). -->
+      <input type="hidden" name="is_active" value={liveActive ? 'on' : ''} />
+      <div class="live-active">
+        <span class="live-lbl">{t('commandEditor.active')}</span>
+        <Switch
+          checked={liveActive}
+          pending={busy}
+          onchange={() => onToggleActive(!liveActive)}
+          label={t('commandEditor.active')}
+        />
+      </div>
+    {:else}
+      <CheckButton name="is_active" bind:checked={draft.is_active} label={t('commandEditor.active')} />
+    {/if}
   </div>
 
   <div class="check">
@@ -208,6 +235,17 @@
 
   .check { margin: 4px 0 14px; }
   .check :global(.cb) { align-items: center; }
+  .live-active {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+  }
+  .live-lbl {
+    font-family: var(--bb-font-body);
+    font-size: 13.5px;
+    color: var(--bb-white, var(--bb-text, #e8e0d6));
+  }
 
   @media (max-width: 480px) {
     .field-row { flex-direction: column; gap: 0; }

--- a/console/dashboard/src/routes/(app)/commands/+page.svelte
+++ b/console/dashboard/src/routes/(app)/commands/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	// Copyright (c) 2026 Adam Ousmer. All rights reserved.
 	// Proprietary. No license granted. See LICENSE.md.
-  import { onMount } from 'svelte';
+  import { onMount, untrack } from 'svelte';
   import { deserialize } from '$app/forms';
   import { replaceState } from '$app/navigation';
   import type { SubmitFunction } from '@sveltejs/kit';
@@ -22,6 +22,9 @@
     builtinDef,
     BUILTIN_NAMES,
     validateCommand,
+    persistCommandActive,
+    overlayLiveActive,
+    commandContentSnapshot,
     PERM_LABELS,
     PERMS,
     COMMAND_NAME_MAX,
@@ -244,7 +247,9 @@
   });
   const isDirty = $derived(
     !!editorDraft && !editorDraft.builtin && committedDraft !== null
-      ? JSON.stringify(editorDraft) !== JSON.stringify(committedDraft)
+      ? editorDraft.edit
+        ? commandContentSnapshot(editorDraft) !== commandContentSnapshot(committedDraft)
+        : JSON.stringify(editorDraft) !== JSON.stringify(committedDraft)
       : false
   );
 
@@ -290,33 +295,24 @@
       editorGen++;
       return;
     }
-    // loadDraft only returns something after a forced reload; restore quietly.
-    editorDraft = loadDraft(c.name, true) ?? fromView(c);
+    // Overlay live Active onto a restored sessionStorage draft: a snapshot
+    // taken while the command was on must not re-enable it (#221).
+    editorDraft = overlayLiveActive(loadDraft(c.name, true) ?? fromView(c), c.is_active);
     expanded = c.name;
     editorGen++;
   }
 
-  // #221: the draft snapshots Active at open, so anything flipping the row
-  // afterwards (the row Switch, a second tab, a failed-save rollback) left the
-  // editor holding the stale value — and the next Save wrote it straight back:
-  // toggling off with the inspector open reverted on save, and a sessionStorage
-  // draft captured while the command was active re-activated a disabled command
-  // when restored. Reconcile on every committed move instead. The effect never
-  // reads draft.is_active after first sight on purpose: tracking it would re-run
-  // this effect on the user's own checkbox click and snap it back to committed.
-  let committedActive: boolean | null = null;
+  // Keep the open edit draft's Active in lockstep with the live row. Reassign
+  // (don't mutate) so the bound Switch sees the new value; untrack the write
+  // so overlaying is_active cannot re-enter the effect.
   $effect(() => {
     const d = editorDraft;
     const live =
       d && d.edit && !d.builtin ? items.find((c) => c.name === d.originalName) : undefined;
-    if (!d || !live) {
-      committedActive = null;
-      return;
-    }
-    if (committedActive === null || committedActive !== live.is_active) {
-      committedActive = live.is_active;
-      d.is_active = live.is_active;
-    }
+    if (!d || !live || d.is_active === live.is_active) return;
+    untrack(() => {
+      editorDraft = overlayLiveActive(d, live.is_active);
+    });
   });
   // Unguarded close for the delete path (the command is already gone).
   function doCloseEditor() {
@@ -459,7 +455,7 @@
   };
 
   // --- Save (optimistic with row-level rollback) -----------------------------
-  const saveSubmit: SubmitFunction = () => {
+  const saveSubmit: SubmitFunction = ({ formData }) => {
     const d = editorDraft;
     if (!d) return;
     const key = normName(d.name);
@@ -470,6 +466,13 @@
     // is still on the command it was submitted for.
     const submittedExpanded = expanded;
 
+    // Content save must not write the inspector's Active snapshot (#221): a
+    // disabled command stayed disabled, and a row toggle with the inspector
+    // open is not reverted. Create still uses the draft checkbox.
+    const live = items.find((c) => c.name === (orig ?? key));
+    const isActive = persistCommandActive(d.edit, d.is_active, live?.is_active);
+    formData.set('is_active', isActive ? 'on' : '');
+
     // Row-level snapshot: rollback restores only the affected row(s), so a
     // concurrent toggle on another row can't be clobbered.
     const prevRows = items.filter((c) => c.name === key || c.name === orig);
@@ -477,12 +480,12 @@
       name: key,
       aliases: d.aliases.map(normName).filter(Boolean),
       response: d.response,
-      is_active: d.is_active,
+      is_active: isActive,
       stream_online_only: d.stream_online_only,
       perm: d.perm,
       cooldown: Math.floor(Number(d.cooldown) || 0),
       allowed_user_id: d.allowed_user_id.replace(/\D/g, ''),
-      uses: items.find((c) => c.name === (orig ?? key))?.uses
+      uses: live?.uses
     };
     items = [...items.filter((c) => c.name !== key && c.name !== orig), optimistic];
     busy = true;
@@ -533,6 +536,17 @@
   };
 
   // --- Toggle (optimistic flip) ----------------------------------------------
+  function settleToggle(name: string, before: CommandView, payload: ActionResult | null | undefined, ok: boolean) {
+    if (ok && payload?.ok) {
+      applyResult(payload);
+      ackSaved(name);
+      return;
+    }
+    items = items.map((x) => (x.name === name ? before : x));
+    flagError(name);
+    toast('err', payload?.error ?? t('commands.toastToggleFailed'));
+  }
+
   const toggleSubmit =
     (c: CommandView): SubmitFunction =>
     () => {
@@ -544,14 +558,7 @@
           result.type === 'success' || result.type === 'failure'
             ? (result.data as ActionResult | undefined)
             : undefined;
-        if (result.type === 'success' && payload?.ok) {
-          applyResult(payload); // silent from the server
-          ackSaved(c.name);
-        } else {
-          items = items.map((x) => (x.name === c.name ? before : x));
-          flagError(c.name);
-          toast('err', payload?.error ?? t('commands.toastToggleFailed'));
-        }
+        settleToggle(c.name, before, payload, result.type === 'success');
       };
     };
 
@@ -655,6 +662,20 @@
   const selectedCmd = $derived(
     expanded && expanded !== NEW ? items.find((c) => c.name === expanded) : undefined
   );
+
+  // Inspector Active Switch: same optimistic toggle as the row, without a
+  // nested form inside ?/save. no-ops when the requested state is already live
+  // so Switch's local flip + this setter cannot double-toggle.
+  function setSelectedActive(next: boolean) {
+    const c = selectedCmd;
+    if (!c || c.builtin || c.is_active === next) return;
+    const before = { ...c };
+    items = items.map((x) => (x.name === c.name ? { ...x, is_active: next } : x));
+    setStatus(c.name, 'saving');
+    void postAction('toggle', formDataFor({ ...c, is_active: next })).then((payload) => {
+      settleToggle(c.name, before, payload, payload?.ok === true);
+    });
+  }
 
   // The open editor's footer status. Maps the legacy 'live' row state (no longer
   // produced) to 'saved' so it fits the footer's state set.
@@ -799,6 +820,8 @@
               onFetchDefsChanged={(next) => (fetchDefs = next)}
               onCancel={closeEditor}
               onSubmit={saveSubmit}
+              liveActive={selectedCmd?.is_active ?? editorDraft.is_active}
+              onToggleActive={setSelectedActive}
             />
           {/key}
         {/if}

--- a/console/shared/lib/command-active.test.ts
+++ b/console/shared/lib/command-active.test.ts
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+import { describe, expect, test } from 'bun:test';
+import { commandContentSnapshot, overlayLiveActive, persistCommandActive } from './command-active';
+
+describe('persistCommandActive', () => {
+  test('create uses the draft checkbox (new commands default on)', () => {
+    expect(persistCommandActive(false, true, false)).toBe(true);
+    expect(persistCommandActive(false, false, true)).toBe(false);
+  });
+
+  test('edit uses the live row, not the inspector snapshot (#221)', () => {
+    // Disabled command, stale draft still checked → stay disabled.
+    expect(persistCommandActive(true, true, false)).toBe(false);
+    // Row toggle on while inspector still shows off → keep the toggle.
+    expect(persistCommandActive(true, false, true)).toBe(true);
+  });
+
+  test('edit falls back to the draft when the live row is gone', () => {
+    expect(persistCommandActive(true, true, undefined)).toBe(true);
+    expect(persistCommandActive(true, false, undefined)).toBe(false);
+  });
+});
+
+describe('overlayLiveActive', () => {
+  test('replaces a stale snapshot and keeps the same object when already live', () => {
+    const stale = { name: 'lurk', is_active: true };
+    expect(overlayLiveActive(stale, false)).toEqual({ name: 'lurk', is_active: false });
+    expect(overlayLiveActive(stale, true)).toBe(stale);
+  });
+});
+
+describe('commandContentSnapshot', () => {
+  test('ignores is_active so a live toggle is not unsaved work', () => {
+    const a = { name: 'lurk', response: 'hi', is_active: true };
+    const b = { name: 'lurk', response: 'hi', is_active: false };
+    expect(commandContentSnapshot(a)).toBe(commandContentSnapshot(b));
+    expect(commandContentSnapshot({ ...a, response: 'yo' })).not.toBe(commandContentSnapshot(a));
+  });
+});

--- a/console/shared/lib/command-active.ts
+++ b/console/shared/lib/command-active.ts
@@ -1,0 +1,29 @@
+// Copyright (c) 2026 Adam Ousmer. All rights reserved.
+// Proprietary. No license granted. See LICENSE.md.
+
+// #221: editing a command must not change whether it is enabled. The inspector
+// draft used to snapshot Active at open, so a content Save wrote that snapshot
+// back — a disabled command came back on, and a row toggle with the inspector
+// open reverted on save. Content writes take the live row; only Create (no
+// live row yet) takes the draft checkbox.
+
+export function persistCommandActive(
+  edit: boolean,
+  draftActive: boolean,
+  liveActive: boolean | undefined
+): boolean {
+  if (!edit) return draftActive;
+  return liveActive ?? draftActive;
+}
+
+export function overlayLiveActive<T extends { is_active: boolean }>(draft: T, liveActive: boolean): T {
+  if (draft.is_active === liveActive) return draft;
+  return { ...draft, is_active: liveActive };
+}
+
+// Dirty / sessionStorage compare without Active: a live toggle must not flag
+// the editor unsaved or persist a draft that only differs in is_active.
+export function commandContentSnapshot(draft: object): string {
+  const { is_active: _ignored, ...content } = draft as { is_active?: unknown };
+  return JSON.stringify(content);
+}

--- a/console/shared/lib/index.ts
+++ b/console/shared/lib/index.ts
@@ -78,6 +78,7 @@ export * from './toast';
 export * from './connection-state';
 export * from './overlay-stack';
 export * from './inspector-machine';
+export * from './command-active';
 export * from './commands-validate';
 export * from './rehearsal';
 export * from './validation';


### PR DESCRIPTION
## Summary
- Content saves no longer write the inspector's Active snapshot, so editing a disabled command stays disabled (#221).
- Edits use a live Active toggle (same optimistic `?/toggle` as the row); only Create still uses the draft checkbox.
- Overlay the live row onto restored sessionStorage drafts so a snapshot taken while the command was on cannot re-enable it.

## Test plan
- [ ] Open a disabled custom command (`!debug` in DEMO), edit the response, Save — header still shows it disabled; row Switch stays off
- [ ] With the inspector still open, flip the row Switch — inspector Active tracks immediately
- [ ] Edit content and Save after that toggle — Active is not reverted
- [ ] Flip inspector Active — row Switch and active/disabled counts follow; Save stays disabled (active-only is not unsaved content)
- [ ] New command still defaults Active on via the create checkbox

Closes #221

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a live Active toggle when editing commands.
  * Added an Active switch to the command inspector.
  * Command activation changes now apply immediately without affecting draft content.

* **Bug Fixes**
  * Prevented active-state changes from incorrectly marking drafts as unsaved.
  * Preserved live activation status when editing or restoring drafts.
  * Ensured newly created commands retain their selected draft state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->