### PR TITLE
fix(bus): namespace-qualify leaf failback health probe

### DIFF
--- a/pkg/bus/failback.go
+++ b/pkg/bus/failback.go
@@ -41,8 +41,15 @@ func leafFailbackOption() nats.Option {
 
 func loadFailbackConfig() failbackConfig {
 	return failbackConfig{
-		nodeName:  env.Get("NODE_NAME", ""),
-		healthURL: env.Get("NATS_LOCAL_LEAF_HEALTH_URL", "http://nats-leaf-local:8222/healthz"),
+		nodeName: env.Get("NODE_NAME", ""),
+		// The namespace qualifier is load-bearing: the nats-leaf-local Service
+		// exists only in messaging, while every workload runs in app/db. The
+		// original short-name default resolved through the caller's search
+		// path, NXDOMAINed from those namespaces, and left the failback loop
+		// permanently inert — audited live 2026-08-30: 28 of 39 leaf client
+		// connections were parked on a wrong-node leaf for days with zero
+		// ForceReconnect attempts, because localLeafReady never returned true.
+		healthURL: env.Get("NATS_LOCAL_LEAF_HEALTH_URL", "http://nats-leaf-local.messaging:8222/healthz"),
 		interval:  durationEnv("NATS_FAILBACK_INTERVAL", defaultFailbackInterval),
 		successes: positiveIntEnv("NATS_FAILBACK_SUCCESSES", defaultFailbackSuccesses),
 		timeout:   durationEnv("NATS_FAILBACK_PROBE_TIMEOUT", defaultFailbackTimeout),


### PR DESCRIPTION
The leaf failback loop probes the node-local leaf via the nats-leaf-local Service before force-reconnecting a client that failed over to a remote leaf. The default probe URL used the short service name, which only resolves from inside the messaging namespace; every workload runs in app/db, so the probe NXDOMAINed and failback never fired anywhere.

Live audit 2026-08-30: 28 of 39 leaf client connections were parked on a wrong-node leaf (17/4/18 spread across the three leaves), left there by the last leaf DaemonSet roll and a node3 restart, with connection uptimes of days and zero ForceReconnect attempts. No deployment overrides NATS_LOCAL_LEAF_HEALTH_URL, so the in-code default was the only path.

Fix: qualify the default as nats-leaf-local.messaging. Apps migrate home within ~90s of the probe succeeding (30s interval x 3 consecutive successes).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default local leaf health-check URL to consistently target the `nats-leaf-local` service in the `messaging` namespace.
  * Preserved existing failback configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->