### PR TITLE
fix(automod): honor strict static thresholds and harden review findings

### DIFF
--- a/app/sesame/automod/baseline.go
+++ b/app/sesame/automod/baseline.go
@@ -50,8 +50,10 @@ const (
 
 	// baselineChanCap mirrors bot_stats.go channelStatsMaxKeys=4096: a memory
 	// backstop against pathological fan-out or a bug minting broadcaster ids,
-	// not a working limit. Overflow drops the stalest half by lastSeen so a
-	// returning active channel re-warms rather than staying evicted.
+	// not a working limit. GLOBAL across all shards - eviction call sites pass
+	// baselineChanCap/baselineShards per shard. Overflow drops the stalest
+	// half by lastSeen so a returning active channel re-warms rather than
+	// staying evicted.
 	baselineChanCap = 4096
 )
 
@@ -144,7 +146,7 @@ func (b *Baseline) Observe(ch uint64, caps, symbol, tokens float64) {
 	s.Lock()
 	cs := s.m[ch]
 	if cs == nil {
-		evictStalestHalf(s.m, func(cs *chanStats) int64 { return cs.lastSeen })
+		evictStalestHalf(s.m, baselineChanCap/baselineShards, func(cs *chanStats) int64 { return cs.lastSeen })
 		cs = &chanStats{}
 		s.m[ch] = cs
 	}
@@ -156,31 +158,39 @@ func (b *Baseline) Observe(ch uint64, caps, symbol, tokens float64) {
 	s.Unlock()
 }
 
-// Adjust returns the EFFECTIVE threshold for kind on channel ch:
-// max(ceiling[kind], mean + zScore·stddev) once the channel is warm
-// (>= coldFloorN observations), else max(ceiling[kind], ratio). ratio is the
-// static threshold the caller was about to apply and floors BOTH paths - on
-// the cold path too, so a stricter per-channel config survives adaptation
-// from line one and wiring this in cannot flip a single pre-existing verdict
-// until ~coldFloorN judged lines accumulate. Direction is raise-only by
-// construction: every branch bottoms out at a documented ceiling.
+// Adjust returns the EFFECTIVE threshold for kind on channel ch. ratio is
+// the profile-resolved static threshold the caller was about to apply, and it
+// is the floor on every path: a cold channel sees it verbatim, so wiring a
+// baseline in cannot flip a single pre-existing verdict until ~coldFloorN
+// judged lines accumulate. A warm channel's learned value (mean +
+// zScore·stddev) applies only when it clears BOTH ratio and the fleet
+// ceiling: the ceiling clamps the LEARNED contribution alone - learned data
+// is attacker-observable (frog-boiling), a broadcaster's static config is
+// not, so the ceiling must never override a deliberately tighter static
+// threshold (2026-08-30: it used to, silently erasing LevelStrict's 0.6 caps
+// on every baseline-wired channel). Direction stays raise-only by
+// construction.
 func (b *Baseline) Adjust(ch uint64, kind StyleKind, ratio float64) float64 {
-	return b.floored(kind, b.rawThresh(ch, kind), ratio)
+	t, warm := b.rawThresh(ch, kind)
+	if !warm || t < b.ceilingOf(kind) {
+		return ratio
+	}
+	return math.Max(t, ratio)
 }
 
-// rawThresh is the stats-lookup half of Adjust: kind's observed threshold for
-// channel ch under the shard lock - the ceiling until the channel is warm
-// (below coldFloorN observations the variance estimate is garbage), and
-// mean+zScore*stddev of the learned series afterwards.
-func (b *Baseline) rawThresh(ch uint64, kind StyleKind) float64 {
+// rawThresh is the stats-lookup half of Adjust: kind's observed
+// mean+zScore*stddev for channel ch under the shard lock, and whether the
+// channel is warm. Below coldFloorN observations the variance estimate is
+// garbage, so the cold path reports no learned value at all.
+func (b *Baseline) rawThresh(ch uint64, kind StyleKind) (float64, bool) {
 	s := &b.shards[ch&baselineShardMask]
 	s.Lock()
 	defer s.Unlock()
 	cs := s.m[ch]
 	if cs == nil || cs.n < coldFloorN {
-		return b.ceilingOf(kind)
+		return 0, false
 	}
-	return kind.series(cs).thresh()
+	return kind.series(cs).thresh(), true
 }
 
 // series selects the EWMA Adjust consults for kind.
@@ -195,19 +205,6 @@ func (k StyleKind) series(cs *chanStats) *metricEWMA {
 	}
 }
 
-// floored applies BOTH raise-only floors in one place - the documented
-// ceiling for the series and the caller's static threshold - so every return
-// path of Adjust (cold and warm alike) bottoms out at a documented ceiling.
-func (b *Baseline) floored(kind StyleKind, t, ratio float64) float64 {
-	if eff := b.ceilingOf(kind); t < eff {
-		t = eff
-	}
-	if t < ratio {
-		t = ratio
-	}
-	return t
-}
-
 func (b *Baseline) ceilingOf(kind StyleKind) float64 {
 	switch kind {
 	case KindCaps:
@@ -220,10 +217,13 @@ func (b *Baseline) ceilingOf(kind StyleKind) float64 {
 }
 
 // evictStalestHalf drops the oldest half of m by lastSeen when a shard map
-// hits its cap. Runs only on the overflow path (once per ~2048 new channels),
-// so its sort allocation never touches the steady state.
-func evictStalestHalf[V any](m map[uint64]V, lastSeen func(V) int64) {
-	if len(m) < baselineChanCap {
+// hits maxKeys. Runs only on the overflow path, so its sort allocation never
+// touches the steady state. maxKeys is the PER-SHARD share of the documented
+// global cap - callers pass cap/shards (2026-08-30: this used to hardcode
+// baselineChanCap per shard, silently making the real backstop 64x the
+// documented 4096 and leaving vocabChanCap decorative).
+func evictStalestHalf[V any](m map[uint64]V, maxKeys int, lastSeen func(V) int64) {
+	if len(m) < maxKeys {
 		return
 	}
 	type ageKey struct {

--- a/app/sesame/automod/baseline_test.go
+++ b/app/sesame/automod/baseline_test.go
@@ -14,15 +14,21 @@ func newTestBaseline() *Baseline {
 	return b
 }
 
-func TestBaselineColdChannelReturnsPlainCeiling(t *testing.T) {
+func TestBaselineColdChannelReturnsCallerStatic(t *testing.T) {
 	b := newTestBaseline()
+	// Cold channels see the caller's static threshold VERBATIM - including a
+	// static tighter than the fleet ceiling (LevelStrict caps 0.6): the
+	// ceiling clamps only the learned contribution, never a config choice.
 	for kind, want := range map[StyleKind]float64{
 		KindCaps:   0.7,
 		KindSymbol: 0.6,
 	} {
-		if got := b.Adjust(42, kind, 0.0); got != want {
-			t.Fatalf("cold channel kind=%d: got %v, want plain ceiling %v", kind, got, want)
+		if got := b.Adjust(42, kind, want); got != want {
+			t.Fatalf("cold channel kind=%d: got %v, want caller static %v", kind, got, want)
 		}
+	}
+	if got := b.Adjust(42, KindCaps, 0.6); got != 0.6 {
+		t.Fatalf("cold strict caps: got %v, want the tighter static 0.6", got)
 	}
 }
 
@@ -43,17 +49,28 @@ func TestBaselineWarmChannelRaisesForHypeCulture(t *testing.T) {
 	}
 }
 
-func TestBaselineNeverDropsBelowCeiling(t *testing.T) {
+func TestBaselineNeverDropsBelowCallerStatic(t *testing.T) {
 	b := newTestBaseline()
-	// A quiet channel: every branch of Adjust bottoms out at the ceiling.
+	// A quiet channel: the learned value sits under the fleet ceiling, so it
+	// is discarded and every kind pins to the caller's static exactly - the
+	// frog-boiling clamp: attacker-fed quiet lines can never tighten (or
+	// loosen) the gate below what the config says.
 	for i := 0; i < 500; i++ {
 		b.Observe(9, 0.2, 0.1, 8)
 	}
-	for kind, floor := range map[StyleKind]float64{KindCaps: 0.7, KindSymbol: 0.6} {
-		got := b.Adjust(9, kind, 0.0)
-		if got != floor {
-			t.Fatalf("kind=%d quiet warm channel must pin to ceiling exactly, got %v want %v", kind, got, floor)
+	for kind, static := range map[StyleKind]float64{KindCaps: 0.7, KindSymbol: 0.6} {
+		got := b.Adjust(9, kind, static)
+		if got != static {
+			t.Fatalf("kind=%d quiet warm channel must pin to static exactly, got %v want %v", kind, got, static)
 		}
+	}
+	// A learned value between a strict static (0.6) and the fleet ceiling
+	// (0.7) is likewise discarded: raises act only from the ceiling up.
+	for i := 0; i < 500; i++ {
+		b.Observe(11, 0.62, 0.1, 8)
+	}
+	if got := b.Adjust(11, KindCaps, 0.6); got != 0.6 {
+		t.Fatalf("sub-ceiling learned value must not move a strict static: got %v want 0.6", got)
 	}
 }
 
@@ -76,8 +93,10 @@ func TestBaselineEvictsStalestHalfAtCap(t *testing.T) {
 		b.Observe(ch, 0.3, 0.1, 5)
 	}
 	s := &b.shards[shardBase&baselineShardMask]
-	if len(s.m) > baselineChanCap {
-		t.Fatalf("shard map exceeded cap: %d", len(s.m))
+	// The documented global backstop divides across shards: one shard holds
+	// at most its share, so 64 shards aggregate to baselineChanCap, not 64x it.
+	if len(s.m) > baselineChanCap/baselineShards {
+		t.Fatalf("shard map exceeded its per-shard cap: %d > %d", len(s.m), baselineChanCap/baselineShards)
 	}
 	freshest := shardBase + (baselineChanCap+511)*64
 	if _, ok := s.m[freshest]; !ok {

--- a/app/sesame/automod/gate.go
+++ b/app/sesame/automod/gate.go
@@ -272,18 +272,9 @@ func (g *Gate) Assess(role module.Role, text string, cfg *Config, opts ...Assess
 	// allow-term (broadcaster owns that risk); the floor above already returned.
 	allowed := cfg.allows(skel)
 	if !allowed {
-		if v, ok := lexVerdict(cat, term, sec); ok {
-			g.purgeLearned(uint64(sc.ch), text)
+		ln := sectionLine{sec: sec, cfg: cfg, skel: skel, text: text, ch: uint64(sc.ch)}
+		if v, ok := g.sectionVerdict(cat, term, ln); ok {
 			return v, out
-		}
-		if v, ok := cfg.blockTermVerdict(skel); ok {
-			g.purgeLearned(uint64(sc.ch), text)
-			return v, out
-		}
-		// clips_only is a channel preference (not the immovable floor): allow
-		// terms suppress it the same way they suppress heuristics / block terms.
-		if sec.clipsOnly && hasNonClipLink(text) {
-			return Verdict{Action: ActionDelete, Rule: "clips_only"}, out
 		}
 	}
 
@@ -301,6 +292,38 @@ func (g *Gate) linkConvicted(sec sections, sc assessScope, text string) bool {
 		return false
 	}
 	return lk.Evaluate(text, uint64(sc.ch), sc.sender)
+}
+
+// sectionLine bundles the per-line evidence the section checks read, so
+// sectionVerdict takes one view of the line instead of six loose arguments -
+// same shape as styleAttempt below.
+type sectionLine struct {
+	sec  sections
+	cfg  *Config
+	skel []byte
+	text string
+	ch   uint64
+}
+
+// sectionVerdict resolves the allow-term-suppressible section checks in
+// council order - profile lexicon categories, channel block-terms, the
+// clips-only link filter. Split from Assess only to stay under the repo's
+// cyclomatic gate; behavior is Assess's verbatim.
+func (g *Gate) sectionVerdict(cat moderation.Category, term string, ln sectionLine) (Verdict, bool) {
+	if v, ok := lexVerdict(cat, term, ln.sec); ok {
+		g.purgeLearned(ln.ch, ln.text)
+		return v, true
+	}
+	if v, ok := ln.cfg.blockTermVerdict(ln.skel); ok {
+		g.purgeLearned(ln.ch, ln.text)
+		return v, true
+	}
+	// clips_only is a channel preference (not the immovable floor): allow
+	// terms suppress it the same way they suppress heuristics / block terms.
+	if ln.sec.clipsOnly && hasNonClipLink(ln.text) {
+		return Verdict{Action: ActionDelete, Rule: "clips_only"}, true
+	}
+	return Verdict{}, false
 }
 
 // styleAttempt is the style-juror's full view of one line: the resolved flags,

--- a/app/sesame/automod/learned_gate_test.go
+++ b/app/sesame/automod/learned_gate_test.go
@@ -72,9 +72,11 @@ func TestBaselineColdFloorsCallerStaticThreshold(t *testing.T) {
 	if got := b.Adjust(42, KindSymbol, 0.9); got != 0.9 {
 		t.Fatalf("cold symbol Adjust = %v, want caller static 0.9", got)
 	}
-	// ...and never below its own ceiling when the static value sits under it.
-	if got := b.Adjust(42, KindCaps, 0.6); got != 0.7 {
-		t.Fatalf("cold Adjust under ceiling = %v, want 0.7", got)
+	// ...including a static tighter than the fleet ceiling: LevelStrict's 0.6
+	// caps is a config choice, not learned data, so the ceiling never
+	// overrides it (it silently did before 2026-08-30).
+	if got := b.Adjust(42, KindCaps, 0.6); got != 0.6 {
+		t.Fatalf("cold Adjust under ceiling = %v, want the static 0.6", got)
 	}
 }
 
@@ -216,11 +218,13 @@ func TestUnscopedLinesKeepLayersInert(t *testing.T) {
 	}
 
 	// A per-channel stricter config also floors through the adapted threshold:
+	// quiet culture's learned value sits under the fleet ceiling, so strict's
+	// static 0.6 applies verbatim - the ceiling gates only learned raises.
 	cfg := ParseConfig(codec.RawMessage(`{"level":"strict"}`))
 	warm := uint64(5)
 	observeQuietCulture(b, warm, 300)
-	if got := b.Adjust(warm, KindCaps, cfg.resolved().capsThresh); got < 0.7 {
-		t.Fatalf("adapted strict threshold %v dropped below the fleet ceiling", got)
+	if got := b.Adjust(warm, KindCaps, cfg.resolved().capsThresh); got != 0.6 {
+		t.Fatalf("adapted strict threshold = %v, want the broadcaster's static 0.6", got)
 	}
 }
 

--- a/app/sesame/automod/scan.go
+++ b/app/sesame/automod/scan.go
@@ -104,6 +104,55 @@ func (s signals) symbolRatio() float64 {
 	return float64(s.symbols) / float64(s.runes)
 }
 
+// classify buckets one rune into the style counters. Split from scan's walk
+// so the loop keeps only the repeat-run tracking and each half stays under
+// the repo's cyclomatic gate. last is the previous rune (zero on the first),
+// which the combining-mark case reads to tell a stacked mark from a base one.
+func (s *signals) classify(r, last rune) {
+	switch {
+	case unicode.IsLetter(r):
+		s.letters++
+		if r > unicode.MaxASCII {
+			s.lettersNonASCII++
+		}
+		if unicode.IsUpper(r) {
+			s.upper++
+		}
+	// Emoji-structure glue must not read as evasion: U+200D ZWJ and
+	// U+FE0F VS16 are the JOINERS of 👨‍👩‍👧 / 🏳️‍🌈, and counting them
+	// as invisible (IsInvisible lists ZWJ) deleted every composed emoji.
+	// They route here instead of into zeroWidth; every other invisible
+	// (U+200B ZWSP, U+200C ZWNJ, word joiner, BOM, RTL overrides) still
+	// counts. ZWJ also does NOT enter symbols - it was never a symbol
+	// before, and minting one per joiner would inflate symbolRatio for
+	// multi-member families without any evasion being present.
+	case isEmojiRune(r):
+		s.emoji++
+		if r != 0x200d { // ZWJ
+			s.symbols++
+		}
+	case moderation.IsInvisible(r):
+		s.zeroWidth++
+	// Combining marks ride their base letter and are style-neutral:
+	// Devanagari matras, Arabic harakat, NFD accents. The old catch-all
+	// counted every one as a symbol, so mark-heavy scripts ran at 3-4x an
+	// ASCII line's symbolRatio (measured 2026-08-30: Hindi 0.36, Tamil
+	// 0.39, Arabic+harakat 0.42 against symbolRatioHi 0.6) - margin, not
+	// evasion. Only a STACKED mark (2nd+ Mn in a row, the zalgo shape)
+	// still counts: no natural script stacks marks the way zalgo does
+	// (Vietnamese NFD tops out at 2 per letter), so mark-wall spam keeps
+	// its symbol signal instead of gaining a free evasion channel.
+	case unicode.Is(unicode.Mn, r):
+		if unicode.Is(unicode.Mn, last) {
+			s.symbols++
+		}
+	case unicode.IsSpace(r):
+		s.spaces++
+	case !unicode.IsDigit(r):
+		s.symbols++
+	}
+}
+
 // scan walks the raw text once (range over a string does not allocate) and
 // gathers the cheap signals.
 func scan(text string) signals {
@@ -115,35 +164,7 @@ func scan(text string) signals {
 		if r > unicode.MaxASCII {
 			s.hasNonASCII = true
 		}
-		switch {
-		case unicode.IsLetter(r):
-			s.letters++
-			if r > unicode.MaxASCII {
-				s.lettersNonASCII++
-			}
-			if unicode.IsUpper(r) {
-				s.upper++
-			}
-		// Emoji-structure glue must not read as evasion: U+200D ZWJ and
-		// U+FE0F VS16 are the JOINERS of 👨‍👩‍👧 / 🏳️‍🌈, and counting them
-		// as invisible (IsInvisible lists ZWJ) deleted every composed emoji.
-		// They route here instead of into zeroWidth; every other invisible
-		// (U+200B ZWSP, U+200C ZWNJ, word joiner, BOM, RTL overrides) still
-		// counts. ZWJ also does NOT enter symbols - it was never a symbol
-		// before, and minting one per joiner would inflate symbolRatio for
-		// multi-member families without any evasion being present.
-		case isEmojiRune(r):
-			s.emoji++
-			if r != 0x200d { // ZWJ
-				s.symbols++
-			}
-		case moderation.IsInvisible(r):
-			s.zeroWidth++
-		case unicode.IsSpace(r):
-			s.spaces++
-		case !unicode.IsDigit(r):
-			s.symbols++
-		}
+		s.classify(r, last)
 		if r == last {
 			run++
 			if run > s.maxRepeat {

--- a/app/sesame/automod/vocab.go
+++ b/app/sesame/automod/vocab.go
@@ -126,7 +126,7 @@ func vocabChannel(m map[uint64]*chanVocab, channel uint64) *chanVocab {
 	if cv := m[channel]; cv != nil {
 		return cv
 	}
-	evictStalestHalf(m, func(cv *chanVocab) int64 { return cv.lastSeen })
+	evictStalestHalf(m, vocabChanCap/baselineShards, func(cv *chanVocab) int64 { return cv.lastSeen })
 	cv := &chanVocab{bins: make(map[string]*tokenStat)}
 	m[channel] = cv
 	return cv

--- a/app/sesame/engine/pipeline.go
+++ b/app/sesame/engine/pipeline.go
@@ -151,6 +151,12 @@ func NewPipeline(d Deps, registry *Registry, cfg Config) *Pipeline {
 		special:           d.Special,
 		autoRefundChannel: cfg.AutoRefundChannel,
 	}
+	if d.Automod == nil && d.Log != nil {
+		// gateChat/gateCohort fail OPEN on a nil gate - every message passes
+		// unmoderated. Legitimate in unit tests, a silent misconfiguration in
+		// prod, so say it once at wiring time instead of never.
+		d.Log.Warn("automod gate not wired; chat moderation disabled")
+	}
 	if cfg.CountUses && d.Pub != nil {
 		p.uses = newUseReporter(d.Pub, d.Log)
 	}


### PR DESCRIPTION
Fixes from a review pass over the automod package.

## Bugs
- **Strict mode caps threshold was silently erased.** `Baseline.Adjust` floored every result at the fleet ceiling (0.7), so `LevelStrict`'s deliberately tighter 0.6 caps threshold never applied on any baseline-wired channel, cold or warm. The ceiling now clamps only the learned contribution: learned data is attacker-observable (frog-boiling), a broadcaster's static config is not. Cold channels see the static threshold verbatim, matching the documented intent.
- **Eviction backstop was 64x the documented cap.** `evictStalestHalf` compared the global 4096 cap against a single shard's map, so the real ceiling was ~262k channel entries. It now takes a per-shard share of the cap, and `vocabChanCap` is actually wired instead of decorative.
- **Combining marks counted as symbols.** Devanagari matras, Arabic harakat and NFD accents fell into the symbol catch-all, running mark-heavy scripts at 3-4x an ASCII line's symbolRatio (measured: Hindi 0.36, Tamil 0.39, Arabic 0.42 against the 0.6 gate). A first mark on a base is now free; stacked marks (the zalgo shape) still count, so mark-wall spam keeps its signal.

## Hardening
- `Assess` section checks extracted into `sectionVerdict` (evidence bundled in `sectionLine`, mirroring `styleAttempt`) and `scan`'s classification switch into `signals.classify`, keeping both under the cyclomatic gate.
- Pipeline warns once at wiring time when the automod gate is nil - the nil path fails open (every message passes unmoderated) and was previously silent.

Tests: baseline/learned pins updated to the corrected Adjust semantics, eviction test tightened to the per-shard cap. `go test ./app/sesame/...` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved configured moderation thresholds across cold and warm channels, preventing adaptive settings from weakening stricter static limits.
  - Corrected channel eviction limits so capacity is enforced consistently across partitions.
  - Improved text signal handling for combining marks, including stacked marks used in symbols.
  - Preserved existing moderation behavior for lexicon, blocked terms, and clips-only rules.
- **Diagnostics**
  - Added an initialization warning when moderation is not connected to the processing pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->