### PR TITLE
fix(deploy): status probes answer for the deployment, not the entry node

### DIFF
--- a/deploy/db/status-routes.yaml
+++ b/deploy/db/status-routes.yaml
@@ -8,17 +8,18 @@
 # the app/db split. The webhook route rides along: it terminates on the same
 # transactions Service.
 #
-# Path-shape note (measured 2026-08-25): edge normalization folds //svc,
-# /./svc onto the clean path before matching, but replacePath pins the
-# backend to /status for every match, so the reachable set is still exactly
-# {<svc> -> /status}. See deploy/k8s/status-routes.yaml for the probe list.
+# No trafficDistribution on these Services (deliberate, mirrors the app half):
+# PreferSameNode pinned every external probe to the entry node's own replica,
+# so one dead pod read as service-down while the other replicas were healthy
+# (2026-08-30 node3 uplink blip: Better Stack reported projector down with 2/3
+# replicas serving). Status traffic is one probe per ~30s behind the rate
+# limiter, so the cross-node hop this reintroduces costs nothing.
 apiVersion: v1
 kind: Service
 metadata:
   name: commands-status
   namespace: db
 spec:
-  trafficDistribution: PreferSameNode
   selector:
     app: commands
   ports:
@@ -32,7 +33,6 @@ metadata:
   name: loyalty-status
   namespace: db
 spec:
-  trafficDistribution: PreferSameNode
   selector:
     app: loyalty
   ports:
@@ -46,7 +46,6 @@ metadata:
   name: modules-status
   namespace: db
 spec:
-  trafficDistribution: PreferSameNode
   selector:
     app: modules
   ports:
@@ -60,7 +59,6 @@ metadata:
   name: notifications-status
   namespace: db
 spec:
-  trafficDistribution: PreferSameNode
   selector:
     app: notifications
   ports:
@@ -74,7 +72,6 @@ metadata:
   name: projector-status
   namespace: db
 spec:
-  trafficDistribution: PreferSameNode
   selector:
     app: projector
   ports:
@@ -88,7 +85,6 @@ metadata:
   name: users-status
   namespace: db
 spec:
-  trafficDistribution: PreferSameNode
   selector:
     app: users
   ports:
@@ -113,14 +109,31 @@ metadata:
   name: status-ratelimit
   namespace: db
 spec:
-  # Mirrors deploy/k8s/status-routes.yaml: the app half shipped this limiter,
-  # this copy didn't, leaving seven backends hammerable at line rate by anyone
-  # who can reach health.itsbagelbot.com (red-team finding F3b).
+  # Mirrors deploy/k8s/status-routes.yaml (red-team finding F3b). The limiter
+  # shipped here without being attached to the routes below, leaving seven
+  # backends hammerable at line rate for 11 days; attached 2026-08-30 — keep
+  # every route's middleware list starting with this limiter.
   rateLimit:
     average: 1
     burst: 10
     sourceCriterion:
       requestHeaderName: CF-Connecting-IP
+---
+# Re-pick a backend when the first pick fails at the connection level. With
+# PreferSameNode gone (header comment) the pool is every ready replica, so a
+# pod that died faster than its EndpointSlice updated (the NotReady grace is
+# 40s+) no longer turns one bad pick into a public "down": 2026-08-30 node3
+# blip, Better Stack reported projector down with 2/3 replicas serving.
+# Sits after the rate limiter so retries don't re-count against the caller.
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: status-retry
+  namespace: db
+spec:
+  retry:
+    attempts: 3
+    initialInterval: 100ms
 ---
 apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
@@ -132,7 +145,7 @@ spec:
   routes:
     - match: Host(`health.itsbagelbot.com`) && Path(`/commands`)
       kind: Rule
-      middlewares: [{name: status-path}]
+      middlewares: [{name: status-ratelimit}, {name: status-retry}, {name: status-path}]
       services:
         - name: commands-status
           port: 443
@@ -140,7 +153,7 @@ spec:
           serversTransport: commands-status-transport
     - match: Host(`health.itsbagelbot.com`) && Path(`/loyalty`)
       kind: Rule
-      middlewares: [{name: status-path}]
+      middlewares: [{name: status-ratelimit}, {name: status-retry}, {name: status-path}]
       services:
         - name: loyalty-status
           port: 443
@@ -148,7 +161,7 @@ spec:
           serversTransport: loyalty-status-transport
     - match: Host(`health.itsbagelbot.com`) && Path(`/modules`)
       kind: Rule
-      middlewares: [{name: status-path}]
+      middlewares: [{name: status-ratelimit}, {name: status-retry}, {name: status-path}]
       services:
         - name: modules-status
           port: 443
@@ -156,7 +169,7 @@ spec:
           serversTransport: modules-status-transport
     - match: Host(`health.itsbagelbot.com`) && Path(`/notifications`)
       kind: Rule
-      middlewares: [{name: status-path}]
+      middlewares: [{name: status-ratelimit}, {name: status-retry}, {name: status-path}]
       services:
         - name: notifications-status
           port: 443
@@ -164,7 +177,7 @@ spec:
           serversTransport: notifications-status-transport
     - match: Host(`health.itsbagelbot.com`) && Path(`/projector`)
       kind: Rule
-      middlewares: [{name: status-path}]
+      middlewares: [{name: status-ratelimit}, {name: status-retry}, {name: status-path}]
       services:
         - name: projector-status
           port: 443
@@ -172,7 +185,7 @@ spec:
           serversTransport: projector-status-transport
     - match: Host(`health.itsbagelbot.com`) && Path(`/users`)
       kind: Rule
-      middlewares: [{name: status-path}]
+      middlewares: [{name: status-ratelimit}, {name: status-retry}, {name: status-path}]
       services:
         - name: users-status
           port: 443
@@ -180,7 +193,7 @@ spec:
           serversTransport: users-status-transport
     - match: Host(`health.itsbagelbot.com`) && Path(`/transactions`)
       kind: Rule
-      middlewares: [{name: status-path}]
+      middlewares: [{name: status-ratelimit}, {name: status-retry}, {name: status-path}]
       services:
         - name: transactions
           port: 443

--- a/deploy/k8s/status-routes.yaml
+++ b/deploy/k8s/status-routes.yaml
@@ -8,15 +8,6 @@
 # from outside; /healthz, /readyz and /drain stay cluster-internal (a public
 # /drain would let anyone hold handler goroutines for 10s a request).
 #
-# Path-shape note (measured 2026-08-25, live-probed): edge URL normalization
-# folds //gossip and /./gossip onto the clean path before matching, so those
-# shapes DO reach this router — but replacePath pins every match to /status,
-# and /gossip%2fstatus, /gossip/../drain, //gossip/drain all miss into the
-# unrouted fallback (302). The reachable-endpoint invariant survives every
-# observed shape: exactly {<svc> -> /status}. Accepted as-is rather than
-# adding a canonicalization middleware: it would buy zero reachable-set
-# reduction on a surface whose only endpoint is already public.
-#
 # DNS needs no record work: the cloudflared tunnel wildcard admits any
 # *.itsbagelbot.com hostname, and this router claiming Host(health...) is what
 # lifts it out of the unrouted-host fallback (web-error-pages.yaml, priority 1).
@@ -27,13 +18,19 @@
 # transactions.yaml. Every backend hop is TLS: pkg/health terminates it with
 # the per-service cert-manager <svc>-tls cert (SAN <svc>-status), and the
 # per-service ServersTransports below verify it against the fleet CA.
+#
+# No trafficDistribution on these Services (deliberate, mirrors the db half):
+# PreferSameNode pinned every external probe to the entry node's own replica,
+# so one dead pod read as service-down while the other replicas were healthy
+# (2026-08-30 node3 uplink blip: Better Stack reported projector down with 2/3
+# replicas serving). Status traffic is one probe per ~30s behind the rate
+# limiter, so the cross-node hop this reintroduces costs nothing.
 apiVersion: v1
 kind: Service
 metadata:
   name: gossip-status
   namespace: app
 spec:
-  trafficDistribution: PreferSameNode
   selector:
     app: gossip
   ports:
@@ -47,7 +44,6 @@ metadata:
   name: outgress-status
   namespace: app
 spec:
-  trafficDistribution: PreferSameNode
   selector:
     app: outgress
   ports:
@@ -61,7 +57,6 @@ metadata:
   name: sesame-status
   namespace: app
 spec:
-  trafficDistribution: PreferSameNode
   selector:
     app: sesame
   ports:
@@ -91,6 +86,22 @@ spec:
     sourceCriterion:
       requestHeaderName: CF-Connecting-IP
 ---
+# Re-pick a backend when the first pick fails at the connection level. With
+# PreferSameNode gone (header comment) the pool is every ready replica, so a
+# pod that died faster than its EndpointSlice updated (the NotReady grace is
+# 40s+) no longer turns one bad pick into a public "down": 2026-08-30 node3
+# blip, Better Stack reported projector down with 2/3 replicas serving.
+# Sits after the rate limiter so retries don't re-count against the caller.
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: status-retry
+  namespace: app
+spec:
+  retry:
+    attempts: 3
+    initialInterval: 100ms
+---
 # Rewrites every routed path to the one endpoint the backends actually serve.
 # Shared by all routes below: the per-service path only exists to pick the
 # backend, never to reach a different endpoint.
@@ -113,7 +124,7 @@ spec:
   routes:
     - match: Host(`health.itsbagelbot.com`) && Path(`/dashboard`)
       kind: Rule
-      middlewares: [{name: status-ratelimit}, {name: status-path}]
+      middlewares: [{name: status-ratelimit}, {name: status-retry}, {name: status-path}]
       services:
         - name: console-dashboard
           port: 443
@@ -122,7 +133,7 @@ spec:
           nativeLB: true
     - match: Host(`health.itsbagelbot.com`) && Path(`/gossip`)
       kind: Rule
-      middlewares: [{name: status-ratelimit}, {name: status-path}]
+      middlewares: [{name: status-ratelimit}, {name: status-retry}, {name: status-path}]
       services:
         - name: gossip-status
           port: 443
@@ -130,7 +141,7 @@ spec:
           serversTransport: gossip-status-transport
     - match: Host(`health.itsbagelbot.com`) && Path(`/ingress`)
       kind: Rule
-      middlewares: [{name: status-ratelimit}, {name: status-path}]
+      middlewares: [{name: status-ratelimit}, {name: status-retry}, {name: status-path}]
       services:
         - name: twitch-ingress-status
           port: 443
@@ -138,7 +149,7 @@ spec:
           serversTransport: twitch-ingress-status-transport
     - match: Host(`health.itsbagelbot.com`) && Path(`/outgress`)
       kind: Rule
-      middlewares: [{name: status-ratelimit}, {name: status-path}]
+      middlewares: [{name: status-ratelimit}, {name: status-retry}, {name: status-path}]
       services:
         - name: outgress-status
           port: 443
@@ -146,7 +157,7 @@ spec:
           serversTransport: outgress-status-transport
     - match: Host(`health.itsbagelbot.com`) && Path(`/sesame`)
       kind: Rule
-      middlewares: [{name: status-ratelimit}, {name: status-path}]
+      middlewares: [{name: status-ratelimit}, {name: status-retry}, {name: status-path}]
       services:
         - name: sesame-status
           port: 443
@@ -172,6 +183,18 @@ spec:
     sourceCriterion:
       requestHeaderName: CF-Connecting-IP
 ---
+# db copy of status-retry above, same reasoning; deploy/db/status-routes.yaml
+# ships an identical one so either file applies standalone.
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: status-retry
+  namespace: db
+spec:
+  retry:
+    attempts: 3
+    initialInterval: 100ms
+---
 apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
@@ -191,7 +214,7 @@ spec:
   routes:
     - match: Host(`health.itsbagelbot.com`) && Path(`/transactions`)
       kind: Rule
-      middlewares: [{name: status-ratelimit}, {name: status-path}]
+      middlewares: [{name: status-ratelimit}, {name: status-retry}, {name: status-path}]
       services:
         - name: transactions
           port: 443


### PR DESCRIPTION
## Why
During the 2026-08-30 node3 uplink blip, Better Stack reported projector down while 2 of 3 replicas were healthy. Three pins collapsed the probe path onto the sick node:

1. `trafficDistribution: PreferSameNode` on every `*-status` Service pinned the probe to the entry node's replica.
2. No retry on the status routes: one dead backend pick = public 502.
3. EndpointSlice lag: a pod on a NotReady node stays `ready: true` for the 40s+ grace window.

## What
- Drop `PreferSameNode` from all 9 status Services (probe traffic is ~1 req/30s behind the rate limiter; cross-node hop cost is nothing).
- New `status-retry` middleware (3 attempts) on every status route, ordered after the rate limiter so retries don't count against the caller.
- Attach `status-ratelimit` to the db-half routes: the middleware shipped 11 days ago (red-team F3b) but was never referenced by the routes, leaving seven backends unlimited. Live cluster confirmed.

Validated with `kubectl apply --dry-run=server` against the live cluster.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability for service status checks by retrying failed connections across available replicas.
  * Reduced the likelihood of status requests failing due to instance-specific connectivity issues.
  * Standardized request handling with rate limiting, retry behavior, and path processing across status endpoints.
* **Performance**
  * Improved distribution of status traffic across ready service instances for more consistent availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->