### PR TITLE
docs(web): retag beta changelogs as 0.1.x

### DIFF
--- a/TRANSLATIONS.md
+++ b/TRANSLATIONS.md
@@ -53,7 +53,7 @@ Locale codes are lowercase base tags (`es`, `pt-br`), maximum 8 characters.
 
 ## Rules for changelog JSON
 
-- One file per GitHub release: `web/src/content/changelog/<version>.json`. Name it after the git tag (`v1.0.0-beta.json`).
+- One file per GitHub release: `web/src/content/changelog/<version>.json`. Name it after the git tag (`v0.1.0-beta.json`).
 - Required fields: `tag` (`alpha`, `beta`, `prerelease`, or `release`), `version` (the git tag shown on the page), `date` (ISO, used for sort and display), `title`, `description`, `github` (the GitHub release URL).
 - `title` and `description` are either a plain English string or a locale map with `en` required. Add your language as another key (`"fr": "..."`). Missing locales fall back to English; do not rename keys.
 

--- a/web/src/content/changelog/v0.1.0-beta.json
+++ b/web/src/content/changelog/v0.1.0-beta.json
@@ -1,6 +1,6 @@
 {
   "tag": "beta",
-  "version": "v1.0.0-beta",
+  "version": "v0.1.0-beta",
   "date": "2026-08-14",
   "title": {
     "en": "Beta launch",
@@ -18,5 +18,5 @@
       "Performance : API externes (stats de jeux)."
     ]
   },
-  "github": "https://github.com/AdamOusmer/ItsBagelBot/releases/tag/v1.0.0-beta"
+  "github": "https://github.com/AdamOusmer/ItsBagelBot/releases/tag/v0.1.0-beta"
 }

--- a/web/src/content/changelog/v0.1.1-beta.json
+++ b/web/src/content/changelog/v0.1.1-beta.json
@@ -1,6 +1,6 @@
 {
   "tag": "beta",
-  "version": "v1.0.1-beta",
+  "version": "v0.1.1-beta",
   "date": "2026-08-25",
   "title": {
     "en": "Games in chat and AutoMod beta",
@@ -22,5 +22,5 @@
       "Correctifs de sécurité."
     ]
   },
-  "github": "https://github.com/AdamOusmer/ItsBagelBot/releases/tag/v1.0.1-beta"
+  "github": "https://github.com/AdamOusmer/ItsBagelBot/releases/tag/v0.1.1-beta"
 }

--- a/web/src/content/changelog/v0.1.2-beta.json
+++ b/web/src/content/changelog/v0.1.2-beta.json
@@ -1,6 +1,6 @@
 {
   "tag": "beta",
-  "version": "v1.0.2-beta",
+  "version": "v0.1.2-beta",
   "date": "2026-08-25",
   "title": {
     "en": "Leaderboards, song requests, and a clearer command editor",
@@ -24,5 +24,5 @@
       "Performance : démarrage de la console, cache."
     ]
   },
-  "github": "https://github.com/AdamOusmer/ItsBagelBot/releases/tag/v1.0.2-beta"
+  "github": "https://github.com/AdamOusmer/ItsBagelBot/releases/tag/v0.1.2-beta"
 }

--- a/web/src/content/changelog/v0.1.3-beta.json
+++ b/web/src/content/changelog/v0.1.3-beta.json
@@ -1,6 +1,6 @@
 {
   "tag": "beta",
-  "version": "v1.0.3-beta",
+  "version": "v0.1.3-beta",
   "date": "2026-08-25",
   "title": {
     "en": "Your Spotify, your modules, fewer clicks",
@@ -20,5 +20,5 @@
       "Ajouter à Twitch lance l'OAuth tout de suite. Un clic depuis le site vers le consentement Twitch, puis directement dans le tableau de bord. Plus d'écran de connexion intermédiaire. Déjà connecté ? Vous arrivez dans la console sans nouveau consentement."
     ]
   },
-  "github": "https://github.com/AdamOusmer/ItsBagelBot/releases/tag/v1.0.3-beta"
+  "github": "https://github.com/AdamOusmer/ItsBagelBot/releases/tag/v0.1.3-beta"
 }

--- a/web/src/lib/compareVersion.ts
+++ b/web/src/lib/compareVersion.ts
@@ -2,11 +2,11 @@
 // Proprietary. No license granted. See LICENSE.md.
 
 /**
- * Compare git tags like `v1.0.3-beta` for newest-first changelog order.
+ * Compare git tags like `v0.1.3-beta` for newest-first changelog order.
  * Core numbers win first. A release without a prerelease suffix outranks
  * the same core with one (`v1.0.0` > `v1.0.0-beta`). Prerelease labels
  * then sort lexicographically (`alpha` < `beta`), which matches how we
- * ship. Same-day `date` values made date sort unstable across 1.0.1–1.0.3.
+ * ship. Same-day `date` values made date sort unstable across 0.1.1–0.1.3.
  */
 export function compareVersion(a: string, b: string): number {
   const pa = parseVersion(a);

--- a/web/tests/compareVersion.spec.js
+++ b/web/tests/compareVersion.spec.js
@@ -6,9 +6,9 @@ import { compareVersion } from '../src/lib/compareVersion.ts';
 
 describe('compareVersion', () => {
   test('orders core versions numerically', () => {
-    expect(compareVersion('v1.0.3-beta', 'v1.0.2-beta')).toBeGreaterThan(0);
-    expect(compareVersion('v1.0.1-beta', 'v1.0.3-beta')).toBeLessThan(0);
-    expect(compareVersion('v0.1.0-alpha', 'v1.0.0-beta')).toBeLessThan(0);
+    expect(compareVersion('v0.1.3-beta', 'v0.1.2-beta')).toBeGreaterThan(0);
+    expect(compareVersion('v0.1.1-beta', 'v0.1.3-beta')).toBeLessThan(0);
+    expect(compareVersion('v0.1.0-alpha', 'v0.1.3-beta')).toBeLessThan(0);
   });
 
   test('treats bare release as newer than the same core with a prerelease', () => {
@@ -21,17 +21,17 @@ describe('compareVersion', () => {
 
   test('newest-first sort matches the changelog page', () => {
     const tags = [
-      'v1.0.0-beta',
-      'v1.0.3-beta',
+      'v0.1.0-beta',
+      'v0.1.3-beta',
       'v0.1.0-alpha',
-      'v1.0.1-beta',
-      'v1.0.2-beta',
+      'v0.1.1-beta',
+      'v0.1.2-beta',
     ];
     expect([...tags].sort((a, b) => compareVersion(b, a))).toEqual([
-      'v1.0.3-beta',
-      'v1.0.2-beta',
-      'v1.0.1-beta',
-      'v1.0.0-beta',
+      'v0.1.3-beta',
+      'v0.1.2-beta',
+      'v0.1.1-beta',
+      'v0.1.0-beta',
       'v0.1.0-alpha',
     ]);
   });

--- a/web/tests/site.spec.js
+++ b/web/tests/site.spec.js
@@ -194,17 +194,17 @@ test.describe('ItsBagelBot site', () => {
         await expect(items).toHaveCount(5);
 
         // Same publish day must not scramble order: newest version tag first.
-        await expect(items.nth(0).locator('.clog__ver')).toHaveText('v1.0.3-beta');
-        await expect(items.nth(1).locator('.clog__ver')).toHaveText('v1.0.2-beta');
-        await expect(items.nth(2).locator('.clog__ver')).toHaveText('v1.0.1-beta');
-        await expect(items.nth(3).locator('.clog__ver')).toHaveText('v1.0.0-beta');
+        await expect(items.nth(0).locator('.clog__ver')).toHaveText('v0.1.3-beta');
+        await expect(items.nth(1).locator('.clog__ver')).toHaveText('v0.1.2-beta');
+        await expect(items.nth(2).locator('.clog__ver')).toHaveText('v0.1.1-beta');
+        await expect(items.nth(3).locator('.clog__ver')).toHaveText('v0.1.0-beta');
         await expect(items.nth(4).locator('.clog__ver')).toHaveText('v0.1.0-alpha');
 
         await expect(items.first()).toContainText('Your Spotify, your modules, fewer clicks');
         await expect(items.first().locator('.rtag--beta')).toHaveCount(1);
         await expect(items.first().locator('.clog__highlights li')).toHaveCount(4);
         await expect(items.first()).toContainText('Add to Twitch starts OAuth right away');
-        await expect(items.first().locator('a[href="https://github.com/AdamOusmer/ItsBagelBot/releases/tag/v1.0.3-beta"]')).toHaveCount(1);
+        await expect(items.first().locator('a[href="https://github.com/AdamOusmer/ItsBagelBot/releases/tag/v0.1.3-beta"]')).toHaveCount(1);
 
         await expect(items.nth(1)).toContainText('JSON data sources in the command editor');
         await expect(items.nth(2)).toContainText('Security fixes.');


### PR DESCRIPTION
## Summary
- Rename site changelog entries `v1.0.0-beta`–`v1.0.3-beta` to `v0.1.0-beta`–`v0.1.3-beta` so they match the GitHub tags (already retagged on the same commits).
- Keep newest-first version order; alpha stays `v0.1.0-alpha`.

## Test plan
- [ ] Open https://github.com/AdamOusmer/ItsBagelBot/releases and confirm only `v0.1.x-beta` / `v0.1.0-alpha` (no `v1.0.x-beta`)
- [ ] After merge, open `/changelog` and `/fr/changelog`: versions read `v0.1.3-beta` … `v0.1.0-beta` … `v0.1.0-alpha`
- [ ] Click the GitHub link on the newest card; it should land on `.../releases/tag/v0.1.3-beta`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected release examples and references to consistently use the `v0.1.x-beta` version series.
  - Updated changelog entries and release links to point to the correct beta versions.

- **Tests**
  - Updated version comparison and changelog checks to reflect the `v0.1.x-beta` release sequence.
  - Corrected expected release links and ordering in site validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->